### PR TITLE
[turbopack] tweak the ui of the module-cost benchmark

### DIFF
--- a/bench/module-cost/components/client.js
+++ b/bench/module-cost/components/client.js
@@ -1,49 +1,52 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { format, measure } from '../lib/measure'
 
-function log(result) {
-  console.log(format(result))
+function report(result, element, textarea) {
+  const formattedResult = format(result)
+  element.textContent = formattedResult
+  textarea.current.value += `\n    ${formattedResult}`
+  console.log(formattedResult)
+  element.disabled = true
 }
 
-async function measureClientButton(element, name, fn) {
+async function measureClientButton(element, textarea, name, fn) {
   if (element.textContent.includes('Loading time')) {
     return
   }
 
   const result = await measure(name, fn)
-
-  element.textContent = format(result)
-  log(result)
+  report(result, element, textarea)
 }
 
-async function measureActionButton(element, action) {
+async function measureActionButton(element, textarea, action) {
   if (element.textContent.includes('Loading time')) {
     return
   }
 
   const result = await action()
 
-  element.textContent = format(result)
-  log(result)
+  report(result, element, textarea)
 }
 
-async function measureApiButton(element, url) {
+async function measureApiButton(element, textarea, url) {
   if (element.textContent.includes('Loading time')) {
     return
   }
 
   const result = await fetch(url).then((res) => res.json())
 
-  element.textContent = format(result)
-  log(result)
+  report(result, element, textarea)
 }
 
 export function Client({ prefix, commonjsAction, esmAction }) {
   const [runtime, setRuntime] = useState('')
+  const textarea = useRef()
   useEffect(() => {
-    setRuntime(globalThis.TURBOPACK ? 'Turbopack' : 'Webpack')
+    setRuntime(
+      `${globalThis.TURBOPACK ? 'Turbopack' : 'Webpack'} (${process.env.NODE_ENV})`
+    )
   }, [])
   return (
     <>
@@ -54,6 +57,7 @@ export function Client({ prefix, commonjsAction, esmAction }) {
           onClick={(e) =>
             measureClientButton(
               e.target,
+              textarea,
               'client commonjs',
               () => import('../lib/commonjs.js')
             )
@@ -68,6 +72,7 @@ export function Client({ prefix, commonjsAction, esmAction }) {
           onClick={(e) =>
             measureClientButton(
               e.target,
+              textarea,
               'client esm',
               () => import('../lib/esm.js')
             )
@@ -80,7 +85,9 @@ export function Client({ prefix, commonjsAction, esmAction }) {
         <p>
           <button
             type="button"
-            onClick={(e) => measureActionButton(e.target, commonjsAction)}
+            onClick={(e) =>
+              measureActionButton(e.target, textarea, commonjsAction)
+            }
           >
             CommonJs server action
           </button>
@@ -90,7 +97,7 @@ export function Client({ prefix, commonjsAction, esmAction }) {
         <p>
           <button
             type="button"
-            onClick={(e) => measureActionButton(e.target, esmAction)}
+            onClick={(e) => measureActionButton(e.target, textarea, esmAction)}
           >
             ESM server action
           </button>
@@ -99,7 +106,9 @@ export function Client({ prefix, commonjsAction, esmAction }) {
       <p>
         <button
           type="button"
-          onClick={(e) => measureApiButton(e.target, `${prefix}/commonjs`)}
+          onClick={(e) =>
+            measureApiButton(e.target, textarea, `${prefix}/commonjs`)
+          }
         >
           CommonJs API
         </button>
@@ -107,11 +116,20 @@ export function Client({ prefix, commonjsAction, esmAction }) {
       <p>
         <button
           type="button"
-          onClick={(e) => measureApiButton(e.target, `${prefix}/esm`)}
+          onClick={(e) => measureApiButton(e.target, textarea, `${prefix}/esm`)}
         >
           ESM API
         </button>
       </p>
+      {
+        // holds all the timing data for easier copy past
+      }
+      <textarea
+        readOnly={true}
+        ref={textarea}
+        value={runtime}
+        style={{ fieldSizing: 'content' }}
+      ></textarea>
     </>
   )
 }

--- a/bench/module-cost/components/client.js
+++ b/bench/module-cost/components/client.js
@@ -122,7 +122,7 @@ export function Client({ prefix, commonjsAction, esmAction }) {
         </button>
       </p>
       {
-        // holds all the timing data for easier copy past
+        // holds all the timing data for easier copy paste
       }
       <textarea
         readOnly={true}

--- a/bench/module-cost/components/client.js
+++ b/bench/module-cost/components/client.js
@@ -1,6 +1,7 @@
 'use client'
 
 import { format, measure } from '../lib/measure'
+import { useState, useEffect } from 'react'
 
 async function measureClientButton(element, name, fn) {
   if (element.textContent.includes('Loading time')) {
@@ -33,10 +34,16 @@ async function measureApiButton(element, url) {
 }
 
 export function Client({ prefix, commonjsAction, esmAction }) {
+  const [runtime, setRuntime] = useState('')
+  useEffect(() => {
+    setRuntime(globalThis.TURBOPACK ? 'Turbopack' : 'Webpack')
+  }, [])
   return (
     <>
+      <h1>{runtime}</h1>
       <p>
         <button
+          type="button"
           onClick={(e) =>
             measureClientButton(
               e.target,
@@ -50,6 +57,7 @@ export function Client({ prefix, commonjsAction, esmAction }) {
       </p>
       <p>
         <button
+          type="button"
           onClick={(e) =>
             measureClientButton(
               e.target,
@@ -64,6 +72,7 @@ export function Client({ prefix, commonjsAction, esmAction }) {
       {commonjsAction && (
         <p>
           <button
+            type="button"
             onClick={(e) => measureActionButton(e.target, commonjsAction)}
           >
             CommonJs server action
@@ -72,20 +81,27 @@ export function Client({ prefix, commonjsAction, esmAction }) {
       )}
       {esmAction && (
         <p>
-          <button onClick={(e) => measureActionButton(e.target, esmAction)}>
+          <button
+            type="button"
+            onClick={(e) => measureActionButton(e.target, esmAction)}
+          >
             ESM server action
           </button>
         </p>
       )}
       <p>
         <button
+          type="button"
           onClick={(e) => measureApiButton(e.target, `${prefix}/commonjs`)}
         >
           CommonJs API
         </button>
       </p>
       <p>
-        <button onClick={(e) => measureApiButton(e.target, `${prefix}/esm`)}>
+        <button
+          type="button"
+          onClick={(e) => measureApiButton(e.target, `${prefix}/esm`)}
+        >
           ESM API
         </button>
       </p>

--- a/bench/module-cost/components/client.js
+++ b/bench/module-cost/components/client.js
@@ -5,7 +5,7 @@ import { format, measure } from '../lib/measure'
 
 function report(result, element, textarea) {
   const formattedResult = format(result)
-  element.textContent = formattedResult
+  element.textContent += `: ${formattedResult}`
   textarea.current.value += `\n    ${formattedResult}`
   console.log(formattedResult)
   element.disabled = true

--- a/bench/module-cost/components/client.js
+++ b/bench/module-cost/components/client.js
@@ -1,7 +1,11 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { format, measure } from '../lib/measure'
-import { useState, useEffect } from 'react'
+
+function log(result) {
+  console.log(format(result))
+}
 
 async function measureClientButton(element, name, fn) {
   if (element.textContent.includes('Loading time')) {
@@ -10,7 +14,8 @@ async function measureClientButton(element, name, fn) {
 
   const result = await measure(name, fn)
 
-  element.textContent += ` (${format(result)})`
+  element.textContent = format(result)
+  log(result)
 }
 
 async function measureActionButton(element, action) {
@@ -20,7 +25,8 @@ async function measureActionButton(element, action) {
 
   const result = await action()
 
-  element.textContent += ` (${format(result)})`
+  element.textContent = format(result)
+  log(result)
 }
 
 async function measureApiButton(element, url) {
@@ -30,7 +36,8 @@ async function measureApiButton(element, url) {
 
   const result = await fetch(url).then((res) => res.json())
 
-  element.textContent += ` (${format(result)})`
+  element.textContent = format(result)
+  log(result)
 }
 
 export function Client({ prefix, commonjsAction, esmAction }) {

--- a/bench/module-cost/lib/measure.js
+++ b/bench/module-cost/lib/measure.js
@@ -18,12 +18,11 @@ export async function measure(name, fn) {
     executeDuration = end - start
   }
 
-  const result = { loadDuration, executeDuration, files }
-  console.log(`${name} Measurement: ${format(result)}`)
+  const result = { name, loadDuration, executeDuration, files }
 
   return result
 }
 
 export function format(result) {
-  return `Load duration: ${result.loadDuration.toFixed(2)}ms, Execution duration: ${result.executeDuration.toFixed(2)}ms, Files: ${result.files}`
+  return `${result.name}: Load duration: ${result.loadDuration.toFixed(2)}ms, Execution duration: ${result.executeDuration.toFixed(2)}ms, Files: ${result.files}`
 }

--- a/bench/module-cost/scripts/prepare-bench.mjs
+++ b/bench/module-cost/scripts/prepare-bench.mjs
@@ -1,6 +1,6 @@
-import fs from 'fs/promises'
-import path from 'path'
-import { fileURLToPath } from 'url'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const commonjsDir = path.join(__dirname, '../commonjs')


### PR DESCRIPTION
Have the module-cost benchmark page self identify and output into a text box to make copy-pasting the data out easier.

Closes PACK-5144