### PR TITLE
Turbopack: Add an option to use system TLS certificates (fixes #79060, fixes #79059)

### DIFF
--- a/.changeset/silent-houses-lay.md
+++ b/.changeset/silent-houses-lay.md
@@ -1,0 +1,5 @@
+---
+'@next/swc': patch
+---
+
+Added an experimental option for using the system CA store for fetching Google Fonts in Turbopack

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2869,6 +2869,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -5945,9 +5946,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5966,6 +5967,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6192,6 +6194,28 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -9313,7 +9337,7 @@ dependencies = [
  "anyhow",
  "mockito",
  "quick_cache",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde",
  "tokio",
  "turbo-rcstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,7 +400,7 @@ rand = "0.9.0"
 rayon = "1.10.0"
 regex = "1.10.6"
 regress = "0.10.3"
-reqwest = { version = "0.12.20", default-features = false }
+reqwest = { version = "0.12.22", default-features = false }
 ringmap = "0.1.3"
 roaring = "0.10.10"
 rstest = "0.16.0"

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -3,12 +3,13 @@ use rustc_hash::FxHashSet;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value as JsonValue;
 use turbo_esregex::EsRegex;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, NonLocalValue, OperationValue, ResolvedVc, TaskInput, Vc, debug::ValueDebugFormat,
     trace::TraceRawVcs,
 };
-use turbo_tasks_env::EnvMap;
+use turbo_tasks_env::{EnvMap, ProcessEnv};
+use turbo_tasks_fetch::ReqwestClientConfig;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{
     ConditionItem, ConditionPath, LoaderRuleItem, OptionWebpackRules,
@@ -801,6 +802,7 @@ pub struct ExperimentalConfig {
     turbopack_source_maps: Option<bool>,
     turbopack_tree_shaking: Option<bool>,
     turbopack_scope_hoisting: Option<bool>,
+    turbopack_use_system_tls_certs: Option<bool>,
     // Whether to enable the global-not-found convention
     global_not_found: Option<bool>,
     /// Defaults to false in development mode, true in production mode.
@@ -1720,6 +1722,29 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn output_file_tracing_excludes(&self) -> Vc<OptionJsonValue> {
         Vc::cell(self.output_file_tracing_excludes.clone())
+    }
+
+    #[turbo_tasks::function]
+    pub async fn reqwest_client_config(
+        &self,
+        env: Vc<Box<dyn ProcessEnv>>,
+    ) -> Result<Vc<ReqwestClientConfig>> {
+        let use_system_tls_certs = env
+            .read(rcstr!("NEXT_TURBOPACK_EXPERIMENTAL_USE_SYSTEM_TLS_CERTS"))
+            .await?
+            .as_ref()
+            .and_then(|env_value| {
+                // treat empty value same as an unset value
+                (!env_value.is_empty()).then(|| env_value == "1" || env_value == "true")
+            })
+            .or(self.experimental.turbopack_use_system_tls_certs)
+            .unwrap_or(false);
+        Ok(ReqwestClientConfig {
+            proxy: None,
+            tls_built_in_webpki_certs: !use_system_tls_certs,
+            tls_built_in_native_certs: use_system_tls_certs,
+        }
+        .cell())
     }
 }
 

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1729,6 +1729,9 @@ impl NextConfig {
         &self,
         env: Vc<Box<dyn ProcessEnv>>,
     ) -> Result<Vc<ReqwestClientConfig>> {
+        // Support both an env var and the experimental flag to provide more flexibility to
+        // developers on locked down systems, depending on if they want to configure this on a
+        // per-system or per-project basis.
         let use_system_tls_certs = env
             .read(rcstr!("NEXT_TURBOPACK_EXPERIMENTAL_USE_SYSTEM_TLS_CERTS"))
             .await?

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1022,6 +1022,7 @@ async fn insert_next_shared_aliases(
         next_font_google_replacer_mapping,
     );
 
+    let reqwest_client_config = next_config.reqwest_client_config(execution_context.env());
     import_map.insert_alias(
         AliasPattern::exact("@vercel/turbopack-next/internal/font/google/cssmodule.module.css"),
         ImportMapping::Dynamic(ResolvedVc::upcast(
@@ -1029,6 +1030,7 @@ async fn insert_next_shared_aliases(
                 project_path.clone(),
                 execution_context,
                 next_mode,
+                reqwest_client_config,
             )
             .to_resolved()
             .await?,
@@ -1039,7 +1041,7 @@ async fn insert_next_shared_aliases(
     import_map.insert_alias(
         AliasPattern::exact(GOOGLE_FONTS_INTERNAL_PREFIX),
         ImportMapping::Dynamic(ResolvedVc::upcast(
-            NextFontGoogleFontFileReplacer::new(project_path.clone())
+            NextFontGoogleFontFileReplacer::new(project_path.clone(), reqwest_client_config)
                 .to_resolved()
                 .await?,
         ))

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -462,6 +462,26 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         turbopackTreeShaking: z.boolean().optional(),
         turbopackRemoveUnusedExports: z.boolean().optional(),
         turbopackScopeHoisting: z.boolean().optional(),
+        /**
+         * Use the system-provided CA roots instead of bundled CA roots for external HTTPS requests
+         * made by Turbopack. Currently this is only used for fetching data from Google Fonts.
+         *
+         * This may be useful in cases where you or an employer are MITMing traffic.
+         *
+         * This option is experimental because:
+         * - This may cause small performance problems, as it uses [`rustls-native-certs`](
+         *   https://github.com/rustls/rustls-native-certs).
+         * - In the future, this may become the default, and this option may be eliminated, once
+         *   <https://github.com/seanmonstar/reqwest/issues/2159> is resolved.
+         *
+         * Users who need to configure this behavior system-wide can override the project
+         * configuration using the `NEXT_TURBOPACK_EXPERIMENTAL_USE_SYSTEM_TLS_CERTS=1` environment
+         * variable.
+         *
+         * This option is ignored on Windows on ARM, where the native TLS implementation is always
+         * used.
+         */
+        turbopackUseSystemTlsCerts: z.boolean().optional(),
         optimizePackageImports: z.array(z.string()).optional(),
         optimizeServerReact: z.boolean().optional(),
         clientTraceMetadata: z.array(z.string()).optional(),

--- a/turbopack/crates/turbo-tasks-fetch/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fetch/Cargo.toml
@@ -20,8 +20,9 @@ workspace = true
 [target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
 reqwest = { workspace = true, features = ["native-tls"] }
 
+# If you modify this cfg, make sure you update `ReqwestClientConfig::try_build`.
 [target.'cfg(not(any(all(target_os = "windows", target_arch = "aarch64"), target_arch="wasm32")))'.dependencies]
-reqwest = { workspace = true, features = ["rustls-tls"] }
+reqwest = { workspace = true, features = ["rustls-tls-webpki-roots", "rustls-tls-native-roots"] }
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
It's common in enterprise environments for employers to MITM all HTTPS traffic on employee machines to enforce network policies or to detect and block malware. For this to work, they install custom CA roots into the system store. Applications must read from this store.

The default behavior of `reqwests` is to bundle the mozilla CA roots into the application, and only trust those. This is reasonable given some of the tradeoffs of the current rustls resolver implementations they use, but long-term it's better for most applications to just use the system CA store.

This provides an opt-in experimental option for using the system CA store. We may use system CA certs by default in the future once https://github.com/seanmonstar/reqwest/issues/2159 is resolved.

Fixes #79059
Fixes #79060

### Testing

- Install [mitmproxy](https://docs.mitmproxy.org/stable/overview/installation/).
- Install the generated mitmproxy CA cert to the system store: https://docs.mitmproxy.org/stable/concepts/certificates/
- Run `./mitmdump` (with no arguments)
- Run an example app that uses google fonts:

```
pnpm pack-next --project ~/shadcn-ui/apps/v4 --no-js-build -- --release
cd ~/shadcn-ui/apps/v4
pnpm i
NEXT_TURBOPACK_EXPERIMENTAL_USE_SYSTEM_TLS_CERTS=0 HTTP_PROXY=localhost:8080 HTTPS_PROXY=localhost:8080 pnpm dev
NEXT_TURBOPACK_EXPERIMENTAL_USE_SYSTEM_TLS_CERTS=1 HTTP_PROXY=localhost:8080 HTTPS_PROXY=localhost:8080 pnpm dev
```

When system TLS certs are disabled, we get warnings like this:

```
 ⚠ [next]/internal/font/google/geist_mono_77f2790.module.css
Error while requesting resource
There was an issue establishing a connection while requesting https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400&display=swap.

Import trace:
  [next]/internal/font/google/geist_mono_77f2790.module.css
  [next]/internal/font/google/geist_mono_77f2790.js
  ./apps/v4/lib/fonts.ts
  ./apps/v4/app/layout.tsx
```

And mitmproxy shows the handshakes failing

![Screenshot 2025-07-21 at 1.11.11 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HAZVitxRNnZz8QMiPn4a/2efc4b97-f50e-412c-9daf-5cdd00a6d82b.png)

When system TLS certs are enabled, the app works.

Closes PACK-5127