### PR TITLE
Fix image aspect ratio warnings in app-tw TypeScript template

### DIFF
--- a/packages/create-next-app/templates/app-tw/ts/app/page.tsx
+++ b/packages/create-next-app/templates/app-tw/ts/app/page.tsx
@@ -8,8 +8,9 @@ export default function Home() {
           className="dark:invert"
           src="/next.svg"
           alt="Next.js logo"
-          width={180}
-          height={38}
+          width={394}
+          height={80}
+          style={{ width: "180px" }}
           priority
         />
         <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
@@ -36,8 +37,9 @@ export default function Home() {
               className="dark:invert"
               src="/vercel.svg"
               alt="Vercel logomark"
-              width={20}
-              height={20}
+              width={1155}
+              height={1000}
+              style={{ width: "20px" }}
             />
             Deploy now
           </a>


### PR DESCRIPTION
### What?

Fixed browser warnings related to image sizing for `next.svg` and `vercel.svg`.

```
Image with src "http://localhost:3000/next.svg" has either width or height modified, but not the other. If you use CSS to change the size of your image, also include the styles 'width: "auto"' or 'height: "auto"' to maintain the aspect ratio.
```

To keep the change set small, only the TypeScript template in `app-tw` was modified.

### Why?

The browser console showed warnings because only the width or height was modified via CSS for some images, which can break the aspect ratio. The warning suggested adding either `width: "auto"` or `height: "auto"` to maintain the aspect ratio.

Since this template is likely often used for bootstrapping new Next.js projects, I wanted to eliminate errors and warnings as much as possible.

### How?

- The `width` and `height` props of the Image component are now set to match the original SVG dimensions.
- To maintain the template's design, the displayed image size is controlled via the `style` attribute.
