### PR TITLE
refactor: encapsulate content type within RenderResult

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -728,5 +728,8 @@
   "727": "Route %s couldn't be rendered statically because it used IO that was not cached. See more info here: https://nextjs.org/docs/messages/cache-components",
   "728": "CacheSignal cannot be used in the edge runtime, because `cacheComponents` does not support it.",
   "729": "\\`experimental.ppr\\` can not be \\`%s\\` when \\`experimental.cacheComponents\\` is \\`true\\`. PPR is implicitly enabled when Cache Components is enabled.",
-  "730": "Dynamic imports should not be instrumented in the edge runtime, because `cacheComponents` doesn't support it"
+  "730": "Dynamic imports should not be instrumented in the edge runtime, because `cacheComponents` doesn't support it",
+  "731": "chainStreams requires at least one stream",
+  "732": "dynamic responses cannot be unchunked. This is a bug in Next.js",
+  "733": "null responses cannot be unchunked"
 }

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -28,6 +28,7 @@ import type RenderResult from '../../server/render-result'
 import type { RenderResultMetadata } from '../../server/render-result'
 import { getTracer, SpanKind, type Span } from '../../server/lib/trace/tracer'
 import { BaseServerSpan } from '../../server/lib/trace/constants'
+import { HTML_CONTENT_TYPE_HEADER } from '../../lib/constants'
 
 // injected by the loader afterwards.
 declare const nextConfig: NextConfigComplete
@@ -195,7 +196,7 @@ async function requestHandler(
     const headers = new Headers()
 
     // Set content type
-    const contentType = result.contentType || 'text/html; charset=utf-8'
+    const contentType = result.contentType || HTML_CONTENT_TYPE_HEADER
     headers.set('Content-Type', contentType)
 
     // Add metadata headers

--- a/packages/next/src/build/templates/pages.ts
+++ b/packages/next/src/build/templates/pages.ts
@@ -31,7 +31,11 @@ import {
 } from '../../server/lib/cache-control'
 import { normalizeRepeatedSlashes } from '../../shared/lib/utils'
 import { getRedirectStatus } from '../../lib/redirect-status'
-import { CACHE_ONE_YEAR } from '../../lib/constants'
+import {
+  CACHE_ONE_YEAR,
+  HTML_CONTENT_TYPE_HEADER,
+  JSON_CONTENT_TYPE_HEADER,
+} from '../../lib/constants'
 import { sendRenderResult } from '../../server/send-payload'
 import RenderResult from '../../server/render-result'
 import { toResponseCacheEntry } from '../../server/response-cache/utils'
@@ -526,7 +530,7 @@ export async function handler(
               html: new RenderResult(
                 Buffer.from(previousCacheEntry.value.html),
                 {
-                  contentType: 'text/html;utf-8',
+                  contentType: HTML_CONTENT_TYPE_HEADER,
                   metadata: {
                     statusCode: previousCacheEntry.value.status,
                     headers: previousCacheEntry.value.headers,
@@ -653,7 +657,7 @@ export async function handler(
 
       if (result.value.kind === CachedRouteKind.REDIRECT) {
         if (isNextDataRequest) {
-          res.setHeader('content-type', 'application/json')
+          res.setHeader('content-type', JSON_CONTENT_TYPE_HEADER)
           res.end(JSON.stringify(result.value.props))
           return
         } else {
@@ -732,7 +736,7 @@ export async function handler(
             ? new RenderResult(
                 Buffer.from(JSON.stringify(result.value.pageData)),
                 {
-                  contentType: 'application/json',
+                  contentType: JSON_CONTENT_TYPE_HEADER,
                   metadata: result.value.html.metadata,
                 }
               )
@@ -740,7 +744,6 @@ export async function handler(
         generateEtags: nextConfig.generateEtags,
         poweredByHeader: nextConfig.poweredByHeader,
         cacheControl: routeModule.isDev ? undefined : cacheControl,
-        type: isNextDataRequest ? 'json' : 'html',
       })
     }
 

--- a/packages/next/src/export/routes/pages.ts
+++ b/packages/next/src/export/routes/pages.ts
@@ -17,6 +17,7 @@ import type {
 } from '../../server/lib/mock-request'
 import { isInAmpMode } from '../../shared/lib/amp-mode'
 import {
+  HTML_CONTENT_TYPE_HEADER,
   NEXT_DATA_SUFFIX,
   SERVER_PROPS_EXPORT_ERROR,
 } from '../../lib/constants'
@@ -96,7 +97,10 @@ export async function exportPagesPage(
   let renderResult: RenderResult | undefined
 
   if (typeof components.Component === 'string') {
-    renderResult = RenderResult.fromStatic(components.Component)
+    renderResult = RenderResult.fromStatic(
+      components.Component,
+      HTML_CONTENT_TYPE_HEADER
+    )
 
     if (hasOrigQueryValues) {
       throw new Error(

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -1,5 +1,8 @@
 import type { ServerRuntime } from '../types'
 
+export const TEXT_PLAIN_CONTENT_TYPE_HEADER = 'text/plain'
+export const HTML_CONTENT_TYPE_HEADER = 'text/html; charset=utf-8'
+export const JSON_CONTENT_TYPE_HEADER = 'application/json; charset=utf-8'
 export const NEXT_QUERY_PARAM_PREFIX = 'nxtP'
 export const NEXT_INTERCEPTION_MARKER_PREFIX = 'nxtI'
 

--- a/packages/next/src/server/api-utils/node/api-resolver.ts
+++ b/packages/next/src/server/api-utils/node/api-resolver.ts
@@ -24,6 +24,7 @@ import {
 } from './../index'
 import { getCookieParser } from './../get-cookie-parser'
 import {
+  JSON_CONTENT_TYPE_HEADER,
   PRERENDER_REVALIDATE_HEADER,
   PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER,
 } from '../../../lib/constants'
@@ -106,7 +107,7 @@ function sendData(req: NextApiRequest, res: NextApiResponse, body: any): void {
   }
 
   if (isJSONLike) {
-    res.setHeader('Content-Type', 'application/json; charset=utf-8')
+    res.setHeader('Content-Type', JSON_CONTENT_TYPE_HEADER)
   }
 
   res.setHeader('Content-Length', Buffer.byteLength(stringifiedBody))
@@ -120,7 +121,7 @@ function sendData(req: NextApiRequest, res: NextApiResponse, body: any): void {
  */
 function sendJson(res: NextApiResponse, jsonBody: any): void {
   // Set header to application/json
-  res.setHeader('Content-Type', 'application/json; charset=utf-8')
+  res.setHeader('Content-Type', JSON_CONTENT_TYPE_HEADER)
 
   // Use send to handle request
   res.send(JSON.stringify(jsonBody))

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -39,6 +39,7 @@ import {
 import { getModifiedCookieValues } from '../web/spec-extension/adapters/request-cookies'
 
 import {
+  JSON_CONTENT_TYPE_HEADER,
   NEXT_CACHE_REVALIDATED_TAGS_HEADER,
   NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
 } from '../../lib/constants'
@@ -247,7 +248,7 @@ async function createForwardedActionResponse(
     console.error(`failed to forward action response`, err)
   }
 
-  return RenderResult.fromStatic('{}')
+  return RenderResult.fromStatic('{}', JSON_CONTENT_TYPE_HEADER)
 }
 
 /**
@@ -389,7 +390,7 @@ async function createRedirectRenderResult(
     }
   }
 
-  return RenderResult.fromStatic('')
+  return RenderResult.EMPTY
 }
 
 // Used to compare Host header and Origin header.
@@ -655,7 +656,7 @@ export async function handleAction({
     res.statusCode = 404
     return {
       type: 'done',
-      result: RenderResult.fromStatic('Server action not found.'),
+      result: RenderResult.fromStatic('Server action not found.', 'text/plain'),
     }
   }
 
@@ -1060,7 +1061,7 @@ export async function handleAction({
       res.setHeader('Location', redirectUrl)
       return {
         type: 'done',
-        result: RenderResult.fromStatic(''),
+        result: RenderResult.EMPTY,
       }
     } else if (isHTTPAccessFallbackError(err)) {
       res.statusCode = getAccessFallbackHTTPStatus(err)

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -173,7 +173,7 @@ import { CacheSignal } from './cache-signal'
 import { getTracedMetadata } from '../lib/trace/utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
-import { INFINITE_CACHE } from '../../lib/constants'
+import { HTML_CONTENT_TYPE_HEADER, INFINITE_CACHE } from '../../lib/constants'
 import { createComponentStylesAndScripts } from './create-component-styles-and-scripts'
 import { parseLoaderTree } from './parse-loader-tree'
 import {
@@ -1476,6 +1476,7 @@ async function renderToHTMLOrFlightImpl(
 
     const options: RenderResultOptions = {
       metadata,
+      contentType: HTML_CONTENT_TYPE_HEADER,
     }
     // If we have pending revalidates, wait until they are all resolved.
     if (
@@ -1624,7 +1625,10 @@ async function renderToHTMLOrFlightImpl(
             metadata
           )
 
-          return new RenderResult(stream, { metadata })
+          return new RenderResult(stream, {
+            metadata,
+            contentType: HTML_CONTENT_TYPE_HEADER,
+          })
         } else if (actionRequestResult.type === 'done') {
           if (actionRequestResult.result) {
             actionRequestResult.result.assignMetadata(metadata)
@@ -1638,6 +1642,7 @@ async function renderToHTMLOrFlightImpl(
 
     const options: RenderResultOptions = {
       metadata,
+      contentType: HTML_CONTENT_TYPE_HEADER,
     }
 
     const stream = await renderToStreamWithTracing(

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -105,6 +105,7 @@ import {
   NEXT_URL,
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_IS_PRERENDER_HEADER,
+  RSC_CONTENT_TYPE_HEADER,
 } from '../client/components/app-router-headers'
 import type {
   MatchOptions,
@@ -124,6 +125,8 @@ import { sendResponse } from './send-response'
 import { normalizeNextQueryParam } from './web/utils'
 import {
   CACHE_ONE_YEAR,
+  HTML_CONTENT_TYPE_HEADER,
+  JSON_CONTENT_TYPE_HEADER,
   MATCHED_PATH_HEADER,
   NEXT_CACHE_TAGS_HEADER,
   NEXT_RESUME_HEADER,
@@ -314,7 +317,6 @@ export class WrappedBuildError extends Error {
 }
 
 type ResponsePayload = {
-  type: 'html' | 'json' | 'rsc'
   body: RenderResult
   cacheControl?: CacheControl
 }
@@ -391,7 +393,6 @@ export default abstract class Server<
     res: ServerResponse,
     options: {
       result: RenderResult
-      type: 'html' | 'json' | 'rsc'
       generateEtags: boolean
       poweredByHeader: boolean
       cacheControl: CacheControl | undefined
@@ -1811,7 +1812,7 @@ export default abstract class Server<
     }
     const { req, res } = ctx
     const originalStatus = res.statusCode
-    const { body, type } = payload
+    const { body } = payload
     let { cacheControl } = payload
     if (!res.sent) {
       const { generateEtags, poweredByHeader, dev } = this.renderOpts
@@ -1828,7 +1829,6 @@ export default abstract class Server<
 
       await this.sendRenderResult(req, res, {
         result: body,
-        type,
         generateEtags,
         poweredByHeader,
         cacheControl,
@@ -2332,9 +2332,10 @@ export default abstract class Server<
     // handle static page
     if (typeof components.Component === 'string') {
       return {
-        type: 'html',
-        // TODO: Static pages should be serialized as RenderResult
-        body: RenderResult.fromStatic(components.Component),
+        body: RenderResult.fromStatic(
+          components.Component,
+          HTML_CONTENT_TYPE_HEADER
+        ),
       }
     }
 
@@ -3129,7 +3130,7 @@ export default abstract class Server<
           cacheControl: { revalidate: 1, expire: undefined },
           value: {
             kind: CachedRouteKind.PAGES,
-            html: RenderResult.fromStatic(''),
+            html: RenderResult.EMPTY,
             pageData: {},
             headers: undefined,
             status: undefined,
@@ -3365,8 +3366,10 @@ export default abstract class Server<
       if (matchedSegment !== undefined) {
         // Cache hit
         return {
-          type: 'rsc',
-          body: RenderResult.fromStatic(matchedSegment),
+          body: RenderResult.fromStatic(
+            matchedSegment,
+            RSC_CONTENT_TYPE_HEADER
+          ),
           // TODO: Eventually this should use cache control of the individual
           // segment, not the whole page.
           cacheControl: cacheEntry.cacheControl,
@@ -3381,8 +3384,7 @@ export default abstract class Server<
       // issued as part of a prefetch.
       res.statusCode = 204
       return {
-        type: 'rsc',
-        body: RenderResult.fromStatic(''),
+        body: RenderResult.EMPTY,
         cacheControl: cacheEntry?.cacheControl,
       }
     }
@@ -3456,10 +3458,9 @@ export default abstract class Server<
 
       if (isNextDataRequest) {
         return {
-          type: 'json',
           body: RenderResult.fromStatic(
-            // @TODO: Handle flight data.
-            JSON.stringify(cachedData.props)
+            JSON.stringify(cachedData.props),
+            JSON_CONTENT_TYPE_HEADER
           ),
           cacheControl: cacheEntry.cacheControl,
         }
@@ -3543,7 +3544,6 @@ export default abstract class Server<
           }
 
           return {
-            type: 'rsc',
             body: cachedData.html,
             // Dynamic RSC responses cannot be cached, even if they're
             // configured with `force-static` because we have no way of
@@ -3559,8 +3559,10 @@ export default abstract class Server<
         // As this isn't a prefetch request, we should serve the static flight
         // data.
         return {
-          type: 'rsc',
-          body: RenderResult.fromStatic(cachedData.rscData),
+          body: RenderResult.fromStatic(
+            cachedData.rscData,
+            RSC_CONTENT_TYPE_HEADER
+          ),
           cacheControl: cacheEntry.cacheControl,
         }
       }
@@ -3573,7 +3575,6 @@ export default abstract class Server<
       // as a server render (rather than a static render).
       if (!didPostpone || this.minimalMode) {
         return {
-          type: 'html',
           body,
           cacheControl: cacheEntry.cacheControl,
         }
@@ -3596,7 +3597,6 @@ export default abstract class Server<
         )
 
         return {
-          type: 'html',
           body,
           cacheControl: { revalidate: 0, expire: undefined },
         }
@@ -3641,7 +3641,6 @@ export default abstract class Server<
         })
 
       return {
-        type: 'html',
         body,
         // We don't want to cache the response if it has postponed data because
         // the response being sent to the client it's dynamic parts are streamed
@@ -3650,13 +3649,14 @@ export default abstract class Server<
       }
     } else if (isNextDataRequest) {
       return {
-        type: 'json',
-        body: RenderResult.fromStatic(JSON.stringify(cachedData.pageData)),
+        body: RenderResult.fromStatic(
+          JSON.stringify(cachedData.pageData),
+          JSON_CONTENT_TYPE_HEADER
+        ),
         cacheControl: cacheEntry.cacheControl,
       }
     } else {
       return {
-        type: 'html',
         body: cachedData.html,
         cacheControl: cacheEntry.cacheControl,
       }
@@ -3891,7 +3891,7 @@ export default abstract class Server<
         `${locale ? `/${locale}` : ''}${pathname}`
       )
       res.statusCode = 200
-      res.setHeader('content-type', 'application/json')
+      res.setHeader('Content-Type', JSON_CONTENT_TYPE_HEADER)
       res.body('{}')
       res.send()
       return null
@@ -3989,8 +3989,7 @@ export default abstract class Server<
     // Since favicon.ico is automatically requested by the browser.
     if (this.renderOpts.dev && ctx.pathname === '/favicon.ico') {
       return {
-        type: 'html',
-        body: RenderResult.fromStatic(''),
+        body: RenderResult.EMPTY,
       }
     }
     const { res, query } = ctx
@@ -4083,7 +4082,6 @@ export default abstract class Server<
         // which is handled in the parent process in development
         if (this.renderOpts.dev) {
           return {
-            type: 'html',
             // wait for dev-server to restart before refreshing
             body: RenderResult.fromStatic(
               `
@@ -4099,7 +4097,8 @@ export default abstract class Server<
                   }
                 }
                 check()
-              </script>`
+              </script>`,
+              HTML_CONTENT_TYPE_HEADER
             ),
           }
         }
@@ -4177,8 +4176,7 @@ export default abstract class Server<
         )
       }
       return {
-        type: 'html',
-        body: RenderResult.fromStatic('Internal Server Error'),
+        body: RenderResult.fromStatic('Internal Server Error', 'text/plain'),
       }
     }
   }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -84,6 +84,7 @@ import {
 import { getDefineEnv } from '../../../build/define-env'
 import { TurbopackInternalError } from '../../../shared/lib/turbopack/internal-error'
 import { normalizePath } from '../../../lib/normalize-path'
+import { JSON_CONTENT_TYPE_HEADER } from '../../../lib/constants'
 
 export type SetupOpts = {
   renderServer: LazyRenderServerInstance
@@ -973,7 +974,7 @@ async function startWatcher(
 
     if (parsedUrl.pathname?.includes(clientPagesManifestPath)) {
       res.statusCode = 200
-      res.setHeader('Content-Type', 'application/json; charset=utf-8')
+      res.setHeader('Content-Type', JSON_CONTENT_TYPE_HEADER)
       res.end(
         JSON.stringify({
           pages: prevSortedRoutes.filter(
@@ -989,7 +990,7 @@ async function startWatcher(
       parsedUrl.pathname?.includes(devTurbopackMiddlewareManifestPath)
     ) {
       res.statusCode = 200
-      res.setHeader('Content-Type', 'application/json; charset=utf-8')
+      res.setHeader('Content-Type', JSON_CONTENT_TYPE_HEADER)
       res.end(JSON.stringify(serverFields.middleware?.matchers || []))
       return { finished: true }
     }

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -610,7 +610,6 @@ export default class NextNodeServer extends BaseServer<
     res: NodeNextResponse,
     options: {
       result: RenderResult
-      type: 'html' | 'json' | 'rsc'
       generateEtags: boolean
       poweredByHeader: boolean
       cacheControl: CacheControl | undefined
@@ -620,7 +619,6 @@ export default class NextNodeServer extends BaseServer<
       req: req.originalRequest,
       res: res.originalResponse,
       result: options.result,
-      type: options.type,
       generateEtags: options.generateEtags,
       poweredByHeader: options.poweredByHeader,
       cacheControl: options.cacheControl,

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -51,6 +51,8 @@ import {
   SERVER_PROPS_SSG_CONFLICT,
   SSG_GET_INITIAL_PROPS_CONFLICT,
   UNSTABLE_REVALIDATE_RENAME_ERROR,
+  HTML_CONTENT_TYPE_HEADER,
+  JSON_CONTENT_TYPE_HEADER,
 } from '../lib/constants'
 import {
   NEXT_BUILTIN_DOCUMENT,
@@ -1063,7 +1065,10 @@ export async function renderToHTMLImpl(
 
     // this must come after revalidate is added to renderResultMeta
     if (metadata.isNotFound) {
-      return new RenderResult(null, { metadata })
+      return new RenderResult(null, {
+        metadata,
+        contentType: null,
+      })
     }
   }
 
@@ -1179,7 +1184,10 @@ export async function renderToHTMLImpl(
       }
 
       metadata.isNotFound = true
-      return new RenderResult(null, { metadata })
+      return new RenderResult(null, {
+        metadata,
+        contentType: null,
+      })
     }
 
     if ('redirect' in data && typeof data.redirect === 'object') {
@@ -1229,6 +1237,7 @@ export async function renderToHTMLImpl(
   if ((isNextDataRequest && !isSSG) || metadata.isRedirect) {
     return new RenderResult(JSON.stringify(props), {
       metadata,
+      contentType: JSON_CONTENT_TYPE_HEADER,
     })
   }
 
@@ -1239,7 +1248,7 @@ export async function renderToHTMLImpl(
   }
 
   // the response might be finished on the getInitialProps call
-  if (isResSent(res) && !isSSG) return new RenderResult(null, { metadata })
+  if (isResSent(res) && !isSSG) return RenderResult.EMPTY
 
   // we preload the buildManifest for auto-export dynamic pages
   // to speed up hydrating query values
@@ -1453,7 +1462,10 @@ export async function renderToHTMLImpl(
     async () => renderDocument()
   )
   if (!documentResult) {
-    return new RenderResult(null, { metadata })
+    return new RenderResult(null, {
+      metadata,
+      contentType: HTML_CONTENT_TYPE_HEADER,
+    })
   }
 
   const dynamicImportsIds = new Set<string | number>()
@@ -1608,7 +1620,10 @@ export async function renderToHTMLImpl(
     hybridAmp,
   })
 
-  return new RenderResult(optimizedHtml, { metadata })
+  return new RenderResult(optimizedHtml, {
+    metadata,
+    contentType: HTML_CONTENT_TYPE_HEADER,
+  })
 }
 
 export type PagesRender = (

--- a/packages/next/src/server/response-cache/utils.ts
+++ b/packages/next/src/server/response-cache/utils.ts
@@ -9,6 +9,7 @@ import {
 
 import RenderResult from '../render-result'
 import { RouteKind } from '../route-kind'
+import { HTML_CONTENT_TYPE_HEADER } from '../../lib/constants'
 
 export async function fromResponseCacheEntry(
   cacheEntry: ResponseCacheEntry
@@ -51,7 +52,10 @@ export async function toResponseCacheEntry(
       response.value?.kind === CachedRouteKind.PAGES
         ? ({
             kind: CachedRouteKind.PAGES,
-            html: RenderResult.fromStatic(response.value.html),
+            html: RenderResult.fromStatic(
+              response.value.html,
+              HTML_CONTENT_TYPE_HEADER
+            ),
             pageData: response.value.pageData,
             headers: response.value.headers,
             status: response.value.status,
@@ -59,7 +63,10 @@ export async function toResponseCacheEntry(
         : response.value?.kind === CachedRouteKind.APP_PAGE
           ? ({
               kind: CachedRouteKind.APP_PAGE,
-              html: RenderResult.fromStatic(response.value.html),
+              html: RenderResult.fromStatic(
+                response.value.html,
+                HTML_CONTENT_TYPE_HEADER
+              ),
               rscData: response.value.rscData,
               headers: response.value.headers,
               status: response.value.status,

--- a/packages/next/src/server/send-payload.ts
+++ b/packages/next/src/server/send-payload.ts
@@ -6,7 +6,7 @@ import { isResSent } from '../shared/lib/utils'
 import { generateETag } from './lib/etag'
 import fresh from 'next/dist/compiled/fresh'
 import { getCacheControlHeader } from './lib/cache-control'
-import { RSC_CONTENT_TYPE_HEADER } from '../client/components/app-router-headers'
+import { HTML_CONTENT_TYPE_HEADER } from '../lib/constants'
 
 export function sendEtagResponse(
   req: IncomingMessage,
@@ -36,7 +36,6 @@ export async function sendRenderResult({
   req,
   res,
   result,
-  type,
   generateEtags,
   poweredByHeader,
   cacheControl,
@@ -44,7 +43,6 @@ export async function sendRenderResult({
   req: IncomingMessage
   res: ServerResponse
   result: RenderResult
-  type: 'html' | 'json' | 'rsc'
   generateEtags: boolean
   poweredByHeader: boolean
   cacheControl: CacheControl | undefined
@@ -53,7 +51,7 @@ export async function sendRenderResult({
     return
   }
 
-  if (poweredByHeader && type === 'html') {
+  if (poweredByHeader && result.contentType === HTML_CONTENT_TYPE_HEADER) {
     res.setHeader('X-Powered-By', 'Next.js')
   }
 
@@ -72,17 +70,8 @@ export async function sendRenderResult({
     }
   }
 
-  if (!res.getHeader('Content-Type')) {
-    res.setHeader(
-      'Content-Type',
-      result.contentType
-        ? result.contentType
-        : type === 'rsc'
-          ? RSC_CONTENT_TYPE_HEADER
-          : type === 'json'
-            ? 'application/json'
-            : 'text/html; charset=utf-8'
-    )
+  if (!res.getHeader('Content-Type') && result.contentType) {
+    res.setHeader('Content-Type', result.contentType)
   }
 
   if (payload) {

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -10,6 +10,7 @@ import {
 } from './uint8array-helpers'
 import { MISSING_ROOT_TAGS_ERROR } from '../../shared/lib/errors/constants'
 import { insertBuildIdComment } from '../../shared/lib/segment-cache/output-export-prefetch-encoding'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 function voidCatch() {
   // this catcher is designed to be used with pipeTo where we expect the underlying
@@ -32,7 +33,7 @@ export function chainStreams<T>(
   // We could encode this invariant in the arguments but current uses of this function pass
   // use spread so it would be missed by
   if (streams.length === 0) {
-    throw new Error('Invariant: chainStreams requires at least one stream')
+    throw new InvariantError('chainStreams requires at least one stream')
   }
 
   // If we only have 1 stream we fast path it by returning just this stream

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -155,12 +155,16 @@ describe('unrecognized server actions', () => {
             // We also don't seem to display the error page correctly,
             // and the response is inconsistent between nodejs and edge.
             expect(response.status()).toBe(runtime === 'nodejs' ? 405 : 500)
-            expect(response.headers()['content-type']).toStartWith('text/html')
+            expect(response.headers()['content-type']).toStartWith(
+              runtime === 'nodejs' ? 'text/html' : 'text/plain'
+            )
           } else {
             // FIXME: Currently, an unrecognized id in an MPA action results in a 500.
             // This is not ideal, and ignores all nested `error.js` files, only showing the topmost one.
             expect(response.status()).toBe(500)
-            expect(response.headers()['content-type']).toStartWith('text/html')
+            expect(response.headers()['content-type']).toStartWith(
+              runtime === 'nodejs' ? 'text/html' : 'text/plain'
+            )
             // In dev, the 500 page doesn't have any SSR'd html, so it won't show anything without JS.
             if (!isNextDev) {
               expect(await browser.elementByCss('body').text()).toContain(

--- a/test/e2e/i18n-data-route/i18n-data-route.test.ts
+++ b/test/e2e/i18n-data-route/i18n-data-route.test.ts
@@ -54,7 +54,9 @@ describe('i18n-data-route', () => {
 
           const res = await next.fetch(url)
           expect(res.status).toBe(200)
-          expect(res.headers.get('content-type')).toBe('application/json')
+          expect(res.headers.get('content-type')).toStartWith(
+            'application/json'
+          )
           const data = await res.json()
           checkDataRoute(data, page)
         }
@@ -80,7 +82,7 @@ describe('i18n-data-route', () => {
         }
         const res = await next.fetch(url)
         expect(res.status).toBe(200)
-        expect(res.headers.get('content-type')).toBe('application/json')
+        expect(res.headers.get('content-type')).toStartWith('application/json')
         const data = await res.json()
         checkDataRoute(data, page)
       }


### PR DESCRIPTION
### Problem
The PPR boundary sentinel was being incorrectly added to responses due to flawed content type logic in `sendRenderResult`. The original conditional logic had complex fallbacks that caused the sentinel to be added when it shouldn't be:

```javascript
// BEFORE: Incorrect logic - sentinel added to wrong response types
if (
  process.env.__NEXT_TEST_MODE &&
  minimalMode &&
  isRoutePPREnabled &&
  // ❌ This logic was inverted and unreliable
  body.contentType !== RSC_CONTENT_TYPE_HEADER &&
  !isRSCRequest
) {
  body.unshift(createPPRBoundarySentinel())
}
```

The problem was that `body.contentType` was inconsistently determined through external logic in `sendRenderResult`, causing the sentinel to appear in responses that shouldn't have it.

### Solution
By moving content type into `RenderResult` constructor, the sentinel logic now correctly identifies HTML responses:

```javascript
// AFTER: Correct logic - sentinel only added to HTML responses
if (
  process.env.__NEXT_TEST_MODE &&
  minimalMode &&
  isRoutePPREnabled &&
  body.contentType === HTML_CONTENT_TYPE_HEADER // ✅ Reliable content type check
) {
  body.unshift(createPPRBoundarySentinel())
}
```

### Key Changes
- **Fixed sentinel logic**: PPR boundary sentinel now only appears in HTML responses where it belongs
- **Reliable content type**: Content type is determined at RenderResult creation, not through fallback logic
- **Consistent API**: Removed redundant `type` parameter that was causing the confusion

This ensures PPR test assertions work correctly by only adding the boundary sentinel to the appropriate response types.