### PR TITLE
Fix: For static exports, if not in generateStaticParams, do 404 instead of uncaught error

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2137,9 +2137,7 @@ export default abstract class Server<
 
         const resolvedWithoutSlash = removeTrailingSlash(resolvedUrlPathname)
         if (!staticPaths.includes(resolvedWithoutSlash)) {
-          throw new Error(
-            `Page "${page}" is missing param "${resolvedWithoutSlash}" in "generateStaticParams()", which is required with "output: export" config.`
-          )
+          await this.render404(req, res);
         }
       }
 


### PR DESCRIPTION
## Issue

Fix #56253 an old issue annoying many

## References to the current documentation:
* https://nextjs.org/docs/app/api-reference/functions/generate-static-params#disable-rendering-for-unspecified-paths
> To prevent unspecified paths from being statically rendered at runtime, add the `export const dynamicParams = false` option in a route segment. When this config option is used, only paths provided by `generateStaticParams` will be served, and unspecified routes will 404 or match (in the case of [catch-all routes](https://nextjs.org/docs/app/api-reference/file-conventions/dynamic-routes#catch-all-segments)).
* https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamicparams
> [...]
> `false`: Dynamic segments not included in `generateStaticParams` will return a 404.

## Description of the problem

Using the App Router, for a path with
* a slug
* and a `generateStaticParams`
* with a static config (either `export const dynamicParams = false` in the file or `output: "export"` in the config),

the **documentation** states that, when navigating to such a path with a slug that is not in the output of `generateStaticParams`, it will throw a 404.

**In practice** it does not 404, instead it throws an uncaught error 500 which has annoyed everyone since Next 14, with a noisy log in dev and a blank page in prod.

(I did not check whether the issue still exists in the last canary, I assume it's not, given the age of this issue and the frequency of the complaints)

## Fix

**This tiny PR just replaces this specific error with a 404 *as intended* per the docs, that's all.**

*Note: if rendering the default 404 page throws an error saying there's no `<html>` and `<body>`, you can just add a `template.tsx` in the parent folder :*
```tsx
// Example: if /[locale] or a subpath of it has a "locale" slug not in your `generateStaticParams`, add the template in the parent of the [locale] folder, here it's app: src/app/template.tsx

import { PropsWithChildren } from "react";

export default function Template({ children }: PropsWithChildren) {
  return (
    <html>
      <body>{children}</body>
    </html>
  );
}

```

## Example situation

An internationalized website using `next-intl`, but with a static export. So the `src/app/[locale]/layout.tsx` contains:
```tsx
export function generateStaticParams() {
  return routing.locales.map((locale) => ({ locale }));
}
```

If a user navigates to `/zz` or `/zz/login`, `zz` not being in the output of `generateStaticParams`, obviously in production you want to display a 404 not have your app going blank.

## Disclaimer

Being my 1st contribution here, I can't be sure I have tested it well.

Actually I modified by hand this file in `node_modules/next` in a project (and added the `template.tsx` above) and it worked (both in dev with `rm -r .next/ && yarn dev` and prod with `yarn build -d && npx serve@latest out`).

So I'd like this fix to be tested by someone else in dev and production afeter building a static export.