### PR TITLE
Fix cookie serialization bug in cookies() function

### DIFF
--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.test.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.test.ts
@@ -104,6 +104,23 @@ describe('MutableRequestCookiesAdapter', () => {
       expect.stringContaining('bar=;'),
     ])
   })
+
+  it('should set SameSite=Strict when sameSite is true', () => {
+    const headers = new Headers({})
+    const underlyingCookies = new RequestCookies(headers)
+
+    const onUpdateCookies = jest.fn<void, [string[]]>()
+    const wrappedCookies = MutableRequestCookiesAdapter.wrap(
+      underlyingCookies,
+      onUpdateCookies
+    )
+
+    wrappedCookies.set('foo', 'bar', { sameSite: true })
+
+    expect(onUpdateCookies).toHaveBeenCalledWith([
+      expect.stringContaining('SameSite=Strict'),
+    ])
+  })
 })
 
 describe('wrapWithMutableAccessCheck', () => {

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
@@ -100,6 +100,9 @@ type ResponseCookie = NonNullable<
   ReturnType<InstanceType<typeof ResponseCookies>['get']>
 >
 
+const { serialize } =
+  require('next/dist/compiled/cookie') as typeof import('next/dist/compiled/cookie')
+
 export class MutableRequestCookiesAdapter {
   public static wrap(
     cookies: RequestCookies,
@@ -122,13 +125,13 @@ export class MutableRequestCookiesAdapter {
       const allCookies = responseCookies.getAll()
       modifiedValues = allCookies.filter((c) => modifiedCookies.has(c.name))
       if (onUpdateCookies) {
-        const serializedCookies: string[] = []
-        for (const cookie of modifiedValues) {
-          const tempCookies = new ResponseCookies(new Headers())
-          tempCookies.set(cookie)
-          serializedCookies.push(tempCookies.toString())
-        }
-
+        const serializedCookies = modifiedValues.map(
+          ({ name, value, expires, ...rest }) =>
+            serialize(name, value, {
+              ...rest,
+              expires: expires instanceof Date ? expires : undefined,
+            })
+        )
         onUpdateCookies(serializedCookies)
       }
     }


### PR DESCRIPTION
## Summary

This PR fixes a bug in `cookies()` function where the `sameSite` attribute was not correctly applied.  
Although both the official documentation and internal logic allow a boolean value for `sameSite`, the underlying cookie serialization did not properly handle it, resulting in incorrect behavior.

## Changes

- Replaced the cookie serialization logic with `serialize` from `next/dist/compiled/cookie`.
- Added corresponding test code to validate the correct behavior.

## Attachments

<img width="800" alt="1" src="https://github.com/user-attachments/assets/43cf7004-9d35-4884-a543-6ea3f6076aef" />

<img width="800" alt="2" src="https://github.com/user-attachments/assets/13112c08-a2ce-4755-aba5-c73e95d17220" />

<img width="800" alt="3" src="https://github.com/user-attachments/assets/c8bfa635-f9fd-43ab-8bbe-3bf4909e1a15" />

<img width="800" alt="4" src="https://github.com/user-attachments/assets/f5b0a69d-0e4f-45e9-af95-584077169ba1" />
