### PR TITLE
Remove `experimental.strictNextHead`

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -254,8 +254,6 @@ export function getDefineEnv({
       config.experimental.scrollRestoration ?? false,
     ...getImageConfig(config, dev),
     'process.env.__NEXT_ROUTER_BASEPATH': config.basePath,
-    'process.env.__NEXT_STRICT_NEXT_HEAD':
-      config.experimental.strictNextHead ?? true,
     'process.env.__NEXT_HAS_REWRITES': hasRewrites,
     'process.env.__NEXT_CONFIG_OUTPUT': config.output,
     'process.env.__NEXT_I18N_SUPPORT': !!config.i18n,

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -143,7 +143,6 @@ async function requestHandler(
       ComponentMod: pageMod,
       pageConfig: pageMod.pageConfig,
       routeModule: pageMod.routeModule,
-      strictNextHead: nextConfig.experimental.strictNextHead ?? true,
       canonicalBase: nextConfig.amp.canonicalBase || '',
       previewProps: prerenderManifest.preview,
       ampOptimizerConfig: nextConfig.experimental.amp?.optimizer,

--- a/packages/next/src/build/templates/pages.ts
+++ b/packages/next/src/build/templates/pages.ts
@@ -289,8 +289,6 @@ export async function handler(
                   reactLoadableManifest,
 
                   assetPrefix: nextConfig.assetPrefix,
-                  strictNextHead:
-                    nextConfig.experimental.strictNextHead ?? true,
                   previewProps: prerenderManifest.preview,
                   images: nextConfig.images as any,
                   nextConfigOutput: nextConfig.output,

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -393,7 +393,6 @@ async function exportAppImpl(
           serverActionsManifest,
         }
       : {}),
-    strictNextHead: nextConfig.experimental.strictNextHead ?? true,
     deploymentId: nextConfig.deploymentId,
     htmlLimitedBots: nextConfig.htmlLimitedBots.source,
     experimental: {

--- a/packages/next/src/pages/_document.tsx
+++ b/packages/next/src/pages/_document.tsx
@@ -657,22 +657,12 @@ export class Head extends React.Component<HeadProps> {
           child.props['rel'] === 'preload' &&
           child.props['as'] === 'style'
         ) {
-          if (this.context.strictNextHead) {
-            cssPreloads.push(
-              React.cloneElement(child, { 'data-next-head': '' })
-            )
-          } else {
-            cssPreloads.push(child)
-          }
+          cssPreloads.push(child)
         } else {
           if (child) {
-            if (this.context.strictNextHead) {
-              otherHeadElements.push(
-                React.cloneElement(child, { 'data-next-head': '' })
-              )
-            } else {
-              otherHeadElements.push(child)
-            }
+            otherHeadElements.push(
+              React.cloneElement(child, { 'data-next-head': '' })
+            )
           }
         }
       })
@@ -811,12 +801,6 @@ export class Head extends React.Component<HeadProps> {
           </>
         )}
         {head}
-        {this.context.strictNextHead ? null : (
-          <meta
-            name="next-head-count"
-            content={React.Children.count(head || []).toString()}
-          />
-        )}
 
         {children}
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -564,7 +564,6 @@ export default abstract class Server<
       supportsDynamicResponse: true,
       trailingSlash: this.nextConfig.trailingSlash,
       deploymentId: this.nextConfig.deploymentId,
-      strictNextHead: this.nextConfig.experimental.strictNextHead ?? true,
       poweredByHeader: this.nextConfig.poweredByHeader,
       canonicalBase: this.nextConfig.amp.canonicalBase || '',
       generateEtags,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -414,7 +414,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             algorithm: z.enum(['sha256', 'sha384', 'sha512']).optional(),
           })
           .optional(),
-        strictNextHead: z.boolean().optional(),
         swcPlugins: z
           // The specific swc plugin's option is unknown, use z.any() here
           .array(z.tuple([z.string(), z.record(z.string(), z.any())]))

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -335,8 +335,6 @@ export interface ExperimentalConfig {
   dynamicOnHover?: boolean
   appDocumentPreloading?: boolean
   preloadEntriesOnStart?: boolean
-  /** @default true */
-  strictNextHead?: boolean
   clientRouterFilter?: boolean
   clientRouterFilterRedirects?: boolean
   /**
@@ -1472,7 +1470,6 @@ export const defaultConfig = Object.freeze({
     devtoolSegmentExplorer: true,
     browserDebugInfoInTerminal: false,
     optimizeRouterScrolling: false,
-    strictNextHead: true,
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -285,7 +285,6 @@ export type RenderOptsPartial = {
   images: ImageConfigComplete
   largePageDataBytes?: number
   isOnDemandRevalidate?: boolean
-  strictNextHead: boolean
   isPossibleServerAction?: boolean
   isExperimentalCompile?: boolean
   isPrefetch?: boolean
@@ -1512,7 +1511,6 @@ export async function renderToHTMLImpl(
       notFoundSrcPage: notFoundSrcPage && dev ? notFoundSrcPage : undefined,
     },
     nonce,
-    strictNextHead: renderOpts.strictNextHead,
     buildManifest: filteredBuildManifest,
     docComponentsRendered,
     dangerousAsPath: router.asPath,

--- a/packages/next/src/shared/lib/html-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/html-context.shared-runtime.ts
@@ -9,7 +9,6 @@ import { createContext, useContext, type JSX } from 'react'
 export type HtmlProps = {
   __NEXT_DATA__: NEXT_DATA
   nonce?: string
-  strictNextHead: boolean
   dangerousAsPath: string
   docComponentsRendered: {
     Html?: boolean

--- a/test/development/pages-dir/client-navigation/fixture/next.config.js
+++ b/test/development/pages-dir/client-navigation/fixture/next.config.js
@@ -4,12 +4,6 @@ module.exports = {
     // Make sure entries are not getting disposed.
     maxInactiveAge: 1000 * 60 * 60,
   },
-  experimental:
-    process.env.TEST_STRICT_NEXT_HEAD !== undefined
-      ? {
-          strictNextHead: process.env.TEST_STRICT_NEXT_HEAD === 'true',
-        }
-      : {},
   // scroll position can be finicky with the
   // indicators showing so hide by default
   devIndicators: false,

--- a/test/development/pages-dir/client-navigation/head.test.ts
+++ b/test/development/pages-dir/client-navigation/head.test.ts
@@ -4,202 +4,174 @@ import { waitFor } from 'next-test-utils'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
-const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+describe('updating <Head /> while client routing', () => {
+  const { next } = nextTestSetup({
+    files: path.join(__dirname, 'fixture'),
+  })
 
-describe.each([[false], [true]])(
-  'updating <Head /> with strictNextHead=%s while client routing',
-  (strictNextHead) => {
-    const { next } = nextTestSetup({
-      files: path.join(__dirname, 'fixture'),
-      env: {
-        TEST_STRICT_NEXT_HEAD: String(strictNextHead),
-      },
-    })
+  it.each([true, false])(
+    'should handle boolean async prop in next/head client-side: %s',
+    async (bool) => {
+      const browser = await next.browser('/head')
+      const value = await browser.eval(
+        `document.querySelector('script[src="/test-async-${JSON.stringify(
+          bool
+        )}.js"]').async`
+      )
 
-    it.each([true, false])(
-      'should handle boolean async prop in next/head client-side: %s',
-      async (bool) => {
-        const browser = await next.browser('/head')
-        const value = await browser.eval(
-          `document.querySelector('script[src="/test-async-${JSON.stringify(
-            bool
-          )}.js"]').async`
-        )
+      expect(value).toBe(bool)
+    }
+  )
 
-        expect(value).toBe(bool)
+  it('should only execute async and defer scripts once', async () => {
+    const browser = await next.browser('/head')
+
+    await browser.waitForElementByCss('h1')
+    await waitFor(2000)
+    expect(Number(await browser.eval('window.__test_async_executions'))).toBe(1)
+    expect(Number(await browser.eval('window.__test_defer_executions'))).toBe(1)
+
+    await browser.elementByCss('#reverseScriptOrder').click()
+    await waitFor(2000)
+
+    expect(Number(await browser.eval('window.__test_async_executions'))).toBe(1)
+    expect(Number(await browser.eval('window.__test_defer_executions'))).toBe(1)
+
+    await browser.elementByCss('#toggleScript').click()
+    await waitFor(2000)
+
+    expect(Number(await browser.eval('window.__test_async_executions'))).toBe(1)
+    expect(Number(await browser.eval('window.__test_defer_executions'))).toBe(1)
+  })
+
+  it('should warn when stylesheets or scripts are in head', async () => {
+    const browser = await next.browser('/head')
+
+    await browser.waitForElementByCss('h1')
+    await waitFor(1000)
+    const browserLogs = await browser.log()
+    let foundStyles = false
+    let foundScripts = false
+    const logs = []
+    browserLogs.forEach(({ message }) => {
+      if (message.includes('Do not add stylesheets using next/head')) {
+        foundStyles = true
+        logs.push(message)
       }
-    )
-
-    it('should only execute async and defer scripts once', async () => {
-      const browser = await next.browser('/head')
-
-      await browser.waitForElementByCss('h1')
-      await waitFor(2000)
-      expect(Number(await browser.eval('window.__test_async_executions'))).toBe(
-        strictNextHead || isReact18
-          ? 1
-          : // <meta name="next-head-count" /> is floated before <script />.
-            // head-manager thinks it needs to add these again resulting in another execution.
-            2
-      )
-      expect(Number(await browser.eval('window.__test_defer_executions'))).toBe(
-        strictNextHead || isReact18
-          ? 1
-          : // <meta name="next-head-count" /> is floated before <script defer />.
-            // head-manager thinks it needs to add these again resulting in another execution.
-            2
-      )
-
-      await browser.elementByCss('#reverseScriptOrder').click()
-      await waitFor(2000)
-
-      expect(Number(await browser.eval('window.__test_async_executions'))).toBe(
-        strictNextHead || isReact18 ? 1 : 2
-      )
-      expect(Number(await browser.eval('window.__test_defer_executions'))).toBe(
-        strictNextHead || isReact18 ? 1 : 2
-      )
-
-      await browser.elementByCss('#toggleScript').click()
-      await waitFor(2000)
-
-      expect(Number(await browser.eval('window.__test_async_executions'))).toBe(
-        strictNextHead || isReact18 ? 1 : 2
-      )
-      expect(Number(await browser.eval('window.__test_defer_executions'))).toBe(
-        strictNextHead || isReact18 ? 1 : 2
-      )
+      if (message.includes('Do not add <script> tags using next/head')) {
+        foundScripts = true
+        logs.push(message)
+      }
     })
 
-    it('should warn when stylesheets or scripts are in head', async () => {
-      const browser = await next.browser('/head')
+    expect(foundStyles).toEqual(true)
+    expect(foundScripts).toEqual(true)
 
-      await browser.waitForElementByCss('h1')
-      await waitFor(1000)
-      const browserLogs = await browser.log()
-      let foundStyles = false
-      let foundScripts = false
-      const logs = []
-      browserLogs.forEach(({ message }) => {
-        if (message.includes('Do not add stylesheets using next/head')) {
-          foundStyles = true
-          logs.push(message)
-        }
-        if (message.includes('Do not add <script> tags using next/head')) {
-          foundScripts = true
-          logs.push(message)
-        }
-      })
+    // Warnings are unique
+    expect(logs.length).toEqual(new Set(logs).size)
+  })
 
-      expect(foundStyles).toEqual(true)
-      expect(foundScripts).toEqual(true)
-
-      // Warnings are unique
-      expect(logs.length).toEqual(new Set(logs).size)
+  it('should warn when scripts are in head', async () => {
+    const browser = await next.browser('/head')
+    await browser.waitForElementByCss('h1')
+    await waitFor(1000)
+    const browserLogs = await browser.log()
+    let found = false
+    browserLogs.forEach((log) => {
+      if (log.message.includes('Use next/script instead')) {
+        found = true
+      }
     })
+    expect(found).toEqual(true)
+  })
 
-    it('should warn when scripts are in head', async () => {
-      const browser = await next.browser('/head')
-      await browser.waitForElementByCss('h1')
-      await waitFor(1000)
-      const browserLogs = await browser.log()
-      let found = false
-      browserLogs.forEach((log) => {
-        if (log.message.includes('Use next/script instead')) {
-          found = true
-        }
-      })
-      expect(found).toEqual(true)
+  it('should not warn when application/ld+json scripts are in head', async () => {
+    const browser = await next.browser('/head-with-json-ld-snippet')
+    await browser.waitForElementByCss('h1')
+    await waitFor(1000)
+    const browserLogs = await browser.log()
+    let found = false
+    browserLogs.forEach((log) => {
+      if (log.message.includes('Use next/script instead')) {
+        found = true
+      }
     })
+    expect(found).toEqual(false)
+  })
 
-    it('should not warn when application/ld+json scripts are in head', async () => {
-      const browser = await next.browser('/head-with-json-ld-snippet')
-      await browser.waitForElementByCss('h1')
-      await waitFor(1000)
-      const browserLogs = await browser.log()
-      let found = false
-      browserLogs.forEach((log) => {
-        if (log.message.includes('Use next/script instead')) {
-          found = true
-        }
-      })
-      expect(found).toEqual(false)
-    })
-
-    it('should update head during client routing', async () => {
-      const browser = await next.browser('/nav/head-1')
-      expect(
-        await browser
-          .elementByCss('meta[name="description"]')
-          .getAttribute('content')
-      ).toBe('Head One')
-
+  it('should update head during client routing', async () => {
+    const browser = await next.browser('/nav/head-1')
+    expect(
       await browser
-        .elementByCss('#to-head-2')
-        .click()
-        .waitForElementByCss('#head-2', 3000)
-      expect(
-        await browser
-          .elementByCss('meta[name="description"]')
-          .getAttribute('content')
-      ).toBe('Head Two')
+        .elementByCss('meta[name="description"]')
+        .getAttribute('content')
+    ).toBe('Head One')
 
+    await browser
+      .elementByCss('#to-head-2')
+      .click()
+      .waitForElementByCss('#head-2', 3000)
+    expect(
       await browser
-        .elementByCss('#to-head-1')
-        .click()
-        .waitForElementByCss('#head-1', 3000)
-      expect(
-        await browser
-          .elementByCss('meta[name="description"]')
-          .getAttribute('content')
-      ).toBe('Head One')
+        .elementByCss('meta[name="description"]')
+        .getAttribute('content')
+    ).toBe('Head Two')
 
+    await browser
+      .elementByCss('#to-head-1')
+      .click()
+      .waitForElementByCss('#head-1', 3000)
+    expect(
       await browser
-        .elementByCss('#to-head-3')
-        .click()
-        .waitForElementByCss('#head-3', 3000)
-      expect(
-        await browser
-          .elementByCss('meta[name="description"]')
-          .getAttribute('content')
-      ).toBe('Head Three')
-      expect(await browser.eval('document.title')).toBe('')
+        .elementByCss('meta[name="description"]')
+        .getAttribute('content')
+    ).toBe('Head One')
 
+    await browser
+      .elementByCss('#to-head-3')
+      .click()
+      .waitForElementByCss('#head-3', 3000)
+    expect(
       await browser
-        .elementByCss('#to-head-1')
-        .click()
-        .waitForElementByCss('#head-1', 3000)
-      expect(
-        await browser
-          .elementByCss('meta[name="description"]')
-          .getAttribute('content')
-      ).toBe('Head One')
-    })
+        .elementByCss('meta[name="description"]')
+        .getAttribute('content')
+    ).toBe('Head Three')
+    expect(await browser.eval('document.title')).toBe('')
 
-    it('should update title during client routing', async () => {
-      const browser = await next.browser('/nav/head-1')
-      expect(await browser.eval('document.title')).toBe('this is head-1')
-
+    await browser
+      .elementByCss('#to-head-1')
+      .click()
+      .waitForElementByCss('#head-1', 3000)
+    expect(
       await browser
-        .elementByCss('#to-head-2')
-        .click()
-        .waitForElementByCss('#head-2', 3000)
-      expect(await browser.eval('document.title')).toBe('this is head-2')
+        .elementByCss('meta[name="description"]')
+        .getAttribute('content')
+    ).toBe('Head One')
+  })
 
-      await browser
-        .elementByCss('#to-head-1')
-        .click()
-        .waitForElementByCss('#head-1', 3000)
-      expect(await browser.eval('document.title')).toBe('this is head-1')
-    })
+  it('should update title during client routing', async () => {
+    const browser = await next.browser('/nav/head-1')
+    expect(await browser.eval('document.title')).toBe('this is head-1')
 
-    it('should update head when unmounting component', async () => {
-      const browser = await next.browser('/head-dynamic')
-      expect(await browser.eval('document.title')).toBe('B')
-      await browser.elementByCss('button').click()
-      expect(await browser.eval('document.title')).toBe('A')
-      await browser.elementByCss('button').click()
-      expect(await browser.eval('document.title')).toBe('B')
-    })
-  }
-)
+    await browser
+      .elementByCss('#to-head-2')
+      .click()
+      .waitForElementByCss('#head-2', 3000)
+    expect(await browser.eval('document.title')).toBe('this is head-2')
+
+    await browser
+      .elementByCss('#to-head-1')
+      .click()
+      .waitForElementByCss('#head-1', 3000)
+    expect(await browser.eval('document.title')).toBe('this is head-1')
+  })
+
+  it('should update head when unmounting component', async () => {
+    const browser = await next.browser('/head-dynamic')
+    expect(await browser.eval('document.title')).toBe('B')
+    await browser.elementByCss('button').click()
+    expect(await browser.eval('document.title')).toBe('A')
+    await browser.elementByCss('button').click()
+    expect(await browser.eval('document.title')).toBe('B')
+  })
+})

--- a/test/development/pages-dir/client-navigation/rendering-head.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering-head.test.ts
@@ -8,336 +8,225 @@ import path from 'path'
 const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
 describe('Client Navigation rendering <Head />', () => {
-  describe.each([[false], [true], [undefined]])(
-    'with strictNextHead=%s',
-    (strictNextHead) => {
-      const { next } = nextTestSetup({
-        files: path.join(__dirname, 'fixture'),
-        env:
-          strictNextHead !== undefined
-            ? {
-                TEST_STRICT_NEXT_HEAD: String(strictNextHead),
-              }
-            : {},
-      })
+  const { next } = nextTestSetup({
+    files: path.join(__dirname, 'fixture'),
+  })
 
-      function render(
-        pathname: Parameters<typeof renderViaHTTP>[1],
-        query?: Parameters<typeof renderViaHTTP>[2]
-      ) {
-        return renderViaHTTP(next.appPort, pathname, query)
-      }
+  function render(
+    pathname: Parameters<typeof renderViaHTTP>[1],
+    query?: Parameters<typeof renderViaHTTP>[2]
+  ) {
+    return renderViaHTTP(next.appPort, pathname, query)
+  }
 
-      it('should handle undefined prop in head server-side', async () => {
-        const html = await render('/head')
-        const $ = cheerio.load(html)
-        const value = 'content' in $('meta[name="empty-content"]').attr()
+  it('should handle undefined prop in head server-side', async () => {
+    const html = await render('/head')
+    const $ = cheerio.load(html)
+    const value = 'content' in $('meta[name="empty-content"]').attr()
 
-        expect(value).toBe(false)
-      })
+    expect(value).toBe(false)
+  })
 
-      // default-head contains an empty <Head />.
-      test('header renders default charset', async () => {
-        const html = await render('/default-head')
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta charSet="utf-8" data-next-head=""/>'
-            : '<meta charSet="utf-8"/>'
-        )
-        expect(html).toContain('next-head, but only once.')
-      })
+  // default-head contains an empty <Head />.
+  test('header renders default charset', async () => {
+    const html = await render('/default-head')
+    expect(html).toContain('<meta charSet="utf-8" data-next-head=""/>')
+    expect(html).toContain('next-head, but only once.')
+  })
 
-      test('header renders default viewport', async () => {
-        const html = await render('/default-head')
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta name="viewport" content="width=device-width" data-next-head=""/>'
-            : '<meta name="viewport" content="width=device-width"/>'
-        )
-      })
+  test('header renders default viewport', async () => {
+    const html = await render('/default-head')
+    expect(html).toContain(
+      '<meta name="viewport" content="width=device-width" data-next-head=""/>'
+    )
+  })
 
-      test('header helper renders header information', async () => {
-        const html = await render('/head')
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta charSet="iso-8859-5" data-next-head=""/>'
-            : '<meta charSet="iso-8859-5"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta content="my meta" data-next-head=""/>'
-            : '<meta content="my meta"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta name="viewport" content="width=device-width,initial-scale=1" data-next-head=""/>'
-            : '<meta name="viewport" content="width=device-width,initial-scale=1"/>'
-        )
-        expect(html).toContain('I can have meta tags')
-      })
+  test('header helper renders header information', async () => {
+    const html = await render('/head')
+    expect(html).toContain('<meta charSet="iso-8859-5" data-next-head=""/>')
+    expect(html).toContain('<meta content="my meta" data-next-head=""/>')
+    expect(html).toContain(
+      '<meta name="viewport" content="width=device-width,initial-scale=1" data-next-head=""/>'
+    )
+    expect(html).toContain('I can have meta tags')
+  })
 
-      test('header helper dedupes tags', async () => {
-        const html = await render('/head')
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta charSet="iso-8859-5" data-next-head=""/>'
-            : '<meta charSet="iso-8859-5"/>'
-        )
-        expect(html).not.toContain(
-          strictNextHead !== false
-            ? '<meta charSet="utf-8" data-next-head=""/>'
-            : '<meta charSet="utf-8"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta name="viewport" content="width=device-width,initial-scale=1" data-next-head=""/>'
-            : '<meta name="viewport" content="width=device-width,initial-scale=1"/>'
-        )
-        // Should contain only one viewport
-        expect(html.match(/<meta name="viewport" /g).length).toBe(1)
-        expect(html).not.toContain(
-          '<meta name="viewport" content="width=device-width"'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta content="my meta" data-next-head=""/>'
-            : '<meta content="my meta"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<link rel="stylesheet" href="/dup-style.css" data-next-head=""/><link rel="stylesheet" href="/dup-style.css" data-next-head=""/>'
-            : '<link rel="stylesheet" href="/dup-style.css"/><link rel="stylesheet" href="/dup-style.css"/>'
-        )
-        const dedupeLink =
-          strictNextHead !== false
-            ? '<link rel="stylesheet" href="dedupe-style.css" data-next-head=""/>'
-            : '<link rel="stylesheet" href="dedupe-style.css"/>'
-        expect(html).toContain(dedupeLink)
-        expect(
-          html.substring(html.indexOf(dedupeLink) + dedupeLink.length)
-        ).not.toContain('<link rel="stylesheet" href="dedupe-style.css"')
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<link rel="alternate" hrefLang="en" href="/last/en" data-next-head=""/>'
-            : '<link rel="alternate" hrefLang="en" href="/last/en"/>'
-        )
-        expect(html).not.toContain(
-          '<link rel="alternate" hrefLang="en" href="/first/en"'
-        )
-      })
+  test('header helper dedupes tags', async () => {
+    const html = await render('/head')
+    expect(html).toContain('<meta charSet="iso-8859-5" data-next-head=""/>')
+    expect(html).not.toContain('<meta charSet="utf-8" data-next-head=""/>')
+    expect(html).toContain(
+      '<meta name="viewport" content="width=device-width,initial-scale=1" data-next-head=""/>'
+    )
+    // Should contain only one viewport
+    expect(html.match(/<meta name="viewport" /g).length).toBe(1)
+    expect(html).not.toContain(
+      '<meta name="viewport" content="width=device-width"'
+    )
+    expect(html).toContain('<meta content="my meta" data-next-head=""/>')
+    expect(html).toContain(
+      '<link rel="stylesheet" href="/dup-style.css" data-next-head=""/><link rel="stylesheet" href="/dup-style.css" data-next-head=""/>'
+    )
+    const dedupeLink =
+      '<link rel="stylesheet" href="dedupe-style.css" data-next-head=""/>'
+    expect(html).toContain(dedupeLink)
+    expect(
+      html.substring(html.indexOf(dedupeLink) + dedupeLink.length)
+    ).not.toContain('<link rel="stylesheet" href="dedupe-style.css"')
+    expect(html).toContain(
+      '<link rel="alternate" hrefLang="en" href="/last/en" data-next-head=""/>'
+    )
+    expect(html).not.toContain(
+      '<link rel="alternate" hrefLang="en" href="/first/en"'
+    )
+  })
 
-      test('header helper dedupes tags with the same key as the default', async () => {
-        const html = await render('/head-duplicate-default-keys')
-        // Expect exactly one `charSet`
-        expect((html.match(/charSet=/g) || []).length).toBe(1)
-        // Expect exactly one `viewport`
-        expect((html.match(/name="viewport"/g) || []).length).toBe(1)
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta charSet="iso-8859-1" data-next-head=""/>'
-            : '<meta charSet="iso-8859-1"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta name="viewport" content="width=500" data-next-head=""/>'
-            : '<meta name="viewport" content="width=500"/>'
-        )
-      })
+  test('header helper dedupes tags with the same key as the default', async () => {
+    const html = await render('/head-duplicate-default-keys')
+    // Expect exactly one `charSet`
+    expect((html.match(/charSet=/g) || []).length).toBe(1)
+    // Expect exactly one `viewport`
+    expect((html.match(/name="viewport"/g) || []).length).toBe(1)
+    expect(html).toContain('<meta charSet="iso-8859-1" data-next-head=""/>')
+    expect(html).toContain(
+      '<meta name="viewport" content="width=500" data-next-head=""/>'
+    )
+  })
 
-      test('header helper avoids dedupe of specific tags', async () => {
-        const html = await render('/head')
-        console.log(html)
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="article:tag" content="tag1" data-next-head=""/>'
-            : '<meta property="article:tag" content="tag1"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="article:tag" content="tag2" data-next-head=""/>'
-            : '<meta property="article:tag" content="tag2"/>'
-        )
-        expect(html).not.toContain('<meta property="dedupe:tag" content="tag3"')
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="dedupe:tag" content="tag4" data-next-head=""/>'
-            : '<meta property="dedupe:tag" content="tag4"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image" content="ogImageTag1" data-next-head=""/>'
-            : '<meta property="og:image" content="ogImageTag1"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image" content="ogImageTag2" data-next-head=""/>'
-            : '<meta property="og:image" content="ogImageTag2"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image:alt" content="ogImageAltTag1" data-next-head=""/>'
-            : '<meta property="og:image:alt" content="ogImageAltTag1"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image:alt" content="ogImageAltTag2" data-next-head=""/>'
-            : '<meta property="og:image:alt" content="ogImageAltTag2"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image:width" content="ogImageWidthTag1" data-next-head=""/>'
-            : '<meta property="og:image:width" content="ogImageWidthTag1"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image:width" content="ogImageWidthTag2" data-next-head=""/>'
-            : '<meta property="og:image:width" content="ogImageWidthTag2"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image:height" content="ogImageHeightTag1" data-next-head=""/>'
-            : '<meta property="og:image:height" content="ogImageHeightTag1"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image:height" content="ogImageHeightTag2" data-next-head=""/>'
-            : '<meta property="og:image:height" content="ogImageHeightTag2"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image:type" content="ogImageTypeTag1" data-next-head=""/>'
-            : '<meta property="og:image:type" content="ogImageTypeTag1"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image:type" content="ogImageTypeTag2" data-next-head=""/>'
-            : '<meta property="og:image:type" content="ogImageTypeTag2"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image:secure_url" content="ogImageSecureUrlTag1" data-next-head=""/>'
-            : '<meta property="og:image:secure_url" content="ogImageSecureUrlTag1"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image:secure_url" content="ogImageSecureUrlTag2" data-next-head=""/>'
-            : '<meta property="og:image:secure_url" content="ogImageSecureUrlTag2"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image:url" content="ogImageUrlTag1" data-next-head=""/>'
-            : '<meta property="og:image:url" content="ogImageUrlTag1"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="og:image:url" content="ogImageUrlTag2" data-next-head=""/>'
-            : '<meta property="og:image:url" content="ogImageUrlTag2"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="fb:pages" content="fbpages1" data-next-head=""/>'
-            : '<meta property="fb:pages" content="fbpages1"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta property="fb:pages" content="fbpages2" data-next-head=""/>'
-            : '<meta property="fb:pages" content="fbpages2"/>'
-        )
-      })
+  test('header helper avoids dedupe of specific tags', async () => {
+    const html = await render('/head')
+    console.log(html)
+    expect(html).toContain(
+      '<meta property="article:tag" content="tag1" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="article:tag" content="tag2" data-next-head=""/>'
+    )
+    expect(html).not.toContain('<meta property="dedupe:tag" content="tag3"')
+    expect(html).toContain(
+      '<meta property="dedupe:tag" content="tag4" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image" content="ogImageTag1" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image" content="ogImageTag2" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image:alt" content="ogImageAltTag1" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image:alt" content="ogImageAltTag2" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image:width" content="ogImageWidthTag1" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image:width" content="ogImageWidthTag2" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image:height" content="ogImageHeightTag1" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image:height" content="ogImageHeightTag2" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image:type" content="ogImageTypeTag1" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image:type" content="ogImageTypeTag2" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image:secure_url" content="ogImageSecureUrlTag1" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image:secure_url" content="ogImageSecureUrlTag2" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image:url" content="ogImageUrlTag1" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="og:image:url" content="ogImageUrlTag2" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="fb:pages" content="fbpages1" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta property="fb:pages" content="fbpages2" data-next-head=""/>'
+    )
+  })
 
-      test('header helper avoids dedupe of meta tags with the same name if they use unique keys', async () => {
-        const html = await render('/head')
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta name="citation_author" content="authorName1" data-next-head=""/>'
-            : '<meta name="citation_author" content="authorName1"/>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta name="citation_author" content="authorName2" data-next-head=""/>'
-            : '<meta name="citation_author" content="authorName2"/>'
-        )
-      })
+  test('header helper avoids dedupe of meta tags with the same name if they use unique keys', async () => {
+    const html = await render('/head')
+    expect(html).toContain(
+      '<meta name="citation_author" content="authorName1" data-next-head=""/>'
+    )
+    expect(html).toContain(
+      '<meta name="citation_author" content="authorName2" data-next-head=""/>'
+    )
+  })
 
-      test('header helper renders Fragment children', async () => {
-        const html = await render('/head')
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<title data-next-head="">Fragment title</title>'
-            : '<title>Fragment title</title>'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<meta content="meta fragment" data-next-head=""/>'
-            : '<meta content="meta fragment"/>'
-        )
-      })
+  test('header helper renders Fragment children', async () => {
+    const html = await render('/head')
+    expect(html).toContain('<title data-next-head="">Fragment title</title>')
+    expect(html).toContain('<meta content="meta fragment" data-next-head=""/>')
+  })
 
-      test('header helper renders boolean attributes correctly children', async () => {
-        const html = await render('/head')
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<script src="/test-async-false.js" data-next-head="">'
-            : '<script src="/test-async-false.js">'
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<script src="/test-async-true.js" async="" data-next-head="">'
-            : ''
-        )
-        expect(html).toContain(
-          strictNextHead !== false
-            ? '<script src="/test-defer.js" defer="" data-next-head="">'
-            : ''
-        )
-      })
+  test('header helper renders boolean attributes correctly children', async () => {
+    const html = await render('/head')
+    expect(html).toContain(
+      '<script src="/test-async-false.js" data-next-head="">'
+    )
+    expect(html).toContain(
+      '<script src="/test-async-true.js" async="" data-next-head="">'
+    )
+    expect(html).toContain(
+      '<script src="/test-defer.js" defer="" data-next-head="">'
+    )
+  })
 
-      it('should place charset element at the top of <head>', async () => {
-        const html = await render('/head-priority')
-        const nextHeadElement =
-          strictNextHead !== false
-            ? '<meta charSet="iso-8859-5" data-next-head=""/><meta name="viewport" content="width=device-width,initial-scale=1" data-next-head=""/><meta name="title" content="head title" data-next-head=""/>'
-            : '<meta charSet="iso-8859-5"/><meta name="viewport" content="width=device-width,initial-scale=1"/><meta name="title" content="head title"/><meta name="next-head-count" content="3"/>'
-        const documentHeadElement =
-          '<meta name="keywords" content="document head test"/>'
+  it('should place charset element at the top of <head>', async () => {
+    const html = await render('/head-priority')
+    const nextHeadElement =
+      '<meta charSet="iso-8859-5" data-next-head=""/><meta name="viewport" content="width=device-width,initial-scale=1" data-next-head=""/><meta name="title" content="head title" data-next-head=""/>'
+    const documentHeadElement =
+      '<meta name="keywords" content="document head test"/>'
 
-        expect(html).toContain(
-          isReact18
-            ? // charset is not actually at the top.
-              // data-next-hide-fouc comes first
-              `</style></noscript>${nextHeadElement}${documentHeadElement}`
-            : `<head>${nextHeadElement}${documentHeadElement}`
-        )
-      })
+    expect(html).toContain(
+      isReact18
+        ? // charset is not actually at the top.
+          // data-next-hide-fouc comes first
+          `</style></noscript>${nextHeadElement}${documentHeadElement}`
+        : `<head>${nextHeadElement}${documentHeadElement}`
+    )
+  })
 
-      test('custom meta properties are rendered only once', async () => {
-        const browser = await next.browser('/head-with-custom-metadata')
+  test('custom meta properties are rendered only once', async () => {
+    const browser = await next.browser('/head-with-custom-metadata')
 
-        // Check that title appears only once
-        const titleElements = await browser.elementsByCss('title')
-        expect(titleElements).toHaveLength(1)
-        const titleText = await browser.elementByCss('title').text()
-        expect(titleText).toBe('Title Page')
+    // Check that title appears only once
+    const titleElements = await browser.elementsByCss('title')
+    expect(titleElements).toHaveLength(1)
+    const titleText = await browser.elementByCss('title').text()
+    expect(titleText).toBe('Title Page')
 
-        // Check that each meta property appears only once
-        const ogTitleElements = await browser.elementsByCss(
-          'meta[property="og:title"]'
-        )
-        expect(ogTitleElements).toHaveLength(1)
-        const ogTitleContent = await browser
-          .elementByCss('meta[property="og:title"]')
-          .getAttribute('content')
-        expect(ogTitleContent).toBe('Title Content')
+    // Check that each meta property appears only once
+    const ogTitleElements = await browser.elementsByCss(
+      'meta[property="og:title"]'
+    )
+    expect(ogTitleElements).toHaveLength(1)
+    const ogTitleContent = await browser
+      .elementByCss('meta[property="og:title"]')
+      .getAttribute('content')
+    expect(ogTitleContent).toBe('Title Content')
 
-        const descriptionElements = await browser.elementsByCss(
-          'meta[name="description"]'
-        )
-        expect(descriptionElements).toHaveLength(1)
-        const descriptionContent = await browser
-          .elementByCss('meta[name="description"]')
-          .getAttribute('content')
-        expect(descriptionContent).toBe('Description Content')
-      })
-    }
-  )
+    const descriptionElements = await browser.elementsByCss(
+      'meta[name="description"]'
+    )
+    expect(descriptionElements).toHaveLength(1)
+    const descriptionContent = await browser
+      .elementByCss('meta[name="description"]')
+      .getAttribute('content')
+    expect(descriptionContent).toBe('Description Content')
+  })
 })


### PR DESCRIPTION
Has been the default during all of v15. We haven't heard any feedback.
We only left it in as an escape hatch in case of issues but that hasn't materialized.