### PR TITLE
Build: Move routes manifest generation into dedicated function

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -639,10 +639,6 @@ export default abstract class Server<
     this.responseCache = this.getResponseCache({ dev })
   }
 
-  protected reloadMatchers() {
-    return this.matchers.reload()
-  }
-
   private handleRSCRequest: RouteHandler<ServerRequest, ServerResponse> = (
     req,
     _res,

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -117,7 +117,6 @@ export default class DevServer extends Server {
   private actualMiddlewareFile?: string
   private actualInstrumentationHookFile?: string
   private middleware?: MiddlewareRoutingItem
-  private originalFetch?: typeof fetch
   private readonly bundlerService: DevBundlerService
   private staticPathsCache: LRUCache<
     UnwrapPromise<ReturnType<DevServer['getStaticPaths']>>

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -107,9 +107,6 @@ export async function setupFsCheck(opts: {
   dev: boolean
   minimalMode?: boolean
   config: NextConfigComplete
-  addDevWatcherCallback?: (
-    arg: (files: Map<string, { timestamp: number }>) => void
-  ) => void
 }) {
   const getItemsLru = !opts.dev
     ? new LRUCache<FsOutput | null>(1024 * 1024, function length(value) {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -122,8 +122,6 @@ import {
 
 export * from './base-server'
 
-declare const __non_webpack_require__: NodeRequire
-
 // For module that can be both CJS or ESM
 const dynamicImportEsmDefault = process.env.NEXT_MINIMAL
   ? (id: string) =>
@@ -251,7 +249,6 @@ export default class NextNodeServer extends BaseServer<
   protected middlewareManifestPath: string
   private _serverDistDir: string | undefined
   private imageResponseCache?: ResponseCache
-  private registeredInstrumentation: boolean = false
   protected renderWorkersPromises?: Promise<void>
   protected dynamicRoutes?: {
     match: import('../shared/lib/router/utils/route-matcher').RouteMatchFn


### PR DESCRIPTION
## What?

I'm looking at reusing this logic to generate the manifest in development too. That way the dev server can base the routing logic on the exact same rules as production, currently it relies on having it's own filesystem crawling logic.

This PR is just the first step to get there, by splitting the manifest generation from the main build function.

Closes PACK-5101