### PR TITLE
Build: Include rewrites in manifest generation

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1404,9 +1404,15 @@ export default async function build(
             ),
             headers: headers.map((r) => buildCustomRoute('header', r)),
             rewrites: {
-              beforeFiles: [],
-              afterFiles: [],
-              fallback: [],
+              beforeFiles: rewrites.beforeFiles.map((r) =>
+                buildCustomRoute('rewrite', r)
+              ),
+              afterFiles: rewrites.afterFiles.map((r) =>
+                buildCustomRoute('rewrite', r)
+              ),
+              fallback: rewrites.fallback.map((r) =>
+                buildCustomRoute('rewrite', r)
+              ),
             },
             dynamicRoutes,
             staticRoutes,
@@ -1442,16 +1448,6 @@ export default async function build(
               : undefined,
           } satisfies RoutesManifest
         })
-
-      routesManifest.rewrites = {
-        beforeFiles: rewrites.beforeFiles.map((r) =>
-          buildCustomRoute('rewrite', r)
-        ),
-        afterFiles: rewrites.afterFiles.map((r) =>
-          buildCustomRoute('rewrite', r)
-        ),
-        fallback: rewrites.fallback.map((r) => buildCustomRoute('rewrite', r)),
-      }
 
       let clientRouterFilters:
         | undefined


### PR DESCRIPTION
## What?

These values get assigned right after creating the object. So they can just be included when creating the object. I think in the past it might have had conditions wrapping it but they're no longer there.

Closes PACK-5108