### PR TITLE
[Segment Cache] Implement prefetch inlining

### DIFF
--- a/packages/next/src/client/components/segment-cache-impl/cache.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache.ts
@@ -845,13 +845,21 @@ function rejectSegmentCacheEntry(
   }
 }
 
-function convertRootTreePrefetchToRouteTree(rootTree: RootTreePrefetch) {
-  return convertTreePrefetchToRouteTree(rootTree.tree, ROOT_SEGMENT_KEY)
+function convertRootTreePrefetchToRouteTree(
+  rootTree: RootTreePrefetch,
+  inlinedSegments: Map<string, SegmentPrefetch>
+) {
+  return convertTreePrefetchToRouteTree(
+    rootTree.tree,
+    ROOT_SEGMENT_KEY,
+    inlinedSegments
+  )
 }
 
 function convertTreePrefetchToRouteTree(
   prefetch: TreePrefetch,
-  key: string
+  key: string,
+  inlinedSegments: Map<string, SegmentPrefetch>
 ): RouteTree {
   // Converts the route tree sent by the server into the format used by the
   // cache. The cached version of the tree includes additional fields, such as a
@@ -875,10 +883,17 @@ function convertTreePrefetchToRouteTree(
       )
       slots[parallelRouteKey] = convertTreePrefetchToRouteTree(
         childPrefetch,
-        childKey
+        childKey,
+        inlinedSegments
       )
     }
   }
+
+  const inlinedSegment = prefetch.data
+  if (inlinedSegment !== null) {
+    inlinedSegments.set(key, inlinedSegment)
+  }
+
   return {
     key,
     segment: prefetch.segment,
@@ -1133,17 +1148,34 @@ export async function fetchRouteOnCacheMiss(
         return null
       }
 
+      const now = Date.now()
       const staleTimeMs = serverData.staleTime * 1000
-      fulfillRouteCacheEntry(
+      const staleAt = now + staleTimeMs
+      const inlinedSegments = new Map<string, SegmentPrefetch>()
+      const route = fulfillRouteCacheEntry(
         entry,
-        convertRootTreePrefetchToRouteTree(serverData),
+        convertRootTreePrefetchToRouteTree(serverData, inlinedSegments),
         serverData.head,
         serverData.isHeadPartial,
-        Date.now() + staleTimeMs,
+        staleAt,
         couldBeIntercepted,
         canonicalUrl,
         routeIsPPREnabled
       )
+      // The tree prefetch response may contain inlined segment data. If so, we
+      // can write those into the cache now to avoid an extra request later.
+      for (const [segmentKey, segment] of inlinedSegments) {
+        writeInlinedSegmentIntoCache(
+          now,
+          task,
+          route,
+          segmentKey,
+          segment.rsc,
+          segment.loading,
+          segment.isPartial,
+          staleAt
+        )
+      }
     } else {
       // PPR is not enabled for this route. The server responds with a
       // different format (FlightRouterState) that we need to convert.
@@ -1644,32 +1676,16 @@ function writeSeedDataIntoCache(
     fulfillSegmentCacheEntry(ownedEntry, rsc, loading, staleAt, isPartial)
   } else {
     // There's no matching entry. Attempt to create a new one.
-    const possiblyNewEntry = readOrCreateSegmentCacheEntry(
+    writeInlinedSegmentIntoCache(
       now,
       task,
       route,
-      key
+      key,
+      rsc,
+      loading,
+      isPartial,
+      staleAt
     )
-    if (possiblyNewEntry.status === EntryStatus.Empty) {
-      // Confirmed this is a new entry. We can fulfill it.
-      const newEntry = possiblyNewEntry
-      fulfillSegmentCacheEntry(newEntry, rsc, loading, staleAt, isPartial)
-    } else {
-      // There was already an entry in the cache. But we may be able to
-      // replace it with the new one from the server.
-      const newEntry = fulfillSegmentCacheEntry(
-        createDetachedSegmentCacheEntry(staleAt),
-        rsc,
-        loading,
-        staleAt,
-        isPartial
-      )
-      upsertSegmentEntry(
-        now,
-        getSegmentKeypathForTask(task, route, key),
-        newEntry
-      )
-    }
   }
   // Recursively write the child data into the cache.
   const seedDataChildren = seedData[2]
@@ -1694,6 +1710,40 @@ function writeSeedDataIntoCache(
         )
       }
     }
+  }
+}
+
+function writeInlinedSegmentIntoCache(
+  now: number,
+  task: PrefetchTask,
+  route: FulfilledRouteCacheEntry,
+  key: string,
+  rsc: React.ReactNode,
+  loading: LoadingModuleData | Promise<LoadingModuleData>,
+  isPartial: boolean,
+  staleAt: number
+) {
+  // Attempt to create a new entry.
+  const possiblyNewEntry = readOrCreateSegmentCacheEntry(now, task, route, key)
+  if (possiblyNewEntry.status === EntryStatus.Empty) {
+    // Confirmed this is a new entry. We can fulfill it.
+    const newEntry = possiblyNewEntry
+    fulfillSegmentCacheEntry(newEntry, rsc, loading, staleAt, isPartial)
+  } else {
+    // There was already an entry in the cache. But we may be able to
+    // replace it with the new one from the server.
+    const newEntry = fulfillSegmentCacheEntry(
+      createDetachedSegmentCacheEntry(staleAt),
+      rsc,
+      loading,
+      staleAt,
+      isPartial
+    )
+    upsertSegmentEntry(
+      now,
+      getSegmentKeypathForTask(task, route, key),
+      newEntry
+    )
   }
 }
 

--- a/packages/next/src/client/components/segment-cache-impl/lru.ts
+++ b/packages/next/src/client/components/segment-cache-impl/lru.ts
@@ -94,6 +94,8 @@ export function createLRU<T extends LRUNode>(
           head = null
         } else {
           head = next
+          prev.next = next
+          next.prev = prev
         }
       } else {
         prev.next = next

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -55,6 +55,11 @@ export type TreePrefetch = {
   // bunch of new prefetch-only fields to FlightRouterState. So think of
   // TreePrefetch as a superset of FlightRouterState.
   isRootLayout: boolean
+
+  // The segment data, if it's small enough to be inlined into the initial
+  // prefetch. If empty, it's because we've decided to outline it. The client
+  // will issue a separate request
+  data: SegmentPrefetch | null
 }
 
 export type SegmentPrefetch = {
@@ -79,6 +84,11 @@ function onSegmentPrerenderError(error: unknown) {
   // when generating the original Flight stream for the whole page.
 }
 
+type AccumulatedSegmentData = {
+  segmentData: Map<string, Buffer>
+  inlinedGzipBytes: number
+}
+
 export async function collectSegmentData(
   fullPageDataBuffer: Buffer,
   staleTime: number,
@@ -88,8 +98,11 @@ export async function collectSegmentData(
 ): Promise<Map<string, Buffer>> {
   // Traverse the router tree and generate a prefetch response for each segment.
 
-  // A mutable map to collect the results as we traverse the route tree.
-  const resultMap = new Map<string, Buffer>()
+  // A mutable object to collect the results as we traverse the route tree.
+  const accumulation: AccumulatedSegmentData = {
+    segmentData: new Map<string, Buffer>(),
+    inlinedGzipBytes: 0,
+  }
 
   // Before we start, warm up the module cache by decoding the page data once.
   // Then we can assume that any remaining async tasks that occur the next time
@@ -114,10 +127,8 @@ export async function collectSegmentData(
   }
 
   // Generate a stream for the route tree prefetch. While we're walking the
-  // tree, we'll also spawn additional tasks to generate the segment prefetches.
-  // The promises for these tasks are pushed to a mutable array that we will
-  // await once the route tree is fully rendered.
-  const segmentTasks: Array<Promise<[string, Buffer]>> = []
+  // tree, we'll also generate the segment prefetches and write the output
+  // to resultMap.
   const { prelude: treeStream } = await prerender(
     // RootTreePrefetch is not a valid return type for a React component, but
     // we need to use a component so that when we decode the original stream
@@ -129,7 +140,7 @@ export async function collectSegmentData(
       serverConsumerManifest={serverConsumerManifest}
       clientModules={clientModules}
       staleTime={staleTime}
-      segmentTasks={segmentTasks}
+      accumulation={accumulation}
       onCompletedProcessingRouteTree={onCompletedProcessingRouteTree}
     />,
     clientModules,
@@ -142,16 +153,10 @@ export async function collectSegmentData(
 
   // Write the route tree to a special `/_tree` segment.
   const treeBuffer = await streamToBuffer(treeStream)
-  resultMap.set('/_tree', treeBuffer)
+  const segmentData = accumulation.segmentData
+  segmentData.set('/_tree', treeBuffer)
 
-  // Now that we've finished rendering the route tree, all the segment tasks
-  // should have been spawned. Await them in parallel and write the segment
-  // prefetches to the result map.
-  for (const [segmentPath, buffer] of await Promise.all(segmentTasks)) {
-    resultMap.set(segmentPath, buffer)
-  }
-
-  return resultMap
+  return segmentData
 }
 
 async function PrefetchTreeData({
@@ -160,7 +165,7 @@ async function PrefetchTreeData({
   serverConsumerManifest,
   clientModules,
   staleTime,
-  segmentTasks,
+  accumulation,
   onCompletedProcessingRouteTree,
 }: {
   fullPageDataBuffer: Buffer
@@ -168,7 +173,7 @@ async function PrefetchTreeData({
   fallbackRouteParams: FallbackRouteParams | null
   clientModules: ManifestNode
   staleTime: number
-  segmentTasks: Array<Promise<[string, Buffer]>>
+  accumulation: AccumulatedSegmentData
   onCompletedProcessingRouteTree: () => void
 }): Promise<RootTreePrefetch | null> {
   // We're currently rendering a Flight response for the route tree prefetch.
@@ -201,14 +206,14 @@ async function PrefetchTreeData({
   // Compute the route metadata tree by traversing the FlightRouterState. As we
   // walk the tree, we will also spawn a task to produce a prefetch response for
   // each segment.
-  const tree = collectSegmentDataImpl(
+  const tree = await collectSegmentDataImpl(
     flightRouterState,
     buildId,
     seedData,
     fallbackRouteParams,
     clientModules,
     ROOT_SEGMENT_KEY,
-    segmentTasks
+    accumulation
   )
 
   const isHeadPartial = await isPartialRSCData(head, clientModules)
@@ -229,18 +234,18 @@ async function PrefetchTreeData({
   return treePrefetch
 }
 
-function collectSegmentDataImpl(
+async function collectSegmentDataImpl(
   route: FlightRouterState,
   buildId: string,
   seedData: CacheNodeSeedData | null,
   fallbackRouteParams: FallbackRouteParams | null,
   clientModules: ManifestNode,
   key: string,
-  segmentTasks: Array<Promise<[string, Buffer]>>
-): TreePrefetch {
+  accumulation: AccumulatedSegmentData
+): Promise<TreePrefetch> {
   // Metadata about the segment. Sent as part of the tree prefetch. Null if
   // there are no children.
-  let slotMetadata: { [parallelRouteKey: string]: TreePrefetch } | null = null
+  const slotMetadata: { [parallelRouteKey: string]: TreePrefetch } | null = {}
 
   const children = route[1]
   const seedDataChildren = seedData !== null ? seedData[2] : null
@@ -260,30 +265,86 @@ function collectSegmentDataImpl(
           )
         : encodeSegment(childSegment)
     )
-    const childTree = collectSegmentDataImpl(
+
+    // Intentionally rendering each child in serial. This is because we track the
+    // total number of inlined bytes as we go, to decide whether to inline the
+    // next segment. If we rendered them in parallel, the result would be
+    // non-deterministic. Since this function is not bound by unresolved data,
+    // this is unlikely to impact build times.
+    const childTree = await collectSegmentDataImpl(
       childRoute,
       buildId,
       childSeedData,
       fallbackRouteParams,
       clientModules,
       childKey,
-      segmentTasks
+      accumulation
     )
-    if (slotMetadata === null) {
-      slotMetadata = {}
-    }
     slotMetadata[parallelRouteKey] = childTree
   }
 
+  let possiblyInlinedSegmentData: SegmentPrefetch | null = null
+
   if (seedData !== null) {
-    // Spawn a task to write the segment data to a new Flight stream.
-    segmentTasks.push(
-      // Since we're already in the middle of a render, wait until after the
-      // current task to escape the current rendering context.
-      waitAtLeastOneReactRenderTask().then(() =>
-        renderSegmentPrefetch(buildId, seedData, key, clientModules)
-      )
+    const [segmentPath, buffer, segmentPrefetch] = await renderSegmentPrefetch(
+      buildId,
+      seedData,
+      key,
+      clientModules
     )
+    accumulation.segmentData.set(segmentPath, buffer)
+
+    // Measure the gzipped size of the segment response. If it's below the given
+    // threshold, inline it into the route tree prefetch. This prevents the
+    // client from having to prefetch it separately, at the cost of potentially
+    // greater transfer size when prefetching multiple pages with shared
+    // layouts. If it's above the threshold, omit it from the route tree
+    // prefetch response, i.e. "outline" it to a separate response.
+    //
+    // The benefit of outlining is that the same segment response can be reused
+    // across multiple pages. This is often worth the additional prefetch
+    // request, since each response can be cached independently. It's similar
+    // to how JS bundlers decide whether to inline a module chunk.
+    //
+    // The inlining threshold is only a heuristic. The idea is that below some
+    // size, the potential deduping benefits are not worth the cost of the
+    // additional request.
+    //
+    // TODO: The ideal theoretical thresholds depends on the network conditions.
+    // Consider generating multiple tree prefetches with different thresholds.
+    // The client would then request the appropriate one based on its
+    // connection type.
+    // TODO: We may make these configurable, but ideally the defaults are good
+    // enough that it isn't necessary.
+    const segmentGzipBytes = await getGzipSize(buffer)
+    if (segmentGzipBytes < 2_048) {
+      // In addition to using the size of the segment prefetch, we also take
+      // into consideration the total inlined size of the tree prefetch. The
+      // idea is that even if each individual segment is below the inlining
+      // threshold, at some point it no longer makes sense to add more bytes to
+      // the tree prefetch, because the tree prefetch requests are unique per
+      // URL and cannot be deduped the way segments can.
+      //
+      // Deeper segments are more likely to be unique to a page, so they are
+      // more likely to benefit from inlining. Since we're inside a depth-first
+      // traversal, we're prioritizing inlining the deepest segments first.
+      //
+      // Note that this is only an estimate of the number of bytes added to the
+      // tree prefetch. The actual number is likely smaller, because of object
+      // deduplication by Flight and (similarly) additional gzip chunk
+      // deduplication in the combined result.
+      //
+      // TODO: If we wanted a more accurate value, we could measure the size of
+      // the actual output stream as we process the tree. Since the inlining
+      // thresholds are just a heuristic, leaving this as a future improvement
+      // for now.
+      const totalInlinedGzipBytes =
+        accumulation.inlinedGzipBytes + segmentGzipBytes
+      if (totalInlinedGzipBytes < 10_240) {
+        possiblyInlinedSegmentData = segmentPrefetch
+        accumulation.inlinedGzipBytes = totalInlinedGzipBytes
+      }
+    }
   } else {
     // This segment does not have any seed data. Skip generating a prefetch
     // response for it. We'll still include it in the route tree, though.
@@ -298,7 +359,18 @@ function collectSegmentDataImpl(
     segment: route[0],
     slots: slotMetadata,
     isRootLayout: route[4] === true,
+    data: possiblyInlinedSegmentData,
   }
+}
+
+async function getGzipSize(buffer: Buffer): Promise<number> {
+  const encoder = new TextEncoder()
+  const encoded = encoder.encode(buffer.toString())
+  const stream = new Blob([encoded])
+    .stream()
+    .pipeThrough(new CompressionStream('gzip'))
+  const compressedBlob = await new Response(stream).blob()
+  return compressedBlob.size
 }
 
 function encodeSegmentWithPossibleFallbackParam(
@@ -335,7 +407,7 @@ async function renderSegmentPrefetch(
   seedData: CacheNodeSeedData,
   key: string,
   clientModules: ManifestNode
-): Promise<[string, Buffer]> {
+): Promise<[string, Buffer, SegmentPrefetch]> {
   // Render the segment data to a stream.
   // In the future, this is where we can include additional metadata, like the
   // stale time and cache tags.
@@ -363,9 +435,9 @@ async function renderSegmentPrefetch(
   )
   const segmentBuffer = await streamToBuffer(segmentStream)
   if (key === ROOT_SEGMENT_KEY) {
-    return ['/_index', segmentBuffer]
+    return ['/_index', segmentBuffer, segmentPrefetch]
   } else {
-    return [key, segmentBuffer]
+    return [key, segmentBuffer, segmentPrefetch]
   }
 }
 

--- a/test/e2e/app-dir/app-client-cache/fixtures/parallel-routes/app/[id]/page.js
+++ b/test/e2e/app-dir/app-client-cache/fixtures/parallel-routes/app/[id]/page.js
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { NoInline } from '../no-inline'
 
 export default async function Page() {
   const randomNumber = await new Promise((resolve) => {
@@ -9,6 +10,7 @@ export default async function Page() {
 
   return (
     <>
+      <NoInline />
       <div>
         <Link href="/">Back to Home</Link>
       </div>

--- a/test/e2e/app-dir/app-client-cache/fixtures/parallel-routes/app/no-inline.tsx
+++ b/test/e2e/app-dir/app-client-cache/fixtures/parallel-routes/app/no-inline.tsx
@@ -1,0 +1,21 @@
+import { gzipSync } from 'zlib'
+import { randomBytes } from 'crypto'
+
+// Default size is 2 KB, the threshold used by Next to decide whether to inline
+// a segment into the route tree prefetch.
+export async function NoInline({ size = 2048 }: { size?: number }) {
+  let content = ''
+  let compressedLength = 0
+  let iterations = 0
+  while (compressedLength < size) {
+    const chunk =
+      iterations % 2 === 0
+        ? '**Arbitrary hidden content to prevent this component from being inlined** '
+        : randomBytes(128).toString('base64') + ' '
+    content += chunk
+    compressedLength = gzipSync(content).length
+    iterations++
+    if (iterations > 10000) break
+  }
+  return <div style={{ display: 'none' }}>{content}</div>
+}

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/has-loading-boundary/a/b/shared-layout/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/mixed-fetch-strategies/has-loading-boundary/a/b/shared-layout/layout.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react'
 import { connection } from 'next/server'
+import { NoInline } from '../../../../../no-inline'
 
 async function DynamicContentInSharedLayout() {
   await connection()
@@ -17,6 +18,7 @@ export default function SharedLayout({
 }) {
   return (
     <div id="shared-layout">
+      <NoInline />
       <Suspense
         fallback={
           <div id="shared-layout-ppr-boundary">

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/no-inline.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/no-inline.tsx
@@ -1,0 +1,21 @@
+import { gzipSync } from 'zlib'
+import { randomBytes } from 'crypto'
+
+// Default size is 2 KB, the threshold used by Next to decide whether to inline
+// a segment into the route tree prefetch.
+export async function NoInline({ size = 2048 }: { size?: number }) {
+  let content = ''
+  let compressedLength = 0
+  let iterations = 0
+  while (compressedLength < size) {
+    const chunk =
+      iterations % 2 === 0
+        ? '**Arbitrary hidden content to prevent this component from being inlined** '
+        : randomBytes(128).toString('base64') + ' '
+    content += chunk
+    compressedLength = gzipSync(content).length
+    iterations++
+    if (iterations > 10000) break
+  }
+  return <div style={{ display: 'none' }}>{content}</div>
+}

--- a/test/e2e/app-dir/segment-cache/memory-pressure/app/memory-pressure/[step]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/app/memory-pressure/[step]/page.tsx
@@ -1,15 +1,17 @@
 import { Suspense } from 'react'
+import { randomBytes } from 'crypto'
 
 type Params = { step: string }
 
 async function Content({ params }: { params: Promise<Params> }) {
+  'use cache'
   const { step } = await params
   return (
     <div id="memory-pressure-step-page">
       <h1>{`Page ${step}.`}</h1>
       {/* Render a large string such that a prefetch of this segment is roughly
           1MB over the network */}
-      <p>{'a'.repeat(1024 * 1024)}</p>
+      <p>{randomBytes(1024 * 1024).toString('base64')}</p>
     </div>
   )
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-scheduling/app/cancellation/[pageNumber]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-scheduling/app/cancellation/[pageNumber]/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react'
+import { NoInline } from '../../no-inline'
 
 type Params = {
   pageNumber: string
@@ -29,6 +30,7 @@ export default async function LinkCancellationTargetPage({
 }) {
   return (
     <Suspense fallback="Loading...">
+      <NoInline />
       <Content params={params} />
     </Suspense>
   )

--- a/test/e2e/app-dir/segment-cache/prefetch-scheduling/app/no-inline.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-scheduling/app/no-inline.tsx
@@ -1,0 +1,23 @@
+'use cache'
+
+import { gzipSync } from 'zlib'
+import { randomBytes } from 'crypto'
+
+// Default size is 2 KB, the threshold used by Next to decide whether to
+// inline a segment into the route tree prefetch.
+export async function NoInline({ size = 2048 }: { size?: number }) {
+  let content = ''
+  let compressedLength = 0
+  let iterations = 0
+  while (compressedLength < size) {
+    const chunk =
+      iterations % 2 === 0
+        ? '**Arbitrary hidden content to prevent this component from being inlined** '
+        : randomBytes(128).toString('base64') + ' '
+    content += chunk
+    compressedLength = gzipSync(content).length
+    iterations++
+    if (iterations > 10000) break
+  }
+  return <div style={{ display: 'none' }}>{content}</div>
+}

--- a/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/a/page.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/a/page.tsx
@@ -1,5 +1,6 @@
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { NoInline } from '../../../components/no-inline'
 
 async function Content() {
   await connection()
@@ -9,6 +10,7 @@ async function Content() {
 export default async function PageA() {
   return (
     <Suspense fallback="Loading...">
+      <NoInline />
       <Content />
     </Suspense>
   )

--- a/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/b/page.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/b/page.tsx
@@ -1,5 +1,6 @@
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { NoInline } from '../../../components/no-inline'
 
 async function Content() {
   await connection()
@@ -9,6 +10,7 @@ async function Content() {
 export default async function PageB() {
   return (
     <Suspense fallback="Loading...">
+      <NoInline />
       <Content />
     </Suspense>
   )

--- a/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/layout.tsx
@@ -1,4 +1,5 @@
 import { LinkAccordion } from '../../components/link-accordion'
+import { NoInline } from '../../components/no-inline'
 
 export default function RefetchOnNewBaseTreeLayout({
   children,
@@ -7,6 +8,7 @@ export default function RefetchOnNewBaseTreeLayout({
 }) {
   return (
     <>
+      <NoInline />
       <div style={{ backgroundColor: 'lightgray', padding: '1rem' }}>
         <p>
           This demonstrates what happens when a link is prefetched using{' '}

--- a/test/e2e/app-dir/segment-cache/revalidation/components/no-inline.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/components/no-inline.tsx
@@ -1,0 +1,23 @@
+'use cache'
+
+import { gzipSync } from 'zlib'
+import { randomBytes } from 'crypto'
+
+// Default size is 2 KB, the threshold used by Next to decide whether to inline
+// a segment into the route tree prefetch.
+export async function NoInline({ size = 2048 }: { size?: number }) {
+  let content = ''
+  let compressedLength = 0
+  let iterations = 0
+  while (compressedLength < size) {
+    const chunk =
+      iterations % 2 === 0
+        ? '**Arbitrary hidden content to prevent this component from being inlined** '
+        : randomBytes(128).toString('base64') + ' '
+    content += chunk
+    compressedLength = gzipSync(content).length
+    iterations++
+    if (iterations > 10000) break
+  }
+  return <div style={{ display: 'none' }}>{content}</div>
+}

--- a/test/e2e/app-dir/segment-cache/search-params/app/search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/app/search-params/target-page/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react'
+import { NoInline } from '../../../components/no-inline'
 
 async function Content({ searchParams }) {
   const { searchParam } = await searchParams
@@ -8,6 +9,7 @@ async function Content({ searchParams }) {
 export default async function Target({ searchParams }) {
   return (
     <Suspense fallback="Loading...">
+      <NoInline />
       <div id="target-page-with-search-param">
         <Content searchParams={searchParams} />
       </div>

--- a/test/e2e/app-dir/segment-cache/search-params/components/no-inline.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/components/no-inline.tsx
@@ -1,0 +1,23 @@
+'use cache'
+
+import { gzipSync } from 'zlib'
+import { randomBytes } from 'crypto'
+
+// Default size is 2 KB, the threshold used by Next to decide whether to inline
+// a segment into the route tree prefetch.
+export async function NoInline({ size = 2048 }: { size?: number }) {
+  let content = ''
+  let compressedLength = 0
+  let iterations = 0
+  while (compressedLength < size) {
+    const chunk =
+      iterations % 2 === 0
+        ? '**Arbitrary hidden content to prevent this component from being inlined** '
+        : randomBytes(128).toString('base64') + ' '
+    content += chunk
+    compressedLength = gzipSync(content).length
+    iterations++
+    if (iterations > 10000) break
+  }
+  return <div style={{ display: 'none' }}>{content}</div>
+}


### PR DESCRIPTION
Based on:

- #81896 

---

In the Segment Cache implementation, we split page prefetches into multiple requests so that each one can be cached and deduped independently. For example, if multiple pages share the same layout, the data for that layout only needs to be fetched once. This approach can greatly reduce the overall transfer size at the cost of additional requests, which is typically minimal, especially since it happens during the prefetch phase.

However, some segments are small enough that the potential caching benefits are not worth additional network overhead. So we can inline them directly into the initial route tree prefetch response, potentially avoiding a separate request. Again, it's not a perfect trade-off, since that separate request may have been skipped anyway if the segment was already cached. It's just a heuristic. But below some size, inlining is worth it.

(Publicly, we may end up referring to this strategy as prefetch _outlining_ rather than _inlining_, since compared to the current Next.js behavior, that's the part that's actually new in the Segment Cache.)

I've chosen 2KB (gzipped) as the default threshold. We can do some more research and tweak this later.

In addition to using the size of the segment prefetch, we also take into consideration the total inlined size of the tree prefetch. The idea is that even if each individual segment is below the inlining threshold, at some point it no longer makes sense to add more bytes to the tree prefetch, because the tree prefetch requests are unique per URL and cannot be deduped the way segments can. I've chosen 10KB as the default for this limit.

Deeper segments are more likely to be unique to a page, so they are more likely to benefit from inlining. We prioritize the deepest segments when inlining.

For now, the prefetch thresholds are hardcoded. We may make them configurable, but ideally the defaults are good enough that it isn't necessary. One reason to expose the configuration, though, is that some apps may be more sensitive to the number of requests than others. By setting a very large inlining threshold, you can effectively disable the layout deduping feature and "revert" back to something closer to the existing Next.js behavior. We'll think about this more before release.

Another thing worth considering is whether to use different inlining thresholds for different network conditions. For example, mobile devices on slow networks may benefit from more aggressive inlining, whereas devices on WiFi benefit more from deduping. To do this, we would generate multiple prefetch responses per page and the client would request the appropriate one based on the [Network Information API](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API).