### PR TITLE
[sourcemaps] Fully sourcemap stacks on the Server

### DIFF
--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -69,6 +69,11 @@ const filterStackFrame =
     ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
         .filterStackFrameDEV
     : undefined
+const findSourceMapURL =
+  process.env.NODE_ENV !== 'production'
+    ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
+        .findSourceMapURLDEV
+    : undefined
 
 function onSegmentPrerenderError(error: unknown) {
   const digest = getDigestForWellKnownError(error)
@@ -98,6 +103,7 @@ export async function collectSegmentData(
   //
   try {
     await createFromReadableStream(streamFromBuffer(fullPageDataBuffer), {
+      findSourceMapURL,
       serverConsumerManifest,
     })
     await waitAtLeastOneReactRenderTask()
@@ -179,6 +185,7 @@ async function PrefetchTreeData({
   const initialRSCPayload: InitialRSCPayload = await createFromReadableStream(
     createUnclosingPrefetchStream(streamFromBuffer(fullPageDataBuffer)),
     {
+      findSourceMapURL,
       serverConsumerManifest,
     }
   )

--- a/packages/next/src/server/app-render/encryption.ts
+++ b/packages/next/src/server/app-render/encryption.ts
@@ -30,6 +30,17 @@ const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
 const textEncoder = new TextEncoder()
 const textDecoder = new TextDecoder()
 
+const filterStackFrame =
+  process.env.NODE_ENV !== 'production'
+    ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
+        .filterStackFrameDEV
+    : undefined
+const findSourceMapURL =
+  process.env.NODE_ENV !== 'production'
+    ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
+        .findSourceMapURLDEV
+    : undefined
+
 /**
  * Decrypt the serialized string with the action id as the salt.
  */
@@ -139,12 +150,6 @@ export const encryptActionBoundArgs = React.cache(
         once: true,
       })
     }
-
-    const filterStackFrame =
-      process.env.NODE_ENV !== 'production'
-        ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
-            .filterStackFrameDEV
-        : undefined
 
     // Using Flight to serialize the args into a string.
     const serialized = await streamToString(
@@ -282,6 +287,7 @@ export async function decryptActionBoundArgs(
       },
     }),
     {
+      findSourceMapURL,
       serverConsumerManifest: {
         // moduleLoading must be null because we don't want to trigger preloads of ClientReferences
         // to be added to the current execution. Instead, we'll wait for any ClientReference

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -16,6 +16,12 @@ const INLINE_FLIGHT_PAYLOAD_BINARY = 3
 const flightResponses = new WeakMap<BinaryStreamOf<any>, Promise<any>>()
 const encoder = new TextEncoder()
 
+const findSourceMapURL =
+  process.env.NODE_ENV !== 'production'
+    ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
+        .findSourceMapURLDEV
+    : undefined
+
 /**
  * Render Flight stream.
  * This is only used for renderToHTML, the Flight response does not need additional wrappers.
@@ -37,6 +43,7 @@ export function useFlightStream<T>(
     require('react-server-dom-webpack/client') as typeof import('react-server-dom-webpack/client')
 
   const newResponse = createFromReadableStream<T>(flightStream, {
+    findSourceMapURL,
     serverConsumerManifest: {
       moduleLoading: clientReferenceManifest.moduleLoading,
       moduleMap: isEdgeRuntime

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -111,6 +111,11 @@ const filterStackFrame =
     ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
         .filterStackFrameDEV
     : undefined
+const findSourceMapURL =
+  process.env.NODE_ENV !== 'production'
+    ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
+        .findSourceMapURLDEV
+    : undefined
 
 function generateCacheEntry(
   workStore: WorkStore,
@@ -1469,6 +1474,7 @@ export function cache(
       }
 
       return createFromReadableStream(stream, {
+        findSourceMapURL,
         serverConsumerManifest,
         temporaryReferences,
         replayConsoleLogs,

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -68,9 +68,9 @@ declare module 'react-server-dom-webpack/client' {
   export function createServerReference(
     id: string,
     callServer: CallServerCallback,
-    encodeFormAction?: EncodeFormActionCallback,
-    findSourceMapURL?: FindSourceMapURLCallback, // DEV-only
-    functionName?: string
+    encodeFormAction: EncodeFormActionCallback | undefined,
+    findSourceMapURL: FindSourceMapURLCallback | undefined, // DEV-only
+    functionName: string | undefined
   ): (...args: unknown[]) => Promise<unknown>
 
   export function createTemporaryReferenceSet(
@@ -100,7 +100,8 @@ declare module 'react-server-dom-webpack/client.browser' {
   export interface Options {
     callServer?: CallServerCallback
     environmentName?: string
-    findSourceMapURL?: FindSourceMapURLCallback
+    // It's optional but we want to avoid accidentally omitting it.
+    findSourceMapURL: FindSourceMapURLCallback | undefined
     replayConsoleLogs?: boolean
     temporaryReferences?: TemporaryReferenceSet
   }
@@ -300,7 +301,8 @@ declare module 'react-server-dom-webpack/client.edge' {
     nonce?: string
     encodeFormAction?: EncodeFormActionCallback
     temporaryReferences?: TemporaryReferenceSet
-    findSourceMapURL?: FindSourceMapURLCallback
+    // It's optional but we want to avoid accidentally omitting it.
+    findSourceMapURL: FindSourceMapURLCallback | undefined
     replayConsoleLogs?: boolean
     environmentName?: string
   }

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -85,37 +85,17 @@ describe('Cache Components Dev Errors', () => {
       )
     })
 
-    if (isTurbopack) {
-      const normalizedCliOutput = stripAnsi(
-        next.cliOutput.slice(outputIndex)
-      ).replaceAll(`file:` + next.testDir, '<FIXME-file-protocol>')
-
-      // TODO(veil): Source mapping breaks due to double-encoding of the square
-      // brackets.
-      expect(normalizedCliOutput).toContain(
-        `\nError: Route "/no-accessed-data": ` +
-          `A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. ` +
-          `See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense` +
-          '\n    at Page (<FIXME-file-protocol>/app/no-accessed-data/page.js:1:31)' +
-          '\n> 1 | export default async function Page() {' +
-          '\n    |                               ^' +
-          '\n  2 |   await new Promise((r) => setTimeout(r, 200))' +
-          '\n  3 |   return <p>Page</p>' +
-          '\n  4 | }'
-      )
-    } else {
-      expect(stripAnsi(next.cliOutput.slice(outputIndex))).toContain(
-        `\nError: Route "/no-accessed-data": ` +
-          `A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. ` +
-          `See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense` +
-          '\n    at Page (app/no-accessed-data/page.js:1:31)' +
-          '\n> 1 | export default async function Page() {' +
-          '\n    |                               ^' +
-          '\n  2 |   await new Promise((r) => setTimeout(r, 200))' +
-          '\n  3 |   return <p>Page</p>' +
-          '\n  4 | }'
-      )
-    }
+    expect(stripAnsi(next.cliOutput.slice(outputIndex))).toContain(
+      `\nError: Route "/no-accessed-data": ` +
+        `A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. ` +
+        `See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense` +
+        '\n    at Page (app/no-accessed-data/page.js:1:31)' +
+        '\n> 1 | export default async function Page() {' +
+        '\n    |                               ^' +
+        '\n  2 |   await new Promise((r) => setTimeout(r, 200))' +
+        '\n  3 |   return <p>Page</p>' +
+        '\n  4 | }'
+    )
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -416,11 +416,12 @@ describe('app-dir - server source maps', () => {
         // Expect the invalid sourcemap warning only once per render.
         // Dynamic I/O renders three times.
         // One from filterStackFrameDEV.
+        // One from findSourceMapURLDEV.
         expect(
           normalizeCliOutput(next.cliOutput.slice(outputIndex)).split(
             'Invalid source map.'
           ).length - 1
-        ).toEqual(4)
+        ).toEqual(5)
       }
     } else {
       // Bundlers silently drop invalid sourcemaps.


### PR DESCRIPTION
React replays the stacks via `eval` which requires valid URLs so it needs to use `encodeURI`. We can't just blindly apply `decodeURI` since that may under-encode. Debuggers take source URLs at face value so they wouldn't get sourcemapping. We need to implement `findSourceMapURL` otherwise any sourcemapping guarantees are off.

Node.js currently does not dedupe source map payloads by URL. This is something we could contribute. I'm still caching the `data:` URLs to dedupe the serialization work.

We do need to be aware that running a script always leaks its source map in Node.js. That's usually not an issue since the number of scripts is usually bounded. Long living dev servers have unbounded scripts though. 

If memory consumption due to `data:` sourcemaps becomes too high in Node.js, we need to opt out of `data:` URLs in favor of just trying different decoding levels in `patch-error-inspect`. That way we could still sourcemap errors in the terminal. Debuggers would fail where `encodeURI(scriptNameOrSourceURL) !== scriptNameOrSourceURL`. Another approach would be to create a Node.js specific implementation of `createFakeFunction` in React that uses `pathToFileURL` for absolute paths and keeps source URLs as-is if they already start with `file:` (https://github.com/facebook/react/pull/33969). 

Closes https://linear.app/vercel/issue/NAR-236