### PR TITLE
Turbopack: Remove unused proxy option in turbo-tasks-fetch, lightly document HTTP_PROXY/HTTPS_PROXY environment variables

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1743,7 +1743,6 @@ impl NextConfig {
             .or(self.experimental.turbopack_use_system_tls_certs)
             .unwrap_or(false);
         Ok(ReqwestClientConfig {
-            proxy: None,
             tls_built_in_webpki_certs: !use_system_tls_certs,
             tls_built_in_native_certs: use_system_tls_certs,
         }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -480,6 +480,10 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
          *
          * This option is ignored on Windows on ARM, where the native TLS implementation is always
          * used.
+         *
+         * If you need to set a proxy, Turbopack [respects the common `HTTP_PROXY` and `HTTPS_PROXY`
+         * environment variable convention](https://docs.rs/reqwest/latest/reqwest/#proxies). HTTP
+         * proxies are supported, SOCKS proxies are not currently supported.
          */
         turbopackUseSystemTlsCerts: z.boolean().optional(),
         optimizePackageImports: z.array(z.string()).optional(),

--- a/turbopack/crates/turbo-tasks-fetch/src/reqwest_client_cache.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/reqwest_client_cache.rs
@@ -25,7 +25,6 @@ pub enum ProxyConfig {
 #[turbo_tasks::value(shared)]
 #[derive(Hash)]
 pub struct ReqwestClientConfig {
-    pub proxy: Option<ProxyConfig>,
     /// Whether to load embedded webpki root certs with rustls. Default is true.
     ///
     /// Ignored for:
@@ -44,7 +43,6 @@ pub struct ReqwestClientConfig {
 impl Default for ReqwestClientConfig {
     fn default() -> Self {
         Self {
-            proxy: None,
             tls_built_in_webpki_certs: true,
             tls_built_in_native_certs: false,
         }
@@ -53,16 +51,7 @@ impl Default for ReqwestClientConfig {
 
 impl ReqwestClientConfig {
     fn try_build(&self) -> reqwest::Result<reqwest::Client> {
-        let mut client_builder = reqwest::Client::builder();
-        match &self.proxy {
-            Some(ProxyConfig::Http(proxy)) => {
-                client_builder = client_builder.proxy(reqwest::Proxy::http(proxy.as_str())?)
-            }
-            Some(ProxyConfig::Https(proxy)) => {
-                client_builder = client_builder.proxy(reqwest::Proxy::https(proxy.as_str())?)
-            }
-            None => {}
-        };
+        let client_builder = reqwest::Client::builder();
 
         // make sure this cfg matches the one in `Cargo.toml`!
         #[cfg(not(any(


### PR DESCRIPTION
We had this proxy option on `turbo-tasks-fetch`, but it was never passed anywhere.

I don't think the option is very useful, because `reqwest` already respects the conventional `HTTP_PROXY`/`HTTPS_PROXY` environment variables by default: https://docs.rs/reqwest/latest/reqwest/#proxies

It could make sense alongside the new experimental `turbopackUseSystemTlsCerts` option, but `turbopackUseSystemTlsCerts` is a simple boolean, and there's not a lot of harm in setting it to `true`, even if some of your users don't use system TLS certs. In contrast, HTTP proxies are very system-specific, and IMO make a lot more sense as an environment variable, often set in the user's `.profile` or in `/etc/environment`.

See the manual test plan on #81905 for how to set an HTTP/HTTPS proxy.

Closes PACK-5128