### PR TITLE
Turbopack: Update bundled webpki-roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11114,9 +11114,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]


### PR DESCRIPTION
- It makes sense to update these certs periodically. The long-term solution would be to stop shipping certs once https://github.com/seanmonstar/reqwest/issues/2159 is fixed.
- ~`webpki-roots 0.26.11` is just a dumb re-export of `1.x`, so this avoids shipping the CA roots twice! https://github.com/rustls/webpki-roots/releases/tag/v%2F0.26.11  -- Should save a few hundred KBs~ **Edit:** This dependency was removed by the latest swc+wasmer update.

Closes PACK-5129