### PR TITLE
Stabilize node middleware support

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
@@ -180,31 +180,7 @@ Middleware will be invoked for **every route in your project**. Given this, it's
 
 ## Runtime
 
-Middleware defaults to using the Edge runtime. As of v15.2 (canary), we have experimental support for using the Node.js runtime. To enable, add the flag to your `next.config` file:
-
-```ts filename="next.config.ts" switcher
-import type { NextConfig } from 'next'
-
-const nextConfig: NextConfig = {
-  experimental: {
-    nodeMiddleware: true,
-  },
-}
-
-export default nextConfig
-```
-
-```js filename="next.config.js" switcher
-const nextConfig = {
-  experimental: {
-    nodeMiddleware: true,
-  },
-}
-
-export default nextConfig
-```
-
-Then in your middleware file, set the runtime to `nodejs` in the `config` object:
+Middleware defaults to using the Edge runtime. As of v15.5, we have support for using the Node.js runtime. To enable, in your middleware file, set the runtime to `nodejs` in the `config` object:
 
 ```js highlight={2} filename="middleware.js" switcher
 export const config = {

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -9,7 +9,6 @@ import type {
   MiddlewareMatcher,
   PageStaticInfo,
 } from './analysis/get-page-static-info'
-import * as Log from './output/log'
 import type { LoadedEnvFiles } from '@next/env'
 import type { AppLoaderOptions } from './webpack/loaders/next-app-loader'
 
@@ -673,19 +672,6 @@ export async function createEntrypoints(
 
       const isInstrumentation =
         isInstrumentationHookFile(page) && pagesType === PAGE_TYPES.ROOT
-
-      let pageRuntime = staticInfo?.runtime
-
-      if (
-        isMiddlewareFile(page) &&
-        !config.experimental.nodeMiddleware &&
-        pageRuntime === 'nodejs'
-      ) {
-        Log.warn(
-          'nodejs runtime support for middleware requires experimental.nodeMiddleware be enabled in your next.config'
-        )
-        pageRuntime = 'edge'
-      }
 
       runDependingOnPageType({
         page,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -319,7 +319,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
       .strictObject({
         adapterPath: z.string().optional(),
         useSkewCookie: z.boolean().optional(),
-        nodeMiddleware: z.boolean().optional(),
         after: z.boolean().optional(),
         appDocumentPreloading: z.boolean().optional(),
         appNavFailHandling: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -319,7 +319,6 @@ export interface LoggingConfig {
 export interface ExperimentalConfig {
   adapterPath?: string
   useSkewCookie?: boolean
-  nodeMiddleware?: boolean
   cacheHandlers?: {
     default?: string
     remote?: string
@@ -1343,7 +1342,6 @@ export const defaultConfig = Object.freeze({
   experimental: {
     adapterPath: process.env.NEXT_ADAPTER_PATH || undefined,
     useSkewCookie: false,
-    nodeMiddleware: false,
     cacheLife: {
       default: {
         stale: undefined, // defaults to staleTimes.static

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -293,8 +293,6 @@ function assignDefaults(
       throw new CanaryOnlyError({
         feature: 'experimental.turbopackPersistentCaching',
       })
-    } else if (result.experimental?.nodeMiddleware) {
-      throw new CanaryOnlyError({ feature: 'experimental.nodeMiddleware' })
     }
   }
 

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -933,17 +933,6 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
 
             let pageRuntime = staticInfo?.runtime
 
-            if (
-              isMiddlewareFile(page) &&
-              !this.config.experimental.nodeMiddleware &&
-              pageRuntime === 'nodejs'
-            ) {
-              Log.warn(
-                'nodejs runtime support for middleware requires experimental.nodeMiddleware be enabled in your next.config'
-              )
-              pageRuntime = 'edge'
-            }
-
             runDependingOnPageType({
               page,
               pageRuntime,

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -829,10 +829,6 @@ export function onDemandEntryHandler({
 
       let pageRuntime = staticInfo.runtime
 
-      if (isMiddlewareFile(page) && !nextConfig.experimental.nodeMiddleware) {
-        pageRuntime = 'edge'
-      }
-
       runDependingOnPageType({
         page: route.page,
         pageRuntime,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1538,10 +1538,6 @@ export default class NextNodeServer extends BaseServer<
 
   private async loadNodeMiddleware() {
     if (!process.env.NEXT_MINIMAL) {
-      if (!this.nextConfig.experimental.nodeMiddleware) {
-        return
-      }
-
       try {
         const functionsConfig = this.renderOpts.dev
           ? {}

--- a/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
+++ b/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
@@ -50,7 +50,6 @@ describe('app-dir action size limit invalid config', () => {
       module.exports = {
         experimental: {
           serverActions: { bodySizeLimit: -3000 },
-          nodeMiddleware: true
         },
       }
       `
@@ -69,7 +68,6 @@ describe('app-dir action size limit invalid config', () => {
       module.exports = {
         experimental: {
           serverActions: { bodySizeLimit: 'testmb' },
-          nodeMiddleware: true
         },
       }
       `
@@ -88,7 +86,6 @@ describe('app-dir action size limit invalid config', () => {
       module.exports = {
         experimental: {
           serverActions: { bodySizeLimit: '-3000mb' },
-          nodeMiddleware: true
         },
       }
       `

--- a/test/e2e/app-dir/actions/next.config.js
+++ b/test/e2e/app-dir/actions/next.config.js
@@ -5,7 +5,6 @@ module.exports = {
     fetches: {},
   },
   experimental: {
-    nodeMiddleware: true,
     serverActions: { bodySizeLimit: '2mb' },
   },
 }

--- a/test/e2e/middleware-custom-matchers/app/next.config.js
+++ b/test/e2e/middleware-custom-matchers/app/next.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-  experimental: {
-    nodeMiddleware: true,
-  },
-}
+module.exports = {}

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -46,7 +46,6 @@ describe('Middleware Runtime', () => {
         nextConfig: {
           experimental: {
             webpackBuildWorker: true,
-            nodeMiddleware: true,
           },
           ...(i18n
             ? {

--- a/test/integration/middleware-src-node/next.config.js
+++ b/test/integration/middleware-src-node/next.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-  experimental: {
-    nodeMiddleware: true,
-  },
-}
+module.exports = {}

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -56,9 +56,6 @@ describe('required server files', () => {
         eslint: {
           ignoreDuringBuilds: true,
         },
-        experimental: {
-          nodeMiddleware: Boolean(process.env.TEST_NODE_MIDDLEWARE),
-        },
         output: 'standalone',
         async rewrites() {
           return {


### PR DESCRIPTION
As mentioned in our last blog post we are going to be stabilizing node middleware now so this removes the experimental flag canary gating the feature. 