### PR TITLE
Add `run-turbopack-compiler` trace span

### DIFF
--- a/packages/next/src/build/turbopack-build/index.ts
+++ b/packages/next/src/build/turbopack-build/index.ts
@@ -51,10 +51,16 @@ async function turbopackBuildWithWorker() {
 export function turbopackBuild(
   withWorker: boolean
 ): ReturnType<typeof import('./impl').turbopackBuild> {
-  if (withWorker) {
-    return turbopackBuildWithWorker()
-  } else {
-    const build = (require('./impl') as typeof import('./impl')).turbopackBuild
-    return build()
-  }
+  const nextBuildSpan = NextBuildContext.nextBuildSpan!
+  return nextBuildSpan
+    .traceChild('run-turbopack-compiler')
+    .traceAsyncFn(async () => {
+      if (withWorker) {
+        return await turbopackBuildWithWorker()
+      } else {
+        const build = (require('./impl') as typeof import('./impl'))
+          .turbopackBuild
+        return await build()
+      }
+    })
 }

--- a/packages/next/src/trace/trace-uploader.ts
+++ b/packages/next/src/trace/trace-uploader.ts
@@ -28,6 +28,7 @@ const DEV_ALLOWED_EVENTS = new Set([
 const BUILD_ALLOWED_EVENTS = new Set([
   ...COMMON_ALLOWED_EVENTS,
   'next-build',
+  'run-turbopack-compiler',
   'webpack-compilation',
   'run-webpack-compiler',
   'create-entrypoints',


### PR DESCRIPTION
Add a span to `.next/trace` for Turbopack just as there is for Webpack

This span is consistently ~400ms longer than the `Compiled successfully in X ms` message though, due to the worker startup. With the worker disabled, it's accurate within 10ms.

<img width="2560" height="349" alt="Bildschirmfoto 2025-07-22 um 11 27 52" src="https://github.com/user-attachments/assets/4c12198c-02dd-4075-97a9-13342976ac41" />

Closes PACK-5106