### PR TITLE
Add `@sentry/node-native` to server-external-packages

### DIFF
--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -14,6 +14,7 @@
   "@prisma/client",
   "@react-pdf/renderer",
   "@sentry/profiling-node",
+  "@sentry/node-native",
   "@sparticuz/chromium",
   "@sparticuz/chromium-min",
   "@swc/core",


### PR DESCRIPTION
Like `@sentry/profiling-node`, the `@sentry/node-native` package contains a native module which cannot be bundled with the default nextjs webpack config.