### PR TITLE
[test] Add dedicated test for error when client functions are called from server components

### DIFF
--- a/test/development/app-dir/source-mapping/app/server-client/client.js
+++ b/test/development/app-dir/source-mapping/app/server-client/client.js
@@ -1,0 +1,5 @@
+'use client'
+
+export function useClient() {
+  return 'client function'
+}

--- a/test/development/app-dir/source-mapping/app/server-client/page.js
+++ b/test/development/app-dir/source-mapping/app/server-client/page.js
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+import { useClient } from './client'
+
+function Component() {
+  useClient()
+
+  return <p>Hello, Dave</p>
+}
+export default function Page() {
+  return (
+    <Suspense>
+      <Component />
+    </Suspense>
+  )
+}


### PR DESCRIPTION
We have a more specific one for `use cache`. This is the counterpart for the default environment.