### PR TITLE
Revert "[metadata] use https protocol for schema urls"

### DIFF
--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts
@@ -87,16 +87,16 @@ describe('resolveRouteData', () => {
           },
         ])
       ).toMatchInlineSnapshot(`
-       "<?xml version="1.0" encoding="UTF-8"?>
-       <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
-       <url>
-       <loc>https://example.com</loc>
-       <lastmod>2021-01-01</lastmod>
-       <changefreq>weekly</changefreq>
-       <priority>0.5</priority>
-       </url>
-       </urlset>
-       "
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <url>
+        <loc>https://example.com</loc>
+        <lastmod>2021-01-01</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.5</priority>
+        </url>
+        </urlset>
+        "
       `)
     })
     it('should resolve sitemap.xml with alternates', () => {
@@ -114,16 +114,16 @@ describe('resolveRouteData', () => {
           },
         ])
       ).toMatchInlineSnapshot(`
-       "<?xml version="1.0" encoding="UTF-8"?>
-       <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="https://www.w3.org/1999/xhtml">
-       <url>
-       <loc>https://example.com</loc>
-       <xhtml:link rel="alternate" hreflang="es" href="https://example.com/es" />
-       <xhtml:link rel="alternate" hreflang="de" href="https://example.com/de" />
-       <lastmod>2021-01-01</lastmod>
-       </url>
-       </urlset>
-       "
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+        <url>
+        <loc>https://example.com</loc>
+        <xhtml:link rel="alternate" hreflang="es" href="https://example.com/es" />
+        <xhtml:link rel="alternate" hreflang="de" href="https://example.com/de" />
+        <lastmod>2021-01-01</lastmod>
+        </url>
+        </urlset>
+        "
       `)
     })
     it('should resolve sitemap.xml with images', () => {
@@ -138,19 +138,19 @@ describe('resolveRouteData', () => {
           },
         ])
       ).toMatchInlineSnapshot(`
-       "<?xml version="1.0" encoding="UTF-8"?>
-       <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="https://www.google.com/schemas/sitemap-image/1.1">
-       <url>
-       <loc>https://example.com</loc>
-       <image:image>
-       <image:loc>https://example.com/image.jpg</image:loc>
-       </image:image>
-       <lastmod>2021-01-01</lastmod>
-       <changefreq>weekly</changefreq>
-       <priority>0.5</priority>
-       </url>
-       </urlset>
-       "
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+        <url>
+        <loc>https://example.com</loc>
+        <image:image>
+        <image:loc>https://example.com/image.jpg</image:loc>
+        </image:image>
+        <lastmod>2021-01-01</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.5</priority>
+        </url>
+        </urlset>
+        "
       `)
     })
     it('should resolve sitemap.xml with videos', () => {
@@ -194,35 +194,35 @@ describe('resolveRouteData', () => {
           },
         ])
       ).toMatchInlineSnapshot(`
-       "<?xml version="1.0" encoding="UTF-8"?>
-       <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">
-       <url>
-       <loc>https://example.com</loc>
-       <video:video>
-       <video:title>example</video:title>
-       <video:thumbnail_loc>https://example.com/image.jpg</video:thumbnail_loc>
-       <video:description>this is the description</video:description>
-       <video:content_loc>http://streamserver.example.com/video123.mp4</video:content_loc>
-       <video:player_loc>https://www.example.com/videoplayer.php?video=123</video:player_loc>
-       <video:duration>2</video:duration>
-       <video:view_count>50</video:view_count>
-       <video:tag>summer</video:tag>
-       <video:rating>4</video:rating>
-       <video:expiration_date>2025-09-16</video:expiration_date>
-       <video:publication_date>2024-09-16</video:publication_date>
-       <video:family_friendly>yes</video:family_friendly>
-       <video:requires_subscription>no</video:requires_subscription>
-       <video:live>no</video:live>
-       <video:restriction relationship="allow">IE GB US CA</video:restriction>
-       <video:platform relationship="allow">web</video:platform>
-       <video:uploader info="https://www.example.com/users/grillymcgrillerson">GrillyMcGrillerson</video:uploader>
-       </video:video>
-       <lastmod>2021-01-01</lastmod>
-       <changefreq>weekly</changefreq>
-       <priority>0.5</priority>
-       </url>
-       </urlset>
-       "
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+        <url>
+        <loc>https://example.com</loc>
+        <video:video>
+        <video:title>example</video:title>
+        <video:thumbnail_loc>https://example.com/image.jpg</video:thumbnail_loc>
+        <video:description>this is the description</video:description>
+        <video:content_loc>http://streamserver.example.com/video123.mp4</video:content_loc>
+        <video:player_loc>https://www.example.com/videoplayer.php?video=123</video:player_loc>
+        <video:duration>2</video:duration>
+        <video:view_count>50</video:view_count>
+        <video:tag>summer</video:tag>
+        <video:rating>4</video:rating>
+        <video:expiration_date>2025-09-16</video:expiration_date>
+        <video:publication_date>2024-09-16</video:publication_date>
+        <video:family_friendly>yes</video:family_friendly>
+        <video:requires_subscription>no</video:requires_subscription>
+        <video:live>no</video:live>
+        <video:restriction relationship="allow">IE GB US CA</video:restriction>
+        <video:platform relationship="allow">web</video:platform>
+        <video:uploader info="https://www.example.com/users/grillymcgrillerson">GrillyMcGrillerson</video:uploader>
+        </video:video>
+        <lastmod>2021-01-01</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.5</priority>
+        </url>
+        </urlset>
+        "
       `)
     })
   })

--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
@@ -52,15 +52,15 @@ export function resolveSitemap(data: MetadataRoute.Sitemap): string {
 
   let content = ''
   content += '<?xml version="1.0" encoding="UTF-8"?>\n'
-  content += '<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"'
+  content += '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
   if (hasImages) {
-    content += ' xmlns:image="https://www.google.com/schemas/sitemap-image/1.1"'
+    content += ' xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"'
   }
   if (hasVideos) {
-    content += ' xmlns:video="https://www.google.com/schemas/sitemap-video/1.1"'
+    content += ' xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"'
   }
   if (hasAlternates) {
-    content += ' xmlns:xhtml="https://www.w3.org/1999/xhtml">\n'
+    content += ' xmlns:xhtml="http://www.w3.org/1999/xhtml">\n'
   } else {
     content += '>\n'
   }

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -52,7 +52,7 @@ describe('app dir - metadata dynamic routes', () => {
 
       expect(text).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?>
-      <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
       <url>
       <loc>https://example.com</loc>
       <lastmod>2021-01-01</lastmod>
@@ -95,7 +95,7 @@ describe('app dir - metadata dynamic routes', () => {
     it('should support alternate.languages in sitemap', async () => {
       const xml = await (await next.fetch('/lang/sitemap.xml')).text()
 
-      expect(xml).toContain('xmlns:xhtml="https://www.w3.org/1999/xhtml')
+      expect(xml).toContain('xmlns:xhtml="http://www.w3.org/1999/xhtml')
       expect(xml).toContain(
         `<xhtml:link rel="alternate" hreflang="es" href="https://example.com/es/about" />`
       )
@@ -119,7 +119,7 @@ describe('app dir - metadata dynamic routes', () => {
       const xml = await (await next.fetch('/sitemap-video/sitemap.xml')).text()
       expect(xml).toMatchInlineSnapshot(`
         "<?xml version="1.0" encoding="UTF-8"?>
-        <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
         <url>
         <loc>https://example.com/about</loc>
         <video:video>

--- a/test/e2e/app-dir/middleware-sitemap/matcher-exclude-sitemap/app/sitemap.ts
+++ b/test/e2e/app-dir/middleware-sitemap/matcher-exclude-sitemap/app/sitemap.ts
@@ -4,7 +4,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
       url: 'https://vercel.com',
-      lastModified: new Date(),
+      lastModified: '2023-10-01',
       changeFrequency: 'yearly',
       priority: 1,
     },

--- a/test/e2e/app-dir/middleware-sitemap/matcher-exclude-sitemap/app/sitemap.ts
+++ b/test/e2e/app-dir/middleware-sitemap/matcher-exclude-sitemap/app/sitemap.ts
@@ -4,7 +4,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
       url: 'https://vercel.com',
-      lastModified: '2023-10-01',
+      lastModified: new Date(),
       changeFrequency: 'yearly',
       priority: 1,
     },

--- a/test/e2e/app-dir/middleware-sitemap/matcher-exclude-sitemap/index.test.ts
+++ b/test/e2e/app-dir/middleware-sitemap/matcher-exclude-sitemap/index.test.ts
@@ -6,14 +6,21 @@ describe('middleware-sitemap', () => {
   })
 
   it('should not be affected by middleware if sitemap.xml is excluded from the matcher', async () => {
-    let html = await next.render('/')
+    const html = await next.render('/')
     expect(html).toContain('redirected')
 
-    html = await next.render('/sitemap.xml')
-    expect(html).not.toContain('redirected')
-    expect(html).toContain('<?xml version="1.0" encoding="UTF-8"?>')
-    expect(html).toContain(
-      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
-    )
+    const xml = await next.render('/sitemap.xml')
+    expect(xml).toMatchInlineSnapshot(`
+     "<?xml version="1.0" encoding="UTF-8"?>
+     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+     <url>
+     <loc>https://vercel.com</loc>
+     <lastmod>2023-10-01</lastmod>
+     <changefreq>yearly</changefreq>
+     <priority>1</priority>
+     </url>
+     </urlset>
+     "
+    `)
   })
 })

--- a/test/e2e/app-dir/middleware-sitemap/matcher-exclude-sitemap/index.test.ts
+++ b/test/e2e/app-dir/middleware-sitemap/matcher-exclude-sitemap/index.test.ts
@@ -9,18 +9,11 @@ describe('middleware-sitemap', () => {
     let html = await next.render('/')
     expect(html).toContain('redirected')
 
-    const xml = await next.render('/sitemap.xml')
-    expect(xml).toMatchInlineSnapshot(`
-     "<?xml version="1.0" encoding="UTF-8"?>
-     <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
-     <url>
-     <loc>https://vercel.com</loc>
-     <lastmod>2023-10-01</lastmod>
-     <changefreq>yearly</changefreq>
-     <priority>1</priority>
-     </url>
-     </urlset>
-     "
-    `)
+    html = await next.render('/sitemap.xml')
+    expect(html).not.toContain('redirected')
+    expect(html).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+    expect(html).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+    )
   })
 })

--- a/test/e2e/app-dir/sitemap-group/sitemap-group.test.ts
+++ b/test/e2e/app-dir/sitemap-group/sitemap-group.test.ts
@@ -12,7 +12,7 @@ describe('sitemap-group', () => {
     const text = await res.text()
     expect(text).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?>
-      <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
       <url>
       <loc>https://www.vercel.com</loc>
       <lastmod>2024-12-05T23:45:13.405Z</lastmod>

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts
@@ -44,7 +44,7 @@ describe('use-cache-metadata-route-handler', () => {
     if (isNextDev) {
       expect(body).toMatchInlineSnapshot(`
        "<?xml version="1.0" encoding="UTF-8"?>
-       <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+       <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
        <url>
        <loc>https://acme.com?sentinel=runtime</loc>
        </url>
@@ -54,7 +54,7 @@ describe('use-cache-metadata-route-handler', () => {
     } else {
       expect(body).toMatchInlineSnapshot(`
        "<?xml version="1.0" encoding="UTF-8"?>
-       <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+       <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
        <url>
        <loc>https://acme.com?sentinel=buildtime</loc>
        </url>
@@ -74,7 +74,7 @@ describe('use-cache-metadata-route-handler', () => {
     if (isNextDev) {
       expect(body).toMatchInlineSnapshot(`
        "<?xml version="1.0" encoding="UTF-8"?>
-       <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+       <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
        <url>
        <loc>https://acme.com/1?sentinel=runtime</loc>
        </url>
@@ -84,7 +84,7 @@ describe('use-cache-metadata-route-handler', () => {
     } else {
       expect(body).toMatchInlineSnapshot(`
        "<?xml version="1.0" encoding="UTF-8"?>
-       <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+       <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
        <url>
        <loc>https://acme.com/1?sentinel=buildtime</loc>
        </url>


### PR DESCRIPTION
Reverts vercel/next.js#80356
x-ref: https://github.com/vercel/next.js/issues/67005#issuecomment-2474289548
Reported that Google Search Console is having issue on handling the https schema which leads to sitemap is not well crawled. Reverting the original change back to before. This will cause the localized sitemap not visualized well in the Chrome again, but it should be fixed on Chrome XML viewer side.

Closes #81644