### PR TITLE
[turbopack] Rename ClientReferenceSet

### DIFF
--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -31,6 +31,8 @@ pub enum ClientReferenceMapType {
     ServerComponent(ResolvedVc<NextServerComponentModule>),
 }
 
+/// Tracks information about all the css and js client references in the graph as well as how server
+/// components depend on them.
 #[turbo_tasks::value]
 pub struct ClientReferencesSet {
     pub client_references: FxHashMap<ResolvedVc<Box<dyn Module>>, ClientReferenceMapType>,

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -68,7 +68,7 @@ pub async fn map_client_references(
     graph: Vc<SingleModuleGraph>,
 ) -> Result<Vc<ClientReferenceManifest>> {
     let graph = graph.await?;
-    let client_references = graph
+    let manifest = graph
         .iter_nodes()
         .map(|node| async move {
             let module = node.module;
@@ -110,12 +110,12 @@ pub async fn map_client_references(
 
     let mut server_components = FxIndexSet::default();
     let mut module_to_server_component_bits = FxHashMap::default();
-    if !client_references.is_empty() {
+    if !manifest.is_empty() {
         graph.traverse_edges_from_entries_fixed_point(
             graph.entry_modules(),
             |parent_info, node| {
                 let module = node.module();
-                let module_type = client_references.get(&module);
+                let module_type = manifest.get(&module);
                 let mut should_visit_children = match module_to_server_component_bits.entry(module)
                 {
                     std::collections::hash_map::Entry::Occupied(_) => false,
@@ -185,7 +185,7 @@ pub async fn map_client_references(
     // Filter down to just the client reference modules to reduce datastructure size
     let server_components_for_client_references = module_to_server_component_bits
         .into_iter()
-        .filter_map(|(k, v)| match client_references.get(&k) {
+        .filter_map(|(k, v)| match manifest.get(&k) {
             Some(
                 ClientManifestEntryType::CssClientReference(_)
                 | ClientManifestEntryType::EcmascriptClientReference { .. },

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -22,7 +22,7 @@ use turbopack_core::{
 #[derive(
     Copy, Clone, Serialize, Deserialize, Eq, PartialEq, TraceRawVcs, ValueDebugFormat, NonLocalValue,
 )]
-pub enum ClientReferenceMapType {
+pub enum ClientManifestEntryType {
     EcmascriptClientReference {
         module: ResolvedVc<EcmascriptClientReferenceModule>,
         ssr_module: ResolvedVc<Box<dyn Module>>,
@@ -34,8 +34,8 @@ pub enum ClientReferenceMapType {
 /// Tracks information about all the css and js client references in the graph as well as how server
 /// components depend on them.
 #[turbo_tasks::value]
-pub struct ClientReferencesSet {
-    pub client_references: FxHashMap<ResolvedVc<Box<dyn Module>>, ClientReferenceMapType>,
+pub struct ClientReferenceManifest {
+    pub manifest: FxHashMap<ResolvedVc<Box<dyn Module>>, ClientManifestEntryType>,
     // All the server components in the graph.
     server_components: FxIndexSet<ResolvedVc<NextServerComponentModule>>,
     // All the server components that depend on each module
@@ -45,7 +45,7 @@ pub struct ClientReferencesSet {
         FxHashMap<ResolvedVc<Box<dyn Module>>, RoaringBitmapWrapper>,
 }
 
-impl ClientReferencesSet {
+impl ClientReferenceManifest {
     /// Returns all the server components that depend on the given client reference
     pub fn server_components_for_client_reference(
         &self,
@@ -66,7 +66,7 @@ impl ClientReferencesSet {
 #[turbo_tasks::function]
 pub async fn map_client_references(
     graph: Vc<SingleModuleGraph>,
-) -> Result<Vc<ClientReferencesSet>> {
+) -> Result<Vc<ClientReferenceManifest>> {
     let graph = graph.await?;
     let client_references = graph
         .iter_nodes()
@@ -78,7 +78,7 @@ pub async fn map_client_references(
             {
                 Ok(Some((
                     module,
-                    ClientReferenceMapType::EcmascriptClientReference {
+                    ClientManifestEntryType::EcmascriptClientReference {
                         module: client_reference_module,
                         ssr_module: ResolvedVc::upcast(client_reference_module.await?.ssr_module),
                     },
@@ -88,7 +88,7 @@ pub async fn map_client_references(
             {
                 Ok(Some((
                     module,
-                    ClientReferenceMapType::CssClientReference(
+                    ClientManifestEntryType::CssClientReference(
                         client_reference_module.await?.client_module,
                     ),
                 )))
@@ -97,7 +97,7 @@ pub async fn map_client_references(
             {
                 Ok(Some((
                     module,
-                    ClientReferenceMapType::ServerComponent(server_component),
+                    ClientManifestEntryType::ServerComponent(server_component),
                 )))
             } else {
                 Ok(None)
@@ -122,7 +122,7 @@ pub async fn map_client_references(
                     std::collections::hash_map::Entry::Vacant(vacant_entry) => {
                         // only do this the first time we visit the node.
                         let bits = vacant_entry.insert(RoaringBitmap::new());
-                        if let Some(ClientReferenceMapType::ServerComponent(
+                        if let Some(ClientManifestEntryType::ServerComponent(
                             server_component_module,
                         )) = module_type
                         {
@@ -161,8 +161,8 @@ pub async fn map_client_references(
 
                 Ok(match module_type {
                     Some(
-                        ClientReferenceMapType::EcmascriptClientReference { .. }
-                        | ClientReferenceMapType::CssClientReference { .. },
+                        ClientManifestEntryType::EcmascriptClientReference { .. }
+                        | ClientManifestEntryType::CssClientReference { .. },
                     ) => {
                         // No need to explore these subgraphs ever, these are the leaves in the
                         // server component graph
@@ -187,15 +187,15 @@ pub async fn map_client_references(
         .into_iter()
         .filter_map(|(k, v)| match client_references.get(&k) {
             Some(
-                ClientReferenceMapType::CssClientReference(_)
-                | ClientReferenceMapType::EcmascriptClientReference { .. },
+                ClientManifestEntryType::CssClientReference(_)
+                | ClientManifestEntryType::EcmascriptClientReference { .. },
             ) => Some((k, RoaringBitmapWrapper(v))),
             _ => None,
         })
         .collect();
 
-    Ok(ClientReferencesSet::cell(ClientReferencesSet {
-        client_references,
+    Ok(ClientReferenceManifest::cell(ClientReferenceManifest {
+        manifest,
         server_components,
         server_components_for_client_references,
     }))

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -27,7 +27,7 @@ use turbopack_core::{
 };
 
 use crate::{
-    client_references::{ClientReferenceMapType, ClientReferencesSet, map_client_references},
+    client_references::{ClientManifestEntryType, ClientReferenceManifest, map_client_references},
     dynamic_imports::{DynamicImportEntries, DynamicImportEntriesMapType, map_next_dynamic},
     server_actions::{AllActions, AllModuleActions, map_server_actions, to_rsc_context},
 };
@@ -243,7 +243,7 @@ pub struct ClientReferencesGraph {
     is_single_page: bool,
     graph: ResolvedVc<SingleModuleGraph>,
     /// List of client references (modules that entries into the client graph)
-    data: ResolvedVc<ClientReferencesSet>,
+    data: ResolvedVc<ClientReferenceManifest>,
 }
 
 #[turbo_tasks::value_impl]
@@ -320,10 +320,10 @@ impl ClientReferencesGraph {
                 &mut FxHashMap::default(),
                 |parent_info, node, state_map| {
                     let module = node.module();
-                    let module_type = data.client_references.get(&module);
+                    let module_type = data.manifest.get(&module);
 
                     let parent_type =
-                        if let Some(ClientReferenceMapType::ServerComponent(_)) = module_type {
+                        if let Some(ClientManifestEntryType::ServerComponent(_)) = module_type {
                             ParentType::ServerComponent
                         } else if let Some((parent_node, _)) = parent_info {
                             *state_map.get(&parent_node.module).unwrap()
@@ -347,27 +347,27 @@ impl ClientReferencesGraph {
 
                     Ok(match module_type {
                         Some(
-                            ClientReferenceMapType::EcmascriptClientReference { .. }
-                            | ClientReferenceMapType::CssClientReference { .. },
+                            ClientManifestEntryType::EcmascriptClientReference { .. }
+                            | ClientManifestEntryType::CssClientReference { .. },
                         ) => GraphTraversalAction::Skip,
                         _ => GraphTraversalAction::Continue,
                     })
                 },
                 |_, node, state_map| {
                     let module = node.module();
-                    let Some(module_type) = data.client_references.get(&module) else {
+                    let Some(module_type) = data.manifest.get(&module) else {
                         return Ok(());
                     };
 
                     let ty = match module_type {
-                        ClientReferenceMapType::EcmascriptClientReference {
+                        ClientManifestEntryType::EcmascriptClientReference {
                             module,
                             ssr_module: _,
                         } => ClientReferenceType::EcmascriptClientReference(*module),
-                        ClientReferenceMapType::CssClientReference(module) => {
+                        ClientManifestEntryType::CssClientReference(module) => {
                             ClientReferenceType::CssClientReference(*module)
                         }
-                        ClientReferenceMapType::ServerComponent(sc) => {
+                        ClientManifestEntryType::ServerComponent(sc) => {
                             server_components.insert(*sc);
                             return Ok(());
                         }

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -315,7 +315,7 @@ impl ClientReferencesGraph {
             // components for each module.
             graph.traverse_edges_from_entries_dfs(
                 entries,
-                // state_map is `module -> ParentType` to tracke whether the module is reachable
+                // state_map is `module -> ParentType` to track whether the module is reachable
                 // directly from an entry point.
                 &mut FxHashMap::default(),
                 |parent_info, node, state_map| {


### PR DESCRIPTION
# Rename ClientReferencesSet to ClientReferenceManifest for better clarity

## What?

Currently the `ClientReferenceSet` struct tracks information that allows us to efficiently create a manifest of css and js files referenced by entry points and server components.

Naming this is tough because we are really just doing half of an algorithm and the structures are dictated by the other half.

Closes PACK-5122