### PR TITLE
fix(Turbopack): Fix duplicated layout rendering in edge cases

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -872,21 +872,53 @@ async fn directory_tree_to_loader_tree(
 ///   set.
 /// * `file_path` - The file path to the default page if neither the current module nor the parent
 ///   module is set.
+/// * `is_first_layer_group_route` - If true, the module will be overridden with the parent module
+///   if it is not set.
 async fn check_and_update_module_references(
     app_dir: FileSystemPath,
     module: &mut Option<FileSystemPath>,
     parent_module: &mut Option<FileSystemPath>,
     file_path: &str,
+    is_first_layer_group_route: bool,
 ) -> Result<()> {
     match (module.as_mut(), parent_module.as_mut()) {
+        // If the module is set, update the parent module to the same value
         (Some(module), _) => *parent_module = Some(module.clone()),
-        (None, Some(parent_module)) => *module = Some(parent_module.clone()),
+        // If we are in a first layer group route and we have a parent module, we want to override
+        // a nonexistent module with the parent module
+        (None, Some(parent_module)) if is_first_layer_group_route => {
+            *module = Some(parent_module.clone())
+        }
+        // If we are not in a first layer group route, and the module is not set, and the parent
+        // module is set, we do nothing
+        (None, Some(_)) => {}
+        // If the module is not set, and the parent module is not set, we override with the default
+        // page. This can only happen in the root directory because after this the parent module
+        // will always be set.
         (None, None) => {
-            let default_page = get_next_package(app_dir.clone()).await?.join(file_path)?;
-
+            let default_page = get_next_package(app_dir).await?.join(file_path)?;
             *module = Some(default_page.clone());
             *parent_module = Some(default_page);
         }
+    }
+
+    Ok(())
+}
+
+/// Checks if the current directory is the root directory and if the module is not set.
+/// If the module is not set, it will be set to the default page.
+///
+/// # Arguments
+/// * `app_dir` - The application directory.
+/// * `module` - The module to check and update if it is not set.
+/// * `file_path` - The file path to the default page if the module is not set.
+async fn check_and_update_global_module_references(
+    app_dir: FileSystemPath,
+    module: &mut Option<FileSystemPath>,
+    file_path: &str,
+) -> Result<()> {
+    if module.is_none() {
+        *module = Some(get_next_package(app_dir).await?.join(file_path)?);
     }
 
     Ok(())
@@ -916,16 +948,19 @@ async fn directory_tree_to_loader_tree_internal(
 
     // the root directory in the app dir.
     let is_root_directory = app_page.is_root();
-    // an alternative root layout (in a route group which affects the page, but not
-    // the path).
-    let is_root_layout = app_path.is_root() && modules.layout.is_some();
 
-    if is_root_directory || is_root_layout {
+    // If the first layer is a group route, we treat it as root layer
+    let is_first_layer_group_route = app_page.is_first_layer_group_route();
+
+    // Handle the non-global modules that should always be overridden for top level groups or set to
+    // the default page if they are not set.
+    if is_root_directory || is_first_layer_group_route {
         check_and_update_module_references(
             app_dir.clone(),
             &mut modules.not_found,
             &mut parent_modules.not_found,
             "dist/client/components/builtin/not-found.js",
+            is_first_layer_group_route,
         )
         .await?;
 
@@ -934,6 +969,7 @@ async fn directory_tree_to_loader_tree_internal(
             &mut modules.forbidden,
             &mut parent_modules.forbidden,
             "dist/client/components/builtin/forbidden.js",
+            is_first_layer_group_route,
         )
         .await?;
 
@@ -942,13 +978,15 @@ async fn directory_tree_to_loader_tree_internal(
             &mut modules.unauthorized,
             &mut parent_modules.unauthorized,
             "dist/client/components/builtin/unauthorized.js",
+            is_first_layer_group_route,
         )
         .await?;
+    }
 
-        check_and_update_module_references(
+    if is_root_directory {
+        check_and_update_global_module_references(
             app_dir.clone(),
             &mut modules.global_error,
-            &mut parent_modules.global_error,
             "dist/client/components/builtin/global-error.js",
         )
         .await?;

--- a/crates/next-core/src/next_app/mod.rs
+++ b/crates/next-core/src/next_app/mod.rs
@@ -293,6 +293,11 @@ impl AppPage {
         )
     }
 
+    /// Returns true if there is only one segment and it is a group.
+    pub fn is_first_layer_group_route(&self) -> bool {
+        self.0.len() == 1 && matches!(self.0.last(), Some(PageSegment::Group(_)))
+    }
+
     pub fn complete(&self, page_type: PageType) -> Result<Self> {
         self.clone_push(PageSegment::PageType(page_type))
     }

--- a/test/e2e/app-dir/duplicate-layout-components/app/(site)/(default)/layout.jsx
+++ b/test/e2e/app-dir/duplicate-layout-components/app/(site)/(default)/layout.jsx
@@ -1,0 +1,12 @@
+import Header from '../../components/Header'
+import Footer from '../../components/Footer'
+
+export default function DefaultLayout({ children }) {
+  return (
+    <>
+      <Header />
+      {children}
+      <Footer />
+    </>
+  )
+}

--- a/test/e2e/app-dir/duplicate-layout-components/app/(site)/(default)/solutions/[notfound.jsx]/page.jsx
+++ b/test/e2e/app-dir/duplicate-layout-components/app/(site)/(default)/solutions/[notfound.jsx]/page.jsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function NotFoundTemp() {
+  notFound()
+}

--- a/test/e2e/app-dir/duplicate-layout-components/app/(site)/(default)/solutions/layout.jsx
+++ b/test/e2e/app-dir/duplicate-layout-components/app/(site)/(default)/solutions/layout.jsx
@@ -1,0 +1,9 @@
+export default function SolutionsLayout({ children }) {
+  return (
+    <>
+      <h1>Solutions Layout</h1>
+      <main>{children}</main>
+      <h1>Solutions Footer Test</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir/duplicate-layout-components/app/(site)/layout.jsx
+++ b/test/e2e/app-dir/duplicate-layout-components/app/(site)/layout.jsx
@@ -1,0 +1,9 @@
+export default function Layout({ children }) {
+  return (
+    <>
+      <h1>Default Layout</h1>
+      {children}
+      <h1>Default Footer Test</h1>
+    </>
+  )
+}

--- a/test/e2e/app-dir/duplicate-layout-components/app/(site)/not-found.jsx
+++ b/test/e2e/app-dir/duplicate-layout-components/app/(site)/not-found.jsx
@@ -1,0 +1,12 @@
+import { NotFoundTemp } from '../components/NotFoundTemp'
+import DefaultLayout from './(default)/layout'
+
+export default function NotFound() {
+  return (
+    <>
+      <DefaultLayout>
+        <NotFoundTemp />
+      </DefaultLayout>
+    </>
+  )
+}

--- a/test/e2e/app-dir/duplicate-layout-components/app/components/Footer.jsx
+++ b/test/e2e/app-dir/duplicate-layout-components/app/components/Footer.jsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer id="footer">
+      <h1>Footer</h1>
+    </footer>
+  )
+}

--- a/test/e2e/app-dir/duplicate-layout-components/app/components/Header.jsx
+++ b/test/e2e/app-dir/duplicate-layout-components/app/components/Header.jsx
@@ -1,0 +1,7 @@
+export default function Header() {
+  return (
+    <header>
+      <h1 id="header">Header</h1>
+    </header>
+  )
+}

--- a/test/e2e/app-dir/duplicate-layout-components/app/components/NotFoundTemp.jsx
+++ b/test/e2e/app-dir/duplicate-layout-components/app/components/NotFoundTemp.jsx
@@ -1,0 +1,3 @@
+export function NotFoundTemp() {
+  return <div>Not Found</div>
+}

--- a/test/e2e/app-dir/duplicate-layout-components/app/layout.jsx
+++ b/test/e2e/app-dir/duplicate-layout-components/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/duplicate-layout-components/app/page.jsx
+++ b/test/e2e/app-dir/duplicate-layout-components/app/page.jsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Home Page</h1>
+      <Link href="/solutions/404" id="to-404">
+        Go to 404
+      </Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/duplicate-layout-components/duplicate-layout-components.test.js
+++ b/test/e2e/app-dir/duplicate-layout-components/duplicate-layout-components.test.js
@@ -1,0 +1,21 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app dir - duplicate layout components', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should not duplicate layout elements when navigating to 404', async () => {
+    const browser = await next.browser('/solutions/404')
+
+    // Verify counts haven't changed - no duplication
+    expect((await browser.elementsByCss('body')).length).toBe(1)
+    expect((await browser.elementsByCss('#header')).length).toBe(1)
+    expect((await browser.elementsByCss('#footer')).length).toBe(1)
+  })
+})

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -2348,6 +2348,15 @@
     "flakey": [],
     "runtimeError": false
   },
+  "test/e2e/app-dir/duplicate-layout-components/duplicate-layout-components.test.js": {
+    "passed": [
+      "app dir - duplicate layout components should not duplicate layout elements when navigating to 404"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
   "test/e2e/app-dir/dynamic-requests/dynamic-requests.test.ts": {
     "passed": [
       "dynamic-requests should not error for dynamic requests in pages",

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -6162,6 +6162,15 @@
     "flakey": [],
     "runtimeError": false
   },
+  "test/e2e/app-dir/duplicate-layout-components/duplicate-layout-components.test.js": {
+    "passed": [
+      "app dir - duplicate layout components should not duplicate layout elements when navigating to 404"
+    ],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
   "test/e2e/app-dir/dynamic-requests/dynamic-requests.test.ts": {
     "passed": [
       "dynamic-requests should not error for dynamic requests in pages",


### PR DESCRIPTION
## Fix module reference handling in app_structure.rs

### What?
Fixed a bug in the `check_and_update_module_references` function by making the code always overrides the `not-found`, `unauthorized`, etc files at the top level group route layer.

### Why?
The previous implementation had a bug that when a directory was setup like the added test case where the layouts from a lower directory would render when only the layouts at the level of the not-found page should have rendered.

### How?
- Added the ability to force overriding of the `module` when running `check_and_update_module_references`

Fixes #PACK-5081