### PR TITLE
CI: add workflow_branch data to deploy test failure message

### DIFF
--- a/.github/workflows/retry_deploy_test.yml
+++ b/.github/workflows/retry_deploy_test.yml
@@ -54,7 +54,8 @@ jobs:
             {
               "commit_title": ${{ toJSON(github.event.workflow_run.display_title) }},
               "commit_url": "github.com/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha }}",
-              "workflow_run_url": "github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/attempts/${{ github.event.workflow_run.run_attempt }}"
+              "workflow_run_url": "github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/attempts/${{ github.event.workflow_run.run_attempt }}",
+              "workflow_branch": ${{ toJSON(github.event.workflow_run.head_branch) }}
             }
         env:
           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
These can be triggered on PRs or release branches, so provides additional metadata about where the failure comes from. 