### PR TITLE
Turbopack: Use workaround for rustc miscompilation bug on macos intel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,8 +2809,7 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+source = "git+https://github.com/bgw/hyper-rs.git?branch=v1.6.0-with-macos-intel-miscompilation-workaround#ab3544930722e6c270c16d3239dbb1d58f713393"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -438,6 +438,7 @@ vergen-gitcl = { version = "1.0.8", features = [
 webbrowser = "0.8.7"
 
 [patch.crates-io]
-mdxjs = { git = "https://github.com/kdy1/mdxjs-rs.git", branch = "swc-core-30" }
+hyper = { git = "https://github.com/bgw/hyper-rs.git", branch = "v1.6.0-with-macos-intel-miscompilation-workaround" }
 lightningcss = { git = "https://github.com/parcel-bundler/lightningcss.git", branch = "mischnic/bump-browserslist" }
+mdxjs = { git = "https://github.com/kdy1/mdxjs-rs.git", branch = "swc-core-30" }
 parcel_selectors = { git = "https://github.com/parcel-bundler/lightningcss.git", branch = "mischnic/bump-browserslist" }


### PR DESCRIPTION
Uses https://github.com/hyperium/hyper/pull/3908 cherry-picked on top of hyper v1.6.0 to work around https://github.com/hyperium/hyper/issues/3902 and https://github.com/rust-lang/rust/issues/140686

- Git Branch: https://github.com/bgw/hyper-rs/commits/v1.6.0-with-macos-intel-miscompilation-workaround/
- Cherry-picked commit: https://github.com/bgw/hyper-rs/commit/ab3544930722e6c270c16d3239dbb1d58f713393

Fixes #81697

The proper fix is to update the rustc toolchain, but since we use nightly toolchains, this is too risky for a minor patch release. So this applies the workaround instead.

## Test Plan

Force using x86-64 under Rosetta by downloading a "standalone" version of nodejs and adding it to the front of the `PATH` with:

```
export PATH=/Users/bgw/Downloads/node-v22.17.1-darwin-x64/bin/:"$PATH"
```

Use `create-next-app` to create a new app. This fetching Geist by default.

Run `pnpm dev`, see the 404 errors.

Modify the `package.json` to use this preview version:

```
    "next": "https://vercel-packages.vercel.app/next/commits/16196a3d2d7df65222727619e8db993336cf7aff/next"
```

Run `pnpm i && pnpm dev`, see that the 404s are solved!

Closes PACK-5117