### PR TITLE
[rspack]: skip code branch for certain webpack api calls

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts
@@ -148,19 +148,21 @@ ${JSON.stringify(ref)},
       }
 
       const compilation = this._compilation!
-      const originalSourceURL = ModuleFilenameHelpers.createFilename(
-        module,
-        {
-          moduleFilenameTemplate:
-            'webpack://[namespace]/[resource-path]/__nextjs-internal-proxy.mjs',
-          namespace: '_N_E',
-        },
-        {
-          requestShortener: compilation.requestShortener,
-          chunkGraph: compilation.chunkGraph,
-          hashFunction: compilation.outputOptions.hashFunction,
-        }
-      )
+      const originalSourceURL = process.env.NEXT_RSPACK
+        ? `webpack://_N_E/${this.resourcePath}/__nextjs-internal-proxy.mjs`
+        : ModuleFilenameHelpers.createFilename(
+            module,
+            {
+              moduleFilenameTemplate:
+                'webpack://[namespace]/[resource-path]/__nextjs-internal-proxy.mjs',
+              namespace: '_N_E',
+            },
+            {
+              requestShortener: compilation.requestShortener,
+              chunkGraph: compilation.chunkGraph,
+              hashFunction: compilation.outputOptions.hashFunction,
+            }
+          )
 
       return this.callback(null, esmSource, {
         version: 3,
@@ -179,19 +181,21 @@ module.exports = createProxy(${stringifiedResourceKey})
 `
 
       const compilation = this._compilation!
-      const originalSourceURL = ModuleFilenameHelpers.createFilename(
-        module,
-        {
-          moduleFilenameTemplate:
-            'webpack://[namespace]/[resource-path]/__nextjs-internal-proxy.cjs',
-          namespace: '_N_E',
-        },
-        {
-          requestShortener: compilation.requestShortener,
-          chunkGraph: compilation.chunkGraph,
-          hashFunction: compilation.outputOptions.hashFunction,
-        }
-      )
+      const originalSourceURL = process.env.NEXT_RSPACK
+        ? `webpack://_N_E/${this.resourcePath}/__nextjs-internal-proxy.cjs`
+        : ModuleFilenameHelpers.createFilename(
+            module,
+            {
+              moduleFilenameTemplate:
+                'webpack://[namespace]/[resource-path]/__nextjs-internal-proxy.cjs',
+              namespace: '_N_E',
+            },
+            {
+              requestShortener: compilation.requestShortener,
+              chunkGraph: compilation.chunkGraph,
+              hashFunction: compilation.outputOptions.hashFunction,
+            }
+          )
 
       return this.callback(null, cjsSource, {
         version: 3,

--- a/packages/next/src/build/webpack/plugins/eval-source-map-dev-tool-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/eval-source-map-dev-tool-plugin.ts
@@ -165,27 +165,40 @@ export default class EvalSourceMapDevToolPlugin {
               const module = compilation.findModule(sourceMapSource)
               return module || sourceMapSource
             })
-            let moduleFilenames = modules.map((module) =>
-              ModuleFilenameHelpers.createFilename(
-                module,
-                {
-                  moduleFilenameTemplate: this.moduleFilenameTemplate,
-                  namespace,
-                },
-                {
-                  requestShortener: runtimeTemplate.requestShortener,
-                  chunkGraph,
-                  hashFunction: compilation.outputOptions.hashFunction!,
+            let moduleFilenames: string[]
+            if (process.env.NEXT_RSPACK) {
+              // rspack doesn't have ModuleFilenameHelpers.createFilename
+              // Use a simplified fallback
+              moduleFilenames = modules.map((module) => {
+                if (typeof module === 'string') {
+                  return module
+                }
+                // For non-string modules, use a basic fallback
+                return 'webpack://[namespace]/[resource]'
+              })
+            } else {
+              moduleFilenames = modules.map((module) =>
+                ModuleFilenameHelpers.createFilename(
+                  module,
+                  {
+                    moduleFilenameTemplate: this.moduleFilenameTemplate,
+                    namespace,
+                  },
+                  {
+                    requestShortener: runtimeTemplate.requestShortener,
+                    chunkGraph,
+                    hashFunction: compilation.outputOptions.hashFunction!,
+                  }
+                )
+              )
+              moduleFilenames = ModuleFilenameHelpers.replaceDuplicates(
+                moduleFilenames,
+                (filename, _i, n) => {
+                  for (let j = 0; j < n; j++) filename += '*'
+                  return filename
                 }
               )
-            )
-            moduleFilenames = ModuleFilenameHelpers.replaceDuplicates(
-              moduleFilenames,
-              (filename, _i, n) => {
-                for (let j = 0; j < n; j++) filename += '*'
-                return filename
-              }
-            )
+            }
             sourceMap.sources = moduleFilenames
             sourceMap.ignoreList = []
             for (let index = 0; index < moduleFilenames.length; index++) {


### PR DESCRIPTION
Workaround the unsupported webpack api on rspack

x-ref: https://github.com/vercel/next.js/actions/runs/16456908717/job/46516063941?pr=80570

```
 × Module build failed:
    ╰─▶   × TypeError: _webpack.ModuleFilenameHelpers.createFilename is not a function
          │     at Object.transformSource (/tmp/next-install-f9e578a6d19ed3001b3e2cff9c1239b7a37afaace9e8ea87bc508ee031dabf69/node_modules/.pnpm/file+..+next-repo-e8dde52e86b7ae700f716fd35e08fb0ab80f4e8e4be353f5c8181a43a8d498a0+packages+n_hehxmcudcebau7hcufqg25aiba/node_modules/next/dist/build/webpack/loaders/next-flight-loader/index.js:164:70)
```

