### PR TITLE
Turbopack: Update to rustc nightly-2025-07-22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,7 +2809,8 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "1.6.0"
-source = "git+https://github.com/bgw/hyper-rs.git?branch=v1.6.0-with-macos-intel-miscompilation-workaround#ab3544930722e6c270c16d3239dbb1d58f713393"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -438,7 +438,6 @@ vergen-gitcl = { version = "1.0.8", features = [
 webbrowser = "0.8.7"
 
 [patch.crates-io]
-hyper = { git = "https://github.com/bgw/hyper-rs.git", branch = "v1.6.0-with-macos-intel-miscompilation-workaround" }
 lightningcss = { git = "https://github.com/parcel-bundler/lightningcss.git", branch = "mischnic/bump-browserslist" }
 mdxjs = { git = "https://github.com/kdy1/mdxjs-rs.git", branch = "swc-core-30" }
 parcel_selectors = { git = "https://github.com/parcel-bundler/lightningcss.git", branch = "mischnic/bump-browserslist" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-06-04"
+channel = "nightly-2025-07-22"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/turbopack/crates/turbopack/src/global_module_ids.rs
+++ b/turbopack/crates/turbopack/src/global_module_ids.rs
@@ -109,7 +109,7 @@ fn finalize_module_ids(
     // Filter conflicts
     let mut conflicting_hashes = used_ids
         .iter()
-        .filter(|(_, list)| (list.len() > 1))
+        .filter(|(_, list)| list.len() > 1)
         .map(|(hash, _)| *hash)
         .collect::<Vec<_>>();
     conflicting_hashes.sort();


### PR DESCRIPTION
- Removes the workaround for a hyper miscompilation bug (#81950)
- Fixes a new lint rule

Closes PACK-5118