### PR TITLE
fix: Include CSP nonce in next/dynamic preload (#81260)

### DIFF
--- a/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
@@ -1,15 +1,20 @@
 'use client'
 
 import { preload } from 'react-dom'
+import { useContext } from 'react'
 
 import { workAsyncStorage } from '../../../server/app-render/work-async-storage.external'
 import { encodeURIPath } from '../encode-uri-path'
+import { HeadManagerContext } from '../head-manager-context.shared-runtime'
 
 export function PreloadChunks({
   moduleIds,
 }: {
   moduleIds: string[] | undefined
 }) {
+  // Get nonce from HeadManagerContext for CSP compliance
+  const { nonce } = useContext(HeadManagerContext)
+
   // Early return in client compilation and only load requestStore on server side
   if (typeof window !== 'undefined') {
     return null
@@ -65,6 +70,7 @@ export function PreloadChunks({
           preload(href, {
             as: 'script',
             fetchPriority: 'low',
+            nonce,
           })
           return null
         }

--- a/test/e2e/app-dir/dynamic-import-csp/app/dynamic-button.tsx
+++ b/test/e2e/app-dir/dynamic-import-csp/app/dynamic-button.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export function DynamicButton() {
+  return <button>Dynamic Button</button>
+}

--- a/test/e2e/app-dir/dynamic-import-csp/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-import-csp/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-import-csp/app/page.tsx
+++ b/test/e2e/app-dir/dynamic-import-csp/app/page.tsx
@@ -1,0 +1,18 @@
+import dynamic from 'next/dynamic'
+
+const DynamicButton = dynamic(
+  () =>
+    import('./dynamic-button').then((mod) => ({ default: mod.DynamicButton })),
+  {
+    loading: () => <p>Loading...</p>,
+  }
+)
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Dynamic Import with CSP Test</h1>
+      <DynamicButton />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/dynamic-import-csp/dynamic-import-csp.test.ts
+++ b/test/e2e/app-dir/dynamic-import-csp/dynamic-import-csp.test.ts
@@ -1,0 +1,47 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('dynamic-import with CSP nonce', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should include nonce in preload link tags for dynamic imports', async () => {
+    const browser = await next.browser('/')
+
+    // Check that the dynamic component renders
+    expect(await browser.elementByCss('button').text()).toBe('Dynamic Button')
+
+    // Check that preload link tags have the nonce attribute
+    const preloadLinks = await browser.elementsByCss(
+      'link[rel="preload"][as="script"]'
+    )
+
+    // There should be at least one preload link for the dynamic import
+    expect(preloadLinks.length).toBeGreaterThan(0)
+
+    // Check that each preload link has the nonce attribute
+    for (const link of preloadLinks) {
+      const nonce = await link.getAttribute('nonce')
+      expect(nonce).toBeTruthy()
+      expect(nonce).toBe('test-nonce-123')
+    }
+  })
+
+  it('should not have CSP violations in browser console', async () => {
+    const browser = await next.browser('/')
+
+    // Wait for the page to fully load
+    await browser.waitForElementByCss('button')
+
+    // Check for CSP violations in the console
+    const logs = await browser.log()
+    const cspViolations = logs.filter(
+      (log) =>
+        log.message.includes('Content Security Policy') ||
+        log.message.includes('CSP') ||
+        log.source === 'security'
+    )
+
+    expect(cspViolations).toEqual([])
+  })
+})

--- a/test/e2e/app-dir/dynamic-import-csp/middleware.ts
+++ b/test/e2e/app-dir/dynamic-import-csp/middleware.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const nonce = 'test-nonce-123'
+  const cspHeader = `
+    default-src 'self';
+    script-src 'self' 'nonce-${nonce}' 'strict-dynamic';
+    style-src 'self' 'nonce-${nonce}';
+    img-src 'self' blob: data:;
+    font-src 'self';
+    object-src 'none';
+    base-uri 'self';
+    form-action 'self';
+    frame-ancestors 'none';
+    upgrade-insecure-requests;
+  `
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('x-nonce', nonce)
+  requestHeaders.set('Content-Security-Policy', cspHeader)
+
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+    headers: {
+      'Content-Security-Policy': cspHeader,
+    },
+  })
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    {
+      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
+}

--- a/test/e2e/app-dir/dynamic-import-csp/next.config.js
+++ b/test/e2e/app-dir/dynamic-import-csp/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
Calling react-dom's `preload` without the CSP's `nonce` causes Chrome to log an error and refuse to preload the script. This commit supplies the required nonce and adds e2e test coverage for this scenario.

**LLM disclosure:** Claude Sonnet 4 did the legwork here, but I've reviewed this code and believe it to be sane.

Fixes #81260