### PR TITLE
Add edge_side_panel support to manifest types

### DIFF
--- a/packages/next/src/lib/metadata/types/manifest-types.ts
+++ b/packages/next/src/lib/metadata/types/manifest-types.ts
@@ -31,6 +31,11 @@ export type Manifest = {
         | 'window-controls-overlay'
       )[]
     | undefined
+  edge_side_panel?:
+    | {
+        preferred_width?: number | undefined
+      }
+    | undefined
   file_handlers?:
     | {
         action: string


### PR DESCRIPTION
  Add support for the `edge_side_panel` field in PWA manifest types to enable Microsoft Edge sidebar functionality.

  - Adds `edge_side_panel` as an optional object in the Manifest type
  - Includes `preferred_width` as an optional number property
  - Follows existing TypeScript patterns and maintains backward compatibility

  ## Why?

  Microsoft Edge now supports PWAs in the sidebar, which requires the `edge_side_panel` manifest member. This field
  allows PWAs to:
  - Be promoted in the Microsoft Edge sidebar store
  - Specify preferred sidebar width
  - Detect when running in the sidebar context

  Reference: [Microsoft Edge PWA Sidebar  Documentation](https://learn.microsoft.com/en-us/microsoft-edge/progressive-web-apps/how-to/sidebar)

  ## How?

  Added the TypeScript type definition following the existing codebase patterns:

  ```typescript
  edge_side_panel?:
    | {
        preferred_width?: number | undefined
      }
    | undefined

  This enables developers to use the field in their Next.js app manifests:

  {
    "edge_side_panel": {
      "preferred_width": 400
    }
  }
