### PR TITLE
[test] workaround test that needs stylus

### DIFF
--- a/test/e2e/app-dir/nx-handling/nx-handling.test.ts
+++ b/test/e2e/app-dir/nx-handling/nx-handling.test.ts
@@ -32,6 +32,10 @@ describe('nx-handling', () => {
         tslib: '^2.3.0',
         typescript: '~5.7.2',
       },
+      overrides: {
+        // Workaround for `stylus` marked as a security vulnerability on npm
+        stylus: '0.0.1-security',
+      },
       workspaces: ['apps/*'],
     },
   })


### PR DESCRIPTION
`stylus` package is removed from npm due to unknown security reason, which leads to the installation failed. Workaround with specifying the security version in tests to get pass on installation but expect it's not being used in runtime

<img width="1267" height="503" alt="image" src="https://github.com/user-attachments/assets/64fd473d-903d-4b02-8715-18d2390b436d" />
