### PR TITLE
chore(examples): use async and await headers in strict-csp

### DIFF
--- a/examples/with-strict-csp/app/page.js
+++ b/examples/with-strict-csp/app/page.js
@@ -1,8 +1,9 @@
 import { headers } from "next/headers";
 import Script from "next/script";
 
-export default function Page() {
-  const nonce = headers().get("x-nonce");
+export default async function Page() {
+  const headersList = await headers();
+  const nonce = headersList.get("x-nonce");
 
   return <Script src="https://..." strategy="afterInteractive" nonce={nonce} />;
 }


### PR DESCRIPTION
## For Maintainers

### What?

Make the page function in strict-csp async to await the headers util

### Why?

Errors in the console expecting headers util to be awaited

### How?

Introduce await and async keywords where needed
