### PR TITLE
[turbopack] Fix the build under `--features=tokio_tracing`

### DIFF
--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -810,7 +810,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
         let description = format!(
             "[local] (parent: {}) {}",
             self.backend.get_task_description(parent_task_id),
-            ty,
+            ty.task_type,
         );
         #[cfg(not(feature = "tokio_tracing"))]
         let _ = parent_task_id; // suppress unused variable warning


### PR DESCRIPTION
## Fix the build under the `tokio_tracing` feature

https://github.com/vercel/next.js/pull/80738 changed the definition of LocalTaskSpec and moved the Display trait impl down to LocalTaskType but updating this use was missed since it is guarded by a feature.


Closes PACK-5224