### PR TITLE
Revert "[test] workaround test that needs stylus"

### DIFF
--- a/test/e2e/app-dir/nx-handling/nx-handling.test.ts
+++ b/test/e2e/app-dir/nx-handling/nx-handling.test.ts
@@ -32,10 +32,6 @@ describe('nx-handling', () => {
         tslib: '^2.3.0',
         typescript: '~5.7.2',
       },
-      overrides: {
-        // Workaround for `stylus` marked as a security vulnerability on npm
-        stylus: '0.0.1-security',
-      },
       workspaces: ['apps/*'],
     },
   })


### PR DESCRIPTION
stylus is back to life

Reverts vercel/next.js#81965