### PR TITLE
Fix: Unresolved param in x-nextjs-rewritten-query

### DIFF
--- a/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.ts
@@ -193,12 +193,18 @@ export function parseDestination(args: {
     hash = unescapeSegments(hash)
   }
 
+  let search = parsed.search
+  if (search) {
+    search = unescapeSegments(search)
+  }
+
   return {
     ...parsed,
     pathname,
     hostname,
     href,
     hash,
+    search,
   }
 }
 
@@ -210,7 +216,11 @@ export function prepareDestination(args: {
 }) {
   const parsedDestination = parseDestination(args)
 
-  const { hostname: destHostname, query: destQuery } = parsedDestination
+  const {
+    hostname: destHostname,
+    query: destQuery,
+    search: destSearch,
+  } = parsedDestination
 
   // The following code assumes that the pathname here includes the hash if it's
   // present.
@@ -311,7 +321,9 @@ export function prepareDestination(args: {
     }
     parsedDestination.pathname = pathname
     parsedDestination.hash = `${hash ? '#' : ''}${hash || ''}`
-    delete (parsedDestination as any).search
+    parsedDestination.search = destSearch
+      ? compileNonPath(destSearch, args.params)
+      : ''
   } catch (err: any) {
     if (err.message.match(/Expected .*? to not repeat, but got an array/)) {
       throw new Error(

--- a/test/e2e/app-dir/rewrite-headers/next.config.js
+++ b/test/e2e/app-dir/rewrite-headers/next.config.js
@@ -18,6 +18,10 @@ module.exports = {
         source: '/hello/(.*)/google',
         destination: 'https://www.google.$1/',
       },
+      {
+        source: '/rewrites-to-query/:name',
+        destination: '/other?key=:name',
+      },
     ]
   },
 }

--- a/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
+++ b/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
@@ -368,6 +368,37 @@ const cases: {
       'x-nextjs-rewritten-query': 'key=value',
     },
   },
+  {
+    name: 'next.config.js rewrites with path-matched query HTML',
+    pathname: '/rewrites-to-query/andrew',
+    expected: {
+      'x-nextjs-rewritten-path': null,
+      'x-nextjs-rewritten-query': null,
+    },
+  },
+  {
+    name: 'next.config.js rewrites with path-matched query RSC',
+    pathname: '/rewrites-to-query/andrew',
+    headers: {
+      RSC: '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': '/other',
+      'x-nextjs-rewritten-query': 'key=andrew',
+    },
+  },
+  {
+    name: 'next.config.js rewrites with path-matched query Prefetch RSC',
+    pathname: '/rewrites-to-query/andrew',
+    headers: {
+      RSC: '1',
+      'Next-Router-Prefetch': '1',
+    },
+    expected: {
+      'x-nextjs-rewritten-path': '/other',
+      'x-nextjs-rewritten-query': 'key=andrew',
+    },
+  },
 ]
 
 describe('rewrite-headers', () => {


### PR DESCRIPTION
Fixes an issue with the x-nextjs-rewritten-query header where it responded without the dynamic parts of the URL filled in.

For example, when rewriting to `/hello?id=123` to `/hello/123`:
- Before: `x-nextjs-rewritten-query: id=__ESC_COLON_id`
- After: `x-nextjs-rewritten-query: id=123`