### PR TITLE
Turbopack: Move fs watcher anyhow::Context import inline to fix compilation warnings

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use notify::{
     Config, EventKind, PollWatcher, RecommendedWatcher, RecursiveMode, Watcher,
     event::{MetadataKind, ModifyKind, RenameMode},
@@ -113,6 +113,8 @@ impl DiskWatcher {
         dir_path: &Path,
         root_path: &Path,
     ) -> Result<()> {
+        use anyhow::Context; // inner import due to conditional compilation
+
         if let Some(watcher) = watcher.as_mut() {
             let mut path = dir_path;
             let err_with_context = |err| {


### PR DESCRIPTION
I broke this in my previous PR

https://github.com/vercel/next.js/pull/81909/files#r2225998847

Closes PACK-5130