### PR TITLE
Track fallback params on workUnitStore

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -755,5 +755,6 @@
   "754": "%s cannot be used outside of a request context.",
   "755": "Route must be a string",
   "756": "Route %s not found",
-  "757": "Unknown styled string type: %s"
+  "757": "Unknown styled string type: %s",
+  "758": "Missing workStore in useDynamicRouteParams"
 }

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -687,9 +687,6 @@ export async function buildAppStaticPaths({
 
   const store = createWorkStore({
     page,
-    // We're discovering the parameters here, so we don't have any unknown
-    // ones.
-    fallbackRouteParams: null,
     renderOpts: {
       incrementalCache,
       cacheLifeProfiles,

--- a/packages/next/src/client/components/navigation-untracked.ts
+++ b/packages/next/src/client/components/navigation-untracked.ts
@@ -7,19 +7,32 @@ import { PathnameContext } from '../../shared/lib/hooks-client-context.shared-ru
  *
  * @returns true if there are any unknown route parameters, false otherwise
  */
-function hasFallbackRouteParams() {
+function hasFallbackRouteParams(): boolean {
   if (typeof window === 'undefined') {
     // AsyncLocalStorage should not be included in the client bundle.
-    const { workAsyncStorage } =
-      require('../../server/app-render/work-async-storage.external') as typeof import('../../server/app-render/work-async-storage.external')
+    const { workUnitAsyncStorage } =
+      require('../../server/app-render/work-unit-async-storage.external') as typeof import('../../server/app-render/work-unit-async-storage.external')
 
-    const workStore = workAsyncStorage.getStore()
-    if (!workStore) return false
+    const workUnitStore = workUnitAsyncStorage.getStore()
+    if (!workUnitStore) return false
 
-    const { fallbackRouteParams } = workStore
-    if (!fallbackRouteParams || fallbackRouteParams.size === 0) return false
+    switch (workUnitStore.type) {
+      case 'prerender':
+      case 'prerender-client':
+      case 'prerender-ppr':
+        const fallbackParams = workUnitStore.fallbackRouteParams
+        return fallbackParams ? fallbackParams.size > 0 : false
+      case 'prerender-legacy':
+      case 'request':
+      case 'cache':
+      case 'private-cache':
+      case 'unstable-cache':
+        break
+      default:
+        workUnitStore satisfies never
+    }
 
-    return true
+    return false
   }
 
   return false

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -752,10 +752,8 @@ async function createComponentTreeInternal(
     let pageElement: React.ReactNode
     if (isClientComponent) {
       if (isStaticGeneration) {
-        const promiseOfParams = createPrerenderParamsForClientSegment(
-          currentParams,
-          workStore
-        )
+        const promiseOfParams =
+          createPrerenderParamsForClientSegment(currentParams)
         const promiseOfSearchParams =
           createPrerenderSearchParamsForClientPage(workStore)
         pageElement = (
@@ -851,10 +849,8 @@ async function createComponentTreeInternal(
       let clientSegment: React.ReactNode
 
       if (isStaticGeneration) {
-        const promiseOfParams = createPrerenderParamsForClientSegment(
-          currentParams,
-          workStore
-        )
+        const promiseOfParams =
+          createPrerenderParamsForClientSegment(currentParams)
 
         clientSegment = (
           <ClientSegmentRoot

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -1,7 +1,6 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 import type { IncrementalCache } from '../lib/incremental-cache'
 import type { FetchMetrics } from '../base-http'
-import type { FallbackRouteParams } from '../request/fallback-params'
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
 import type { AppSegmentConfig } from '../../build/segment-config/app/app-segment-config'
 import type { AfterContext } from '../after/after-context'
@@ -24,12 +23,6 @@ export interface WorkStore {
    * trailing `/page` or `/route` suffix.
    */
   readonly route: string
-
-  /**
-   * The set of unknown route parameters. Accessing these will be tracked as
-   * a dynamic access.
-   */
-  readonly fallbackRouteParams: FallbackRouteParams | null
 
   readonly incrementalCache?: IncrementalCache
   readonly cacheLifeProfiles?: { [profile: string]: CacheLife }

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -5,6 +5,7 @@ import type { ReadonlyHeaders } from '../web/spec-extension/adapters/headers'
 import type { ReadonlyRequestCookies } from '../web/spec-extension/adapters/request-cookies'
 import type { CacheSignal } from './cache-signal'
 import type { DynamicTrackingState } from './dynamic-rendering'
+import type { FallbackRouteParams } from '../request/fallback-params'
 
 // Share the instance module in the next-shared layer
 import { workUnitAsyncStorageInstance } from './work-unit-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
@@ -139,6 +140,12 @@ interface PrerenderStoreModernCommon
   readonly rootParams: Params
 
   /**
+   * The set of unknown route parameters. Accessing these will be tracked as
+   * a dynamic access.
+   */
+  readonly fallbackRouteParams: FallbackRouteParams | null
+
+  /**
    * When true, the page is prerendered as a fallback shell, while allowing any
    * dynamic accesses to result in an empty shell. This is the case when there
    * are also routes prerendered with a more complete set of params.
@@ -178,6 +185,12 @@ export interface PrerenderStorePPR
   readonly type: 'prerender-ppr'
   readonly rootParams: Params
   readonly dynamicTracking: null | DynamicTrackingState
+
+  /**
+   * The set of unknown route parameters. Accessing these will be tracked as
+   * a dynamic access.
+   */
+  readonly fallbackRouteParams: FallbackRouteParams | null
 
   /**
    * The resume data cache for this prerender.

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -3,7 +3,6 @@ import type { IncrementalCache } from '../lib/incremental-cache'
 import type { RenderOpts } from '../app-render/types'
 import type { FetchMetric } from '../base-http'
 import type { RequestLifecycleOpts } from '../base-server'
-import type { FallbackRouteParams } from '../request/fallback-params'
 import type { AppSegmentConfig } from '../../build/segment-config/app/app-segment-config'
 import type { CacheLife } from '../use-cache/cache-life'
 
@@ -19,11 +18,6 @@ export type WorkStoreContext = {
    * The page that is being rendered. This relates to the path to the page file.
    */
   page: string
-
-  /**
-   * The route parameters that are currently unknown.
-   */
-  fallbackRouteParams: FallbackRouteParams | null
 
   requestEndedState?: { ended?: boolean }
   isPrefetchRequest?: boolean
@@ -82,7 +76,6 @@ export type WorkStoreContext = {
 
 export function createWorkStore({
   page,
-  fallbackRouteParams,
   renderOpts,
   requestEndedState,
   isPrefetchRequest,
@@ -115,7 +108,6 @@ export function createWorkStore({
   const store: WorkStore = {
     isStaticGeneration,
     page,
-    fallbackRouteParams,
     route: normalizeAppPath(page),
     incrementalCache:
       // we fallback to a global incremental cache for edge-runtime locally

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -49,25 +49,32 @@ function createPrerenderPathname(
   workStore: WorkStore,
   prerenderStore: PrerenderStore
 ): Promise<string> {
-  const fallbackParams = workStore.fallbackRouteParams
-  if (fallbackParams && fallbackParams.size > 0) {
-    switch (prerenderStore.type) {
-      case 'prerender':
+  switch (prerenderStore.type) {
+    case 'prerender-client':
+      throw new InvariantError(
+        'createPrerenderPathname was called inside a client component scope.'
+      )
+    case 'prerender': {
+      const fallbackParams = prerenderStore.fallbackRouteParams
+      if (fallbackParams && fallbackParams.size > 0) {
         return makeHangingPromise<string>(
           prerenderStore.renderSignal,
           '`pathname`'
         )
-      case 'prerender-client':
-        throw new InvariantError(
-          'createPrerenderPathname was called inside a client component scope.'
-        )
-      case 'prerender-ppr':
-        return makeErroringPathname(workStore, prerenderStore.dynamicTracking)
-      case 'prerender-legacy':
-        return makeErroringPathname(workStore, null)
-      default:
-        prerenderStore satisfies never
+      }
+      break
     }
+    case 'prerender-ppr': {
+      const fallbackParams = prerenderStore.fallbackRouteParams
+      if (fallbackParams && fallbackParams.size > 0) {
+        return makeErroringPathname(workStore, prerenderStore.dynamicTracking)
+      }
+      break
+    }
+    case 'prerender-legacy':
+      break
+    default:
+      prerenderStore satisfies never
   }
 
   // We don't have any fallback params so we have an entirely static safe params object

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -387,6 +387,7 @@ export class AppRouteRouteModule extends RouteModule<
               // This replicates prior behavior where rootParams is empty in routes
               // TODO we need to make this have the proper rootParams for this route
               rootParams: {},
+              fallbackRouteParams: null,
               implicitTags,
               renderSignal: prospectiveController.signal,
               controller: prospectiveController,
@@ -481,6 +482,7 @@ export class AppRouteRouteModule extends RouteModule<
             type: 'prerender',
             phase: 'action',
             rootParams: {},
+            fallbackRouteParams: null,
             implicitTags,
             renderSignal: finalController.signal,
             controller: finalController,
@@ -667,8 +669,6 @@ export class AppRouteRouteModule extends RouteModule<
 
     // Get the context for the static generation.
     const staticGenerationContext: WorkStoreContext = {
-      // App Routes don't support unknown route params.
-      fallbackRouteParams: null,
       page: this.definition.page,
       renderOpts: context.renderOpts,
       buildId: context.sharedContext.buildId,

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -281,7 +281,6 @@ export async function adapter(
 
             const workStore = createWorkStore({
               page,
-              fallbackRouteParams,
               renderOpts: {
                 cacheLifeProfiles:
                   params.request.nextConfig?.experimental?.cacheLife,

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group2)/[rootParam]/(groupA)/page.tsx
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/app/(group2)/[rootParam]/(groupA)/page.tsx
@@ -4,8 +4,10 @@ export function generateStaticParams() {
   return [{ rootParam: 'foo' }, { rootParam: 'bar' }]
 }
 
-export default async function Page({ params }) {
-  const { rootParam } = params
+export default async function Page(props: {
+  params: Promise<{ rootParam: string }>
+}) {
+  const { rootParam } = await props.params
   const otherRootParam = rootParam === 'foo' ? 'bar' : 'foo'
   return (
     <>


### PR DESCRIPTION
fallbackParams are current tracked on the work store but the work store can conceptually be scoped around more than one logical render. A practical example of this is where we want to dynamically render a page in dev with all params but validate a prerender in dev simultaneously with some fallback params. This change only moves the param tracking location in preparation for this future use.