### PR TITLE
Revert "[test] workaround test that needs stylus"

### DIFF
--- a/test/e2e/app-dir/nx-handling/nx-handling.test.ts
+++ b/test/e2e/app-dir/nx-handling/nx-handling.test.ts
@@ -32,10 +32,6 @@ describe('nx-handling', () => {
         tslib: '^2.3.0',
         typescript: '~5.7.2',
       },
-      overrides: {
-        // Workaround for `stylus` marked as a security vulnerability on npm
-        stylus: '0.0.1-security',
-      },
       workspaces: ['apps/*'],
     },
   })


### PR DESCRIPTION
This reverts commit 7c62caba0067c0e64179c8ed8322329838913e32.

The library has been reinstated: https://github.com/stylus/stylus/issues/2938. It was accidentally removed out of precaution.