### PR TITLE
[devtools] Fix "open in editor" for locations in stackframes

### DIFF
--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -370,25 +370,28 @@ export function getOverlayMiddleware({
       let openEditorResult
       if (isAppRelativePath) {
         const relativeFilePath = searchParams.get('file') || ''
-        const absoluteFilePath = path.join(
-          projectPath,
+        const appPath = path.join(
           'app',
           isSrcDir ? 'src' : '',
           relativeFilePath
         )
-        openEditorResult = await openFileInEditor(absoluteFilePath, 1, 1)
+        openEditorResult = await openFileInEditor(appPath, 1, 1, projectPath)
       } else {
         const frame = createStackFrame(searchParams)
         if (!frame) return middlewareResponse.badRequest(res)
         openEditorResult = await openFileInEditor(
           frame.file,
           frame.line ?? 1,
-          frame.column ?? 1
+          frame.column ?? 1,
+          projectPath
         )
       }
 
       if (openEditorResult.error) {
-        return middlewareResponse.internalServerError(res)
+        return middlewareResponse.internalServerError(
+          res,
+          openEditorResult.error
+        )
       }
       if (!openEditorResult.found) {
         return middlewareResponse.notFound(res)

--- a/packages/next/src/server/dev/middleware-webpack.ts
+++ b/packages/next/src/server/dev/middleware-webpack.ts
@@ -600,23 +600,21 @@ export function getOverlayMiddleware(options: {
       const isAppRelativePath = searchParams.get('isAppRelativePath') === '1'
       if (isAppRelativePath) {
         const relativeFilePath = searchParams.get('file') || ''
-        const absoluteFilePath = path.join(
-          rootDirectory,
+        const appPath = path.join(
           'app',
           isSrcDir ? 'src' : '',
           relativeFilePath
         )
-        openEditorResult = await openFileInEditor(absoluteFilePath, 1, 1)
+        openEditorResult = await openFileInEditor(appPath, 1, 1, rootDirectory)
       } else {
+        // TODO: How do we differentiate layers and actual file paths with round brackets?
         // frame files may start with their webpack layer, like (middleware)/middleware.js
-        const filePath = path.resolve(
-          rootDirectory,
-          frame.file.replace(/^\([^)]+\)\//, '')
-        )
+        const filePath = frame.file.replace(/^\([^)]+\)\//, '')
         openEditorResult = await openFileInEditor(
           filePath,
           frame.line1,
-          frame.column1 ?? 1
+          frame.column1 ?? 1,
+          rootDirectory
         )
       }
       if (openEditorResult.error) {


### PR DESCRIPTION
This broke when we started sending relative paths as sourcemapped locations.

Manually tested that `test/e2e/app-dir/server-source-maps/fixtures/default` can open files in stackframes and Route Info for both Webpack and Turbopack.

