### PR TITLE
default to using turbopack in package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prepublishOnly": "turbo run build",
     "lint-staged": "lint-staged",
     "next-with-deps": "./scripts/next-with-deps.sh",
-    "next": "cross-env NEXT_PRIVATE_LOCAL_DEV=1 NEXT_TELEMETRY_DISABLED=1 NODE_OPTIONS=\"--trace-deprecation --enable-source-maps\" next",
+    "next": "cross-env NEXT_PRIVATE_LOCAL_DEV=1 NEXT_TELEMETRY_DISABLED=1 NODE_OPTIONS=\"--trace-deprecation --enable-source-maps\" next --turbopack",
     "next-no-sourcemaps": "echo 'No longer supported. Use `pnpm next --disable-source-maps` instead'; exit 1;",
     "clean-trace-jaeger": "node scripts/rm.mjs test/integration/basic/.next && TRACE_TARGET=JAEGER pnpm next build test/integration/basic",
     "debug": "cross-env NEXT_PRIVATE_LOCAL_DEV=1 NEXT_TELEMETRY_DISABLED=1 node --inspect --trace-deprecation --enable-source-maps packages/next/dist/bin/next",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "prepublishOnly": "turbo run build",
     "lint-staged": "lint-staged",
     "next-with-deps": "./scripts/next-with-deps.sh",
+    "next-turbopack": "pnpm next --turbopack",
     "next": "cross-env NEXT_PRIVATE_LOCAL_DEV=1 NEXT_TELEMETRY_DISABLED=1 NODE_OPTIONS=\"--trace-deprecation --enable-source-maps\" next --turbopack",
     "next-no-sourcemaps": "echo 'No longer supported. Use `pnpm next --disable-source-maps` instead'; exit 1;",
     "clean-trace-jaeger": "node scripts/rm.mjs test/integration/basic/.next && TRACE_TARGET=JAEGER pnpm next build test/integration/basic",

--- a/scripts/next-with-deps.sh
+++ b/scripts/next-with-deps.sh
@@ -36,4 +36,4 @@ if [ ! -z $HAS_CONFLICTING_DEP ] || [ ! -d "$PROJECT_DIR/node_modules" ];then
 fi
 
 cd $START_DIR
-pnpm next $@
+pnpm next $@ --turbopack


### PR DESCRIPTION
When running local apps / reproductions for local development within the monorepo, we run locally (ie `next-with-deps` scripts). We should default to using Turbopack here.