### PR TITLE
[backport] Fix dynamicParams false layout case in dev

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1180,7 +1180,7 @@ export async function handler(
     }
   } catch (err) {
     // if we aren't wrapped by base-server handle here
-    if (!activeSpan) {
+    if (!activeSpan && !(err instanceof NoFallbackError)) {
       await routeModule.onRequestError(
         req,
         err,

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -449,7 +449,7 @@ export async function handler(
     }
   } catch (err) {
     // if we aren't wrapped by base-server handle here
-    if (!activeSpan) {
+    if (!activeSpan && !(err instanceof NoFallbackError)) {
       await routeModule.onRequestError(req, err, {
         routerKind: 'App Router',
         routePath: normalizedSrcPage,

--- a/packages/next/src/build/templates/pages.ts
+++ b/packages/next/src/build/templates/pages.ts
@@ -765,21 +765,22 @@ export async function handler(
       )
     }
   } catch (err) {
-    await routeModule.onRequestError(
-      req,
-      err,
-      {
-        routerKind: 'Pages Router',
-        routePath: srcPage,
-        routeType: 'render',
-        revalidateReason: getRevalidateReason({
-          isRevalidate: hasStaticProps,
-          isOnDemandRevalidate,
-        }),
-      },
-      routerServerContext
-    )
-
+    if (!(err instanceof NoFallbackError)) {
+      await routeModule.onRequestError(
+        req,
+        err,
+        {
+          routerKind: 'Pages Router',
+          routePath: srcPage,
+          routeType: 'render',
+          revalidateReason: getRevalidateReason({
+            isRevalidate: hasStaticProps,
+            isOnDemandRevalidate,
+          }),
+        },
+        routerServerContext
+      )
+    }
     // rethrow so that we can handle serving error page
     throw err
   }

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -874,7 +874,12 @@ export default class DevServer extends Server {
           fallbackMode: fallback,
         }
 
-        if (res.value?.fallbackMode !== undefined) {
+        if (
+          res.value?.fallbackMode !== undefined &&
+          // This matches the hasGenerateStaticParams logic
+          // we do during build
+          (!isAppPath || (staticPaths && staticPaths.length > 0))
+        ) {
           // we write the static paths to partial manifest for
           // fallback handling inside of entry handler's
           const rawExistingManifest = await fs.promises.readFile(

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -40,6 +40,18 @@ describe('app-dir static/dynamic handling', () => {
     }
   })
 
+  if (!process.env.__NEXT_EXPERIMENTAL_PPR) {
+    it('should respond correctly for dynamic route with dynamicParams false in layout', async () => {
+      const res = await next.fetch('/partial-params-false/en/another')
+      expect(res.status).toBe(200)
+    })
+
+    it('should respond correctly for partially dynamic route with dynamicParams false in layout', async () => {
+      const res = await next.fetch('/partial-params-false/en/static')
+      expect(res.status).toBe(200)
+    })
+  }
+
   it('should use auto no cache when no fetch config', async () => {
     const res = await next.fetch('/no-config-fetch')
     expect(res.status).toBe(200)
@@ -877,6 +889,10 @@ describe('app-dir static/dynamic handling', () => {
          "partial-gen-params-no-additional-slug/fr/first.rsc",
          "partial-gen-params-no-additional-slug/fr/second.html",
          "partial-gen-params-no-additional-slug/fr/second.rsc",
+         "partial-params-false/en/static.html",
+         "partial-params-false/en/static.rsc",
+         "partial-params-false/fr/static.html",
+         "partial-params-false/fr/static.rsc",
          "prerendered-not-found/first.html",
          "prerendered-not-found/first.rsc",
          "prerendered-not-found/second.html",
@@ -1822,6 +1838,54 @@ describe('app-dir static/dynamic handling', () => {
            "initialRevalidateSeconds": false,
            "srcRoute": "/partial-gen-params-no-additional-slug/[lang]/[slug]",
          },
+         "/partial-params-false/en/static": {
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token",
+           ],
+           "dataRoute": "/partial-params-false/en/static.rsc",
+           "experimentalBypassFor": [
+             {
+               "key": "Next-Action",
+               "type": "header",
+             },
+             {
+               "key": "content-type",
+               "type": "header",
+               "value": "multipart/form-data;.*",
+             },
+           ],
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/partial-params-false/[locale]/static",
+         },
+         "/partial-params-false/fr/static": {
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token",
+           ],
+           "dataRoute": "/partial-params-false/fr/static.rsc",
+           "experimentalBypassFor": [
+             {
+               "key": "Next-Action",
+               "type": "header",
+             },
+             {
+               "key": "content-type",
+               "type": "header",
+               "value": "multipart/form-data;.*",
+             },
+           ],
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/partial-params-false/[locale]/static",
+         },
          "/prerendered-not-found/first": {
            "allowHeader": [
              "host",
@@ -2579,6 +2643,31 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "fallback": false,
            "routeRegex": "^\\/partial\\-gen\\-params\\-no\\-additional\\-slug\\/([^\\/]+?)\\/([^\\/]+?)(?:\\/)?$",
+         },
+         "/partial-params-false/[locale]/static": {
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token",
+           ],
+           "dataRoute": "/partial-params-false/[locale]/static.rsc",
+           "dataRouteRegex": "^\\/partial\\-params\\-false\\/([^\\/]+?)\\/static\\.rsc$",
+           "experimentalBypassFor": [
+             {
+               "key": "Next-Action",
+               "type": "header",
+             },
+             {
+               "key": "content-type",
+               "type": "header",
+               "value": "multipart/form-data;.*",
+             },
+           ],
+           "fallback": false,
+           "routeRegex": "^\\/partial\\-params\\-false\\/([^\\/]+?)\\/static(?:\\/)?$",
          },
          "/prerendered-not-found/[slug]": {
            "allowHeader": [

--- a/test/e2e/app-dir/app-static/app/partial-params-false/[locale]/[slug]/page.js
+++ b/test/e2e/app-dir/app-static/app/partial-params-false/[locale]/[slug]/page.js
@@ -1,0 +1,10 @@
+export default async function Page({ params }) {
+  const { locale, slug } = await params
+
+  return (
+    <>
+      <p>/[locale]/[slug]/page</p>
+      <p>params: {JSON.stringify({ locale, slug })}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/partial-params-false/[locale]/layout.js
+++ b/test/e2e/app-dir/app-static/app/partial-params-false/[locale]/layout.js
@@ -1,0 +1,16 @@
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return [
+    {
+      locale: 'en',
+    },
+    {
+      locale: 'fr',
+    },
+  ]
+}
+
+export default function Layout({ children }) {
+  return <>{children}</>
+}

--- a/test/e2e/app-dir/app-static/app/partial-params-false/[locale]/static/page.js
+++ b/test/e2e/app-dir/app-static/app/partial-params-false/[locale]/static/page.js
@@ -1,0 +1,9 @@
+export default async function Page({ params }) {
+  const { locale } = await params
+  return (
+    <>
+      <p>/[locale]/static</p>
+      <p>locale: {locale}</p>
+    </>
+  )
+}


### PR DESCRIPTION
This ensures we don't consider a path as ISR in development when it will
be dynamic during a build due to no `generateStaticParams` being fully
generated for a path.

backports #81990