### PR TITLE
use FetchStrategy to control prefetching behavior everywhere

### DIFF
--- a/packages/next/src/client/app-dir/form.tsx
+++ b/packages/next/src/client/app-dir/form.tsx
@@ -7,7 +7,6 @@ import {
   AppRouterContext,
   type AppRouterInstance,
 } from '../../shared/lib/app-router-context.shared-runtime'
-import { PrefetchKind } from '../components/router-reducer/router-reducer-types'
 import {
   checkFormActionUrl,
   createFormSubmitDestinationUrl,
@@ -20,6 +19,7 @@ import {
   mountFormInstance,
   unmountPrefetchableInstance,
 } from '../components/links'
+import { FetchStrategy } from '../components/segment-cache'
 
 export type { FormProps }
 
@@ -99,7 +99,13 @@ export default function Form({
   const observeFormVisibilityOnMount = useCallback(
     (element: HTMLFormElement) => {
       if (isPrefetchEnabled && router !== null) {
-        mountFormInstance(element, actionProp, router, PrefetchKind.AUTO)
+        mountFormInstance(
+          element,
+          actionProp,
+          router,
+          // We default to PPR. We'll discover whether or not the route supports it with the initial prefetch.
+          FetchStrategy.PPR
+        )
       }
       return () => {
         unmountPrefetchableInstance(element)

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -4,7 +4,6 @@ import React, { createContext, useContext, useOptimistic, useRef } from 'react'
 import type { UrlObject } from 'url'
 import { formatUrl } from '../../shared/lib/router/utils/format-url'
 import { AppRouterContext } from '../../shared/lib/app-router-context.shared-runtime'
-import { PrefetchKind } from '../components/router-reducer/router-reducer-types'
 import { useMergedRef } from '../use-merged-ref'
 import { isAbsoluteUrl } from '../../shared/lib/utils'
 import { addBasePath } from '../add-base-path'
@@ -21,6 +20,7 @@ import {
 import { isLocalURL } from '../../shared/lib/router/utils/is-local-url'
 import { dispatchNavigateAction } from '../components/app-router-instance'
 import { errorOnce } from '../../shared/lib/utils/error-once'
+import { FetchStrategy } from '../components/segment-cache'
 
 type Url = string | UrlObject
 type RequiredKeys<T> = {
@@ -363,10 +363,11 @@ export default function LinkComponent(
    * - false: we will not prefetch if in the viewport at all
    * - 'unstable_dynamicOnHover': this starts in "auto" mode, but switches to "full" when the link is hovered
    */
-  const appPrefetchKind =
+  const fetchStrategy =
     prefetchProp === null || prefetchProp === 'auto'
-      ? PrefetchKind.AUTO
-      : PrefetchKind.FULL
+      ? // We default to PPR. We'll discover whether or not the route supports it with the initial prefetch.
+        FetchStrategy.PPR
+      : FetchStrategy.Full
 
   if (process.env.NODE_ENV !== 'production') {
     function createPropError(args: {
@@ -581,7 +582,7 @@ export default function LinkComponent(
           element,
           href,
           router,
-          appPrefetchKind,
+          fetchStrategy,
           prefetchEnabled,
           setOptimisticLinkStatus
         )
@@ -595,7 +596,7 @@ export default function LinkComponent(
         unmountPrefetchableInstance(element)
       }
     },
-    [prefetchEnabled, href, router, appPrefetchKind, setOptimisticLinkStatus]
+    [prefetchEnabled, href, router, fetchStrategy, setOptimisticLinkStatus]
   )
 
   const mergedRef = useMergedRef(observeLinkVisibilityOnMount, childRef)

--- a/packages/next/src/client/components/links.ts
+++ b/packages/next/src/client/components/links.ts
@@ -2,8 +2,11 @@ import type { FlightRouterState } from '../../server/app-render/types'
 import type { AppRouterInstance } from '../../shared/lib/app-router-context.shared-runtime'
 import { getCurrentAppRouterState } from './app-router-instance'
 import { createPrefetchURL } from './app-router'
-import { PrefetchKind } from './router-reducer/router-reducer-types'
-import { isPrefetchTaskDirty } from './segment-cache'
+import {
+  FetchStrategy,
+  isPrefetchTaskDirty,
+  type PrefetchTaskFetchStrategy,
+} from './segment-cache'
 import { createCacheKey } from './segment-cache'
 import {
   type PrefetchTask,
@@ -13,6 +16,7 @@ import {
   reschedulePrefetchTask,
 } from './segment-cache'
 import { startTransition } from 'react'
+import { PrefetchKind } from './router-reducer/router-reducer-types'
 
 type LinkElement = HTMLAnchorElement | SVGAElement
 
@@ -22,7 +26,7 @@ type Element = LinkElement | HTMLFormElement
 // shape for both to prevent a polymorphic de-opt in the VM.
 type LinkOrFormInstanceShared = {
   router: AppRouterInstance
-  kind: PrefetchKind.AUTO | PrefetchKind.FULL
+  fetchStrategy: PrefetchTaskFetchStrategy
 
   isVisible: boolean
 
@@ -140,7 +144,7 @@ export function mountLinkInstance(
   element: LinkElement,
   href: string,
   router: AppRouterInstance,
-  kind: PrefetchKind.AUTO | PrefetchKind.FULL,
+  fetchStrategy: PrefetchTaskFetchStrategy,
   prefetchEnabled: boolean,
   setOptimisticLinkStatus: (status: { pending: boolean }) => void
 ): LinkInstance {
@@ -149,7 +153,7 @@ export function mountLinkInstance(
     if (prefetchURL !== null) {
       const instance: PrefetchableLinkInstance = {
         router,
-        kind,
+        fetchStrategy,
         isVisible: false,
         prefetchTask: null,
         prefetchHref: prefetchURL.href,
@@ -165,7 +169,7 @@ export function mountLinkInstance(
   // track its optimistic state (i.e. useLinkStatus).
   const instance: NonPrefetchableLinkInstance = {
     router,
-    kind,
+    fetchStrategy,
     isVisible: false,
     prefetchTask: null,
     prefetchHref: null,
@@ -178,7 +182,7 @@ export function mountFormInstance(
   element: HTMLFormElement,
   href: string,
   router: AppRouterInstance,
-  kind: PrefetchKind.AUTO | PrefetchKind.FULL
+  fetchStrategy: PrefetchTaskFetchStrategy
 ): void {
   const prefetchURL = coercePrefetchableUrl(href)
   if (prefetchURL === null) {
@@ -190,7 +194,7 @@ export function mountFormInstance(
   }
   const instance: FormInstance = {
     router,
-    kind,
+    fetchStrategy,
     isVisible: false,
     prefetchTask: null,
     prefetchHref: prefetchURL.href,
@@ -261,7 +265,7 @@ export function onNavigationIntent(
       unstable_upgradeToDynamicPrefetch
     ) {
       // Switch to a full, dynamic prefetch
-      instance.kind = PrefetchKind.FULL
+      instance.fetchStrategy = FetchStrategy.Full
     }
     rescheduleLinkPrefetch(instance, PrefetchPriority.Intent)
   }
@@ -303,7 +307,7 @@ function rescheduleLinkPrefetch(
       instance.prefetchTask = scheduleSegmentPrefetchTask(
         cacheKey,
         treeAtTimeOfPrefetch,
-        instance.kind === PrefetchKind.FULL,
+        instance.fetchStrategy,
         priority,
         null
       )
@@ -313,7 +317,7 @@ function rescheduleLinkPrefetch(
       reschedulePrefetchTask(
         existingPrefetchTask,
         treeAtTimeOfPrefetch,
-        instance.kind === PrefetchKind.FULL,
+        instance.fetchStrategy,
         priority
       )
     }
@@ -347,7 +351,7 @@ export function pingVisibleLinks(
     instance.prefetchTask = scheduleSegmentPrefetchTask(
       cacheKey,
       tree,
-      instance.kind === PrefetchKind.FULL,
+      instance.fetchStrategy,
       PrefetchPriority.Default,
       null
     )
@@ -363,8 +367,26 @@ function prefetchWithOldCacheImplementation(instance: PrefetchableInstance) {
   const doPrefetch = async () => {
     // note that `appRouter.prefetch()` is currently sync,
     // so we have to wrap this call in an async function to be able to catch() errors below.
+
+    let prefetchKind: PrefetchKind
+    switch (instance.fetchStrategy) {
+      case FetchStrategy.PPR: {
+        prefetchKind = PrefetchKind.AUTO
+        break
+      }
+      case FetchStrategy.Full: {
+        prefetchKind = PrefetchKind.FULL
+        break
+      }
+      default: {
+        instance.fetchStrategy satisfies never
+        // Unreachable, but otherwise typescript will consider the variable unassigned
+        prefetchKind = undefined!
+      }
+    }
+
     return instance.router.prefetch(instance.prefetchHref, {
-      kind: instance.kind,
+      kind: prefetchKind,
     })
   }
 

--- a/packages/next/src/client/components/segment-cache-impl/cache.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache.ts
@@ -63,6 +63,7 @@ import {
   DOC_PREFETCH_RANGE_HEADER_VALUE,
   doesExportedHtmlMatchBuildId,
 } from '../../../shared/lib/segment-cache/output-export-prefetch-encoding'
+import { FetchStrategy } from '../segment-cache'
 
 // A note on async/await when working in the prefetch cache:
 //
@@ -164,12 +165,6 @@ export type RouteCacheEntry =
   | PendingRouteCacheEntry
   | FulfilledRouteCacheEntry
   | RejectedRouteCacheEntry
-
-export const enum FetchStrategy {
-  PPR,
-  Full,
-  LoadingBoundary,
-}
 
 type SegmentCacheEntryShared = {
   staleAt: number
@@ -415,7 +410,8 @@ export function getSegmentKeypathForTask(
   // If we're fetching using PPR, we do not need to include the search params in
   // the cache key, because the search params are treated as dynamic data. The
   // cache entry is valid for all possible search param values.
-  const isDynamicTask = task.includeDynamicData || !route.isPPREnabled
+  const isDynamicTask =
+    task.fetchStrategy === FetchStrategy.Full || !route.isPPREnabled
   return isDynamicTask && path.endsWith('/' + PAGE_SEGMENT_KEY)
     ? [path, route.renderedSearch]
     : [path]

--- a/packages/next/src/client/components/segment-cache-impl/prefetch.ts
+++ b/packages/next/src/client/components/segment-cache-impl/prefetch.ts
@@ -2,7 +2,10 @@ import type { FlightRouterState } from '../../../server/app-render/types'
 import { createPrefetchURL } from '../app-router'
 import { createCacheKey } from './cache-key'
 import { schedulePrefetchTask } from './scheduler'
-import { PrefetchPriority } from '../segment-cache'
+import {
+  PrefetchPriority,
+  type PrefetchTaskFetchStrategy,
+} from '../segment-cache'
 
 /**
  * Entrypoint for prefetching a URL into the Segment Cache.
@@ -12,8 +15,8 @@ import { PrefetchPriority } from '../segment-cache'
  * Roughly corresponds to the current URL.
  * @param treeAtTimeOfPrefetch - The FlightRouterState at the time the prefetch
  * was requested. This is only used when PPR is disabled.
- * @param includeDynamicData - Whether to prefetch dynamic data, in addition to
- * static data. This is used by <Link prefetch={true}>.
+ * @param fetchStrategy - Whether to prefetch dynamic data, in addition to
+ * static data. This is used by `<Link prefetch={true}>`.
  * @param onInvalidate - A callback that will be called when the prefetch cache
  * When called, it signals to the listener that the data associated with the
  * prefetch may have been invalidated from the cache. This is not a live
@@ -28,7 +31,7 @@ export function prefetch(
   href: string,
   nextUrl: string | null,
   treeAtTimeOfPrefetch: FlightRouterState,
-  includeDynamicData: boolean,
+  fetchStrategy: PrefetchTaskFetchStrategy,
   onInvalidate: null | (() => void)
 ) {
   const url = createPrefetchURL(href)
@@ -40,7 +43,7 @@ export function prefetch(
   schedulePrefetchTask(
     cacheKey,
     treeAtTimeOfPrefetch,
-    includeDynamicData,
+    fetchStrategy,
     PrefetchPriority.Default,
     onInvalidate
   )

--- a/packages/next/src/client/components/segment-cache.ts
+++ b/packages/next/src/client/components/segment-cache.ts
@@ -140,3 +140,17 @@ export const enum PrefetchPriority {
    */
   Background = 0,
 }
+
+export const enum FetchStrategy {
+  PPR,
+  Full,
+  LoadingBoundary,
+}
+
+/**
+ * A subset of fetch strategies used for prefetch tasks.
+ * A prefetch task can't know if it should use `PPR` or `LoadingBoundary`
+ * until we complete the initial tree prefetch request, so we use `PPR` to signal both cases
+ * and adjust it based on the route when actually fetching.
+ * */
+export type PrefetchTaskFetchStrategy = FetchStrategy.PPR | FetchStrategy.Full


### PR DESCRIPTION
Replaces `includeDynamicData` and `PrefetchKind` with `FetchStrategy` wherever possible. We convert it from into a `PrefetchKind` in `router.prefetch()`, and back into a `PrefetchKind` when using the old prefetching implementation.

