### PR TITLE
Optimize segment data routes

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -756,5 +756,6 @@
   "755": "Route must be a string",
   "756": "Route %s not found",
   "757": "Unknown styled string type: %s",
-  "758": "Missing workStore in useDynamicRouteParams"
+  "758": "Missing workStore in useDynamicRouteParams",
+  "759": "Invariant: missing __PAGE__ segmentPath"
 }

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -216,8 +216,12 @@ export async function exportAppPage(
     )
 
     return {
-      // Only include the metadata if the environment has next support.
-      metadata: hasNextSupport ? meta : undefined,
+      // Filter the metadata if the environment does not have next support.
+      metadata: hasNextSupport
+        ? meta
+        : {
+            segmentPaths: meta.segmentPaths,
+          },
       hasEmptyStaticShell: Boolean(postponed) && html === '',
       hasPostponed: Boolean(postponed),
       cacheControl,

--- a/test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts
+++ b/test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts
@@ -61,21 +61,11 @@ describe('conflicting routes', () => {
   it('handles conflict between App Router and Pages Router routes', async () => {
     const res = await segmentPrefetch('/new/templates', '/_tree')
 
-    // Should match the route defined at pages/new/templates/[[...slug]].js,
-    // not the one at app/new/[teamSlug]/page.tsx
-    if (isNextDeploy) {
-      // In a deployed environment the builder routes this to the .prefetch.rsc
-      // route, which doesn't exist, so it returns a 404.
-      // TODO: It'd probably be more correct if it didn't re-route to
-      // .prefetch.rsc and just routed to the normal Pages route. This would
-      // match the behavior in server mode. This only happens when the
-      // prefetch header is present, though, so the only observable effect right
-      // now is that it shows up as a 404 in the network panel. Either way, the
-      // page can't be prefetched by App Router because it's a Pages route.
-      expect(res.status).toBe(404)
-    } else {
-      expect(res.status).toBe(200)
-      expect(await res.text()).toContain('/new/templates/[[...slug]].js')
-    }
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain(
+      // when deployed we map to an empty object to signal to
+      // client router it should MPA navigate
+      isNextDeploy ? '{}' : '/new/templates/[[...slug]].js'
+    )
   })
 })

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts
@@ -3,7 +3,7 @@ import { createRouterAct } from '../router-act'
 import { Page } from 'playwright'
 
 describe('segment cache (incremental opt in)', () => {
-  const { next, isNextDeploy, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
   })
   if (isNextDev) {
@@ -102,11 +102,8 @@ describe('segment cache (incremental opt in)', () => {
 
   describe('multiple prefetches to same link are deduped', () => {
     it('page with PPR enabled', () => testPrefetchDeduping('/ppr-enabled'))
-    // FIXME: When deployed, the _tree prefetch request returns an empty 204.
-    ;(isNextDeploy ? it.failing : it)(
-      'page with PPR enabled, and has a dynamic param',
-      () => testPrefetchDeduping('/ppr-enabled/dynamic-param')
-    )
+    it('page with PPR enabled, and has a dynamic param', () =>
+      testPrefetchDeduping('/ppr-enabled/dynamic-param'))
     it('page with PPR disabled', () => testPrefetchDeduping('/ppr-disabled'))
     it('page with PPR disabled, and has a loading boundary', () =>
       testPrefetchDeduping('/ppr-disabled-with-loading-boundary'))


### PR DESCRIPTION
This tweaks the segment data routes we create for dynamic routes to be derived from the `__PAGE__` segment route as we can create one route to handle the 3 segment outputs for a dynamic route. 

This also removes the segment data routes for static routes as they are not needed and be routed to without an explicit regex route per entry.  