### PR TITLE
Turbopack: move block offsets from header to footer

### DIFF
--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -61,10 +61,10 @@ The SST file contains only data without any header.
 - serialized key Compression Dictionary
 - serialized value Compression Dictionary
 - foreach block
-  - 4 bytes end of block offset relative to start of all blocks
-- foreach block
   - 4 bytes uncompressed block length
   - compressed data
+- foreach block
+  - 4 bytes end of block offset relative to start of all blocks
 
 #### Index Block
 


### PR DESCRIPTION
### What?

move block offset map to the end of the file to enable streaming write of the SST file.

Closes PACK-5171