### PR TITLE
Adjusted the warning message to be more descriptive

### DIFF
--- a/packages/next/src/lib/find-root.ts
+++ b/packages/next/src/lib/find-root.ts
@@ -35,11 +35,19 @@ export function findRootDir(cwd: string) {
 
   // Only warn if not in a build worker to avoid duplicate warnings
   if (typeof process.send !== 'function' && lockFiles.length > 1) {
+    const additionalLockFiles = lockFiles
+      .slice(0, -1)
+      .map((str) => '\n   * ' + str)
+      .join('')
+
     Log.warnOnce(
-      `Warning: Found multiple lockfiles. Selecting ${lockFiles[lockFiles.length - 1]}.\n   Consider removing the lockfiles at:${lockFiles
-        .slice(0, -1)
-        .map((str) => '\n   * ' + str)
-        .join('')}\n`
+      `Warning: Next.js inferred your workspace root, but it may not be correct.\n` +
+        `We detected multiple lockfiles and selected ${lockFiles[lockFiles.length - 1]} as the root directory.\n` +
+        `To silence this warning, set turbopack.root in your Next.js config, or consider ` +
+        `removing one of the lockfiles if it's not needed.\n` +
+        `  See https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#root-directory for more information.\n` +
+        `Detected lockfiles:\n` +
+        `${additionalLockFiles}`
     )
   }
 


### PR DESCRIPTION
## Improve warning message for multiple lockfiles detection

### What?
Enhances the warning message when multiple lockfiles are detected to provide clearer guidance to users.

### Why?
The previous warning message was less informative and didn't provide clear instructions on how to resolve the issue. The improved message explicitly mentions:
- That Next.js is inferring the workspace root
- How to silence the warning by setting `turbopack.root` in the Next.js config
- A link to documentation for more information

### How?
Updated the warning text to be more descriptive and helpful, including a link to the relevant documentation.

<img width="1433" height="306" alt="image" src="https://github.com/user-attachments/assets/f92b3dd3-061c-45d0-8135-03b625079256" />


Addresses #81864