### PR TITLE
Fix API stripping JSON incorrectly

### DIFF
--- a/packages/next/src/shared/lib/page-path/normalize-data-path.ts
+++ b/packages/next/src/shared/lib/page-path/normalize-data-path.ts
@@ -1,7 +1,12 @@
+import { pathHasPrefix } from '../router/utils/path-has-prefix'
+
 /**
  * strip _next/data/<build-id>/ prefix and .json suffix
  */
 export function normalizeDataPath(pathname: string) {
+  if (!pathHasPrefix(pathname || '/', '/_next/data')) {
+    return pathname
+  }
   pathname = pathname
     .replace(/\/_next\/data\/[^/]{1,}/, '')
     .replace(/\.json$/, '')

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -25,6 +25,12 @@ let mode
 let app
 
 function runTests(dev = false) {
+  it('should not strip .json from API route', async () => {
+    const res = await fetchViaHTTP(appPort, '/api/hello.json')
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ post: 'hello.json' })
+  })
+
   it('should handle proxying to self correctly', async () => {
     const res1 = await fetchViaHTTP(appPort, '/api/proxy-self')
     expect(res1.status).toBe(200)


### PR DESCRIPTION
This ensures we don't normalize unless it's actually a `_next/data` request. 

Fixes: https://github.com/vercel/next.js/issues/81936