### PR TITLE
[turbopack] Documentation fixes for rcstr! and a tiny improvement to `hash`

### DIFF
--- a/turbopack/crates/turbo-rcstr/src/dynamic.rs
+++ b/turbopack/crates/turbo-rcstr/src/dynamic.rs
@@ -93,7 +93,7 @@ pub(crate) fn new_static_atom(string: &'static PrehashedString) -> RcStr {
     // Tag it as a static pointer
     entry = ((entry as usize) | STATIC_TAG as usize) as *mut PrehashedString;
     let ptr: NonNull<PrehashedString> = unsafe {
-        // Safety: Box::into_raw returns a non-null pointer
+        // Safety: references always return a non-null pointers
         NonNull::new_unchecked(entry as *mut _)
     };
 

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -340,10 +340,10 @@ impl Hash for RcStr {
             PREHASHED_STRING_LOCATION => {
                 let l = unsafe { deref_from(self.unsafe_data) };
                 state.write_u64(l.hash);
-                state.write_u8(0xff);
+                state.write_u8(0xff); // matches the implementation of the `str` Hash impl
             }
             INLINE_LOCATION => {
-                self.as_str().hash(state);
+                self.inline_as_str().hash(state);
             }
             _ => unsafe { debug_unreachable!() },
         }


### PR DESCRIPTION
Fix safety comment and hash implementation in turbo-rcstr

Noticed this while porting https://github.com/vercel/next.js/pull/81994 to swc


Closes PACK-5141