### PR TITLE
docs: Update styling example links 

### DIFF
--- a/docs/01-app/02-guides/css-in-js.mdx
+++ b/docs/01-app/02-guides/css-in-js.mdx
@@ -126,7 +126,7 @@ export default function RootLayout({ children }) {
 }
 ```
 
-[View an example here](https://github.com/vercel/app-playground/tree/main/app/styling/styled-jsx).
+[View an example here](https://github.com/vercel/next.js/tree/canary/examples/with-styled-jsx).
 
 ### Styled Components
 
@@ -238,7 +238,7 @@ export default function RootLayout({ children }) {
 }
 ```
 
-[View an example here](https://github.com/vercel/app-playground/tree/main/app/styling/styled-components).
+[View an example here](https://github.com/vercel/next.js/tree/canary/examples/with-styled-components).
 
 > **Good to know**:
 >


### PR DESCRIPTION
Fixes: https://github.com/vercel/next.js/issues/82098

