### PR TITLE
fix(next/image): fix image-optimizer.ts headers

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -634,7 +634,6 @@ export async function fetchInternalImage(
     const mocked = createRequestResponseMocks({
       url: href,
       method: _req.method || 'GET',
-      headers: _req.headers,
       socket: _req.socket,
     })
 

--- a/test/integration/image-optimizer/app/pages/api/conditional-cookie.js
+++ b/test/integration/image-optimizer/app/pages/api/conditional-cookie.js
@@ -1,0 +1,11 @@
+const pixel =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPj/HwADBwIAMCbHYQAAAABJRU5ErkJggg=='
+
+export default function handler(req, res) {
+  if (req.headers['cookie']) {
+    res.setHeader('content-type', 'image/png')
+    res.end(Buffer.from(pixel, 'base64'))
+  } else {
+    res.status(401).end('cookie was not found')
+  }
+}

--- a/test/integration/image-optimizer/test/util.ts
+++ b/test/integration/image-optimizer/test/util.ts
@@ -308,6 +308,13 @@ export function runTests(ctx: RunTestsCtx) {
     expect(ctx.nextOutput).toContain(animatedWarnText)
   })
 
+  it('should not forward cookie header', async () => {
+    const query = { w: ctx.w, q: 30, url: '/api/conditional-cookie' }
+    const opts = { headers: { accept: 'image/webp', cookie: '1' } }
+    const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
+    expect(res.status).toBe(400)
+  })
+
   if (ctx.nextConfigImages?.dangerouslyAllowSVG) {
     it('should maintain vector svg', async () => {
       const query = { w: ctx.w, q: 90, url: '/test.svg' }


### PR DESCRIPTION
The headers were forwarded to the serverless function for "internal" images but not "external" images.

This PR changes the behavior to be the same for both, such that neither receive headers.