### PR TITLE
allow root params access in private caches

### DIFF
--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -246,6 +246,13 @@ export interface PrivateUseCacheStore extends CommonUseCacheStore {
    * access the request cookies.
    */
   readonly cookies: ReadonlyRequestCookies
+
+  /**
+   * Private caches don't currently need to track root params in the cache key
+   * because they're not persisted anywhere, so we can allow root params access
+   * (unlike public caches)
+   */
+  readonly rootParams: Params
 }
 
 export type UseCacheStore = PublicUseCacheStore | PrivateUseCacheStore

--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -41,7 +41,6 @@ export async function unstable_rootParams(): Promise<Params> {
 
   switch (workUnitStore.type) {
     case 'cache':
-    case 'private-cache':
     case 'unstable-cache': {
       throw new Error(
         `Route ${workStore.route} used \`unstable_rootParams()\` inside \`"use cache"\` or \`unstable_cache\`. Support for this API inside cache scopes is planned for a future version of Next.js.`
@@ -56,6 +55,7 @@ export async function unstable_rootParams(): Promise<Params> {
         workStore,
         workUnitStore
       )
+    case 'private-cache':
     case 'request':
       return Promise.resolve(workUnitStore.rootParams)
     default:
@@ -228,7 +228,6 @@ export function getRootParam(paramName: string): Promise<ParamValue> {
 
   switch (workUnitStore.type) {
     case 'unstable-cache':
-    case 'private-cache':
     case 'cache': {
       throw new Error(
         `Route ${workStore.route} used ${apiName} inside \`"use cache"\` or \`unstable_cache\`. Support for this API inside cache scopes is planned for a future version of Next.js.`
@@ -245,6 +244,7 @@ export function getRootParam(paramName: string): Promise<ParamValue> {
         apiName
       )
     }
+    case 'private-cache':
     case 'request': {
       break
     }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -187,14 +187,15 @@ function createUseCacheStore(
       explicitExpire: undefined,
       explicitStale: undefined,
       tags: null,
-      hmrRefreshHash:
-        outerWorkUnitStore && getHmrRefreshHash(workStore, outerWorkUnitStore),
-      isHmrRefresh: outerWorkUnitStore?.isHmrRefresh ?? false,
-      serverComponentsHmrCache: outerWorkUnitStore?.serverComponentsHmrCache,
+      hmrRefreshHash: getHmrRefreshHash(workStore, outerWorkUnitStore),
+      isHmrRefresh: outerWorkUnitStore.isHmrRefresh ?? false,
+      serverComponentsHmrCache: outerWorkUnitStore.serverComponentsHmrCache,
       forceRevalidate: shouldForceRevalidate(workStore, outerWorkUnitStore),
-      draftMode:
-        outerWorkUnitStore &&
-        getDraftModeProviderForCacheScope(workStore, outerWorkUnitStore),
+      draftMode: getDraftModeProviderForCacheScope(
+        workStore,
+        outerWorkUnitStore
+      ),
+      rootParams: outerWorkUnitStore.rootParams,
       cookies: outerWorkUnitStore.cookies,
     }
   } else {

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-private/app/[lang]/[locale]/layout.tsx
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-private/app/[lang]/[locale]/layout.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}
+
+export function generateStaticParams() {
+  // the param values are not accessed in tests,
+  // we just need a value here to avoid errors in PPR/cacheComponents
+  // where we need to provide at least one set of values for root params
+  return [{ lang: 'foo', locale: 'bar' }]
+}

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-private/app/[lang]/[locale]/use-cache-private/page.tsx
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-private/app/[lang]/[locale]/use-cache-private/page.tsx
@@ -1,0 +1,34 @@
+import { lang, locale } from 'next/root-params'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export default async function Page() {
+  return (
+    <Suspense fallback="Loading...">
+      <Runtime />
+    </Suspense>
+  )
+}
+
+async function Runtime() {
+  await connection()
+
+  const rootParams = await getCachedParams()
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random'
+  ).then((res) => res.text())
+
+  return (
+    <p>
+      <span id="param">
+        {rootParams.lang} {rootParams.locale}
+      </span>{' '}
+      <span id="random">{data}</span>
+    </p>
+  )
+}
+
+async function getCachedParams() {
+  'use cache: private'
+  return { lang: await lang(), locale: await locale() }
+}

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-private/next.config.ts
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-private/next.config.ts
@@ -1,0 +1,10 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    useCache: true,
+    rootParams: true,
+  },
+}
+
+export default nextConfig


### PR DESCRIPTION
Accessing root params in a private cache should work, but I missed it in the `next/root-params` PR.
```tsx
import { lang } from 'next/root-params'

async function foo() {
  'use cache: private'
  await lang() // this is okay
}
```
With this PR, we'll now allow this (and `unstable_rootParams()`)