### PR TITLE
docs: Add more links to app docs root

### DIFF
--- a/docs/01-app/index.mdx
+++ b/docs/01-app/index.mdx
@@ -3,9 +3,13 @@ title: App Router
 description: The App Router is a file-system based router that uses React's latest features such as Server Components, Suspense, Server Functions, and more.
 related:
   title: Next Steps
-  description: Get started by following the installation guide.
+  description: Learn the fundamentals of building an App Router project, from installation to layouts, navigation, server and client components.
   links:
     - app/getting-started/installation
+    - app/getting-started/project-structure
+    - app/getting-started/layouts-and-pages
+    - app/getting-started/linking-and-navigating
+    - app/getting-started/server-and-client-components
 ---
 
 The **App Router** is a file-system based router that uses React's latest features such as [Server Components](https://react.dev/reference/rsc/server-components), [Suspense](https://react.dev/reference/react/Suspense), and [Server Functions](https://react.dev/reference/rsc/server-functions).


### PR DESCRIPTION
This page https://nextjs.org/docs/app has too little actionable paths to go on