### PR TITLE
Turbopack: Fix accidental doctest in globset module license

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/globset.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/globset.rs
@@ -2,18 +2,17 @@
 /// After discussing upstreaming our usecase with the authors of `globset`, we decided that a
 /// fork was appropriate given our divergent usecases. See discussion https://github.com/BurntSushi/ripgrep/issues/3049
 /// The original code had the following license:
-/// ```
-/// The MIT License (MIT)
 ///
-/// Copyright (c) 2015 Andrew Gallant
-///
-/// Permission is hereby granted, free of charge, to any person obtaining a copy
-/// of this software and associated documentation files (the "Software"), to deal
-/// in the Software without restriction, including without limitation the rights
-/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-/// copies of the Software, and to permit persons to whom the Software is
-/// furnished to do so, subject to the following conditions:
-/// ```
+/// > The MIT License (MIT)
+/// >
+/// > Copyright (c) 2015 Andrew Gallant
+/// >
+/// > Permission is hereby granted, free of charge, to any person obtaining a copy
+/// > of this software and associated documentation files (the "Software"), to deal
+/// > in the Software without restriction, including without limitation the rights
+/// > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// > copies of the Software, and to permit persons to whom the Software is
+/// > furnished to do so, subject to the following conditions:
 ///
 /// Here it has been heavily modified to:
 /// - Eliminate various configuration options we don't need


### PR DESCRIPTION
The code block syntax in a documentation comment is interpreted as a doctest: https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html

Tested with:

```
cargo test -p turbo-tasks-fs
```

Closes PACK-5143