### PR TITLE
Turbopack: Use `Path`/`PathBuf` for all of the invalidation logic

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -323,14 +323,15 @@ impl ProjectContainer {
                 .await?;
         } else {
             project_fs.invalidate_with_reason(|path| invalidation::Initialize {
-                path: RcStr::from(path),
+                // this path is just used for display purposes
+                path: RcStr::from(path.to_string_lossy()),
             });
         }
         let output_fs = output_fs_operation(project)
             .read_strongly_consistent()
             .await?;
         output_fs.invalidate_with_reason(|path| invalidation::Initialize {
-            path: RcStr::from(path),
+            path: RcStr::from(path.to_string_lossy()),
         });
         Ok(())
     }
@@ -421,13 +422,14 @@ impl ProjectContainer {
                     .await?;
             } else {
                 project_fs.invalidate_with_reason(|path| invalidation::Initialize {
-                    path: RcStr::from(path),
+                    // this path is just used for display purposes
+                    path: RcStr::from(path.to_string_lossy()),
                 });
             }
         }
         if !ReadRef::ptr_eq(&prev_output_fs, &output_fs) {
             prev_output_fs.invalidate_with_reason(|path| invalidation::Initialize {
-                path: RcStr::from(path),
+                path: RcStr::from(path.to_string_lossy()),
             });
         }
 

--- a/turbopack/crates/turbo-tasks-fs/src/invalidator_map.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/invalidator_map.rs
@@ -69,10 +69,14 @@ impl Serialize for InvalidatorMap {
     where
         S: serde::Serializer,
     {
-        // TODO: This stores `PathBuf`s, which are machine-specific, but turbo_tasks doesn't
-        // actually care about these, so we should skip serializing them entirely. Really we just
-        // need a way to store list of invalidator task ids across restarts.
-        let inner: &LockedInvalidatorMap = &self.lock().unwrap();
+        // TODO: This stores absolute `PathBuf`s, which are machine-specific. This should
+        // normalize/denormalize paths relative to the disk filesystem root.
+        //
+        // Potential optimization: We invalidate all fs reads immediately upon resuming from a
+        // persisted cache, but we don't invalidate the fs writes. Those read invalidations trigger
+        // re-inserts into the `InvalidatorMap`. If we knew that certain invalidators were only
+        // needed for reads, we could potentially avoid serializing those paths entirely.
+        let inner: &InnerMap = &self.lock().unwrap();
         serializer.serialize_newtype_struct("InvalidatorMap", inner)
     }
 }

--- a/turbopack/crates/turbo-tasks-fs/src/invalidator_map.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/invalidator_map.rs
@@ -1,4 +1,7 @@
-use std::sync::{LockResult, Mutex, MutexGuard};
+use std::{
+    path::PathBuf,
+    sync::{LockResult, Mutex, MutexGuard},
+};
 
 use concurrent_queue::ConcurrentQueue;
 use rustc_hash::FxHashMap;
@@ -13,10 +16,10 @@ pub enum WriteContent {
     Link(ReadRef<LinkContent>),
 }
 
-type InnerMap = FxHashMap<String, FxHashMap<Invalidator, Option<WriteContent>>>;
+type InnerMap = FxHashMap<PathBuf, FxHashMap<Invalidator, Option<WriteContent>>>;
 
 pub struct InvalidatorMap {
-    queue: ConcurrentQueue<(String, Invalidator, Option<WriteContent>)>,
+    queue: ConcurrentQueue<(PathBuf, Invalidator, Option<WriteContent>)>,
     map: Mutex<InnerMap>,
 }
 
@@ -44,7 +47,7 @@ impl InvalidatorMap {
 
     pub fn insert(
         &self,
-        key: String,
+        key: PathBuf,
         invalidator: Invalidator,
         write_content: Option<WriteContent>,
     ) {
@@ -66,7 +69,11 @@ impl Serialize for InvalidatorMap {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_newtype_struct("InvalidatorMap", &*self.lock().unwrap())
+        // TODO: This stores `PathBuf`s, which are machine-specific, but turbo_tasks doesn't
+        // actually care about these, so we should skip serializing them entirely. Really we just
+        // need a way to store list of invalidator task ids across restarts.
+        let inner: &LockedInvalidatorMap = &self.lock().unwrap();
+        serializer.serialize_newtype_struct("InvalidatorMap", inner)
     }
 }
 


### PR DESCRIPTION
Common convention in our codebase is that `Path`/`PathBuf` are used for raw OS-level paths, and `RcStr` is used for normalized paths exposed by `turbo_tasks_fs`.

These are raw OS paths, so we should use `Path`/`PathBuf`.

This has some benefits in that it makes the implementation of https://github.com/vercel/next.js/pull/82133 easier, because `Path`'s `Ord` implementation is better for our use-case.

Closes PACK-5151