### PR TITLE
Fix i18n fallback: false collision

### DIFF
--- a/packages/next/src/server/lib/i18n-provider.ts
+++ b/packages/next/src/server/lib/i18n-provider.ts
@@ -118,8 +118,8 @@ export class I18NProvider {
       // query and strip it from the pathname.
       if (analysis.detectedLocale) {
         if (analysis.detectedLocale !== detectedLocale) {
-          throw new Error(
-            `Invariant: The detected locale does not match the locale in the query. Expected to find '${detectedLocale}' in '${pathname}' but found '${analysis.detectedLocale}'}`
+          console.warn(
+            `The detected locale does not match the locale in the query. Expected to find '${detectedLocale}' in '${pathname}' but found '${analysis.detectedLocale}'}`
           )
         }
 

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1095,9 +1095,9 @@ export default class NextNodeServer extends BaseServer<
       throw new Error('Invariant: pathname is undefined')
     }
 
-    // This is a catch-all route, there should be no fallbacks so mark it as
-    // such.
-    addRequestMeta(req, 'bubbleNoFallback', true)
+    // When in minimal mode we do not bubble the fallback as the
+    // router-server is not present to handle the error
+    addRequestMeta(req, 'bubbleNoFallback', this.minimalMode ? undefined : true)
 
     // This is needed to expose render404 and nextConfig
     // for environments without router-server

--- a/test/e2e/i18n-fallback-collision/i18n-fallback-collision.test.ts
+++ b/test/e2e/i18n-fallback-collision/i18n-fallback-collision.test.ts
@@ -1,0 +1,45 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('i18n-disallow-multiple-locales', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it.each([
+    ['/non-existent'],
+    ['/es/non-existent'],
+    ['/first/non-existent'],
+    ['/es/first/non-existent'],
+    ['/first/second/non-existent'],
+    ['/es/first/second/non-existent'],
+  ])(
+    'should 404 properly for fallback: false non-prerendered %s',
+    async (pathname) => {
+      const res = await next.fetch(pathname)
+      expect(res.status).toBe(404)
+    }
+  )
+
+  it.each([
+    { urlPath: '/first', page: '/[first]' },
+    { urlPath: '/first/second', page: '/[first]/[second]' },
+    { urlPath: '/first/second/third', page: '/[first]/[second]/[third]' },
+    {
+      urlPath: '/first/second/third/fourth',
+      page: '/[first]/[second]/[third]/[fourth]',
+    },
+  ])(
+    'should render properly for fallback: false prerendered $urlPath',
+    async ({ urlPath, page }) => {
+      const res = await next.fetch(urlPath)
+      expect(res.status).toBe(200)
+      expect(await res.text()).toContain(page)
+    }
+  )
+
+  it('should render properly for fallback: blocking', async () => {
+    const res = await next.fetch('/first/second/third/another')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('/[first]/[second]/[third]/[fourth]')
+  })
+})

--- a/test/e2e/i18n-fallback-collision/next.config.ts
+++ b/test/e2e/i18n-fallback-collision/next.config.ts
@@ -1,0 +1,13 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  /* config options here */
+  reactStrictMode: true,
+
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
+  },
+}
+
+export default nextConfig

--- a/test/e2e/i18n-fallback-collision/pages/[first]/[second]/[third]/[fourth]/index.js
+++ b/test/e2e/i18n-fallback-collision/pages/[first]/[second]/[third]/[fourth]/index.js
@@ -1,0 +1,32 @@
+export default function Page() {
+  return (
+    <>
+      <p>page: /[first]/[second]/[third]/[fourth]</p>
+    </>
+  )
+}
+
+export function getStaticProps({ params }) {
+  return {
+    props: {
+      params,
+      now: Date.now(),
+    },
+  }
+}
+
+export function getStaticPaths() {
+  return {
+    paths: [
+      {
+        params: {
+          first: 'first',
+          second: 'second',
+          third: 'third',
+          fourth: 'fourth',
+        },
+      },
+    ],
+    fallback: 'blocking',
+  }
+}

--- a/test/e2e/i18n-fallback-collision/pages/[first]/[second]/[third]/index.js
+++ b/test/e2e/i18n-fallback-collision/pages/[first]/[second]/[third]/index.js
@@ -1,0 +1,27 @@
+export default function Page() {
+  return (
+    <>
+      <p>page: /[first]/[second]/[third]</p>
+    </>
+  )
+}
+
+export function getStaticProps({ params }) {
+  return {
+    props: {
+      params,
+      now: Date.now(),
+    },
+  }
+}
+
+export function getStaticPaths() {
+  return {
+    paths: [
+      {
+        params: { first: 'first', second: 'second', third: 'third' },
+      },
+    ],
+    fallback: false,
+  }
+}

--- a/test/e2e/i18n-fallback-collision/pages/[first]/[second]/index.js
+++ b/test/e2e/i18n-fallback-collision/pages/[first]/[second]/index.js
@@ -1,0 +1,27 @@
+export default function Page() {
+  return (
+    <>
+      <p>page: /[first]/[second]</p>
+    </>
+  )
+}
+
+export function getStaticProps({ params }) {
+  return {
+    props: {
+      params,
+      now: Date.now(),
+    },
+  }
+}
+
+export function getStaticPaths() {
+  return {
+    paths: [
+      {
+        params: { first: 'first', second: 'second' },
+      },
+    ],
+    fallback: false,
+  }
+}

--- a/test/e2e/i18n-fallback-collision/pages/[first]/index.js
+++ b/test/e2e/i18n-fallback-collision/pages/[first]/index.js
@@ -1,0 +1,27 @@
+export default function Page() {
+  return (
+    <>
+      <p>page: /[first]</p>
+    </>
+  )
+}
+
+export function getStaticProps({ params }) {
+  return {
+    props: {
+      params,
+      now: Date.now(),
+    },
+  }
+}
+
+export function getStaticPaths() {
+  return {
+    paths: [
+      {
+        params: { first: 'first' },
+      },
+    ],
+    fallback: false,
+  }
+}

--- a/test/e2e/i18n-fallback-collision/pages/_app.tsx
+++ b/test/e2e/i18n-fallback-collision/pages/_app.tsx
@@ -1,0 +1,5 @@
+import type { AppProps } from 'next/app'
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/test/e2e/i18n-fallback-collision/pages/_document.tsx
+++ b/test/e2e/i18n-fallback-collision/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body className="antialiased">
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}

--- a/test/e2e/i18n-fallback-collision/pages/index.tsx
+++ b/test/e2e/i18n-fallback-collision/pages/index.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <>
+      <p>index page</p>
+    </>
+  )
+}


### PR DESCRIPTION
This fixes a case with i18n in pages router with deeply nested mixed `fallback: false` and `fallback: 'blocking'` routes where the internal `NoFallbackError` would be bubbled outside of the server handler causing the invariant to leak instead of rendering the 404 page like expected. 

Verified against our E2E deploy tests here https://github.com/vercel/vercel/actions/runs/16586881087/job/46913897238 and https://github.com/vercel/next.js/actions/runs/16586877291/job/46913935296 

Closes: NEXT-4655