### PR TITLE
Add test to capture priority of next.config `header` overrides vs getServerSideProps `setHeader`

### DIFF
--- a/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
+++ b/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
@@ -81,4 +81,11 @@ describe('custom-cache-control', () => {
       isNextDev ? 'no-store, must-revalidate' : 's-maxage=36'
     )
   })
+
+  it('should respect cache-control header set in getServerSideProps', async () => {
+    const res = await next.fetch('/pages-ssr-overridden')
+    expect(res.headers.get('cache-control')).toBe(
+      isNextDev ? 'no-store, must-revalidate' : 's-maxage=getServerSideProps'
+    )
+  })
 })

--- a/test/e2e/app-dir/custom-cache-control/next.config.js
+++ b/test/e2e/app-dir/custom-cache-control/next.config.js
@@ -67,6 +67,15 @@ const nextConfig = {
           },
         ],
       },
+      {
+        source: '/pages-ssr-overridden',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 's-maxage=37',
+          },
+        ],
+      },
     ]
   },
 }

--- a/test/e2e/app-dir/custom-cache-control/pages/pages-ssr-overridden.tsx
+++ b/test/e2e/app-dir/custom-cache-control/pages/pages-ssr-overridden.tsx
@@ -1,0 +1,18 @@
+export function getServerSideProps(context) {
+
+  context.res.setHeader("Cache-Control", "s-maxage=getServerSideProps");
+
+  return {
+    props: {
+      now: Date.now(),
+    },
+  }
+}
+
+export default function Page() {
+  return (
+    <>
+      <p>/pages-ssr-overridden</p>
+    </>
+  )
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

Since https://github.com/vercel/next.js/pull/69802, `Cache-Control` is supported via `headers` in next.config.js. I wanted to clarify header priority when the `Cache-Control` header is also set on the response object of `getServerSideProps`. 

For context, we currently set `Cache-Control` via gssp in pages router, and want that same control in app router. For us, targeting specific paths in app router alone with `headers` is difficult (many catch all routes). I want to understand if the header set in gssp would be respected when header config in next.config also matches the same page, after finding a few snippets like this - does `res.setHeader` fall under 'If cache control is already set on the response'?

https://github.com/vercel/next.js/blob/16c220f37604edc2c8419171fe8740a1e1f8c66d/packages/next/src/server/send-payload.ts#L58-L62



