### PR TITLE
Ensure setAssetPrefix updates config instance

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1652,7 +1652,7 @@ export default abstract class Server<
   ): Promise<void>
 
   public setAssetPrefix(prefix?: string): void {
-    this.renderOpts.assetPrefix = prefix ? prefix.replace(/\/$/, '') : ''
+    this.nextConfig.assetPrefix = prefix ? prefix.replace(/\/$/, '') : ''
   }
 
   protected prepared: boolean = false

--- a/test/e2e/app-dir/asset-prefix-absolute/asset-prefix-absolute-no-path.test.ts
+++ b/test/e2e/app-dir/asset-prefix-absolute/asset-prefix-absolute-no-path.test.ts
@@ -4,7 +4,7 @@ describe('app-dir absolute assetPrefix', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     nextConfig: {
-      assetPrefix: 'https://example.vercel.sh/custom-asset-prefix',
+      assetPrefix: 'https://example.vercel.sh/',
     },
   })
 
@@ -14,11 +14,7 @@ describe('app-dir absolute assetPrefix', () => {
     let bundles = []
     for (const script of $('script').toArray()) {
       const { src } = script.attribs
-      if (
-        src?.includes(
-          'https://example.vercel.sh/custom-asset-prefix/_next/static'
-        )
-      ) {
+      if (src?.includes('https://example.vercel.sh/_next/static')) {
         bundles.push(src)
       }
     }

--- a/test/e2e/app-dir/asset-prefix-absolute/next.config.js
+++ b/test/e2e/app-dir/asset-prefix-absolute/next.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  assetPrefix: 'https://example.vercel.sh/custom-asset-prefix',
-}


### PR DESCRIPTION
This ensures we update `nextConfig.assetPrefix` instead of `renderOpts` as we aren't relying on `renderOpts` for these values anymore. 

Closes: https://github.com/vercel/next.js/issues/82150