### PR TITLE
Backport: Turbopack: update mimalloc (#81993)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3655,9 +3655,9 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.38"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7bb23d733dfcc8af652a78b7bf232f0e967710d044732185e561e47c0336b6"
+checksum = "bf88cd67e9de251c1781dbe2f641a1a3ad66eaae831b8a2c38fbdc5ddae16d4d"
 dependencies = [
  "cc",
  "libc",
@@ -4034,9 +4034,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.42"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9186d86b79b52f4a77af65604b51225e8db1d6ee7e3f41aec1e40829c71a176"
+checksum = "b1791cbe101e95af5764f06f20f6760521f7158f69dbf9d6baf941ee1bf6bc40"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -10,10 +10,10 @@ autobenches = false
 bench = false
 
 [target.'cfg(not(any(target_os = "linux", target_family = "wasm", target_env = "musl")))'.dependencies]
-mimalloc = { version = "0.1.42", features = [], optional = true }
+mimalloc = { version = "0.1.47", features = [], optional = true }
 
 [target.'cfg(all(target_os = "linux", not(any(target_family = "wasm", target_env = "musl"))))'.dependencies]
-mimalloc = { version = "0.1.42", features = [
+mimalloc = { version = "0.1.47", features = [
   "local_dynamic_tls",
 ], optional = true }
 


### PR DESCRIPTION
We're heard about significant real-world reductions in memory usage from this change in canary. It seem relatively low-risk, so IMO we should backport it.

Original PR: https://github.com/vercel/next.js/pull/81993

Closes PACK-5145