### PR TITLE
Parse dynamic params on the client

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -764,5 +764,6 @@
   "763": "\\`unstable_rootParams\\` must not be used within a client component. Next.js should be preventing it from being included in client components statically, but did not in this case.",
   "764": "Missing workStore in %s",
   "765": "Route %s used %s inside a Route Handler. Support for this API in Route Handlers is planned for a future version of Next.js.",
-  "766": "%s was used inside a Server Action. This is not supported. Functions from 'next/root-params' can only be called in the context of a route."
+  "766": "%s was used inside a Server Action. This is not supported. Functions from 'next/root-params' can only be called in the context of a route.",
+  "767": "An unexpected response was received from the server."
 }

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -254,6 +254,8 @@ export function hydrate(
                 couldBeIntercepted: initialRSCPayload.i,
                 postponed: initialRSCPayload.s,
                 prerendered: initialRSCPayload.S,
+                routeRegex: initialRSCPayload.r,
+                pagePath: initialRSCPayload.t,
               }),
               instrumentationHooks
             )

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -3,6 +3,7 @@ import type { FlightRouterState } from '../../../server/app-render/types'
 import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
 import { createInitialRouterState } from './create-initial-router-state'
 import { PrefetchCacheEntryStatus, PrefetchKind } from './router-reducer-types'
+import type { RouteRegexFlightSafe } from '../../../shared/lib/router/utils/route-regex'
 
 const getInitialRouterStateTree = (): FlightRouterState => [
   '',
@@ -25,6 +26,11 @@ describe('createInitialRouterState', () => {
   it('should return the correct initial router state', () => {
     const initialTree = getInitialRouterStateTree()
     const initialCanonicalUrl = '/linking'
+    const pagePath = '/linking'
+    const routeRegex: RouteRegexFlightSafe = {
+      groups: {},
+      reParts: ['^/linking$', ''],
+    } as any
     const children = (
       <html>
         <head></head>
@@ -42,6 +48,8 @@ describe('createInitialRouterState', () => {
       couldBeIntercepted: false,
       postponed: false,
       prerendered: false,
+      pagePath,
+      routeRegex,
     })
 
     const state2 = createInitialRouterState({
@@ -53,6 +61,8 @@ describe('createInitialRouterState', () => {
       couldBeIntercepted: false,
       postponed: false,
       prerendered: false,
+      pagePath,
+      routeRegex,
     })
 
     const expectedCache: CacheNode = {

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -10,7 +10,11 @@ import {
 } from './prefetch-cache-utils'
 import { PrefetchKind, type PrefetchCacheEntry } from './router-reducer-types'
 import { addRefreshMarkerToActiveParallelSegments } from './refetch-inactive-parallel-segments'
-import { getFlightDataPartsFromPath } from '../../flight-data-helpers'
+import {
+  getFlightDataPartsFromPath,
+  getRenderedParams,
+} from '../../flight-data-helpers'
+import type { RouteRegexFlightSafe } from '../../../shared/lib/router/utils/route-regex'
 
 export interface InitialRouterStateParameters {
   navigatedAt: number
@@ -21,6 +25,8 @@ export interface InitialRouterStateParameters {
   couldBeIntercepted: boolean
   postponed: boolean
   prerendered: boolean
+  pagePath: string
+  routeRegex: RouteRegexFlightSafe
 }
 
 export function createInitialRouterState({
@@ -32,12 +38,39 @@ export function createInitialRouterState({
   couldBeIntercepted,
   postponed,
   prerendered,
+  pagePath,
+  routeRegex,
 }: InitialRouterStateParameters) {
   // When initialized on the server, the canonical URL is provided as an array of parts.
   // This is to ensure that when the RSC payload streamed to the client, crawlers don't interpret it
   // as a URL that should be crawled.
   const initialCanonicalUrl = initialCanonicalUrlParts.join('/')
-  const normalizedFlightData = getFlightDataPartsFromPath(initialFlightData[0])
+
+  // TODO: Eventually we want to always read the rendered params from the URL
+  // and/or the x-rewritten-path header, so that we can omit them from the
+  // response body. This lets reuse cached responses if params aren't referenced
+  // anywhere in the actual page data, e.g. if they're only accessed by client
+  // components. However, during the initial render, there's no way to access
+  // the headers. For a partially dynamic page, this is OK, because there's
+  // going to be a dynamic server render regardless, so we can send the URL
+  // in the resume body. For a completely static page, though, there's no
+  // dynamic server render, so that won't work.
+  //
+  // Instead, we'll perform a HEAD request and read the rewritten URL from
+  // that response.
+  const renderedPathname = new URL(initialCanonicalUrl, 'http://localhost')
+    .pathname
+  const renderedParams = getRenderedParams(renderedPathname, routeRegex)
+
+  const normalizedFlightData = getFlightDataPartsFromPath(
+    initialFlightData[0],
+    // TODO: If the params cannot be parsed during page load, this suggests a
+    // malformed response. Rather than silently continue, we should consider
+    // erroring instead. Tricky to know what to do to recover, since this is the
+    // initial render; a hard refresh would likely result in the same error.
+    renderedParams ?? {},
+    pagePath
+  )
   const {
     tree: initialTree,
     seedData: initialSeedData,

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -25,6 +25,8 @@ import { callServer } from '../../app-call-server'
 import { findSourceMapURL } from '../../app-find-source-map-url'
 import { PrefetchKind } from './router-reducer-types'
 import {
+  getRenderedParams,
+  getRenderedPathname,
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
   type NormalizedFlightData,
@@ -235,8 +237,27 @@ export async function fetchServerResponse(
       return doMpaNavigation(res.url)
     }
 
+    let renderedPathname
+    if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
+      // Read the URL from the response object.
+      renderedPathname = getRenderedPathname(res)
+    } else {
+      // Before Segment Cache is enabled, we should not rely on the new
+      // rewrite headers (x-rewritten-path, x-rewritten-query) because that
+      // is a breaking change. Read the URL from the response body.
+      const renderedUrlParts = response.c
+      renderedPathname = new URL(renderedUrlParts.join('/'), 'http://localhost')
+        .pathname
+    }
+    const renderedParams = getRenderedParams(renderedPathname, response.r)
+    if (renderedParams === null) {
+      // Params could not be parsed. This is a malformed response. Fall back
+      // to an MPA navigation.
+      return doMpaNavigation(res.url)
+    }
+
     return {
-      flightData: normalizeFlightData(response.f),
+      flightData: normalizeFlightData(response.f, renderedParams, response.t),
       canonicalUrl: canonicalUrl,
       couldBeIntercepted: interception,
       prerendered: response.S,

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
@@ -13,6 +13,7 @@ const getFlightData = (): NormalizedFlightData[] => {
       head: null,
       isHeadPartial: false,
       isRootRender: false,
+      dynamicParams: null,
     },
   ]
 }

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -15,6 +15,7 @@ const getFlightData = (): NormalizedFlightData[] => {
       head: null,
       isHeadPartial: false,
       isRootRender: false,
+      dynamicParams: null,
     },
   ]
 }

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -41,6 +41,8 @@ import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-c
 import { handleSegmentMismatch } from '../handle-segment-mismatch'
 import { refreshInactiveParallelSegments } from '../refetch-inactive-parallel-segments'
 import {
+  getRenderedParams,
+  getRenderedPathname,
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
   type NormalizedFlightData,
@@ -180,9 +182,33 @@ async function fetchServerAction(
       Promise.resolve(res),
       { callServer, findSourceMapURL, temporaryReferences }
     )
+
+    let renderedPathname
+    if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
+      // Read the URL from the response object.
+      renderedPathname = getRenderedPathname(res)
+    } else {
+      // Before Segment Cache is enabled, we should not rely on the new
+      // rewrite headers (x-rewritten-path, x-rewritten-query) because that
+      // is a breaking change. Read the URL from the response body.
+      const canonicalUrlParts = response.c
+      renderedPathname = new URL(
+        canonicalUrlParts.join('/'),
+        'http://localhost'
+      ).pathname
+    }
+    const renderedParams = getRenderedParams(renderedPathname, response.r)
+    if (renderedParams === null) {
+      throw new Error('An unexpected response was received from the server.')
+    }
+
     // An internal redirect can send an RSC response, but does not have a useful `actionResult`.
     actionResult = redirectLocation ? undefined : response.a
-    actionFlightData = normalizeFlightData(response.f)
+    actionFlightData = normalizeFlightData(
+      response.f,
+      renderedParams,
+      response.t
+    )
   } else {
     // An external redirect doesn't contain RSC data.
     actionResult = undefined

--- a/packages/next/src/client/components/segment-cache-impl/cache-key.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache-key.ts
@@ -1,6 +1,3 @@
-import { NEXT_REWRITTEN_QUERY_HEADER } from '../app-router-headers'
-import type { RSCResponse } from '../router-reducer/fetch-server-response'
-
 // TypeScript trick to simulate opaque types, like in Flow.
 type Opaque<K, T> = T & { __brand: K }
 
@@ -31,19 +28,4 @@ export function createCacheKey(
     nextUrl: nextUrl as NormalizedNextUrl | null,
   } as RouteCacheKey
   return cacheKey
-}
-
-export function getRenderedSearch(response: RSCResponse): NormalizedSearch {
-  // If the server performed a rewrite, the search params used to render the
-  // page will be different from the params in the request URL. In this case,
-  // the response will include a header that gives the rewritten search query.
-  const rewrittenQuery = response.headers.get(NEXT_REWRITTEN_QUERY_HEADER)
-  if (rewrittenQuery !== null) {
-    return (
-      rewrittenQuery === '' ? '' : '?' + rewrittenQuery
-    ) as NormalizedSearch
-  }
-  // If the header is not present, there was no rewrite, so we use the search
-  // query of the response URL.
-  return new URL(response.url).search as NormalizedSearch
 }

--- a/packages/next/src/client/components/segment-cache-impl/cache.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../../shared/lib/app-router-context.shared-runtime'
 import type {
   CacheNodeSeedData,
+  DynamicParamTypesShort,
   Segment as FlightRouterStateSegment,
 } from '../../../server/app-render/types'
 import { HasLoadingBoundary } from '../../../server/app-render/types'
@@ -42,7 +43,11 @@ import type {
   NormalizedSearch,
   RouteCacheKey,
 } from './cache-key'
-import { getRenderedSearch } from './cache-key'
+import {
+  getRenderedPathname,
+  getRenderedSearch,
+  getRenderedParams,
+} from '../../flight-data-helpers'
 import { createTupleMap, type TupleMap, type Prefix } from './tuple-map'
 import { createLRU } from './lru'
 import {
@@ -64,6 +69,9 @@ import {
   doesExportedHtmlMatchBuildId,
 } from '../../../shared/lib/segment-cache/output-export-prefetch-encoding'
 import { FetchStrategy } from '../segment-cache'
+import type { DynamicParam } from '../../../server/app-render/app-render'
+import { getDynamicParam } from '../../../shared/lib/router/utils/get-dynamic-param'
+import type { Params } from '../../../server/request/params'
 
 // A note on async/await when working in the prefetch cache:
 //
@@ -132,6 +140,7 @@ type PendingRouteCacheEntry = RouteCacheEntryShared & {
   status: EntryStatus.Empty | EntryStatus.Pending
   blockedTasks: Set<PrefetchTask> | null
   canonicalUrl: null
+  renderedParams: null
   renderedSearch: null
   tree: null
   head: HeadData | null
@@ -143,6 +152,7 @@ type RejectedRouteCacheEntry = RouteCacheEntryShared & {
   status: EntryStatus.Rejected
   blockedTasks: Set<PrefetchTask> | null
   canonicalUrl: null
+  renderedParams: null
   renderedSearch: null
   tree: null
   head: null
@@ -154,6 +164,7 @@ export type FulfilledRouteCacheEntry = RouteCacheEntryShared & {
   status: EntryStatus.Fulfilled
   blockedTasks: null
   canonicalUrl: string
+  renderedParams: Map<string, DynamicParam> | null
   renderedSearch: NormalizedSearch
   tree: RouteTree
   head: HeadData
@@ -553,6 +564,7 @@ export function readOrCreateRouteCacheEntry(
     couldBeIntercepted: true,
     // Similarly, we don't yet know if the route supports PPR.
     isPPREnabled: false,
+    renderedParams: null,
     renderedSearch: null,
 
     // LRU-related fields
@@ -787,6 +799,7 @@ function fulfillRouteCacheEntry(
   staleAt: number,
   couldBeIntercepted: boolean,
   canonicalUrl: string,
+  renderedParams: Map<string, DynamicParam> | null,
   renderedSearch: NormalizedSearch,
   isPPREnabled: boolean
 ): FulfilledRouteCacheEntry {
@@ -798,6 +811,7 @@ function fulfillRouteCacheEntry(
   fulfilledEntry.staleAt = staleAt
   fulfilledEntry.couldBeIntercepted = couldBeIntercepted
   fulfilledEntry.canonicalUrl = canonicalUrl
+  fulfilledEntry.renderedParams = renderedParams
   fulfilledEntry.renderedSearch = renderedSearch
   fulfilledEntry.isPPREnabled = isPPREnabled
   pingBlockedTasks(entry)
@@ -851,13 +865,26 @@ function rejectSegmentCacheEntry(
   }
 }
 
-function convertRootTreePrefetchToRouteTree(rootTree: RootTreePrefetch) {
-  return convertTreePrefetchToRouteTree(rootTree.tree, ROOT_SEGMENT_KEY)
+function convertRootTreePrefetchToRouteTree(
+  rootTree: RootTreePrefetch,
+  rawParams: Params,
+  dynamicParamsResult: Map<string, DynamicParam>
+) {
+  return convertTreePrefetchToRouteTree(
+    rootTree.tree,
+    ROOT_SEGMENT_KEY,
+    rootTree.pagePath,
+    rawParams,
+    dynamicParamsResult
+  )
 }
 
 function convertTreePrefetchToRouteTree(
   prefetch: TreePrefetch,
-  key: string
+  key: string,
+  pagePath: string,
+  rawParams: Params,
+  dynamicParamsResult: Map<string, DynamicParam>
 ): RouteTree {
   // Converts the route tree sent by the server into the format used by the
   // cache. The cached version of the tree includes additional fields, such as a
@@ -881,13 +908,35 @@ function convertTreePrefetchToRouteTree(
       )
       slots[parallelRouteKey] = convertTreePrefetchToRouteTree(
         childPrefetch,
-        childKey
+        childKey,
+        pagePath,
+        rawParams,
+        dynamicParamsResult
       )
     }
   }
+
+  const segment = prefetch.segment
+  if (Array.isArray(segment)) {
+    // This segment contains a dynamic param. Collect these as we traverse the
+    // tree and write the result to a map.
+    const segmentParamName = segment[0]
+    if (!dynamicParamsResult.has(segmentParamName)) {
+      const dynamicParamType = segment[1] as DynamicParamTypesShort
+      const dynamicParam = getDynamicParam(
+        rawParams,
+        segmentParamName,
+        dynamicParamType,
+        pagePath,
+        null
+      )
+      dynamicParamsResult.set(segmentParamName, dynamicParam)
+    }
+  }
+
   return {
     key,
-    segment: prefetch.segment,
+    segment,
     slots,
     isRootLayout: prefetch.isRootLayout,
     // This field is only relevant to dynamic routes. For a PPR/static route,
@@ -1139,20 +1188,38 @@ export async function fetchRouteOnCacheMiss(
         return null
       }
 
-      // Get the search params that were used to render the target page. This may
-      // be different from the search params in the request URL, if the page
+      // Get the params that were used to render the target page. These may
+      // be different from the params in the request URL, if the page
       // was rewritten.
+      const routeRegex = serverData.routeRegex
+      const renderedPathname = getRenderedPathname(response)
       const renderedSearch = getRenderedSearch(response)
+      const renderedParamsRaw = getRenderedParams(renderedPathname, routeRegex)
+      if (renderedParamsRaw === null) {
+        // The pathname did not match the route regex. This suggests a malformed
+        // response. The most likely cause is there was a rewrite, but it did
+        // not get propagated correctly to the Next-Rewritten-Path header.
+        rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+        return null
+      }
+
+      const renderedParams = new Map()
+      const routeTree = convertRootTreePrefetchToRouteTree(
+        serverData,
+        renderedParamsRaw,
+        renderedParams
+      )
 
       const staleTimeMs = serverData.staleTime * 1000
       fulfillRouteCacheEntry(
         entry,
-        convertRootTreePrefetchToRouteTree(serverData),
+        routeTree,
         serverData.head,
         serverData.isHeadPartial,
         Date.now() + staleTimeMs,
         couldBeIntercepted,
         canonicalUrl,
+        renderedParams.size > 0 ? renderedParams : null,
         renderedSearch,
         routeIsPPREnabled
       )
@@ -1458,7 +1525,25 @@ function writeDynamicTreeResponseIntoCache(
   canonicalUrl: string,
   routeIsPPREnabled: boolean
 ) {
-  const normalizedFlightDataResult = normalizeFlightData(serverData.f)
+  // Get the params that were used to render the target page. This may be
+  // different from the params in the request URL, if the page was rewritten.
+  const routeRegex = serverData.r
+  const renderedSearch = getRenderedSearch(response)
+  const renderedPathname = getRenderedPathname(response)
+  const renderedParamsRaw = getRenderedParams(renderedPathname, routeRegex)
+  if (renderedParamsRaw === null) {
+    // The pathname did not match the route regex. This suggests a malformed
+    // response. The most likely cause is there was a rewrite, but it did
+    // not get propagated correctly to the Next-Rewritten-Path header.
+    rejectRouteCacheEntry(entry, now + 10 * 1000)
+    return
+  }
+
+  const normalizedFlightDataResult = normalizeFlightData(
+    serverData.f,
+    renderedParamsRaw,
+    serverData.t
+  )
   if (
     // A string result means navigating to this route will result in an
     // MPA navigation.
@@ -1492,11 +1577,6 @@ function writeDynamicTreeResponseIntoCache(
   const isResponsePartial =
     response.headers.get(NEXT_DID_POSTPONE_HEADER) === '1'
 
-  // Get the search params that were used to render the target page. This may
-  // be different from the search params in the request URL, if the page
-  // was rewritten.
-  const renderedSearch = getRenderedSearch(response)
-
   const fulfilledEntry = fulfillRouteCacheEntry(
     entry,
     convertRootFlightRouterStateToRouteTree(flightRouterState),
@@ -1505,6 +1585,7 @@ function writeDynamicTreeResponseIntoCache(
     now + staleTimeMs,
     couldBeIntercepted,
     canonicalUrl,
+    flightData.dynamicParams,
     renderedSearch,
     routeIsPPREnabled
   )
@@ -1566,7 +1647,27 @@ function writeDynamicRenderResponseIntoCache(
     }
     return null
   }
-  const flightDatas = normalizeFlightData(serverData.f)
+
+  // Get the params that were used to render the target page. This may be
+  // different from the params in the request URL, if the page was rewritten.
+  const routeRegex = serverData.r
+  const renderedPathname = getRenderedPathname(response)
+  const renderedParams = getRenderedParams(renderedPathname, routeRegex)
+  if (renderedParams === null) {
+    // The pathname did not match the route regex. This suggests a malformed
+    // response. The most likely cause is there was a rewrite, but it did
+    // not get propagated correctly to the Next-Rewritten-Path header.
+    if (spawnedEntries !== null) {
+      rejectSegmentEntriesIfStillPending(spawnedEntries, now + 10 * 1000)
+    }
+    return null
+  }
+
+  const flightDatas = normalizeFlightData(
+    serverData.f,
+    renderedParams,
+    serverData.t
+  )
   if (typeof flightDatas === 'string') {
     // This means navigating to this route will result in an MPA navigation.
     // TODO: We should cache this, too, so that the MPA navigation is immediate.

--- a/packages/next/src/client/components/segment-cache.ts
+++ b/packages/next/src/client/components/segment-cache.ts
@@ -19,6 +19,7 @@
 
 export type { NavigationResult } from './segment-cache-impl/navigation'
 export type { PrefetchTask } from './segment-cache-impl/scheduler'
+export type { NormalizedSearch } from './segment-cache-impl/cache-key'
 
 const notEnabled: any = () => {
   throw new Error(

--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -1,13 +1,28 @@
+import type { DynamicParam } from '../server/app-render/app-render'
 import type {
   CacheNodeSeedData,
+  DynamicParamTypesShort,
   FlightData,
   FlightDataPath,
   FlightRouterState,
   FlightSegmentPath,
   Segment,
 } from '../server/app-render/types'
+import type { Params } from '../server/request/params'
 import type { HeadData } from '../shared/lib/app-router-context.shared-runtime'
+import { getDynamicParam } from '../shared/lib/router/utils/get-dynamic-param'
+import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
+import type {
+  RouteRegex,
+  RouteRegexFlightSafe,
+} from '../shared/lib/router/utils/route-regex'
 import { PAGE_SEGMENT_KEY } from '../shared/lib/segment'
+import {
+  NEXT_REWRITTEN_PATH_HEADER,
+  NEXT_REWRITTEN_QUERY_HEADER,
+} from './components/app-router-headers'
+import type { RSCResponse } from './components/router-reducer/fetch-server-response'
+import type { NormalizedSearch } from './components/segment-cache'
 
 export type NormalizedFlightData = {
   /**
@@ -20,6 +35,7 @@ export type NormalizedFlightData = {
   pathToSegment: FlightSegmentPath
   segment: Segment
   tree: FlightRouterState
+  dynamicParams: Map<string, DynamicParam> | null
   seedData: CacheNodeSeedData | null
   head: HeadData
   isHeadPartial: boolean
@@ -31,7 +47,9 @@ export type NormalizedFlightData = {
 // we're currently exporting it so we can use it directly. This should be fixed as part of the unification of
 // the different ways we express `FlightSegmentPath`.
 export function getFlightDataPartsFromPath(
-  flightDataPath: FlightDataPath
+  flightDataPath: FlightDataPath,
+  params: Params,
+  pagePath: string
 ): NormalizedFlightData {
   // Pick the last 4 items from the `FlightDataPath` to get the [tree, seedData, viewport, isHeadPartial].
   const flightDataPathLength = 4
@@ -51,6 +69,7 @@ export function getFlightDataPartsFromPath(
     // in which case we default to ''.
     segment: segmentPath[segmentPath.length - 1] ?? '',
     tree,
+    dynamicParams: getDynamicParamsFromTree(params, tree, pagePath),
     seedData,
     head,
     isHeadPartial,
@@ -67,7 +86,9 @@ export function getNextFlightSegmentPath(
 }
 
 export function normalizeFlightData(
-  flightData: FlightData
+  flightData: FlightData,
+  renderedParams: Params,
+  pagePath: string
 ): NormalizedFlightData[] | string {
   // FlightData can be a string when the server didn't respond with a proper flight response,
   // or when a redirect happens, to signal to the client that it needs to perform an MPA navigation.
@@ -75,7 +96,9 @@ export function normalizeFlightData(
     return flightData
   }
 
-  return flightData.map(getFlightDataPartsFromPath)
+  return flightData.map((flightDataPath) =>
+    getFlightDataPartsFromPath(flightDataPath, renderedParams, pagePath)
+  )
 }
 
 /**
@@ -168,4 +191,96 @@ function shouldPreserveRefreshMarker(
   refreshMarker: FlightRouterState[3]
 ): boolean {
   return Boolean(refreshMarker && refreshMarker !== 'refresh')
+}
+
+export function getRenderedSearch(response: RSCResponse): NormalizedSearch {
+  // If the server performed a rewrite, the search params used to render the
+  // page will be different from the params in the request URL. In this case,
+  // the response will include a header that gives the rewritten search query.
+  const rewrittenQuery = response.headers.get(NEXT_REWRITTEN_QUERY_HEADER)
+  if (rewrittenQuery !== null) {
+    return (
+      rewrittenQuery === '' ? '' : '?' + rewrittenQuery
+    ) as NormalizedSearch
+  }
+  // If the header is not present, there was no rewrite, so we use the search
+  // query of the response URL.
+  return new URL(response.url).search as NormalizedSearch
+}
+
+export function getRenderedPathname(response: RSCResponse): string {
+  // If the server performed a rewrite, the pathname used to render the
+  // page will be different from the pathname in the request URL. In this case,
+  // the response will include a header that gives the rewritten pathname.
+  const rewrittenPath = response.headers.get(NEXT_REWRITTEN_PATH_HEADER)
+  return rewrittenPath ?? new URL(response.url).pathname
+}
+
+export function getRenderedParams(
+  pathname: string,
+  flightSafeRouteRegex: RouteRegexFlightSafe
+): Params | null {
+  // Parse the route params from the pathname, using the regex sent from
+  // the server.
+  //
+  // This returns a "raw" params object, which is later turned into a "full"
+  // dynamic params object that can be passed to page components
+  // (getDynamicParamsFromTree). The only reason these separate steps is
+  // because creating the full dynamic params object requires traversing the
+  // router tree. Since we already do that elsewhere, we create the dynamic
+  // params during that traversal instead of adding a new traversal here.
+  const [source, flags] = flightSafeRouteRegex.reParts
+  const routeRegex: RouteRegex = {
+    groups: flightSafeRouteRegex.groups,
+    re: new RegExp(source, flags),
+  }
+  const matcher = getRouteMatcher(routeRegex)
+  const params = matcher(pathname)
+  return params ? params : null
+}
+
+function getDynamicParamsFromTree(
+  params: Params,
+  flightRouterState: FlightRouterState,
+  pagePath: string
+): Map<string, DynamicParam> | null {
+  // Traverse the FlightRouterState to build a map of dynamic params.
+  // TODO: Eventually this function will accept a subset of the
+  // FlightRouterState, and will be responsible for reconstructing the full
+  // FlightRouterState using the dynamic params.
+  const result = new Map()
+  getDynamicParamsFromTreeImpl(params, flightRouterState, pagePath, result)
+  return result.size > 0 ? result : null
+}
+
+function getDynamicParamsFromTreeImpl(
+  params: Params,
+  flightRouterState: FlightRouterState,
+  pagePath: string,
+  result: Map<string, DynamicParam>
+): void {
+  const segment = flightRouterState[0]
+  if (Array.isArray(segment)) {
+    const segmentKey = segment[0]
+    if (!result.has(segmentKey)) {
+      const dynamicParamType = segment[1] as DynamicParamTypesShort
+      const dynamicParam = getDynamicParam(
+        params,
+        segmentKey,
+        dynamicParamType,
+        pagePath,
+        null
+      )
+      result.set(segmentKey, dynamicParam)
+    }
+  }
+  const parallelRoutes = flightRouterState[1]
+  for (const parallelRouteKey in parallelRoutes) {
+    getDynamicParamsFromTreeImpl(
+      params,
+      parallelRoutes[parallelRouteKey],
+      pagePath,
+      result
+    )
+  }
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -140,6 +140,10 @@ import {
 } from '../client-component-renderer-logger'
 import { createServerModuleMap } from './action-utils'
 import { isNodeNextRequest } from '../base-http/helpers'
+import {
+  getRouteRegex,
+  toFlightSafeRouteRegex,
+} from '../../shared/lib/router/utils/route-regex'
 import { parseRelativeUrl } from '../../shared/lib/router/utils/parse-relative-url'
 import AppRouter from '../../client/components/app-router'
 import type { ServerComponentsHmrCache } from '../response-cache'
@@ -489,6 +493,9 @@ async function generateDynamicRSCPayload(
     ).map((path) => path.slice(1)) // remove the '' (root) segment
   }
 
+  const pagePath = ctx.pagePath
+  const routeRegex = toFlightSafeRouteRegex(getRouteRegex(pagePath))
+
   // If we have an action result, then this is a server action response.
   // We can rely on this because `ActionResult` will always be a promise, even if
   // the result is falsey.
@@ -497,12 +504,18 @@ async function generateDynamicRSCPayload(
       a: options.actionResult,
       f: flightData,
       b: ctx.sharedContext.buildId,
+      r: routeRegex,
+      c: prepareInitialCanonicalUrl(url),
+      t: pagePath,
     }
   }
 
   // Otherwise, it's a regular RSC response.
   return {
     b: ctx.sharedContext.buildId,
+    r: routeRegex,
+    c: prepareInitialCanonicalUrl(url),
+    t: pagePath,
     f: flightData,
     S: workStore.isStaticGeneration,
   }
@@ -852,10 +865,14 @@ async function getRSCPayload(
     workStore.isStaticGeneration &&
     ctx.renderOpts.experimental.isRoutePPREnabled === true
 
+  const pagePath = ctx.pagePath
+
   return {
     // See the comment above the `Preloads` component (below) for why this is part of the payload
     P: <Preloads preloadCallbacks={preloadCallbacks} />,
     b: ctx.sharedContext.buildId,
+    r: toFlightSafeRouteRegex(getRouteRegex(pagePath)),
+    t: pagePath,
     p: ctx.assetPrefix,
     c: prepareInitialCanonicalUrl(url),
     i: !!couldBeIntercepted,
@@ -976,8 +993,12 @@ async function getErrorRSCPayload(
     workStore.isStaticGeneration &&
     ctx.renderOpts.experimental.isRoutePPREnabled === true
 
+  const pagePath = ctx.pagePath
+
   return {
     b: ctx.sharedContext.buildId,
+    r: toFlightSafeRouteRegex(getRouteRegex(pagePath)),
+    t: pagePath,
     p: ctx.assetPrefix,
     c: prepareInitialCanonicalUrl(url),
     m: undefined,
@@ -1044,6 +1065,8 @@ function App<T>({
     couldBeIntercepted: response.i,
     postponed: response.s,
     prerendered: response.S,
+    pagePath: response.t,
+    routeRegex: response.r,
   })
 
   const actionQueue = createMutableActionQueue(initialState, null)
@@ -1110,6 +1133,8 @@ function ErrorApp<T>({
     couldBeIntercepted: response.i,
     postponed: response.s,
     prerendered: response.S,
+    pagePath: response.t,
+    routeRegex: response.r,
   })
 
   const actionQueue = createMutableActionQueue(initialState, null)

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -29,11 +29,14 @@ import {
 } from '../../shared/lib/segment-cache/segment-value-encoding'
 import { getDigestForWellKnownError } from './create-error-handler'
 import type { FallbackRouteParams } from '../request/fallback-params'
+import type { RouteRegexFlightSafe } from '../../shared/lib/router/utils/route-regex'
 
 // Contains metadata about the route tree. The client must fetch this before
 // it can fetch any actual segment data.
 export type RootTreePrefetch = {
   buildId: string
+  routeRegex: RouteRegexFlightSafe
+  pagePath: string
   tree: TreePrefetch
   head: HeadData
   isHeadPartial: boolean
@@ -201,9 +204,11 @@ async function PrefetchTreeData({
     )
     return null
   }
+  const routeRegex = initialRSCPayload.r
   const flightRouterState: FlightRouterState = flightDataPaths[0][0]
   const seedData: CacheNodeSeedData = flightDataPaths[0][1]
   const head: HeadData = flightDataPaths[0][2]
+  const pagePath = initialRSCPayload.t
 
   // Compute the route metadata tree by traversing the FlightRouterState. As we
   // walk the tree, we will also spawn a task to produce a prefetch response for
@@ -211,6 +216,7 @@ async function PrefetchTreeData({
   const tree = collectSegmentDataImpl(
     flightRouterState,
     buildId,
+    routeRegex,
     seedData,
     fallbackRouteParams,
     clientModules,
@@ -228,6 +234,8 @@ async function PrefetchTreeData({
   // Render the route tree to a special `/_tree` segment.
   const treePrefetch: RootTreePrefetch = {
     buildId,
+    routeRegex,
+    pagePath,
     tree,
     head,
     isHeadPartial,
@@ -239,6 +247,7 @@ async function PrefetchTreeData({
 function collectSegmentDataImpl(
   route: FlightRouterState,
   buildId: string,
+  routeRegex: RouteRegexFlightSafe,
   seedData: CacheNodeSeedData | null,
   fallbackRouteParams: FallbackRouteParams | null,
   clientModules: ManifestNode,
@@ -270,6 +279,7 @@ function collectSegmentDataImpl(
     const childTree = collectSegmentDataImpl(
       childRoute,
       buildId,
+      routeRegex,
       childSeedData,
       fallbackRouteParams,
       clientModules,

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -22,6 +22,7 @@ import type { NextRequestHint } from '../web/adapter'
 import type { BaseNextRequest } from '../base-http'
 import type { IncomingMessage } from 'http'
 import type { RenderResumeDataCache } from '../resume-data-cache/resume-data-cache'
+import type { RouteRegexFlightSafe } from '../../shared/lib/router/utils/route-regex'
 
 export type DynamicParamTypes =
   | 'catchall'
@@ -302,8 +303,15 @@ export type PreloadCallbacks = (() => void)[]
 export type InitialRSCPayload = {
   /** buildId */
   b: string
+  /** routeRegex*/
+  r: RouteRegexFlightSafe
+  /** pagePath */
+  t: string
   /** assetPrefix */
   p: string
+  // TODO: This isn't really the "canonical" URL (which we usually use to refer
+  // to the URL shown in the browser), it's the URL used to render the page,
+  // which may have been rewritten on the server.
   /** initialCanonicalUrlParts */
   c: string[]
   /** couldBeIntercepted */
@@ -324,6 +332,15 @@ export type InitialRSCPayload = {
 export type NavigationFlightResponse = {
   /** buildId */
   b: string
+  /** routeRegex */
+  r: RouteRegexFlightSafe
+  // TODO: This isn't really the "canonical" URL (which we usually use to refer
+  // to the URL shown in the browser), it's the URL used to render the page,
+  // which may have been rewritten on the server.
+  /** canonicalUrlParts */
+  c: string[]
+  /** pagePath */
+  t: string
   /** flightData */
   f: FlightData
   /** prerendered */
@@ -336,6 +353,15 @@ export type ActionFlightResponse = {
   a: ActionResult
   /** buildId */
   b: string
+  /** routeRegex */
+  r: RouteRegexFlightSafe
+  // TODO: This isn't really the "canonical" URL (which we usually use to refer
+  // to the URL shown in the browser), it's the URL used to render the page,
+  // which may have been rewritten on the server.
+  /** canonicalUrlParts */
+  c: string[]
+  /** pagePath */
+  t: string
   /** flightData */
   f: FlightData
 }

--- a/packages/next/src/shared/lib/router/utils/route-regex.ts
+++ b/packages/next/src/shared/lib/router/utils/route-regex.ts
@@ -18,6 +18,13 @@ export interface RouteRegex {
   re: RegExp
 }
 
+// Same as RouteRegex, but the regex is split into parts so it can be sent to
+// the client and re-assembled.
+export interface RouteRegexFlightSafe {
+  groups: { [groupName: string]: Group }
+  reParts: [string, string]
+}
+
 type GetNamedRouteRegexOptions = {
   /**
    * Whether to prefix the route keys with the NEXT_INTERCEPTION_MARKER_PREFIX
@@ -156,6 +163,15 @@ export function getRouteRegex(
   return {
     re: new RegExp(`^${re}$`),
     groups: groups,
+  }
+}
+
+export function toFlightSafeRouteRegex(
+  routeRegex: RouteRegex
+): RouteRegexFlightSafe {
+  return {
+    groups: routeRegex.groups,
+    reParts: [routeRegex.re.source, routeRegex.re.flags],
   }
 }
 


### PR DESCRIPTION
This is part of a larger effort to remove dynamic params from server responses except in cases where they are needed to render a Server Component. If a param is not rendered by a Server Component, then it can omitted from the cache key, and cached responses can be reused across pages with different param values.

In this step, I've implemented client parsing of the params from the response headers. This requires sending some additional data in the response body, such as the regex for the route.

Note: Although the ultimate goal is to remove the dynamic params from the response body (e.g. FlightRouterState), I have not done so yet this PR. The rest of the work will be split up into multiple subsequent PRs.