### PR TITLE
docs: App Router's React version

### DIFF
--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -56,6 +56,8 @@ yarn add next@latest react@latest react-dom@latest
 bun add next@latest react@latest react-dom@latest
 ```
 
+> **Good to know**: The App Router uses [React canary releases](https://react.dev/blog/2023/05/03/react-canaries) built-in, which include all the stable React 19 changes, as well as newer features being validated in frameworks. The Pages Router uses the React version you install in `package.json`.
+
 Then, add the following scripts to your `package.json` file:
 
 ```json filename="package.json"

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -37,6 +37,16 @@ Next.js has two different routers:
 
 At the top of the sidebar, you'll notice a dropdown menu that allows you to switch between the [App Router](/docs/app) and the [Pages Router](/docs/pages) docs.
 
+### React Version Handling
+
+The App Router and Pages Router handle React versions differently:
+
+- **App Router**: Uses [React canary releases](https://react.dev/blog/2023/05/03/react-canaries) built-in, which include all the stable React 19 changes, as well as newer features being validated in frameworks, prior to a new React release.
+
+- **Pages Router**: Uses the React version installed in your project's `package.json`.
+
+This approach ensures new React features work reliably in the App Router while maintaining backwards compatibility for existing Pages Router applications.
+
 ## Pre-requisite knowledge
 
 Our documentation assumes some familiarity with web development. Before getting started, it'll help if you're comfortable with:

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -37,7 +37,7 @@ Next.js has two different routers:
 
 At the top of the sidebar, you'll notice a dropdown menu that allows you to switch between the [App Router](/docs/app) and the [Pages Router](/docs/pages) docs.
 
-### React Version Handling
+### React version handling
 
 The App Router and Pages Router handle React versions differently:
 


### PR DESCRIPTION
Closes: https://linear.app/vercel/issue/DOC-4930/notes-about-app-routers-react-version