### PR TITLE
feat(eslint-plugin): expose flatConfigs as property of default export

### DIFF
--- a/packages/eslint-plugin-next/package.json
+++ b/packages/eslint-plugin-next/package.json
@@ -16,6 +16,7 @@
     "fast-glob": "3.3.1"
   },
   "devDependencies": {
+    "@types/eslint": "9.6.1",
     "eslint": "8.56.0"
   },
   "scripts": {

--- a/packages/eslint-plugin-next/package.json
+++ b/packages/eslint-plugin-next/package.json
@@ -13,11 +13,10 @@
     "dist"
   ],
   "dependencies": {
-    "@types/eslint": "^9.0.0",
     "fast-glob": "3.3.1"
   },
   "devDependencies": {
-    "eslint": "8.56.0"
+    "@types/eslint": "^9.6.1"
   },
   "scripts": {
     "dev": "pnpm build",

--- a/packages/eslint-plugin-next/package.json
+++ b/packages/eslint-plugin-next/package.json
@@ -13,10 +13,10 @@
     "dist"
   ],
   "dependencies": {
+    "@types/eslint": "^9.0.0",
     "fast-glob": "3.3.1"
   },
   "devDependencies": {
-    "@types/eslint": "9.6.1",
     "eslint": "8.56.0"
   },
   "scripts": {

--- a/packages/eslint-plugin-next/src/index.ts
+++ b/packages/eslint-plugin-next/src/index.ts
@@ -1,4 +1,50 @@
-const recommendedRules = {
+import type { ESLint, Linter, Rule } from 'eslint'
+
+const rules: Record<string, Rule.RuleModule> = {
+  'google-font-display':
+    require('./rules/google-font-display') as typeof import('./rules/google-font-display'),
+  'google-font-preconnect':
+    require('./rules/google-font-preconnect') as typeof import('./rules/google-font-preconnect'),
+  'inline-script-id':
+    require('./rules/inline-script-id') as typeof import('./rules/inline-script-id'),
+  'next-script-for-ga':
+    require('./rules/next-script-for-ga') as typeof import('./rules/next-script-for-ga'),
+  'no-assign-module-variable':
+    require('./rules/no-assign-module-variable') as typeof import('./rules/no-assign-module-variable'),
+  'no-async-client-component':
+    require('./rules/no-async-client-component') as typeof import('./rules/no-async-client-component'),
+  'no-before-interactive-script-outside-document':
+    require('./rules/no-before-interactive-script-outside-document') as typeof import('./rules/no-before-interactive-script-outside-document'),
+  'no-css-tags':
+    require('./rules/no-css-tags') as typeof import('./rules/no-css-tags'),
+  'no-document-import-in-page':
+    require('./rules/no-document-import-in-page') as typeof import('./rules/no-document-import-in-page'),
+  'no-duplicate-head':
+    require('./rules/no-duplicate-head') as typeof import('./rules/no-duplicate-head'),
+  'no-head-element':
+    require('./rules/no-head-element') as typeof import('./rules/no-head-element'),
+  'no-head-import-in-document':
+    require('./rules/no-head-import-in-document') as typeof import('./rules/no-head-import-in-document'),
+  'no-html-link-for-pages':
+    require('./rules/no-html-link-for-pages') as typeof import('./rules/no-html-link-for-pages'),
+  'no-img-element':
+    require('./rules/no-img-element') as typeof import('./rules/no-img-element'),
+  'no-page-custom-font':
+    require('./rules/no-page-custom-font') as typeof import('./rules/no-page-custom-font'),
+  'no-script-component-in-head':
+    require('./rules/no-script-component-in-head') as typeof import('./rules/no-script-component-in-head'),
+  'no-styled-jsx-in-document':
+    require('./rules/no-styled-jsx-in-document') as typeof import('./rules/no-styled-jsx-in-document'),
+  'no-sync-scripts':
+    require('./rules/no-sync-scripts') as typeof import('./rules/no-sync-scripts'),
+  'no-title-in-document-head':
+    require('./rules/no-title-in-document-head') as typeof import('./rules/no-title-in-document-head'),
+  'no-typos': require('./rules/no-typos') as typeof import('./rules/no-typos'),
+  'no-unwanted-polyfillio':
+    require('./rules/no-unwanted-polyfillio') as typeof import('./rules/no-unwanted-polyfillio'),
+}
+
+const recommendedRules: Linter.RulesRecord = {
   // warnings
   '@next/next/google-font-display': 'warn',
   '@next/next/google-font-preconnect': 'warn',
@@ -24,70 +70,29 @@ const recommendedRules = {
   '@next/next/no-script-component-in-head': 'error',
 }
 
-const coreWebVitalsRules = {
+const coreWebVitalsRules: Linter.RulesRecord = {
   '@next/next/no-html-link-for-pages': 'error',
   '@next/next/no-sync-scripts': 'error',
 }
 
-const plugin = {
-  rules: {
-    'google-font-display':
-      require('./rules/google-font-display') as typeof import('./rules/google-font-display'),
-    'google-font-preconnect':
-      require('./rules/google-font-preconnect') as typeof import('./rules/google-font-preconnect'),
-    'inline-script-id':
-      require('./rules/inline-script-id') as typeof import('./rules/inline-script-id'),
-    'next-script-for-ga':
-      require('./rules/next-script-for-ga') as typeof import('./rules/next-script-for-ga'),
-    'no-assign-module-variable':
-      require('./rules/no-assign-module-variable') as typeof import('./rules/no-assign-module-variable'),
-    'no-async-client-component':
-      require('./rules/no-async-client-component') as typeof import('./rules/no-async-client-component'),
-    'no-before-interactive-script-outside-document':
-      require('./rules/no-before-interactive-script-outside-document') as typeof import('./rules/no-before-interactive-script-outside-document'),
-    'no-css-tags':
-      require('./rules/no-css-tags') as typeof import('./rules/no-css-tags'),
-    'no-document-import-in-page':
-      require('./rules/no-document-import-in-page') as typeof import('./rules/no-document-import-in-page'),
-    'no-duplicate-head':
-      require('./rules/no-duplicate-head') as typeof import('./rules/no-duplicate-head'),
-    'no-head-element':
-      require('./rules/no-head-element') as typeof import('./rules/no-head-element'),
-    'no-head-import-in-document':
-      require('./rules/no-head-import-in-document') as typeof import('./rules/no-head-import-in-document'),
-    'no-html-link-for-pages':
-      require('./rules/no-html-link-for-pages') as typeof import('./rules/no-html-link-for-pages'),
-    'no-img-element':
-      require('./rules/no-img-element') as typeof import('./rules/no-img-element'),
-    'no-page-custom-font':
-      require('./rules/no-page-custom-font') as typeof import('./rules/no-page-custom-font'),
-    'no-script-component-in-head':
-      require('./rules/no-script-component-in-head') as typeof import('./rules/no-script-component-in-head'),
-    'no-styled-jsx-in-document':
-      require('./rules/no-styled-jsx-in-document') as typeof import('./rules/no-styled-jsx-in-document'),
-    'no-sync-scripts':
-      require('./rules/no-sync-scripts') as typeof import('./rules/no-sync-scripts'),
-    'no-title-in-document-head':
-      require('./rules/no-title-in-document-head') as typeof import('./rules/no-title-in-document-head'),
-    'no-typos':
-      require('./rules/no-typos') as typeof import('./rules/no-typos'),
-    'no-unwanted-polyfillio':
-      require('./rules/no-unwanted-polyfillio') as typeof import('./rules/no-unwanted-polyfillio'),
+const configs: Record<string, Linter.LegacyConfig> = {
+  recommended: {
+    plugins: ['@next/next'],
+    rules: recommendedRules,
   },
-  configs: {
-    recommended: {
-      plugins: ['@next/next'],
-      rules: recommendedRules,
-    },
-    'core-web-vitals': {
-      plugins: ['@next/next'],
-      extends: ['plugin:@next/next/recommended'],
-      rules: coreWebVitalsRules,
-    },
+  'core-web-vitals': {
+    plugins: ['@next/next'],
+    extends: ['plugin:@next/next/recommended'],
+    rules: coreWebVitalsRules,
   },
 }
 
-const flatConfig = {
+const plugin: ESLint.Plugin = {
+  rules,
+  configs,
+}
+
+const flatConfig: Record<string, Linter.Config> = {
   recommended: {
     name: 'next/recommended',
     plugins: {
@@ -107,6 +112,5 @@ const flatConfig = {
   },
 }
 
-export default plugin
-export const { rules, configs } = plugin
-export { flatConfig }
+export default { ...plugin, flatConfigs: flatConfig }
+export { configs, flatConfig, rules }

--- a/packages/eslint-plugin-next/src/index.ts
+++ b/packages/eslint-plugin-next/src/index.ts
@@ -1,6 +1,6 @@
 import type { ESLint, Linter, Rule } from 'eslint'
 
-const rules: Record<string, Rule.RuleModule> = {
+const rules = {
   'google-font-display':
     require('./rules/google-font-display') as typeof import('./rules/google-font-display'),
   'google-font-preconnect':
@@ -42,9 +42,9 @@ const rules: Record<string, Rule.RuleModule> = {
   'no-typos': require('./rules/no-typos') as typeof import('./rules/no-typos'),
   'no-unwanted-polyfillio':
     require('./rules/no-unwanted-polyfillio') as typeof import('./rules/no-unwanted-polyfillio'),
-}
+} as const satisfies Record<string, Rule.RuleModule>
 
-const recommendedRules: Linter.RulesRecord = {
+const recommendedRules = {
   // warnings
   '@next/next/google-font-display': 'warn',
   '@next/next/google-font-preconnect': 'warn',
@@ -68,14 +68,14 @@ const recommendedRules: Linter.RulesRecord = {
   '@next/next/no-duplicate-head': 'error',
   '@next/next/no-head-import-in-document': 'error',
   '@next/next/no-script-component-in-head': 'error',
-}
+} as const satisfies Linter.RulesRecord
 
-const coreWebVitalsRules: Linter.RulesRecord = {
+const coreWebVitalsRules = {
   '@next/next/no-html-link-for-pages': 'error',
   '@next/next/no-sync-scripts': 'error',
-}
+} as const satisfies Linter.RulesRecord
 
-const configs: Record<string, Linter.LegacyConfig> = {
+const configs = {
   recommended: {
     plugins: ['@next/next'],
     rules: recommendedRules,
@@ -85,14 +85,14 @@ const configs: Record<string, Linter.LegacyConfig> = {
     extends: ['plugin:@next/next/recommended'],
     rules: coreWebVitalsRules,
   },
-}
+} as const satisfies Record<string, Linter.LegacyConfig>
 
-const plugin: ESLint.Plugin = {
+const plugin = {
   rules,
   configs,
-}
+} as const satisfies ESLint.Plugin
 
-const flatConfig: Record<string, Linter.Config> = {
+const flatConfig = {
   recommended: {
     name: 'next/recommended',
     plugins: {
@@ -110,7 +110,7 @@ const flatConfig: Record<string, Linter.Config> = {
       ...coreWebVitalsRules,
     },
   },
-}
+} as const satisfies Record<string, Linter.Config>
 
 export default { ...plugin, flatConfigs: flatConfig }
 export { configs, flatConfig, rules }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -903,11 +903,8 @@ importers:
         version: 3.3.1
     devDependencies:
       '@types/eslint':
-        specifier: 9.6.1
+        specifier: ^9.6.1
         version: 9.6.1
-      eslint:
-        specifier: 8.56.0
-        version: 8.56.0
 
   packages/font:
     devDependencies:
@@ -3497,10 +3494,6 @@ packages:
     resolution: {integrity: sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@8.56.0':
-    resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3719,11 +3712,6 @@ packages:
   '@humanfs/node@0.16.5':
     resolution: {integrity: sha512-KSPA4umqSG4LHYRodq31VDwKAvaTF4xmVlzM8Aeh4PlU1JQ3IG0wiA8C25d3RQ9nJyM3mBHyI53K06VVL/oFFg==}
     engines: {node: '>=18.18.0'}
-
-  '@humanwhocodes/config-array@0.11.14':
-    resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
-    engines: {node: '>=10.10.0'}
-    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -5567,9 +5555,6 @@ packages:
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
-
-  '@types/eslint@7.28.0':
-    resolution: {integrity: sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==}
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
@@ -8996,12 +8981,6 @@ packages:
   eslint@7.32.0:
     resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
     engines: {node: ^10.12.0 || >=12.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
-    hasBin: true
-
-  eslint@8.56.0:
-    resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
@@ -18849,11 +18828,6 @@ snapshots:
   '@esbuild/win32-x64@0.25.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
-    dependencies:
-      eslint: 8.56.0
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.4.0(eslint@9.12.0)':
     dependencies:
       eslint: 9.12.0
@@ -18924,8 +18898,6 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-
-  '@eslint/js@8.56.0': {}
 
   '@eslint/js@8.57.1': {}
 
@@ -19196,14 +19168,6 @@ snapshots:
     dependencies:
       '@humanfs/core': 0.19.0
       '@humanwhocodes/retry': 0.3.1
-
-  '@humanwhocodes/config-array@0.11.14':
-    dependencies:
-      '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -21703,13 +21667,8 @@ snapshots:
 
   '@types/eslint-scope@3.7.7':
     dependencies:
-      '@types/eslint': 7.28.0
+      '@types/eslint': 9.6.1
       '@types/estree': 1.0.7
-
-  '@types/eslint@7.28.0':
-    dependencies:
-      '@types/estree': 1.0.7
-      '@types/json-schema': 7.0.15
 
   '@types/eslint@9.6.1':
     dependencies:
@@ -26021,49 +25980,6 @@ snapshots:
       table: 6.8.0
       text-table: 0.2.0
       v8-compile-cache: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint@8.56.0:
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
-      '@eslint-community/regexpp': 4.11.1
-      '@eslint/eslintrc': 2.1.4
-      '@eslint/js': 8.56.0
-      '@humanwhocodes/config-array': 0.11.14
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      '@ungap/structured-clone': 1.2.0
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.7
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.24.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -902,6 +902,9 @@ importers:
         specifier: 3.3.1
         version: 3.3.1
     devDependencies:
+      '@types/eslint':
+        specifier: 9.6.1
+        version: 9.6.1
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -5567,6 +5570,9 @@ packages:
 
   '@types/eslint@7.28.0':
     resolution: {integrity: sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==}
+
+  '@types/eslint@9.6.1':
+    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
   '@types/estree-jsx@1.0.0':
     resolution: {integrity: sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==}
@@ -15277,6 +15283,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -15641,7 +15648,7 @@ packages:
   superagent@3.8.3:
     resolution: {integrity: sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   superstruct@1.0.3:
     resolution: {integrity: sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==}
@@ -21700,6 +21707,11 @@ snapshots:
       '@types/estree': 1.0.7
 
   '@types/eslint@7.28.0':
+    dependencies:
+      '@types/estree': 1.0.7
+      '@types/json-schema': 7.0.15
+
+  '@types/eslint@9.6.1':
     dependencies:
       '@types/estree': 1.0.7
       '@types/json-schema': 7.0.15


### PR DESCRIPTION
Currently, the flat configs object is only available as a named export named `flatConfig`, which means that the usage example on #73873 (where it's used as a property of the default export named `flatConfigs`) doesn't work.

If you try to use `flatConfig` as a property of the default export, it works but causes TypeScript errors if the consumer has type checking enabled in their ESLint config:

```
eslint.config.mjs:180:24 - error TS2339: Property 'flatConfig' does not exist on type '{ rules: { 'google-font-display': RuleModule; 'google-font-preconnect': RuleModule; 'inline-script-id': RuleModule; 'next-script-for-ga': RuleModule; ... 16 more ...; 'no-unwanted-polyfillio': RuleModule; }; configs: { ...; }; }'.

180       eslintPluginNext.flatConfig.recommended,
                           ~~~~~~~~~~
```

This has caused quite a bit of confusion, as evidenced by activity on https://github.com/vercel/next.js/discussions/49337 from after that PR was merged. (I shared that confusion for a while!)

This PR attaches `flatConfig` to the default export as a property named `flatConfigs`, while continuing to make it available as a named export named `flatConfig` for backward compatibility. With this change, the flat config is more easily usable like those of other popular ESLint libraries:

```
// eslint.config.mjs
import js from "@eslint/js";
import reactPlugin from 'eslint-plugin-react';
import eslintPluginNext from '@next/eslint-plugin-next';

export default [
  ...js.configs.recommended,
  ...reactPlugin.configs.flat.recommended,
  ...eslintPluginImportX.flatConfigs.recommended,
]
```

I've also reorganized the code a bit, and added proper type checking through `@eslint/types`.

/cc @SukkaW @CHC383 @rakleed @juliolmuller @devjiwonchoi