### PR TITLE
fix: preserve file extensions for metadata routes during static export

### DIFF
--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -238,15 +238,15 @@ async function exportPageImpl(
     
     if (isPageMetadataRoute) {
       // Extract the original file extension from the page path
-      const pageExt = extname(page)
-      if (pageExt) {
+      const actualPageExt = extname(page)
+      if (actualPageExt) {
         // For metadata routes, we want to preserve the file extension
         // so static file servers can serve them with correct MIME types
         // This fixes the issue where opengraph-image.png was served as /opengraph-image
         // instead of /opengraph-image.png, causing static file servers to serve
         // the file as application/octet-stream instead of the proper image MIME type
         const basePath = path.replace(/\.html$/, '')
-        htmlFilename = subFolders ? `${basePath}${sep}index${pageExt}` : `${basePath}${pageExt}`
+        htmlFilename = subFolders ? `${basePath}${sep}index${actualPageExt}` : `${basePath}${actualPageExt}`
       }
     }
   }

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -50,6 +50,7 @@ import type { PagesRenderContext, PagesSharedContext } from '../server/render'
 import type { AppSharedContext } from '../server/app-render/app-render'
 import { MultiFileWriter } from '../lib/multi-file-writer'
 import { createRenderResumeDataCache } from '../server/resume-data-cache/resume-data-cache'
+import { isMetadataRoute } from '../../lib/metadata/is-metadata-route'
 
 const envConfig =
   require('../shared/lib/runtime-config.external') as typeof import('../shared/lib/runtime-config.external')
@@ -227,6 +228,27 @@ async function exportPageImpl(
   } else if (path === '/') {
     // If the path is the root, just use index.html
     htmlFilename = 'index.html'
+  }
+
+  // For metadata routes, preserve the file extension to ensure proper MIME type serving
+  // by static file servers like GitHub Pages
+  if (isAppDir && isAppRouteRoute(page)) {
+    const routePath = normalizeAppPath(page) + '/route'
+    const isPageMetadataRoute = isMetadataRoute(routePath)
+    
+    if (isPageMetadataRoute) {
+      // Extract the original file extension from the page path
+      const pageExt = extname(page)
+      if (pageExt) {
+        // For metadata routes, we want to preserve the file extension
+        // so static file servers can serve them with correct MIME types
+        // This fixes the issue where opengraph-image.png was served as /opengraph-image
+        // instead of /opengraph-image.png, causing static file servers to serve
+        // the file as application/octet-stream instead of the proper image MIME type
+        const basePath = path.replace(/\.html$/, '')
+        htmlFilename = subFolders ? `${basePath}${sep}index${pageExt}` : `${basePath}${pageExt}`
+      }
+    }
   }
 
   const baseDir = join(outDir, dirname(htmlFilename))


### PR DESCRIPTION
### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.

 fix: #82177

### What?

Fix metadata route file extensions during static export to prevent `application/octet-stream` MIME type serving.

### Why?

Metadata routes like `opengraph-image.png` were exported without file extensions, causing static file servers like GitHub Pages to serve them as `application/octet-stream` instead of proper image MIME types.

### How?

Preserve file extensions for metadata routes in the export worker by detecting metadata routes and maintaining their original file extensions in the output filename.