### PR TITLE
fix: static not-found missing in prerender manifest

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -77,7 +77,6 @@ import {
   SERVER_REFERENCE_MANIFEST,
   FUNCTIONS_CONFIG_MANIFEST,
   UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
-  UNDERSCORE_NOT_FOUND_ROUTE,
   DYNAMIC_CSS_MANIFEST,
   TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST,
 } from '../shared/lib/constants'
@@ -3090,12 +3089,6 @@ export default async function build(
             ]
 
             for (const prerenderedRoute of prerenderedRoutes) {
-              // TODO: check if still needed?
-              // Exclude the /_not-found route.
-              if (prerenderedRoute.pathname === UNDERSCORE_NOT_FOUND_ROUTE) {
-                continue
-              }
-
               if (
                 isRoutePPREnabled &&
                 prerenderedRoute.fallbackRouteParams &&
@@ -3114,7 +3107,6 @@ export default async function build(
             // Handle all the static routes.
             for (const route of staticPrerenderedRoutes) {
               if (isDynamicRoute(page) && route.pathname === page) continue
-              if (route.pathname === UNDERSCORE_NOT_FOUND_ROUTE) continue
 
               const {
                 metadata = {},
@@ -3530,7 +3522,7 @@ export default async function build(
             return staticGenerationSpan
               .traceChild('move-exported-app-not-found-')
               .traceAsyncFn(async () => {
-                const orig = path.join(
+                const underscoreNotFoundHtml = path.join(
                   distDir,
                   'server',
                   'app',
@@ -3540,9 +3532,10 @@ export default async function build(
                   .join('pages', '404.html')
                   .replace(/\\/g, '/')
 
-                if (existsSync(orig)) {
+                // If the _not-found.html exists, use it instead of the pages 404.html
+                if (existsSync(underscoreNotFoundHtml)) {
                   await fs.copyFile(
-                    orig,
+                    underscoreNotFoundHtml,
                     path.join(distDir, 'server', updatedRelativeDest)
                   )
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -76,6 +76,7 @@ import {
   MIDDLEWARE_REACT_LOADABLE_MANIFEST,
   SERVER_REFERENCE_MANIFEST,
   FUNCTIONS_CONFIG_MANIFEST,
+  UNDERSCORE_NOT_FOUND_ROUTE,
   UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
   DYNAMIC_CSS_MANIFEST,
   TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST,
@@ -3156,9 +3157,13 @@ export default async function build(
                 }
 
                 const meta = collectMeta(metadata)
+                const status =
+                  route.pathname === UNDERSCORE_NOT_FOUND_ROUTE
+                    ? 404
+                    : meta.status
 
                 prerenderManifest.routes[route.pathname] = {
-                  initialStatus: meta.status,
+                  initialStatus: status,
                   initialHeaders: meta.headers,
                   renderingMode: isAppPPREnabled
                     ? isRoutePPREnabled
@@ -3522,7 +3527,7 @@ export default async function build(
             return staticGenerationSpan
               .traceChild('move-exported-app-not-found-')
               .traceAsyncFn(async () => {
-                const underscoreNotFoundHtml = path.join(
+                const orig = path.join(
                   distDir,
                   'server',
                   'app',
@@ -3532,10 +3537,9 @@ export default async function build(
                   .join('pages', '404.html')
                   .replace(/\\/g, '/')
 
-                // If the _not-found.html exists, use it instead of the pages 404.html
-                if (existsSync(underscoreNotFoundHtml)) {
+                if (existsSync(orig)) {
                   await fs.copyFile(
-                    underscoreNotFoundHtml,
+                    orig,
                     path.join(distDir, 'server', updatedRelativeDest)
                   )
 

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -763,6 +763,10 @@ async function exportAppImpl(
   if (!options.buildExport && prerenderManifest) {
     await Promise.all(
       Object.keys(prerenderManifest.routes).map(async (unnormalizedRoute) => {
+        // Skip handling /_not-found route, it will copy the 404.html file later
+        if (unnormalizedRoute === '/_not-found') {
+          return
+        }
         const { srcRoute } = prerenderManifest!.routes[unnormalizedRoute]
         const appPageName = mapAppRouteToPage.get(srcRoute || '')
         const pageName = appPageName || srcRoute || unnormalizedRoute

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -987,6 +987,19 @@ describe('app-dir static/dynamic handling', () => {
            "initialRevalidateSeconds": false,
            "srcRoute": "/",
          },
+         "/_not-found": {
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token",
+           ],
+           "dataRoute": "/_not-found.rsc",
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+         },
          "/api/large-data": {
            "allowHeader": [
              "host",

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -997,8 +997,19 @@ describe('app-dir static/dynamic handling', () => {
              "x-next-revalidate-tag-token",
            ],
            "dataRoute": "/_not-found.rsc",
+           "experimentalBypassFor": [
+             {
+               "key": "next-action",
+               "type": "header",
+             },
+             {
+               "key": "content-type",
+               "type": "header",
+               "value": "multipart/form-data;.*",
+             },
+           ],
            "initialRevalidateSeconds": false,
-           "srcRoute": null,
+           "srcRoute": "/_not-found",
          },
          "/api/large-data": {
            "allowHeader": [

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -1009,6 +1009,7 @@ describe('app-dir static/dynamic handling', () => {
              },
            ],
            "initialRevalidateSeconds": false,
+           "initialStatus": 404,
            "srcRoute": "/_not-found",
          },
          "/api/large-data": {

--- a/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
+++ b/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
@@ -39,6 +39,7 @@ describe('async imports in cacheComponents', () => {
 
       expect(prerenderedRoutes).toMatchInlineSnapshot(`
        [
+         "/_not-found",
          "/inside-render/client/async-module",
          "/inside-render/client/sync-module",
          "/inside-render/route-handler/async-module",

--- a/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
@@ -24,6 +24,7 @@ const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
         const staticRoutes = prerenderManifest.routes
         expect(Object.keys(staticRoutes).sort()).toEqual([
           '/',
+          '_not-found',
           '/suspenseful/static',
         ])
       })

--- a/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-static-generation/metadata-static-generation.test.ts
@@ -24,7 +24,7 @@ const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
         const staticRoutes = prerenderManifest.routes
         expect(Object.keys(staticRoutes).sort()).toEqual([
           '/',
-          '_not-found',
+          '/_not-found',
           '/suspenseful/static',
         ])
       })

--- a/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
@@ -22,6 +22,7 @@ const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
         const staticRoutes = prerenderManifest.routes
         expect(Object.keys(staticRoutes).sort()).toEqual([
           '/',
+          '_not-found',
           '/slow/static',
           '/suspenseful/static',
         ])

--- a/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
@@ -22,7 +22,7 @@ const isPPREnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
         const staticRoutes = prerenderManifest.routes
         expect(Object.keys(staticRoutes).sort()).toEqual([
           '/',
-          '_not-found',
+          '/_not-found',
           '/slow/static',
           '/suspenseful/static',
         ])

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -473,6 +473,7 @@ describe('use-cache', () => {
 
       expect(prerenderedRouteKeys).toEqual(
         [
+          '/_not-found',
           // [id] route, first entry in generateStaticParams
           expect.stringMatching(/\/a\d/),
           withCacheComponents && '/api',


### PR DESCRIPTION
The `/_not-found` was excluded out in the prerender manifest, which lead to it's not being treated as static route during `next start`. The route was built into static but still gets re-rendered each time.

<img width="2396" height="748" alt="image" src="https://github.com/user-attachments/assets/374b0e99-0a74-4776-b0cc-cdc9eee13b7b" />


Closes NEXT-4659