### PR TITLE
docs: Add hint about how fetch function time-based cache revalidation works

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/fetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/fetch.mdx
@@ -72,6 +72,7 @@ Set the cache lifetime of a resource (in seconds). [Data Cache](/docs/app/guides
 > - If an individual `fetch()` request sets a `revalidate` number lower than the [default `revalidate`](/docs/app/api-reference/file-conventions/route-segment-config#revalidate) of a route, the whole route revalidation interval will be decreased.
 > - If two fetch requests with the same URL in the same route have different `revalidate` values, the lower value will be used.
 > - Conflicting options such as `{ revalidate: 3600, cache: 'no-store' }` are not allowed, both will be ignored, and in development mode a warning will be printed to the terminal.
+> - Requests called after the `revalidate` timeframe will behave similarly to [**stale-while-revalidate**](https://web.dev/articles/stale-while-revalidate). See the [Time-based Revalidation Caching Guide](/docs/app/guides/caching#time-based-revalidation) to learn more.
 
 ### `options.next.tags`
 


### PR DESCRIPTION
### Improving Documentation
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
Explicitly hint about how cache revalidation works for the fetch function works on the function documentation page as a "Good to know" topic on [options.next.revalidate](https://nextjs.org/docs/app/api-reference/functions/fetch#optionsnextrevalidate).

### Why?

### How?

Closes NEXT-
Fixes #

-->


### What?
Explicitly hint about how cache revalidation works for the fetch function works on the function documentation page as a "Good to know" topic on [options.next.revalidate](https://nextjs.org/docs/app/api-reference/functions/fetch#optionsnextrevalidate).

### Why?
Currently, this info is only buried in the middle of the [Caching Guide](https://nextjs.org/docs/app/guides/caching) page, which has 4k+ words and contains information about multiple kinds of cache, that could not be relevant to someone who is just looking to understand how the cache works for the fetch function.

### How?
Stating that it behaves similarly to `stale-while-revalidate` (just like it is already stated on the caching guide) and adding a link to the relevant section on the guide for learning more about the behavior.
