### PR TITLE
fix createMDX plugin syntax, so that it works

### DIFF
--- a/docs/01-app/02-guides/mdx.mdx
+++ b/docs/01-app/02-guides/mdx.mdx
@@ -701,10 +701,8 @@ const nextConfig = {
 
 const withMDX = createMDX({
   // Add markdown plugins here, as desired
-  options: {
     remarkPlugins: [remarkGfm],
     rehypePlugins: [],
-  },
 })
 
 // Combine MDX and Next.js config


### PR DESCRIPTION
### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### What?

Fixing the documentation for usage of `createMDX()` config on the guides for MDX

### Why?

Passing plugins such as `remarkPlugins` inside an options object (e.g., options: { remarkPlugins: [...] }) causes a runtime error: TypeError: Cannot use 'in' operator to search for 'plugins' in null

which is really annoying.

### How? (does it work?)

CreateMDX is a wrapper for `xdm/unified` pipeline and (apparently) expects these plugin options, like remarkPlugins, to be directly on the top-level config object. [There was a source on this, but I can't seem to find it upon editing. So, idk why this happens.]
