### PR TITLE
Turbopack: implement shutdown for backing storage correct

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -211,6 +211,10 @@ where
             }
         }
     }
+
+    fn shutdown(&self) -> Result<()> {
+        either::for_both!(self, this => this.shutdown())
+    }
 }
 
 // similar to `Either::unwrap_left`, but does not require `R: Debug`.


### PR DESCRIPTION
### What?

This ensures next.js correctly waits for the turbopack shutdown to complete


Closes PACK-5155