### PR TITLE
Turbopack: Compact only at the end for short sessions

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -253,6 +253,8 @@ pub struct NapiTurboEngineOptions {
     pub dependency_tracking: Option<bool>,
     /// Whether the project is running in a CI environment.
     pub is_ci: Option<bool>,
+    /// Whether the project is running in a short session.
+    pub is_short_session: Option<bool>,
 }
 
 impl From<NapiWatchOptions> for WatchOptions {
@@ -434,12 +436,14 @@ pub fn project_new(
         let persistent_caching = turbo_engine_options.persistent_caching.unwrap_or_default();
         let dependency_tracking = turbo_engine_options.dependency_tracking.unwrap_or(true);
         let is_ci = turbo_engine_options.is_ci.unwrap_or(false);
+        let is_short_session = turbo_engine_options.is_short_session.unwrap_or(false);
         let turbo_tasks = create_turbo_tasks(
             PathBuf::from(&options.dist_dir),
             persistent_caching,
             memory_limit,
             dependency_tracking,
             is_ci,
+            is_short_session,
         )?;
         let turbopack_ctx = NextTurbopackContext::new(turbo_tasks.clone(), napi_callbacks);
 

--- a/crates/napi/src/next_api/turbopack_ctx.rs
+++ b/crates/napi/src/next_api/turbopack_ctx.rs
@@ -185,6 +185,7 @@ pub fn create_turbo_tasks(
     _memory_limit: usize,
     dependency_tracking: bool,
     is_ci: bool,
+    is_short_session: bool,
 ) -> Result<NextTurboTasks> {
     Ok(if persistent_caching {
         let version_info = GitVersionInfo {
@@ -192,8 +193,12 @@ pub fn create_turbo_tasks(
             dirty: option_env!("CI").is_none_or(|value| value.is_empty())
                 && env!("VERGEN_GIT_DIRTY") == "true",
         };
-        let (backing_storage, cache_state) =
-            default_backing_storage(&output_path.join("cache/turbopack"), &version_info, is_ci)?;
+        let (backing_storage, cache_state) = default_backing_storage(
+            &output_path.join("cache/turbopack"),
+            &version_info,
+            is_ci,
+            is_short_session,
+        )?;
         let tt = TurboTasks::new(TurboTasksBackend::new(
             BackendOptions {
                 storage_mode: Some(if std::env::var("TURBO_ENGINE_READ_ONLY").is_ok() {

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -212,6 +212,8 @@ export interface NapiTurboEngineOptions {
   dependencyTracking?: boolean
   /** Whether the project is running in a CI environment. */
   isCi?: boolean
+  /** Whether the project is running in a short session. */
+  isShortSession?: boolean
 }
 export declare function projectNew(
   options: NapiProjectOptions,

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -91,6 +91,7 @@ export async function turbopackBuild(): Promise<{
       memoryLimit: config.experimental?.turbopackMemoryLimit,
       dependencyTracking: persistentCaching,
       isCi: isCI,
+      isShortSession: true,
     }
   )
   try {

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -254,6 +254,7 @@ export async function createHotReloaderTurbopack(
     {
       persistentCaching: isPersistentCachingEnabled(opts.nextConfig),
       memoryLimit: opts.nextConfig.experimental?.turbopackMemoryLimit,
+      isShortSession: false,
     }
   )
   backgroundLogCompilationEvents(project, {

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -83,12 +83,13 @@ pub fn turbo_backing_storage(
     base_path: &Path,
     version_info: &GitVersionInfo,
     is_ci: bool,
+    is_short_session: bool,
 ) -> Result<(TurboBackingStorage, StartupCacheState)> {
     KeyValueDatabaseBackingStorage::open_versioned_on_disk(
         base_path.to_owned(),
         version_info,
         is_ci,
-        TurboKeyValueDatabase::new,
+        |path| TurboKeyValueDatabase::new(path, is_ci, is_short_session),
     )
 }
 
@@ -111,6 +112,7 @@ pub fn default_backing_storage(
     path: &Path,
     version_info: &GitVersionInfo,
     is_ci: bool,
+    is_short_session: bool,
 ) -> Result<(DefaultBackingStorage, StartupCacheState)> {
     #[cfg(feature = "lmdb")]
     {
@@ -118,6 +120,6 @@ pub fn default_backing_storage(
     }
     #[cfg(not(feature = "lmdb"))]
     {
-        turbo_backing_storage(path, version_info, is_ci)
+        turbo_backing_storage(path, version_info, is_ci, is_short_session)
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/test_config.trs
+++ b/turbopack/crates/turbo-tasks-backend/tests/test_config.trs
@@ -16,7 +16,8 @@
           describe: "test-unversioned",
           dirty: false,
         },
-        false
+        false,
+        true,
       ).unwrap().0
     )
   )

--- a/turbopack/crates/turbo-tasks-fetch/tests/test_config.trs
+++ b/turbopack/crates/turbo-tasks-fetch/tests/test_config.trs
@@ -16,7 +16,8 @@
           describe: "test-unversioned",
           dirty: false,
         },
-        false
+        false,
+        true,
       ).unwrap().0
     )
   )

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -292,6 +292,7 @@ fn node_file_trace_persistent(#[case] input: CaseInput) {
                     dirty: false,
                 },
                 false,
+                true,
             )
             .unwrap()
             .0,


### PR DESCRIPTION
### What?

Change the compaction behavior for "short sessions" (like next build). A longer "short session" might commit to the DB multiple times (every 60s currently), which previously resulted in compactions happening after multiple commits to the database. As compactions are expensive and memory hungry, we want to avoid them until the end of the session. At the end of the session we can run it in parallel to node.js SSG.

Closes PACK-5163