### PR TITLE
[Pages] fix: use `asPath` for query-only navigation with `useRouter`

### DIFF
--- a/packages/next/src/client/resolve-href.ts
+++ b/packages/next/src/client/resolve-href.ts
@@ -56,8 +56,11 @@ export function resolveHref(
   }
 
   try {
+    const shouldUseAsPath =
+      urlAsString.startsWith('#') || urlAsString.startsWith('?')
+
     base = new URL(
-      urlAsString.startsWith('#') ? router.asPath : router.pathname,
+      shouldUseAsPath ? router.asPath : router.pathname,
       'http://n'
     )
   } catch (_) {

--- a/packages/next/src/client/resolve-href.ts
+++ b/packages/next/src/client/resolve-href.ts
@@ -8,6 +8,8 @@ import { normalizePathTrailingSlash } from './normalize-trailing-slash'
 import { isLocalURL } from '../shared/lib/router/utils/is-local-url'
 import { isDynamicRoute } from '../shared/lib/router/utils'
 import { interpolateAs } from '../shared/lib/router/utils/interpolate-as'
+import { getRouteRegex } from '../shared/lib/router/utils/route-regex'
+import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
 
 /**
  * Resolves a given hyperlink with a certain router state (basePath not included).
@@ -56,13 +58,37 @@ export function resolveHref(
   }
 
   try {
-    const shouldUseAsPath =
-      urlAsString.startsWith('#') || urlAsString.startsWith('?')
+    let baseBase = urlAsString.startsWith('#') ? router.asPath : router.pathname
 
-    base = new URL(
-      shouldUseAsPath ? router.asPath : router.pathname,
-      'http://n'
-    )
+    // If the provided href is only a query string, it is safer to use the asPath
+    // considering rewrites.
+    if (urlAsString.startsWith('?')) {
+      baseBase = router.asPath
+
+      // However, if the pathname is dynamic, we need to use the pathname
+      // to preserve the query interpolation and rewrites.
+      if (isDynamicRoute(router.pathname)) {
+        baseBase = router.pathname
+
+        const routeRegex = getRouteRegex(router.pathname)
+        const match = getRouteMatcher(routeRegex)(router.asPath)
+
+        // For dynamic routes, if asPath doesn't match the pathname regex,
+        // treat it as a rewritten path and use asPath to preserve the current URL
+        // instead of the rewrite destination.
+        if (!match) {
+          baseBase = router.asPath
+        }
+        // Note: There is an edge case where the pathname is dynamic and also rewritten,
+        // but to a same segment.
+        // E.g. in /[slug] path, rewrite /foo -> /bar
+        // In this case, it will be treated as non-rewritten path and possibly interpolate
+        // the query string. This is a trade-off of not resolving rewrites path on every
+        // Router/Link calls.
+      }
+    }
+
+    base = new URL(baseBase, 'http://n')
   } catch (_) {
     // fallback to / for invalid asPath values e.g. //
     base = new URL('/', 'http://n')

--- a/packages/next/src/client/resolve-href.ts
+++ b/packages/next/src/client/resolve-href.ts
@@ -65,26 +65,28 @@ export function resolveHref(
     if (urlAsString.startsWith('?')) {
       baseBase = router.asPath
 
-      // However, if the pathname is dynamic, we need to use the pathname
-      // to preserve the query interpolation and rewrites.
+      // However, if is a dynamic route, we need to use the pathname to preserve the
+      // query interpolation and rewrites (router.pathname will look like "/[slug]").
       if (isDynamicRoute(router.pathname)) {
         baseBase = router.pathname
 
         const routeRegex = getRouteRegex(router.pathname)
         const match = getRouteMatcher(routeRegex)(router.asPath)
 
-        // For dynamic routes, if asPath doesn't match the pathname regex,
-        // treat it as a rewritten path and use asPath to preserve the current URL
-        // instead of the rewrite destination.
+        // For dynamic routes, if asPath doesn't match the pathname regex, it is a rewritten path.
+        // In this case, should use asPath to preserve the current URL.
         if (!match) {
           baseBase = router.asPath
         }
-        // Note: There is an edge case where the pathname is dynamic and also rewritten,
-        // but to a same segment.
-        // E.g. in /[slug] path, rewrite /foo -> /bar
-        // In this case, it will be treated as non-rewritten path and possibly interpolate
-        // the query string. This is a trade-off of not resolving rewrites path on every
-        // Router/Link calls.
+
+        // Note: There is an edge case where the pathname is dynamic, and also a rewrite path to the same segment.
+        // E.g. in "/[slug]" path, rewrite "/foo" -> "/bar"
+
+        // In this case, it will be treated as a non-rewritten path and possibly interpolate the query string.
+        // E.g., "/any?slug=foo" will become the content of "/foo", not rewritten as "/bar"
+
+        // This is currently a trade-off of not resolving rewrite paths on every Router/Link call,
+        // but using a lighter route regex pattern check.
       }
     }
 

--- a/test/e2e/use-router-with-rewrites/next.config.js
+++ b/test/e2e/use-router-with-rewrites/next.config.js
@@ -1,0 +1,16 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  rewrites: async () => {
+    return {
+      beforeFiles: [
+        {
+          source: '/',
+          destination: '/foo',
+        },
+      ],
+    }
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/use-router-with-rewrites/next.config.js
+++ b/test/e2e/use-router-with-rewrites/next.config.js
@@ -8,6 +8,22 @@ const nextConfig = {
           source: '/',
           destination: '/foo',
         },
+        {
+          source: '/rewrite-to-another-segment/:id',
+          destination: '/rewrite-to-another-segment/:id/foo',
+        },
+        {
+          source: '/rewrite-to-same-segment/1',
+          destination: '/rewrite-to-same-segment/001',
+        },
+        {
+          source: '/rewrite-to-same-segment/2',
+          destination: '/rewrite-to-same-segment/002',
+        },
+        {
+          source: '/rewrite-to-same-segment/3',
+          destination: '/rewrite-to-same-segment/003',
+        },
       ],
     }
   },

--- a/test/e2e/use-router-with-rewrites/next.config.js
+++ b/test/e2e/use-router-with-rewrites/next.config.js
@@ -12,6 +12,7 @@ const nextConfig = {
           source: '/rewrite-to-another-segment/:id',
           destination: '/rewrite-to-another-segment/:id/foo',
         },
+        // Even though there's rewrite, below won't work as expected due to trade-off.
         {
           source: '/rewrite-to-same-segment/1',
           destination: '/rewrite-to-same-segment/001',

--- a/test/e2e/use-router-with-rewrites/pages/foo.tsx
+++ b/test/e2e/use-router-with-rewrites/pages/foo.tsx
@@ -1,0 +1,32 @@
+import { useRouter } from 'next/router'
+
+export default function Page() {
+  const router = useRouter()
+
+  function handlePush() {
+    router.push({
+      query: {
+        param: 1,
+      },
+    })
+  }
+
+  function handleReplace() {
+    router.replace({
+      query: {
+        param: 1,
+      },
+    })
+  }
+
+  return (
+    <>
+      <button id="router-push" onClick={handlePush}>
+        router.push
+      </button>
+      <button id="router-replace" onClick={handleReplace}>
+        router.replace
+      </button>
+    </>
+  )
+}

--- a/test/e2e/use-router-with-rewrites/pages/rewrite-to-another-segment/[id]/foo.tsx
+++ b/test/e2e/use-router-with-rewrites/pages/rewrite-to-another-segment/[id]/foo.tsx
@@ -7,7 +7,7 @@ export default function Page() {
   function handlePush() {
     router.push({
       query: {
-        param: 1,
+        id: 1,
       },
     })
   }
@@ -15,20 +15,21 @@ export default function Page() {
   function handleReplace() {
     router.replace({
       query: {
-        param: 1,
+        id: 2,
       },
     })
   }
 
   return (
     <>
+      <p>{router.query.id}</p>
       <button id="router-push" onClick={handlePush}>
         router.push
       </button>
       <button id="router-replace" onClick={handleReplace}>
         router.replace
       </button>
-      <Link href="?param=1">Link</Link>
+      <Link href="?id=3">Link</Link>
     </>
   )
 }

--- a/test/e2e/use-router-with-rewrites/pages/rewrite-to-same-segment/[id]/index.tsx
+++ b/test/e2e/use-router-with-rewrites/pages/rewrite-to-same-segment/[id]/index.tsx
@@ -7,7 +7,7 @@ export default function Page() {
   function handlePush() {
     router.push({
       query: {
-        param: 1,
+        id: 1,
       },
     })
   }
@@ -15,20 +15,21 @@ export default function Page() {
   function handleReplace() {
     router.replace({
       query: {
-        param: 1,
+        id: 2,
       },
     })
   }
 
   return (
     <>
+      <p>{router.query.id}</p>
       <button id="router-push" onClick={handlePush}>
         router.push
       </button>
       <button id="router-replace" onClick={handleReplace}>
         router.replace
       </button>
-      <Link href="?param=1">Link</Link>
+      <Link href="?id=3">Link</Link>
     </>
   )
 }

--- a/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+++ b/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('use-router-with-rewrites', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should preserve current pathname when using useRouter.push with rewrites', async () => {
+    const browser = await next.browser('/')
+    await browser.elementById('router-push').click()
+
+    expect(await browser.url()).toBe(
+      `http://localhost:${next.appPort}/?param=1`
+    )
+  })
+
+  it('should preserve current pathname when using useRouter.replace with rewrites', async () => {
+    const browser = await next.browser('/')
+    await browser.elementById('router-replace').click()
+
+    expect(await browser.url()).toBe(
+      `http://localhost:${next.appPort}/?param=1`
+    )
+  })
+})

--- a/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+++ b/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
@@ -22,4 +22,76 @@ describe('use-router-with-rewrites', () => {
       `http://localhost:${next.appPort}/?param=1`
     )
   })
+
+  it('should preserve current pathname when using Link with rewrites', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('a').click()
+    expect(await browser.url()).toBe(
+      `http://localhost:${next.appPort}/?param=1`
+    )
+  })
+
+  describe('rewrite to another segment', () => {
+    it('should preserve current pathname when using useRouter.push with rewrites on dynamic route', async () => {
+      const browser = await next.browser('/rewrite-to-another-segment/0')
+      await browser.elementById('router-push').click()
+
+      expect(await browser.url()).toBe(
+        `http://localhost:${next.appPort}/rewrite-to-another-segment/1`
+      )
+    })
+
+    it('should preserve current pathname when using useRouter.replace with rewrites on dynamic route', async () => {
+      const browser = await next.browser('/rewrite-to-another-segment/0')
+      await browser.elementById('router-replace').click()
+
+      expect(await browser.url()).toBe(
+        `http://localhost:${next.appPort}/rewrite-to-another-segment/2`
+      )
+    })
+
+    it('should preserve current pathname when using Link with rewrites on dynamic route', async () => {
+      const browser = await next.browser('/rewrite-to-another-segment/0')
+      await browser.elementByCss('a').click()
+
+      expect(await browser.url()).toBe(
+        `http://localhost:${next.appPort}/rewrite-to-another-segment/3`
+      )
+    })
+  })
+
+  describe('rewrite to same segment', () => {
+    it('should preserve current pathname when using useRouter.push with rewrites on dynamic route', async () => {
+      const browser = await next.browser('/rewrite-to-same-segment/0')
+      await browser.elementById('router-push').click()
+
+      expect(await browser.url()).toBe(
+        `http://localhost:${next.appPort}/rewrite-to-same-segment/1`
+      )
+
+      expect(await browser.elementByCss('p').text()).toBe('001')
+    })
+
+    it('should preserve current pathname when using useRouter.replace with rewrites on dynamic route', async () => {
+      const browser = await next.browser('/rewrite-to-same-segment/0')
+      await browser.elementById('router-replace').click()
+
+      expect(await browser.url()).toBe(
+        `http://localhost:${next.appPort}/rewrite-to-same-segment/2`
+      )
+
+      expect(await browser.elementByCss('p').text()).toBe('002')
+    })
+
+    it('should preserve current pathname when using Link with rewrites on dynamic route', async () => {
+      const browser = await next.browser('/rewrite-to-same-segment/0')
+      await browser.elementByCss('a').click()
+
+      expect(await browser.url()).toBe(
+        `http://localhost:${next.appPort}/rewrite-to-same-segment/3`
+      )
+
+      expect(await browser.elementByCss('p').text()).toBe('003')
+    })
+  })
 })

--- a/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+++ b/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
@@ -9,26 +9,24 @@ describe('use-router-with-rewrites', () => {
     const browser = await next.browser('/')
     await browser.elementById('router-push').click()
 
-    expect(await browser.url()).toBe(
-      `http://localhost:${next.appPort}/?param=1`
-    )
+    const url = new URL(await browser.url())
+    expect(url.pathname + url.search).toBe('/?param=1')
   })
 
   it('should preserve current pathname when using useRouter.replace with rewrites', async () => {
     const browser = await next.browser('/')
     await browser.elementById('router-replace').click()
 
-    expect(await browser.url()).toBe(
-      `http://localhost:${next.appPort}/?param=1`
-    )
+    const url = new URL(await browser.url())
+    expect(url.pathname + url.search).toBe('/?param=1')
   })
 
   it('should preserve current pathname when using Link with rewrites', async () => {
     const browser = await next.browser('/')
     await browser.elementByCss('a').click()
-    expect(await browser.url()).toBe(
-      `http://localhost:${next.appPort}/?param=1`
-    )
+
+    const url = new URL(await browser.url())
+    expect(url.pathname + url.search).toBe('/?param=1')
   })
 
   describe('rewrite to another segment', () => {
@@ -36,8 +34,9 @@ describe('use-router-with-rewrites', () => {
       const browser = await next.browser('/rewrite-to-another-segment/0')
       await browser.elementById('router-push').click()
 
-      expect(await browser.url()).toBe(
-        `http://localhost:${next.appPort}/rewrite-to-another-segment/0?id=1`
+      const url = new URL(await browser.url())
+      expect(url.pathname + url.search).toBe(
+        '/rewrite-to-another-segment/0?id=1'
       )
     })
 
@@ -45,8 +44,9 @@ describe('use-router-with-rewrites', () => {
       const browser = await next.browser('/rewrite-to-another-segment/0')
       await browser.elementById('router-replace').click()
 
-      expect(await browser.url()).toBe(
-        `http://localhost:${next.appPort}/rewrite-to-another-segment/0?id=2`
+      const url = new URL(await browser.url())
+      expect(url.pathname + url.search).toBe(
+        '/rewrite-to-another-segment/0?id=2'
       )
     })
 
@@ -54,8 +54,9 @@ describe('use-router-with-rewrites', () => {
       const browser = await next.browser('/rewrite-to-another-segment/0')
       await browser.elementByCss('a').click()
 
-      expect(await browser.url()).toBe(
-        `http://localhost:${next.appPort}/rewrite-to-another-segment/0?id=3`
+      const url = new URL(await browser.url())
+      expect(url.pathname + url.search).toBe(
+        '/rewrite-to-another-segment/0?id=3'
       )
     })
   })
@@ -67,9 +68,8 @@ describe('use-router-with-rewrites', () => {
       const browser = await next.browser('/rewrite-to-same-segment/0')
       await browser.elementById('router-push').click()
 
-      expect(await browser.url()).toBe(
-        `http://localhost:${next.appPort}/rewrite-to-same-segment/1`
-      )
+      const url = new URL(await browser.url())
+      expect(url.pathname + url.search).toBe('/rewrite-to-same-segment/1')
 
       expect(await browser.elementByCss('p').text()).toBe('1')
     })
@@ -78,9 +78,8 @@ describe('use-router-with-rewrites', () => {
       const browser = await next.browser('/rewrite-to-same-segment/0')
       await browser.elementById('router-replace').click()
 
-      expect(await browser.url()).toBe(
-        `http://localhost:${next.appPort}/rewrite-to-same-segment/2`
-      )
+      const url = new URL(await browser.url())
+      expect(url.pathname + url.search).toBe('/rewrite-to-same-segment/2')
 
       expect(await browser.elementByCss('p').text()).toBe('2')
     })
@@ -89,9 +88,8 @@ describe('use-router-with-rewrites', () => {
       const browser = await next.browser('/rewrite-to-same-segment/0')
       await browser.elementByCss('a').click()
 
-      expect(await browser.url()).toBe(
-        `http://localhost:${next.appPort}/rewrite-to-same-segment/3`
-      )
+      const url = new URL(await browser.url())
+      expect(url.pathname + url.search).toBe('/rewrite-to-same-segment/3')
 
       expect(await browser.elementByCss('p').text()).toBe('3')
     })

--- a/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
+++ b/test/e2e/use-router-with-rewrites/use-router-with-rewrites.test.ts
@@ -37,7 +37,7 @@ describe('use-router-with-rewrites', () => {
       await browser.elementById('router-push').click()
 
       expect(await browser.url()).toBe(
-        `http://localhost:${next.appPort}/rewrite-to-another-segment/1`
+        `http://localhost:${next.appPort}/rewrite-to-another-segment/0?id=1`
       )
     })
 
@@ -46,7 +46,7 @@ describe('use-router-with-rewrites', () => {
       await browser.elementById('router-replace').click()
 
       expect(await browser.url()).toBe(
-        `http://localhost:${next.appPort}/rewrite-to-another-segment/2`
+        `http://localhost:${next.appPort}/rewrite-to-another-segment/0?id=2`
       )
     })
 
@@ -55,11 +55,13 @@ describe('use-router-with-rewrites', () => {
       await browser.elementByCss('a').click()
 
       expect(await browser.url()).toBe(
-        `http://localhost:${next.appPort}/rewrite-to-another-segment/3`
+        `http://localhost:${next.appPort}/rewrite-to-another-segment/0?id=3`
       )
     })
   })
 
+  // This is an edge case where rewrite won't work as expected due to trade-off,
+  // but interpolates the query instead.
   describe('rewrite to same segment', () => {
     it('should preserve current pathname when using useRouter.push with rewrites on dynamic route', async () => {
       const browser = await next.browser('/rewrite-to-same-segment/0')
@@ -69,7 +71,7 @@ describe('use-router-with-rewrites', () => {
         `http://localhost:${next.appPort}/rewrite-to-same-segment/1`
       )
 
-      expect(await browser.elementByCss('p').text()).toBe('001')
+      expect(await browser.elementByCss('p').text()).toBe('1')
     })
 
     it('should preserve current pathname when using useRouter.replace with rewrites on dynamic route', async () => {
@@ -80,7 +82,7 @@ describe('use-router-with-rewrites', () => {
         `http://localhost:${next.appPort}/rewrite-to-same-segment/2`
       )
 
-      expect(await browser.elementByCss('p').text()).toBe('002')
+      expect(await browser.elementByCss('p').text()).toBe('2')
     })
 
     it('should preserve current pathname when using Link with rewrites on dynamic route', async () => {
@@ -91,7 +93,7 @@ describe('use-router-with-rewrites', () => {
         `http://localhost:${next.appPort}/rewrite-to-same-segment/3`
       )
 
-      expect(await browser.elementByCss('p').text()).toBe('003')
+      expect(await browser.elementByCss('p').text()).toBe('3')
     })
   })
 })


### PR DESCRIPTION
### Why?

The issue was brought up when the app had rewrites (say `/ -> /foo`), and the page used `useRouter.push/replace` to add the search queries; it used the destination's pathname (`/foo?query=1`) instead of just adding the query (`/?query=1`).

Current Behavior: https://github.com/vercel/next.js/actions/runs/16647831682/job/47112716254?pr=82236#step:34:156

### How?

Therefore, as we handle the hash (`#`), if the target path only needs a query `?`, we may use `router.asPath` by default for static routes to resolve cases with rewrites. However, if it is a dynamic route, it needs to be able to interpolate the query (for `/[id]` segment, `/?id=1` interpolates to `/1` route), so use `router.pathname`. Finally, if it is suspected to be a rewritten path, use `router.asPath`.

**Note:**

There is an edge case where the pathname is dynamic, and also a rewrite path to the same segment.

E.g. in `/[slug]` path, rewrite `/foo -> /bar`

In this case, it will be treated as a non-rewritten path and possibly interpolate the query string.

E.g., `/any?slug=foo` will become the content of `/foo`, not rewritten as `/bar`.

This is currently a trade-off of not resolving rewrite paths on every Router/Link call, but using a lighter route regex pattern check.

Fixes https://github.com/vercel/next.js/issues/81476