### PR TITLE
Fix types of @next/mdx

### DIFF
--- a/packages/next-mdx/index.d.ts
+++ b/packages/next-mdx/index.d.ts
@@ -4,6 +4,8 @@ import type { RuleSetConditionAbsolute } from 'webpack'
 
 type WithMDX = (config: NextConfig) => NextConfig
 
+type PluggableListName = 'remarkPlugins' | 'rehypePlugins' | 'recmaPlugins'
+
 declare namespace nextMDX {
   interface NextMDXOptions {
     /**
@@ -21,21 +23,16 @@ declare namespace nextMDX {
      *
      * @see https://mdxjs.com/packages/mdx/#api
      */
-    options?: Options & {
-      remarkPlugins?:
-        | (
-            | string
-            | [name: string, options: any]
-            | NonNullable<Options['remarkPlugins']>[number]
-          )[]
-        | Options['remarkPlugins']
-      rehypePlugins?:
-        | (
-            | string
-            | [name: string, options: any]
-            | NonNullable<Options['rehypePlugins']>[number]
-          )[]
-        | Options['rehypePlugins']
+    options?: {
+      [Key in keyof Options]: Key extends PluggableListName
+        ?
+            | (
+                | string
+                | [name: string, ...options: any[]]
+                | NonNullable<Options[Key]>[number]
+              )[]
+            | Options[Key]
+        : Options[Key]
     }
   }
 }

--- a/test/e2e/app-dir/mdx/app/recma-plugin/page.mdx
+++ b/test/e2e/app-dir/mdx/app/recma-plugin/page.mdx
@@ -1,0 +1,4 @@
+# Recma plugin
+
+{/* eslint-disable-next-line no-undef, no-unused-expressions */}
+{filepath}

--- a/test/e2e/app-dir/mdx/app/recma-plugin/page.mdx
+++ b/test/e2e/app-dir/mdx/app/recma-plugin/page.mdx
@@ -1,4 +1,4 @@
 # Recma plugin
 
 {/* eslint-disable-next-line no-undef, no-unused-expressions */}
-{filepath}
+{typeof filepath === 'undefined' ? null : filepath}

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -8,6 +8,7 @@ for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
         '@next/mdx': 'canary',
         '@mdx-js/loader': '^2.2.1',
         '@mdx-js/react': '^2.2.1',
+        'recma-export-filepath': '1.2.0',
         'rehype-katex': '7.0.1',
         'rehype-slug': '6.0.0',
         'remark-gfm': '4.0.1',
@@ -65,6 +66,13 @@ for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
       })
 
       if (type === 'without-mdx-rs') {
+        it('should run recma plugins', async () => {
+          const $ = await next.render$('/recma-plugin')
+          const html = $('html').html()
+          expect(html.includes('recma-plugin/page.mdx')).toBe(true)
+          expect($('#rehype-plugin').text()).toBe('Recma plugin')
+        })
+
         it('should run rehype plugins', async () => {
           const $ = await next.render$('/rehype-plugin')
           const html = $('html').html()

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -70,7 +70,7 @@ for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
           const $ = await next.render$('/recma-plugin')
           const html = $('html').html()
           expect(html.includes('recma-plugin/page.mdx')).toBe(true)
-          expect($('#rehype-plugin').text()).toBe('Recma plugin')
+          expect($('#recma-plugin').text()).toBe('Recma plugin')
         })
 
         it('should run rehype plugins', async () => {

--- a/test/e2e/app-dir/mdx/next.config.ts
+++ b/test/e2e/app-dir/mdx/next.config.ts
@@ -7,6 +7,7 @@ const withMDX = nextMDX({
       'rehype-slug',
       ['rehype-katex', { strict: true, throwOnError: true }],
     ],
+    recmaPlugins: ['recma-export-filepath'],
   },
 })
 


### PR DESCRIPTION
### What?

This fixes a couple of things:
- Although it’s rare for MDX plugins to accept more than 1 option, they may accept any number of arguments.
- In addition to `remarkPlugins` and `rehypePlugins`, now `recmaPlugins` is also patched to accept strings
- TypeScript property Descriptions are preserved for patched values.

### Why?

Because it is broken.

### How?

Fixes #77297
