### PR TITLE
Remove params from segment path

### DIFF
--- a/packages/next/src/client/components/segment-cache-impl/navigation.ts
+++ b/packages/next/src/client/components/segment-cache-impl/navigation.ts
@@ -274,7 +274,7 @@ function readRenderSnapshotFromCache(
   let loading: LoadingModuleData | Promise<LoadingModuleData> = null
   let isPartial: boolean = true
 
-  const segmentEntry = readSegmentCacheEntry(now, route, tree.key)
+  const segmentEntry = readSegmentCacheEntry(now, route, tree.cacheKey)
   if (segmentEntry !== null) {
     switch (segmentEntry.status) {
       case EntryStatus.Fulfilled: {

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -1,6 +1,6 @@
 import type { DynamicParamTypesShort } from '../server/app-render/types'
 import { PAGE_SEGMENT_KEY } from '../shared/lib/segment'
-import { ROOT_SEGMENT_KEY } from '../shared/lib/segment-cache/segment-value-encoding'
+import { ROOT_SEGMENT_REQUEST_KEY } from '../shared/lib/segment-cache/segment-value-encoding'
 import {
   NEXT_REWRITTEN_PATH_HEADER,
   NEXT_REWRITTEN_QUERY_HEADER,
@@ -93,7 +93,7 @@ export function doesStaticSegmentAppearInURL(segment: string): boolean {
   // inferring it on the client based on the segment type. Something like
   // a `doesAppearInURL` flag in FlightRouterState.
   if (
-    segment === ROOT_SEGMENT_KEY ||
+    segment === ROOT_SEGMENT_REQUEST_KEY ||
     // For some reason, the loader tree sometimes includes extra __PAGE__
     // "layouts" when part of a parallel route. But it's not a leaf node.
     // Otherwise, we wouldn't need this special case because pages are

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3915,8 +3915,7 @@ async function prerenderToStream(
         flightData,
         finalServerPrerenderStore,
         ComponentMod,
-        renderOpts,
-        fallbackRouteParams
+        renderOpts
       )
 
       // If there are fallback route params, the RSC data is inherently dynamic
@@ -4130,8 +4129,7 @@ async function prerenderToStream(
           flightData,
           ssrPrerenderStore,
           ComponentMod,
-          renderOpts,
-          fallbackRouteParams
+          renderOpts
         )
       }
 
@@ -4331,8 +4329,7 @@ async function prerenderToStream(
           flightData,
           prerenderLegacyStore,
           ComponentMod,
-          renderOpts,
-          fallbackRouteParams
+          renderOpts
         )
       }
 
@@ -4511,8 +4508,7 @@ async function prerenderToStream(
           flightData,
           prerenderLegacyStore,
           ComponentMod,
-          renderOpts,
-          fallbackRouteParams
+          renderOpts
         )
       }
 
@@ -4637,8 +4633,7 @@ async function collectSegmentData(
   fullPageDataBuffer: Buffer,
   prerenderStore: PrerenderStore,
   ComponentMod: AppPageModule,
-  renderOpts: RenderOpts,
-  fallbackRouteParams: FallbackRouteParams | null
+  renderOpts: RenderOpts
 ): Promise<Map<string, Buffer> | undefined> {
   // Per-segment prefetch data
   //
@@ -4687,7 +4682,6 @@ async function collectSegmentData(
     fullPageDataBuffer,
     staleTime,
     clientReferenceManifest.clientModules as ManifestNode,
-    serverConsumerManifest,
-    fallbackRouteParams
+    serverConsumerManifest
   )
 }

--- a/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
@@ -4,11 +4,17 @@ import type { Segment as FlightRouterStateSegment } from '../../../server/app-re
 // TypeScript trick to simulate opaque types, like in Flow.
 type Opaque<K, T> = T & { __brand: K }
 
-export type EncodedSegment = Opaque<'EncodedSegment', string>
+export type SegmentRequestKeyPart = Opaque<'SegmentRequestKeyPart', string>
+export type SegmentRequestKey = Opaque<'SegmentRequestKey', string>
+export type SegmentCacheKeyPart = Opaque<'SegmentCacheKeyPart', string>
+export type SegmentCacheKey = Opaque<'SegmentCacheKey', string>
 
-export function encodeSegment(
+export const ROOT_SEGMENT_REQUEST_KEY = '' as SegmentRequestKey
+export const ROOT_SEGMENT_CACHE_KEY = '' as SegmentCacheKey
+
+export function createSegmentRequestKeyPart(
   segment: FlightRouterStateSegment
-): EncodedSegment {
+): SegmentRequestKeyPart {
   if (typeof segment === 'string') {
     if (segment.startsWith(PAGE_SEGMENT_KEY)) {
       // The Flight Router State type sometimes includes the search params in
@@ -20,7 +26,7 @@ export function encodeSegment(
       // Segment Cache implementation has settled.
       // TODO: We should hoist the search params out of the FlightRouterState
       // type entirely, This is our plan for dynamic route params, too.
-      return PAGE_SEGMENT_KEY as EncodedSegment
+      return PAGE_SEGMENT_KEY as SegmentRequestKeyPart
     }
     const safeName =
       // TODO: FlightRouterState encodes Not Found routes as "/_not-found".
@@ -31,26 +37,22 @@ export function encodeSegment(
         : encodeToFilesystemAndURLSafeString(segment)
     // Since this is not a dynamic segment, it's fully encoded. It does not
     // need to be "hydrated" with a param value.
-    return safeName as EncodedSegment
+    return safeName as SegmentRequestKeyPart
   }
+
   const name = segment[0]
-  const paramValue = segment[1]
   const paramType = segment[2]
   const safeName = encodeToFilesystemAndURLSafeString(name)
-  const safeValue = encodeToFilesystemAndURLSafeString(paramValue)
 
-  const encodedName = '$' + paramType + '$' + safeName + '$' + safeValue
-  return encodedName as EncodedSegment
+  const encodedName = '$' + paramType + '$' + safeName
+  return encodedName as SegmentRequestKeyPart
 }
 
-export const ROOT_SEGMENT_KEY = ''
-
-export function encodeChildSegmentKey(
-  // TODO: Make segment keys an opaque type, too?
-  parentSegmentKey: string,
+export function appendSegmentRequestKeyPart(
+  parentRequestKey: SegmentRequestKey,
   parallelRouteKey: string,
-  segment: EncodedSegment
-): string {
+  childRequestKeyPart: SegmentRequestKeyPart
+): SegmentRequestKey {
   // Aside from being filesystem safe, segment keys are also designed so that
   // each segment and parallel route creates its own subdirectory. Roughly in
   // the same shape as the source app directory. This is mostly just for easier
@@ -61,10 +63,33 @@ export function encodeChildSegmentKey(
   // common case. Saves some bytes (and it's what the app directory does).
   const slotKey =
     parallelRouteKey === 'children'
-      ? segment
-      : `@${encodeToFilesystemAndURLSafeString(parallelRouteKey)}/${segment}`
+      ? childRequestKeyPart
+      : `@${encodeToFilesystemAndURLSafeString(parallelRouteKey)}/${childRequestKeyPart}`
+  return (parentRequestKey + '/' + slotKey) as SegmentRequestKey
+}
 
-  return parentSegmentKey + '/' + slotKey
+export function createSegmentCacheKeyPart(
+  requestKeyPart: SegmentRequestKeyPart,
+  segment: FlightRouterStateSegment
+): SegmentCacheKeyPart {
+  if (typeof segment === 'string') {
+    return requestKeyPart as any as SegmentCacheKeyPart
+  }
+  const paramValue = segment[1]
+  const safeValue = encodeToFilesystemAndURLSafeString(paramValue)
+  return (requestKeyPart + '$' + safeValue) as SegmentCacheKeyPart
+}
+
+export function appendSegmentCacheKeyPart(
+  parentSegmentKey: SegmentCacheKey,
+  parallelRouteKey: string,
+  childCacheKeyPart: SegmentCacheKeyPart
+): SegmentCacheKey {
+  const slotKey =
+    parallelRouteKey === 'children'
+      ? childCacheKeyPart
+      : `@${encodeToFilesystemAndURLSafeString(parallelRouteKey)}/${childCacheKeyPart}`
+  return (parentSegmentKey + '/' + slotKey) as SegmentCacheKey
 }
 
 // Define a regex pattern to match the most common characters found in a route


### PR DESCRIPTION
Based on:
- #82185

---

When performing a segment prefetch, we send a "segment path" to the server, which represents the particular segment that we're requesting. Originally, I thought these needed to fully encode all the param values, but since we already request the segments within the context of a particular target page, it's unnecessary — the base URL already contains all the param information (and is indeed the source of truth for where the param values come from). The only thing we need to put in the paths are the param names.

On the client, though, these segments are cached across pages (that's the whole point of the Segment Cache). So in the prefetch cache, we do need to cache them by their concrete param values.

Splitting out the param names and the param values into separate keys will allow us to implement "fallback PPR" behavior for the client, where if a segment entry does not reference a particular param, it can be reused for all possible values of that param. (We already do this for search strings.)

For now, I've split the current "segment path" key into two separate keys, which I'm calling the "cache key" and the "request key". It's a bit confusing since we have so many different types of cache keys, but I think it's OK for now — this will be refactored soon anyway to support the fallback PPR behavior.

Despite the line count, most of this PR is just a mechanical refactor. Most of it was done by tab completion in Cursor. The substance of the change is in the `segment-value-encoding.ts` file.