### PR TITLE
Remove params from tree response

### DIFF
--- a/packages/next/src/client/components/router-reducer/aliased-prefetch-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/aliased-prefetch-navigations.ts
@@ -79,8 +79,8 @@ export function handleAliasedPrefetchEntry(
     // loading state and not the actual parallel route seed data.
     if (isRootRender && seedData) {
       // Fill in the cache with the new loading / rsc data
-      const rsc = seedData[1]
-      const loading = seedData[3]
+      const rsc = seedData[0]
+      const loading = seedData[2]
       newCache.loading = loading
       newCache.rsc = rsc
 
@@ -132,8 +132,8 @@ export function handleAliasedPrefetchEntry(
 function hasLoadingComponentInSeedData(seedData: CacheNodeSeedData | null) {
   if (!seedData) return false
 
-  const parallelRoutes = seedData[2]
-  const loading = seedData[3]
+  const parallelRoutes = seedData[1]
+  const loading = seedData[2]
 
   if (loading) {
     return true
@@ -166,15 +166,15 @@ function fillNewTreeWithOnlyLoadingSegments(
     const cacheKey = createRouterCacheKey(segmentForParallelRoute)
 
     const parallelSeedData =
-      cacheNodeSeedData !== null && cacheNodeSeedData[2][key] !== undefined
-        ? cacheNodeSeedData[2][key]
+      cacheNodeSeedData !== null && cacheNodeSeedData[1][key] !== undefined
+        ? cacheNodeSeedData[1][key]
         : null
 
     let newCacheNode: CacheNode
     if (parallelSeedData !== null) {
       // New data was sent from the server.
-      const rsc = parallelSeedData[1]
-      const loading = parallelSeedData[3]
+      const rsc = parallelSeedData[0]
+      const loading = parallelSeedData[2]
       newCacheNode = {
         lazyData: null,
         // copy the layout but null the page segment as that's not meant to be used

--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -20,8 +20,8 @@ export function applyFlightData(
   }
 
   if (isRootRender) {
-    const rsc = seedData[1]
-    const loading = seedData[3]
+    const rsc = seedData[0]
+    const loading = seedData[2]
     cache.loading = loading
     cache.rsc = rsc
     // This is a PPR-only field. When PPR is enabled, we shouldn't hit

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -35,7 +35,7 @@ describe('createInitialRouterState', () => {
 
     const state = createInitialRouterState({
       navigatedAt,
-      initialFlightData: [[initialTree, ['', children, {}, null]]],
+      initialFlightData: [[initialTree, [children, {}, null]]],
       initialCanonicalUrlParts: initialCanonicalUrl.split('/'),
       initialParallelRoutes,
       location: new URL('/linking', 'https://localhost') as any,
@@ -46,7 +46,7 @@ describe('createInitialRouterState', () => {
 
     const state2 = createInitialRouterState({
       navigatedAt,
-      initialFlightData: [[initialTree, ['', children, {}, null]]],
+      initialFlightData: [[initialTree, [children, {}, null]]],
       initialCanonicalUrlParts: initialCanonicalUrl.split('/'),
       initialParallelRoutes,
       location: new URL('/linking', 'https://localhost') as any,

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -11,6 +11,8 @@ import {
 import { PrefetchKind, type PrefetchCacheEntry } from './router-reducer-types'
 import { addRefreshMarkerToActiveParallelSegments } from './refetch-inactive-parallel-segments'
 import { getFlightDataPartsFromPath } from '../../flight-data-helpers'
+import type { NormalizedSearch } from '../segment-cache'
+import { urlToUrlWithoutFlightMarker } from '../../route-params'
 
 export interface InitialRouterStateParameters {
   navigatedAt: number
@@ -50,12 +52,16 @@ export function createInitialRouterState({
   //
   // Instead, we'll perform a HEAD request and read the rewritten URL from
   // that response.
-  const renderedPathname = new URL(initialCanonicalUrl, 'http://localhost')
-    .pathname
+  const renderedUrl = urlToUrlWithoutFlightMarker(
+    new URL(initialCanonicalUrl, 'http://localhost')
+  )
+  const renderedPathname = renderedUrl.pathname
+  const renderedSearch = renderedUrl.search as NormalizedSearch
 
   const normalizedFlightData = getFlightDataPartsFromPath(
     initialFlightData[0],
-    renderedPathname
+    renderedPathname,
+    renderedSearch
   )
   const {
     tree: initialTree,
@@ -64,8 +70,8 @@ export function createInitialRouterState({
   } = normalizedFlightData
   // For the SSR render, seed data should always be available (we only send back a `null` response
   // in the case of a `loading` segment, pre-PPR.)
-  const rsc = initialSeedData?.[1]
-  const loading = initialSeedData?.[3] ?? null
+  const rsc = initialSeedData?.[0]
+  const loading = initialSeedData?.[2] ?? null
 
   const cache: CacheNode = {
     lazyData: null,

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -31,7 +31,12 @@ import {
 } from '../../flight-data-helpers'
 import { getAppBuildId } from '../../app-build-id'
 import { setCacheBustingSearchParam } from './set-cache-busting-search-param'
-import { getRenderedPathname } from '../../route-params'
+import {
+  getRenderedPathname,
+  getRenderedSearch,
+  urlToUrlWithoutFlightMarker,
+} from '../../route-params'
+import type { NormalizedSearch } from '../segment-cache'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
@@ -64,26 +69,11 @@ export type RequestHeaders = {
   'Next-Test-Fetch-Priority'?: RequestInit['priority']
 }
 
-export function urlToUrlWithoutFlightMarker(url: string): URL {
-  const urlWithoutFlightParameters = new URL(url, location.origin)
-  urlWithoutFlightParameters.searchParams.delete(NEXT_RSC_UNION_QUERY)
-  if (process.env.NODE_ENV === 'production') {
-    if (
-      process.env.__NEXT_CONFIG_OUTPUT === 'export' &&
-      urlWithoutFlightParameters.pathname.endsWith('.txt')
-    ) {
-      const { pathname } = urlWithoutFlightParameters
-      const length = pathname.endsWith('/index.txt') ? 10 : 4
-      // Slice off `/index.txt` or `.txt` from the end of the pathname
-      urlWithoutFlightParameters.pathname = pathname.slice(0, -length)
-    }
-  }
-  return urlWithoutFlightParameters
-}
-
 function doMpaNavigation(url: string): FetchServerResponseResult {
   return {
-    flightData: urlToUrlWithoutFlightMarker(url).toString(),
+    flightData: urlToUrlWithoutFlightMarker(
+      new URL(url, location.origin)
+    ).toString(),
     canonicalUrl: undefined,
     couldBeIntercepted: false,
     prerendered: false,
@@ -180,7 +170,7 @@ export async function fetchServerResponse(
       abortController.signal
     )
 
-    const responseUrl = urlToUrlWithoutFlightMarker(res.url)
+    const responseUrl = urlToUrlWithoutFlightMarker(new URL(res.url))
     const canonicalUrl = res.redirected ? responseUrl : undefined
 
     const contentType = res.headers.get('content-type') || ''
@@ -237,20 +227,30 @@ export async function fetchServerResponse(
     }
 
     let renderedPathname
+    let renderedSearch
     if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
       // Read the URL from the response object.
       renderedPathname = getRenderedPathname(res)
+      renderedSearch = getRenderedSearch(res)
     } else {
       // Before Segment Cache is enabled, we should not rely on the new
       // rewrite headers (x-rewritten-path, x-rewritten-query) because that
       // is a breaking change. Read the URL from the response body.
       const renderedUrlParts = response.c
-      renderedPathname = new URL(renderedUrlParts.join('/'), 'http://localhost')
-        .pathname
+      const renderedUrl = new URL(
+        renderedUrlParts.join('/'),
+        'http://localhost'
+      )
+      renderedPathname = renderedUrl.pathname
+      renderedSearch = renderedUrl.search as NormalizedSearch
     }
 
     return {
-      flightData: normalizeFlightData(response.f, renderedPathname),
+      flightData: normalizeFlightData(
+        response.f,
+        renderedPathname,
+        renderedSearch
+      ),
       canonicalUrl: canonicalUrl,
       couldBeIntercepted: interception,
       prerendered: response.S,

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
@@ -9,7 +9,7 @@ const getFlightData = (): NormalizedFlightData[] => {
       segmentPath: ['children', 'linking', 'children', 'about'],
       segment: 'about',
       tree: ['about', { children: ['', {}] }],
-      seedData: ['about', <h1>SubTreeData Injected!</h1>, {}, null, false],
+      seedData: [<h1>SubTreeData Injected!</h1>, {}, null, false],
       head: null,
       isHeadPartial: false,
       isRootRender: false,

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -61,16 +61,14 @@ function fillCacheHelper(
           !childCacheNode.lazyData ||
           childCacheNode === existingChildCacheNode)
       ) {
-        const incomingSegment = cacheNodeSeedData[0]
-        const rsc = cacheNodeSeedData[1]
-        const loading = cacheNodeSeedData[3]
+        const rsc = cacheNodeSeedData[0]
+        const loading = cacheNodeSeedData[2]
 
         childCacheNode = {
           lazyData: null,
           // When `fillLazyItems` is false, we only want to fill the RSC data for the layout,
           // not the page segment.
-          rsc:
-            fillLazyItems || incomingSegment !== PAGE_SEGMENT_KEY ? rsc : null,
+          rsc: fillLazyItems || segment !== PAGE_SEGMENT_KEY ? rsc : null,
           prefetchRsc: null,
           head: null,
           prefetchHead: null,

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -40,8 +40,8 @@ export function fillLazyItemsTillLeafWithHead(
     // in the response format, so that we don't have to send the keys twice.
     // Then the client can convert them into separate representations.
     const parallelSeedData =
-      cacheNodeSeedData !== null && cacheNodeSeedData[2][key] !== undefined
-        ? cacheNodeSeedData[2][key]
+      cacheNodeSeedData !== null && cacheNodeSeedData[1][key] !== undefined
+        ? cacheNodeSeedData[1][key]
         : null
     if (existingCache) {
       const existingParallelRoutesCacheNode =
@@ -56,8 +56,8 @@ export function fillLazyItemsTillLeafWithHead(
         let newCacheNode: CacheNode
         if (parallelSeedData !== null) {
           // New data was sent from the server.
-          const seedNode = parallelSeedData[1]
-          const loading = parallelSeedData[3]
+          const seedNode = parallelSeedData[0]
+          const loading = parallelSeedData[2]
           newCacheNode = {
             lazyData: null,
             rsc: seedNode,
@@ -124,8 +124,8 @@ export function fillLazyItemsTillLeafWithHead(
     let newCacheNode: CacheNode
     if (parallelSeedData !== null) {
       // New data was sent from the server.
-      const seedNode = parallelSeedData[1]
-      const loading = parallelSeedData[3]
+      const seedNode = parallelSeedData[0]
+      const loading = parallelSeedData[2]
       newCacheNode = {
         lazyData: null,
         rsc: seedNode,

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -11,7 +11,7 @@ const getFlightData = (): NormalizedFlightData[] => {
       segmentPath: ['children', 'linking', 'children', 'about'],
       segment: 'about',
       tree: ['about', { children: ['', {}] }],
-      seedData: ['about', <h1>About Page!</h1>, {}, null, false],
+      seedData: [<h1>About Page!</h1>, {}, null, false],
       head: null,
       isHeadPartial: false,
       isRootRender: false,

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -130,7 +130,7 @@ function updateCacheNodeOnNavigation(
   // Diff the old and new trees to reuse the shared layouts.
   const oldRouterStateChildren = oldRouterState[1]
   const newRouterStateChildren = newRouterState[1]
-  const prefetchDataChildren = prefetchData !== null ? prefetchData[2] : null
+  const prefetchDataChildren = prefetchData !== null ? prefetchData[1] : null
 
   if (!didFindRootLayout) {
     // We're currently traversing the part of the tree that was also part of
@@ -522,14 +522,14 @@ function createCacheNodeOnNavigation(
     // There's no existing CacheNode for this segment, but we do have prefetch
     // data. If the prefetch data is fully static (i.e. does not contain any
     // dynamic holes), we don't need to request it from the server.
-    rsc = prefetchData[1]
-    loading = prefetchData[3]
+    rsc = prefetchData[0]
+    loading = prefetchData[2]
     head = isLeafSegment ? possiblyPartialPrefetchHead : null
     // Even though we're accessing the data from the prefetch cache, this is
     // conceptually a new segment, not a reused one. So we should update the
     // navigatedAt timestamp.
     cacheNodeNavigatedAt = navigatedAt
-    const isPrefetchRscPartial = prefetchData[4]
+    const isPrefetchRscPartial = prefetchData[3]
     if (
       // Check if the segment data is partial
       isPrefetchRscPartial ||
@@ -570,7 +570,7 @@ function createCacheNodeOnNavigation(
   // We already have a full segment we can render, so we don't need to request a
   // new one from the server. Keep traversing down the tree until we reach
   // something that requires a dynamic request.
-  const prefetchDataChildren = prefetchData !== null ? prefetchData[2] : null
+  const prefetchDataChildren = prefetchData !== null ? prefetchData[1] : null
   const taskChildren = new Map()
   const existingCacheNodeChildren =
     existingCacheNode !== undefined ? existingCacheNode.parallelRoutes : null
@@ -881,7 +881,7 @@ function finishTaskUsingDynamicDataPayload(
   // The server returned more data than we need to finish the task. Skip over
   // the extra segments until we reach the leaf task node.
   const serverChildren = serverRouterState[1]
-  const dynamicDataChildren = dynamicData[2]
+  const dynamicDataChildren = dynamicData[1]
 
   for (const parallelRouteKey in serverRouterState) {
     const serverRouterStateChild: FlightRouterState =
@@ -923,7 +923,7 @@ function createPendingCacheNode(
   scrollableSegmentsResult: Array<FlightSegmentPath>
 ): ReadyCacheNode {
   const routerStateChildren = routerState[1]
-  const prefetchDataChildren = prefetchData !== null ? prefetchData[2] : null
+  const prefetchDataChildren = prefetchData !== null ? prefetchData[1] : null
 
   const parallelRoutes = new Map()
   for (let parallelRouteKey in routerStateChildren) {
@@ -970,8 +970,8 @@ function createPendingCacheNode(
     scrollableSegmentsResult.push(segmentPath)
   }
 
-  const maybePrefetchRsc = prefetchData !== null ? prefetchData[1] : null
-  const maybePrefetchLoading = prefetchData !== null ? prefetchData[3] : null
+  const maybePrefetchRsc = prefetchData !== null ? prefetchData[0] : null
+  const maybePrefetchLoading = prefetchData !== null ? prefetchData[2] : null
   return {
     lazyData: null,
     parallelRoutes: parallelRoutes,
@@ -1012,7 +1012,7 @@ function finishPendingCacheNode(
   // data promise to `null` to trigger a lazy fetch during render.
   const taskStateChildren = taskState[1]
   const serverStateChildren = serverState[1]
-  const dataChildren = dynamicData[2]
+  const dataChildren = dynamicData[1]
 
   // The router state that we traverse the tree with (taskState) is the same one
   // that we used to construct the pending Cache Node tree. That way we're sure
@@ -1072,7 +1072,7 @@ function finishPendingCacheNode(
   // Use the dynamic data from the server to fulfill the deferred RSC promise
   // on the Cache Node.
   const rsc = cacheNode.rsc
-  const dynamicSegmentData = dynamicData[1]
+  const dynamicSegmentData = dynamicData[0]
   if (rsc === null) {
     // This is a lazy cache node. We can overwrite it. This is only safe
     // because we know that the LayoutRouter suspends if `rsc` is `null`.

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -109,8 +109,8 @@ export function refreshReducer(
 
         // Handles case where prefetch only returns the router tree patch without rendered components.
         if (cacheNodeSeedData !== null) {
-          const rsc = cacheNodeSeedData[1]
-          const loading = cacheNodeSeedData[3]
+          const rsc = cacheNodeSeedData[0]
+          const loading = cacheNodeSeedData[2]
           cache.rsc = rsc
           cache.prefetchRsc = null
           cache.loading = loading

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -54,8 +54,11 @@ import {
   extractInfoFromServerReferenceId,
   omitUnusedArgs,
 } from '../../../../shared/lib/server-reference-info'
-import { revalidateEntireCache } from '../../segment-cache'
-import { getRenderedPathname } from '../../../route-params'
+import {
+  revalidateEntireCache,
+  type NormalizedSearch,
+} from '../../segment-cache'
+import { getRenderedPathname, getRenderedSearch } from '../../../route-params'
 
 const createFromFetch =
   createFromFetchBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromFetch']
@@ -183,23 +186,31 @@ async function fetchServerAction(
     )
 
     let renderedPathname
+    let renderedSearch
     if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
       // Read the URL from the response object.
       renderedPathname = getRenderedPathname(res)
+      renderedSearch = getRenderedSearch(res)
     } else {
       // Before Segment Cache is enabled, we should not rely on the new
       // rewrite headers (x-rewritten-path, x-rewritten-query) because that
       // is a breaking change. Read the URL from the response body.
       const canonicalUrlParts = response.c
-      renderedPathname = new URL(
+      const renderedUrl = new URL(
         canonicalUrlParts.join('/'),
         'http://localhost'
-      ).pathname
+      )
+      renderedPathname = renderedUrl.pathname
+      renderedSearch = renderedUrl.search as NormalizedSearch
     }
 
     // An internal redirect can send an RSC response, but does not have a useful `actionResult`.
     actionResult = redirectLocation ? undefined : response.a
-    actionFlightData = normalizeFlightData(response.f, renderedPathname)
+    actionFlightData = normalizeFlightData(
+      response.f,
+      renderedPathname,
+      renderedSearch
+    )
   } else {
     // An external redirect doesn't contain RSC data.
     actionResult = undefined
@@ -349,11 +360,11 @@ export function serverActionReducer(
 
         // The server sent back RSC data for the server action, so we need to apply it to the cache.
         if (cacheNodeSeedData !== null) {
-          const rsc = cacheNodeSeedData[1]
+          const rsc = cacheNodeSeedData[0]
           const cache: CacheNode = createEmptyCacheNode()
           cache.rsc = rsc
           cache.prefetchRsc = null
-          cache.loading = cacheNodeSeedData[3]
+          cache.loading = cacheNodeSeedData[2]
           fillLazyItemsTillLeafWithHead(
             navigatedAt,
             cache,

--- a/packages/next/src/client/components/segment-cache-impl/cache.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache.ts
@@ -67,7 +67,10 @@ import type {
   FlightRouterState,
   NavigationFlightResponse,
 } from '../../../server/app-render/types'
-import { normalizeFlightData } from '../../flight-data-helpers'
+import {
+  normalizeFlightData,
+  writeParamValueIntoSegment,
+} from '../../flight-data-helpers'
 import { STATIC_STALETIME_MS } from '../router-reducer/prefetch-cache-utils'
 import { pingVisibleLinks } from '../links'
 import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
@@ -887,15 +890,19 @@ function rejectSegmentCacheEntry(
 
 function convertRootTreePrefetchToRouteTree(
   rootTree: RootTreePrefetch,
-  renderedPathname: string
+  renderedPathname: string,
+  renderedSearch: NormalizedSearch
 ) {
   // Remove trailing and leading slashes
   const pathnameParts = renderedPathname.split('/').filter((p) => p !== '')
   const index = 0
   return convertTreePrefetchToRouteTree(
     rootTree.tree,
+    rootTree.tree.segment,
+    null,
     ROOT_SEGMENT_REQUEST_KEY,
     ROOT_SEGMENT_CACHE_KEY,
+    renderedSearch,
     pathnameParts,
     index
   )
@@ -903,8 +910,11 @@ function convertRootTreePrefetchToRouteTree(
 
 function convertTreePrefetchToRouteTree(
   prefetch: TreePrefetch,
+  segment: FlightRouterStateSegment,
+  param: RouteParam | null,
   requestKey: SegmentRequestKey,
   cacheKey: SegmentCacheKey,
+  renderedSearch: NormalizedSearch,
   pathnameParts: Array<string>,
   pathnamePartsIndex: number
 ): RouteTree {
@@ -914,42 +924,6 @@ function convertTreePrefetchToRouteTree(
   // it once instead of on every access. This same cache key is also used to
   // request the segment from the server.
 
-  let segment = prefetch.segment
-
-  let doesAppearInURL: boolean
-  let param: RouteParam | null = null
-  if (Array.isArray(segment)) {
-    // This segment is parameterized. Get the param from the pathname.
-    const paramType = segment[2] as DynamicParamTypesShort
-    const paramValue = parseDynamicParamFromURLPart(
-      paramType,
-      pathnameParts,
-      pathnamePartsIndex
-    )
-    param = {
-      name: segment[0],
-      value: paramValue,
-      type: paramType,
-    }
-
-    // Assign a cache key to the segment, based on the param value. In the
-    // pre-Segment Cache implementation, the server computes this and sends it
-    // in the body of the response. In the Segment Cache implementation, the
-    // server sends an empty string and we fill it in here.
-    // TODO: This will land in a follow up PR.
-    // segment[1] = getCacheKeyForDynamicParam(paramValue)
-
-    doesAppearInURL = true
-  } else {
-    doesAppearInURL = doesStaticSegmentAppearInURL(segment)
-  }
-
-  // Only increment the index if the segment appears in the URL. If it's a
-  // "virtual" segment, like a route group, it remains the same.
-  const childPathnamePartsIndex = doesAppearInURL
-    ? pathnamePartsIndex + 1
-    : pathnamePartsIndex
-
   let slots: { [parallelRouteKey: string]: RouteTree } | null = null
   const prefetchSlots = prefetch.slots
   if (prefetchSlots !== null) {
@@ -957,9 +931,41 @@ function convertTreePrefetchToRouteTree(
     for (let parallelRouteKey in prefetchSlots) {
       const childPrefetch = prefetchSlots[parallelRouteKey]
       const childSegment = childPrefetch.segment
-      // TODO: Eventually, the param values will not be included in the response
-      // from the server. We'll instead fill them in on the client by parsing
-      // the URL. This is where we'll do that.
+
+      let childDoesAppearInURL: boolean
+      let childParam: RouteParam | null = null
+      if (Array.isArray(childSegment)) {
+        // This segment is parameterized. Get the param from the pathname.
+        const childParamType = childSegment[2] as DynamicParamTypesShort
+        const childParamValue = parseDynamicParamFromURLPart(
+          childParamType,
+          pathnameParts,
+          pathnamePartsIndex
+        )
+
+        // Update the segment in place to fill in the param value.
+        writeParamValueIntoSegment(
+          childParamValue,
+          childSegment,
+          renderedSearch
+        )
+
+        childParam = {
+          name: childSegment[0],
+          value: childParamValue,
+          type: childParamType,
+        }
+        childDoesAppearInURL = true
+      } else {
+        childDoesAppearInURL = doesStaticSegmentAppearInURL(childSegment)
+      }
+
+      // Only increment the index if the segment appears in the URL. If it's a
+      // "virtual" segment, like a route group, it remains the same.
+      const childPathnamePartsIndex = childDoesAppearInURL
+        ? pathnamePartsIndex + 1
+        : pathnamePartsIndex
+
       const childRequestKeyPart = createSegmentRequestKeyPart(childSegment)
       const childRequestKey = appendSegmentRequestKeyPart(
         requestKey,
@@ -973,8 +979,11 @@ function convertTreePrefetchToRouteTree(
       )
       slots[parallelRouteKey] = convertTreePrefetchToRouteTree(
         childPrefetch,
+        childSegment,
+        childParam,
         childRequestKey,
         childCacheKey,
+        renderedSearch,
         pathnameParts,
         childPathnamePartsIndex
       )
@@ -1268,7 +1277,8 @@ export async function fetchRouteOnCacheMiss(
 
       const routeTree = convertRootTreePrefetchToRouteTree(
         serverData,
-        renderedPathname
+        renderedPathname,
+        renderedSearch
       )
 
       const staleTimeMs = serverData.staleTime * 1000
@@ -1616,7 +1626,8 @@ function writeDynamicTreeResponseIntoCache(
 
   const normalizedFlightDataResult = normalizeFlightData(
     serverData.f,
-    renderedPathname
+    renderedPathname,
+    renderedSearch
   )
   if (
     // A string result means navigating to this route will result in an
@@ -1727,8 +1738,13 @@ function writeDynamicRenderResponseIntoCache(
   // Get the URL that was used to render the target page. This may be different
   // from the URL in the request URL, if the page was rewritten.
   const renderedPathname = getRenderedPathname(response)
+  const renderedSearch = getRenderedSearch(response)
 
-  const flightDatas = normalizeFlightData(serverData.f, renderedPathname)
+  const flightDatas = normalizeFlightData(
+    serverData.f,
+    renderedPathname,
+    renderedSearch
+  )
   if (typeof flightDatas === 'string') {
     // This means navigating to this route will result in an MPA navigation.
     // TODO: We should cache this, too, so that the MPA navigation is immediate.
@@ -1779,6 +1795,7 @@ function writeDynamicRenderResponseIntoCache(
         fetchStrategy,
         route,
         staleAt,
+        flightData.tree,
         seedData,
         isResponsePartial,
         cacheKey,
@@ -1832,6 +1849,7 @@ function writeSeedDataIntoCache(
     | FetchStrategy.Full,
   route: FulfilledRouteCacheEntry,
   staleAt: number,
+  flightRouterState: FlightRouterState,
   seedData: CacheNodeSeedData,
   isResponsePartial: boolean,
   cacheKey: SegmentCacheKey,
@@ -1846,8 +1864,8 @@ function writeSeedDataIntoCache(
   // want to treat a dynamic response as if it were static. The two examples
   // where this happens are <Link prefetch={true}> (which implicitly opts
   // dynamic data into being static) and when prefetching a PPR-disabled route
-  const rsc = seedData[1]
-  const loading = seedData[3]
+  const rsc = seedData[0]
+  const loading = seedData[2]
   const isPartial = rsc === null || isResponsePartial
 
   // We should only write into cache entries that are owned by us. Or create
@@ -1898,36 +1916,38 @@ function writeSeedDataIntoCache(
     }
   }
   // Recursively write the child data into the cache.
-  const seedDataChildren = seedData[2]
-  if (seedDataChildren !== null) {
-    for (const parallelRouteKey in seedDataChildren) {
-      const childSeedData = seedDataChildren[parallelRouteKey]
-      if (childSeedData !== null) {
-        const childSegment = childSeedData[0]
-        const childRequestKeyPart = createSegmentRequestKeyPart(childSegment)
-        const childRequestKey = appendSegmentRequestKeyPart(
-          requestKey,
-          parallelRouteKey,
-          childRequestKeyPart
-        )
-        const childCacheKey = appendSegmentCacheKeyPart(
-          cacheKey,
-          parallelRouteKey,
-          createSegmentCacheKeyPart(childRequestKeyPart, childSegment)
-        )
-        writeSeedDataIntoCache(
-          now,
-          task,
-          fetchStrategy,
-          route,
-          staleAt,
-          childSeedData,
-          isResponsePartial,
-          childCacheKey,
-          childRequestKey,
-          entriesOwnedByCurrentTask
-        )
-      }
+  const flightRouterStateChildren = flightRouterState[1]
+  const seedDataChildren = seedData[1]
+  for (const parallelRouteKey in flightRouterStateChildren) {
+    const childFlightRouterState = flightRouterStateChildren[parallelRouteKey]
+    const childSeedData: CacheNodeSeedData | null | void =
+      seedDataChildren[parallelRouteKey]
+    if (childSeedData !== null && childSeedData !== undefined) {
+      const childSegment = childFlightRouterState[0]
+      const childRequestKeyPart = createSegmentRequestKeyPart(childSegment)
+      const childRequestKey = appendSegmentRequestKeyPart(
+        requestKey,
+        parallelRouteKey,
+        childRequestKeyPart
+      )
+      const childCacheKey = appendSegmentCacheKeyPart(
+        cacheKey,
+        parallelRouteKey,
+        createSegmentCacheKeyPart(childRequestKeyPart, childSegment)
+      )
+      writeSeedDataIntoCache(
+        now,
+        task,
+        fetchStrategy,
+        route,
+        staleAt,
+        childFlightRouterState,
+        childSeedData,
+        isResponsePartial,
+        childCacheKey,
+        childRequestKey,
+        entriesOwnedByCurrentTask
+      )
     }
   }
 }

--- a/packages/next/src/client/components/segment-cache-impl/navigation.ts
+++ b/packages/next/src/client/components/segment-cache-impl/navigation.ts
@@ -332,7 +332,7 @@ function readRenderSnapshotFromCache(
       null,
       tree.isRootLayout,
     ],
-    seedData: [segment, rsc, childSeedDatas, loading, isPartial],
+    seedData: [rsc, childSeedDatas, loading, isPartial],
   }
 }
 

--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -9,8 +9,11 @@ import type {
 } from '../server/app-render/types'
 import type { HeadData } from '../shared/lib/app-router-context.shared-runtime'
 import { PAGE_SEGMENT_KEY } from '../shared/lib/segment'
+import type { NormalizedSearch } from './components/segment-cache'
 import {
+  type RouteParamValue,
   doesStaticSegmentAppearInURL,
+  getCacheKeyForDynamicParam,
   parseDynamicParamFromURLPart,
 } from './route-params'
 
@@ -37,7 +40,8 @@ export type NormalizedFlightData = {
 // the different ways we express `FlightSegmentPath`.
 export function getFlightDataPartsFromPath(
   flightDataPath: FlightDataPath,
-  renderedPathname: string
+  renderedPathname: string,
+  renderedSearch: NormalizedSearch
 ): NormalizedFlightData {
   // Pick the last 4 items from the `FlightDataPath` to get the [tree, seedData, viewport, isHeadPartial].
   const flightDataPathLength = 4
@@ -47,7 +51,13 @@ export function getFlightDataPartsFromPath(
   // The `FlightSegmentPath` is everything except the last three items. For a root render, it won't be present.
   const segmentPath = flightDataPath.slice(0, -flightDataPathLength)
 
-  fillTreeWithParamValues(renderedPathname, segmentPath, tree)
+  // This mutates the tree in place.
+  fillTreeWithParamValues(
+    renderedPathname,
+    renderedSearch,
+    segmentPath[0] === '' ? segmentPath.slice(1) : segmentPath,
+    tree
+  )
 
   return {
     // TODO: Unify these two segment path helpers. We are inconsistently pushing an empty segment ("")
@@ -76,7 +86,8 @@ export function getNextFlightSegmentPath(
 
 export function normalizeFlightData(
   flightData: FlightData,
-  renderedPathname: string
+  renderedPathname: string,
+  renderedSearch: NormalizedSearch
 ): NormalizedFlightData[] | string {
   // FlightData can be a string when the server didn't respond with a proper flight response,
   // or when a redirect happens, to signal to the client that it needs to perform an MPA navigation.
@@ -85,7 +96,7 @@ export function normalizeFlightData(
   }
 
   return flightData.map((flightDataPath) =>
-    getFlightDataPartsFromPath(flightDataPath, renderedPathname)
+    getFlightDataPartsFromPath(flightDataPath, renderedPathname, renderedSearch)
   )
 }
 
@@ -183,6 +194,7 @@ function shouldPreserveRefreshMarker(
 
 function fillTreeWithParamValues(
   renderedPathname: string,
+  renderedSearch: NormalizedSearch,
   segmentPath: FlightSegmentPath,
   flightRouterState: FlightRouterState
 ): void {
@@ -203,15 +215,42 @@ function fillTreeWithParamValues(
   // Iterate through the path and skip over the corresponding pathname parts.
   for (let i = 0; i < segmentPath.length; i += 2) {
     const segment: Segment = segmentPath[i + 1]
-    if (Array.isArray(segment) || doesStaticSegmentAppearInURL(segment)) {
-      // This segment appears in the URL, so we need to skip over this part
-      // of the pathname
+
+    let doesAppearInURL: boolean
+    if (Array.isArray(segment)) {
+      // This segment is parameterized. Get the param from the pathname.
+      const paramType = segment[2] as DynamicParamTypesShort
+      const paramValue = parseDynamicParamFromURLPart(
+        paramType,
+        pathnameParts,
+        pathnamePartsIndex
+      )
+      // Update the segment in place to fill in the param value.
+      writeParamValueIntoSegment(paramValue, segment, renderedSearch)
+
+      doesAppearInURL = true
+    } else {
+      doesAppearInURL = doesStaticSegmentAppearInURL(segment)
+    }
+
+    if (
+      doesAppearInURL &&
+      // Check if this is the last segment of the segment path. The reason is
+      // subtle and somewhat annoying: the last segment of the segment path also
+      // appears as the root of the FlightRouterState tree. We need to process
+      // both positions, but because they represent the same segment, we should
+      // only advance the pathnamePartsIndex once.
+      // TODO: Update the server to only send this segment once. It's
+      // redundant to send it in both places.
+      i !== segmentPath.length - 2
+    ) {
       pathnamePartsIndex++
     }
   }
 
   fillTreeWithParamValuesImpl(
     renderedPathname,
+    renderedSearch,
     flightRouterState,
     pathnameParts,
     pathnamePartsIndex
@@ -220,6 +259,7 @@ function fillTreeWithParamValues(
 
 function fillTreeWithParamValuesImpl(
   renderedPathname: string,
+  renderedSearch: NormalizedSearch,
   flightRouterState: FlightRouterState,
   pathnameParts: Array<string>,
   pathnamePartsIndex: number
@@ -228,8 +268,6 @@ function fillTreeWithParamValuesImpl(
 
   let doesAppearInURL: boolean
   if (Array.isArray(segment)) {
-    doesAppearInURL = true
-
     // This segment is parameterized. Get the param from the pathname.
     const paramType = segment[2] as DynamicParamTypesShort
     const paramValue = parseDynamicParamFromURLPart(
@@ -237,19 +275,10 @@ function fillTreeWithParamValuesImpl(
       pathnameParts,
       pathnamePartsIndex
     )
+    // Update the segment in place to fill in the param value.
+    writeParamValueIntoSegment(paramValue, segment, renderedSearch)
 
-    // Insert the param value into the segment.
-    // TODO: Eventually this is the value that will be passed to client
-    // components that render this param.
-    segment[3] = paramValue
-
-    // Assign a cache key to the segment, based on the param value. In the
-    // pre-Segment Cache implementation, the server computes this and sends it
-    // in the body of the response. In the Segment Cache implementation, the
-    // server sends an empty string and we fill it in here.
-    // TODO: This will land in a follow up PR.
-    // const segmentCacheKey = getCacheKeyForDynamicParam(paramValue)
-    // segment[1] = segmentCacheKey
+    doesAppearInURL = true
   } else {
     doesAppearInURL = doesStaticSegmentAppearInURL(segment)
   }
@@ -264,9 +293,32 @@ function fillTreeWithParamValuesImpl(
   for (const parallelRouteKey in parallelRoutes) {
     fillTreeWithParamValuesImpl(
       renderedPathname,
+      renderedSearch,
       parallelRoutes[parallelRouteKey],
       pathnameParts,
       childPathnamePartsIndex
     )
+  }
+}
+
+export function writeParamValueIntoSegment(
+  paramValue: RouteParamValue,
+  segment: Exclude<Segment, string>,
+  renderedSearch: NormalizedSearch
+): void {
+  // FIXME: This environment variable is undefined during SSR when running in
+  // `next dev`. Figure this out before merging.
+  // const shouldFillParamValues = process.env.__NEXT_CLIENT_SEGMENT_CACHE
+  const shouldFillParamValues = true
+  if (shouldFillParamValues) {
+    // TODO: Eventually this is the value that will be passed to client
+    // components that render this param.
+    segment[3] = paramValue
+
+    // Assign a cache key to the segment, based on the param value. In the
+    // pre-Segment Cache implementation, the server computes this and sends it
+    // in the body of the response. In the Segment Cache implementation, the
+    // server sends an empty string and we fill it in here.
+    segment[1] = getCacheKeyForDynamicParam(paramValue, renderedSearch)
   }
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -360,6 +360,7 @@ function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
  * Returns a function that parses the dynamic segment and return the associated value.
  */
 function makeGetDynamicParamFromSegment(
+  isClientSegmentCacheEnabled: boolean,
   params: { [key: string]: any },
   pagePath: string,
   fallbackRouteParams: FallbackRouteParams | null
@@ -375,6 +376,7 @@ function makeGetDynamicParamFromSegment(
     const segmentKey = segmentParam.param
     const dynamicParamType = dynamicParamTypes[segmentParam.type]
     return getDynamicParam(
+      isClientSegmentCacheEnabled,
       params,
       segmentKey,
       dynamicParamType,
@@ -1271,7 +1273,6 @@ async function getErrorRSCPayload(
   // For metadata notFound error there's no global not found boundary on top
   // so we create a not found page with AppRouter
   const seedData: CacheNodeSeedData = [
-    initialTree[0],
     <html id="__next_error__">
       <head></head>
       <body>
@@ -1660,6 +1661,7 @@ async function renderToHTMLOrFlightImpl(
   const params = renderOpts.params ?? {}
 
   const getDynamicParamFromSegment = makeGetDynamicParamFromSegment(
+    renderOpts.experimental.clientSegmentCache !== false,
     params,
     pagePath,
     fallbackRouteParams

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -242,7 +242,7 @@ function collectSegmentDataImpl(
   let slotMetadata: { [parallelRouteKey: string]: TreePrefetch } | null = null
 
   const children = route[1]
-  const seedDataChildren = seedData !== null ? seedData[2] : null
+  const seedDataChildren = seedData !== null ? seedData[1] : null
   for (const parallelRouteKey in children) {
     const childRoute = children[parallelRouteKey]
     const childSegment = childRoute[0]
@@ -303,8 +303,8 @@ async function renderSegmentPrefetch(
   // Render the segment data to a stream.
   // In the future, this is where we can include additional metadata, like the
   // stale time and cache tags.
-  const rsc = seedData[1]
-  const loading = seedData[3]
+  const rsc = seedData[0]
+  const loading = seedData[2]
   const segmentPrefetch: SegmentPrefetch = {
     buildId,
     rsc,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -412,8 +412,6 @@ async function createComponentTreeInternal(
     }
   }
 
-  // Resolve the segment param
-  const actualSegment = segmentParam ? segmentParam.treeSegment : segment
   const isSegmentViewEnabled =
     process.env.NODE_ENV === 'development' &&
     ctx.renderOpts.devtoolSegmentExplorer
@@ -691,7 +689,6 @@ async function createComponentTreeInternal(
   // When the segment does not have a layout or page we still have to add the layout router to ensure the path holds the loading component
   if (!MaybeComponent) {
     return [
-      actualSegment,
       <React.Fragment key={cacheNodeKey}>
         {layerAssets}
         {parallelRouteProps.children}
@@ -720,7 +717,6 @@ async function createComponentTreeInternal(
     experimental.isRoutePPREnabled
   ) {
     return [
-      actualSegment,
       <React.Fragment key={cacheNodeKey}>
         <Postpone
           reason='dynamic = "force-dynamic" was used'
@@ -824,7 +820,6 @@ async function createComponentTreeInternal(
       )
 
     return [
-      actualSegment,
       <React.Fragment key={cacheNodeKey}>
         {wrappedPageElement}
         {layerAssets}
@@ -1008,7 +1003,6 @@ async function createComponentTreeInternal(
 
     // For layouts we just render the component
     return [
-      actualSegment,
       wrappedSegmentNode,
       parallelRouteCacheNodeSeedData,
       loadingData,

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -161,9 +161,12 @@ export type FlightSegmentPath =
  * however in the future we want to be able to fetch arbitrary partial segments
  * without having to fetch all its children. So this response format will
  * likely change.
+ * TODO: We should combine this with FlightRouterState when sending a response
+ * from the server. It was only introduced as a separate type because of all
+ * the other places that FlightRouterState leaked into the codebase. Should be
+ * easier once Segment Cache lands.
  */
 export type CacheNodeSeedData = [
-  segment: Segment,
   node: React.ReactNode | null,
   parallelRoutes: {
     [parallelRouterKey: string]: CacheNodeSeedData | null

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -5,7 +5,6 @@ import type {
   PreloadCallbacks,
   Segment,
 } from './types'
-import { matchSegment } from '../../client/components/match-segments'
 import type { LoaderTree } from '../lib/app-dir-module'
 import { getLinkAndScriptTags } from './get-css-inlined-link-tags'
 import { getPreloadableFonts } from './get-preloadable-fonts'
@@ -13,7 +12,7 @@ import {
   createFlightRouterStateFromLoaderTree,
   createRouteTreePrefetch,
 } from './create-flight-router-state-from-loader-tree'
-import type { AppRenderContext } from './app-render'
+import type { AppRenderContext, DynamicParam } from './app-render'
 import { hasLoadingComponentInTree } from './has-loading-component-in-tree'
 import {
   DEFAULT_SEGMENT_KEY,
@@ -105,7 +104,11 @@ export async function walkTreeWithFlightRouterState({
     // No further router state available
     !flightRouterState ||
     // Segment in router state does not match current segment
-    !matchSegment(actualSegment, flightRouterState[0]) ||
+    (segmentParam === null
+      ? // Common case: This is not a parameterized segment. Compare strings.
+        actualSegment !== flightRouterState[0]
+      : // This segment has a param. Compare both the param name and value.
+        !doesSegmentParamMatch(segmentParam, flightRouterState[0])) ||
     // Last item in the tree
     parallelRoutesKeys.length === 0 ||
     // Explicit refresh
@@ -329,4 +332,26 @@ const canSegmentBeOverridden = (
   }
 
   return getSegmentParam(existingSegment)?.param === segment[0]
+}
+
+function doesSegmentParamMatch(
+  serverSegmentParam: DynamicParam,
+  clientSegment: Segment
+): boolean {
+  if (typeof clientSegment === 'string') {
+    // The segment sent by the client does not contain a route param.
+    return false
+  }
+  const clientParamName = clientSegment[0]
+  if (clientParamName !== serverSegmentParam.param) {
+    // The name of the param does not match.
+    return false
+  }
+  // Compare the value of the param. If the value is an array, the client
+  // concatenates the values, so we must do the same to compare.
+  const clientParamKey = clientSegment[1]
+  const serverParamKey = Array.isArray(serverSegmentParam.value)
+    ? serverSegmentParam.value.join('/')
+    : serverSegmentParam.value
+  return clientParamKey === serverParamKey
 }

--- a/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
+++ b/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
@@ -14,6 +14,7 @@ import type { FallbackRouteParams } from '../../../../server/request/fallback-pa
  * and optional is, alas, unfortunate.
  */
 export function getDynamicParam(
+  isClientSegmentCacheEnabled: boolean,
   params: { [key: string]: any },
   segmentKey: string,
   dynamicParamType: DynamicParamTypesShort,
@@ -42,7 +43,13 @@ export function getDynamicParam(
           param: segmentKey,
           value: null,
           type: dynamicParamType,
-          treeSegment: [segmentKey, '', dynamicParamType],
+          treeSegment: [
+            segmentKey,
+            // When Segment Cache is enabled, we don't send down a cache key
+            // TODO: Remove this field entirely once Segment Cache lands.
+            '',
+            dynamicParamType,
+          ],
         }
       }
 
@@ -65,7 +72,13 @@ export function getDynamicParam(
         value,
         type: dynamicParamType,
         // This value always has to be a string.
-        treeSegment: [segmentKey, value.join('/'), dynamicParamType],
+        treeSegment: [
+          segmentKey,
+          // When Segment Cache is enabled, we don't send down a cache key
+          // TODO: Remove this field entirely once Segment Cache lands.
+          isClientSegmentCacheEnabled ? '' : value.join('/'),
+          dynamicParamType,
+        ],
       }
     }
   }
@@ -77,7 +90,13 @@ export function getDynamicParam(
     // The value that is rendered in the router tree.
     treeSegment: [
       segmentKey,
-      Array.isArray(value) ? value.join('/') : value,
+      // When Segment Cache is enabled, we don't send down a cache key
+      // TODO: Remove this field entirely once Segment Cache lands.
+      isClientSegmentCacheEnabled
+        ? ''
+        : Array.isArray(value)
+          ? value.join('/')
+          : value,
       dynamicParamType,
     ],
     type: dynamicParamType,


### PR DESCRIPTION
Removes the param values from the router tree sent by the server.

This increases the cacheability of the responses because if the response does not include a certain param in the component data, it can be reused for all possible values of that param. Previously this was not possible because even if the components did not reference a param, it was included in the router tree regardless.