### PR TITLE
feat: next typegen command

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -20,6 +20,7 @@ import type { NextLintOptions } from '../cli/next-lint.js'
 import type { NextInfoOptions } from '../cli/next-info.js'
 import type { NextDevOptions } from '../cli/next-dev.js'
 import type { NextBuildOptions } from '../cli/next-build.js'
+import type { NextTypegenOptions } from '../cli/next-typegen.js'
 
 if (process.env.NEXT_RSPACK) {
   // silent rspack's schema check
@@ -381,6 +382,24 @@ program
       mod.nextTelemetry(options, arg)
     )
   )
+
+program
+  .command('typegen')
+  .description(
+    'Generate TypeScript definitions for routes, pages, and layouts without running a full build.'
+  )
+  .argument(
+    '[directory]',
+    `A directory on which to generate types. ${italic(
+      'If no directory is provided, the current directory will be used.'
+    )}`
+  )
+  .action((directory: string, options: NextTypegenOptions) =>
+    import('../cli/next-typegen.js').then((mod) =>
+      mod.nextTypegen(options, directory)
+    )
+  )
+  .usage('[directory] [options]')
 
 program
   .command('experimental-test')

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -108,8 +108,15 @@ import type { EventBuildFeatureUsage } from '../telemetry/events'
 import { Telemetry } from '../telemetry/storage'
 import {
   createPagesMapping,
+  collectAppFiles,
   getStaticInfoIncludingLayouts,
   sortByPageExts,
+  processPageRoutes,
+  processAppRoutes,
+  processLayoutRoutes,
+  extractSlotsFromAppRoutes,
+  type RouteInfo,
+  type SlotInfo,
 } from './entries'
 import { PAGE_TYPES } from '../lib/page-types'
 import { generateBuildId } from './generate-build-id'
@@ -214,8 +221,6 @@ import {
   createRouteTypesManifest,
   writeRouteTypesManifest,
 } from '../server/lib/router-utils/route-types-utils'
-import { isParallelRouteSegment } from '../shared/lib/segment'
-import { ensureLeadingSlash } from '../shared/lib/page-path/ensure-leading-slash'
 
 type Fallback = null | boolean | string
 
@@ -1209,29 +1214,12 @@ export default async function build(
           layoutPaths = []
         } else {
           // Collect both app pages and layouts in a single directory traversal
-          const allAppFiles = await nextBuildSpan
+          const result = await nextBuildSpan
             .traceChild('collect-app-files')
-            .traceAsyncFn(() =>
-              recursiveReadDir(appDir, {
-                pathnameFilter: (absolutePath) =>
-                  validFileMatcher.isAppRouterPage(absolutePath) ||
-                  // For now we only collect the root /not-found page in the app
-                  // directory as the 404 fallback
-                  validFileMatcher.isRootNotFound(absolutePath) ||
-                  validFileMatcher.isAppLayoutPage(absolutePath),
-                ignorePartFilter: (part) => part.startsWith('_'),
-              })
-            )
+            .traceAsyncFn(() => collectAppFiles(appDir, config.pageExtensions))
 
-          // Separate app pages from layouts
-          appPaths = allAppFiles.filter(
-            (absolutePath) =>
-              validFileMatcher.isAppRouterPage(absolutePath) ||
-              validFileMatcher.isRootNotFound(absolutePath)
-          )
-          layoutPaths = allAppFiles.filter((absolutePath) =>
-            validFileMatcher.isAppLayoutPage(absolutePath)
-          )
+          appPaths = result.appPaths
+          layoutPaths = result.layoutPaths
         }
 
         mappedAppPages = await nextBuildSpan
@@ -1314,73 +1302,28 @@ export default async function build(
           const routeTypesFilePath = path.join(distDir, 'types', 'routes.d.ts')
           await fs.mkdir(path.dirname(routeTypesFilePath), { recursive: true })
 
-          const pageRoutes: Array<{ route: string; filePath: string }> = []
-          const appRoutes: Array<{ route: string; filePath: string }> = []
-          const layoutRoutes: Array<{ route: string; filePath: string }> = []
-          const slots: Array<{ name: string; parent: string }> = []
+          let pageRoutes: RouteInfo[] = []
+          let appRoutes: RouteInfo[] = []
+          let layoutRoutes: RouteInfo[] = []
+          let slots: SlotInfo[] = []
 
           // Build pages routes
-          for (const [route, filePath] of Object.entries(mappedPages)) {
-            // Only filter out _app, _error, _document, and API routes
-            // (TODO) should we filter out API routes?
-            if (isReservedPage(route)) continue
-
-            pageRoutes.push({
-              route: normalizePathSep(route),
-              filePath: filePath.replace(/^private-next-pages\//, 'pages/'),
-            })
-          }
+          const processedPages = processPageRoutes(mappedPages, dir)
+          // We combine both page routes and API routes
+          pageRoutes = [
+            ...processedPages.pageRoutes,
+            ...processedPages.pageApiRoutes,
+          ]
 
           // Build app routes
           if (appDir && mappedAppPages) {
-            for (const [route, filePath] of Object.entries(mappedAppPages)) {
-              if (route === '/_not-found/page') continue
-
-              const segments = route.split('/')
-              for (let i = segments.length - 1; i >= 0; i--) {
-                const segment = segments[i]
-                if (isParallelRouteSegment(segment)) {
-                  const parentPath = normalizeAppPath(
-                    segments.slice(0, i).join('/')
-                  )
-
-                  const slotName = segment.slice(1)
-                  // check if the slot already exists
-                  if (
-                    slots.some(
-                      (s) => s.name === slotName && s.parent === parentPath
-                    )
-                  )
-                    continue
-
-                  slots.push({
-                    name: slotName,
-                    parent: parentPath,
-                  })
-                  break
-                }
-              }
-
-              appRoutes.push({
-                route: normalizeAppPath(normalizePathSep(route)),
-                filePath: filePath.replace(/^private-next-app-dir\//, 'app/'),
-              })
-            }
+            slots = extractSlotsFromAppRoutes(mappedAppPages)
+            appRoutes = processAppRoutes(mappedAppPages, dir)
           }
 
           // Build app layouts
           if (appDir && mappedAppLayouts) {
-            for (const [route, filePath] of Object.entries(mappedAppLayouts)) {
-              layoutRoutes.push({
-                route: ensureLeadingSlash(
-                  normalizeAppPath(normalizePathSep(route)).replace(
-                    /\/layout$/,
-                    ''
-                  )
-                ),
-                filePath: filePath.replace(/^private-next-app-dir\//, 'app/'),
-              })
-            }
+            layoutRoutes = processLayoutRoutes(mappedAppLayouts, dir)
           }
 
           const routeTypesManifest = await createRouteTypesManifest({

--- a/packages/next/src/cli/next-typegen.ts
+++ b/packages/next/src/cli/next-typegen.ts
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'fs'
+import { join } from 'path'
+import { mkdir } from 'fs/promises'
+
+import loadConfig from '../server/config'
+import { printAndExit } from '../server/lib/utils'
+import { PHASE_PRODUCTION_BUILD } from '../shared/lib/constants'
+import { getProjectDir } from '../lib/get-project-dir'
+import { findPagesDir } from '../lib/find-pages-dir'
+import { verifyTypeScriptSetup } from '../lib/verify-typescript-setup'
+import { createPagesMapping } from '../build/entries'
+import { PAGE_TYPES } from '../lib/page-types'
+import { recursiveReadDir } from '../lib/recursive-readdir'
+import { isReservedPage } from '../build/utils'
+import { isParallelRouteSegment } from '../shared/lib/segment'
+import { ensureLeadingSlash } from '../shared/lib/page-path/ensure-leading-slash'
+import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
+import { normalizePathSep } from '../shared/lib/page-path/normalize-path-sep'
+import {
+  createRouteTypesManifest,
+  writeRouteTypesManifest,
+  writeValidatorFile,
+  writeServerTypesFile,
+  writeCacheLifeTypesFile,
+} from '../server/lib/router-utils/route-types-utils'
+import { createValidFileMatcher } from '../server/lib/find-page-file'
+
+export type NextTypegenOptions = {
+  dir?: string
+}
+
+const nextTypegen = async (
+  _options: NextTypegenOptions,
+  directory?: string
+) => {
+  const baseDir = getProjectDir(directory)
+
+  // Check if the provided directory exists
+  if (!existsSync(baseDir)) {
+    printAndExit(`> No such directory exists as the project root: ${baseDir}`)
+  }
+
+  const nextConfig = await loadConfig(PHASE_PRODUCTION_BUILD, baseDir)
+  const distDir = join(baseDir, nextConfig.distDir)
+  const { pagesDir, appDir } = findPagesDir(baseDir)
+
+  await verifyTypeScriptSetup({
+    dir: baseDir,
+    distDir: nextConfig.distDir,
+    intentDirs: [pagesDir, appDir].filter(Boolean) as string[],
+    typeCheckPreflight: false,
+    tsconfigPath: nextConfig.typescript.tsconfigPath,
+    disableStaticImages: nextConfig.images.disableStaticImages,
+    hasAppDir: !!appDir,
+    hasPagesDir: !!pagesDir,
+  })
+
+  console.log('Generating route types...')
+
+  const routeTypesFilePath = join(distDir, 'types', 'routes.d.ts')
+  const validatorFilePath = join(distDir, 'types', 'validator.ts')
+  await mkdir(join(distDir, 'types'), { recursive: true })
+
+  const pageRoutes: Array<{ route: string; filePath: string }> = []
+  const appRoutes: Array<{ route: string; filePath: string }> = []
+  const layoutRoutes: Array<{ route: string; filePath: string }> = []
+  const slots: Array<{ name: string; parent: string }> = []
+
+  const pageApiRoutes: Array<{ route: string; filePath: string }> = []
+  const appRouteHandlers: Array<{ route: string; filePath: string }> = []
+
+  let mappedPages: { [page: string]: string } = {}
+  let mappedAppPages: { [page: string]: string } = {}
+  let mappedAppLayouts: { [page: string]: string } = {}
+
+  // Build pages routes
+  if (pagesDir) {
+    const pagePaths = await recursiveReadDir(pagesDir, {
+      pathnameFilter: (absolutePath) => {
+        const relativePath = absolutePath.replace(pagesDir + '/', '')
+        return nextConfig.pageExtensions.some((ext) =>
+          relativePath.endsWith(`.${ext}`)
+        )
+      },
+      ignorePartFilter: (part) => part.startsWith('_'),
+    })
+
+    mappedPages = await createPagesMapping({
+      pagePaths,
+      isDev: false,
+      pagesType: PAGE_TYPES.PAGES,
+      pageExtensions: nextConfig.pageExtensions,
+      pagesDir,
+      appDir,
+    })
+  }
+
+  // Build app routes
+  if (appDir) {
+    const validFileMatcher = createValidFileMatcher(
+      nextConfig.pageExtensions,
+      appDir
+    )
+
+    const appPaths = await recursiveReadDir(appDir, {
+      pathnameFilter: (absolutePath) =>
+        validFileMatcher.isAppRouterPage(absolutePath) ||
+        validFileMatcher.isAppRouterRoute(absolutePath),
+      ignorePartFilter: (part) => part.startsWith('_'),
+    })
+
+    const layoutPaths = await recursiveReadDir(appDir, {
+      pathnameFilter: (absolutePath) =>
+        validFileMatcher.isAppLayoutPage(absolutePath),
+      ignorePartFilter: (part) => part.startsWith('_'),
+    })
+
+    mappedAppPages = await createPagesMapping({
+      pagePaths: appPaths,
+      isDev: false,
+      pagesType: PAGE_TYPES.APP,
+      pageExtensions: nextConfig.pageExtensions,
+      pagesDir,
+      appDir,
+    })
+
+    mappedAppLayouts = await createPagesMapping({
+      pagePaths: layoutPaths,
+      isDev: false,
+      pagesType: PAGE_TYPES.APP,
+      pageExtensions: nextConfig.pageExtensions,
+      pagesDir,
+      appDir,
+    })
+  }
+
+  // Process pages routes
+  for (const [route, filePath] of Object.entries(mappedPages)) {
+    const relativeFilePath = join(
+      baseDir,
+      filePath.replace(/^private-next-pages\//, 'pages/')
+    )
+
+    if (route.startsWith('/api/')) {
+      pageApiRoutes.push({
+        route: normalizePathSep(route),
+        filePath: relativeFilePath,
+      })
+    } else {
+      // Filter out _app, _error, _document
+      if (isReservedPage(route)) continue
+
+      pageRoutes.push({
+        route: normalizePathSep(route),
+        filePath: relativeFilePath,
+      })
+    }
+  }
+
+  // Process app routes
+  if (appDir && mappedAppPages) {
+    const validFileMatcher = createValidFileMatcher(
+      nextConfig.pageExtensions,
+      appDir
+    )
+
+    for (const [route, filePath] of Object.entries(mappedAppPages)) {
+      if (route === '/_not-found/page') continue
+
+      const segments = route.split('/')
+      for (let i = segments.length - 1; i >= 0; i--) {
+        const segment = segments[i]
+        if (isParallelRouteSegment(segment)) {
+          const parentPath = normalizeAppPath(segments.slice(0, i).join('/'))
+
+          const slotName = segment.slice(1)
+          // check if the slot already exists
+          if (slots.some((s) => s.name === slotName && s.parent === parentPath))
+            continue
+
+          slots.push({
+            name: slotName,
+            parent: parentPath,
+          })
+          break
+        }
+      }
+
+      const relativeFilePath = join(
+        baseDir,
+        filePath.replace(/^private-next-app-dir\//, 'app/')
+      )
+
+      if (validFileMatcher.isAppRouterRoute(filePath)) {
+        appRouteHandlers.push({
+          route: normalizeAppPath(normalizePathSep(route)),
+          filePath: relativeFilePath,
+        })
+      } else {
+        appRoutes.push({
+          route: normalizeAppPath(normalizePathSep(route)),
+          filePath: relativeFilePath,
+        })
+      }
+    }
+  }
+
+  // Process app layouts
+  if (appDir && mappedAppLayouts) {
+    for (const [route, filePath] of Object.entries(mappedAppLayouts)) {
+      const relativeFilePath = join(
+        baseDir,
+        filePath.replace(/^private-next-app-dir\//, 'app/')
+      )
+      layoutRoutes.push({
+        route: ensureLeadingSlash(
+          normalizeAppPath(normalizePathSep(route)).replace(/\/layout$/, '')
+        ),
+        filePath: relativeFilePath,
+      })
+    }
+  }
+
+  // Collect layout parameters for root params extraction
+  // Find the root layout (shortest path with dynamic segments)
+  const collectedRootParams: Record<string, string[]> = {}
+
+  // Find layouts that could be root layouts (have dynamic segments)
+  const layoutsWithParams = layoutRoutes
+    .map(({ route }) => {
+      const foundParams = Array.from(
+        route.matchAll(/\[(.*?)\]/g),
+        (match) => match[1]
+      )
+      return { route, params: foundParams }
+    })
+    .filter(({ params }) => params.length > 0)
+
+  // Sort by path depth (ascending) to find the shallowest layout with params
+  layoutsWithParams.sort((a, b) => {
+    const aDepth = a.route.split('/').length
+    const bDepth = b.route.split('/').length
+    return aDepth - bDepth
+  })
+
+  // The root layout is the shallowest layout with dynamic segments
+  if (layoutsWithParams.length > 0) {
+    const rootLayout = layoutsWithParams[0]
+    collectedRootParams[rootLayout.route] = rootLayout.params
+  }
+
+  const routeTypesManifest = await createRouteTypesManifest({
+    dir: baseDir,
+    pageRoutes,
+    appRoutes,
+    appRouteHandlers,
+    pageApiRoutes,
+    layoutRoutes,
+    slots,
+    redirects: nextConfig.redirects,
+    rewrites: nextConfig.rewrites,
+  })
+
+  // Add collected root params and cache life config to manifest
+  routeTypesManifest.collectedRootParams = collectedRootParams
+  routeTypesManifest.cacheLifeConfig = nextConfig.experimental?.cacheLife
+
+  await writeRouteTypesManifest(routeTypesManifest, routeTypesFilePath)
+  await writeValidatorFile(routeTypesManifest, validatorFilePath)
+
+  // Generate server types if we have root params
+  if (Object.keys(collectedRootParams).length > 0) {
+    const serverTypesFilePath = join(distDir, 'types', 'server.d.ts')
+    await writeServerTypesFile(routeTypesManifest, serverTypesFilePath)
+  }
+
+  // Generate cache life types if we have cache life config
+  if (nextConfig.experimental?.cacheLife) {
+    const cacheLifeTypesFilePath = join(distDir, 'types', 'cache-life.d.ts')
+    await writeCacheLifeTypesFile(routeTypesManifest, cacheLifeTypesFilePath)
+  }
+
+  console.log('✓ Route types generated successfully')
+}
+
+export { nextTypegen }

--- a/packages/next/src/cli/next-typegen.ts
+++ b/packages/next/src/cli/next-typegen.ts
@@ -10,22 +10,23 @@ import { PHASE_PRODUCTION_BUILD } from '../shared/lib/constants'
 import { getProjectDir } from '../lib/get-project-dir'
 import { findPagesDir } from '../lib/find-pages-dir'
 import { verifyTypeScriptSetup } from '../lib/verify-typescript-setup'
-import { createPagesMapping } from '../build/entries'
+import {
+  createPagesMapping,
+  collectAppFiles,
+  collectPagesFiles,
+  processPageRoutes,
+  processAppRoutes,
+  processLayoutRoutes,
+  extractSlotsFromAppRoutes,
+  type RouteInfo,
+  type SlotInfo,
+} from '../build/entries'
 import { PAGE_TYPES } from '../lib/page-types'
-import { recursiveReadDir } from '../lib/recursive-readdir'
-import { isReservedPage } from '../build/utils'
-import { isParallelRouteSegment } from '../shared/lib/segment'
-import { ensureLeadingSlash } from '../shared/lib/page-path/ensure-leading-slash'
-import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
-import { normalizePathSep } from '../shared/lib/page-path/normalize-path-sep'
+
 import {
   createRouteTypesManifest,
   writeRouteTypesManifest,
-  writeValidatorFile,
-  writeServerTypesFile,
-  writeCacheLifeTypesFile,
 } from '../server/lib/router-utils/route-types-utils'
-import { createValidFileMatcher } from '../server/lib/find-page-file'
 
 export type NextTypegenOptions = {
   dir?: string
@@ -60,227 +61,75 @@ const nextTypegen = async (
   console.log('Generating route types...')
 
   const routeTypesFilePath = join(distDir, 'types', 'routes.d.ts')
-  const validatorFilePath = join(distDir, 'types', 'validator.ts')
   await mkdir(join(distDir, 'types'), { recursive: true })
 
-  const pageRoutes: Array<{ route: string; filePath: string }> = []
-  const appRoutes: Array<{ route: string; filePath: string }> = []
-  const layoutRoutes: Array<{ route: string; filePath: string }> = []
-  const slots: Array<{ name: string; parent: string }> = []
+  let pageRoutes: RouteInfo[] = []
+  let appRoutes: RouteInfo[] = []
+  let layoutRoutes: RouteInfo[] = []
+  let slots: SlotInfo[] = []
 
-  const pageApiRoutes: Array<{ route: string; filePath: string }> = []
-  const appRouteHandlers: Array<{ route: string; filePath: string }> = []
+  let _pageApiRoutes: RouteInfo[] = []
 
   let mappedPages: { [page: string]: string } = {}
   let mappedAppPages: { [page: string]: string } = {}
   let mappedAppLayouts: { [page: string]: string } = {}
 
-  // Build pages routes
-  if (pagesDir) {
-    const pagePaths = await recursiveReadDir(pagesDir, {
-      pathnameFilter: (absolutePath) => {
-        const relativePath = absolutePath.replace(pagesDir + '/', '')
-        return nextConfig.pageExtensions.some((ext) =>
-          relativePath.endsWith(`.${ext}`)
-        )
-      },
-      ignorePartFilter: (part) => part.startsWith('_'),
-    })
-
-    mappedPages = await createPagesMapping({
+  // Helper function to reduce createPagesMapping duplication
+  const createMapping = (pagePaths: string[], pagesType: any) =>
+    createPagesMapping({
       pagePaths,
       isDev: false,
-      pagesType: PAGE_TYPES.PAGES,
+      pagesType,
       pageExtensions: nextConfig.pageExtensions,
       pagesDir,
       appDir,
     })
+
+  // Build pages routes
+  if (pagesDir) {
+    const pagePaths = await collectPagesFiles(
+      pagesDir,
+      nextConfig.pageExtensions
+    )
+
+    mappedPages = await createMapping(pagePaths, PAGE_TYPES.PAGES)
+
+    // Process pages routes
+    const processedPages = processPageRoutes(mappedPages, baseDir)
+    pageRoutes = processedPages.pageRoutes
+    _pageApiRoutes = processedPages.pageApiRoutes
   }
 
   // Build app routes
   if (appDir) {
-    const validFileMatcher = createValidFileMatcher(
-      nextConfig.pageExtensions,
-      appDir
-    )
-
-    const appPaths = await recursiveReadDir(appDir, {
-      pathnameFilter: (absolutePath) =>
-        validFileMatcher.isAppRouterPage(absolutePath) ||
-        validFileMatcher.isAppRouterRoute(absolutePath),
-      ignorePartFilter: (part) => part.startsWith('_'),
-    })
-
-    const layoutPaths = await recursiveReadDir(appDir, {
-      pathnameFilter: (absolutePath) =>
-        validFileMatcher.isAppLayoutPage(absolutePath),
-      ignorePartFilter: (part) => part.startsWith('_'),
-    })
-
-    mappedAppPages = await createPagesMapping({
-      pagePaths: appPaths,
-      isDev: false,
-      pagesType: PAGE_TYPES.APP,
-      pageExtensions: nextConfig.pageExtensions,
-      pagesDir,
+    // Collect both app pages and layouts in a single directory traversal
+    const { appPaths, layoutPaths } = await collectAppFiles(
       appDir,
-    })
-
-    mappedAppLayouts = await createPagesMapping({
-      pagePaths: layoutPaths,
-      isDev: false,
-      pagesType: PAGE_TYPES.APP,
-      pageExtensions: nextConfig.pageExtensions,
-      pagesDir,
-      appDir,
-    })
-  }
-
-  // Process pages routes
-  for (const [route, filePath] of Object.entries(mappedPages)) {
-    const relativeFilePath = join(
-      baseDir,
-      filePath.replace(/^private-next-pages\//, 'pages/')
+      nextConfig.pageExtensions
     )
 
-    if (route.startsWith('/api/')) {
-      pageApiRoutes.push({
-        route: normalizePathSep(route),
-        filePath: relativeFilePath,
-      })
-    } else {
-      // Filter out _app, _error, _document
-      if (isReservedPage(route)) continue
+    mappedAppPages = await createMapping(appPaths, PAGE_TYPES.APP)
+    mappedAppLayouts = await createMapping(layoutPaths, PAGE_TYPES.APP)
 
-      pageRoutes.push({
-        route: normalizePathSep(route),
-        filePath: relativeFilePath,
-      })
-    }
-  }
+    // Process app routes and extract slots
+    slots = extractSlotsFromAppRoutes(mappedAppPages)
+    appRoutes = processAppRoutes(mappedAppPages, baseDir)
 
-  // Process app routes
-  if (appDir && mappedAppPages) {
-    const validFileMatcher = createValidFileMatcher(
-      nextConfig.pageExtensions,
-      appDir
-    )
-
-    for (const [route, filePath] of Object.entries(mappedAppPages)) {
-      if (route === '/_not-found/page') continue
-
-      const segments = route.split('/')
-      for (let i = segments.length - 1; i >= 0; i--) {
-        const segment = segments[i]
-        if (isParallelRouteSegment(segment)) {
-          const parentPath = normalizeAppPath(segments.slice(0, i).join('/'))
-
-          const slotName = segment.slice(1)
-          // check if the slot already exists
-          if (slots.some((s) => s.name === slotName && s.parent === parentPath))
-            continue
-
-          slots.push({
-            name: slotName,
-            parent: parentPath,
-          })
-          break
-        }
-      }
-
-      const relativeFilePath = join(
-        baseDir,
-        filePath.replace(/^private-next-app-dir\//, 'app/')
-      )
-
-      if (validFileMatcher.isAppRouterRoute(filePath)) {
-        appRouteHandlers.push({
-          route: normalizeAppPath(normalizePathSep(route)),
-          filePath: relativeFilePath,
-        })
-      } else {
-        appRoutes.push({
-          route: normalizeAppPath(normalizePathSep(route)),
-          filePath: relativeFilePath,
-        })
-      }
-    }
-  }
-
-  // Process app layouts
-  if (appDir && mappedAppLayouts) {
-    for (const [route, filePath] of Object.entries(mappedAppLayouts)) {
-      const relativeFilePath = join(
-        baseDir,
-        filePath.replace(/^private-next-app-dir\//, 'app/')
-      )
-      layoutRoutes.push({
-        route: ensureLeadingSlash(
-          normalizeAppPath(normalizePathSep(route)).replace(/\/layout$/, '')
-        ),
-        filePath: relativeFilePath,
-      })
-    }
-  }
-
-  // Collect layout parameters for root params extraction
-  // Find the root layout (shortest path with dynamic segments)
-  const collectedRootParams: Record<string, string[]> = {}
-
-  // Find layouts that could be root layouts (have dynamic segments)
-  const layoutsWithParams = layoutRoutes
-    .map(({ route }) => {
-      const foundParams = Array.from(
-        route.matchAll(/\[(.*?)\]/g),
-        (match) => match[1]
-      )
-      return { route, params: foundParams }
-    })
-    .filter(({ params }) => params.length > 0)
-
-  // Sort by path depth (ascending) to find the shallowest layout with params
-  layoutsWithParams.sort((a, b) => {
-    const aDepth = a.route.split('/').length
-    const bDepth = b.route.split('/').length
-    return aDepth - bDepth
-  })
-
-  // The root layout is the shallowest layout with dynamic segments
-  if (layoutsWithParams.length > 0) {
-    const rootLayout = layoutsWithParams[0]
-    collectedRootParams[rootLayout.route] = rootLayout.params
+    // Process layout routes
+    layoutRoutes = processLayoutRoutes(mappedAppLayouts, baseDir)
   }
 
   const routeTypesManifest = await createRouteTypesManifest({
     dir: baseDir,
     pageRoutes,
     appRoutes,
-    appRouteHandlers,
-    pageApiRoutes,
     layoutRoutes,
     slots,
     redirects: nextConfig.redirects,
     rewrites: nextConfig.rewrites,
   })
 
-  // Add collected root params and cache life config to manifest
-  routeTypesManifest.collectedRootParams = collectedRootParams
-  routeTypesManifest.cacheLifeConfig = nextConfig.experimental?.cacheLife
-
   await writeRouteTypesManifest(routeTypesManifest, routeTypesFilePath)
-  await writeValidatorFile(routeTypesManifest, validatorFilePath)
-
-  // Generate server types if we have root params
-  if (Object.keys(collectedRootParams).length > 0) {
-    const serverTypesFilePath = join(distDir, 'types', 'server.d.ts')
-    await writeServerTypesFile(routeTypesManifest, serverTypesFilePath)
-  }
-
-  // Generate cache life types if we have cache life config
-  if (nextConfig.experimental?.cacheLife) {
-    const cacheLifeTypesFilePath = join(distDir, 'types', 'cache-life.d.ts')
-    await writeCacheLifeTypesFile(routeTypesManifest, cacheLifeTypesFilePath)
-  }
 
   console.log('✓ Route types generated successfully')
 }


### PR DESCRIPTION
## Add `next typegen` CLI command for fast type generation

Adds a new `next typegen` command that generates TypeScript definitions for routes, pages, and layouts without running a full build, enabling faster type checking in CI and development workflows.

**New command:**
```bash
next typegen [directory]
```

**Implementation:**
- Extracts type generation logic from `packages/next/src/build/index.ts` into standalone CLI command
- Reuses existing route manifest creation and file writing utilities
- Maintains all functionality from build-time type generation
- Proper CLI integration with help text and error handling