### PR TITLE
Turbopack: fix glob with empty alternative branch

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -193,6 +193,8 @@ mod tests {
     #[case::alternatives_nested2("{a,b/c,d/e/{f,g/h}}", "b/c")]
     #[case::alternatives_nested3("{a,b/c,d/e/{f,g/h}}", "d/e/f")]
     #[case::alternatives_nested4("{a,b/c,d/e/{f,g/h}}", "d/e/g/h")]
+    #[case::alternatives_empty1("react{,-dom}", "react")]
+    #[case::alternatives_empty2("react{,-dom}", "react-dom")]
     #[case::alternatives_chars("[abc]", "b")]
     fn glob_match(#[case] glob: &str, #[case] path: &str) {
         let glob = Glob::parse(glob).unwrap();

--- a/turbopack/crates/turbo-tasks-fs/src/globset.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/globset.rs
@@ -253,10 +253,13 @@ impl Tokens {
 
 fn build_alternates(re: &mut String, patterns: &Vec<Tokens>, branch_fn: fn(&[Token], &mut String)) {
     let mut parts = Vec::with_capacity(patterns.len());
+    let mut has_empty_part = false;
     for pat in patterns {
         let mut altre = String::new();
         branch_fn(pat, &mut altre);
-        if !altre.is_empty() {
+        if altre.is_empty() {
+            has_empty_part = true;
+        } else {
             parts.push(altre);
         }
     }
@@ -265,6 +268,9 @@ fn build_alternates(re: &mut String, patterns: &Vec<Tokens>, branch_fn: fn(&[Tok
     // resulting alternation '()' would be an error.
     if !parts.is_empty() {
         re.push_str("(?:");
+        if has_empty_part {
+            re.push('|');
+        }
         re.push_str(&parts.join("|"));
         re.push(')');
     }


### PR DESCRIPTION
This came up during NFT where the ignore pattern `'**/node_modules/react{,-dom,-dom-server-turbopack}/**/*.development.js'` wasn't applied.

Closes PACK-5165