### PR TITLE
Turbopack: Remove the `lazy-regex` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3506,29 +3506,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy-regex"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57451d19ad5e289ff6c3d69c2a2424652995c42b79dafa11e9c4d5508c913c01"
-dependencies = [
- "lazy-regex-proc_macros",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "lazy-regex-proc_macros"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0a1d9139f0ee2e862e08a9c5d0ba0470f2aa21cd1e1aa1b1562f83116c725f"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4373,7 +4350,6 @@ dependencies = [
  "indexmap 2.9.0",
  "indoc",
  "itertools 0.10.5",
- "lazy-regex",
  "mime_guess",
  "modularize_imports",
  "next-custom-transforms",

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -16,7 +16,6 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = "0.21.0"
 either = { workspace = true }
-lazy-regex = "3.0.1"
 next-custom-transforms = { workspace = true }
 once_cell = { workspace = true }
 qstring = { workspace = true }

--- a/crates/next-core/src/next_font/util.rs
+++ b/crates/next-core/src/next_font/util.rs
@@ -1,4 +1,7 @@
+use std::sync::LazyLock;
+
 use anyhow::{Context, Result};
+use regex::Regex;
 use serde::Deserialize;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::ResolvedVc;
@@ -78,9 +81,10 @@ pub(crate) async fn can_use_next_font(project_path: FileSystemPath, query: &RcSt
             .0,
     )?;
 
-    let document_re = lazy_regex::regex!("^(src/)?_document\\.[^/]+$");
+    static DOCUMENT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new("^(src/)?_document\\.[^/]+$").unwrap());
     let path = project_path.join(&request.path)?;
-    let can_use = !document_re.is_match(&request.path);
+    let can_use = !DOCUMENT_RE.is_match(&request.path);
     if !can_use {
         NextFontIssue {
             path: path.clone(),

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -1,4 +1,7 @@
+use std::sync::LazyLock;
+
 use anyhow::Result;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs};
@@ -93,13 +96,15 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         };
 
         // from https://github.com/vercel/next.js/blob/8d1c619ad650f5d147207f267441caf12acd91d1/packages/next/src/build/handle-externals.ts#L188
-        let never_external_regex = lazy_regex::regex!("^(?:private-next-pages\\/|next\\/(?:dist\\/pages\\/|(?:app|cache|document|link|form|head|image|legacy\\/image|constants|dynamic|script|navigation|headers|router|compat\\/router|server)$)|string-hash|private-next-rsc-action-validate|private-next-rsc-action-client-wrapper|private-next-rsc-server-reference|private-next-rsc-cache-wrapper$)");
+        static NEVER_EXTERNAL_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new("^(?:private-next-pages\\/|next\\/(?:dist\\/pages\\/|(?:app|cache|document|link|form|head|image|legacy\\/image|constants|dynamic|script|navigation|headers|router|compat\\/router|server)$)|string-hash|private-next-rsc-action-validate|private-next-rsc-action-client-wrapper|private-next-rsc-server-reference|private-next-rsc-cache-wrapper$)").unwrap()
+        });
 
         let Pattern::Constant(package_subpath) = package_subpath else {
             return Ok(ResolveResultOption::none());
         };
         let request_str: RcStr = format!("{package}{package_subpath}").into();
-        if never_external_regex.is_match(&request_str) {
+        if NEVER_EXTERNAL_RE.is_match(&request_str) {
             return Ok(ResolveResultOption::none());
         }
 

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -1,6 +1,7 @@
-use std::future::Future;
+use std::{future::Future, sync::LazyLock};
 
 use anyhow::{Context, Result, bail};
+use regex::Regex;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use swc_core::{
     common::{GLOBALS, Spanned, source_map::SmallPos},
@@ -762,10 +763,11 @@ pub async fn load_next_js_template(
 
     // Update the relative imports to be absolute. This will update any relative
     // imports to be relative to the root of the `next` package.
-    let regex = lazy_regex::regex!("(?:from '(\\..*)'|import '(\\..*)')");
+    static IMPORT_PATH_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new("(?:from '(\\..*)'|import '(\\..*)')").unwrap());
 
     let mut count = 0;
-    let mut content = replace_all(regex, &content, |caps| {
+    let mut content = replace_all(&IMPORT_PATH_RE, &content, |caps| {
         let from_request = caps.get(1).map_or("", |c| c.as_str());
         let import_request = caps.get(2).map_or("", |c| c.as_str());
 
@@ -830,16 +832,13 @@ pub async fn load_next_js_template(
     }
 
     // Check to see if there's any remaining template variables.
-    let regex = lazy_regex::regex!("/VAR_[A-Z_]+");
-    let matches = regex
-        .find_iter(&content)
-        .map(|m| m.as_str().to_string())
-        .collect::<Vec<_>>();
+    static TEMPLATE_VAR_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("VAR_[A-Z_]+").unwrap());
+    let mut matches = TEMPLATE_VAR_RE.find_iter(&content).peekable();
 
-    if !matches.is_empty() {
+    if matches.peek().is_some() {
         bail!(
             "Invariant: Expected to replace all template variables, found {}",
-            matches.join(", "),
+            matches.map(|m| m.as_str()).collect::<Vec<_>>().join(", "),
         )
     }
 
@@ -851,7 +850,7 @@ pub async fn load_next_js_template(
         let difference = replacements
             .keys()
             .filter(|k| !replaced.contains(*k))
-            .cloned()
+            .copied()
             .collect::<Vec<_>>();
 
         bail!(
@@ -873,16 +872,14 @@ pub async fn load_next_js_template(
     }
 
     // Check to see if there's any remaining injections.
-    let regex = lazy_regex::regex!("// INJECT:[A-Za-z0-9_]+");
-    let matches = regex
-        .find_iter(&content)
-        .map(|m| m.as_str().to_string())
-        .collect::<Vec<_>>();
+    static INJECT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new("// INJECT:[A-Za-z0-9_]+").unwrap());
+    let mut matches = INJECT_RE.find_iter(&content).peekable();
 
-    if !matches.is_empty() {
+    if matches.peek().is_some() {
         bail!(
             "Invariant: Expected to inject all injections, found {}",
-            matches.join(", "),
+            matches.map(|m| m.as_str()).collect::<Vec<_>>().join(", "),
         )
     }
 
@@ -894,7 +891,7 @@ pub async fn load_next_js_template(
         let difference = injections
             .keys()
             .filter(|k| !injected.contains(*k))
-            .cloned()
+            .copied()
             .collect::<Vec<_>>();
 
         bail!(
@@ -937,16 +934,14 @@ pub async fn load_next_js_template(
     }
 
     // Check to see if there's any remaining imports.
-    let regex = lazy_regex::regex!("// OPTIONAL_IMPORT:(\\* as )?[A-Za-z0-9_]+");
-    let matches = regex
-        .find_iter(&content)
-        .map(|m| m.as_str().to_string())
-        .collect::<Vec<_>>();
+    static OPTIONAL_IMPORT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new("// OPTIONAL_IMPORT:(\\* as )?[A-Za-z0-9_]+").unwrap());
+    let mut matches = OPTIONAL_IMPORT_RE.find_iter(&content).peekable();
 
-    if !matches.is_empty() {
+    if matches.peek().is_some() {
         bail!(
             "Invariant: Expected to inject all imports, found {}",
-            matches.join(", "),
+            matches.map(|m| m.as_str()).collect::<Vec<_>>().join(", "),
         )
     }
 


### PR DESCRIPTION
Yes, `lazy_regex` makes this code slightly cleaner, and it does have the nice side-effect of compile-time checking the regexes but:

- We've got test coverage for all of these regexes.
- It adds a proc macro, proc macros are detrimental to build performance.
- It doesn't really clean up the code that much versus the new stdlib `LazyLock`.
- This is the only crate using it.

So I don't think it's worth it.

Closes PACK-5170