### PR TITLE
Include `eslint-plugin-react-hooks` in React sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "eslint-plugin-jsdoc": "48.0.4",
     "eslint-plugin-mdx": "3.1.5",
     "eslint-plugin-react": "7.35.0",
-    "eslint-plugin-react-hooks": "6.0.0-rc.1",
+    "eslint-plugin-react-hooks": "0.0.0-experimental-c260b38d-20250731",
     "eslint-v8": "npm:eslint@^8.57.0",
     "event-stream": "4.0.1",
     "execa": "2.0.3",

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/hooks/use-minimum-loading-time-multiple.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/hooks/use-minimum-loading-time-multiple.ts
@@ -31,6 +31,7 @@ export function useMinimumLoadingTimeMultiple(
       if (loadStartTimeRef.current === null) {
         loadStartTimeRef.current = Date.now()
       }
+      // eslint-disable-next-line react-hooks/react-compiler -- TODO
       setIsLoading(true)
     } else {
       // If we're exiting the "loading" state:

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/hooks/use-update-animation.ts
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/hooks/use-update-animation.ts
@@ -19,6 +19,7 @@ export function useUpdateAnimation(
         return
       }
 
+      // eslint-disable-next-line react-hooks/react-compiler -- TODO
       setAnimate(true)
       // It is important to use a CSS transitioned state, not a CSS keyframed animation
       // because if the issue count increases faster than the animation duration, it

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
@@ -44,6 +44,7 @@ export function NextLogo({
   const width = measuredWidth === 0 ? 'auto' : measuredWidth
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/react-compiler -- TODO
     setIsErrorExpanded(hasError)
   }, [hasError])
 

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-panel/resize/resize-handle.tsx
@@ -76,6 +76,7 @@ export const ResizeHandle = ({
     const borderBottom = parseFloat(computedStyle.borderBottomWidth) || 0
     const borderLeft = parseFloat(computedStyle.borderLeftWidth) || 0
 
+    // eslint-disable-next-line react-hooks/react-compiler -- TODO
     setBorderWidths({
       top: borderTop,
       right: borderRight,

--- a/packages/next/src/next-devtools/dev-overlay/components/dialog/dialog.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/dialog/dialog.tsx
@@ -36,6 +36,7 @@ const Dialog: React.FC<DialogProps> = function Dialog({
   )
 
   useOnClickOutside(
+    // eslint-disable-next-line react-hooks/react-compiler -- TODO
     dialogRef.current,
     CSS_SELECTORS_TO_EXCLUDE_ON_CLICK_OUTSIDE,
     (e) => {

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/shortcut-recorder.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/shortcut-recorder.tsx
@@ -316,6 +316,7 @@ function MetaKey() {
   useEffect(() => {
     // Meta is Command on Apple devices, otherwise Control
     if (apple === true) {
+      // eslint-disable-next-line react-hooks/react-compiler -- TODO
       setLabel('⌘')
     }
 

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/drag-context.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/drag-context.tsx
@@ -36,6 +36,7 @@ export function DragProvider({
   }, [])
 
   const value = useMemo<DragContextValue>(
+    // eslint-disable-next-line react-hooks/react-compiler -- TODO
     () => ({ register, unregister, handles: handlesRef.current, disabled }),
     [register, unregister, disabled]
   )

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-message/error-message.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-message/error-message.tsx
@@ -13,6 +13,7 @@ export function ErrorMessage({ errorMessage }: ErrorMessageProps) {
 
   useLayoutEffect(() => {
     if (messageRef.current) {
+      // eslint-disable-next-line react-hooks/react-compiler -- TODO
       setShouldTruncate(messageRef.current.scrollHeight > 200)
     }
   }, [errorMessage])

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.tsx
@@ -48,6 +48,7 @@ export function SegmentBoundaryTrigger({
     () => {
       setIsOpen(false)
     },
+    // eslint-disable-next-line react-hooks/react-compiler -- TODO
     triggerRef.current?.ownerDocument
   )
 

--- a/packages/next/src/next-devtools/dev-overlay/components/shadow-portal.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/shadow-portal.tsx
@@ -38,7 +38,7 @@ export function ShadowPortal({ children }: { children: React.ReactNode }) {
     forceUpdate({})
   }, [state.theme])
 
-  return shadowNode.current
-    ? createPortal(children, shadowNode.current as any)
-    : null
+  // eslint-disable-next-line react-hooks/react-compiler -- TODO
+  const shadowRoot = shadowNode.current
+  return shadowRoot ? createPortal(children, shadowRoot as any) : null
 }

--- a/packages/next/src/next-devtools/dev-overlay/hooks/use-delayed-render.ts
+++ b/packages/next/src/next-devtools/dev-overlay/hooks/use-delayed-render.ts
@@ -43,6 +43,7 @@ export function useDelayedRender(active = false, options: Options = {}) {
     let unmountTimeout: Timeout | undefined
 
     if (active) {
+      // eslint-disable-next-line react-hooks/react-compiler -- intentional cascading update
       setMounted(true)
       if (enterDelay <= 0) {
         setRendered(true)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,8 +308,8 @@ importers:
         specifier: 7.35.0
         version: 7.35.0(eslint@9.12.0)
       eslint-plugin-react-hooks:
-        specifier: 6.0.0-rc.1
-        version: 6.0.0-rc.1(eslint@9.12.0)
+        specifier: 0.0.0-experimental-c260b38d-20250731
+        version: 0.0.0-experimental-c260b38d-20250731(eslint@9.12.0)
       eslint-v8:
         specifier: npm:eslint@^8.57.0
         version: eslint@8.57.1
@@ -8885,15 +8885,15 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  eslint-plugin-react-hooks@5.0.0:
-    resolution: {integrity: sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==}
-    engines: {node: '>=10'}
+  eslint-plugin-react-hooks@0.0.0-experimental-c260b38d-20250731:
+    resolution: {integrity: sha512-pDvUu0gLJQHFDh9Wq+M1Kh002RdacFTD5xHnOY4uLCwhKo3gerFrJSe09e+ZwdwN15E1vY0ZF+3Ymj6HFtAfGw==}
+    engines: {node: '>=18'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
-  eslint-plugin-react-hooks@6.0.0-rc.1:
-    resolution: {integrity: sha512-7C4c7bdtd/B7Q+HruZxYhGjwZVvJawvQpilEYlRG1Jncuk1ZNqrFy9bO8SJNieyj3iDh8WPQA7BzzPO7sNAyEA==}
-    engines: {node: '>=18'}
+  eslint-plugin-react-hooks@5.0.0:
+    resolution: {integrity: sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==}
+    engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
@@ -25658,11 +25658,7 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-plugin-react-hooks@5.0.0(eslint@9.12.0):
-    dependencies:
-      eslint: 9.12.0
-
-  eslint-plugin-react-hooks@6.0.0-rc.1(eslint@9.12.0):
+  eslint-plugin-react-hooks@0.0.0-experimental-c260b38d-20250731(eslint@9.12.0):
     dependencies:
       '@babel/core': 7.26.10
       '@babel/parser': 7.27.0
@@ -25673,6 +25669,10 @@ snapshots:
       zod-validation-error: 3.4.0(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-react-hooks@5.0.0(eslint@9.12.0):
+    dependencies:
+      eslint: 9.12.0
 
   eslint-plugin-react@7.35.0(eslint@9.12.0):
     dependencies:


### PR DESCRIPTION
`eslint-plugin-react-hooks` is also published in React's nightly release cycle. I want to start dog fooding it in Next.js so that we can spot issues as early as possible.

It also includes some new heuristics that are important to flag React Compiler incompatibilities. Compat with the React Compiler of the Next.js codebase is especially relevant for Next DevTools which uses the React Compiler.

I'll follow-up on these violations. Each need different treatment.