### PR TITLE
fix: Prevent race condition during HMR that causes 404 errors

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -355,10 +355,9 @@ async function startWatcher(
       let conflictingPageChange = 0
       let hasRootAppNotFound = false
 
-      const { appFiles, pageFiles } = opts.fsChecker
+      const appFilesList: string[] = []
+      const pageFilesList: string[] = []
 
-      appFiles.clear()
-      pageFiles.clear()
       devPageFiles.clear()
 
       const sortedKnownFiles: string[] = [...knownFiles.keys()].sort(
@@ -585,7 +584,7 @@ async function startWatcher(
           )
 
           if (useFileSystemPublicRoutes) {
-            appFiles.add(pageName)
+            appFilesList.push(pageName)
           }
 
           appRoutes.push({
@@ -598,7 +597,7 @@ async function startWatcher(
           }
         } else {
           if (useFileSystemPublicRoutes) {
-            pageFiles.add(pageName)
+            pageFilesList.push(pageName)
             // always add to nextDataRoutes for now but in future only add
             // entries that actually use getStaticProps/getServerSideProps
             opts.fsChecker.nextDataRoutes.add(pageName)
@@ -634,6 +633,12 @@ async function startWatcher(
 
         routedPages.push(pageName)
       }
+
+      const { appFiles, pageFiles } = opts.fsChecker
+      appFiles.clear()
+      pageFiles.clear()
+      appFilesList.forEach((pageName) => appFiles.add(pageName))
+      pageFilesList.forEach((pageName) => pageFiles.add(pageName))
 
       const numConflicting = conflictingAppPagePaths.size
       conflictingPageChange = numConflicting - previousConflictingPagePaths.size


### PR DESCRIPTION
fixes #82315

## Overview

This PR resolves an intermittent `404 Not Found` error that can occur during Hot Module Replacement in development mode.

## The Cause

As detailed in the issue, the bug is caused by a race condition in `setup-dev-bundler.ts`. `appFiles`, which stores the known routes in app directory, is cleared and then repopulated inside an `async` loop.

This creates a small window of time where `appFiles` is incomplete. If a page request comes in during this exact window, the route resolver fails to find the correct path, resulting in a 404 error.

## The Solution

This change fixes the race condition by ensuring `appFiles` is updated atomically.

Instead of clearing and repopulating `appFiles` inside the async loop, this PR first collects all the new route files into a temporary array. After all async operations are complete, it then clears `appFiles` and populates it from the temporary array in a synchronous operation.

This eliminates the inconsistent state and ensures that the route resolver always works with a complete set of routes.
