### PR TITLE
docs: add React Developer Tools section for debugging

### DIFF
--- a/docs/01-app/02-guides/debugging.mdx
+++ b/docs/01-app/02-guides/debugging.mdx
@@ -101,6 +101,14 @@ In either browser, any time your client-side code reaches a [`debugger`](https:/
 
 Note that when searching, your source files will have paths starting with `webpack://_N_E/./`.
 
+### React Developer Tools
+
+For React-specific debugging, install the [React Developer Tools](https://react.dev/learn/react-developer-tools) browser extension. This essential tool helps you:
+
+- Inspect React components
+- Edit props and state
+- Identify performance problems
+
 ### Server-side code
 
 To debug server-side Next.js code with browser DevTools, you need to pass the [`--inspect`](https://nodejs.org/api/cli.html#cli_inspect_host_port) flag to the underlying Node.js process:


### PR DESCRIPTION
﻿## What?

Added a new "React Developer Tools" section to the debugging documentation.
﻿
## Why?
﻿
This PR resolves #82308 which highlighted that React DevTools - a fundamental debugging tool for React applications - was missing from Next.js debugging documentation. 
﻿
Since the Next.js framework is built on React, React DevTools is crucial for:
- Inspecting component hierarchies
- Debugging state and props
- Identifying performance issues
- Understanding application structure
﻿
## How?
﻿
Inserted a concise section between "Client-side code" and "Server-side code" in [docs/01-app/02-guides/debugging.mdx](https://github.com/vercel/next.js/blob/canary/docs/01-app/02-guides/debugging.mdx):

- Introduces developers to the essential React debugging tool and its key features
- Direct users to the corresponding React documentation

### Checklist: Improving Documentation
﻿
- [x] Ran `pnpm prettier-fix` to ensure proper formatting
- [x] Followed the Docs Contribution Guide: https://nextjs.org/docs/community/contribution-guide
﻿

Closes #82308