### PR TITLE
Import correct react-server version in action-handler

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -796,9 +796,8 @@ export async function handleAction({
             decodeReplyFromBusboy,
             decodeAction,
             decodeFormState,
-          } = require(
-            `./react-server.node`
-          ) as typeof import('react-server-dom-webpack/server.node')
+          } =
+            require('./react-server.node') as typeof import('./react-server.node')
 
           temporaryReferences = createTemporaryReferenceSet()
 

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -798,7 +798,7 @@ export async function handleAction({
             decodeFormState,
           } = require(
             `./react-server.node`
-          ) as typeof import('./react-server.node')
+          ) as typeof import('react-server-dom-webpack/server.node')
 
           temporaryReferences = createTemporaryReferenceSet()
 

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -797,6 +797,7 @@ export async function handleAction({
             decodeAction,
             decodeFormState,
           } =
+            // @ts-expect-error File 'react-server.node.ts' is not a module. ts(2306)
             require('./react-server.node') as typeof import('./react-server.node')
 
           temporaryReferences = createTemporaryReferenceSet()

--- a/packages/next/src/server/app-render/react-server.node.d.ts
+++ b/packages/next/src/server/app-render/react-server.node.d.ts
@@ -1,0 +1,2 @@
+declare const ty: typeof import('react-server-dom-webpack/server.node')
+export = ty

--- a/packages/next/src/server/app-render/react-server.node.ts
+++ b/packages/next/src/server/app-render/react-server.node.ts
@@ -1,10 +1,11 @@
 // This file should be opted into the react-server layer
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-export {
-  createTemporaryReferenceSet,
-  decodeReply,
-  decodeReplyFromBusboy,
-  decodeAction,
-  decodeFormState,
-} from 'react-server-dom-webpack/server.node'
+if (process.env.TURBOPACK) {
+  module.exports =
+    // eslint-disable-next-line import/no-extraneous-dependencies, @next/internal/typechecked-require
+    require('react-server-dom-turbopack/server.node') as typeof import('react-server-dom-webpack/server.node')
+} else {
+  module.exports =
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    require('react-server-dom-webpack/server.node') as typeof import('react-server-dom-webpack/server.node')
+}

--- a/packages/next/src/server/app-render/react-server.node.ts
+++ b/packages/next/src/server/app-render/react-server.node.ts
@@ -2,8 +2,8 @@
 
 if (process.env.TURBOPACK) {
   module.exports =
-    // eslint-disable-next-line import/no-extraneous-dependencies, @next/internal/typechecked-require
-    require('react-server-dom-turbopack/server.node') as typeof import('react-server-dom-webpack/server.node')
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    require('react-server-dom-turbopack/server.node') as typeof import('react-server-dom-turbopack/server.node')
 } else {
   module.exports =
     // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/next/src/server/route-modules/app-page/vendored/rsc/entrypoints.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/rsc/entrypoints.ts
@@ -34,7 +34,6 @@ let ReactServerDOMTurbopackStatic, ReactServerDOMWebpackStatic
 
 if (process.env.TURBOPACK) {
   ReactServerDOMTurbopackServer =
-    // @ts-expect-error -- TODO: Add types
     // eslint-disable-next-line import/no-extraneous-dependencies
     require('react-server-dom-turbopack/server') as typeof import('react-server-dom-turbopack/server')
   if (process.env.NODE_ENV === 'development') {
@@ -44,7 +43,6 @@ if (process.env.TURBOPACK) {
     )
   }
   ReactServerDOMTurbopackStatic =
-    // @ts-expect-error -- TODO: Add types
     // eslint-disable-next-line import/no-extraneous-dependencies
     require('react-server-dom-turbopack/static') as typeof import('react-server-dom-turbopack/static')
   if (process.env.NODE_ENV === 'development') {

--- a/packages/next/src/server/route-modules/app-page/vendored/ssr/entrypoints.ts
+++ b/packages/next/src/server/route-modules/app-page/vendored/ssr/entrypoints.ts
@@ -30,7 +30,6 @@ function getAltProxyForBindingsDEV(
 let ReactServerDOMTurbopackClient, ReactServerDOMWebpackClient
 if (process.env.TURBOPACK) {
   ReactServerDOMTurbopackClient =
-    // @ts-expect-error -- TODO: Add types
     // eslint-disable-next-line import/no-extraneous-dependencies
     require('react-server-dom-turbopack/client') as typeof import('react-server-dom-turbopack/client')
   if (process.env.NODE_ENV === 'development') {

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -390,6 +390,28 @@ declare module 'react-server-dom-webpack/client.edge' {
   ): Promise<string | FormData>
 }
 
+declare module 'react-server-dom-turbopack/client' {
+  export * from 'react-server-dom-webpack/client'
+}
+declare module 'react-server-dom-turbopack/client.browser' {
+  export * from 'react-server-dom-webpack/client.browser'
+}
+declare module 'react-server-dom-turbopack/server.edge' {
+  export * from 'react-server-dom-webpack/server.edge'
+}
+declare module 'react-server-dom-turbopack/server' {
+  export * from 'react-server-dom-webpack/server'
+}
+declare module 'react-server-dom-turbopack/server.node' {
+  export * from 'react-server-dom-webpack/server.node'
+}
+declare module 'react-server-dom-turbopack/static' {
+  export * from 'react-server-dom-webpack/static'
+}
+declare module 'react-server-dom-turbopack/client.edge' {
+  export * from 'react-server-dom-webpack/client.edge'
+}
+
 declare module 'VAR_MODULE_GLOBAL_ERROR'
 declare module 'VAR_MODULE_GLOBAL_NOT_FOUND'
 declare module 'VAR_USERLAND'


### PR DESCRIPTION
This file isn't bundled, so the bundler compile time alias doesn't apply here and the Webpack version was used even for Turbopack.

Closes PACK-5176