### PR TITLE
Add `path` to Image documentation

### DIFF
--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -638,7 +638,7 @@ export default function myImageLoader({ src, width, quality }) {
 
 #### `path`
 
-If you want to change or prefix the default path for the image optimization api, you can do so with the `path` property. The default value for `path` is `/_next/image`.
+If you want to change or prefix the default path for the Image Optimization API, you can do so with the `path` property. The default value for `path` is `/_next/image`.
 
 ```js filename="next.config.js"
 module.exports = {

--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -636,7 +636,7 @@ export default function myImageLoader({ src, width, quality }) {
 
 > Alternatively, you can use the [`loader` prop](#loader) to configure each instance of `next/image`.
 
-### `path`
+#### `path`
 
 If you want to change or prefix the default path for the image, you can do so with the `path` property. The default value for `path` is `/_next/image`.
 

--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -638,7 +638,7 @@ export default function myImageLoader({ src, width, quality }) {
 
 #### `path`
 
-If you want to change or prefix the default path for the image, you can do so with the `path` property. The default value for `path` is `/_next/image`.
+If you want to change or prefix the default path for the image optimization api, you can do so with the `path` property. The default value for `path` is `/_next/image`.
 
 ```js filename="next.config.js"
 module.exports = {

--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -636,6 +636,18 @@ export default function myImageLoader({ src, width, quality }) {
 
 > Alternatively, you can use the [`loader` prop](#loader) to configure each instance of `next/image`.
 
+### `path`
+
+If you want to change or prefix the default path for the image, you can do so with the `path` property. The default value for `path` is `/_next/image`.
+
+```js filename="next.config.js"
+module.exports = {
+  images: {
+    path: '/my-prefix/_next/image',
+  },
+}
+```
+
 #### `deviceSizes`
 
 `deviceSizes` allows you to specify a list of device width breakpoints. These widths are used when the `next/image` component uses [`sizes`](#sizes) prop to ensure the correct image is served for the user's device.

--- a/docs/02-pages/04-api-reference/01-components/image-legacy.mdx
+++ b/docs/02-pages/04-api-reference/01-components/image-legacy.mdx
@@ -441,7 +441,9 @@ module.exports = {
 }
 ```
 
-If you want to change or prefix the default path for the image, you can do so with the `path` property. The default value for `path` is `/_next/image`.
+#### Customizing the Built-in Image Path
+
+If you want to change or prefix the default path for the built-in Next.js image optimization, you can do so with the `path` property. The default value for `path` is `/_next/image`.
 
 ```js filename="next.config.js"
 module.exports = {

--- a/docs/02-pages/04-api-reference/01-components/image-legacy.mdx
+++ b/docs/02-pages/04-api-reference/01-components/image-legacy.mdx
@@ -441,6 +441,16 @@ module.exports = {
 }
 ```
 
+If you want to change or prefix the default path for the image, you can do so with the `path` property. The default value for `path` is `/_next/image`.
+
+```js filename="next.config.js"
+module.exports = {
+  images: {
+    path: '/my-prefix/_next/image',
+  },
+}
+```
+
 ### Built-in Loaders
 
 The following Image Optimization cloud providers are included:

--- a/packages/next/src/shared/lib/image-config.ts
+++ b/packages/next/src/shared/lib/image-config.ts
@@ -83,7 +83,7 @@ export type ImageConfigComplete = {
   /** @see [Image loaders configuration](https://nextjs.org/docs/api-reference/next/legacy/image#loader) */
   loader: LoaderValue
 
-  /** @see [Image loader configuration](https://nextjs.org/docs/api-reference/next/legacy/image#loader-configuration) */
+  /** @see [Image loader configuration](https://nextjs.org/docs/app/api-reference/components/image#path) */
   path: string
 
   /** @see [Image loader configuration](https://nextjs.org/docs/api-reference/next/image#loader-configuration) */


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change


### How?

Closes NEXT-
Fixes #

-->

### What?

Add the `path` field to the App Router https://nextjs.org/docs/app/api-reference/components/image and Pages Router https://nextjs.org/docs/pages/api-reference/components/image docs. This field is valid for both, and currently it's use is hidden in the code.

### Why?

Allow people to find and use the field as it is useful for prefixing the `/_next/image` path.
