### PR TITLE
[Pages] fix: `_error` page's `req.url` can be overwritten to dynamic param on minimal mode

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2340,7 +2340,13 @@ export default abstract class Server<
         initPathname = normalizer.normalize(initPathname)
       }
     }
-    request.url = `${initPathname}${parsedInitUrl.search || ''}`
+
+    // On minimal mode, the request url of dynamic route can be a
+    // dynamic param instead of actual URL, so overwriting to initPathname
+    // will transform back the resolved url to the dynamic route pathname.
+    if (this.minimalMode && !isErrorPathname) {
+      request.url = `${initPathname}${parsedInitUrl.search || ''}`
+    }
 
     // propagate the request context for dev
     setRequestMeta(request, getRequestMeta(req))

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2342,7 +2342,7 @@ export default abstract class Server<
     }
 
     // On minimal mode, the request url of dynamic route can be a
-    // dynamic param instead of actual URL, so overwriting to initPathname
+    // literal dynamic route ('/[slug]') instead of actual URL, so overwriting to initPathname
     // will transform back the resolved url to the dynamic route pathname.
     if (this.minimalMode && !isErrorPathname) {
       request.url = `${initPathname}${parsedInitUrl.search || ''}`

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2344,7 +2344,7 @@ export default abstract class Server<
     // On minimal mode, the request url of dynamic route can be a
     // literal dynamic route ('/[slug]') instead of actual URL, so overwriting to initPathname
     // will transform back the resolved url to the dynamic route pathname.
-    if (this.minimalMode && !isErrorPathname) {
+    if (!(this.minimalMode && isErrorPathname)) {
       request.url = `${initPathname}${parsedInitUrl.search || ''}`
     }
 

--- a/test/e2e/error-handler-not-found-req-url/error-handler-not-found-req-url.test.ts
+++ b/test/e2e/error-handler-not-found-req-url/error-handler-not-found-req-url.test.ts
@@ -6,8 +6,8 @@ describe('error-handler-not-found-req-url', () => {
   })
 
   it('should log the correct request url and asPath for not found _error page', async () => {
-    await next.browser('/3')
-
-    expect(await next.cliOutput).toContain(`{ reqUrl: '/3', asPath: '/3' }`)
+    const browser = await next.browser('/3')
+    const p = await browser.elementByCss('p')
+    expect(await p.text()).toBe('reqUrl: /3, asPath: /3')
   })
 })

--- a/test/e2e/error-handler-not-found-req-url/error-handler-not-found-req-url.test.ts
+++ b/test/e2e/error-handler-not-found-req-url/error-handler-not-found-req-url.test.ts
@@ -1,0 +1,13 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('error-handler-not-found-req-url', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should log the correct request url and asPath for not found _error page', async () => {
+    await next.browser('/3')
+
+    expect(await next.cliOutput).toContain(`{ reqUrl: '/3', asPath: '/3' }`)
+  })
+})

--- a/test/e2e/error-handler-not-found-req-url/pages/[slug].tsx
+++ b/test/e2e/error-handler-not-found-req-url/pages/[slug].tsx
@@ -1,0 +1,16 @@
+export default function Page() {
+  return <p>hello world</p>
+}
+
+export async function getStaticProps() {
+  return {
+    notFound: true,
+  }
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  }
+}

--- a/test/e2e/error-handler-not-found-req-url/pages/_error.tsx
+++ b/test/e2e/error-handler-not-found-req-url/pages/_error.tsx
@@ -1,13 +1,22 @@
 import type { NextPageContext } from 'next'
 
 Error.getInitialProps = (ctx: NextPageContext) => {
-  console.log({
+  return {
     reqUrl: ctx.req?.url,
     asPath: ctx.asPath,
-  })
-  return {}
+  }
 }
 
-export default function Error() {
-  return <>Error</>
+export default function Error({
+  reqUrl,
+  asPath,
+}: {
+  reqUrl?: string
+  asPath?: string
+}) {
+  return (
+    <p>
+      reqUrl: {reqUrl}, asPath: {asPath}
+    </p>
+  )
 }

--- a/test/e2e/error-handler-not-found-req-url/pages/_error.tsx
+++ b/test/e2e/error-handler-not-found-req-url/pages/_error.tsx
@@ -1,0 +1,13 @@
+import type { NextPageContext } from 'next'
+
+Error.getInitialProps = (ctx: NextPageContext) => {
+  console.log({
+    reqUrl: ctx.req?.url,
+    asPath: ctx.asPath,
+  })
+  return {}
+}
+
+export default function Error() {
+  return <>Error</>
+}

--- a/test/e2e/error-handler-not-found-req-url/pages/index.tsx
+++ b/test/e2e/error-handler-not-found-req-url/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}


### PR DESCRIPTION
In minimal mode, if there was `/[slug].js` with `notFound: true` on the same segment of `_error.js`, `req.url` and `ctx.asPath` were returned as `/[slug]`, since it was re-initialized to the request url.

Therefore, don't re-initialize the URL if it is in minimal mode && is the `_error` page.

Fixes NEXT-4660