### PR TITLE
Documentation: Removed reference to treeShaking in 08-turbopack.mdx

### DIFF
--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -132,8 +132,6 @@ Turbopack can be configured via `next.config.js` (or `next.config.ts`) under the
   Change or extend file extensions for module resolution.
 - **`moduleIds`**
   Set how module IDs are generated (`'named'` vs `'deterministic'`).
-- **`treeShaking`**
-  Enable or disable tree shaking in dev and future production builds.
 - **`memoryLimit`**
   Set a memory limit (in bytes) for Turbopack.
 


### PR DESCRIPTION
Removed reference to treeShaking, which isn't a known property in TurbopackOptions.