### PR TITLE
Turbopack: run styled-jsx after typescript transform

### DIFF
--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -58,7 +58,7 @@ use crate::{
             get_invalid_styled_jsx_resolve_plugin,
         },
         transforms::{
-            emotion::get_emotion_transform_rule, get_ecma_transform_rule,
+            EcmascriptTransformStage, emotion::get_emotion_transform_rule, get_ecma_transform_rule,
             next_react_server_components::get_next_react_server_components_transform_rule,
             react_remove_properties::get_react_remove_properties_transform_rule,
             relay::get_relay_transform_rule, remove_console::get_remove_console_transform_rule,
@@ -768,7 +768,7 @@ pub async fn get_server_module_options_context(
                         ecmascript_client_reference_transition_name,
                     )),
                     enable_mdx_rs.is_some(),
-                    true,
+                    EcmascriptTransformStage::Preprocess,
                 ));
             }
 
@@ -844,7 +844,7 @@ pub async fn get_server_module_options_context(
                         ecmascript_client_reference_transition_name,
                     )),
                     enable_mdx_rs.is_some(),
-                    true,
+                    EcmascriptTransformStage::Preprocess,
                 ));
             }
 
@@ -922,7 +922,7 @@ pub async fn get_server_module_options_context(
                         ecmascript_client_reference_transition_name,
                     )),
                     enable_mdx_rs.is_some(),
-                    true,
+                    EcmascriptTransformStage::Preprocess,
                 ));
             } else {
                 custom_source_transform_rules.push(get_ecma_transform_rule(
@@ -930,7 +930,7 @@ pub async fn get_server_module_options_context(
                         "next/dist/client/use-client-disallowed.js".to_string(),
                     )),
                     enable_mdx_rs.is_some(),
-                    true,
+                    EcmascriptTransformStage::Preprocess,
                 ));
             }
 

--- a/crates/next-core/src/next_shared/transforms/debug_fn_name.rs
+++ b/crates/next-core/src/next_shared/transforms/debug_fn_name.rs
@@ -16,8 +16,9 @@ pub fn get_debug_fn_name_rule(enable_mdx_rs: bool) -> ModuleRule {
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![debug_fn_name_transform]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![debug_fn_name_transform]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/emotion.rs
+++ b/crates/next-core/src/next_shared/transforms/emotion.rs
@@ -4,7 +4,10 @@ use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript_plugins::transform::emotion::EmotionTransformer;
 
 use super::get_ecma_transform_rule;
-use crate::next_config::{EmotionTransformOptionsOrBoolean, NextConfig};
+use crate::{
+    next_config::{EmotionTransformOptionsOrBoolean, NextConfig},
+    next_shared::transforms::EcmascriptTransformStage,
+};
 
 pub async fn get_emotion_transform_rule(next_config: Vc<NextConfig>) -> Result<Option<ModuleRule>> {
     let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
@@ -20,7 +23,13 @@ pub async fn get_emotion_transform_rule(next_config: Vc<NextConfig>) -> Result<O
             EmotionTransformOptionsOrBoolean::Options(value) => EmotionTransformer::new(value),
             _ => None,
         })
-        .map(|transformer| get_ecma_transform_rule(Box::new(transformer), enable_mdx_rs, true));
+        .map(|transformer| {
+            get_ecma_transform_rule(
+                Box::new(transformer),
+                enable_mdx_rs,
+                EcmascriptTransformStage::Main,
+            )
+        });
 
     Ok(module_rule)
 }

--- a/crates/next-core/src/next_shared/transforms/modularize_imports.rs
+++ b/crates/next-core/src/next_shared/transforms/modularize_imports.rs
@@ -63,8 +63,9 @@ pub fn get_next_modularize_imports_rule(
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![transformer]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_amp_attributes.rs
+++ b/crates/next-core/src/next_shared/transforms/next_amp_attributes.rs
@@ -14,8 +14,9 @@ pub fn get_next_amp_attr_rule(enable_mdx_rs: bool) -> ModuleRule {
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![transformer]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![transformer]),
+            postprocess: ResolvedVc::cell(vec![]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
+++ b/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
@@ -54,8 +54,9 @@ pub fn get_next_cjs_optimizer_rule(enable_mdx_rs: bool) -> ModuleRule {
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![transformer]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
+++ b/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
@@ -19,8 +19,9 @@ pub fn get_next_disallow_export_all_in_page_rule(
     ModuleRule::new(
         module_rule_match_pages_page_file(enable_mdx_rs, pages_dir),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![transformer]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_dynamic.rs
+++ b/crates/next-core/src/next_shared/transforms/next_dynamic.rs
@@ -27,8 +27,9 @@ pub async fn get_next_dynamic_transform_rule(
     Ok(ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![dynamic_transform]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![dynamic_transform]),
         }],
     ))
 }

--- a/crates/next-core/src/next_shared/transforms/next_edge_node_api_assert.rs
+++ b/crates/next-core/src/next_shared/transforms/next_edge_node_api_assert.rs
@@ -24,8 +24,9 @@ pub fn next_edge_node_api_assert(
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![transformer]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_font.rs
+++ b/crates/next-core/src/next_shared/transforms/next_font.rs
@@ -28,8 +28,9 @@ pub fn get_next_font_transform_rule(enable_mdx_rs: bool) -> ModuleRule {
         // TODO: Only match in pages (not pages/api), app/, etc.
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![transformer]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_lint.rs
+++ b/crates/next-core/src/next_shared/transforms/next_lint.rs
@@ -6,9 +6,14 @@ use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
 use super::get_ecma_transform_rule;
+use crate::next_shared::transforms::EcmascriptTransformStage;
 
 pub fn get_next_lint_transform_rule(enable_mdx_rs: bool) -> ModuleRule {
-    get_ecma_transform_rule(Box::new(LintTransformer {}), enable_mdx_rs, true)
+    get_ecma_transform_rule(
+        Box::new(LintTransformer {}),
+        enable_mdx_rs,
+        EcmascriptTransformStage::Main,
+    )
 }
 
 #[derive(Debug)]

--- a/crates/next-core/src/next_shared/transforms/next_lint.rs
+++ b/crates/next-core/src/next_shared/transforms/next_lint.rs
@@ -12,7 +12,7 @@ pub fn get_next_lint_transform_rule(enable_mdx_rs: bool) -> ModuleRule {
     get_ecma_transform_rule(
         Box::new(LintTransformer {}),
         enable_mdx_rs,
-        EcmascriptTransformStage::Main,
+        EcmascriptTransformStage::Preprocess,
     )
 }
 

--- a/crates/next-core/src/next_shared/transforms/next_middleware_dynamic_assert.rs
+++ b/crates/next-core/src/next_shared/transforms/next_middleware_dynamic_assert.rs
@@ -16,8 +16,8 @@ pub fn get_middleware_dynamic_assert_rule(enable_mdx_rs: bool) -> ModuleRule {
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
             preprocess: ResolvedVc::cell(vec![]),
-            main: ResolvedVc::cell(vec![transformer]),
-            postprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_middleware_dynamic_assert.rs
+++ b/crates/next-core/src/next_shared/transforms/next_middleware_dynamic_assert.rs
@@ -15,8 +15,9 @@ pub fn get_middleware_dynamic_assert_rule(enable_mdx_rs: bool) -> ModuleRule {
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![transformer]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![transformer]),
+            postprocess: ResolvedVc::cell(vec![]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
+++ b/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
@@ -21,8 +21,8 @@ pub fn get_next_optimize_server_react_rule(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
             preprocess: ResolvedVc::cell(vec![]),
-            main: ResolvedVc::cell(vec![transformer]),
-            postprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
+++ b/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
@@ -20,8 +20,9 @@ pub fn get_next_optimize_server_react_rule(
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![transformer]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![transformer]),
+            postprocess: ResolvedVc::cell(vec![]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_page_config.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_config.rs
@@ -17,8 +17,9 @@ pub fn get_next_page_config_rule(enable_mdx_rs: bool, pages_dir: FileSystemPath)
     ModuleRule::new(
         module_rule_match_pages_page_file(enable_mdx_rs, pages_dir),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![transformer]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![transformer]),
+            postprocess: ResolvedVc::cell(vec![]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_page_config.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_config.rs
@@ -18,8 +18,8 @@ pub fn get_next_page_config_rule(enable_mdx_rs: bool, pages_dir: FileSystemPath)
         module_rule_match_pages_page_file(enable_mdx_rs, pages_dir),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
             preprocess: ResolvedVc::cell(vec![]),
-            main: ResolvedVc::cell(vec![transformer]),
-            postprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -39,8 +39,8 @@ pub fn get_next_page_static_info_assert_rule(
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            preprocess: ResolvedVc::cell(vec![]),
-            main: ResolvedVc::cell(vec![transformer]),
+            preprocess: ResolvedVc::cell(vec![transformer]),
+            main: ResolvedVc::cell(vec![]),
             postprocess: ResolvedVc::cell(vec![]),
         }],
     )

--- a/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
+++ b/crates/next-core/src/next_shared/transforms/next_page_static_info.rs
@@ -39,8 +39,9 @@ pub fn get_next_page_static_info_assert_rule(
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![transformer]),
-            append: ResolvedVc::cell(vec![]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![transformer]),
+            postprocess: ResolvedVc::cell(vec![]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_pure.rs
+++ b/crates/next-core/src/next_shared/transforms/next_pure.rs
@@ -14,8 +14,9 @@ pub fn get_next_pure_rule(enable_mdx_rs: bool) -> ModuleRule {
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![transformer]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -44,7 +44,7 @@ pub async fn get_next_react_server_components_transform_rule(
             app_dir,
         )),
         enable_mdx_rs,
-        EcmascriptTransformStage::Main,
+        EcmascriptTransformStage::Preprocess,
     ))
 }
 

--- a/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -11,7 +11,7 @@ use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
 use super::get_ecma_transform_rule;
-use crate::next_config::NextConfig;
+use crate::{next_config::NextConfig, next_shared::transforms::EcmascriptTransformStage};
 
 /// Returns a rule which applies the Next.js react server components transform.
 /// This transform owns responsibility to assert various import / usage
@@ -44,7 +44,7 @@ pub async fn get_next_react_server_components_transform_rule(
             app_dir,
         )),
         enable_mdx_rs,
-        true,
+        EcmascriptTransformStage::Main,
     ))
 }
 

--- a/crates/next-core/src/next_shared/transforms/next_shake_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_shake_exports.rs
@@ -16,8 +16,9 @@ pub fn get_next_shake_exports_rule(enable_mdx_rs: bool, ignore: Vec<String>) -> 
     ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![transformer]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![transformer]),
         }],
     )
 }

--- a/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -40,8 +40,9 @@ pub async fn get_next_pages_transforms_rule(
             module_rule_match_js_no_url(enable_mdx_rs),
         ]),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![strip_transform]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![strip_transform]),
         }],
     ))
 }

--- a/crates/next-core/src/next_shared/transforms/next_track_dynamic_imports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_track_dynamic_imports.rs
@@ -6,9 +6,14 @@ use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
 use super::get_ecma_transform_rule;
+use crate::next_shared::transforms::EcmascriptTransformStage;
 
 pub fn get_next_track_dynamic_imports_transform_rule(mdx_rs: bool) -> ModuleRule {
-    get_ecma_transform_rule(Box::new(NextTrackDynamicImports {}), mdx_rs, false)
+    get_ecma_transform_rule(
+        Box::new(NextTrackDynamicImports {}),
+        mdx_rs,
+        EcmascriptTransformStage::Postprocess,
+    )
 }
 
 #[derive(Debug)]

--- a/crates/next-core/src/next_shared/transforms/react_remove_properties.rs
+++ b/crates/next-core/src/next_shared/transforms/react_remove_properties.rs
@@ -6,7 +6,10 @@ use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
 use super::get_ecma_transform_rule;
-use crate::next_config::{NextConfig, ReactRemoveProperties};
+use crate::{
+    next_config::{NextConfig, ReactRemoveProperties},
+    next_shared::transforms::EcmascriptTransformStage,
+};
 
 /// Returns a rule which applies the react_remove_properties transform.
 pub async fn get_react_remove_properties_transform_rule(
@@ -34,7 +37,7 @@ pub async fn get_react_remove_properties_transform_rule(
             get_ecma_transform_rule(
                 Box::new(ReactRemovePropertiesTransformer { config }),
                 enable_mdx_rs,
-                true,
+                EcmascriptTransformStage::Main,
             )
         });
 

--- a/crates/next-core/src/next_shared/transforms/react_remove_properties.rs
+++ b/crates/next-core/src/next_shared/transforms/react_remove_properties.rs
@@ -37,7 +37,7 @@ pub async fn get_react_remove_properties_transform_rule(
             get_ecma_transform_rule(
                 Box::new(ReactRemovePropertiesTransformer { config }),
                 enable_mdx_rs,
-                EcmascriptTransformStage::Main,
+                EcmascriptTransformStage::Preprocess,
             )
         });
 

--- a/crates/next-core/src/next_shared/transforms/relay.rs
+++ b/crates/next-core/src/next_shared/transforms/relay.rs
@@ -5,7 +5,7 @@ use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript_plugins::transform::relay::RelayTransformer;
 
 use super::get_ecma_transform_rule;
-use crate::next_config::NextConfig;
+use crate::{next_config::NextConfig, next_shared::transforms::EcmascriptTransformStage};
 
 /// Returns a transform rule for the relay graphql transform.
 pub async fn get_relay_transform_rule(
@@ -17,7 +17,7 @@ pub async fn get_relay_transform_rule(
         get_ecma_transform_rule(
             Box::new(RelayTransformer::new(config, &project_path)),
             enable_mdx_rs,
-            true,
+            EcmascriptTransformStage::Main,
         )
     });
 

--- a/crates/next-core/src/next_shared/transforms/relay.rs
+++ b/crates/next-core/src/next_shared/transforms/relay.rs
@@ -17,7 +17,7 @@ pub async fn get_relay_transform_rule(
         get_ecma_transform_rule(
             Box::new(RelayTransformer::new(config, &project_path)),
             enable_mdx_rs,
-            EcmascriptTransformStage::Main,
+            EcmascriptTransformStage::Preprocess,
         )
     });
 

--- a/crates/next-core/src/next_shared/transforms/remove_console.rs
+++ b/crates/next-core/src/next_shared/transforms/remove_console.rs
@@ -40,7 +40,7 @@ pub async fn get_remove_console_transform_rule(
             get_ecma_transform_rule(
                 Box::new(RemoveConsoleTransformer { config }),
                 enable_mdx_rs,
-                EcmascriptTransformStage::Main,
+                EcmascriptTransformStage::Preprocess,
             )
         });
 

--- a/crates/next-core/src/next_shared/transforms/remove_console.rs
+++ b/crates/next-core/src/next_shared/transforms/remove_console.rs
@@ -6,7 +6,10 @@ use turbopack::module_options::ModuleRule;
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
 use super::get_ecma_transform_rule;
-use crate::next_config::{NextConfig, RemoveConsoleConfig};
+use crate::{
+    next_config::{NextConfig, RemoveConsoleConfig},
+    next_shared::transforms::EcmascriptTransformStage,
+};
 
 /// Returns a rule which applies the remove_console transform.
 pub async fn get_remove_console_transform_rule(
@@ -37,7 +40,7 @@ pub async fn get_remove_console_transform_rule(
             get_ecma_transform_rule(
                 Box::new(RemoveConsoleTransformer { config }),
                 enable_mdx_rs,
-                true,
+                EcmascriptTransformStage::Main,
             )
         });
 

--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -40,8 +40,8 @@ pub async fn get_server_actions_transform_rule(
     Ok(ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            preprocess: ResolvedVc::cell(vec![]),
-            main: ResolvedVc::cell(vec![transformer]),
+            preprocess: ResolvedVc::cell(vec![transformer]),
+            main: ResolvedVc::cell(vec![]),
             postprocess: ResolvedVc::cell(vec![]),
         }],
     ))

--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -40,8 +40,9 @@ pub async fn get_server_actions_transform_rule(
     Ok(ModuleRule::new(
         module_rule_match_js_no_url(enable_mdx_rs),
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![transformer]),
-            append: ResolvedVc::cell(vec![]),
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![transformer]),
+            postprocess: ResolvedVc::cell(vec![]),
         }],
     ))
 }

--- a/crates/next-core/src/next_shared/transforms/styled_components.rs
+++ b/crates/next-core/src/next_shared/transforms/styled_components.rs
@@ -5,7 +5,7 @@ use turbopack_ecmascript_plugins::transform::styled_components::StyledComponents
 
 use crate::{
     next_config::{NextConfig, StyledComponentsTransformOptionsOrBoolean},
-    next_shared::transforms::get_ecma_transform_rule,
+    next_shared::transforms::{EcmascriptTransformStage, get_ecma_transform_rule},
 };
 
 pub async fn get_styled_components_transform_rule(
@@ -27,7 +27,13 @@ pub async fn get_styled_components_transform_rule(
             }
             _ => None,
         })
-        .map(|transformer| get_ecma_transform_rule(Box::new(transformer), enable_mdx_rs, true));
+        .map(|transformer| {
+            get_ecma_transform_rule(
+                Box::new(transformer),
+                enable_mdx_rs,
+                EcmascriptTransformStage::Main,
+            )
+        });
 
     Ok(module_rule)
 }

--- a/crates/next-core/src/next_shared/transforms/styled_jsx.rs
+++ b/crates/next-core/src/next_shared/transforms/styled_jsx.rs
@@ -19,6 +19,6 @@ pub async fn get_styled_jsx_transform_rule(
     Ok(Some(get_ecma_transform_rule(
         Box::new(transformer),
         enable_mdx_rs,
-        true,
+        false,
     )))
 }

--- a/crates/next-core/src/next_shared/transforms/styled_jsx.rs
+++ b/crates/next-core/src/next_shared/transforms/styled_jsx.rs
@@ -5,7 +5,7 @@ use turbopack_core::environment::RuntimeVersions;
 use turbopack_ecmascript_plugins::transform::styled_jsx::StyledJsxTransformer;
 
 use super::get_ecma_transform_rule;
-use crate::next_config::NextConfig;
+use crate::{next_config::NextConfig, next_shared::transforms::EcmascriptTransformStage};
 
 /// Returns a transform rule for the styled jsx transform.
 pub async fn get_styled_jsx_transform_rule(
@@ -19,6 +19,6 @@ pub async fn get_styled_jsx_transform_rule(
     Ok(Some(get_ecma_transform_rule(
         Box::new(transformer),
         enable_mdx_rs,
-        false,
+        EcmascriptTransformStage::Main,
     )))
 }

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -48,7 +48,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
         SwcEcmaTransformPluginsTransformer, SwcPluginModule,
     };
 
-    use crate::next_shared::transforms::get_ecma_transform_rule;
+    use crate::next_shared::transforms::{EcmascriptTransformStage, get_ecma_transform_rule};
 
     let plugins = plugin_configs
         .iter()
@@ -116,6 +116,6 @@ pub async fn get_swc_ecma_transform_rule_impl(
     Ok(Some(get_ecma_transform_rule(
         Box::new(SwcEcmaTransformPluginsTransformer::new(plugins)),
         enable_mdx_rs,
-        true,
+        EcmascriptTransformStage::Main,
     )))
 }

--- a/test/e2e/styled-jsx/index.test.ts
+++ b/test/e2e/styled-jsx/index.test.ts
@@ -41,4 +41,13 @@ describe('styled-jsx', () => {
     const html = await next.render('/amp')
     expect(html).toMatch(/color:.*?cyan/)
   })
+
+  it('should render styles inside TypeScript', async () => {
+    const browser = await next.browser('/typescript')
+    const color = await browser.eval(
+      `getComputedStyle(document.querySelector('button')).color`
+    )
+
+    expect(color).toMatch('255, 0, 0')
+  })
 })

--- a/test/e2e/styled-jsx/pages/typescript.tsx
+++ b/test/e2e/styled-jsx/pages/typescript.tsx
@@ -2,13 +2,19 @@ interface Props {
   color: string
 }
 
-export default (p: Props) => (
-  <div>
-    <p>test</p>
-    <style jsx>{`
-      span {
-        color: ${p.color};
-      }
-    `}</style>
-  </div>
-)
+function Test(p: Props) {
+  return (
+    <div>
+      <button>test</button>
+      <style jsx>{`
+        button {
+          color: ${p.color};
+        }
+      `}</style>
+    </div>
+  )
+}
+
+export default function Page() {
+  return <Test color="red" />
+}

--- a/test/e2e/styled-jsx/pages/typescript.tsx
+++ b/test/e2e/styled-jsx/pages/typescript.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  color: string
+}
+
+export default (p: Props) => (
+  <div>
+    <p>test</p>
+    <style jsx>{`
+      span {
+        color: ${p.color};
+      }
+    `}</style>
+  </div>
+)

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -8,8 +8,8 @@ use turbopack::{
     ModuleAssetContext,
     ecmascript::TreeShakingMode,
     module_options::{
-        EcmascriptOptionsContext, JsxTransformOptions, ModuleOptionsContext, ModuleRule,
-        ModuleRuleEffect, RuleCondition, TypescriptTransformOptions,
+        EcmascriptOptionsContext, JsxTransformOptions, ModuleOptionsContext,
+        TypescriptTransformOptions,
     },
 };
 use turbopack_browser::react_refresh::assert_can_resolve_react_refresh;
@@ -135,21 +135,6 @@ async fn get_client_module_options_context(
         .resolved_cell(),
     );
 
-    let conditions = RuleCondition::any(vec![
-        RuleCondition::ResourcePathEndsWith(".js".to_string()),
-        RuleCondition::ResourcePathEndsWith(".jsx".to_string()),
-        RuleCondition::ResourcePathEndsWith(".ts".to_string()),
-        RuleCondition::ResourcePathEndsWith(".tsx".to_string()),
-    ]);
-
-    let module_rules = ModuleRule::new(
-        conditions,
-        vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![]),
-            append: ResolvedVc::cell(vec![]),
-        }],
-    );
-
     let module_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
             enable_jsx,
@@ -164,7 +149,6 @@ async fn get_client_module_options_context(
             foreign_code_context_condition(),
             module_options_context.clone().resolved_cell(),
         )],
-        module_rules: vec![module_rules],
         ..module_options_context
     }
     .cell();

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -321,7 +321,8 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
     let module_rules = ModuleRule::new(
         conditions,
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
-            prepend: ResolvedVc::cell(vec![
+            preprocess: ResolvedVc::cell(vec![]),
+            main: ResolvedVc::cell(vec![
                 EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(
                     EmotionTransformer::new(&EmotionTransformConfig::default())
                         .expect("Should be able to create emotion transformer"),
@@ -330,7 +331,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                     StyledComponentsTransformer::new(&StyledComponentsTransformConfig::default()),
                 ) as _)),
             ]),
-            append: ResolvedVc::cell(vec![]),
+            postprocess: ResolvedVc::cell(vec![]),
         }],
     );
     let asset_context: Vc<Box<dyn AssetContext>> = Vc::upcast(ModuleAssetContext::new(

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -582,8 +582,8 @@ async fn process_default_internal(
                                     .to_resolved()
                                     .await?,
                                 main: extend_main.extend(*main).to_resolved().await?,
-                                postprocess: extend_postprocess
-                                    .extend(*postprocess)
+                                postprocess: postprocess
+                                    .extend(**extend_postprocess)
                                     .to_resolved()
                                     .await?,
                                 options,
@@ -601,8 +601,8 @@ async fn process_default_internal(
                                     .to_resolved()
                                     .await?,
                                 main: extend_main.extend(*main).to_resolved().await?,
-                                postprocess: extend_postprocess
-                                    .extend(*postprocess)
+                                postprocess: postprocess
+                                    .extend(**extend_postprocess)
                                     .to_resolved()
                                     .await?,
                                 tsx,

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -80,17 +80,23 @@ async fn apply_module_type(
     let module_type = &*module_type.await?;
     Ok(ProcessResult::Module(match module_type {
         ModuleType::Ecmascript {
-            transforms,
+            preprocess,
+            main,
+            postprocess,
             options,
         }
         | ModuleType::Typescript {
-            transforms,
+            preprocess,
+            main,
+            postprocess,
             tsx: _,
             analyze_types: _,
             options,
         }
         | ModuleType::TypescriptDeclaration {
-            transforms,
+            preprocess,
+            main,
+            postprocess,
             options,
         } => {
             let context_for_module = match module_type {
@@ -107,7 +113,11 @@ async fn apply_module_type(
             let mut builder = EcmascriptModuleAsset::builder(
                 source,
                 ResolvedVc::upcast(context_for_module),
-                *transforms,
+                preprocess
+                    .extend(**main)
+                    .extend(**postprocess)
+                    .to_resolved()
+                    .await?,
                 *options,
                 module_asset_context
                     .compile_time_info()
@@ -555,28 +565,44 @@ async fn process_default_internal(
                     ModuleRuleEffect::ModuleType(module) => {
                         current_module_type = Some(module.clone());
                     }
-                    ModuleRuleEffect::ExtendEcmascriptTransforms { prepend, append } => {
+                    ModuleRuleEffect::ExtendEcmascriptTransforms {
+                        preprocess: extend_preprocess,
+                        main: extend_main,
+                        postprocess: extend_postprocess,
+                    } => {
                         current_module_type = match current_module_type {
                             Some(ModuleType::Ecmascript {
-                                transforms,
+                                preprocess,
+                                main,
+                                postprocess,
                                 options,
                             }) => Some(ModuleType::Ecmascript {
-                                transforms: prepend
-                                    .extend(*transforms)
-                                    .extend(**append)
+                                preprocess: extend_preprocess
+                                    .extend(*preprocess)
+                                    .to_resolved()
+                                    .await?,
+                                main: extend_main.extend(*main).to_resolved().await?,
+                                postprocess: extend_postprocess
+                                    .extend(*postprocess)
                                     .to_resolved()
                                     .await?,
                                 options,
                             }),
                             Some(ModuleType::Typescript {
-                                transforms,
+                                preprocess,
+                                main,
+                                postprocess,
                                 tsx,
                                 analyze_types,
                                 options,
                             }) => Some(ModuleType::Typescript {
-                                transforms: prepend
-                                    .extend(*transforms)
-                                    .extend(**append)
+                                preprocess: extend_preprocess
+                                    .extend(*preprocess)
+                                    .to_resolved()
+                                    .await?,
+                                main: extend_main.extend(*main).to_resolved().await?,
+                                postprocess: extend_postprocess
+                                    .extend(*postprocess)
                                     .to_resolved()
                                     .await?,
                                 tsx,

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -67,11 +67,14 @@ impl ModuleRule {
 pub enum ModuleRuleEffect {
     ModuleType(ModuleType),
     /// Allow to extend an existing Ecmascript module rules for the additional
-    /// transforms. First argument will prepend the existing transforms, and
-    /// the second argument will append the new transforms.
+    /// transforms
     ExtendEcmascriptTransforms {
-        prepend: ResolvedVc<EcmascriptInputTransforms>,
-        append: ResolvedVc<EcmascriptInputTransforms>,
+        /// Transforms to run first: transpile TypeScript, decorators, ...
+        preprocess: ResolvedVc<EcmascriptInputTransforms>,
+        /// Transforms to execute on standard EcmaScript (plus JSX): styled-jsx, swc plugins, ...
+        main: ResolvedVc<EcmascriptInputTransforms>,
+        /// Transforms to run last: JSX, preset-env, scan for imports, ...
+        postprocess: ResolvedVc<EcmascriptInputTransforms>,
     },
     SourceTransforms(ResolvedVc<SourceTransforms>),
     Ignore,
@@ -81,12 +84,22 @@ pub enum ModuleRuleEffect {
 #[derive(Hash, Debug, Clone)]
 pub enum ModuleType {
     Ecmascript {
-        transforms: ResolvedVc<EcmascriptInputTransforms>,
+        /// Transforms to run first: transpile TypeScript, decorators, ...
+        preprocess: ResolvedVc<EcmascriptInputTransforms>,
+        /// Transforms to execute on standard EcmaScript (plus JSX): styled-jsx, swc plugins, ...
+        main: ResolvedVc<EcmascriptInputTransforms>,
+        /// Transforms to run last: JSX, preset-env, scan for imports, ...
+        postprocess: ResolvedVc<EcmascriptInputTransforms>,
         #[turbo_tasks(trace_ignore)]
         options: ResolvedVc<EcmascriptOptions>,
     },
     Typescript {
-        transforms: ResolvedVc<EcmascriptInputTransforms>,
+        /// Transforms to run first: transpile TypeScript, decorators, ...
+        preprocess: ResolvedVc<EcmascriptInputTransforms>,
+        /// Transforms to execute on standard EcmaScript (plus JSX): styled-jsx, swc plugins, ...
+        main: ResolvedVc<EcmascriptInputTransforms>,
+        /// Transforms to run last: JSX, preset-env, scan for imports, ...
+        postprocess: ResolvedVc<EcmascriptInputTransforms>,
         // parse JSX syntax.
         tsx: bool,
         // follow references to imported types.
@@ -95,7 +108,12 @@ pub enum ModuleType {
         options: ResolvedVc<EcmascriptOptions>,
     },
     TypescriptDeclaration {
-        transforms: ResolvedVc<EcmascriptInputTransforms>,
+        /// Transforms to run first: transpile TypeScript, decorators, ...
+        preprocess: ResolvedVc<EcmascriptInputTransforms>,
+        /// Transforms to execute on standard EcmaScript (plus JSX): styled-jsx, swc plugins, ...
+        main: ResolvedVc<EcmascriptInputTransforms>,
+        /// Transforms to run last: JSX, preset-env, scan for imports, ...
+        postprocess: ResolvedVc<EcmascriptInputTransforms>,
         #[turbo_tasks(trace_ignore)]
         options: ResolvedVc<EcmascriptOptions>,
     },


### PR DESCRIPTION
Closes PACK-5183

Based on https://github.com/swc-project/swc/issues/10944#issuecomment-3120775091, we need to run styled-jsx after typescript


Fixes this crash
```
entered unreachable code: This visitor does not support TypeScript. This method fails for optimization purposes. Encountered in unreachable visitor: visit_ts_interface_decl
```

This has become more pressing as swc seems to have turned the debug_assertion into a proper panic/crash in recent versions (I was seeing SIGSEGV when building some app): https://vercel.slack.com/archives/C03EWR7LGEN/p1754390155508789?thread_ts=1753477535.369549&cid=C03EWR7LGEN


We now have three phases/stages:
- preprocess: to strip typescript/decorators (so to normalize the syntax)
- main: for transforms that want to operate on "standard" EcmaScript (though still with raw JSX)
- postprocess: react transform, preset-env, etc (so low level "codegen")