### PR TITLE
Backport "[Pages] fix: `_error` page's `req.url` can be overwritten t…

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2649,7 +2649,13 @@ export default abstract class Server<
                 initPathname = normalizer.normalize(initPathname)
               }
             }
-            request.url = `${initPathname}${parsedInitUrl.search || ''}`
+
+            // On minimal mode, the request url of dynamic route can be a
+            // literal dynamic route ('/[slug]') instead of actual URL, so overwriting to initPathname
+            // will transform back the resolved url to the dynamic route pathname.
+            if (!(this.minimalMode && isErrorPathname)) {
+              request.url = `${initPathname}${parsedInitUrl.search || ''}`
+            }
 
             // propagate the request context for dev
             setRequestMeta(request, getRequestMeta(req))

--- a/test/e2e/error-handler-not-found-req-url/error-handler-not-found-req-url.test.ts
+++ b/test/e2e/error-handler-not-found-req-url/error-handler-not-found-req-url.test.ts
@@ -1,0 +1,13 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('error-handler-not-found-req-url', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should log the correct request url and asPath for not found _error page', async () => {
+    const browser = await next.browser('/3')
+    const p = await browser.elementByCss('p')
+    expect(await p.text()).toBe('reqUrl: /3, asPath: /3')
+  })
+})

--- a/test/e2e/error-handler-not-found-req-url/pages/[slug].tsx
+++ b/test/e2e/error-handler-not-found-req-url/pages/[slug].tsx
@@ -1,0 +1,16 @@
+export default function Page() {
+  return <p>hello world</p>
+}
+
+export async function getStaticProps() {
+  return {
+    notFound: true,
+  }
+}
+
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  }
+}

--- a/test/e2e/error-handler-not-found-req-url/pages/_error.tsx
+++ b/test/e2e/error-handler-not-found-req-url/pages/_error.tsx
@@ -1,0 +1,22 @@
+import type { NextPageContext } from 'next'
+
+Error.getInitialProps = (ctx: NextPageContext) => {
+  return {
+    reqUrl: ctx.req?.url,
+    asPath: ctx.asPath,
+  }
+}
+
+export default function Error({
+  reqUrl,
+  asPath,
+}: {
+  reqUrl?: string
+  asPath?: string
+}) {
+  return (
+    <p>
+      reqUrl: {reqUrl}, asPath: {asPath}
+    </p>
+  )
+}

--- a/test/e2e/error-handler-not-found-req-url/pages/index.tsx
+++ b/test/e2e/error-handler-not-found-req-url/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}


### PR DESCRIPTION
…o dynamic param on minimal mode (#82347)"