### PR TITLE
docs: fix Supabase import paths in fetch-data-steps tutorial

### DIFF
--- a/examples/with-supabase/components/tutorial/fetch-data-steps.tsx
+++ b/examples/with-supabase/components/tutorial/fetch-data-steps.tsx
@@ -13,7 +13,7 @@ values
   ('It was awesome!');
 `.trim();
 
-const server = `import { createClient } from '@/utils/supabase/server'
+const server = `import { createClient } from '@/lib/supabase/server'
 
 export default async function Page() {
   const supabase = await createClient()
@@ -25,7 +25,7 @@ export default async function Page() {
 
 const client = `'use client'
 
-import { createClient } from '@/utils/supabase/client'
+import { createClient } from '@/lib/supabase/client'
 import { useEffect, useState } from 'react'
 
 export default function Page() {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### What?

This PR fixes inconsistent Supabase import paths in the `with-supabase` example's tutorial documentation.

### Why?

The tutorial code examples in `examples/with-supabase/components/tutorial/fetch-data-steps.tsx` were showing import paths that don't match:
- The actual folder structure in the `with-supabase` example (`@/lib/supabase/*`)
- The official Supabase documentation conventions
- What new developers would expect when following the tutorial

This inconsistency was causing confusion for developers trying to follow the tutorial, as the import paths in the documentation didn't work with the actual project structure.

### How?

Updated the import paths in the tutorial code examples from:
- `@/utils/supabase/server` → `@/lib/supabase/server`  
- `@/utils/supabase/client` → `@/lib/supabase/client`

This aligns the tutorial documentation with the actual file structure used in the example and matches the official Supabase documentation patterns.

Fixes #82218

-->