### PR TITLE
loader tree: add special segment name to virtual parallel route segments

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1054,7 +1054,7 @@ async fn directory_tree_to_loader_tree_internal(
     let current_level_is_parallel_route = is_parallel_route(&directory_name);
 
     if current_level_is_parallel_route {
-        tree.segment = rcstr!("children");
+        tree.segment = rcstr!("__virtual_segment__");
     }
 
     if let Some(page) = (app_path == for_app_path || app_path.is_catchall())
@@ -1075,10 +1075,6 @@ async fn directory_tree_to_loader_tree_internal(
                 global_metadata: global_metadata.to_resolved().await?,
             },
         );
-
-        if current_level_is_parallel_route {
-            tree.segment = rcstr!("page$");
-        }
     }
 
     let mut duplicate = FxHashMap::default();

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -77,7 +77,7 @@ const FILE_TYPES = {
 const GLOBAL_ERROR_FILE_TYPE = 'global-error'
 const GLOBAL_NOT_FOUND_FILE_TYPE = 'global-not-found'
 const PAGE_SEGMENT = 'page$'
-const PARALLEL_CHILDREN_SEGMENT = 'children$'
+const PARALLEL_VIRTUAL_SEGMENT = 'slot$'
 
 const defaultGlobalErrorPath =
   'next/dist/client/components/builtin/global-error.js'
@@ -275,7 +275,7 @@ async function createTreeCodeFromPath(
 
       if (
         normalizedParallelSegment !== PAGE_SEGMENT &&
-        normalizedParallelSegment !== PARALLEL_CHILDREN_SEGMENT
+        normalizedParallelSegment !== PARALLEL_VIRTUAL_SEGMENT
       ) {
         // If we don't have a page segment, nor a special $children marker, it means we need to traverse the next directory
         // (ie, `normalizedParallelSegment` would correspond with the folder that contains the next level of pages/layout/etc)
@@ -396,8 +396,8 @@ async function createTreeCodeFromPath(
       // earlier logic (such as children$ and page$). These should never appear in the loader tree, and
       // should instead be the corresponding segment keys (ie `__PAGE__`) or the `children` parallel route.
       parallelSegmentKey =
-        parallelSegmentKey === PARALLEL_CHILDREN_SEGMENT
-          ? 'children'
+        parallelSegmentKey === PARALLEL_VIRTUAL_SEGMENT
+          ? '__virtual_segment__'
           : parallelSegmentKey === PAGE_SEGMENT
             ? PAGE_SEGMENT_KEY
             : parallelSegmentKey
@@ -624,7 +624,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
           // If it was a parallel route but we weren't able to find the page segment (ie, maybe the page is nested further)
           // we first insert a special marker to ensure that we still process layout/default/etc at the slot level prior to continuing
           // on to the page segment.
-          matched[rest[0]] = [PARALLEL_CHILDREN_SEGMENT, ...rest.slice(1)]
+          matched[rest[0]] = [PARALLEL_VIRTUAL_SEGMENT, ...rest.slice(1)]
           continue
         }
 


### PR DESCRIPTION
When constructing the loader tree for parallel route segments, we inject a `children` segment, which could contain things like slot level layout/error/loading files. We want a way to distinguish between these virtual segments that exist just for organizational purposes rather than relying on `children`. This updates the loader tree construction code to give these more unique names. In the future, we should see if we can remove the need for this virtual segment if there are no special files needed at that segment of the tree.