### PR TITLE
[Cache Components] Defer Request Data API resolution to another task in dev when it would suspend when prerendering

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1783,6 +1783,8 @@ async function renderToHTMLOrFlightImpl(
       renderOpts.renderResumeDataCache ?? postponedState?.renderResumeDataCache
 
     const rootParams = getRootParams(loaderTree, ctx.getDynamicParamFromSegment)
+    const devValidatingFallbackParams =
+      getRequestMeta(req, 'devValidatingFallbackParams') || null
     const requestStore = createRequestStoreForRender(
       req,
       res,
@@ -1793,7 +1795,8 @@ async function renderToHTMLOrFlightImpl(
       renderOpts.previewProps,
       isHmrRefresh,
       serverComponentsHmrCache,
-      renderResumeDataCache
+      renderResumeDataCache,
+      devValidatingFallbackParams
     )
 
     if (
@@ -1865,7 +1868,8 @@ async function renderToHTMLOrFlightImpl(
             notFoundLoaderTree,
             formState,
             postponedState,
-            metadata
+            metadata,
+            devValidatingFallbackParams
           )
 
           return new RenderResult(stream, {
@@ -1896,7 +1900,8 @@ async function renderToHTMLOrFlightImpl(
       loaderTree,
       formState,
       postponedState,
-      metadata
+      metadata,
+      devValidatingFallbackParams
     )
 
     // Invalid dynamic usages should only error the request in development.
@@ -2079,7 +2084,8 @@ async function renderToStream(
   tree: LoaderTree,
   formState: any,
   postponedState: PostponedState | null,
-  metadata: AppPageRenderResultMetadata
+  metadata: AppPageRenderResultMetadata,
+  devValidatingFallbackParams: FallbackRouteParams | null
 ): Promise<ReadableStream<Uint8Array>> {
   const { assetPrefix, nonce, pagePath, renderOpts } = ctx
 
@@ -2225,9 +2231,6 @@ async function renderToStream(
           requestStore.prerenderPhase = false
         }
       )
-
-      const devValidatingFallbackParams =
-        getRequestMeta(req, 'devValidatingFallbackParams') || null
 
       spawnDynamicValidationInDev(
         resolveValidation,

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -18,6 +18,7 @@ import type { Params } from '../request/params'
 import type { ImplicitTags } from '../lib/implicit-tags'
 import type { WorkStore } from './work-async-storage.external'
 import { NEXT_HMR_REFRESH_HASH_COOKIE } from '../../client/components/app-router-headers'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 export type WorkUnitPhase = 'action' | 'render' | 'after'
 
@@ -67,6 +68,7 @@ export interface RequestStore extends CommonWorkUnitStore {
   // DEV-only
   usedDynamic?: boolean
   prerenderPhase?: boolean
+  devFallbackParams?: FallbackRouteParams | null
 }
 
 /**
@@ -333,6 +335,10 @@ export function throwForMissingRequestStore(callingExpression: string): never {
   throw new Error(
     `\`${callingExpression}\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context`
   )
+}
+
+export function throwInvariantForMissingStore(): never {
+  throw new InvariantError('Expected workUnitAsyncStorage to have a store.')
 }
 
 export function getPrerenderResumeDataCache(

--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -24,6 +24,7 @@ import type { ServerComponentsHmrCache } from '../response-cache'
 import type { RenderResumeDataCache } from '../resume-data-cache/resume-data-cache'
 import type { Params } from '../request/params'
 import type { ImplicitTags } from '../lib/implicit-tags'
+import type { FallbackRouteParams } from '../request/fallback-params'
 
 function getHeaders(headers: Headers | IncomingHttpHeaders): ReadonlyHeaders {
   const cleaned = HeadersAdapter.from(headers)
@@ -114,7 +115,8 @@ export function createRequestStoreForRender(
   previewProps: WrapperRenderOpts['previewProps'],
   isHmrRefresh: RequestContext['isHmrRefresh'],
   serverComponentsHmrCache: RequestContext['serverComponentsHmrCache'],
-  renderResumeDataCache: RenderResumeDataCache | undefined
+  renderResumeDataCache: RenderResumeDataCache | undefined,
+  devFallbackParams: FallbackRouteParams | null
 ): RequestStore {
   return createRequestStoreImpl(
     // Pages start in render phase by default
@@ -128,7 +130,8 @@ export function createRequestStoreForRender(
     renderResumeDataCache,
     previewProps,
     isHmrRefresh,
-    serverComponentsHmrCache
+    serverComponentsHmrCache,
+    devFallbackParams
   )
 }
 
@@ -151,7 +154,8 @@ export function createRequestStoreForAPI(
     undefined,
     previewProps,
     false,
-    undefined
+    undefined,
+    null
   )
 }
 
@@ -166,7 +170,8 @@ function createRequestStoreImpl(
   renderResumeDataCache: RenderResumeDataCache | undefined,
   previewProps: WrapperRenderOpts['previewProps'],
   isHmrRefresh: RequestContext['isHmrRefresh'],
-  serverComponentsHmrCache: RequestContext['serverComponentsHmrCache']
+  serverComponentsHmrCache: RequestContext['serverComponentsHmrCache'],
+  devFallbackParams: FallbackRouteParams | null | undefined
 ): RequestStore {
   function defaultOnUpdateCookies(cookies: string[]) {
     if (res) {
@@ -258,6 +263,7 @@ function createRequestStoreImpl(
     serverComponentsHmrCache:
       serverComponentsHmrCache ||
       (globalThis as any).__serverComponentsHmrCache,
+    devFallbackParams,
   }
 }
 

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -72,3 +72,14 @@ export function makeHangingPromise<T>(
 }
 
 function ignoreReject() {}
+
+export function makeDevtoolsIOAwarePromise<T>(underlying: T): Promise<T> {
+  // in React DevTools if we resolve in a setTimeout we will observe
+  // the promise resolution as something that can suspend a boundary or root.
+  return new Promise<T>((resolve) => {
+    // Must use setTimeout to be considered IO React DevTools. setImmediate will not work.
+    setTimeout(() => {
+      resolve(underlying)
+    }, 0)
+  })
+}

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -22,9 +22,11 @@ import {
   trackSynchronousRequestDataAccessInDev,
 } from '../app-render/dynamic-rendering'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
-import { makeHangingPromise } from '../dynamic-rendering-utils'
+import {
+  makeDevtoolsIOAwarePromise,
+  makeHangingPromise,
+} from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
-import { scheduleImmediate } from '../../lib/scheduler'
 import { isRequestAPICallableInsideAfter } from './utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
@@ -143,10 +145,10 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
             underlyingCookies = workUnitStore.cookies
           }
 
-          if (
-            process.env.NODE_ENV === 'development' &&
-            !workStore?.isPrefetchRequest
-          ) {
+          if (process.env.NODE_ENV === 'development') {
+            // Semantically we only need the dev tracking when running in `next dev`
+            // but since you would never use next dev with production NODE_ENV we use this
+            // as a proxy so we can statically exclude this code from production builds.
             if (process.env.__NEXT_CACHE_COMPONENTS) {
               return makeUntrackedCookiesWithDevWarnings(
                 underlyingCookies,
@@ -290,9 +292,7 @@ function makeUntrackedExoticCookiesWithDevWarnings(
     return cachedCookies
   }
 
-  const promise = new Promise<ReadonlyRequestCookies>((resolve) =>
-    scheduleImmediate(() => resolve(underlyingCookies))
-  )
+  const promise = makeDevtoolsIOAwarePromise(underlyingCookies)
   CachedCookies.set(underlyingCookies, promise)
 
   Object.defineProperties(promise, {
@@ -443,9 +443,7 @@ function makeUntrackedCookiesWithDevWarnings(
     return cachedCookies
   }
 
-  const promise = new Promise<ReadonlyRequestCookies>((resolve) =>
-    scheduleImmediate(() => resolve(underlyingCookies))
-  )
+  const promise = makeDevtoolsIOAwarePromise(underlyingCookies)
 
   const proxiedPromise = new Proxy(promise, {
     get(target, prop, receiver) {

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -18,15 +18,19 @@ import {
   type PrerenderStoreLegacy,
   type StaticPrerenderStoreModern,
   type StaticPrerenderStore,
+  throwInvariantForMissingStore,
+  type PrerenderStoreModernRuntime,
 } from '../app-render/work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import {
   describeStringPropertyAccess,
   wellKnownProperties,
 } from '../../shared/lib/utils/reflect-utils'
-import { makeHangingPromise } from '../dynamic-rendering-utils'
+import {
+  makeDevtoolsIOAwarePromise,
+  makeHangingPromise,
+} from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
-import { scheduleImmediate } from '../../lib/scheduler'
 import { dynamicAccessAsyncStorage } from '../app-render/dynamic-access-async-storage.external'
 
 export type ParamValue = string | Array<string> | undefined
@@ -63,7 +67,7 @@ export type UnsafeUnwrappedParams<P> =
 export function createParamsFromClient(
   underlyingParams: Params,
   workStore: WorkStore
-) {
+): Promise<Params> {
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
@@ -71,7 +75,11 @@ export function createParamsFromClient(
       case 'prerender-client':
       case 'prerender-ppr':
       case 'prerender-legacy':
-        return createPrerenderParams(underlyingParams, workStore, workUnitStore)
+        return createStaticPrerenderParams(
+          underlyingParams,
+          workStore,
+          workUnitStore
+        )
       case 'cache':
       case 'private-cache':
       case 'unstable-cache':
@@ -83,12 +91,24 @@ export function createParamsFromClient(
           'createParamsFromClient should not be called in a runtime prerender.'
         )
       case 'request':
-        break
+        if (process.env.NODE_ENV === 'development') {
+          // Semantically we only need the dev tracking when running in `next dev`
+          // but since you would never use next dev with production NODE_ENV we use this
+          // as a proxy so we can statically exclude this code from production builds.
+          const devFallbackParams = workUnitStore.devFallbackParams
+          return createRenderParamsInDev(
+            underlyingParams,
+            devFallbackParams,
+            workStore
+          )
+        } else {
+          return createRenderParamsInProd(underlyingParams)
+        }
       default:
         workUnitStore satisfies never
     }
   }
-  return createRenderParams(underlyingParams, workStore)
+  throwInvariantForMissingStore()
 }
 
 // generateMetadata always runs in RSC context so it is equivalent to a Server Page Component
@@ -99,7 +119,7 @@ export const createServerParamsForMetadata = createServerParamsForServerSegment
 export function createServerParamsForRoute(
   underlyingParams: Params,
   workStore: WorkStore
-) {
+): Promise<Params> {
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
@@ -107,7 +127,11 @@ export function createServerParamsForRoute(
       case 'prerender-client':
       case 'prerender-ppr':
       case 'prerender-legacy':
-        return createPrerenderParams(underlyingParams, workStore, workUnitStore)
+        return createStaticPrerenderParams(
+          underlyingParams,
+          workStore,
+          workUnitStore
+        )
       case 'cache':
       case 'private-cache':
       case 'unstable-cache':
@@ -115,17 +139,26 @@ export function createServerParamsForRoute(
           'createServerParamsForRoute should not be called in cache contexts.'
         )
       case 'prerender-runtime':
-        return delayUntilRuntimeStage(
-          workUnitStore,
-          createRenderParams(underlyingParams, workStore)
-        )
+        return createRuntimePrerenderParams(underlyingParams, workUnitStore)
       case 'request':
-        break
+        if (process.env.NODE_ENV === 'development') {
+          // Semantically we only need the dev tracking when running in `next dev`
+          // but since you would never use next dev with production NODE_ENV we use this
+          // as a proxy so we can statically exclude this code from production builds.
+          const devFallbackParams = workUnitStore.devFallbackParams
+          return createRenderParamsInDev(
+            underlyingParams,
+            devFallbackParams,
+            workStore
+          )
+        } else {
+          return createRenderParamsInProd(underlyingParams)
+        }
       default:
         workUnitStore satisfies never
     }
   }
-  return createRenderParams(underlyingParams, workStore)
+  throwInvariantForMissingStore()
 }
 
 export function createServerParamsForServerSegment(
@@ -139,7 +172,11 @@ export function createServerParamsForServerSegment(
       case 'prerender-client':
       case 'prerender-ppr':
       case 'prerender-legacy':
-        return createPrerenderParams(underlyingParams, workStore, workUnitStore)
+        return createStaticPrerenderParams(
+          underlyingParams,
+          workStore,
+          workUnitStore
+        )
       case 'cache':
       case 'private-cache':
       case 'unstable-cache':
@@ -147,17 +184,26 @@ export function createServerParamsForServerSegment(
           'createServerParamsForServerSegment should not be called in cache contexts.'
         )
       case 'prerender-runtime':
-        return delayUntilRuntimeStage(
-          workUnitStore,
-          createRenderParams(underlyingParams, workStore)
-        )
+        return createRuntimePrerenderParams(underlyingParams, workUnitStore)
       case 'request':
-        break
+        if (process.env.NODE_ENV === 'development') {
+          // Semantically we only need the dev tracking when running in `next dev`
+          // but since you would never use next dev with production NODE_ENV we use this
+          // as a proxy so we can statically exclude this code from production builds.
+          const devFallbackParams = workUnitStore.devFallbackParams
+          return createRenderParamsInDev(
+            underlyingParams,
+            devFallbackParams,
+            workStore
+          )
+        } else {
+          return createRenderParamsInProd(underlyingParams)
+        }
       default:
         workUnitStore satisfies never
     }
   }
-  return createRenderParams(underlyingParams, workStore)
+  throwInvariantForMissingStore()
 }
 
 export function createPrerenderParamsForClientSegment(
@@ -213,7 +259,7 @@ export function createPrerenderParamsForClientSegment(
   return Promise.resolve(underlyingParams)
 }
 
-function createPrerenderParams(
+function createStaticPrerenderParams(
   underlyingParams: Params,
   workStore: WorkStore,
   prerenderStore: StaticPrerenderStore
@@ -268,29 +314,53 @@ function createPrerenderParams(
   }
 }
 
-function createRenderParams(
+function createRuntimePrerenderParams(
   underlyingParams: Params,
+  workUnitStore: PrerenderStoreModernRuntime
+): Promise<Params> {
+  return delayUntilRuntimeStage(
+    workUnitStore,
+    process.env.__NEXT_CACHE_COMPONENTS
+      ? makeUntrackedParams(underlyingParams)
+      : makeUntrackedExoticParams(underlyingParams)
+  )
+}
+
+function createRenderParamsInProd(underlyingParams: Params): Promise<Params> {
+  if (process.env.__NEXT_CACHE_COMPONENTS) {
+    return makeUntrackedParams(underlyingParams)
+  }
+
+  return makeUntrackedExoticParams(underlyingParams)
+}
+
+function createRenderParamsInDev(
+  underlyingParams: Params,
+  devFallbackParams: FallbackRouteParams | null | undefined,
   workStore: WorkStore
 ): Promise<Params> {
-  if (process.env.NODE_ENV === 'development' && !workStore.isPrefetchRequest) {
-    if (process.env.__NEXT_CACHE_COMPONENTS) {
-      return makeDynamicallyTrackedParamsWithDevWarnings(
-        underlyingParams,
-        workStore
-      )
+  let hasFallbackParams = false
+  if (devFallbackParams) {
+    for (let key in underlyingParams) {
+      if (devFallbackParams.has(key)) {
+        hasFallbackParams = true
+        break
+      }
     }
-
-    return makeDynamicallyTrackedExoticParamsWithDevWarnings(
+  }
+  if (process.env.__NEXT_CACHE_COMPONENTS) {
+    return makeDynamicallyTrackedParamsWithDevWarnings(
       underlyingParams,
+      hasFallbackParams,
       workStore
     )
-  } else {
-    if (process.env.__NEXT_CACHE_COMPONENTS) {
-      return makeUntrackedParams(underlyingParams)
-    }
-
-    return makeUntrackedExoticParams(underlyingParams)
   }
+
+  return makeDynamicallyTrackedExoticParamsWithDevWarnings(
+    underlyingParams,
+    hasFallbackParams,
+    workStore
+  )
 }
 
 interface CacheLifetime {}
@@ -481,6 +551,7 @@ function makeUntrackedParams(underlyingParams: Params): Promise<Params> {
 
 function makeDynamicallyTrackedExoticParamsWithDevWarnings(
   underlyingParams: Params,
+  hasFallbackParams: boolean,
   store: WorkStore
 ): Promise<Params> {
   const cachedParams = CachedParams.get(underlyingParams)
@@ -491,9 +562,10 @@ function makeDynamicallyTrackedExoticParamsWithDevWarnings(
   // We don't use makeResolvedReactPromise here because params
   // supports copying with spread and we don't want to unnecessarily
   // instrument the promise with spreadable properties of ReactPromise.
-  const promise = new Promise<Params>((resolve) =>
-    scheduleImmediate(() => resolve(underlyingParams))
-  )
+  const promise = hasFallbackParams
+    ? makeDevtoolsIOAwarePromise(underlyingParams)
+    : // We don't want to force an environment transition when this params is not part of the fallback params set
+      Promise.resolve(underlyingParams)
 
   const proxiedProperties = new Set<string>()
   const unproxiedProperties: Array<string> = []
@@ -543,6 +615,7 @@ function makeDynamicallyTrackedExoticParamsWithDevWarnings(
 // logging the sync access without actually defining the params on the promise.
 function makeDynamicallyTrackedParamsWithDevWarnings(
   underlyingParams: Params,
+  hasFallbackParams: boolean,
   store: WorkStore
 ): Promise<Params> {
   const cachedParams = CachedParams.get(underlyingParams)
@@ -553,9 +626,10 @@ function makeDynamicallyTrackedParamsWithDevWarnings(
   // We don't use makeResolvedReactPromise here because params
   // supports copying with spread and we don't want to unnecessarily
   // instrument the promise with spreadable properties of ReactPromise.
-  const promise = new Promise<Params>((resolve) =>
-    scheduleImmediate(() => resolve(underlyingParams))
-  )
+  const promise = hasFallbackParams
+    ? makeDevtoolsIOAwarePromise(underlyingParams)
+    : // We don't want to force an environment transition when this params is not part of the fallback params set
+      Promise.resolve(underlyingParams)
 
   const proxiedProperties = new Set<string>()
   const unproxiedProperties: Array<string> = []

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -7,6 +7,7 @@ import {
 } from '../app-render/dynamic-rendering'
 
 import {
+  throwInvariantForMissingStore,
   workUnitAsyncStorage,
   type StaticPrerenderStore,
 } from '../app-render/work-unit-async-storage.external'
@@ -43,12 +44,12 @@ export function createServerPathnameForMetadata(
           createRenderPathname(underlyingPathname)
         )
       case 'request':
-        break
+        return createRenderPathname(underlyingPathname)
       default:
         workUnitStore satisfies never
     }
   }
-  return createRenderPathname(underlyingPathname)
+  throwInvariantForMissingStore()
 }
 
 function createPrerenderPathname(

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -15,10 +15,15 @@ import {
   type PrerenderStoreLegacy,
   type PrerenderStorePPR,
   type PrerenderStoreModern,
+  type PrerenderStoreModernRuntime,
   type StaticPrerenderStore,
+  throwInvariantForMissingStore,
 } from '../app-render/work-unit-async-storage.external'
 import { InvariantError } from '../../shared/lib/invariant-error'
-import { makeHangingPromise } from '../dynamic-rendering-utils'
+import {
+  makeDevtoolsIOAwarePromise,
+  makeHangingPromise,
+} from '../dynamic-rendering-utils'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
 import {
   describeStringPropertyAccess,
@@ -29,7 +34,6 @@ import {
   throwWithStaticGenerationBailoutErrorWithDynamicError,
   throwForSearchParamsAccessInUseCache,
 } from './utils'
-import { scheduleImmediate } from '../../lib/scheduler'
 
 export type SearchParams = { [key: string]: string | string[] | undefined }
 
@@ -64,7 +68,7 @@ export type UnsafeUnwrappedSearchParams<P> =
 export function createSearchParamsFromClient(
   underlyingSearchParams: SearchParams,
   workStore: WorkStore
-) {
+): Promise<SearchParams> {
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
@@ -72,7 +76,7 @@ export function createSearchParamsFromClient(
       case 'prerender-client':
       case 'prerender-ppr':
       case 'prerender-legacy':
-        return createPrerenderSearchParams(workStore, workUnitStore)
+        return createStaticPrerenderSearchParams(workStore, workUnitStore)
       case 'prerender-runtime':
         throw new InvariantError(
           'createSearchParamsFromClient should not be called in a runtime prerender.'
@@ -84,12 +88,12 @@ export function createSearchParamsFromClient(
           'createSearchParamsFromClient should not be called in cache contexts.'
         )
       case 'request':
-        break
+        return createRenderSearchParams(underlyingSearchParams, workStore)
       default:
         workUnitStore satisfies never
     }
   }
-  return createRenderSearchParams(underlyingSearchParams, workStore)
+  throwInvariantForMissingStore()
 }
 
 // generateMetadata always runs in RSC context so it is equivalent to a Server Page Component
@@ -107,7 +111,7 @@ export function createServerSearchParamsForServerPage(
       case 'prerender-client':
       case 'prerender-ppr':
       case 'prerender-legacy':
-        return createPrerenderSearchParams(workStore, workUnitStore)
+        return createStaticPrerenderSearchParams(workStore, workUnitStore)
       case 'cache':
       case 'private-cache':
       case 'unstable-cache':
@@ -115,17 +119,17 @@ export function createServerSearchParamsForServerPage(
           'createServerSearchParamsForServerPage should not be called in cache contexts.'
         )
       case 'prerender-runtime':
-        return delayUntilRuntimeStage(
-          workUnitStore,
-          createRenderSearchParams(underlyingSearchParams, workStore)
+        return createRuntimePrerenderSearchParams(
+          underlyingSearchParams,
+          workUnitStore
         )
       case 'request':
-        break
+        return createRenderSearchParams(underlyingSearchParams, workStore)
       default:
         workUnitStore satisfies never
     }
   }
-  return createRenderSearchParams(underlyingSearchParams, workStore)
+  throwInvariantForMissingStore()
 }
 
 export function createPrerenderSearchParamsForClientPage(
@@ -162,18 +166,15 @@ export function createPrerenderSearchParamsForClientPage(
       case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':
-        break
+        return Promise.resolve({})
       default:
         workUnitStore satisfies never
     }
   }
-  // We're prerendering in a mode that does not abort. We resolve the promise
-  // without any tracking because we're just transporting a value from server to
-  // client where the tracking will be applied.
-  return Promise.resolve({})
+  throwInvariantForMissingStore()
 }
 
-function createPrerenderSearchParams(
+function createStaticPrerenderSearchParams(
   workStore: WorkStore,
   prerenderStore: StaticPrerenderStore
 ): Promise<SearchParams> {
@@ -198,6 +199,18 @@ function createPrerenderSearchParams(
   }
 }
 
+function createRuntimePrerenderSearchParams(
+  underlyingSearchParams: SearchParams,
+  workUnitStore: PrerenderStoreModernRuntime
+): Promise<SearchParams> {
+  return delayUntilRuntimeStage(
+    workUnitStore,
+    process.env.__NEXT_CACHE_COMPONENTS
+      ? makeUntrackedSearchParams(underlyingSearchParams)
+      : makeUntrackedExoticSearchParams(underlyingSearchParams)
+  )
+}
+
 function createRenderSearchParams(
   underlyingSearchParams: SearchParams,
   workStore: WorkStore
@@ -207,10 +220,10 @@ function createRenderSearchParams(
     // dictionary object.
     return Promise.resolve({})
   } else {
-    if (
-      process.env.NODE_ENV === 'development' &&
-      !workStore.isPrefetchRequest
-    ) {
+    if (process.env.NODE_ENV === 'development') {
+      // Semantically we only need the dev tracking when running in `next dev`
+      // but since you would never use next dev with production NODE_ENV we use this
+      // as a proxy so we can statically exclude this code from production builds.
       if (process.env.__NEXT_CACHE_COMPONENTS) {
         return makeUntrackedSearchParamsWithDevWarnings(
           underlyingSearchParams,
@@ -633,9 +646,7 @@ function makeDynamicallyTrackedExoticSearchParamsWithDevWarnings(
   // We don't use makeResolvedReactPromise here because searchParams
   // supports copying with spread and we don't want to unnecessarily
   // instrument the promise with spreadable properties of ReactPromise.
-  const promise = new Promise<SearchParams>((resolve) =>
-    scheduleImmediate(() => resolve(underlyingSearchParams))
-  )
+  const promise = makeDevtoolsIOAwarePromise(underlyingSearchParams)
   promise.then(() => {
     promiseInitialized = true
   })
@@ -736,7 +747,7 @@ function makeUntrackedSearchParamsWithDevWarnings(
 
   const proxiedProperties = new Set<string>()
   const unproxiedProperties: Array<string> = []
-  const promise = Promise.resolve(underlyingSearchParams)
+  const promise = makeDevtoolsIOAwarePromise(underlyingSearchParams)
 
   Object.keys(underlyingSearchParams).forEach((prop) => {
     if (wellKnownProperties.has(prop)) {

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -1275,7 +1275,7 @@ describe('Cache Components Errors', () => {
                [
                  {
                    "description": "Route "/sync-cookies-runtime" used \`cookies().get\`. \`cookies()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
-                   "environmentLabel": "Prerender",
+                   "environmentLabel": "Server",
                    "label": "Console Error",
                    "source": "app/sync-cookies-runtime/page.tsx (24:25) @ CookiesReadingComponent
                > 24 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
@@ -1287,7 +1287,7 @@ describe('Cache Components Errors', () => {
                  },
                  {
                    "description": "(0 , <turbopack-module-id>.cookies)(...).get is not a function",
-                   "environmentLabel": "Prerender",
+                   "environmentLabel": "Server",
                    "label": "Runtime TypeError",
                    "source": "app/sync-cookies-runtime/page.tsx (24:66) @ CookiesReadingComponent
                > 24 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
@@ -1303,7 +1303,7 @@ describe('Cache Components Errors', () => {
                [
                  {
                    "description": "Route "/sync-cookies-runtime" used \`cookies().get\`. \`cookies()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
-                   "environmentLabel": "Prerender",
+                   "environmentLabel": "Server",
                    "label": "Console Error",
                    "source": "app/sync-cookies-runtime/page.tsx (24:17) @ CookiesReadingComponent
                > 24 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
@@ -1315,7 +1315,7 @@ describe('Cache Components Errors', () => {
                  },
                  {
                    "description": "(0 , <webpack-module-id>.cookies)(...).get is not a function",
-                   "environmentLabel": "Prerender",
+                   "environmentLabel": "Server",
                    "label": "Runtime TypeError",
                    "source": "app/sync-cookies-runtime/page.tsx (24:66) @ CookiesReadingComponent
                > 24 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
@@ -1592,7 +1592,7 @@ describe('Cache Components Errors', () => {
                [
                  {
                    "description": "Route "/sync-headers-runtime" used \`headers().get\`. \`headers()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
-                   "environmentLabel": "Prerender",
+                   "environmentLabel": "Server",
                    "label": "Console Error",
                    "source": "app/sync-headers-runtime/page.tsx (24:29) @ HeadersReadingComponent
                > 24 |   const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
@@ -1604,7 +1604,7 @@ describe('Cache Components Errors', () => {
                  },
                  {
                    "description": "(0 , <turbopack-module-id>.headers)(...).get is not a function",
-                   "environmentLabel": "Prerender",
+                   "environmentLabel": "Server",
                    "label": "Runtime TypeError",
                    "source": "app/sync-headers-runtime/page.tsx (24:70) @ HeadersReadingComponent
                > 24 |   const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
@@ -1620,7 +1620,7 @@ describe('Cache Components Errors', () => {
                [
                  {
                    "description": "Route "/sync-headers-runtime" used \`headers().get\`. \`headers()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
-                   "environmentLabel": "Prerender",
+                   "environmentLabel": "Server",
                    "label": "Console Error",
                    "source": "app/sync-headers-runtime/page.tsx (24:21) @ HeadersReadingComponent
                > 24 |   const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
@@ -1632,7 +1632,7 @@ describe('Cache Components Errors', () => {
                  },
                  {
                    "description": "(0 , <webpack-module-id>.headers)(...).get is not a function",
-                   "environmentLabel": "Prerender",
+                   "environmentLabel": "Server",
                    "label": "Runtime TypeError",
                    "source": "app/sync-headers-runtime/page.tsx (24:70) @ HeadersReadingComponent
                > 24 |   const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -624,7 +624,7 @@ describe('opentelemetry', () => {
                       },
                       {
                         attributes: {
-                          'next.clientComponentLoadCount': isNextDev ? 9 : 8,
+                          'next.clientComponentLoadCount': isNextDev ? 11 : 8,
                           'next.span_type':
                             'NextNodeServer.clientComponentLoading',
                         },


### PR DESCRIPTION
Stacked on #82381

When resolving these Request Data APIs in dev we now do so in a new Task. This allows the environment tracking to properly move stuff that was previously in the Prerender environment to the Server environment when a Request Data API is used before them. This also has the nice side effect of causing these functions to appear as IO in the new suspended-by features of React Devtools.

In Prod we don't need to do any additional delaying because all of the features this is designed to interact with are dev only.