### PR TITLE
[Segment Cache]: fix infinite prefetching when staleTime is 0

### DIFF
--- a/packages/next/src/client/components/segment-cache-impl/cache.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache.ts
@@ -244,6 +244,14 @@ const isOutputExportMode =
   process.env.NODE_ENV === 'production' &&
   process.env.__NEXT_CONFIG_OUTPUT === 'export'
 
+/**
+ * Ensures a minimum stale time of 30s to avoid issues where the server sends a too
+ * short-lived stale time, which would prevent anything from being prefetched.
+ */
+function getStaleTimeMs(staleTimeSeconds: number): number {
+  return Math.max(staleTimeSeconds, 30) * 1000
+}
+
 // Route cache entries vary on multiple keys: the href and the Next-Url. Each of
 // these parts needs to be included in the internal cache key. Rather than
 // concatenate the keys into a single key, we use a multi-level map, where the
@@ -1271,7 +1279,7 @@ export async function fetchRouteOnCacheMiss(
         renderedPathname
       )
 
-      const staleTimeMs = serverData.staleTime * 1000
+      const staleTimeMs = getStaleTimeMs(serverData.staleTime)
       fulfillRouteCacheEntry(
         entry,
         routeTree,
@@ -1641,7 +1649,7 @@ function writeDynamicTreeResponseIntoCache(
   )
   const staleTimeMs =
     staleTimeHeaderSeconds !== null
-      ? parseInt(staleTimeHeaderSeconds, 10) * 1000
+      ? getStaleTimeMs(parseInt(staleTimeHeaderSeconds, 10))
       : STATIC_STALETIME_MS
 
   // If the response contains dynamic holes, then we must conservatively assume
@@ -1740,7 +1748,7 @@ function writeDynamicRenderResponseIntoCache(
   )
   const staleTimeMs =
     staleTimeHeaderSeconds !== null
-      ? parseInt(staleTimeHeaderSeconds, 10) * 1000
+      ? getStaleTimeMs(parseInt(staleTimeHeaderSeconds, 10))
       : STATIC_STALETIME_MS
   const staleAt = now + staleTimeMs
 

--- a/test/e2e/app-dir/segment-cache/basic/app/cache-life-seconds-test/page.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/cache-life-seconds-test/page.tsx
@@ -1,0 +1,12 @@
+import { LinkAccordion } from '../../components/link-accordion'
+
+export default function CacheLifeSecondsTestPage() {
+  return (
+    <div>
+      <h1>Cache Life Seconds Test</h1>
+      <LinkAccordion href="/cache-life-seconds">
+        Go to cache-life-seconds page
+      </LinkAccordion>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/basic/app/cache-life-seconds/loading.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/cache-life-seconds/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div>
+      <h1>Loading...</h1>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/basic/app/cache-life-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/cache-life-seconds/page.tsx
@@ -1,0 +1,15 @@
+import { unstable_cacheLife } from 'next/cache'
+
+export default async function CacheLifeSecondsPage() {
+  'use cache'
+  unstable_cacheLife({ stale: 0, revalidate: 1, expire: 60 })
+
+  const randomNumber = Math.random()
+
+  return (
+    <div id="cache-life-seconds-page">
+      <p>Cache Life Seconds Page</p>
+      <p id="random-value">{randomNumber}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
This PR fixes an infinite loop bug that occurred when using `cacheLife({ stale: 0 })` with `clientSegmentCache`. When the server returned a stale time of 0 seconds, cache entries would have `staleAt = Date.now()`, making them immediately stale. The cache would evict these entries on the same tick they were created, triggering continuous refetch requests.

The fix updates the minimum stale time to be 30s, in the event that the server sends a low value. The rationale being that a value lower than 30s here would render prefetching ineffective. This prevents the immediate eviction while still respecting the server's intent for very short-lived cache entries. 

Closes NAR-269