### PR TITLE
test: renders after a redirect() should not bypass caches

### DIFF
--- a/test/e2e/app-dir/use-cache/app/(dynamic)/revalidate-and-redirect/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/revalidate-and-redirect/page.tsx
@@ -10,17 +10,27 @@ async function getCachedValue() {
   return Math.random()
 }
 
+async function getCachedValue2() {
+  'use cache'
+  return Math.random()
+}
+
 export default async function Page() {
   // Make the page dynamic, as we don't want to deal with ISR in this scenario.
   await connection()
 
   const a = await getCachedValue()
   const b = await getCachedValue()
+  const c = await getCachedValue2()
+
+  const timestamp = Date.now()
 
   return (
     <div>
       <p id="a">{a}</p>
       <p id="b">{b}</p>
+      <p id="c">{c}</p>
+      <div id="timestamp">{timestamp}</div>
       <Link href="/revalidate-and-redirect/redirect">
         Go to /revalidate-and-redirect/redirect
       </Link>

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/revalidate-and-redirect/redirect/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/revalidate-and-redirect/redirect/page.tsx
@@ -26,6 +26,15 @@ export default function Page() {
       >
         Revalidate path and redirect
       </button>
+      <button
+        id="redirect-without-revalidations"
+        formAction={async () => {
+          'use server'
+          redirect('/revalidate-and-redirect')
+        }}
+      >
+        Redirect without revalidations
+      </button>
     </form>
   )
 }


### PR DESCRIPTION
This PR adds some tests to make sure that an action that called `redirect()`but didn't trigger any revalidations does not bypass exististing caches (in particular, the fetch-cache and "use cache"). This works fine, but i couldn't find any existing tests that cover this.