### PR TITLE
Represent "virtual" segments like route groups

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1054,7 +1054,7 @@ async fn directory_tree_to_loader_tree_internal(
     let current_level_is_parallel_route = is_parallel_route(&directory_name);
 
     if current_level_is_parallel_route {
-        tree.segment = rcstr!("__virtual_segment__");
+        tree.segment = rcstr!("(slot)");
     }
 
     if let Some(page) = (app_path == for_app_path || app_path.is_catchall())

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -397,7 +397,7 @@ async function createTreeCodeFromPath(
       // should instead be the corresponding segment keys (ie `__PAGE__`) or the `children` parallel route.
       parallelSegmentKey =
         parallelSegmentKey === PARALLEL_VIRTUAL_SEGMENT
-          ? '__virtual_segment__'
+          ? '(slot)'
           : parallelSegmentKey === PAGE_SEGMENT
             ? PAGE_SEGMENT_KEY
             : parallelSegmentKey


### PR DESCRIPTION
Small update to #82383. Instead of using a special symbol to represent the "virtual" segments that get inserted into the loader tree for parallel routes, we can represent them like route groups, since they serve the same purpose. That will allow us to remove a special case in the param parsing logic, since we have to skip groups regardless; both will be skipped by the same check.