### PR TITLE
chore(Next.js sync): open draft PRs immediately

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -32,6 +32,8 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'vercel'
+    outputs:
+      next-version: ${{ steps.version.outputs.value }}
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -49,6 +51,19 @@ jobs:
         with:
           fetch-depth: 25
 
+      - id: nextPackageInfo
+        name: Get `next` package info
+        run: |
+          cd packages/next 
+          {
+            echo 'value<<EOF'
+            cat package.json
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - id: version
+        name: Extract `next` version
+        run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
+
       - name: Setup test project
         run: |
           pnpm install
@@ -56,7 +71,7 @@ jobs:
           node scripts/run-e2e-test-project-reset.mjs
 
   test-deploy:
-    name: test deploy
+    name: Run Deploy Tests
     needs: setup
     uses: ./.github/workflows/build_reusable.yml
     secrets: inherit
@@ -77,7 +92,7 @@ jobs:
     if: ${{ always() }}
 
     runs-on: ubuntu-latest
-    name: report test results to datadog
+    name: Report test results to datadog
     steps:
       - name: Download test report artifacts
         id: download-test-reports
@@ -93,9 +108,10 @@ jobs:
             DD_ENV=ci npx @datadog/datadog-ci@2.23.1 junit upload --tags test.type:deploy --service nextjs ./test/test-junit-report
           fi
 
-  sync-repositories:
-    needs: test-deploy
-    if: ${{ always() && github.repository_owner == 'vercel' && github.event_name == 'release' }}
+  create-draft-prs:
+    name: Immediately open draft prs
+    needs: setup
+    if: ${{ github.repository_owner == 'vercel' && github.event_name == 'release' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -103,27 +119,9 @@ jobs:
         include:
           - repo: front
             workflow_id: cron-update-next.yml
-            workflow_url: https://github.com/vercel/front/actions/workflows/cron-update-next.yml?query=event%3Aworkflow_dispatch
           - repo: v0
             workflow_id: update-next.yml
-            workflow_url: https://github.com/vercel/v0/actions/workflows/update-next.yml?query=event%3Aworkflow_dispatch
     steps:
-      - uses: actions/checkout@v4
-      - id: nextPackageInfo
-        name: Get `next` package info
-        run: |
-          cd packages/next 
-          {
-            echo 'value<<EOF'
-            cat package.json
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
-      - id: version
-        name: Extract `next` version
-        run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
-      - id: test-result
-        name: Set test result variable
-        run: echo 'immediately-close=${{ needs.test-deploy.result != 'success' && 'true' || 'false' }}' >> "$GITHUB_OUTPUT"
       - name: Check token
         run: gh auth status
         env:
@@ -157,26 +155,18 @@ jobs:
               return 'false';
             }
       - uses: actions/github-script@v7
-        name: Trigger vercel/${{ matrix.repo }} sync
-        id: trigger-sync
+        name: Create draft PR for vercel/${{ matrix.repo }}
+        id: create-draft-pr
         if: steps.check-workflow-enabled.outputs.result == 'true'
         with:
           retries: 3
           retry-exempt-status-codes: 400,401,404
-          # Default github token cannot dispatch events to the remote repo, it should be
-          # a PAT with Actions write access (https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)
           github-token: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
-          # Note `workflow_id` and `inputs` are contract between vercel/${{ matrix.repo }},
-          # if these need to be changed both side should be updated accordingly.
+          result-encoding: string
           script: |
-            const immediatelyClose = '${{ steps.test-result.outputs.immediately-close }}';
             const inputs = {
-              version: "${{ steps.version.outputs.value }}",
+              version: "${{ needs.setup.outputs.next-version }}"
             };
-
-            if (immediatelyClose === 'true') {
-              inputs['immediately-close'] = 'true';
-            }
 
             await github.request(
               "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
@@ -188,16 +178,89 @@ jobs:
                 inputs: inputs,
               }
             );
-            // Ideally we'd include a URL to this specific sync.
-            // However, creating a workflow_dispatch event does not produce an ID: https://github.com/orgs/community/discussions/9752
-            console.info(
-              "Sync started in ${{ matrix.workflow_url }}"
-            );
-            console.info(
-              "This may not start a new sync if one is already in progress. Check the logs of the workflow run."
-            );
-            if (immediatelyClose === 'true') {
-              console.info(
-                "Sync triggered with immediately-close=true due to test failure."
+
+            console.info(`Draft PR creation triggered for ${{ matrix.repo }}`);
+            console.info(`Workflow will create draft PR by default`);
+
+  update-prs:
+    name: Update prs as ready for review
+    needs: [test-deploy, create-draft-prs]
+    if: ${{ needs.test-deploy.result == 'success' && github.repository_owner == 'vercel' && github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repo: front
+            workflow_id: cron-update-next.yml
+            workflow_url: https://github.com/vercel/front/actions/workflows/cron-update-next.yml?query=event%3Aworkflow_dispatch
+          - repo: v0
+            workflow_id: update-next.yml
+            workflow_url: https://github.com/vercel/v0/actions/workflows/update-next.yml?query=event%3Aworkflow_dispatch
+    steps:
+      - name: Check token
+        run: gh auth status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
+      - uses: actions/github-script@v7
+        name: Check if target workflow is enabled
+        id: check-workflow-enabled
+        with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,404
+          github-token: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
+          result-encoding: string
+          script: |
+            try {
+              const response = await github.request(
+                "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}",
+                {
+                  owner: "vercel",
+                  repo: "${{ matrix.repo }}",
+                  workflow_id: "${{ matrix.workflow_id }}",
+                }
               );
+              
+              const isEnabled = response.data.state === 'active';
+              console.info(`Target workflow state: ${response.data.state}`);
+              console.info(`Target workflow enabled: ${isEnabled}`);
+              
+              return isEnabled ? 'true' : 'false';
+            } catch (error) {
+              console.error('Error checking workflow status:', error);
+              return 'false';
             }
+      - uses: actions/github-script@v7
+        name: Mark PR ready for review in vercel/${{ matrix.repo }}
+        id: mark-pr-ready
+        if: steps.check-workflow-enabled.outputs.result == 'true'
+        with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,404
+          # Default github token cannot dispatch events to the remote repo, it should be
+          # a PAT with Actions write access (https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)
+          github-token: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
+          # Note `workflow_id` and `inputs` are contract between vercel/${{ matrix.repo }},
+          # if these need to be changed both side should be updated accordingly.
+          script: |
+            const inputs = {
+              version: "${{ needs.setup.outputs.next-version }}",
+              'make-ready-for-review': 'true',
+              force: 'true'
+            };
+
+            await github.request(
+              "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
+              {
+                owner: "vercel",
+                repo: "${{ matrix.repo }}",
+                workflow_id: "${{ matrix.workflow_id }}",
+                ref: "main",
+                inputs: inputs,
+              }
+            );
+
+            console.info("Tests passed - PR will be marked ready for review");
+            console.info(
+              "PR ready-for-review triggered in ${{ matrix.workflow_url }}"
+            );

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -135,25 +135,20 @@ jobs:
           github-token: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
           result-encoding: string
           script: |
-            try {
-              const response = await github.request(
-                "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}",
-                {
-                  owner: "vercel",
-                  repo: "${{ matrix.repo }}",
-                  workflow_id: "${{ matrix.workflow_id }}",
-                }
-              );
-              
-              const isEnabled = response.data.state === 'active';
-              console.info(`Target workflow state: ${response.data.state}`);
-              console.info(`Target workflow enabled: ${isEnabled}`);
-              
-              return isEnabled ? 'true' : 'false';
-            } catch (error) {
-              console.error('Error checking workflow status:', error);
-              return 'false';
-            }
+            const response = await github.request(
+              "GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}",
+              {
+                owner: "vercel",
+                repo: "${{ matrix.repo }}",
+                workflow_id: "${{ matrix.workflow_id }}",
+              }
+            );
+
+            const isEnabled = response.data.state === 'active';
+            console.info(`Target workflow state: ${response.data.state}`);
+            console.info(`Target workflow enabled: ${isEnabled}`);
+
+            return isEnabled ? 'true' : 'false';
       - uses: actions/github-script@v7
         name: Create draft PR for vercel/${{ matrix.repo }}
         id: create-draft-pr

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -131,7 +131,7 @@ jobs:
         id: check-workflow-enabled
         with:
           retries: 3
-          retry-exempt-status-codes: 400,401,404
+          retry-exempt-status-codes: 400,401,403,404,422
           github-token: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
           result-encoding: string
           script: |


### PR DESCRIPTION
Before:
Cron runs would open a Draft PR if they happened to run before deployment tests finished. Once deployment tests completed, the system would either open a PR and immediately close it (if tests failed) or open it as ready for review (if tests passed).

After:
Both cron runs and new releases will open Draft PRs. Once deployment tests run and pass, these PRs will be marked as ready for review. If tests fail, the PRs remain as drafts.

Related PRS:
https://github.com/vercel/v0/pull/12992
https://github.com/vercel/front/pull/50036

Closes PACK-5196