### PR TITLE
Update to run rspack tests on release

### DIFF
--- a/.github/labeler.json
+++ b/.github/labeler.json
@@ -31,8 +31,7 @@
       { "type": "user", "pattern": "valorkin" },
       { "type": "user", "pattern": "xc2" },
       { "type": "user", "pattern": "zackarychapple" },
-      { "type": "user", "pattern": "zoolsher" },
-      "packages/next/src/build/**"
+      { "type": "user", "pattern": "zoolsher" }
     ],
     "created-by: Chrome Aurora": [
       { "type": "user", "pattern": "atcastle" },

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,8 +52,10 @@ jobs:
       is-release: ${{ steps.is-release.outputs.IS_RELEASE == 'true' }}
       rspack: >-
         ${{
-          github.event_name == 'pull_request' &&
-          contains(github.event.pull_request.labels.*.name, 'Rspack')
+          steps.is-release.outputs.IS_RELEASE == 'true' || (
+            github.event_name == 'pull_request' &&
+            contains(github.event.pull_request.labels.*.name, 'Rspack')
+          )
         }}
 
   build-native:


### PR DESCRIPTION
As discussed we can move these tests to run on canary release instead of on every PR. 

x-ref: [slack thread](https://vercel.slack.com/archives/C02CDC2ALJH/p1754522330101839?thread_ts=1754493332.436339&cid=C02CDC2ALJH)