### PR TITLE
Add setTagStale method for background revalidate

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/revalidateTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/revalidateTag.mdx
@@ -31,11 +31,9 @@ fetch(url, { next: { tags: [...] } });
 
 `revalidateTag` does not return a value.
 
-## Relationship with `revalidatePath` and `setTagStale`
+## Relationship with `revalidatePath`
 
 `revalidateTag` invalidates data with specific tags across all pages that use those tags, while [`revalidatePath`](/docs/app/api-reference/functions/revalidatePath) invalidates specific page or layout paths.
-
-[`setTagStale`](/docs/app/api-reference/functions/setTagStale) provides more granular cache control by marking data as stale while preserving timestamps. When `revalidateTag` is called on a tag that was previously marked stale with `setTagStale`, it uses the preserved `expire` timestamp for invalidation checks.
 
 > **Good to know**: These functions serve different purposes and may need to be used together for comprehensive data consistency. For detailed examples and considerations, see [Relationship with revalidateTag](/docs/app/api-reference/functions/revalidatePath#relationship-with-revalidatetag).
 

--- a/docs/01-app/03-api-reference/04-functions/revalidateTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/revalidateTag.mdx
@@ -31,9 +31,11 @@ fetch(url, { next: { tags: [...] } });
 
 `revalidateTag` does not return a value.
 
-## Relationship with `revalidatePath`
+## Relationship with `revalidatePath` and `setTagStale`
 
 `revalidateTag` invalidates data with specific tags across all pages that use those tags, while [`revalidatePath`](/docs/app/api-reference/functions/revalidatePath) invalidates specific page or layout paths.
+
+[`setTagStale`](/docs/app/api-reference/functions/setTagStale) provides more granular cache control by marking data as stale while preserving timestamps. When `revalidateTag` is called on a tag that was previously marked stale with `setTagStale`, it uses the preserved `expire` timestamp for invalidation checks.
 
 > **Good to know**: These functions serve different purposes and may need to be used together for comprehensive data consistency. For detailed examples and considerations, see [Relationship with revalidateTag](/docs/app/api-reference/functions/revalidatePath#relationship-with-revalidatetag).
 

--- a/docs/01-app/03-api-reference/04-functions/setTagStale.mdx
+++ b/docs/01-app/03-api-reference/04-functions/setTagStale.mdx
@@ -1,0 +1,152 @@
+---
+title: setTagStale
+description: API Reference for the setTagStale function.
+---
+
+`setTagStale` allows you to mark [cached data](/docs/app/guides/caching) as stale for specific cache tags without immediately invalidating it.
+
+## Usage
+
+`setTagStale` can be called in Server Functions and Route Handlers.
+
+`setTagStale` cannot be called in Client Components or Middleware, as it only works in server environments.
+
+> **Good to know**: Unlike [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag), `setTagStale` marks data as stale but preserves the existing timestamp under an `expire` field in the tag manifest. This allows for more granular cache control where data can be marked stale without immediate invalidation.
+
+## Parameters
+
+```tsx
+setTagStale(tags: string | string[]): void;
+```
+
+- `tags`: A string or array of strings representing the cache tags associated with the data you want to mark as stale. Each tag must not exceed 256 characters and values are case-sensitive.
+
+You can add tags to `fetch` as follows:
+
+```tsx
+fetch(url, { next: { tags: [...] } });
+```
+
+## Returns
+
+`setTagStale` does not return a value.
+
+## Relationship with `revalidateTag`
+
+`setTagStale` complements [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) by providing more granular cache control:
+
+- `setTagStale` marks data as stale while preserving the original timestamp under an `expire` field
+- `revalidateTag` uses the `expire` timestamp (if present) for invalidation checks instead of the stale timestamp
+- This allows for strategies where data can be progressively marked as stale and later invalidated
+
+## Examples
+
+### Server Action with Single Tag
+
+```ts filename="app/actions.ts" switcher
+'use server'
+
+import { setTagStale } from 'next/cache'
+
+export default async function markPostsStale() {
+  // Mark posts data as stale without immediately invalidating
+  setTagStale('posts')
+}
+```
+
+```js filename="app/actions.js" switcher
+'use server'
+
+import { setTagStale } from 'next/cache'
+
+export default async function markPostsStale() {
+  // Mark posts data as stale without immediately invalidating
+  setTagStale('posts')
+}
+```
+
+### Server Action with Multiple Tags
+
+```ts filename="app/actions.ts" switcher
+'use server'
+
+import { setTagStale } from 'next/cache'
+
+export default async function markContentStale() {
+  // Mark multiple content types as stale
+  setTagStale(['posts', 'users', 'comments'])
+}
+```
+
+```js filename="app/actions.js" switcher
+'use server'
+
+import { setTagStale } from 'next/cache'
+
+export default async function markContentStale() {
+  // Mark multiple content types as stale
+  setTagStale(['posts', 'users', 'comments'])
+}
+```
+
+### Route Handler
+
+```ts filename="app/api/mark-stale/route.ts" switcher
+import { setTagStale } from 'next/cache'
+
+export async function POST(request: Request) {
+  const { tags } = await request.json()
+
+  setTagStale(tags)
+
+  return Response.json({ message: 'Tags marked as stale' })
+}
+```
+
+```js filename="app/api/mark-stale/route.js" switcher
+import { setTagStale } from 'next/cache'
+
+export async function POST(request) {
+  const { tags } = await request.json()
+
+  setTagStale(tags)
+
+  return Response.json({ message: 'Tags marked as stale' })
+}
+```
+
+### Combined with revalidateTag
+
+```ts filename="app/actions.ts" switcher
+'use server'
+
+import { setTagStale, revalidateTag } from 'next/cache'
+
+export async function updatePost() {
+  // First mark as stale
+  setTagStale('posts')
+
+  // Later, fully invalidate when ready
+  // revalidateTag('posts') // Will use the expire timestamp
+}
+```
+
+```js filename="app/actions.js" switcher
+'use server'
+
+import { setTagStale, revalidateTag } from 'next/cache'
+
+export async function updatePost() {
+  // First mark as stale
+  setTagStale('posts')
+
+  // Later, fully invalidate when ready
+  // revalidateTag('posts') // Will use the expire timestamp
+}
+```
+
+## Version History
+
+| Version   | Changes                   |
+| --------- | ------------------------- |
+| `v15.5.0` | `setTagStale` introduced. |

--- a/docs/01-app/03-api-reference/04-functions/setTagStale.mdx
+++ b/docs/01-app/03-api-reference/04-functions/setTagStale.mdx
@@ -3,7 +3,7 @@ title: setTagStale
 description: API Reference for the setTagStale function.
 ---
 
-`setTagStale` allows you to mark [cached data](/docs/app/guides/caching) as stale for specific cache tags without immediately invalidating it.
+`setTagStale` allows you to mark a cache tag and any pages that use that tag as stale for background revalidation on the next request, instead of the blocking revalidation used by [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag).
 
 ## Usage
 
@@ -11,7 +11,7 @@ description: API Reference for the setTagStale function.
 
 `setTagStale` cannot be called in Client Components or Middleware, as it only works in server environments.
 
-> **Good to know**: Unlike [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag), `setTagStale` marks data as stale but preserves the existing timestamp under an `expire` field in the tag manifest. This allows for more granular cache control where data can be marked stale without immediate invalidation.
+> **Good to know**: Unlike [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) which performs blocking revalidation, `setTagStale` marks tags for background revalidation that occurs on the next request. This provides better performance by avoiding blocking operations during user requests.
 
 ## Parameters
 
@@ -21,23 +21,17 @@ setTagStale(tags: string | string[]): void;
 
 - `tags`: A string or array of strings representing the cache tags associated with the data you want to mark as stale. Each tag must not exceed 256 characters and values are case-sensitive.
 
-You can add tags to `fetch` as follows:
-
-```tsx
-fetch(url, { next: { tags: [...] } });
-```
-
 ## Returns
 
 `setTagStale` does not return a value.
 
 ## Relationship with `revalidateTag`
 
-`setTagStale` complements [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) by providing more granular cache control:
+`setTagStale` provides an alternative to [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) for different revalidation strategies:
 
-- `setTagStale` marks data as stale while preserving the original timestamp under an `expire` field
-- `revalidateTag` uses the `expire` timestamp (if present) for invalidation checks instead of the stale timestamp
-- This allows for strategies where data can be progressively marked as stale and later invalidated
+- `setTagStale` marks a tag and pages using that tag for background revalidation on the next request
+- `revalidateTag` performs blocking revalidation that happens immediately when the tagged data is accessed
+- Use `setTagStale` when you want better performance by avoiding blocking operations during user requests and don't need read your write behavior.
 
 ## Examples
 
@@ -49,7 +43,7 @@ fetch(url, { next: { tags: [...] } });
 import { setTagStale } from 'next/cache'
 
 export default async function markPostsStale() {
-  // Mark posts data as stale without immediately invalidating
+  // Mark posts tag for background revalidation on next request
   setTagStale('posts')
 }
 ```
@@ -60,32 +54,8 @@ export default async function markPostsStale() {
 import { setTagStale } from 'next/cache'
 
 export default async function markPostsStale() {
-  // Mark posts data as stale without immediately invalidating
+  // Mark posts tag for background revalidation on next request
   setTagStale('posts')
-}
-```
-
-### Server Action with Multiple Tags
-
-```ts filename="app/actions.ts" switcher
-'use server'
-
-import { setTagStale } from 'next/cache'
-
-export default async function markContentStale() {
-  // Mark multiple content types as stale
-  setTagStale(['posts', 'users', 'comments'])
-}
-```
-
-```js filename="app/actions.js" switcher
-'use server'
-
-import { setTagStale } from 'next/cache'
-
-export default async function markContentStale() {
-  // Mark multiple content types as stale
-  setTagStale(['posts', 'users', 'comments'])
 }
 ```
 
@@ -99,7 +69,7 @@ export async function POST(request: Request) {
 
   setTagStale(tags)
 
-  return Response.json({ message: 'Tags marked as stale' })
+  return Response.json({ message: 'Tags marked for background revalidation' })
 }
 ```
 
@@ -111,37 +81,7 @@ export async function POST(request) {
 
   setTagStale(tags)
 
-  return Response.json({ message: 'Tags marked as stale' })
-}
-```
-
-### Combined with revalidateTag
-
-```ts filename="app/actions.ts" switcher
-'use server'
-
-import { setTagStale, revalidateTag } from 'next/cache'
-
-export async function updatePost() {
-  // First mark as stale
-  setTagStale('posts')
-
-  // Later, fully invalidate when ready
-  // revalidateTag('posts') // Will use the expire timestamp
-}
-```
-
-```js filename="app/actions.js" switcher
-'use server'
-
-import { setTagStale, revalidateTag } from 'next/cache'
-
-export async function updatePost() {
-  // First mark as stale
-  setTagStale('posts')
-
-  // Later, fully invalidate when ready
-  // revalidateTag('posts') // Will use the expire timestamp
+  return Response.json({ message: 'Tags marked for background revalidation' })
 }
 ```
 

--- a/packages/next/cache.d.ts
+++ b/packages/next/cache.d.ts
@@ -3,6 +3,7 @@ export { unstable_cache } from 'next/dist/server/web/spec-extension/unstable-cac
 export {
   revalidatePath,
   revalidateTag,
+  setTagStale,
   unstable_expirePath,
   unstable_expireTag,
 } from 'next/dist/server/web/spec-extension/revalidate'

--- a/packages/next/cache.js
+++ b/packages/next/cache.js
@@ -6,6 +6,8 @@ const cacheExports = {
     .revalidateTag,
   revalidatePath: require('next/dist/server/web/spec-extension/revalidate')
     .revalidatePath,
+  setTagStale: require('next/dist/server/web/spec-extension/revalidate')
+    .setTagStale,
 
   unstable_expireTag: require('next/dist/server/web/spec-extension/revalidate')
     .unstable_expireTag,
@@ -28,6 +30,7 @@ module.exports = cacheExports
 exports.unstable_cache = cacheExports.unstable_cache
 exports.revalidatePath = cacheExports.revalidatePath
 exports.revalidateTag = cacheExports.revalidateTag
+exports.setTagStale = cacheExports.setTagStale
 exports.unstable_expireTag = cacheExports.unstable_expireTag
 exports.unstable_expirePath = cacheExports.unstable_expirePath
 exports.unstable_noStore = cacheExports.unstable_noStore

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -541,6 +541,7 @@ declare module 'next/cache' {
   export {
     revalidateTag,
     revalidatePath,
+    setTagStale,
     unstable_expireTag,
     unstable_expirePath,
   } from 'next/dist/server/web/spec-extension/revalidate'

--- a/packages/next/src/server/after/after-context.test.ts
+++ b/packages/next/src/server/after/after-context.test.ts
@@ -542,6 +542,7 @@ const createMockWorkStore = (afterContext: AfterContext): WorkStore => {
     forceDynamic: false,
     dynamicShouldError: false,
     isStaticGeneration: false,
+    pendingStaleTags: [],
     pendingRevalidatedTags: [],
     pendingRevalidates: undefined,
     pendingRevalidateWrites: undefined,

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -71,6 +71,12 @@ export interface WorkStore {
   pendingRevalidatedTags?: string[]
 
   /**
+   * Tags that were marked as stale during the current request. They need to be
+   * processed to update the tag manifest with stale timestamps.
+   */
+  pendingStaleTags?: string[]
+
+  /**
    * Tags that were previously revalidated (e.g. by a redirecting server action)
    * and have already been sent to cache handlers. Retrieved cache entries that
    * include any of these tags must be discarded.

--- a/packages/next/src/server/lib/cache-handlers/default.external.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.external.ts
@@ -79,10 +79,12 @@ const DefaultCacheHandler: CacheHandlerV2 = {
       debug?.('get', cacheKey, 'had expired tag')
       return undefined
     }
+    const entryTimestamp = state === 'STALE' ? -1 : entry.timestamp
     const [returnStream, newSaved] = entry.value.tee()
     entry.value = newSaved
 
     debug?.('get', cacheKey, 'found', {
+      tagState: state,
       tags: entry.tags,
       timestamp: entry.timestamp,
       revalidate: entry.revalidate,
@@ -91,6 +93,7 @@ const DefaultCacheHandler: CacheHandlerV2 = {
 
     return {
       ...entry,
+      timestamp: entryTimestamp,
       value: returnStream,
     }
   },
@@ -145,8 +148,7 @@ const DefaultCacheHandler: CacheHandlerV2 = {
         if (typeof entry === 'number') {
           return entry
         } else if (entry && typeof entry === 'object') {
-          // Use expire timestamp if available, fall back to stale
-          return entry.expire || entry.stale || 0
+          return entry.expire || 0
         }
         return 0
       })

--- a/packages/next/src/server/lib/cache-handlers/default.external.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.external.ts
@@ -10,8 +10,8 @@
 import { LRUCache } from '../lru-cache'
 import type { CacheEntry, CacheHandlerV2 } from './types'
 import {
-  isStale,
   tagsManifest,
+  isStaleOrExpired,
 } from '../incremental-cache/tags-manifest.external'
 
 type PrivateCacheEntry = {
@@ -73,10 +73,10 @@ const DefaultCacheHandler: CacheHandlerV2 = {
 
       return undefined
     }
+    const { state } = isStaleOrExpired(entry.tags, entry.timestamp)
 
-    if (isStale(entry.tags, entry.timestamp)) {
-      debug?.('get', cacheKey, 'had stale tag')
-
+    if (state === 'EXPIRED') {
+      debug?.('get', cacheKey, 'had expired tag')
       return undefined
     }
     const [returnStream, newSaved] = entry.value.tee()
@@ -140,7 +140,16 @@ const DefaultCacheHandler: CacheHandlerV2 = {
 
   async getExpiration(...tags) {
     const expiration = Math.max(
-      ...tags.map((tag) => tagsManifest.get(tag) ?? 0)
+      ...tags.map((tag) => {
+        const entry = tagsManifest.get(tag)
+        if (typeof entry === 'number') {
+          return entry
+        } else if (entry && typeof entry === 'object') {
+          // Use expire timestamp if available, fall back to stale
+          return entry.expire || entry.stale || 0
+        }
+        return 0
+      })
     )
 
     debug?.('getExpiration', { tags, expiration })
@@ -153,8 +162,38 @@ const DefaultCacheHandler: CacheHandlerV2 = {
     debug?.('expireTags', { tags, timestamp })
 
     for (const tag of tags) {
-      // TODO: update file-system-cache?
-      tagsManifest.set(tag, timestamp)
+      const existing = tagsManifest.get(tag)
+
+      if (!existing) {
+        // New tag - set expire timestamp
+        tagsManifest.set(tag, { expire: timestamp })
+      } else if (typeof existing === 'number') {
+        // Legacy format - convert to new format and update expire
+        tagsManifest.set(tag, { expire: timestamp })
+      } else {
+        // New format - update expire timestamp
+        existing.expire = timestamp
+      }
+    }
+  },
+
+  async setTagStale(...tags) {
+    const timestamp = Math.round(performance.timeOrigin + performance.now())
+    debug?.('setTagStale', { tags, timestamp })
+
+    for (const tag of tags) {
+      const existing = tagsManifest.get(tag)
+
+      if (!existing) {
+        // New tag - set stale timestamp
+        tagsManifest.set(tag, { stale: timestamp })
+      } else if (typeof existing === 'number') {
+        // Legacy format - convert to new format, preserve as expire and add stale
+        tagsManifest.set(tag, { expire: existing, stale: timestamp })
+      } else {
+        // New format - update stale timestamp, preserve existing expire
+        existing.stale = timestamp
+      }
     }
   },
 }

--- a/packages/next/src/server/lib/cache-handlers/types.ts
+++ b/packages/next/src/server/lib/cache-handlers/types.ts
@@ -113,6 +113,13 @@ export interface CacheHandlerV2 {
    * it should update the tags manifest accordingly.
    */
   expireTags(...tags: string[]): Promise<void>
+
+  /**
+   * This function is called when tags are marked as stale. If applicable,
+   * it should update the tags manifest accordingly by marking tags as stale
+   * while preserving existing expire timestamps.
+   */
+  setTagStale?(...tags: string[]): Promise<void>
 }
 
 /**

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -21,7 +21,7 @@ import {
   RSC_SEGMENTS_DIR_SUFFIX,
   RSC_SUFFIX,
 } from '../../../lib/constants'
-import { isStale, tagsManifest } from './tags-manifest.external'
+import { isStaleOrExpired, tagsManifest } from './tags-manifest.external'
 import { MultiFileWriter } from '../../../lib/multi-file-writer'
 import { getMemoryCache } from './memory-cache.external'
 
@@ -79,8 +79,47 @@ export default class FileSystemCache implements CacheHandler {
     }
 
     for (const tag of tags) {
-      if (!tagsManifest.has(tag)) {
-        tagsManifest.set(tag, Date.now())
+      const existing = tagsManifest.get(tag)
+      const now = Date.now()
+
+      if (!existing) {
+        // New tag - set expire timestamp for revalidateTag
+        tagsManifest.set(tag, { expire: now })
+      } else if (typeof existing === 'number') {
+        // Legacy format - convert to new format and update expire
+        tagsManifest.set(tag, { expire: now })
+      } else {
+        // New format - update expire timestamp
+        existing.expire = now
+      }
+    }
+  }
+
+  public async setTagStale(...args: Parameters<CacheHandler['setTagStale']>) {
+    let [tags] = args
+    tags = typeof tags === 'string' ? [tags] : tags
+
+    if (FileSystemCache.debug) {
+      console.log('setTagStale', tags)
+    }
+
+    if (tags.length === 0) {
+      return
+    }
+
+    const now = Date.now()
+    for (const tag of tags) {
+      const existing = tagsManifest.get(tag)
+
+      if (!existing) {
+        // New tag - set stale timestamp
+        tagsManifest.set(tag, { stale: now })
+      } else if (typeof existing === 'number') {
+        // Legacy format - convert to new format, preserve as expire and add stale
+        tagsManifest.set(tag, { expire: existing, stale: now })
+      } else {
+        // New format - update stale timestamp, preserve existing expire
+        existing.stale = now
       }
     }
   }
@@ -297,12 +336,21 @@ export default class FileSystemCache implements CacheHandler {
         // we trigger a blocking validation if an ISR page
         // had a tag revalidated, if we want to be a background
         // revalidation instead we return data.lastModified = -1
-        if (cacheTags.length > 0 && isStale(cacheTags, data.lastModified)) {
+        const { state } = isStaleOrExpired(
+          cacheTags,
+          data?.lastModified || Date.now()
+        )
+        if (state === 'EXPIRED') {
           if (FileSystemCache.debug) {
-            console.log('FileSystemCache: stale tags', cacheTags)
+            console.log?.('get', key, 'had expired tag', cacheTags)
           }
-
           return null
+        }
+        if (state === 'STALE') {
+          if (FileSystemCache.debug) {
+            console.log?.('get', key, 'had stale tag', cacheTags)
+          }
+          data.lastModified = -1
         }
       }
     } else if (data?.value?.kind === CachedRouteKind.FETCH) {
@@ -311,22 +359,36 @@ export default class FileSystemCache implements CacheHandler {
           ? [...(ctx.tags || []), ...(ctx.softTags || [])]
           : []
 
-      // When revalidate tag is called we don't return stale data so it's
-      // updated right away.
-      if (combinedTags.some((tag) => this.revalidatedTags.includes(tag))) {
-        if (FileSystemCache.debug) {
-          console.log('FileSystemCache: was revalidated', combinedTags)
+      for (const tag of combinedTags) {
+        // When revalidate tag is called we don't return
+        // stale data so it's updated right away
+        if (this.revalidatedTags.includes(tag)) {
+          data = undefined
+          if (FileSystemCache.debug) {
+            console.log?.('get', key, 'had expired tag', this.revalidatedTags)
+          }
+          break
         }
 
-        return null
-      }
+        const { state } = isStaleOrExpired(
+          [tag],
+          data?.lastModified || Date.now()
+        )
 
-      if (isStale(combinedTags, data.lastModified)) {
-        if (FileSystemCache.debug) {
-          console.log('FileSystemCache: stale tags', combinedTags)
+        if (state === 'EXPIRED') {
+          if (FileSystemCache.debug) {
+            console.log?.('get', key, 'had expired tag', tag)
+          }
+          data = undefined
+          break
         }
-
-        return null
+        if (state === 'STALE') {
+          if (FileSystemCache.debug) {
+            console.log?.('get', key, 'had stale tag', tag)
+          }
+          data.lastModified = -1
+          break
+        }
       }
     }
 

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -77,6 +77,10 @@ export class CacheHandler {
     ..._args: Parameters<IncrementalCache['revalidateTag']>
   ): Promise<void> {}
 
+  public async setTagStale(
+    ..._args: Parameters<IncrementalCache['setTagStale']>
+  ): Promise<void> {}
+
   public resetRequestCache(): void {}
 }
 
@@ -279,7 +283,11 @@ export class IncrementalCache implements IncrementalCacheType {
   }
 
   async revalidateTag(tags: string | string[]): Promise<void> {
-    return this.cacheHandler?.revalidateTag(tags)
+    return this.cacheHandler?.revalidateTag?.(tags)
+  }
+
+  async setTagStale(tags: string | string[]): Promise<void> {
+    return this.cacheHandler?.setTagStale?.(tags)
   }
 
   // x-ref: https://github.com/facebook/react/blob/2655c9354d8e1c54ba888444220f63e836925caa/packages/react/src/ReactFetch.js#L23

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -35,7 +35,7 @@ import type { Revalidate } from '../cache-control'
 import { getPreviouslyRevalidatedTags } from '../../server-utils'
 import { workAsyncStorage } from '../../app-render/work-async-storage.external'
 import { DetachedPromise } from '../../../lib/detached-promise'
-import { isStale as isTagsStale } from './tags-manifest.external'
+import { isStaleOrExpired } from './tags-manifest.external'
 
 export interface CacheHandlerContext {
   fs?: CacheFs
@@ -578,8 +578,14 @@ export class IncrementalCache implements IncrementalCacheType {
 
         if (typeof tagsHeader === 'string') {
           const cacheTags = tagsHeader.split(',')
-          if (cacheTags.length > 0 && isTagsStale(cacheTags, lastModified)) {
-            isStale = -1
+          const { state } = isStaleOrExpired(cacheTags, lastModified)
+
+          if (cacheTags.length > 0) {
+            if (state === 'STALE') {
+              isStale = true
+            } else if (state === 'EXPIRED') {
+              isStale = -1
+            }
           }
         }
       }

--- a/packages/next/src/server/lib/incremental-cache/tags-manifest.external.ts
+++ b/packages/next/src/server/lib/incremental-cache/tags-manifest.external.ts
@@ -1,17 +1,45 @@
 import type { Timestamp } from '../cache-handlers/types'
 
+export interface TagManifestEntry {
+  /** Timestamp when the tag was marked as stale */
+  stale?: number
+  /** Timestamp when the tag should expire (for revalidateTag) */
+  expire?: number
+}
+
 // We share the tags manifest between the "use cache" handlers and the previous
 // file-system cache.
-export const tagsManifest = new Map<string, number>()
+export const tagsManifest = new Map<string, number | TagManifestEntry>()
 
-export const isStale = (tags: string[], timestamp: Timestamp) => {
+export const isStaleOrExpired = (
+  tags: string[],
+  timestamp: Timestamp
+): {
+  state: 'FRESH' | 'STALE' | 'EXPIRED'
+} => {
   for (const tag of tags) {
-    const revalidatedAt = tagsManifest.get(tag)
+    const entry = tagsManifest.get(tag)
 
-    if (typeof revalidatedAt === 'number' && revalidatedAt >= timestamp) {
-      return true
+    // Handle legacy number format (revalidatedAt timestamp)
+    if (typeof entry === 'number') {
+      if (entry >= timestamp) {
+        return { state: 'EXPIRED' }
+      }
+    }
+    // Handle new object format with stale/expire
+    else if (entry && typeof entry === 'object') {
+      const expireTimestamp = entry.expire || 0
+
+      if (typeof expireTimestamp === 'number' && expireTimestamp >= timestamp) {
+        return { state: 'EXPIRED' }
+      }
+
+      const staleTimestamp = entry.stale || 0
+      if (typeof staleTimestamp === 'number' && staleTimestamp >= timestamp) {
+        return { state: 'STALE' }
+      }
     }
   }
 
-  return false
+  return { state: 'FRESH' }
 }

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -289,4 +289,6 @@ export interface IncrementalCache extends IncrementalResponseCache {
     data: Exclude<IncrementalCacheValue, CachedFetchValue> | null,
     ctx: SetIncrementalResponseCacheContext
   ): Promise<void>
+  revalidateTag?(tags: string | string[]): Promise<void>
+  setTagStale?(tags: string | string[]): Promise<void>
 }

--- a/packages/next/src/server/revalidation-utils.ts
+++ b/packages/next/src/server/revalidation-utils.ts
@@ -28,7 +28,10 @@ export async function withExecuteRevalidates<T>(
 type RevalidationState = Required<
   Pick<
     WorkStore,
-    'pendingRevalidatedTags' | 'pendingRevalidates' | 'pendingRevalidateWrites'
+    | 'pendingRevalidatedTags'
+    | 'pendingStaleTags'
+    | 'pendingRevalidates'
+    | 'pendingRevalidateWrites'
   >
 >
 
@@ -37,6 +40,7 @@ function cloneRevalidationState(store: WorkStore): RevalidationState {
     pendingRevalidatedTags: store.pendingRevalidatedTags
       ? [...store.pendingRevalidatedTags]
       : [],
+    pendingStaleTags: store.pendingStaleTags ? [...store.pendingStaleTags] : [],
     pendingRevalidates: { ...store.pendingRevalidates },
     pendingRevalidateWrites: store.pendingRevalidateWrites
       ? [...store.pendingRevalidateWrites]
@@ -49,10 +53,14 @@ function diffRevalidationState(
   curr: RevalidationState
 ): RevalidationState {
   const prevTags = new Set(prev.pendingRevalidatedTags)
+  const prevStaleTags = new Set(prev.pendingStaleTags)
   const prevRevalidateWrites = new Set(prev.pendingRevalidateWrites)
   return {
     pendingRevalidatedTags: curr.pendingRevalidatedTags.filter(
       (tag) => !prevTags.has(tag)
+    ),
+    pendingStaleTags: curr.pendingStaleTags.filter(
+      (tag) => !prevStaleTags.has(tag)
     ),
     pendingRevalidates: Object.fromEntries(
       Object.entries(curr.pendingRevalidates).filter(
@@ -89,12 +97,44 @@ async function revalidateTags(
   await Promise.all(promises)
 }
 
+async function setStaleTags(
+  tags: string[],
+  incrementalCache: IncrementalCache | undefined
+): Promise<void> {
+  if (tags.length === 0) {
+    return
+  }
+
+  const promises: Promise<void>[] = []
+
+  if (incrementalCache) {
+    promises.push(incrementalCache.setTagStale(tags))
+  }
+
+  const handlers = getCacheHandlers()
+  if (handlers) {
+    for (const handler of handlers) {
+      if (
+        'setTagStale' in handler &&
+        typeof handler.setTagStale === 'function'
+      ) {
+        promises.push(handler.setTagStale(...tags))
+      }
+    }
+  }
+
+  await Promise.all(promises)
+}
+
 export async function executeRevalidates(
   workStore: WorkStore,
   state?: RevalidationState
 ) {
   const pendingRevalidatedTags =
     state?.pendingRevalidatedTags ?? workStore.pendingRevalidatedTags ?? []
+
+  const pendingStaleTags =
+    state?.pendingStaleTags ?? workStore.pendingStaleTags ?? []
 
   const pendingRevalidates =
     state?.pendingRevalidates ?? workStore.pendingRevalidates ?? {}
@@ -104,6 +144,7 @@ export async function executeRevalidates(
 
   return Promise.all([
     revalidateTags(pendingRevalidatedTags, workStore.incrementalCache),
+    setStaleTags(pendingStaleTags, workStore.incrementalCache),
     ...Object.values(pendingRevalidates),
     ...pendingRevalidateWrites,
   ])

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -22,6 +22,20 @@ export function revalidateTag(tag: string) {
 }
 
 /**
+ * This function allows you to mark [cached data](https://nextjs.org/docs/app/building-your-application/caching) as stale for specific cache tags.
+ *
+ * Unlike `revalidateTag`, this function marks entries as stale but preserves the existing timestamp
+ * under an `expire` field in the tag manifest. This allows for more granular cache control where
+ * data can be marked stale without immediately invalidating it.
+ *
+ * @param tags - A single tag string or array of tag strings to mark as stale
+ */
+export function setTagStale(tags: string | string[]) {
+  const tagArray = Array.isArray(tags) ? tags : [tags]
+  return revalidateStale(tagArray, `setTagStale ${tagArray.join(', ')}`)
+}
+
+/**
  * This function allows you to purge [cached data](https://nextjs.org/docs/app/building-your-application/caching) on-demand for a specific path.
  *
  * Read more: [Next.js Docs: `unstable_expirePath`](https://nextjs.org/docs/app/api-reference/functions/unstable_expirePath)
@@ -166,4 +180,86 @@ function revalidate(tags: string[], expression: string) {
 
   // TODO: only revalidate if the path matches
   store.pathWasRevalidated = true
+}
+
+function revalidateStale(tags: string[], expression: string) {
+  const store = workAsyncStorage.getStore()
+  if (!store || !store.incrementalCache) {
+    throw new Error(
+      `Invariant: static generation store missing in ${expression}`
+    )
+  }
+
+  const workUnitStore = workUnitAsyncStorage.getStore()
+  if (workUnitStore) {
+    if (workUnitStore.phase === 'render') {
+      throw new Error(
+        `Route ${store.route} used "${expression}" during render which is unsupported. To ensure revalidation is performed consistently it must always happen outside of renders and cached functions. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
+      )
+    }
+
+    switch (workUnitStore.type) {
+      case 'cache':
+      case 'private-cache':
+        throw new Error(
+          `Route ${store.route} used "${expression}" inside a "use cache" which is unsupported. To ensure revalidation is performed consistently it must always happen outside of renders and cached functions. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
+        )
+      case 'unstable-cache':
+        throw new Error(
+          `Route ${store.route} used "${expression}" inside a function cached with "unstable_cache(...)" which is unsupported. To ensure revalidation is performed consistently it must always happen outside of renders and cached functions. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering`
+        )
+      case 'prerender':
+      case 'prerender-runtime':
+        // cacheComponents Prerender
+        const error = new Error(
+          `Route ${store.route} used ${expression} without first calling \`await connection()\`.`
+        )
+        return abortAndThrowOnSynchronousRequestDataAccess(
+          store.route,
+          expression,
+          error,
+          workUnitStore
+        )
+      case 'prerender-client':
+        throw new InvariantError(
+          `${expression} must not be used within a client component. Next.js should be preventing ${expression} from being included in client components statically, but did not in this case.`
+        )
+      case 'prerender-ppr':
+        return postponeWithTracking(
+          store.route,
+          expression,
+          workUnitStore.dynamicTracking
+        )
+      case 'prerender-legacy':
+        workUnitStore.revalidate = 0
+
+        const err = new DynamicServerError(
+          `Route ${store.route} couldn't be rendered statically because it used \`${expression}\`. See more info here: https://nextjs.org/docs/messages/dynamic-server-error`
+        )
+        store.dynamicUsageDescription = expression
+        store.dynamicUsageStack = err.stack
+
+        throw err
+      case 'request':
+        if (process.env.NODE_ENV !== 'production') {
+          // TODO: This is most likely incorrect. It would lead to the ISR
+          // status being flipped when revalidating a static page with a server
+          // action.
+          workUnitStore.usedDynamic = true
+        }
+        break
+      default:
+        workUnitStore satisfies never
+    }
+  }
+
+  if (!store.pendingStaleTags) {
+    store.pendingStaleTags = []
+  }
+
+  for (const tag of tags) {
+    if (!store.pendingStaleTags.includes(tag)) {
+      store.pendingStaleTags.push(tag)
+    }
+  }
 }

--- a/test/e2e/app-dir/app-static/app-static-set-tag-stale.test.ts
+++ b/test/e2e/app-dir/app-static/app-static-set-tag-stale.test.ts
@@ -1,0 +1,138 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('app-dir set-tag-stale', () => {
+  const { next, skipped, isNextDev } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped || isNextDev) {
+    it('should skip test', () => {})
+    return
+  }
+
+  it('should mark single tag as stale with setTagStale', async () => {
+    // First, get the initial page
+    const $ = await next.render$('/stale-tag-test')
+    const initialRandom = $('#random').text()
+    const initialNow = $('#now').text()
+
+    // Mark tag as stale
+    await next.fetch('/api/set-tag-stale-node?tag=stale-test')
+
+    // The page should still show the same content initially (not immediately invalidated)
+    const $2 = await next.render$('/stale-tag-test')
+    const secondRandom = $2('#random').text()
+    const secondNow = $2('#now').text()
+
+    // Should be the same since it's marked stale but not invalidated yet
+    expect(secondRandom).toBe(initialRandom)
+    expect(secondNow).toBe(initialNow)
+
+    // Should now show fresh content
+    await retry(async () => {
+      const $3 = await next.render$('/stale-tag-test')
+      const thirdRandom = $3('#random').text()
+      const thirdNow = $3('#now').text()
+
+      expect(thirdRandom).not.toBe(initialRandom)
+      expect(thirdNow).not.toBe(initialNow)
+    })
+  })
+
+  it('should mark multiple tags as stale with setTagStale', async () => {
+    // Get initial state
+    const $ = await next.render$('/multiple-stale-tags')
+    const initialRandom = $('#random').text()
+
+    // Mark multiple tags as stale
+    await next.fetch('/api/set-tag-stale-node?tags=tag1,tag2,shared')
+
+    // Content should still be the same initially
+    const $2 = await next.render$('/multiple-stale-tags')
+    expect($2('#random').text()).toBe(initialRandom)
+
+    // Should now show fresh content
+    await retry(async () => {
+      const $3 = await next.render$('/multiple-stale-tags')
+      expect($3('#random').text()).not.toBe(initialRandom)
+    })
+  })
+
+  it('should work with edge runtime for setTagStale', async () => {
+    const $ = await next.render$('/stale-tag-test')
+    const initialRandom = $('#random').text()
+
+    // Mark tag as stale using edge runtime
+    const response = await next.fetch('/api/set-tag-stale-edge?tag=stale-test')
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.stale).toBe(true)
+
+    // Content should initially remain the same
+    const $2 = await next.render$('/stale-tag-test')
+    const secondRandom = $2('#random').text()
+    expect(secondRandom).toBe(initialRandom)
+
+    // Revalidate to see the change
+    await next.fetch('/api/revalidate-tag-edge?tag=stale-test')
+
+    await retry(async () => {
+      const $3 = await next.render$('/stale-tag-test')
+      const thirdRandom = $3('#random').text()
+      expect(thirdRandom).not.toBe(initialRandom)
+    })
+  })
+
+  it('should handle empty tag gracefully', async () => {
+    const response = await next.fetch('/api/set-tag-stale-node')
+    expect(response.status).toBe(200)
+
+    const data = await response.json()
+    expect(data.stale).toBe(true)
+  })
+
+  it('should preserve expire timestamp when using setTagStale then revalidateTag', async () => {
+    const $ = await next.render$('/stale-tag-test')
+    const initialRandom = $('#random').text()
+    const initialData = $('#data').text()
+
+    // First mark as stale
+    await next.fetch('/api/set-tag-stale-node?tag=stale-test')
+
+    // Should initially remain the same
+    const $2 = await next.render$('/stale-tag-test')
+    expect($2('#random').text()).toBe(initialRandom)
+    expect($2('#data').text()).toBe(initialData)
+
+    await retry(async () => {
+      const $3 = await next.render$('/stale-tag-test')
+      expect($3('#random').text()).not.toBe(initialRandom)
+      expect($3('#data').text()).not.toBe(initialData)
+    })
+  })
+
+  it('should work with array input for multiple tags', async () => {
+    const $ = await next.render$('/multiple-stale-tags')
+    const initialData1 = $('#data1').text()
+    const initialData2 = $('#data2').text()
+
+    // Test with comma-separated tags (simulating array)
+    const response = await next.fetch('/api/set-tag-stale-node?tags=tag1,tag2')
+    expect(response.status).toBe(200)
+
+    // Should initially remain the same
+    const $2 = await next.render$('/multiple-stale-tags')
+    expect($2('#data1').text()).toBe(initialData1)
+    expect($2('#data2').text()).toBe(initialData2)
+
+    await retry(async () => {
+      const $3 = await next.render$('/multiple-stale-tags')
+      expect($3('#random').text()).not.toBe($('#random').text())
+      expect($3('#data1').text()).not.toBe(initialData1)
+      expect($3('#data2').text()).not.toBe(initialData2)
+    })
+  })
+})

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -861,6 +861,8 @@ describe('app-dir static/dynamic handling', () => {
          "index.rsc",
          "isr-error-handling.html",
          "isr-error-handling.rsc",
+         "multiple-stale-tags.html",
+         "multiple-stale-tags.rsc",
          "no-config-fetch.html",
          "no-config-fetch.rsc",
          "no-store/static.html",
@@ -905,6 +907,8 @@ describe('app-dir static/dynamic handling', () => {
          "ssg-draft-mode/test-2.rsc",
          "ssg-draft-mode/test.html",
          "ssg-draft-mode/test.rsc",
+         "stale-tag-test.html",
+         "stale-tag-test.rsc",
          "strip-w3c-trace-context-headers.html",
          "strip-w3c-trace-context-headers.rsc",
          "unstable-cache/fetch/no-cache.html",
@@ -1550,6 +1554,31 @@ describe('app-dir static/dynamic handling', () => {
            "prefetchDataRoute": null,
            "srcRoute": "/isr-error-handling",
          },
+         "/multiple-stale-tags": {
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token",
+           ],
+           "dataRoute": "/multiple-stale-tags.rsc",
+           "experimentalBypassFor": [
+             {
+               "key": "next-action",
+               "type": "header",
+             },
+             {
+               "key": "content-type",
+               "type": "header",
+               "value": "multipart/form-data;.*",
+             },
+           ],
+           "initialExpireSeconds": 31536000,
+           "initialRevalidateSeconds": 60,
+           "srcRoute": "/multiple-stale-tags",
+         },
          "/no-config-fetch": {
            "allowHeader": [
              "host",
@@ -2189,6 +2218,31 @@ describe('app-dir static/dynamic handling', () => {
            "initialRevalidateSeconds": false,
            "prefetchDataRoute": null,
            "srcRoute": "/ssg-draft-mode/[[...route]]",
+         },
+         "/stale-tag-test": {
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token",
+           ],
+           "dataRoute": "/stale-tag-test.rsc",
+           "experimentalBypassFor": [
+             {
+               "key": "next-action",
+               "type": "header",
+             },
+             {
+               "key": "content-type",
+               "type": "header",
+               "value": "multipart/form-data;.*",
+             },
+           ],
+           "initialExpireSeconds": 31536000,
+           "initialRevalidateSeconds": 60,
+           "srcRoute": "/stale-tag-test",
          },
          "/strip-w3c-trace-context-headers": {
            "allowHeader": [

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -1577,6 +1577,7 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 60,
+           "prefetchDataRoute": null,
            "srcRoute": "/multiple-stale-tags",
          },
          "/no-config-fetch": {
@@ -2242,6 +2243,7 @@ describe('app-dir static/dynamic handling', () => {
            ],
            "initialExpireSeconds": 31536000,
            "initialRevalidateSeconds": 60,
+           "prefetchDataRoute": null,
            "srcRoute": "/stale-tag-test",
          },
          "/strip-w3c-trace-context-headers": {

--- a/test/e2e/app-dir/app-static/app/api/data/route.ts
+++ b/test/e2e/app-dir/app-static/app/api/data/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({
+    message: 'test data',
+    timestamp: Date.now(),
+  })
+}

--- a/test/e2e/app-dir/app-static/app/api/data1/route.ts
+++ b/test/e2e/app-dir/app-static/app/api/data1/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({
+    value: 'data1',
+    timestamp: Date.now(),
+  })
+}

--- a/test/e2e/app-dir/app-static/app/api/data2/route.ts
+++ b/test/e2e/app-dir/app-static/app/api/data2/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({
+    value: 'data2',
+    timestamp: Date.now(),
+  })
+}

--- a/test/e2e/app-dir/app-static/app/api/set-tag-stale-edge/route.ts
+++ b/test/e2e/app-dir/app-static/app/api/set-tag-stale-edge/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { setTagStale } from 'next/cache'
+
+export const revalidate = 0
+export const runtime = 'edge'
+
+export async function GET(req) {
+  const tag = req.nextUrl.searchParams.get('tag')
+  const tags = req.nextUrl.searchParams.get('tags')
+
+  if (tags) {
+    // Test multiple tags
+    setTagStale(tags.split(','))
+  } else if (tag) {
+    // Test single tag
+    setTagStale(tag)
+  }
+
+  return NextResponse.json({ stale: true, now: Date.now() })
+}

--- a/test/e2e/app-dir/app-static/app/api/set-tag-stale-node/route.ts
+++ b/test/e2e/app-dir/app-static/app/api/set-tag-stale-node/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import { setTagStale } from 'next/cache'
+
+export const revalidate = 0
+
+export async function GET(req) {
+  const tag = req.nextUrl.searchParams.get('tag')
+  const tags = req.nextUrl.searchParams.get('tags')
+
+  if (tags) {
+    // Test multiple tags
+    setTagStale(tags.split(','))
+  } else if (tag) {
+    // Test single tag
+    setTagStale(tag)
+  }
+
+  return NextResponse.json({ stale: true, now: Date.now() })
+}

--- a/test/e2e/app-dir/app-static/app/multiple-stale-tags/page.tsx
+++ b/test/e2e/app-dir/app-static/app/multiple-stale-tags/page.tsx
@@ -1,0 +1,30 @@
+export const revalidate = 60
+
+export default async function MultipleStaleTagsPage() {
+  // Fetch with multiple tags for testing
+  const data1 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?stale-check-1',
+    {
+      next: { tags: ['tag1', 'shared'] },
+    }
+  ).then((res) => res.text())
+
+  const data2 = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?stale-check-2',
+    {
+      next: { tags: ['tag2', 'shared'] },
+    }
+  ).then((res) => res.text())
+
+  const randomData = Math.random()
+
+  return (
+    <div>
+      <h1>Multiple Stale Tags Test</h1>
+      <p id="random">{randomData}</p>
+      <p id="data1">{data1}</p>
+      <p id="data2">{data2}</p>
+      <p id="now">{Date.now()}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-static/app/stale-tag-test/page.tsx
+++ b/test/e2e/app-dir/app-static/app/stale-tag-test/page.tsx
@@ -1,0 +1,22 @@
+export const revalidate = 60
+
+export default async function StaleTagTestPage() {
+  // Fetch with a specific tag for testing
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?stale-check-3',
+    {
+      next: { tags: ['stale-test'] },
+    }
+  ).then((res) => res.text())
+
+  const randomData = Math.random()
+
+  return (
+    <div>
+      <h1>Stale Tag Test</h1>
+      <p id="random">{randomData}</p>
+      <p id="data">{data}</p>
+      <p id="now">{Date.now()}</p>
+    </div>
+  )
+}

--- a/test/experimental-tests-manifest.json
+++ b/test/experimental-tests-manifest.json
@@ -1,6 +1,20 @@
 {
   "version": 2,
   "suites": {
+    "test/e2e/app-dir/app-static/app-static-set-tag-stale.test.ts": {
+      "passed": [],
+      "failed": [
+        "app-dir set-tag-stale should mark single tag as stale with setTagStale",
+        "app-dir set-tag-stale should mark multiple tags as stale with setTagStale",
+        "app-dir set-tag-stale should work with edge runtime for setTagStale",
+        "app-dir set-tag-stale should handle empty tag gracefully",
+        "app-dir set-tag-stale should preserve expire timestamp when using setTagStale then revalidateTag",
+        "app-dir set-tag-stale should work with array input for multiple tags"
+      ],
+      "pending": [],
+      "flakey": [],
+      "runtimeError": false
+    },
     "test/production/app-dir/fetch-cache/fetch-cache.test.ts": {
       "passed": [
         "fetch-cache should have correct fetchUrl field for fetches and unstable_cache",


### PR DESCRIPTION
This adds a new `setTagStale` method as an alternative to `revalidateTag`. The key difference with this new API is that instead of marking entries with that related tag as expired and needing a blocking update the next time they are requested they instead will be considered stale and are able to be updated in the background.

This avoids the issue when you need durable content to be revalidated in the background without evicting the cache risking downtime on content that can tolerate stale over error states. 

