### PR TITLE
chore: Ignore `compiled` folder in ripgrep/ast-grep/ag/etc

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -3,3 +3,4 @@
 
 # Not valid text
 turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/broken.js
+packages/next/src/compiled


### PR DESCRIPTION
These files need to be committed (why they're not in `.gitignore`), but I'm tired of `ripgrep` capturing these generated files.

Closes PACK-5227