### PR TITLE
chore: Remove unused `Map` support from `next/dynamic` transform

### DIFF
--- a/packages/next/src/build/babel/plugins/react-loadable-plugin.ts
+++ b/packages/next/src/build/babel/plugins/react-loadable-plugin.ts
@@ -19,9 +19,13 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWAR
 */
 // This file is https://github.com/jamiebuilds/react-loadable/blob/master/src/babel.js
-// Modified to also look for `next/dynamic`
-// Modified to put `webpack` and `modules` under `loadableGenerated` to be backwards compatible with next/dynamic which has a `modules` key
-// Modified to support `dynamic(import('something'))` and `dynamic(import('something'), options)
+// - Modified to also look for `next/dynamic`
+// - Modified to put `webpack` and `modules` under `loadableGenerated` to be
+//   backwards compatible with next/dynamic which has a `modules` key
+// - Modified to support `dynamic(import('something'))` and
+//   `dynamic(import('something'), options)
+// - Removed `Loadable.Map` support, `next/dynamic` uses overloaded arguments
+//   instead of a separate API
 
 import type {
   NodePath,
@@ -60,20 +64,6 @@ export default function ({
 
         binding.referencePaths.forEach((refPath) => {
           let callExpression = refPath.parentPath
-
-          if (
-            callExpression?.isMemberExpression() &&
-            callExpression.node.computed === false
-          ) {
-            const property = callExpression.get('property')
-            if (
-              !Array.isArray(property) &&
-              property.isIdentifier({ name: 'Map' })
-            ) {
-              callExpression = callExpression.parentPath
-            }
-          }
-
           if (!callExpression?.isCallExpression()) return
 
           let args = callExpression.get('arguments')


### PR DESCRIPTION
Noticed while skimming over this code.

It looks like `react-loadable` had a separate `Loadable.Map` API (https://github.com/jamiebuilds/react-loadable/tree/master?tab=readme-ov-file#loading-multiple-resources), but `next/dynamic` doesn't, so we shouldn't check for this.

The SWC version of this transform doesn't appear to have copied this code, and doesn't have the `Map` logic.

Closes PACK-5241