### PR TITLE
chore: sort and dedupe cSpell.words

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -78,14 +78,13 @@
     "RUST_BACKTRACE": "0"
   },
   "cSpell.words": [
-    "codemod",
-    "codemods",
-    "Destructuring",
     "buildtime",
     "callsites",
     "codemod",
+    "codemods",
     "datastream",
     "deduped",
+    "Destructuring",
     "draftmode",
     "Entrypoints",
     "jscodeshift",


### PR DESCRIPTION
Alphabetize and deduplicate `cSpell.words` in `.vscode/settings.json` (removes duplicate `codemod`).