### PR TITLE
Turbopack: don't match `..` for `**`

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -27,6 +27,10 @@ pub struct Glob {
     regex: Regex,
     #[turbo_tasks(trace_ignore)]
     directory_match_regex: Regex,
+
+    // TODO We don't want `../foo` to match against regexes starting with `**`. This is not a very
+    // elegant solution, but it works for now.
+    contains_recursive_prefix: bool,
 }
 impl PartialEq for Glob {
     fn eq(&self, other: &Self) -> bool {
@@ -56,12 +60,18 @@ impl TryFrom<GlobForm> for Glob {
 impl Glob {
     // Returns true if the glob matches the given path.
     pub fn matches(&self, path: &str) -> bool {
+        if self.contains_recursive_prefix && (path == ".." || path.starts_with("../")) {
+            return false;
+        }
         self.regex.is_match(path.as_bytes())
     }
 
     // Returns true if the glob might match a filename underneath this `path` where the
     // path represents a directory.
     pub fn can_match_in_directory(&self, path: &str) -> bool {
+        if self.contains_recursive_prefix && (path == ".." || path.starts_with("../")) {
+            return false;
+        }
         debug_assert!(
             !path.ends_with('/'),
             "Path should be a directory name and not end with /"
@@ -70,7 +80,7 @@ impl Glob {
     }
 
     pub fn parse(input: &str) -> Result<Glob> {
-        let (glob_re, directory_match_re) = parse(input)?;
+        let (glob_re, directory_match_re, contains_recursive_prefix) = parse(input)?;
         let regex = new_regex(glob_re.as_str());
         let directory_match_regex = new_regex(directory_match_re.as_str());
 
@@ -78,6 +88,7 @@ impl Glob {
             glob: input.to_string(),
             regex,
             directory_match_regex,
+            contains_recursive_prefix,
         })
     }
 }
@@ -210,6 +221,7 @@ mod tests {
         "**/next/dist/esm/*.shared-runtime.js",
         "next/dist/shared/lib/app-router-context.shared-runtime.js"
     )]
+    #[case::star_parent("**/*.js", "../foo.js")]
     fn glob_not_matching(#[case] glob: &str, #[case] path: &str) {
         let glob = Glob::parse(glob).unwrap();
 
@@ -239,6 +251,10 @@ mod tests {
     #[rstest]
     #[case::dir_and_file_partial("dir/file.js", "dir/file.js")] // even if there was a dir, named `file.js` we know the glob wasn't intended to match it.
     #[case::alternatives_chars("[abc]", "b")]
+    #[case::outside("..dir/file.js", "..")]
+    #[case::star_parent("**", "..")]
+    #[case::star_parent("**/*.js", "..")]
+    #[case::star_parent("{**/*.js,**/*.ts}", "..")]
     fn glob_not_can_match_directory(#[case] glob: &str, #[case] path: &str) {
         let glob = Glob::parse(glob).unwrap();
 

--- a/turbopack/crates/turbo-tasks-fs/src/globset.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/globset.rs
@@ -340,9 +340,13 @@ impl ErrorKind {
 // The directory match regex is guaranteed to be valid and will match the same
 // semantics as the glob when used to check if a directory path might contain files that match
 // this glob. This means we care about matching prefixes that are bounded by `/` characters.
-pub(crate) fn parse(glob: &str) -> Result<(String, String), Error> {
-    let tokens = Parser::new(glob).parse()?;
-    Ok((tokens.to_regex(), tokens.to_directory_match_regex()))
+pub(crate) fn parse(glob: &str) -> Result<(String, String, bool), Error> {
+    let (tokens, contains_recursive_prefix) = Parser::new(glob).parse()?;
+    Ok((
+        tokens.to_regex(),
+        tokens.to_directory_match_regex(),
+        contains_recursive_prefix,
+    ))
 }
 
 struct Parser<'a> {
@@ -357,6 +361,8 @@ struct Parser<'a> {
     char_pos: usize,
     prev: Option<char>,
     cur: Option<char>,
+
+    contains_recursive_prefix: bool,
 }
 fn is_separator(c: char) -> bool {
     c == '/'
@@ -371,6 +377,7 @@ impl<'a> Parser<'a> {
             char_pos: 0,
             prev: None,
             cur: None,
+            contains_recursive_prefix: false,
         }
     }
     fn error(&self, kind: ErrorKind) -> Error {
@@ -379,7 +386,7 @@ impl<'a> Parser<'a> {
     }
 
     // Parsing consumes the parser
-    fn parse(mut self) -> Result<Tokens, Error> {
+    fn parse(mut self) -> Result<(Tokens, bool), Error> {
         while let Some(c) = self.bump() {
             match c {
                 '?' => self.push_token(Token::Any),
@@ -396,7 +403,7 @@ impl<'a> Parser<'a> {
             return Err(self.error(ErrorKind::UnclosedAlternates));
         }
         debug_assert!(self.branches.len() == 1);
-        return Ok(self.branches.pop().unwrap());
+        return Ok((self.branches.pop().unwrap(), self.contains_recursive_prefix));
     }
 
     fn push_alternate(&mut self) {
@@ -466,6 +473,7 @@ impl<'a> Parser<'a> {
                 self.push_token(Token::ZeroOrMore);
             } else {
                 // this is just `**/....`
+                self.contains_recursive_prefix = true;
                 self.push_token(Token::RecursivePrefix);
                 assert!(self.bump().is_none_or(is_separator));
             }
@@ -644,7 +652,7 @@ mod tests {
         #[case] glob_regex: &str,
         #[case] directory_match_regex: &str,
     ) {
-        let (glob_re, directory_match_re) = parse(glob).unwrap();
+        let (glob_re, directory_match_re, _) = parse(glob).unwrap();
         // All our regexes come with a fixed prefix and suffix, just assert and drop them
         fn strip_overhead(s: String) -> String {
             assert!(s.starts_with("(?-u)^"));


### PR DESCRIPTION
We don't want `../` to match `**/foo`, in particular for `can_match_in_directory`

This is not an ideal solution, but it unblocks us

The easiest solution would have been a negative lookahead to not match `..`, but our regex implementation doesn't support that.

Closes PACK-5231