### PR TITLE
Turbopack: fix postcss in RSC CSS

### DIFF
--- a/test/e2e/app-dir/css-modules-rsc-postcss/app/layout.tsx
+++ b/test/e2e/app-dir/css-modules-rsc-postcss/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/css-modules-rsc-postcss/app/page.module.css
+++ b/test/e2e/app-dir/css-modules-rsc-postcss/app/page.module.css
@@ -1,0 +1,5 @@
+:not(html) {
+  .main {
+    color: red;
+  }
+}

--- a/test/e2e/app-dir/css-modules-rsc-postcss/app/page.tsx
+++ b/test/e2e/app-dir/css-modules-rsc-postcss/app/page.tsx
@@ -1,0 +1,5 @@
+import styles from './page.module.css'
+
+export default function Page() {
+  return <p className={styles.main}>hello world</p>
+}

--- a/test/e2e/app-dir/css-modules-rsc-postcss/css-modules-rsc-postcss.test.ts
+++ b/test/e2e/app-dir/css-modules-rsc-postcss/css-modules-rsc-postcss.test.ts
@@ -1,0 +1,17 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('css-modules-rsc-postcss', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    dependencies: {
+      'postcss-nested': '4.2.1',
+    },
+  })
+
+  it('should compile successfully and apply the correct styles', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').getComputedCss('color')).toBe(
+      'rgb(0, 128, 0)'
+    )
+  })
+})

--- a/test/e2e/app-dir/css-modules-rsc-postcss/next.config.js
+++ b/test/e2e/app-dir/css-modules-rsc-postcss/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/css-modules-rsc-postcss/plugin.js
+++ b/test/e2e/app-dir/css-modules-rsc-postcss/plugin.js
@@ -1,0 +1,12 @@
+const plugin = () => {
+  return {
+    postcssPlugin: 'color-change',
+    Declaration: {
+      color(prop) {
+        prop.value = 'green'
+      },
+    },
+  }
+}
+plugin.postcss = true
+module.exports = plugin

--- a/test/e2e/app-dir/css-modules-rsc-postcss/postcss.config.js
+++ b/test/e2e/app-dir/css-modules-rsc-postcss/postcss.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [require('postcss-nested'), require('./plugin')],
+}

--- a/test/e2e/app-dir/css-modules-rsc-postcss/postcss.config.js
+++ b/test/e2e/app-dir/css-modules-rsc-postcss/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: [require('postcss-nested'), require('./plugin')],
+  plugins: ['postcss-nested', require.resolve('./plugin')],
 }

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -162,15 +162,17 @@ impl ModuleOptions {
         // only then be processed with Webpack/PostCSS).
         //
         // Note that this is not an exhaustive condition for PostCSS/Webpack, but excludes certain
-        // cases, so it should be added conjunctively together with the `module_css_condition` rule.
+        // cases, so it should be added conjunctively together with CSS Module rule.
         //
         // If module css, then only when (Inner or Analyze or Compose)
         // <=> (not (module css)) or (Inner or Analyzer or Compose)
-        let module_css_external_transform_conditions = vec![
+        //
+        // So only if this is not a CSS module, or one of the special reference type constraints.
+        let module_css_external_transform_conditions = RuleCondition::Any(vec![
+            RuleCondition::not(module_css_condition.clone()),
             RuleCondition::ReferenceType(ReferenceType::Css(CssReferenceSubType::Inner)),
             RuleCondition::ReferenceType(ReferenceType::Css(CssReferenceSubType::Analyze)),
-            RuleCondition::ReferenceType(ReferenceType::Css(CssReferenceSubType::Compose)),
-        ];
+        ]);
 
         let mut ts_preprocess = vec![];
         let mut ecma_preprocess = vec![];
@@ -505,19 +507,14 @@ impl ModuleOptions {
                 };
 
                 rules.push(ModuleRule::new(
-                    RuleCondition::Any(vec![
-                        RuleCondition::All(vec![
-                            RuleCondition::Any(vec![
-                                RuleCondition::ResourcePathEndsWith(".css".to_string()),
-                                RuleCondition::ContentTypeStartsWith("text/css".to_string()),
-                            ]),
-                            RuleCondition::not(module_css_condition.clone()),
-                        ]),
-                        RuleCondition::All(vec![
+                    RuleCondition::All(vec![
+                        RuleCondition::Any(vec![
+                            // Both CSS and CSS Modules
+                            RuleCondition::ResourcePathEndsWith(".css".to_string()),
+                            RuleCondition::ContentTypeStartsWith("text/css".to_string()),
                             module_css_condition.clone(),
-                            // see comment on module_css_external_transform_conditions
-                            RuleCondition::Any(module_css_external_transform_conditions.clone()),
                         ]),
+                        module_css_external_transform_conditions.clone(),
                     ]),
                     vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
                         ResolvedVc::upcast(
@@ -700,14 +697,7 @@ impl ModuleOptions {
                             RuleCondition::ResourceBasePathGlob(Glob::new(key.clone()).await?)
                         },
                         RuleCondition::not(RuleCondition::ResourceIsVirtualSource),
-                        // see comment on module_css_external_transform_conditions
-                        RuleCondition::Any(
-                            [
-                                vec![RuleCondition::not(module_css_condition.clone())],
-                                module_css_external_transform_conditions.clone(),
-                            ]
-                            .concat(),
-                        ),
+                        module_css_external_transform_conditions.clone(),
                     ]),
                     vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
                         ResolvedVc::upcast(

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -513,14 +513,11 @@ impl ModuleOptions {
                             ]),
                             RuleCondition::not(module_css_condition.clone()),
                         ]),
-                        RuleCondition::All(
-                            [
-                                vec![module_css_condition.clone()],
-                                // see comment on module_css_external_transform_conditions
-                                module_css_external_transform_conditions.clone(),
-                            ]
-                            .concat(),
-                        ),
+                        RuleCondition::All(vec![
+                            module_css_condition.clone(),
+                            // see comment on module_css_external_transform_conditions
+                            RuleCondition::Any(module_css_external_transform_conditions.clone()),
+                        ]),
                     ]),
                     vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
                         ResolvedVc::upcast(


### PR DESCRIPTION
### What?

make sure to apply PostCSS on .module.css that is requested from RSC.

Fixes a regression from #82448

Closes #82545

Closes PACK-5232