### PR TITLE
[Cache Components] Disallow sync access of cookies & headers at runtime

### DIFF
--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -121,9 +121,13 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
         case 'prerender-runtime':
           return delayUntilRuntimeStage(
             workUnitStore,
-            makeUntrackedExoticCookies(workUnitStore.cookies)
+            makeUntrackedCookies(workUnitStore.cookies)
           )
         case 'private-cache':
+          if (process.env.__NEXT_CACHE_COMPONENTS) {
+            return makeUntrackedCookies(workUnitStore.cookies)
+          }
+
           return makeUntrackedExoticCookies(workUnitStore.cookies)
         case 'request':
           trackDynamicDataInDynamicRender(workUnitStore)
@@ -155,6 +159,10 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
               workStore?.route
             )
           } else {
+            if (process.env.__NEXT_CACHE_COMPONENTS) {
+              return makeUntrackedCookies(underlyingCookies)
+            }
+
             return makeUntrackedExoticCookies(underlyingCookies)
           }
         default:
@@ -192,6 +200,20 @@ function makeHangingCookies(
     '`cookies()`'
   )
   CachedCookies.set(prerenderStore, promise)
+
+  return promise
+}
+
+function makeUntrackedCookies(
+  underlyingCookies: ReadonlyRequestCookies
+): Promise<ReadonlyRequestCookies> {
+  const cachedCookies = CachedCookies.get(underlyingCookies)
+  if (cachedCookies) {
+    return cachedCookies
+  }
+
+  const promise = Promise.resolve(underlyingCookies)
+  CachedCookies.set(underlyingCookies, promise)
 
   return promise
 }

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -169,6 +169,10 @@ export function headers(): Promise<ReadonlyHeaders> {
               workStore?.route
             )
           } else {
+            if (process.env.__NEXT_CACHE_COMPONENTS) {
+              return makeUntrackedHeaders(workUnitStore.headers)
+            }
+
             return makeUntrackedExoticHeaders(workUnitStore.headers)
           }
           break
@@ -200,6 +204,20 @@ function makeHangingHeaders(
     '`headers()`'
   )
   CachedHeaders.set(prerenderStore, promise)
+
+  return promise
+}
+
+function makeUntrackedHeaders(
+  underlyingHeaders: ReadonlyHeaders
+): Promise<ReadonlyHeaders> {
+  const cachedHeaders = CachedHeaders.get(underlyingHeaders)
+  if (cachedHeaders) {
+    return cachedHeaders
+  }
+
+  const promise = Promise.resolve(underlyingHeaders)
+  CachedHeaders.set(underlyingHeaders, promise)
 
   return promise
 }

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -1118,60 +1118,60 @@ describe('Cache Components Errors', () => {
 
             if (isTurbopack) {
               await expect(browser).toDisplayRedbox(`
-                            [
-                              {
-                                "description": "Route "/sync-cookies" used \`cookies().get\`. \`cookies()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
-                                "environmentLabel": "Prerender",
-                                "label": "Console Error",
-                                "source": "app/sync-cookies/page.tsx (17:26) @ CookiesReadingComponent
-                            > 17 |   const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
-                                 |                          ^",
-                                "stack": [
-                                  "CookiesReadingComponent app/sync-cookies/page.tsx (17:26)",
-                                  "Page app/sync-cookies/page.tsx (11:7)",
-                                ],
-                              },
-                              {
-                                "description": "(0 , <turbopack-module-id>.cookies)(...).get is not a function",
-                                "environmentLabel": "Prerender",
-                                "label": "Runtime TypeError",
-                                "source": "app/sync-cookies/page.tsx (17:67) @ CookiesReadingComponent
-                            > 17 |   const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
-                                 |                                                                   ^",
-                                "stack": [
-                                  "CookiesReadingComponent app/sync-cookies/page.tsx (17:67)",
-                                ],
-                              },
-                            ]
-                          `)
+               [
+                 {
+                   "description": "Route "/sync-cookies" used \`cookies().get\`. \`cookies()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+                   "environmentLabel": "Prerender",
+                   "label": "Console Error",
+                   "source": "app/sync-cookies/page.tsx (17:25) @ CookiesReadingComponent
+               > 17 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+                    |                         ^",
+                   "stack": [
+                     "CookiesReadingComponent app/sync-cookies/page.tsx (17:25)",
+                     "Page app/sync-cookies/page.tsx (11:7)",
+                   ],
+                 },
+                 {
+                   "description": "(0 , <turbopack-module-id>.cookies)(...).get is not a function",
+                   "environmentLabel": "Prerender",
+                   "label": "Runtime TypeError",
+                   "source": "app/sync-cookies/page.tsx (17:66) @ CookiesReadingComponent
+               > 17 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+                    |                                                                  ^",
+                   "stack": [
+                     "CookiesReadingComponent app/sync-cookies/page.tsx (17:66)",
+                   ],
+                 },
+               ]
+              `)
             } else {
               await expect(browser).toDisplayRedbox(`
-                            [
-                              {
-                                "description": "Route "/sync-cookies" used \`cookies().get\`. \`cookies()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
-                                "environmentLabel": "Prerender",
-                                "label": "Console Error",
-                                "source": "app/sync-cookies/page.tsx (17:18) @ CookiesReadingComponent
-                            > 17 |   const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
-                                 |                  ^",
-                                "stack": [
-                                  "CookiesReadingComponent app/sync-cookies/page.tsx (17:18)",
-                                  "Page app/sync-cookies/page.tsx (11:7)",
-                                ],
-                              },
-                              {
-                                "description": "(0 , <webpack-module-id>.cookies)(...).get is not a function",
-                                "environmentLabel": "Prerender",
-                                "label": "Runtime TypeError",
-                                "source": "app/sync-cookies/page.tsx (17:67) @ CookiesReadingComponent
-                            > 17 |   const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
-                                 |                                                                   ^",
-                                "stack": [
-                                  "CookiesReadingComponent app/sync-cookies/page.tsx (17:67)",
-                                ],
-                              },
-                            ]
-                          `)
+               [
+                 {
+                   "description": "Route "/sync-cookies" used \`cookies().get\`. \`cookies()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+                   "environmentLabel": "Prerender",
+                   "label": "Console Error",
+                   "source": "app/sync-cookies/page.tsx (17:17) @ CookiesReadingComponent
+               > 17 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+                    |                 ^",
+                   "stack": [
+                     "CookiesReadingComponent app/sync-cookies/page.tsx (17:17)",
+                     "Page app/sync-cookies/page.tsx (11:7)",
+                   ],
+                 },
+                 {
+                   "description": "(0 , <webpack-module-id>.cookies)(...).get is not a function",
+                   "environmentLabel": "Prerender",
+                   "label": "Runtime TypeError",
+                   "source": "app/sync-cookies/page.tsx (17:66) @ CookiesReadingComponent
+               > 17 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+                    |                                                                  ^",
+                   "stack": [
+                     "CookiesReadingComponent app/sync-cookies/page.tsx (17:66)",
+                   ],
+                 },
+               ]
+              `)
             }
           })
         } else {
@@ -1192,15 +1192,15 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error occurred prerendering page "/sync-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
                  TypeError: <module-function>().get is not a function
-                     at CookiesReadingComponent (bundler:///app/sync-cookies/page.tsx:17:67)
+                     at CookiesReadingComponent (bundler:///app/sync-cookies/page.tsx:17:66)
                      at stringify (<anonymous>)
                    15 |
                    16 | async function CookiesReadingComponent() {
-                 > 17 |   const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
-                      |                                                                   ^
-                   18 |   return <div>this component reads the \`token\` cookie synchronously</div>
-                   19 | }
-                   20 | {
+                 > 17 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+                      |                                                                  ^
+                   18 |
+                   19 |   return (
+                   20 |     <div> {
                    digest: '<error-digest>'
                  }
 
@@ -1211,15 +1211,15 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error occurred prerendering page "/sync-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
                  TypeError: <module-function>().get is not a function
-                     at a (bundler:///app/sync-cookies/page.tsx:17:67)
+                     at a (bundler:///app/sync-cookies/page.tsx:17:66)
                      at b (<anonymous>)
                    15 |
                    16 | async function CookiesReadingComponent() {
-                 > 17 |   const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
-                      |                                                                   ^
-                   18 |   return <div>this component reads the \`token\` cookie synchronously</div>
-                   19 | }
-                   20 | {
+                 > 17 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+                      |                                                                  ^
+                   18 |
+                   19 |   return (
+                   20 |     <div> {
                    digest: '<error-digest>'
                  }
                  Export encountered an error on /sync-cookies/page: /sync-cookies, exiting the build."
@@ -1230,15 +1230,15 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error occurred prerendering page "/sync-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
                  TypeError: <module-function>().get is not a function
-                     at CookiesReadingComponent (bundler:///app/sync-cookies/page.tsx:17:67)
+                     at CookiesReadingComponent (bundler:///app/sync-cookies/page.tsx:17:66)
                      at stringify (<anonymous>)
                    15 |
                    16 | async function CookiesReadingComponent() {
-                 > 17 |   const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
-                      |                                                                   ^
-                   18 |   return <div>this component reads the \`token\` cookie synchronously</div>
-                   19 | }
-                   20 | {
+                 > 17 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+                      |                                                                  ^
+                   18 |
+                   19 |   return (
+                   20 |     <div> {
                    digest: '<error-digest>'
                  }
 

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -1,6 +1,9 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
-import { assertNoErrorToast } from 'next-test-utils'
-import { getPrerenderOutput } from './utils'
+import { assertNoErrorToast, retry } from 'next-test-utils'
+import {
+  convertModuleFunctionSequenceExpression,
+  getPrerenderOutput,
+} from './utils'
 
 const isRspack = process.env.NEXT_RSPACK !== undefined
 
@@ -1258,6 +1261,98 @@ describe('Cache Components Errors', () => {
         }
       })
 
+      describe('cookies at runtime', () => {
+        if (skipped) {
+          return
+        }
+
+        if (isNextDev) {
+          it('should show a redbox with a sync access error and a runtime error', async () => {
+            const browser = await next.browser('/sync-cookies-runtime')
+
+            if (isTurbopack) {
+              await expect(browser).toDisplayRedbox(`
+               [
+                 {
+                   "description": "Route "/sync-cookies-runtime" used \`cookies().get\`. \`cookies()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+                   "environmentLabel": "Prerender",
+                   "label": "Console Error",
+                   "source": "app/sync-cookies-runtime/page.tsx (24:25) @ CookiesReadingComponent
+               > 24 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+                    |                         ^",
+                   "stack": [
+                     "CookiesReadingComponent app/sync-cookies-runtime/page.tsx (24:25)",
+                     "Page app/sync-cookies-runtime/page.tsx (14:9)",
+                   ],
+                 },
+                 {
+                   "description": "(0 , <turbopack-module-id>.cookies)(...).get is not a function",
+                   "environmentLabel": "Prerender",
+                   "label": "Runtime TypeError",
+                   "source": "app/sync-cookies-runtime/page.tsx (24:66) @ CookiesReadingComponent
+               > 24 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+                    |                                                                  ^",
+                   "stack": [
+                     "CookiesReadingComponent app/sync-cookies-runtime/page.tsx (24:66)",
+                   ],
+                 },
+               ]
+              `)
+            } else {
+              await expect(browser).toDisplayRedbox(`
+               [
+                 {
+                   "description": "Route "/sync-cookies-runtime" used \`cookies().get\`. \`cookies()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+                   "environmentLabel": "Prerender",
+                   "label": "Console Error",
+                   "source": "app/sync-cookies-runtime/page.tsx (24:17) @ CookiesReadingComponent
+               > 24 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+                    |                 ^",
+                   "stack": [
+                     "CookiesReadingComponent app/sync-cookies-runtime/page.tsx (24:17)",
+                     "Page app/sync-cookies-runtime/page.tsx (14:9)",
+                   ],
+                 },
+                 {
+                   "description": "(0 , <webpack-module-id>.cookies)(...).get is not a function",
+                   "environmentLabel": "Prerender",
+                   "label": "Runtime TypeError",
+                   "source": "app/sync-cookies-runtime/page.tsx (24:66) @ CookiesReadingComponent
+               > 24 |   const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+                    |                                                                  ^",
+                   "stack": [
+                     "CookiesReadingComponent app/sync-cookies-runtime/page.tsx (24:66)",
+                   ],
+                 },
+               ]
+              `)
+            }
+          })
+        } else {
+          it('should not error the build, but fail at runtime', async () => {
+            try {
+              await prerender('/sync-cookies-runtime')
+            } catch (error) {
+              throw new Error('expected build not to fail', { cause: error })
+            }
+
+            expect(next.cliOutput).toContain('◐ /sync-cookies-runtime')
+            await next.start({ skipBuild: true })
+            cliOutputLength = next.cliOutput.length
+            await next.fetch('/sync-cookies-runtime')
+
+            await retry(() => {
+              const output = convertModuleFunctionSequenceExpression(
+                next.cliOutput.slice(cliOutputLength)
+              )
+              expect(output).toInclude(
+                'TypeError: <module-function>().get is not a function'
+              )
+            })
+          })
+        }
+      })
+
       describe('draftMode', () => {
         const pathname = '/sync-draft-mode'
 
@@ -1479,6 +1574,99 @@ describe('Cache Components Errors', () => {
                 `)
               }
             }
+          })
+        }
+      })
+
+      describe('headers at runtime', () => {
+        if (skipped) {
+          return
+        }
+
+        if (isNextDev) {
+          it('should show a redbox with a sync access error and a runtime error', async () => {
+            const browser = await next.browser('/sync-headers-runtime')
+
+            if (isTurbopack) {
+              await expect(browser).toDisplayRedbox(`
+               [
+                 {
+                   "description": "Route "/sync-headers-runtime" used \`headers().get\`. \`headers()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+                   "environmentLabel": "Prerender",
+                   "label": "Console Error",
+                   "source": "app/sync-headers-runtime/page.tsx (24:29) @ HeadersReadingComponent
+               > 24 |   const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
+                    |                             ^",
+                   "stack": [
+                     "HeadersReadingComponent app/sync-headers-runtime/page.tsx (24:29)",
+                     "Page app/sync-headers-runtime/page.tsx (14:9)",
+                   ],
+                 },
+                 {
+                   "description": "(0 , <turbopack-module-id>.headers)(...).get is not a function",
+                   "environmentLabel": "Prerender",
+                   "label": "Runtime TypeError",
+                   "source": "app/sync-headers-runtime/page.tsx (24:70) @ HeadersReadingComponent
+               > 24 |   const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
+                    |                                                                      ^",
+                   "stack": [
+                     "HeadersReadingComponent app/sync-headers-runtime/page.tsx (24:70)",
+                   ],
+                 },
+               ]
+              `)
+            } else {
+              await expect(browser).toDisplayRedbox(`
+               [
+                 {
+                   "description": "Route "/sync-headers-runtime" used \`headers().get\`. \`headers()\` should be awaited before using its value. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
+                   "environmentLabel": "Prerender",
+                   "label": "Console Error",
+                   "source": "app/sync-headers-runtime/page.tsx (24:21) @ HeadersReadingComponent
+               > 24 |   const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
+                    |                     ^",
+                   "stack": [
+                     "HeadersReadingComponent app/sync-headers-runtime/page.tsx (24:21)",
+                     "Page app/sync-headers-runtime/page.tsx (14:9)",
+                   ],
+                 },
+                 {
+                   "description": "(0 , <webpack-module-id>.headers)(...).get is not a function",
+                   "environmentLabel": "Prerender",
+                   "label": "Runtime TypeError",
+                   "source": "app/sync-headers-runtime/page.tsx (24:70) @ HeadersReadingComponent
+               > 24 |   const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
+                    |                                                                      ^",
+                   "stack": [
+                     "HeadersReadingComponent app/sync-headers-runtime/page.tsx (24:70)",
+                   ],
+                 },
+               ]
+              `)
+            }
+          })
+        } else {
+          it('should not error the build, but fail at runtime', async () => {
+            try {
+              await prerender('/sync-headers-runtime')
+            } catch (error) {
+              throw new Error('expected build not to fail', { cause: error })
+            }
+
+            expect(next.cliOutput).toContain('◐ /sync-headers-runtime')
+            await next.start({ skipBuild: true })
+            cliOutputLength = next.cliOutput.length
+            await next.fetch('/sync-headers-runtime')
+
+            await retry(() => {
+              const output = convertModuleFunctionSequenceExpression(
+                next.cliOutput.slice(cliOutputLength)
+              )
+
+              expect(output).toInclude(
+                'TypeError: <module-function>().get is not a function'
+              )
+            })
           })
         }
       })

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/sync-cookies-runtime/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/sync-cookies-runtime/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/sync-cookies-runtime/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/sync-cookies-runtime/page.tsx
@@ -1,0 +1,31 @@
+import { cookies, type UnsafeUnwrappedCookies } from 'next/headers'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page accesses cookies synchronously at runtime. This triggers a
+        type error. In dev mode, we also log an explicit error that `cookies()`
+        should be awaited.
+      </p>
+      <Suspense>
+        <CookiesReadingComponent />
+      </Suspense>
+    </>
+  )
+}
+
+async function CookiesReadingComponent() {
+  // Await a connection to test the subsequent sync cookies access at runtime.
+  await connection()
+
+  const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+
+  return (
+    <div>
+      this component reads the `token` cookie synchronously: {token?.value}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/sync-cookies/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/sync-cookies/page.tsx
@@ -14,6 +14,11 @@ export default async function Page() {
 }
 
 async function CookiesReadingComponent() {
-  const _token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
-  return <div>this component reads the `token` cookie synchronously</div>
+  const token = (cookies() as unknown as UnsafeUnwrappedCookies).get('token')
+
+  return (
+    <div>
+      this component reads the `token` cookie synchronously: {token?.value}
+    </div>
+  )
 }

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/sync-headers-runtime/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/sync-headers-runtime/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/sync-headers-runtime/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/sync-headers-runtime/page.tsx
@@ -1,0 +1,32 @@
+import { headers, type UnsafeUnwrappedHeaders } from 'next/headers'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export default async function Page() {
+  return (
+    <>
+      <p>
+        This page accesses headers synchronously at runtime. This triggers a
+        type error. In dev mode, we also log an explicit error that `headers()`
+        should be awaited.
+      </p>
+      <Suspense>
+        <HeadersReadingComponent />
+      </Suspense>
+    </>
+  )
+}
+
+async function HeadersReadingComponent() {
+  // Await a connection to test the subsequent sync headers access at runtime.
+  await connection()
+
+  const userAgent = (headers() as unknown as UnsafeUnwrappedHeaders).get(
+    'user-agent'
+  )
+  return (
+    <div>
+      this component reads the `user-agent` header synchronously: {userAgent}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/utils.ts
+++ b/test/e2e/app-dir/cache-components-errors/utils.ts
@@ -3,6 +3,20 @@ const abc = 'abcdefghijklmnopqrstuvwxyz'
 const hostElementsUsedInFixtures = ['html', 'body', 'main', 'div']
 const ignoredLines = ['Generating static pages', 'Inlining static env']
 
+/**
+ * Converts a module function sequence expression, e.g.:
+ * - (0 , __TURBOPACK__imported__module__1836__.cookies)(...)
+ * - (0 , c.cookies)(...)
+ * - (0 , cookies.U)(...)
+ * - (0 , e.U)(...)
+ * to a deterministic, bundler-agnostic representation.
+ */
+export function convertModuleFunctionSequenceExpression(
+  output: string
+): string {
+  return output.replace(/\(0 , \w+\.(\w+)\)\(\.\.\.\)/, '<module-function>()')
+}
+
 export function getPrerenderOutput(
   cliOutput: string,
   { isMinified }: { isMinified: boolean }
@@ -61,17 +75,11 @@ export function getPrerenderOutput(
         )
         .replace(/at \d+ \(/, replaceNumericModuleId)
         .replace(/digest: '\d+'/, "digest: '<error-digest>'")
-        // Convert a module function sequence expression, e.g.:
-        // - (0 , __TURBOPACK__imported__module__1836__.cookies)(...)
-        // - (0 , c.cookies)(...)
-        // - (0 , cookies.U)(...)
-        // - (0 , e.U)(...)
-        .replace(/\(0 , \w+\.(\w+)\)\(\.\.\.\)/, '<module-function>()')
         // TODO(veil): Bundler protocols should not appear in stack frames.
         .replace('webpack:///', 'bundler:///')
         .replace('turbopack:///[project]/', 'bundler:///')
 
-      lines.push(line)
+      lines.push(convertModuleFunctionSequenceExpression(line))
     }
   }
 


### PR DESCRIPTION
In #81162 we removed the support for accessing request data synchronously when `experimental.cacheComponents` is enabled. However, we missed updating the `cookies()` and `headers()` promises that are created at runtime to not be "exotic" promises, i.e. promises that also have the cookies/headers methods defined on them. Those two cases are now updated as well with this PR. (Params, search params, and draft mode were already handled correctly in the original PR.)

In the next major version we'll remove the support for the legacy synchronous access independent of the `cacheComponents` flag.