### PR TITLE
Turbopack: fix module rules for `.module.scss`

### DIFF
--- a/test/e2e/app-dir/css-modules-rsc-postcss/app/other.module.scss
+++ b/test/e2e/app-dir/css-modules-rsc-postcss/app/other.module.scss
@@ -1,0 +1,4 @@
+.other {
+  // some SCSS
+  color: red;
+}

--- a/test/e2e/app-dir/css-modules-rsc-postcss/app/page.tsx
+++ b/test/e2e/app-dir/css-modules-rsc-postcss/app/page.tsx
@@ -1,5 +1,11 @@
 import styles from './page.module.css'
+import other from './other.module.scss'
 
 export default function Page() {
-  return <p className={styles.main}>hello world</p>
+  return (
+    <div>
+      <p className={styles.main}>hello world</p>
+      <span className={other.other}>hello world</span>
+    </div>
+  )
 }

--- a/test/e2e/app-dir/css-modules-rsc-postcss/css-modules-rsc-postcss.test.ts
+++ b/test/e2e/app-dir/css-modules-rsc-postcss/css-modules-rsc-postcss.test.ts
@@ -13,5 +13,8 @@ describe('css-modules-rsc-postcss', () => {
     expect(await browser.elementByCss('p').getComputedCss('color')).toBe(
       'rgb(0, 128, 0)'
     )
+    expect(await browser.elementByCss('span').getComputedCss('color')).toBe(
+      'rgb(0, 128, 0)'
+    )
   })
 })

--- a/test/e2e/app-dir/css-modules-rsc-postcss/css-modules-rsc-postcss.test.ts
+++ b/test/e2e/app-dir/css-modules-rsc-postcss/css-modules-rsc-postcss.test.ts
@@ -5,6 +5,7 @@ describe('css-modules-rsc-postcss', () => {
     files: __dirname,
     dependencies: {
       'postcss-nested': '4.2.1',
+      sass: 'latest',
     },
   })
 

--- a/test/e2e/app-dir/css-order/app/base-scss.module.scss
+++ b/test/e2e/app-dir/css-order/app/base-scss.module.scss
@@ -1,3 +1,4 @@
+// this is scss
 $base1: rgb(255, 1, 0);
 
 .base {

--- a/test/e2e/app-dir/css-order/app/base2-scss.module.scss
+++ b/test/e2e/app-dir/css-order/app/base2-scss.module.scss
@@ -1,3 +1,4 @@
+// this is scss
 .base {
   color: rgb(255, 3, 0);
 }


### PR DESCRIPTION
It ran `postcss(webpack(postcss(filesource)))`, which doesn't work.

And changing the order does make sense, since we do want Webpack (SCSS) to run first, and only then PostCSS?

#82554 didn't catch every case

Closes PACK-5236