### PR TITLE
fix: amp deprecation warning should assert on user config

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -161,6 +161,26 @@ function assignDefaults(
     delete userConfig.exportTrailingSlash
   }
 
+  // There are a good amount of test fixtures that have amp enabled
+  // that also assert on stderr output being empty, so we're gating the
+  // warning to be skipped when running in Next.js tests until we fully
+  // remove the feature.
+  if (!process.env.__NEXT_TEST_MODE) {
+    warnOptionHasBeenDeprecated(
+      userConfig,
+      'amp',
+      `Built-in amp support is deprecated and the \`amp\` configuration option will be removed in Next.js 16.`,
+      silent
+    )
+
+    warnOptionHasBeenDeprecated(
+      userConfig,
+      'experimental.amp',
+      `Built-in amp support is deprecated and the \`experimental.amp\` configuration option will be removed in Next.js 16.`,
+      silent
+    )
+  }
+
   // Handle deprecation of experimental.dynamicIO and migrate to experimental.cacheComponents
   if (userConfig.experimental?.dynamicIO !== undefined) {
     warnOptionHasBeenDeprecated(
@@ -501,26 +521,6 @@ function assignDefaults(
       }
       images.loaderFile = absolutePath
     }
-  }
-
-  // There are a good amount of test fixtures that have amp enabled
-  // that also assert on stderr output being empty, so we're gating the
-  // warning to be skipped when running in Next.js tests until we fully
-  // remove the feature.
-  if (!process.env.__NEXT_TEST_MODE) {
-    warnOptionHasBeenDeprecated(
-      result,
-      'amp',
-      `Built-in amp support is deprecated and the \`amp\` configuration option will be removed in Next.js 16.`,
-      silent
-    )
-
-    warnOptionHasBeenDeprecated(
-      result,
-      'experimental.amp',
-      `Built-in amp support is deprecated and the \`experimental.amp\` configuration option will be removed in Next.js 16.`,
-      silent
-    )
   }
 
   warnCustomizedOption(

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -114,6 +114,10 @@ export type ResponseLimit = SizeLimit | boolean
  * `Config` type, use it for export const config
  */
 export type PageConfig = {
+  /**
+   * @deprecated built-in amp support will be removed in Next 16
+   * @see [`next/amp`](https://nextjs.org/docs/api-reference/next/amp)
+   */
   amp?: boolean | 'hybrid'
   api?: {
     /**


### PR DESCRIPTION
- The deprecation warning should only be logged when the apps have `amp` defined in `next.config.js`, not always logging it. Follow up of #82551

- Add deprecation as well for public type `PageConfig` from `next`