### PR TITLE
[Deprecation Warnings]: add unstable_rootParams deprecation warning

### DIFF
--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -21,11 +21,18 @@ import {
   wellKnownProperties,
 } from '../../shared/lib/utils/reflect-utils'
 import { actionAsyncStorage } from '../app-render/action-async-storage.external'
+import { warnOnce } from '../../build/output/log'
 
 interface CacheLifetime {}
 const CachedParams = new WeakMap<CacheLifetime, Promise<Params>>()
 
+/**
+ * @deprecated import specific root params from `next/root-params` instead.
+ */
 export async function unstable_rootParams(): Promise<Params> {
+  warnOnce(
+    '`unstable_rootParams()` is deprecated and will be removed in an upcoming major release. Import specific root params from `next/root-params` instead.'
+  )
   const workStore = workAsyncStorage.getStore()
   if (!workStore) {
     throw new InvariantError('Missing workStore in unstable_rootParams')


### PR DESCRIPTION
`unstable_rootParams()` is deprecated in favor of importing specific params from `next/root-params`. This also requires enabling the experimental feature in nextConfig via `experimental.rootParams`. 