### PR TITLE
[Segment Cache] Optimistic prefetch for search params

### DIFF
--- a/packages/next/src/client/components/segment-cache-impl/navigation.ts
+++ b/packages/next/src/client/components/segment-cache-impl/navigation.ts
@@ -21,6 +21,7 @@ import {
   readRouteCacheEntry,
   readSegmentCacheEntry,
   waitForSegmentCacheEntry,
+  requestOptimisticRouteCacheEntry,
   type RouteTree,
   type FulfilledRouteCacheEntry,
 } from './cache'
@@ -136,6 +137,39 @@ export function navigate(
       url.hash
     )
   }
+
+  // There was no matching route tree in the cache. Let's see if we can
+  // construct an "optimistic" route tree.
+  const optimisticRoute = requestOptimisticRouteCacheEntry(now, url, nextUrl)
+  if (optimisticRoute !== null) {
+    // We have an optimistic route tree. Proceed with the normal flow.
+    const snapshot = readRenderSnapshotFromCache(
+      now,
+      optimisticRoute,
+      optimisticRoute.tree
+    )
+    const prefetchFlightRouterState = snapshot.flightRouterState
+    const prefetchSeedData = snapshot.seedData
+    const prefetchHead = optimisticRoute.head
+    const isPrefetchHeadPartial = optimisticRoute.isHeadPartial
+    const newCanonicalUrl = optimisticRoute.canonicalUrl
+    return navigateUsingPrefetchedRouteTree(
+      now,
+      url,
+      nextUrl,
+      isSamePageNavigation,
+      currentCacheNode,
+      currentFlightRouterState,
+      prefetchFlightRouterState,
+      prefetchSeedData,
+      prefetchHead,
+      isPrefetchHeadPartial,
+      newCanonicalUrl,
+      shouldScroll,
+      url.hash
+    )
+  }
+
   // There's no matching prefetch for this route in the cache.
   return {
     tag: NavigationResultTag.Async,

--- a/test/e2e/app-dir/segment-cache/search-params/app/search-params-shared-loading-state/page.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/app/search-params-shared-loading-state/page.tsx
@@ -1,0 +1,25 @@
+import { LinkAccordion } from '../../components/link-accordion'
+
+export default function SearchParamsSharedLoadingStatePage() {
+  return (
+    <div>
+      <p>
+        This page tests whether a prefetched URL without search params can share
+        its loading state with a navigation to the same URL with search params.
+      </p>
+
+      <ul>
+        <li>
+          <LinkAccordion href="/search-params-shared-loading-state/target-page">
+            Prefetch target (no search params)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/search-params-shared-loading-state/target-page?param=test">
+            Prefetch target (with search params)
+          </LinkAccordion>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/search-params/app/search-params-shared-loading-state/target-page/client.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/app/search-params-shared-loading-state/target-page/client.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { useSearchParams } from 'next/navigation'
+
+export function SearchParamsDisplay() {
+  const searchParams = useSearchParams()
+  const param = searchParams.get('param')
+
+  return (
+    <div id="search-params-content">Search param value: {param || 'none'}</div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/search-params/app/search-params-shared-loading-state/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/app/search-params-shared-loading-state/target-page/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+import { SearchParamsDisplay } from './client'
+
+export default function TargetPage() {
+  return (
+    <div>
+      <h1>Target Page</h1>
+      <p id="static-content">Static content</p>
+      <Suspense
+        fallback={
+          <div id="search-params-loading">Loading search params...</div>
+        }
+      >
+        <SearchParamsDisplay />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params-shared-loading-state.test.ts
+++ b/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params-shared-loading-state.test.ts
@@ -1,0 +1,80 @@
+import { nextTestSetup } from 'e2e-utils'
+import { createRouterAct } from '../router-act'
+
+describe('segment cache (search params shared loading state)', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    test('prefetching is disabled', () => {})
+    return
+  }
+
+  it(
+    "if there's no matching prefetch entry for a page with particulular " +
+      'search params, optimistically reuse a prefetch entry with the same ' +
+      'pathname and different search params',
+    async () => {
+      let act: ReturnType<typeof createRouterAct>
+      const browser = await next.browser(
+        '/search-params-shared-loading-state',
+        {
+          beforePageLoad(page) {
+            act = createRouterAct(page)
+          },
+        }
+      )
+
+      // Reveal and prefetch the link without search params
+      const revealFirstLink = await browser.elementByCss(
+        'input[data-link-accordion="/search-params-shared-loading-state/target-page"]'
+      )
+      await act(
+        async () => {
+          await revealFirstLink.click()
+        },
+        {
+          includes: 'Static content',
+        }
+      )
+
+      // Reveal the second link (with search params) but block its prefetch.
+      await act(async () => {
+        // Block any prefetch requests when revealing the second link. We're
+        // going to test what happens if the navigation happens before the
+        // prefetch is fulfilled.
+        const revealSecondLink = await browser.elementByCss(
+          'input[data-link-accordion="/search-params-shared-loading-state/target-page?param=test"]'
+        )
+        await act(async () => {
+          await revealSecondLink.click()
+        }, 'block')
+
+        // Navigate to the target page.
+        const link = await browser.elementByCss(
+          'a[href="/search-params-shared-loading-state/target-page?param=test"]'
+        )
+        await act(
+          async () => {
+            await link.click()
+          },
+          // This should not make any additional requests, because the target
+          // page is fully static and there was already a cached prefetch to
+          // the same pathname. Even though the search params are different,
+          // we're able to reuse that response.
+          'no-requests'
+        )
+
+        // Verify the navigation completed successfully
+        const staticContent = await browser.elementById('static-content')
+        expect(await staticContent.text()).toBe('Static content')
+        const searchParamsContent = await browser.elementById(
+          'search-params-content'
+        )
+        expect(await searchParamsContent.text()).toBe(
+          'Search param value: test'
+        )
+      }, 'no-requests')
+    }
+  )
+})


### PR DESCRIPTION
When there is no matching route tree in the prefetch cache, before we de-opt to a blocking navigation, we will first attempt to construct an "optimistic" route tree by checking the cache for routes are likely to be similar to the one we're missing.

If there's a route with the same pathname, but with different search params, we can base our optimistic route on that entry.

Conceptually, we are simulating what would happen if we did perform a prefetch the requested URL, under the assumption that the server will not redirect or rewrite the request in a different manner than the base route tree. This assumption might not hold, in which case we'll have to recover when we perform the dynamic navigation request. However, this is what would happen if a route were dynamically rewritten/ redirected in between the prefetch and the navigation. So the logic needs to exist to handle this case regardless.

The implementation in this PR is a bit of an incremental step; it's not as general as it should be. Notably, it will bail out if the base route tree contains dynamic metadata, because we currently don't store the route tree separately from the metadata.

We are also currently special-casing prefetch entries with an empty search string. To take advantage of the optimistic prefetch behavior, there must be a prefetch entry for the target URL with no search params, e.g. to navigate to a page at `/target-page?search=foobar`, you must first prefetch `/target-page` (no search string). This is a somewhat arbitrary limitation chosen as a concession to implementation complexity; the empty search string is only used because it's the one that's most likely to already be cached. We will generalize this later to match any search string.

I've added some TODO comments to describe the work necessary to enable this mechanism in more cases.