### PR TITLE
[turbopack] Update Turbopack build warning message 

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3980,7 +3980,7 @@ export default async function build(
     await lockfilePatchPromise.cur
 
     if (isTurbopack && !process.env.__NEXT_TEST_MODE) {
-      warnAboutTurbopackBuilds(loadedConfig)
+      warnAboutTurbopackBuilds()
     }
 
     // Ensure all traces are flushed before finishing the command
@@ -4007,31 +4007,12 @@ function errorFromUnsupportedSegmentConfig(): never {
   process.exit(1)
 }
 
-function warnAboutTurbopackBuilds(config?: NextConfigComplete) {
-  let warningStr =
-    `Support for Turbopack builds is experimental. ` +
-    bold(
-      `We don't recommend deploying mission-critical applications to production.`
-    )
-  warningStr +=
-    '\n\n- ' +
-    bold(
-      'Turbopack currently always builds production source maps for the browser. This will include project source code if deployed to production.'
-    )
-  warningStr +=
-    '\n- It is expected that your bundle size might be different from `next build` with webpack. This will be improved as we work towards stability.'
-
-  if (!config?.experimental.turbopackPersistentCaching) {
-    warningStr +=
-      '\n- This build is without disk caching; subsequent builds will become faster when disk caching becomes available.'
-  }
-
-  warningStr +=
-    '\n- When comparing output to webpack builds, make sure to first clear the Next.js cache by deleting the `.next` directory.'
-  warningStr +=
-    '\n\nProvide feedback for Turbopack builds at https://github.com/vercel/next.js/discussions/77721'
-
-  Log.warn(warningStr)
+function warnAboutTurbopackBuilds() {
+  Log.ready(
+    `Turbopack builds are ${bold('beta')}.\n\n` +
+      '   Please see our docs https://nextjs.org/docs/app/api-reference/turbopack for information on known differences with webpack builds.\n\n' +
+      '   Provide feedback for Turbopack builds at https://github.com/vercel/next.js/discussions/77721'
+  )
 }
 
 function getBundlerForTelemetry(isTurbopack: boolean) {


### PR DESCRIPTION
Drop the scare text about not running turbopack in production.  Instead clarify that builds are beta and direct people to our documentation site.

For example:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/AwJ29EfoPcPdLSwCZxAz/a50ca03c-7065-4fc4-ad3a-2232e14984d3.png)

Compared to the old notice:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/AwJ29EfoPcPdLSwCZxAz/c802c577-39d6-4408-bd9e-144d3f9c23dd.png)

Notably

- mission critical applications are a good idea! just be careful with compatibility issues
- the source maps issues is fixed! no need to talk about it at all
- A discussion of bundle size issues and build caches is being added in #82560

Closes PACK-5237