### PR TITLE
[turbopack] Fix a crash under turbopackPersistentCaching

### DIFF
--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -794,8 +794,9 @@ impl TurboPersistence {
                 if compact_config.max_merge_segment_count == 0 {
                     return Vec::new();
                 }
-                let merge_jobs = get_merge_segments(ssts_with_ranges, &compact_config);
-                compact_config.max_merge_segment_count -= merge_jobs.len();
+                let (merge_jobs, real_merge_job_size) =
+                    get_merge_segments(ssts_with_ranges, &compact_config);
+                compact_config.max_merge_segment_count -= real_merge_job_size;
                 merge_jobs
             })
             .collect::<Vec<_>>();


### PR DESCRIPTION
Address a crash found at head when testing caching while switching back and forth from `dev` and `build`.  

```
thread '<unnamed>' panicked at turbopack/crates/turbo-persistence/src/db.rs:798:17:
attempt to subtract with overflow
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic_const::panic_const_sub_overflow
   3: <core::iter::adapters::map::Map<core::slice::iter::Iter<alloc::vec::Vec<<turbo_persistence::db::TurboPersistence>::compact_internal::SstWithRange>>, <turbo_persistence::db::TurboPersistence>::compact_internal::{closure#2}> as core::iter::traits::iterator::Iterator>::fold::<(), core::iter::traits::iterator::Iterator::for_each::call<alloc::vec::Vec<smallvec::SmallVec<[usize; 1]>>, <alloc::vec::Vec<alloc::vec::Vec<smallvec::SmallVec<[usize; 1]>>>>::extend_trusted<core::iter::adapters::map::Map<core::slice::iter::Iter<alloc::vec::Vec<<turbo_persistence::db::TurboPersistence>::compact_internal::SstWithRange>>, <turbo_persistence::db::TurboPersistence>::compact_internal::{closure#2}>>::{closure#0}>::{closure#0}>
   4: <alloc::vec::Vec<alloc::vec::Vec<smallvec::SmallVec<[usize; 1]>>> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<alloc::vec::Vec<smallvec::SmallVec<[usize; 1]>>, core::iter::adapters::map::Map<core::slice::iter::Iter<alloc::vec::Vec<<turbo_persistence::db::TurboPersistence>::compact_internal::SstWithRange>>, <turbo_persistence::db::TurboPersistence>::compact_internal::{closure#2}>>>::from_iter
   5: <turbo_persistence::db::TurboPersistence>::compact
```

Scenario:
 * build turbopack and next
 * cd bench/module-cost
 * enable persistent caching
 * pnpm i
 * pnpm dev-turbopack
 * load localhost:3000 and click all the buttons
 * pnpm build-turbopack
 * pnpm dev-turbopack
 * load localhost:3000 and see the crash

## What?

The `get_merge_segments` function and its caller had a different idea about what `max_merge_segment_count` means.  Unify how this is accounted to avoid underflow.



Closes PACK-5242