### PR TITLE
fix: should not warn depredated config if next config file does not exist

### DIFF
--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -194,7 +194,7 @@ describe('loadConfig', () => {
             dynamicIO: true,
           },
         },
-        silent: true,
+        silent: false,
       })
 
       expect(result.experimental.cacheComponents).toBe(true)
@@ -212,8 +212,9 @@ describe('loadConfig', () => {
             dynamicIO: true,
             cacheComponents: false,
           },
+          configFile: '/project/next.config.js',
         },
-        silent: true,
+        silent: false,
       })
 
       expect(result.experimental.cacheComponents).toBe(false)
@@ -232,6 +233,7 @@ describe('loadConfig', () => {
           experimental: {
             dynamicIO: true,
           },
+          configFile: '/project/next.config.js',
         },
         silent: false,
       })

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -194,7 +194,7 @@ describe('loadConfig', () => {
             dynamicIO: true,
           },
         },
-        silent: false,
+        silent: true,
       })
 
       expect(result.experimental.cacheComponents).toBe(true)
@@ -214,7 +214,7 @@ describe('loadConfig', () => {
           },
           configFile: '/project/next.config.js',
         },
-        silent: false,
+        silent: true,
       })
 
       expect(result.experimental.cacheComponents).toBe(false)

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -71,13 +71,13 @@ export function warnOptionHasBeenDeprecated(
   let hasWarned = false
   if (!silent) {
     let current = config
-    let found = false
+    let found = true
     const nestedPropertyKeys = nestedPropertyKey.split('.')
     for (const key of nestedPropertyKeys) {
       if (current[key] !== undefined) {
         current = current[key]
-        found = true
       } else {
+        found = false
         break
       }
     }
@@ -525,7 +525,7 @@ function assignDefaults(
   }
 
   warnCustomizedOption(
-    result,
+    userConfig,
     'experimental.esmExternals',
     true,
     'experimental.esmExternals is not recommended to be modified as it may disrupt module resolution',
@@ -534,35 +534,35 @@ function assignDefaults(
   )
 
   warnOptionHasBeenDeprecated(
-    result,
+    userConfig,
     'experimental.instrumentationHook',
     `\`experimental.instrumentationHook\` is no longer needed, because \`instrumentation.js\` is available by default. You can remove it from ${configFileName}.`,
     silent
   )
 
   warnOptionHasBeenDeprecated(
-    result,
+    userConfig,
     'experimental.after',
     `\`experimental.after\` is no longer needed, because \`after\` is available by default. You can remove it from ${configFileName}.`,
     silent
   )
 
   warnOptionHasBeenDeprecated(
-    result,
+    userConfig,
     'devIndicators.appIsrStatus',
     `\`devIndicators.appIsrStatus\` is deprecated and no longer configurable. Please remove it from ${configFileName}.`,
     silent
   )
 
   warnOptionHasBeenDeprecated(
-    result,
+    userConfig,
     'devIndicators.buildActivity',
     `\`devIndicators.buildActivity\` is deprecated and no longer configurable. Please remove it from ${configFileName}.`,
     silent
   )
 
   const hasWarnedBuildActivityPosition = warnOptionHasBeenDeprecated(
-    result,
+    userConfig,
     'devIndicators.buildActivityPosition',
     `\`devIndicators.buildActivityPosition\` has been renamed to \`devIndicators.position\`. Please update your ${configFileName} file accordingly.`,
     silent

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -78,7 +78,6 @@ export function warnOptionHasBeenDeprecated(
         current = current[key]
         found = true
       } else {
-        found = false
         break
       }
     }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -569,9 +569,14 @@ function assignDefaults(
   )
   if (
     hasWarnedBuildActivityPosition &&
-    result.devIndicators !== false &&
-    'buildActivityPosition' in result.devIndicators &&
-    result.devIndicators.buildActivityPosition !== result.devIndicators.position
+    userConfig.devIndicators !== false &&
+    userConfig.devIndicators &&
+    'buildActivityPosition' in userConfig.devIndicators &&
+    userConfig.devIndicators.position &&
+    userConfig.devIndicators.buildActivityPosition !==
+      userConfig.devIndicators.position &&
+    result.devIndicators &&
+    'buildActivityPosition' in result.devIndicators
   ) {
     Log.warnOnce(
       `The \`devIndicators\` option \`buildActivityPosition\` ("${result.devIndicators.buildActivityPosition}") conflicts with \`position\` ("${result.devIndicators.position}"). Using \`buildActivityPosition\` ("${result.devIndicators.buildActivityPosition}") for backward compatibility.`
@@ -580,28 +585,28 @@ function assignDefaults(
   }
 
   warnOptionHasBeenMovedOutOfExperimental(
-    result,
+    userConfig,
     'bundlePagesExternals',
     'bundlePagesRouterDependencies',
     configFileName,
     silent
   )
   warnOptionHasBeenMovedOutOfExperimental(
-    result,
+    userConfig,
     'serverComponentsExternalPackages',
     'serverExternalPackages',
     configFileName,
     silent
   )
   warnOptionHasBeenMovedOutOfExperimental(
-    result,
+    userConfig,
     'relay',
     'compiler.relay',
     configFileName,
     silent
   )
   warnOptionHasBeenMovedOutOfExperimental(
-    result,
+    userConfig,
     'styledComponents',
     'compiler.styledComponents',
     configFileName,
@@ -615,42 +620,42 @@ function assignDefaults(
     silent
   )
   warnOptionHasBeenMovedOutOfExperimental(
-    result,
+    userConfig,
     'reactRemoveProperties',
     'compiler.reactRemoveProperties',
     configFileName,
     silent
   )
   warnOptionHasBeenMovedOutOfExperimental(
-    result,
+    userConfig,
     'removeConsole',
     'compiler.removeConsole',
     configFileName,
     silent
   )
   warnOptionHasBeenMovedOutOfExperimental(
-    result,
+    userConfig,
     'swrDelta',
     'expireTime',
     configFileName,
     silent
   )
   warnOptionHasBeenMovedOutOfExperimental(
-    result,
+    userConfig,
     'outputFileTracingRoot',
     'outputFileTracingRoot',
     configFileName,
     silent
   )
   warnOptionHasBeenMovedOutOfExperimental(
-    result,
+    userConfig,
     'outputFileTracingIncludes',
     'outputFileTracingIncludes',
     configFileName,
     silent
   )
   warnOptionHasBeenMovedOutOfExperimental(
-    result,
+    userConfig,
     'outputFileTracingExcludes',
     'outputFileTracingExcludes',
     configFileName,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -71,17 +71,19 @@ export function warnOptionHasBeenDeprecated(
   let hasWarned = false
   if (!silent) {
     let current = config
-    let found = true
+    let found = false
     const nestedPropertyKeys = nestedPropertyKey.split('.')
     for (const key of nestedPropertyKeys) {
       if (current[key] !== undefined) {
         current = current[key]
+        found = true
       } else {
         found = false
         break
       }
     }
-    if (found) {
+
+    if (found && config.configFile) {
       Log.warnOnce(reason)
       hasWarned = true
     }

--- a/test/integration/build-indicator/test/index.test.js
+++ b/test/integration/build-indicator/test/index.test.js
@@ -3,7 +3,7 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { findPort, launchApp, killApp, waitFor, check } from 'next-test-utils'
+import { findPort, launchApp, killApp, waitFor, retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 const appDir = join(__dirname, '..')
@@ -33,7 +33,7 @@ describe('Build Activity Indicator', () => {
       `
       module.exports = {
         devIndicators: {
-          buildActivityPosition: 'ttop-leff'
+          buildActivityPosition: 'top-leff'
         }
       }
     `
@@ -47,12 +47,13 @@ describe('Build Activity Indicator', () => {
     })
     await fs.remove(configPath)
 
-    await check(
-      () => stripAnsi(stderr),
-      new RegExp(
-        `Invalid "devIndicator.position" provided, expected one of top-left, top-right, bottom-left, bottom-right, received ttop-leff`
+    await retry(() => {
+      const cleanStderr = stripAnsi(stderr)
+      // buildActivityPosition is deprecated, but we should warn it's not a valid option
+      expect(cleanStderr).toContain(
+        `Invalid input at "devIndicators.buildActivityPosition"`
       )
-    )
+    })
 
     if (app) {
       await killApp(app)

--- a/test/production/pnpm-support/app-multi-page/next.config.js
+++ b/test/production/pnpm-support/app-multi-page/next.config.js
@@ -2,8 +2,6 @@ const path = require('path')
 
 module.exports = {
   output: 'standalone',
-  experimental: {
-    // pnpm virtual-store-dir is outside the app directory
-    outputFileTracingRoot: path.resolve(__dirname, '../'),
-  },
+  // pnpm virtual-store-dir is outside the app directory
+  outputFileTracingRoot: path.resolve(__dirname, '../'),
 }

--- a/test/unit/warn-removed-experimental-config.test.ts
+++ b/test/unit/warn-removed-experimental-config.test.ts
@@ -1,6 +1,7 @@
 import {
   warnOptionHasBeenMovedOutOfExperimental,
   warnOptionHasBeenDeprecated,
+  NextConfig,
 } from 'next/dist/server/config'
 import stripAnsi from 'strip-ansi'
 
@@ -139,8 +140,11 @@ describe('warnOptionHasBeenMovedOutOfExperimental', () => {
 
 describe('warnOptionHasBeenDeprecated', () => {
   let spy: jest.SpyInstance
-  beforeAll(() => {
+  beforeEach(() => {
     spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    spy.mockRestore()
   })
 
   it('should warn experimental.appDir has been deprecated', () => {
@@ -156,5 +160,38 @@ describe('warnOptionHasBeenDeprecated', () => {
       false
     )
     expect(spy).toHaveBeenCalled()
+  })
+
+  it('should not warn when config file is not defined', () => {
+    // When config file is not defined, the configFileName is default value,
+    // the configFile is undefined.
+    const config: NextConfig = {
+      configFile: undefined,
+      configFileName: 'next.config.js',
+    }
+
+    warnOptionHasBeenDeprecated(
+      config,
+      'experimental.appDir',
+      'experimental.appDir has been removed',
+      false
+    )
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('should not warn when config key doesn not match', () => {
+    const config = {
+      badAssetPrefixKey: '/bar',
+    }
+
+    warnOptionHasBeenDeprecated(
+      config,
+      'assetPrefix',
+      'assetPrefix is gone',
+      false
+    )
+
+    expect(spy).not.toHaveBeenCalled()
   })
 })

--- a/test/unit/warn-removed-experimental-config.test.ts
+++ b/test/unit/warn-removed-experimental-config.test.ts
@@ -180,7 +180,7 @@ describe('warnOptionHasBeenDeprecated', () => {
     expect(spy).not.toHaveBeenCalled()
   })
 
-  it('should not warn when config key doesn not match', () => {
+  it('should not warn when config key does not match', () => {
     const config = {
       badAssetPrefixKey: '/bar',
     }


### PR DESCRIPTION
Noticed the deprecation warning showed up in a test app without `next.config.js` file, turns out we're still showing the warning even you don't have the config file.

This PR asserts if the actual config file exists, then determine if we are going to log