### PR TITLE
Remove React 17 logic from Pages Router static generation

### DIFF
--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { ParsedUrlQuery } from 'querystring'
+import type { ReactDOMServerReadableStream } from 'react-dom/server'
 import type { NextRouter } from '../shared/lib/router/router'
 import type { HtmlProps } from '../shared/lib/html-context.shared-runtime'
 import type { DomainLocale } from './config'
@@ -30,7 +31,6 @@ import type {
   SizeLimit,
 } from '../types'
 import type { UnwrapPromise } from '../lib/coalesced-function'
-import type { ReactReadableStream } from './stream-utils/node-web-streams-helper'
 import type { ClientReferenceManifest } from '../build/webpack/plugins/flight-manifest-plugin'
 import type { NextFontManifest } from '../build/webpack/plugins/next-font-manifest-plugin'
 import type { PagesModule } from './route-modules/pages/module'
@@ -1305,7 +1305,7 @@ export async function renderToHTMLImpl(
       renderShell: (
         _App: AppType,
         _Component: NextComponentType
-      ) => Promise<ReactReadableStream>
+      ) => Promise<ReactDOMServerReadableStream>
     ) {
       const renderPage: RenderPage = async (
         options: ComponentsEnhancer = {}


### PR DESCRIPTION
`allReady` is available in all supported React versions so we can remove the conditional check.  The helper type can be replaced with the actual type from React.