### PR TITLE
Fix router replace scroll behavior when loading file exists

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -20,7 +20,10 @@ import { handleMutable } from '../handle-mutable'
 import { applyFlightData } from '../apply-flight-data'
 import { prefetchQueue } from './prefetch-reducer'
 import { createEmptyCacheNode } from '../../app-router'
-import { DEFAULT_SEGMENT_KEY } from '../../../../shared/lib/segment'
+import {
+  DEFAULT_SEGMENT_KEY,
+  PAGE_SEGMENT_KEY,
+} from '../../../../shared/lib/segment'
 import { listenForDynamicRequest, startPPRNavigation } from '../ppr-navigations'
 import {
   getOrCreatePrefetchCacheEntry,
@@ -482,10 +485,15 @@ export function navigateReducer(
                 ...flightSegmentPath,
                 ...subSegment,
               ]
+              const lastSegment =
+                scrollableSegmentPath[scrollableSegmentPath.length - 1]
               // Filter out the __DEFAULT__ paths as they shouldn't be scrolled to in this case.
+              // Also filter out non-page segments to avoid scrolling on loading segments.
+              // Only page segments (containing PAGE_SEGMENT_KEY) should trigger scroll behavior.
               if (
-                scrollableSegmentPath[scrollableSegmentPath.length - 1] !==
-                DEFAULT_SEGMENT_KEY
+                lastSegment !== DEFAULT_SEGMENT_KEY &&
+                typeof lastSegment === 'string' &&
+                lastSegment.includes(PAGE_SEGMENT_KEY)
               ) {
                 scrollableSegments.push(scrollableSegmentPath)
               }


### PR DESCRIPTION
  ## Summary

  Based on #82598 - Fixes router replace scroll behavior when loading file exists by filtering out non-page segments during scroll target identification.

  ## Problem

  When using `router.replace()` with `scroll: true`, the page doesn't scroll to top if a `loading.tsx` file exists in the route. The E2E test in the original PR
  was failing because:
  - Expected scroll position: 0
  - Actual scroll position: 1441

  ## Solution

  Modified the scroll target identification logic in `navigate-reducer.ts` to only consider page segments (containing `PAGE_SEGMENT_KEY`) for scroll behavior,
  filtering out loading segments and other non-page segments.

  ## Changes

  - Updated segment filtering logic in `packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts:488-496`
  - Added check for `PAGE_SEGMENT_KEY` to ensure only page segments trigger scroll behavior

  Fixes #82598
