### PR TITLE
run config deprecation checks only on user-provided configuration

### DIFF
--- a/test/e2e/deprecation-warnings/deprecation-warnings.test.ts
+++ b/test/e2e/deprecation-warnings/deprecation-warnings.test.ts
@@ -1,0 +1,40 @@
+import { nextTestSetup } from 'e2e-utils'
+import path from 'path'
+
+describe('deprecation-warnings', () => {
+  describe('without next.config.js', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures/no-config'),
+      skipStart: true,
+    })
+
+    it('should not emit any deprecation warnings when no config file exists', async () => {
+      await next.start()
+
+      const logs = next.cliOutput
+      expect(logs).not.toContain('deprecated')
+      expect(logs).not.toContain('has been renamed')
+      expect(logs).not.toContain('no longer needed')
+    })
+  })
+
+  describe('with deprecated config options', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures/with-deprecated-config'),
+      skipStart: true,
+    })
+
+    it('should emit deprecation warnings for explicitly configured deprecated options', async () => {
+      await next.start()
+
+      const logs = next.cliOutput
+
+      // Should warn about amp configuration
+      expect(logs).toContain('Built-in amp support is deprecated')
+
+      // Should warn about experimental.instrumentationHook
+      expect(logs).toContain('experimental.instrumentationHook')
+      expect(logs).toContain('no longer needed')
+    })
+  })
+})

--- a/test/e2e/deprecation-warnings/fixtures/no-config/app/layout.tsx
+++ b/test/e2e/deprecation-warnings/fixtures/no-config/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/deprecation-warnings/fixtures/no-config/app/page.tsx
+++ b/test/e2e/deprecation-warnings/fixtures/no-config/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Hello World</div>
+}

--- a/test/e2e/deprecation-warnings/fixtures/with-deprecated-config/app/layout.tsx
+++ b/test/e2e/deprecation-warnings/fixtures/with-deprecated-config/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/deprecation-warnings/fixtures/with-deprecated-config/app/page.tsx
+++ b/test/e2e/deprecation-warnings/fixtures/with-deprecated-config/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Hello World</div>
+}

--- a/test/e2e/deprecation-warnings/fixtures/with-deprecated-config/next.config.js
+++ b/test/e2e/deprecation-warnings/fixtures/with-deprecated-config/next.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  // Explicitly configure deprecated options
+  amp: {
+    canonicalBase: 'https://example.com',
+  },
+  experimental: {
+    instrumentationHook: true,
+  },
+}


### PR DESCRIPTION
The deprecation warning code is fairly brittle right now since there's a mixture of calling things with `userConfig` and `result`. It was assumed that `userConfig` was the actual user-provided configuration, but it turns out it's actually the default configuration when a user configuration isn't specified.

This moves all the deprecation checks to be before we actually do any sort of merging. This restores the intent behind `userConfig` and will prevent deprecation warnings from being logged due to defaults.

Alternative to #82593