### PR TITLE
Turbopack: fix edge function name

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -34,7 +34,10 @@ use next_core::{
     },
     next_server_utility::{NEXT_SERVER_UTILITY_MERGE_TAG, NextServerUtilityTransition},
     parse_segment_config_from_source,
-    util::{NextRuntime, module_styles_rule_condition, styles_rule_condition},
+    util::{
+        NextRuntime, app_middleware_function_name, module_styles_rule_condition,
+        styles_rule_condition,
+    },
 };
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
@@ -1587,7 +1590,7 @@ impl AppEndpoint {
                         files: file_paths_from_root.into_iter().collect(),
                         wasm: wasm_paths_to_bindings(wasm_paths_from_root).await?,
                         assets: paths_to_bindings(all_assets),
-                        name: format!("app{}", app_entry.original_name).into(),
+                        name: app_middleware_function_name(&app_entry.original_name).into(),
                         page: app_entry.original_name.clone(),
                         regions: app_entry
                             .config

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1587,7 +1587,7 @@ impl AppEndpoint {
                         files: file_paths_from_root.into_iter().collect(),
                         wasm: wasm_paths_to_bindings(wasm_paths_from_root).await?,
                         assets: paths_to_bindings(all_assets),
-                        name: app_entry.pathname.clone(),
+                        name: format!("app{}", app_entry.original_name).into(),
                         page: app_entry.original_name.clone(),
                         regions: app_entry
                             .config

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -23,7 +23,10 @@ use next_core::{
     pages_structure::{
         PagesDirectoryStructure, PagesStructure, PagesStructureItem, find_pages_structure,
     },
-    util::{NextRuntime, get_asset_prefix_from_pathname, parse_config_from_source},
+    util::{
+        NextRuntime, get_asset_prefix_from_pathname, pages_middleware_function_name,
+        parse_config_from_source,
+    },
 };
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
@@ -1528,7 +1531,7 @@ impl PageEndpoint {
                         files: file_paths_from_root.into_iter().collect(),
                         wasm: wasm_paths_to_bindings(wasm_paths_from_root).await?,
                         assets: paths_to_bindings(all_assets),
-                        name: format!("pages{}", this.original_name).into(),
+                        name: pages_middleware_function_name(&this.original_name).into(),
                         page: this.original_name.clone(),
                         regions,
                         matchers: vec![matchers],

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1385,12 +1385,9 @@ impl PageEndpoint {
             PageEndpointType::SsrOnly => self.ssr_chunk(emit_manifests),
         };
 
-        let pathname = &this.pathname;
-        let original_name = &this.original_name;
-
         let client_assets = OutputAssets::new(client_assets).to_resolved().await?;
 
-        let manifest_path_prefix = get_asset_prefix_from_pathname(pathname);
+        let manifest_path_prefix = get_asset_prefix_from_pathname(&this.pathname);
         let node_root = this.pages_project.project().node_root().owned().await?;
 
         if emit_manifests == EmitManifests::Full {
@@ -1398,9 +1395,9 @@ impl PageEndpoint {
                 this.pages_project.project().client_root().owned().await?,
                 node_root.clone(),
                 this.pages_project.pages_dir().owned().await?,
-                original_name,
+                &this.original_name,
                 &manifest_path_prefix,
-                pathname,
+                &this.pathname,
                 *client_assets,
                 false,
             )
@@ -1416,7 +1413,7 @@ impl PageEndpoint {
         {
             let webpack_stats = generate_webpack_stats(
                 self.client_module_graph(),
-                original_name.to_owned(),
+                this.original_name.clone(),
                 client_assets.await?.iter().copied(),
             )
             .await?;
@@ -1509,10 +1506,10 @@ impl PageEndpoint {
                     let all_assets =
                         get_asset_paths_from_root(&node_root, &all_output_assets).await?;
 
-                    let named_regex = get_named_middleware_regex(pathname).into();
+                    let named_regex = get_named_middleware_regex(&this.pathname).into();
                     let matchers = MiddlewareMatcher {
                         regexp: Some(named_regex),
-                        original_source: pathname.clone(),
+                        original_source: this.pathname.clone(),
                         ..Default::default()
                     };
                     let regions = if let Some(regions) = regions.as_ref() {
@@ -1531,15 +1528,15 @@ impl PageEndpoint {
                         files: file_paths_from_root.into_iter().collect(),
                         wasm: wasm_paths_to_bindings(wasm_paths_from_root).await?,
                         assets: paths_to_bindings(all_assets),
-                        name: pathname.clone(),
+                        name: format!("pages{}", this.original_name).into(),
                         page: this.original_name.clone(),
                         regions,
                         matchers: vec![matchers],
                         env: this.pages_project.project().edge_env().owned().await?,
                     };
                     let middleware_manifest_v2 = MiddlewaresManifestV2 {
-                        sorted_middleware: vec![pathname.clone()],
-                        functions: [(pathname.clone(), edge_function_definition)]
+                        sorted_middleware: vec![this.pathname.clone()],
+                        functions: [(this.pathname.clone(), edge_function_definition)]
                             .into_iter()
                             .collect(),
                         ..Default::default()

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -27,7 +27,7 @@ use crate::{
     next_edge::entry::wrap_edge_entry,
     next_server_component::NextServerComponentTransition,
     parse_segment_config_from_loader_tree,
-    util::{NextRuntime, file_content_rope, load_next_js_template},
+    util::{NextRuntime, app_middleware_function_name, file_content_rope, load_next_js_template},
 };
 
 /// Computes the entry for a Next.js app page.
@@ -186,6 +186,6 @@ async fn wrap_edge_page(
         asset_context,
         project_root,
         wrapped,
-        format!("app{page}").into(),
+        app_middleware_function_name(&page).into(),
     ))
 }

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -186,6 +186,6 @@ async fn wrap_edge_page(
         asset_context,
         project_root,
         wrapped,
-        AppPath::from(page).to_string().into(),
+        format!("app{page}").into(),
     ))
 }

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -162,6 +162,6 @@ async fn wrap_edge_route(
         asset_context,
         project_root.clone(),
         wrapped,
-        AppPath::from(page).to_string().into(),
+        format!("app{page}").into(),
     ))
 }

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -16,7 +16,7 @@ use crate::{
     next_config::{NextConfig, OutputType},
     next_edge::entry::wrap_edge_entry,
     parse_segment_config_from_source,
-    util::{NextRuntime, load_next_js_template},
+    util::{NextRuntime, app_middleware_function_name, load_next_js_template},
 };
 
 /// Computes the entry for a Next.js app route.
@@ -162,6 +162,6 @@ async fn wrap_edge_route(
         asset_context,
         project_root.clone(),
         wrapped,
-        format!("app{page}").into(),
+        app_middleware_function_name(&page).into(),
     ))
 }

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -163,7 +163,7 @@ pub async fn create_page_ssr_entry_module(
                 ssr_module_context,
                 project_root,
                 ssr_module,
-                definition_pathname.clone(),
+                format!("pages{definition_page}").into(),
             );
         }
     }
@@ -288,7 +288,7 @@ async fn wrap_edge_page(
         asset_context,
         project_root,
         wrapped,
-        pathname.clone(),
+        format!("pages{page}").into(),
     ))
 }
 

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -19,7 +19,7 @@ use crate::{
     next_config::NextConfig,
     next_edge::entry::wrap_edge_entry,
     pages_structure::{PagesStructure, PagesStructureItem},
-    util::{NextRuntime, file_content_rope, load_next_js_template},
+    util::{NextRuntime, file_content_rope, load_next_js_template, pages_middleware_function_name},
 };
 
 #[turbo_tasks::value]
@@ -163,7 +163,7 @@ pub async fn create_page_ssr_entry_module(
                 ssr_module_context,
                 project_root,
                 ssr_module,
-                format!("pages{definition_page}").into(),
+                pages_middleware_function_name(&definition_page).into(),
             );
         }
     }
@@ -288,7 +288,7 @@ async fn wrap_edge_page(
         asset_context,
         project_root,
         wrapped,
-        format!("pages{page}").into(),
+        pages_middleware_function_name(&page).into(),
     ))
 }
 

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, str::FromStr};
+use std::{fmt::Display, future::Future, str::FromStr};
 
 use anyhow::{Result, bail};
 use next_taskless::expand_next_js_template;
@@ -194,6 +194,13 @@ pub async fn internal_assets_conditions() -> Result<ContextCondition> {
         ),
         ContextCondition::InPath(turbopack_node::embed_js::embed_fs().root().owned().await?),
     ]))
+}
+
+pub fn app_middleware_function_name(page: impl Display) -> String {
+    format!("app{page}")
+}
+pub fn pages_middleware_function_name(page: impl Display) -> String {
+    format!("pages{page}")
 }
 
 #[derive(


### PR DESCRIPTION
Edge functions with route `/` had `"name": "/"` in the `middleware-manifest.json`. When deploying to Vercel, this wouldn't work as the Vercel builder turned that into `"name": ""`.
For the root function, Webpack emits a name like `"app/page"` or `"pages/index"`.
This aligns Turbopack with Webpack

I think the name itself can be pretty arbitrary. As long as the `_ENTRIES` access and the middleware manifests agree (which is covered by the regular e2e tests), and as long as it's not literally `"/"` which breaks on Vercel.

Closes PACK-5245