### PR TITLE
feat(next/image): warn when images.localPatterns is undefined and src has query

### DIFF
--- a/errors/next-image-unconfigured-localpatterns.mdx
+++ b/errors/next-image-unconfigured-localpatterns.mdx
@@ -16,6 +16,22 @@ module.exports = {
     localPatterns: [
       {
         pathname: '/assets/**',
+      },
+    ],
+  },
+}
+```
+
+Omitting the `search` will allow all query strings.
+
+If you want to prevent the query string from matching, you can use the empty string, for example:
+
+```js filename="next.config.js"
+module.exports = {
+  images: {
+    localPatterns: [
+      {
+        pathname: '/assets/**',
         search: '',
       },
     ],

--- a/packages/next/src/client/legacy/image.tsx
+++ b/packages/next/src/client/legacy/image.tsx
@@ -866,6 +866,13 @@ export default function Image({
         )
       }
 
+      if (!config.localPatterns && src.startsWith('/') && src.includes('?')) {
+        warnOnce(
+          `Image with src "${src}" is using a query string which is not configured in images.localPatterns. This config will be required starting in Next.js 16.` +
+            `\nRead more: https://nextjs.org/docs/messages/next-image-unconfigured-localpatterns`
+        )
+      }
+
       if (!unoptimized && loader !== defaultImageLoader) {
         const urlStr = loader({
           config,

--- a/packages/next/src/client/legacy/image.tsx
+++ b/packages/next/src/client/legacy/image.tsx
@@ -866,7 +866,13 @@ export default function Image({
         )
       }
 
-      if (!config.localPatterns && src.startsWith('/') && src.includes('?')) {
+      if (
+        src.startsWith('/') &&
+        src.includes('?') &&
+        (!config?.localPatterns?.length ||
+          (config.localPatterns.length === 1 &&
+            config.localPatterns[0].pathname === '/_next/static/media/**'))
+      ) {
         warnOnce(
           `Image with src "${src}" is using a query string which is not configured in images.localPatterns. This config will be required starting in Next.js 16.` +
             `\nRead more: https://nextjs.org/docs/messages/next-image-unconfigured-localpatterns`

--- a/packages/next/src/shared/lib/get-img-props.ts
+++ b/packages/next/src/shared/lib/get-img-props.ts
@@ -538,6 +538,12 @@ export function getImgProps(
           `\nRead more: https://nextjs.org/docs/messages/next-image-unconfigured-qualities`
       )
     }
+    if (!config.localPatterns && src.startsWith('/') && src.includes('?')) {
+      warnOnce(
+        `Image with src "${src}" is using a query string which is not configured in images.localPatterns. This config will be required starting in Next.js 16.` +
+          `\nRead more: https://nextjs.org/docs/messages/next-image-unconfigured-localpatterns`
+      )
+    }
     if (placeholder === 'blur' && !blurDataURL) {
       const VALID_BLUR_EXT = ['jpeg', 'png', 'webp', 'avif'] // should match next-image-loader
 

--- a/packages/next/src/shared/lib/get-img-props.ts
+++ b/packages/next/src/shared/lib/get-img-props.ts
@@ -538,7 +538,13 @@ export function getImgProps(
           `\nRead more: https://nextjs.org/docs/messages/next-image-unconfigured-qualities`
       )
     }
-    if (!config.localPatterns && src.startsWith('/') && src.includes('?')) {
+    if (
+      src.startsWith('/') &&
+      src.includes('?') &&
+      (!config?.localPatterns?.length ||
+        (config.localPatterns.length === 1 &&
+          config.localPatterns[0].pathname === '/_next/static/media/**'))
+    ) {
       warnOnce(
         `Image with src "${src}" is using a query string which is not configured in images.localPatterns. This config will be required starting in Next.js 16.` +
           `\nRead more: https://nextjs.org/docs/messages/next-image-unconfigured-localpatterns`

--- a/test/unit/next-image-get-img-props.test.ts
+++ b/test/unit/next-image-get-img-props.test.ts
@@ -401,7 +401,9 @@ describe('getImageProps()', () => {
       width: 100,
       height: 200,
     })
-    expect(warningMessages).toStrictEqual([])
+    expect(warningMessages).toStrictEqual([
+      'Image with src "/test.svg?v=1" is using a query string which is not configured in images.localPatterns. This config will be required starting in Next.js 16.\nRead more: https://nextjs.org/docs/messages/next-image-unconfigured-localpatterns',
+    ])
     expect(Object.entries(props)).toStrictEqual([
       ['alt', 'a nice desc'],
       ['loading', 'lazy'],


### PR DESCRIPTION
Add a warning to Next.js 15.5 to prepare for Next.js 16 when `images.localPatterns` is undefined and the user attempted to optimize a `src` image with a query string, such as

```jsx
<Image src="/api/user?id=1" width="50" height="50" />
```

Note that we have default `localPatterns` so we need to account for that. See https://github.com/vercel/next.js/pull/70529