### PR TITLE
fix: use in operator to check dev indicator option when its obj

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -585,7 +585,7 @@ function assignDefaults(
 
   // Handle buildActivityPosition migration (needs to be done after merging with defaults)
   if (
-    result.devIndicators !== false &&
+    typeof result.devIndicators === 'object' &&
     'buildActivityPosition' in result.devIndicators &&
     result.devIndicators.buildActivityPosition !== result.devIndicators.position
   ) {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -585,6 +585,7 @@ function assignDefaults(
 
   // Handle buildActivityPosition migration (needs to be done after merging with defaults)
   if (
+    result.devIndicators &&
     typeof result.devIndicators === 'object' &&
     'buildActivityPosition' in result.devIndicators &&
     result.devIndicators.buildActivityPosition !== result.devIndicators.position


### PR DESCRIPTION
Noticed an error when deploying an app when `devIndicators` set to true, see error below:
```
[TypeError: Cannot use 'in' operator to search for 'buildActivityPosition' in true]
```

Change to a safer condition to avoid the crash
