### PR TITLE
Turbopack: use a source content regexp for the react compiler

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -803,9 +803,11 @@ function bindingToApi(
    * turbopack's rules if `experimental.reactCompilerOptions` is set.
    */
   function augmentNextConfig(
-    nextConfig: NextConfigComplete,
+    originalNextConfig: NextConfigComplete,
     projectPath: string
   ): Record<string, any> {
+    let nextConfig = { ...(originalNextConfig as NextConfigComplete) }
+
     const reactCompilerOptions = nextConfig.experimental?.reactCompiler
 
     // It is not easy to set the rules inside of rust as resolving, and passing the context identical to the webpack

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -836,8 +836,10 @@ function bindingToApi(
             content:
               options.compilationMode === 'annotation'
                 ? /['"]use memo['"]/
-                : options.compilationMode === 'infer'
-                  ? /\Wuse[A-Z]|<\/|\/>/
+                : !options.compilationMode ||
+                    options.compilationMode === 'infer'
+                  ? // Matches declaration or useXXX or </ (closing jsx) or /> (self closing jsx)
+                    /['"]use memo['"]|\Wuse[A-Z]|<\/|\/>/
                   : undefined,
           }
           nextConfig.turbopack.rules[`#reactCompiler/${key}`] = {

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -10,6 +10,7 @@ import { patchIncorrectLockfile } from '../../lib/patch-incorrect-lockfile'
 import { downloadNativeNextSwc, downloadWasmSwc } from '../../lib/download-swc'
 import type {
   NextConfigComplete,
+  ReactCompilerOptions,
   TurbopackLoaderItem,
   TurbopackRuleConfigItem,
   TurbopackRuleConfigItemOptions,
@@ -802,16 +803,16 @@ function bindingToApi(
    * turbopack's rules if `experimental.reactCompilerOptions` is set.
    */
   function augmentNextConfig(
-    originalNextConfig: NextConfigComplete,
+    nextConfig: NextConfigComplete,
     projectPath: string
   ): Record<string, any> {
-    let nextConfig = { ...(originalNextConfig as any) }
-
     const reactCompilerOptions = nextConfig.experimental?.reactCompiler
 
     // It is not easy to set the rules inside of rust as resolving, and passing the context identical to the webpack
     // config is bit hard, also we can reuse same codes between webpack config in here.
     if (reactCompilerOptions) {
+      const options: ReactCompilerOptions =
+        typeof reactCompilerOptions === 'object' ? reactCompilerOptions : {}
       const ruleKeys = ['*.ts', '*.js', '*.jsx', '*.tsx']
       if (
         Object.keys(nextConfig?.turbopack?.rules ?? {}).some((key) =>
@@ -826,15 +827,25 @@ function bindingToApi(
         )
       } else {
         nextConfig.turbopack ??= {}
+        nextConfig.turbopack.conditions ??= {}
         nextConfig.turbopack.rules ??= {}
 
         for (const key of ruleKeys) {
-          nextConfig.turbopack.rules[key] = {
+          nextConfig.turbopack.conditions[`#reactCompiler/${key}`] = {
+            path: key,
+            content:
+              options.compilationMode === 'annotation'
+                ? /['"]use memo['"]/
+                : options.compilationMode === 'infer'
+                  ? /\Wuse[A-Z]|<\/|\/>/
+                  : undefined,
+          }
+          nextConfig.turbopack.rules[`#reactCompiler/${key}`] = {
             browser: {
               foreign: false,
               loaders: [
                 getReactCompilerLoader(
-                  originalNextConfig.experimental.reactCompiler,
+                  reactCompilerOptions,
                   projectPath,
                   nextConfig.dev,
                   /* isServer */ false,
@@ -905,9 +916,20 @@ function bindingToApi(
     if (conditions) {
       type SerializedConditions = {
         [key: string]: {
-          path:
+          path?:
             | { type: 'regex'; value: { source: string; flags: string } }
             | { type: 'glob'; value: string }
+          content?: { source: string; flags: string }
+        }
+      }
+
+      function regexComponents(regex: RegExp): {
+        source: string
+        flags: string
+      } {
+        return {
+          source: regex.source,
+          flags: regex.flags,
         }
       }
 
@@ -915,13 +937,15 @@ function bindingToApi(
       for (const [key, value] of Object.entries(conditions)) {
         serializedConditions[key] = {
           ...value,
-          path:
-            value.path instanceof RegExp
+          path: !value.path
+            ? undefined
+            : value.path instanceof RegExp
               ? {
                   type: 'regex',
-                  value: { source: value.path.source, flags: value.path.flags },
+                  value: regexComponents(value.path),
                 }
               : { type: 'glob', value: value.path },
+          content: !value.content ? undefined : regexComponents(value.content),
         }
       }
       nextConfigSerializable.turbopack.conditions = serializedConditions

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -129,7 +129,8 @@ const zTurboRuleConfigItemOrShortcut: zod.ZodType<TurbopackRuleConfigItemOrShort
   z.union([z.array(zTurboLoaderItem), zTurboRuleConfigItem])
 
 const zTurboCondition: zod.ZodType<TurbopackRuleCondition> = z.object({
-  path: z.union([z.string(), z.instanceof(RegExp)]),
+  path: z.union([z.string(), z.instanceof(RegExp)]).optional(),
+  content: z.instanceof(RegExp).optional(),
 })
 
 const zTurbopackConfig: zod.ZodType<TurbopackOptions> = z.strictObject({

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -262,7 +262,8 @@ export type TurbopackLoaderItem =
     }
 
 export type TurbopackRuleCondition = {
-  path: string | RegExp
+  path?: string | RegExp
+  content?: RegExp
 }
 
 export type TurbopackRuleConfigItemOrShortcut =

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -507,10 +507,16 @@ impl ModuleOptions {
 
                     match &path {
                         Some(ConditionPath::Glob(glob)) => {
-                            rule_conditions.push(RuleCondition::ResourcePathGlob {
-                                base: execution_context.project_path().owned().await?,
-                                glob: Glob::new(glob.clone()).await?,
-                            });
+                            if glob.contains('/') {
+                                rule_conditions.push(RuleCondition::ResourcePathGlob {
+                                    base: execution_context.project_path().owned().await?,
+                                    glob: Glob::new(glob.clone()).await?,
+                                });
+                            } else {
+                                rule_conditions.push(RuleCondition::ResourceBasePathGlob(
+                                    Glob::new(glob.clone()).await?,
+                                ));
+                            }
                         }
                         Some(ConditionPath::Regex(regex)) => {
                             rule_conditions.push(RuleCondition::ResourcePathEsRegex(regex.await?));

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -489,43 +489,52 @@ impl ModuleOptions {
                 )
             };
             for (key, rule) in webpack_loaders_options.rules.await?.iter() {
-                rules.push(ModuleRule::new(
-                    RuleCondition::All(vec![
-                        if key.starts_with("#") {
-                            // This is a custom marker requiring a corresponding condition entry
-                            let conditions = (*webpack_loaders_options.conditions.await?)
-                                .context(
-                                    "Expected a condition entry for the webpack loader rule \
-                                     matching {key}. Create a `conditions` mapping in your \
-                                     next.config.js",
-                                )?
-                                .await?;
+                let mut rule_conditions = Vec::new();
+                if key.starts_with("#") {
+                    // This is a custom marker requiring a corresponding condition entry
+                    let conditions = (*webpack_loaders_options.conditions.await?)
+                        .context(
+                            "Expected a condition entry for the webpack loader rule matching \
+                             {key}. Create a `conditions` mapping in your next.config.js",
+                        )?
+                        .await?;
 
-                            let condition = conditions.get(key).context(
-                                "Expected a condition entry for the webpack loader rule matching \
-                                 {key}.",
-                            )?;
+                    let condition = conditions.get(key).context(
+                        "Expected a condition entry for the webpack loader rule matching {key}.",
+                    )?;
 
-                            match &condition.path {
-                                ConditionPath::Glob(glob) => RuleCondition::ResourcePathGlob {
-                                    base: execution_context.project_path().owned().await?,
-                                    glob: Glob::new(glob.clone()).await?,
-                                },
-                                ConditionPath::Regex(regex) => {
-                                    RuleCondition::ResourcePathEsRegex(regex.await?)
-                                }
-                            }
-                        } else if key.contains('/') {
-                            RuleCondition::ResourcePathGlob {
+                    let ConditionItem { path, content } = &condition;
+
+                    match &path {
+                        Some(ConditionPath::Glob(glob)) => {
+                            rule_conditions.push(RuleCondition::ResourcePathGlob {
                                 base: execution_context.project_path().owned().await?,
-                                glob: Glob::new(key.clone()).await?,
-                            }
-                        } else {
-                            RuleCondition::ResourceBasePathGlob(Glob::new(key.clone()).await?)
-                        },
-                        RuleCondition::not(RuleCondition::ResourceIsVirtualSource),
-                        module_css_external_transform_conditions.clone(),
-                    ]),
+                                glob: Glob::new(glob.clone()).await?,
+                            });
+                        }
+                        Some(ConditionPath::Regex(regex)) => {
+                            rule_conditions.push(RuleCondition::ResourcePathEsRegex(regex.await?));
+                        }
+                        None => {}
+                    }
+                    if let Some(content) = content {
+                        rule_conditions.push(RuleCondition::ResourceContentEsRegex(content.await?));
+                    }
+                } else if key.contains('/') {
+                    rule_conditions.push(RuleCondition::ResourcePathGlob {
+                        base: execution_context.project_path().owned().await?,
+                        glob: Glob::new(key.clone()).await?,
+                    });
+                } else {
+                    rule_conditions.push(RuleCondition::ResourceBasePathGlob(
+                        Glob::new(key.clone()).await?,
+                    ));
+                };
+                rule_conditions.push(RuleCondition::not(RuleCondition::ResourceIsVirtualSource));
+                rule_conditions.push(module_css_external_transform_conditions.clone());
+
+                rules.push(ModuleRule::new(
+                    RuleCondition::All(rule_conditions),
                     vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
                         ResolvedVc::upcast(
                             WebpackLoaders::new(

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -50,7 +50,8 @@ pub enum ConditionPath {
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 pub struct ConditionItem {
-    pub path: ConditionPath,
+    pub path: Option<ConditionPath>,
+    pub content: Option<ResolvedVc<EsRegex>>,
 }
 
 #[turbo_tasks::value(shared)]


### PR DESCRIPTION
### What?

Depending on compilation mode of the react compiler, check the source code if matches a certain regex

This also adds `content` as condition for webpack loaders

Closes PACK-5252