### PR TITLE
Turbopack: add `turbo_tasks::spawn`

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -1,15 +1,12 @@
 use std::{cmp::max, path::PathBuf, sync::Arc, thread::available_parallelism};
 
-use anyhow::Result;
+use anyhow::{Ok, Result};
 use parking_lot::Mutex;
-use tokio::{
-    runtime::Handle,
-    spawn,
-    task::{JoinHandle, block_in_place},
-};
+use tokio::{runtime::Handle, task::block_in_place};
 use turbo_persistence::{
     ArcSlice, CompactConfig, KeyBase, StoreKey, TurboPersistence, ValueBuffer,
 };
+use turbo_tasks::{JoinHandle, message_queue::TimingEvent, spawn, turbo_tasks};
 
 use crate::database::{
     key_value_database::{KeySpace, KeyValueDatabase},
@@ -225,5 +222,5 @@ impl<'l> From<WriteBuffer<'l>> for ValueBuffer<'l> {
 }
 
 fn join(handle: JoinHandle<Result<()>>) -> Result<()> {
-    block_in_place(|| Handle::current().block_on(handle))?
+    block_in_place(|| Handle::current().block_on(handle))
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -6,7 +6,7 @@ use tokio::{runtime::Handle, task::block_in_place};
 use turbo_persistence::{
     ArcSlice, CompactConfig, KeyBase, StoreKey, TurboPersistence, ValueBuffer,
 };
-use turbo_tasks::{JoinHandle, message_queue::TimingEvent, spawn, turbo_tasks};
+use turbo_tasks::{JoinHandle, spawn};
 
 use crate::database::{
     key_value_database::{KeySpace, KeyValueDatabase},

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -3,6 +3,7 @@ mod counter;
 use std::{
     alloc::{GlobalAlloc, Layout},
     marker::PhantomData,
+    ops::{Add, AddAssign},
 };
 
 use self::counter::{add, flush, get, remove, update};
@@ -16,11 +17,44 @@ pub struct AllocationInfo {
 }
 
 impl AllocationInfo {
+    pub const ZERO: Self = Self {
+        allocations: 0,
+        deallocations: 0,
+        allocation_count: 0,
+        deallocation_count: 0,
+    };
+
     pub fn is_empty(&self) -> bool {
         self.allocations == 0
             && self.deallocations == 0
             && self.allocation_count == 0
             && self.deallocation_count == 0
+    }
+
+    pub fn memory_usage(&self) -> usize {
+        self.allocations.saturating_sub(self.deallocations)
+    }
+}
+
+impl Add<Self> for AllocationInfo {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self {
+            allocations: self.allocations + other.allocations,
+            deallocations: self.deallocations + other.deallocations,
+            allocation_count: self.allocation_count + other.allocation_count,
+            deallocation_count: self.deallocation_count + other.deallocation_count,
+        }
+    }
+}
+
+impl AddAssign<Self> for AllocationInfo {
+    fn add_assign(&mut self, other: Self) {
+        self.allocations += other.allocations;
+        self.deallocations += other.deallocations;
+        self.allocation_count += other.allocation_count;
+        self.deallocation_count += other.deallocation_count;
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -76,6 +76,7 @@ pub mod registry;
 pub mod scope;
 mod serialization_invalidation;
 pub mod small_duration;
+mod spawn;
 mod state;
 pub mod task;
 mod task_execution_reason;
@@ -110,8 +111,7 @@ pub use manager::{
     CurrentCellRef, ReadConsistency, TaskPersistence, TurboTasks, TurboTasksApi,
     TurboTasksBackendApi, TurboTasksBackendApiExt, TurboTasksCallApi, Unused, UpdateInfo,
     dynamic_call, emit, mark_finished, mark_root, mark_session_dependent, mark_stateful,
-    prevent_gc, run_once, run_once_with_reason, spawn_blocking, spawn_thread, trait_call,
-    turbo_tasks, turbo_tasks_scope,
+    prevent_gc, run_once, run_once_with_reason, trait_call, turbo_tasks, turbo_tasks_scope,
 };
 pub use output::OutputContent;
 pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};
@@ -120,6 +120,7 @@ pub use read_ref::ReadRef;
 use rustc_hash::FxHasher;
 pub use serialization_invalidation::SerializationInvalidator;
 pub use shrink_to_fit::ShrinkToFit;
+pub use spawn::{JoinHandle, spawn, spawn_blocking, spawn_thread};
 pub use state::{State, TransientState};
 pub use task::{SharedReference, TypedSharedReference, task_input::TaskInput};
 pub use task_execution_reason::TaskExecutionReason;

--- a/turbopack/crates/turbo-tasks/src/spawn.rs
+++ b/turbopack/crates/turbo-tasks/src/spawn.rs
@@ -1,0 +1,89 @@
+use std::{
+    panic::resume_unwind,
+    pin::Pin,
+    task::{Context, Poll},
+    thread,
+    time::{Duration, Instant},
+};
+
+use anyhow::Result;
+use futures::{FutureExt, ready};
+use tokio::runtime::Handle;
+use tracing::{Instrument, Span, info_span};
+use turbo_tasks_malloc::{AllocationInfo, TurboMalloc};
+
+use crate::{
+    TurboTasksPanic,
+    capture_future::{self, CaptureFuture},
+    manager::turbo_tasks_future_scope,
+    turbo_tasks, turbo_tasks_scope,
+};
+
+pub struct JoinHandle<T> {
+    join_handle: tokio::task::JoinHandle<(Result<T, TurboTasksPanic>, Duration, AllocationInfo)>,
+}
+
+impl<T> Future for JoinHandle<T> {
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        match ready!(this.join_handle.poll_unpin(cx)) {
+            Ok((res, duration, alloc_info)) => {
+                capture_future::add_duration(duration);
+                capture_future::add_allocation_info(alloc_info);
+                match res {
+                    Ok(res) => Poll::Ready(res),
+                    Err(e) => resume_unwind(e.into_panic()),
+                }
+            }
+            Err(e) => resume_unwind(e.into_panic()),
+        }
+    }
+}
+
+/// Spawns a future as separate task and returns a JoinHandle which can be used to await the result.
+/// The future has access to the current TurboTasks context and runs in the same tracing span.
+/// Allocations and cpu time is accounted to the current turbo-tasks function.
+pub fn spawn<T: Send + 'static>(future: impl Future<Output = T> + Send + 'static) -> JoinHandle<T> {
+    let turbo_tasks = turbo_tasks();
+    let span = Span::current();
+    let join_handle = tokio::task::spawn(
+        turbo_tasks_future_scope(turbo_tasks, CaptureFuture::new(future)).instrument(span),
+    );
+    JoinHandle { join_handle }
+}
+
+/// Spawns a blocking function in a separate task using the blocking pool and returns a JoinHandle
+/// which can be used to await the result. The function has access to the current TurboTasks context
+/// and runs in the same tracing span.
+/// Allocations and cpu time is accounted to the current turbo-tasks function.
+pub fn spawn_blocking<T: Send + 'static>(
+    func: impl FnOnce() -> T + Send + 'static,
+) -> JoinHandle<T> {
+    let turbo_tasks = turbo_tasks();
+    let span = Span::current();
+    let join_handle = tokio::task::spawn_blocking(|| {
+        let _guard = span.entered();
+        let start = Instant::now();
+        let start_allocations = TurboMalloc::allocation_counters();
+        let r = turbo_tasks_scope(turbo_tasks, func);
+        (Ok(r), start.elapsed(), start_allocations.until_now())
+    });
+    JoinHandle { join_handle }
+}
+
+/// Spawns a thread which runs in background. It has access to the current TurboTasks context, but
+/// is not accounted towards the current turbo-tasks function.
+pub fn spawn_thread(func: impl FnOnce() + Send + 'static) {
+    let handle = Handle::current();
+    let span = info_span!("thread").or_current();
+    let turbo_tasks = turbo_tasks();
+    thread::spawn(move || {
+        let _span = span.entered();
+        turbo_tasks_scope(turbo_tasks, || {
+            let _guard = handle.enter();
+            func();
+        })
+    });
+}


### PR DESCRIPTION
### What?

add a `spawn` method in turbo_tasks that allows to spawn a async tokio task with the right task locals, spans, etc.

Closes PACK-5255