### PR TITLE
Turbopack: patch sourcemap crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8246,8 +8246,7 @@ dependencies = [
 [[package]]
 name = "swc_sourcemap"
 version = "9.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd6e0cad02163875258edaf9ae6004e2526be137bdde6a46c540515615949b1"
+source = "git+https://github.com/mischnic/rust-sourcemap.git?branch=mischnic%2Fsource-content-mixup#a11f621393345e87145108da20dffb310b5dbfd4"
 dependencies = [
  "base64-simd 0.8.0",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,3 +450,4 @@ hyper = { git = "https://github.com/bgw/hyper-rs.git", branch = "v1.6.0-with-mac
 mdxjs = { git = "https://github.com/mischnic/mdxjs-rs.git", branch = "swc-core-32" }
 lightningcss = { git = "https://github.com/parcel-bundler/lightningcss.git", branch = "mischnic/bump-browserslist" }
 parcel_selectors = { git = "https://github.com/parcel-bundler/lightningcss.git", branch = "mischnic/bump-browserslist" }
+swc_sourcemap = { git = "https://github.com/mischnic/rust-sourcemap.git", branch = "mischnic/source-content-mixup" }


### PR DESCRIPTION
The source content was somethings incorrect with scope hoisting on Turbopack:

<img width="2018" height="721" alt="image" src="https://github.com/user-attachments/assets/e2e1bf1c-2a84-4acb-8388-a809670b4902" />

Fix is in https://github.com/swc-project/swc-sourcemap/pull/7