### PR TITLE
Fix fetch logging after revalidation via server action

### DIFF
--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -85,12 +85,11 @@ export interface WorkStore {
   readonly refreshTagsByCacheKind: Map<string, LazyResult<void>>
 
   fetchMetrics?: FetchMetrics
+  shouldTrackFetchMetrics: boolean
 
   isDraftMode?: boolean
   isUnstableNoStore?: boolean
   isPrefetchRequest?: boolean
-
-  requestEndedState?: { ended?: boolean }
 
   buildId: string
 

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -121,22 +121,7 @@ function trackFetchMetric(
   workStore: WorkStore,
   ctx: Omit<FetchMetric, 'end' | 'idx'>
 ) {
-  // If the static generation store is not available, we can't track the fetch
-  if (!workStore) return
-  if (workStore.requestEndedState?.ended) return
-
-  const isDebugBuild =
-    (!!process.env.NEXT_DEBUG_BUILD ||
-      process.env.NEXT_SSG_FETCH_METRICS === '1') &&
-    workStore.isStaticGeneration
-  const isDevelopment = process.env.NODE_ENV === 'development'
-
-  if (
-    // The only time we want to track fetch metrics outside of development is when
-    // we are performing a static generation & we are in debug mode.
-    !isDebugBuild &&
-    !isDevelopment
-  ) {
+  if (!workStore.shouldTrackFetchMetrics) {
     return
   }
 

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -297,7 +297,6 @@ export async function adapter(
                 onClose: closeController.onClose.bind(closeController),
                 onAfterTaskError: undefined,
               },
-              requestEndedState: { ended: false },
               isPrefetchRequest:
                 request.headers.get(NEXT_ROUTER_PREFETCH_HEADER) === '1',
               buildId: buildId ?? '',

--- a/test/e2e/app-dir/logging/app/default-cache/page.js
+++ b/test/e2e/app-dir/logging/app/default-cache/page.js
@@ -1,3 +1,5 @@
+import { revalidateTag } from 'next/cache'
+
 export const fetchCache = 'default-cache'
 
 async function AnotherRsc() {
@@ -55,7 +57,8 @@ async function FirstRsc() {
   ).then((res) => res.text())
 
   const dataAutoCache = await fetch(
-    'https://next-data-api-endpoint.vercel.app/api/random?auto-cache'
+    'https://next-data-api-endpoint.vercel.app/api/random?auto-cache',
+    { next: { tags: ['test-tag'] } }
   ).then((res) => res.text())
 
   return (
@@ -72,12 +75,26 @@ async function FirstRsc() {
   )
 }
 
+function RevalidateForm() {
+  return (
+    <form
+      action={async () => {
+        'use server'
+        revalidateTag('test-tag')
+      }}
+    >
+      <button id="revalidate-button">Revalidate</button>
+    </form>
+  )
+}
+
 export default async function Page() {
   return (
     <>
       <h1>Default Cache</h1>
       <FirstRsc />
       <AnotherRsc />
+      <RevalidateForm />
     </>
   )
 }

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -267,6 +267,29 @@ describe('app-dir - logging', () => {
           })
         })
 
+        it('should log requests for after revalidation via server action', async () => {
+          let outputIndex = next.cliOutput.length
+          const browser = await next.browser('/default-cache')
+
+          const expectedUrl = withFullUrlFetches
+            ? 'https://next-data-api-endpoint.vercel.app/api/random'
+            : 'https://next-data-api-en../api/random'
+
+          await retry(() => {
+            const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+            expect(logs).toIncludeRepeated(` │ GET ${expectedUrl}`, 7)
+          })
+
+          outputIndex = next.cliOutput.length
+
+          await browser.elementById('revalidate-button').click()
+
+          await retry(() => {
+            const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+            expect(logs).toIncludeRepeated(` │ GET ${expectedUrl}`, 7)
+          })
+        })
+
         describe('when logging.fetches.hmrRefreshes is true', () => {
           beforeAll(async () => {
             await next.patchFile('next.config.js', (content) =>


### PR DESCRIPTION
When revalidating a tag or path with a server action, we do want to log any fetches that are made during the subsequent rerendering, when [fetch logging](https://nextjs.org/docs/app/api-reference/config/next-config-js/logging#fetching) is enabled.

This got accidentally broken in #64746, where we wrote:

> [...] this ensures we don't keep tracking fetch metrics after the request has ended as we only report on request end

That's incorrect though, because we report fetch metrics when the _response_ is closed, and not the request:

https://github.com/vercel/next.js/blob/0bd7423844e218b19537880a7fa4314749fdf57d/packages/next/src/server/dev/next-dev-server.ts#L530-L546

This is crucial for server actions, when the request is likely already closed while we're rerendering and streaming the response to the client.

fixes #80444
closes NAR-307