### PR TITLE
docs: add `experimental.typedEnv`

### DIFF
--- a/docs/01-app/03-api-reference/05-config/02-typescript.mdx
+++ b/docs/01-app/03-api-reference/05-config/02-typescript.mdx
@@ -160,6 +160,26 @@ function Card<T extends string>({ href }: { href: Route<T> | URL }) {
 >
 > When running `next dev` or `next build`, Next.js generates a hidden `.d.ts` file inside `.next` that contains information about all existing routes in your application (all valid routes as the `href` type of `Link`). This `.d.ts` file is included in `tsconfig.json` and the TypeScript compiler will check that `.d.ts` and provide feedback in your editor about invalid links.
 
+### Type Intellisense for Environment Variables
+
+During the development, Next.js generates a `.d.ts` file in `.next/types` that contains information about the loaded environment variables for the intellisense of your editor. When the key of the environment variable is duplicated, it will be deduped based on the [Environment Variable Load Order](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#environment-variable-load-order).
+
+To opt-into this feature, `experimental.typedEnv` need to be enabled and the project needs to be using TypeScript.
+
+```ts filename="next.config.ts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    typedEnv: true,
+  },
+}
+
+export default nextConfig
+```
+
+> **Good to know**: The types will be generated based on the loaded environment variables in the development runtime, which will exclude from the `.env.production*` files by default. To include the production-specific environment variables, run `next dev` with `NODE_ENV=production`.
+
 ### With Async Server Components
 
 To use an `async` Server Component with TypeScript, ensure you are using TypeScript `5.1.3` or higher and `@types/react` `18.2.8` or higher.

--- a/docs/01-app/03-api-reference/05-config/02-typescript.mdx
+++ b/docs/01-app/03-api-reference/05-config/02-typescript.mdx
@@ -160,9 +160,9 @@ function Card<T extends string>({ href }: { href: Route<T> | URL }) {
 >
 > When running `next dev` or `next build`, Next.js generates a hidden `.d.ts` file inside `.next` that contains information about all existing routes in your application (all valid routes as the `href` type of `Link`). This `.d.ts` file is included in `tsconfig.json` and the TypeScript compiler will check that `.d.ts` and provide feedback in your editor about invalid links.
 
-### Type Intellisense for Environment Variables
+### Type IntelliSense for Environment Variables
 
-During the development, Next.js generates a `.d.ts` file in `.next/types` that contains information about the loaded environment variables for the intellisense of your editor. When the key of the environment variable is duplicated, it will be deduped based on the [Environment Variable Load Order](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#environment-variable-load-order).
+During development, Next.js generates a `.d.ts` file in `.next/types` that contains information about the loaded environment variables for your editor's IntelliSense. If the same environment variable key is defined in multiple files, it is deduplicated according to the [Environment Variable Load Order](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#environment-variable-load-order).
 
 To opt-into this feature, `experimental.typedEnv` needs to be enabled and the project needs to be using TypeScript.
 
@@ -178,7 +178,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-> **Good to know**: The types will be generated based on the loaded environment variables in the development runtime, which will exclude variables from the `.env.production*` files by default. To include the production-specific environment variables, run `next dev` with `NODE_ENV=production`.
+> **Good to know**: Types are generated based on the environment variables loaded at development runtime, which excludes variables from `.env.production*` files by default. To include production-specific variables, run `next dev` with `NODE_ENV=production`.
 
 ### With Async Server Components
 

--- a/docs/01-app/03-api-reference/05-config/02-typescript.mdx
+++ b/docs/01-app/03-api-reference/05-config/02-typescript.mdx
@@ -164,7 +164,7 @@ function Card<T extends string>({ href }: { href: Route<T> | URL }) {
 
 During the development, Next.js generates a `.d.ts` file in `.next/types` that contains information about the loaded environment variables for the intellisense of your editor. When the key of the environment variable is duplicated, it will be deduped based on the [Environment Variable Load Order](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#environment-variable-load-order).
 
-To opt-into this feature, `experimental.typedEnv` need to be enabled and the project needs to be using TypeScript.
+To opt-into this feature, `experimental.typedEnv` needs to be enabled and the project needs to be using TypeScript.
 
 ```ts filename="next.config.ts"
 import type { NextConfig } from 'next'
@@ -178,7 +178,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-> **Good to know**: The types will be generated based on the loaded environment variables in the development runtime, which will exclude from the `.env.production*` files by default. To include the production-specific environment variables, run `next dev` with `NODE_ENV=production`.
+> **Good to know**: The types will be generated based on the loaded environment variables in the development runtime, which will exclude variables from the `.env.production*` files by default. To include the production-specific environment variables, run `next dev` with `NODE_ENV=production`.
 
 ### With Async Server Components
 


### PR DESCRIPTION
I added docs at https://github.com/vercel/next.js/pull/70958, but never landed on `canary` ~~due to a git rebase skill issue~~.