### PR TITLE
[perf] only load next config once when start next dev server

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -56,6 +56,7 @@ type PortSource = 'cli' | 'default' | 'env'
 
 let dir: string
 let child: undefined | ChildProcess
+// The config in next-dev is only used to access config.distDir for telemetry and trace.
 let config: NextConfigComplete
 let isTurboSession = false
 let traceUploadUrl: string
@@ -95,18 +96,6 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
     const { eventCliSessionStopped } =
       require('../telemetry/events/session-stopped') as typeof import('../telemetry/events/session-stopped')
 
-    config =
-      config ||
-      (await loadConfig(PHASE_DEVELOPMENT_SERVER, dir, { silent: true }))
-
-    let telemetry =
-      (traceGlobals.get('telemetry') as InstanceType<
-        typeof import('../telemetry/storage').Telemetry
-      >) ||
-      new Telemetry({
-        distDir: path.join(dir, config.distDir),
-      })
-
     let pagesDir: boolean = !!traceGlobals.get('pagesDir')
     let appDir: boolean = !!traceGlobals.get('appDir')
 
@@ -118,6 +107,18 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
       appDir = !!pagesResult.appDir
       pagesDir = !!pagesResult.pagesDir
     }
+
+    config =
+      config ||
+      (await loadConfig(PHASE_DEVELOPMENT_SERVER, dir, { silent: true }))
+
+    let telemetry =
+      (traceGlobals.get('telemetry') as InstanceType<
+        typeof import('../telemetry/storage').Telemetry
+      >) ||
+      new Telemetry({
+        distDir: path.join(dir, config.distDir),
+      })
 
     telemetry.record(
       eventCliSessionStopped({
@@ -316,9 +317,6 @@ const nextDev = async (
       })
 
       child.on('exit', async (code, signal) => {
-        config = await loadConfig(PHASE_DEVELOPMENT_SERVER, dir, {
-          silent: true,
-        })
         if (sessionStopHandled || signal) {
           return
         }
@@ -327,6 +325,13 @@ const nextDev = async (
           // must upload the existing contents before restarting the server to
           // preserve the metrics.
           if (traceUploadUrl) {
+            // Postpone loading next config when we need to get
+            //  config.distDir for upload trace.
+            config =
+              config ||
+              (await loadConfig(PHASE_DEVELOPMENT_SERVER, dir, {
+                silent: true,
+              }))
             uploadTrace({
               traceUploadUrl,
               mode: 'dev',

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -17,7 +17,7 @@ import { getProjectDir } from '../lib/get-project-dir'
 import { PHASE_DEVELOPMENT_SERVER } from '../shared/lib/constants'
 import path from 'path'
 import type { NextConfigComplete } from '../server/config-shared'
-import { setGlobal, traceGlobals } from '../trace/shared'
+import { traceGlobals } from '../trace/shared'
 import { Telemetry } from '../telemetry/storage'
 import loadConfig from '../server/config'
 import { findPagesDir } from '../lib/find-pages-dir'
@@ -228,10 +228,6 @@ const nextDev = async (
   // some set-ups that rely on listening on other interfaces
   const host = options.hostname
 
-  config = await loadConfig(PHASE_DEVELOPMENT_SERVER, dir, {
-    silent: false,
-  })
-
   if (
     options.experimentalUploadTrace &&
     !process.env.NEXT_TRACE_UPLOAD_DISABLED
@@ -246,10 +242,6 @@ const nextDev = async (
     isDev: true,
     hostname: host,
   }
-
-  const distDir = path.join(dir, config.distDir ?? '.next')
-  setGlobal('phase', PHASE_DEVELOPMENT_SERVER)
-  setGlobal('distDir', distDir)
 
   const startServerPath = require.resolve('../server/lib/start-server')
 
@@ -322,6 +314,9 @@ const nextDev = async (
       })
 
       child.on('exit', async (code, signal) => {
+        config = await loadConfig(PHASE_DEVELOPMENT_SERVER, dir, {
+          silent: true,
+        })
         if (sessionStopHandled || signal) {
           return
         }

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -95,7 +95,9 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
     const { eventCliSessionStopped } =
       require('../telemetry/events/session-stopped') as typeof import('../telemetry/events/session-stopped')
 
-    config = config || (await loadConfig(PHASE_DEVELOPMENT_SERVER, dir))
+    config =
+      config ||
+      (await loadConfig(PHASE_DEVELOPMENT_SERVER, dir, { silent: true }))
 
     let telemetry =
       (traceGlobals.get('telemetry') as InstanceType<

--- a/packages/next/src/lib/find-root.ts
+++ b/packages/next/src/lib/find-root.ts
@@ -17,9 +17,16 @@ export function findRootLockFile(cwd: string) {
   )
 }
 
-export function findRootDir(cwd: string): string {
+export function findRootDirAndLockFiles(cwd: string): {
+  lockFiles: string[]
+  rootDir: string
+} {
   const lockFile = findRootLockFile(cwd)
-  if (!lockFile) return cwd
+  if (!lockFile)
+    return {
+      lockFiles: [],
+      rootDir: cwd,
+    }
 
   const lockFiles = [lockFile]
   while (true) {
@@ -37,8 +44,14 @@ export function findRootDir(cwd: string): string {
     lockFiles.push(newLockFile)
   }
 
-  // Only warn if not in a build worker to avoid duplicate warnings
-  if (typeof process.send !== 'function' && lockFiles.length > 1) {
+  return {
+    lockFiles,
+    rootDir: dirname(lockFiles[lockFiles.length - 1]),
+  }
+}
+
+export function warnDuplicatedLockFiles(lockFiles: string[]) {
+  if (lockFiles.length > 1) {
     const additionalLockFiles = lockFiles
       .slice(0, -1)
       .map((str) => `\n   * ${str}`)
@@ -64,6 +77,4 @@ export function findRootDir(cwd: string): string {
       )
     }
   }
-
-  return dirname(lockFiles[lockFiles.length - 1])
 }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -764,7 +764,9 @@ function assignDefaults(
   if (!rootDir) {
     const { rootDir: foundRootDir, lockFiles } = findRootDirAndLockFiles(dir)
     rootDir = foundRootDir
-    warnDuplicatedLockFiles(lockFiles)
+    if (!silent) {
+      warnDuplicatedLockFiles(lockFiles)
+    }
   }
 
   if (!rootDir) {
@@ -1434,7 +1436,7 @@ export default async function loadConfig(
     checkDeprecations(userConfig, configFileName, silent, dir)
 
     // Always validate the config against schema in non minimal mode
-    if (!process.env.NEXT_MINIMAL) {
+    if (!process.env.NEXT_MINIMAL && !silent) {
       validateConfigSchema(userConfig, configFileName, curLog.warn)
     }
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -25,7 +25,10 @@ import { imageConfigDefault } from '../shared/lib/image-config'
 import type { ImageConfig } from '../shared/lib/image-config'
 import { loadEnvConfig, updateInitialEnv } from '@next/env'
 import { flushAndExit } from '../telemetry/flush-and-exit'
-import { findRootDir } from '../lib/find-root'
+import {
+  findRootDirAndLockFiles,
+  warnDuplicatedLockFiles,
+} from '../lib/find-root'
 import { setHttpClientAndAgentOptions } from './setup-http-agent-env'
 import { pathHasPrefix } from '../shared/lib/router/utils/path-has-prefix'
 import { matchRemotePattern } from '../shared/lib/match-remote-pattern'
@@ -757,7 +760,12 @@ function assignDefaults(
     )
   }
 
-  const rootDir = tracingRoot || turbopackRoot || findRootDir(dir)
+  let rootDir = tracingRoot || turbopackRoot
+  if (!rootDir) {
+    const { rootDir: foundRootDir, lockFiles } = findRootDirAndLockFiles(dir)
+    rootDir = foundRootDir
+    warnDuplicatedLockFiles(lockFiles)
+  }
 
   if (!rootDir) {
     throw new Error(
@@ -1425,43 +1433,9 @@ export default async function loadConfig(
     // Check deprecation warnings on the actual user config before merging with defaults
     checkDeprecations(userConfig, configFileName, silent, dir)
 
-    // Always validate the config against schema in non minimal mode.
-    // Only validate once in the root Next.js process, not in forked processes.
-    const isRootProcess = typeof process.send !== 'function'
-    if (!process.env.NEXT_MINIMAL && isRootProcess) {
-      // We only validate the config against schema in non minimal mode
-      const { configSchema } =
-        require('./config-schema') as typeof import('./config-schema')
-      const state = configSchema.safeParse(userConfig)
-
-      if (!state.success) {
-        // error message header
-        const messages = [`Invalid ${configFileName} options detected: `]
-
-        const [errorMessages, shouldExit] = normalizeNextConfigZodErrors(
-          state.error
-        )
-        // ident list item
-        for (const error of errorMessages) {
-          messages.push(`    ${error}`)
-        }
-
-        // error message footer
-        messages.push(
-          'See more info here: https://nextjs.org/docs/messages/invalid-next-config'
-        )
-
-        if (shouldExit) {
-          for (const message of messages) {
-            console.error(message)
-          }
-          await flushAndExit(1)
-        } else {
-          for (const message of messages) {
-            curLog.warn(message)
-          }
-        }
-      }
+    // Always validate the config against schema in non minimal mode
+    if (!process.env.NEXT_MINIMAL) {
+      validateConfigSchema(userConfig, configFileName, curLog.warn)
     }
 
     if (userConfig.target && userConfig.target !== 'server') {
@@ -1889,4 +1863,44 @@ function cloneObject(obj: any): any {
   }
 
   return result
+}
+
+async function validateConfigSchema(
+  userConfig: NextConfig,
+  configFileName: string,
+  warn: (message: string) => void
+) {
+  // We only validate the config against schema in non minimal mode
+  const { configSchema } =
+    require('./config-schema') as typeof import('./config-schema')
+  const state = configSchema.safeParse(userConfig)
+
+  if (!state.success) {
+    // error message header
+    const messages = [`Invalid ${configFileName} options detected: `]
+
+    const [errorMessages, shouldExit] = normalizeNextConfigZodErrors(
+      state.error
+    )
+    // ident list item
+    for (const error of errorMessages) {
+      messages.push(`    ${error}`)
+    }
+
+    // error message footer
+    messages.push(
+      'See more info here: https://nextjs.org/docs/messages/invalid-next-config'
+    )
+
+    if (shouldExit) {
+      for (const message of messages) {
+        console.error(message)
+      }
+      await flushAndExit(1)
+    } else {
+      for (const message of messages) {
+        warn(message)
+      }
+    }
+  }
 }

--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -95,6 +95,7 @@ export async function getStartServerInfo({
         )
       },
       debugPrerender,
+      silent: false,
     }
   )
 

--- a/test/development/load-config-freq/app/layout.js
+++ b/test/development/load-config-freq/app/layout.js
@@ -1,0 +1,7 @@
+export default function Root({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/load-config-freq/app/page.js
+++ b/test/development/load-config-freq/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/load-config-freq/load-config-freq.test.ts
+++ b/test/development/load-config-freq/load-config-freq.test.ts
@@ -1,0 +1,16 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('load-config-freq', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should only load next config once when start next dev server', async () => {
+    await next.fetch('/')
+    const output = next.cliOutput
+
+    // Ensure there's only one "[ASSERTION] load nextConfig" in the text
+    const parts = output.split(/\[ASSERTION\] load nextConfig/g)
+    expect(parts).toHaveLength(2)
+  })
+})

--- a/test/development/load-config-freq/next.config.js
+++ b/test/development/load-config-freq/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+console.log('[ASSERTION] load nextConfig')
+
+module.exports = nextConfig


### PR DESCRIPTION
We were adding a small improvement in #80570 that we can cache next config for certain loading phase. This PR is an improvement based on that

Currently when you start `next dev` we'll load next config to access the `config.distDir` for tracing in cli. Since it's in a different process than router-server, it will load `next.config.js` and since the `phase` is different so we cannot cache the next config based on the input as the result could vary. Since we only need `config.distDir` in the server teardown phase, we can only load config there in order to save sometime on start next server. This will help the `loadConfig` is only called once when you run `next dev` before stop the server.

Previously we noticed that each time when we call `loadConfig`, we'll do the config schema invalidation, and check. Now since the config is only loading once in `next dev` we removed the `process.send` check for ensuring to run only in parent process, and let it run naturally.

Closes NEXT-4682