### PR TITLE
feat: add RouteContext type for app router route handlers

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -569,6 +569,20 @@ declare global {
   } & {
     [K in LayoutSlotMap[LayoutRoute]]: React.ReactNode
   }
+
+  /**
+   * Context for Next.js App Router route handlers
+   * @example
+   * \`\`\`tsx
+   * export async function GET(request: NextRequest, context: RouteContext<'/api/users/[id]'>) {
+   *   const { id } = await context.params
+   *   return Response.json({ id })
+   * }
+   * \`\`\`
+   */
+  interface RouteContext<AppRouteHandlerRoute extends AppRouteHandlerRoutes> {
+    params: Promise<ParamMap[AppRouteHandlerRoute]>
+  }
 }
 `
 }

--- a/test/e2e/app-dir/typed-routes/app/api/docs/[...slug]/route.ts
+++ b/test/e2e/app-dir/typed-routes/app/api/docs/[...slug]/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest } from 'next/server'
+
+export async function GET(
+  request: NextRequest,
+  context: RouteContext<'/api/docs/[...slug]'>
+) {
+  const { slug } = await context.params
+  return Response.json({ slug })
+}

--- a/test/e2e/app-dir/typed-routes/app/api/shop/[[...category]]/route.ts
+++ b/test/e2e/app-dir/typed-routes/app/api/shop/[[...category]]/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest } from 'next/server'
+
+export async function GET(
+  request: NextRequest,
+  context: RouteContext<'/api/shop/[[...category]]'>
+) {
+  const { category } = await context.params
+  return Response.json({ category })
+}

--- a/test/e2e/app-dir/typed-routes/app/api/users/[id]/route.ts
+++ b/test/e2e/app-dir/typed-routes/app/api/users/[id]/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from 'next/server'
+
+export async function GET(
+  request: NextRequest,
+  context: RouteContext<'/api/users/[id]'>
+) {
+  const { id } = await context.params
+  return Response.json({ id })
+}
+
+export async function POST(
+  request: NextRequest,
+  context: RouteContext<'/api/users/[id]'>
+) {
+  const { id } = await context.params
+  const body = await request.json()
+  return Response.json({ id, ...body })
+}


### PR DESCRIPTION
## Add typed RouteContext for App Router route handlers

This PR adds type support for route handlers in the App Router by introducing a new `RouteContext` interface. This allows for strongly-typed access to route parameters in API routes.

### Features:

- Adds a new global `RouteContext<AppRouteHandlerRoute>` interface with typed `params` property
- Adds test cases for various route parameter patterns
- Updates type tests to verify correct type checking for route handlers

This enhancement improves the developer experience by providing type safety when accessing route parameters in API route handlers, similar to the existing type support for pages and layouts.