### PR TITLE
Add additional handling for build-complete

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -777,5 +777,6 @@
   "776": "`unstable_isUnrecognizedActionError` can only be used on the client.",
   "777": "Invariant: failed to find source route %s for prerender %s",
   "778": "`prerenderAndAbortInSequentialTasksWithStages` should not be called in edge runtime.",
-  "779": "Route %s used \"searchParams\" inside \"use cache\". Accessing dynamic request data inside a cache scope is not supported. If you need some search params inside a cached function await \"searchParams\" outside of the cached function and pass only the required search params as arguments to the cached function. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache"
+  "779": "Route %s used \"searchParams\" inside \"use cache\". Accessing dynamic request data inside a cache scope is not supported. If you need some search params inside a cached function await \"searchParams\" outside of the cached function and pass only the required search params as arguments to the cached function. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
+  "780": "Invariant: failed to find parent dynamic route for notFound route %s"
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3955,6 +3955,7 @@ export default async function build(
           prerenderManifest,
           middlewareManifest,
           functionsConfigManifest,
+          hasStatic404: useStaticPages404,
           requiredServerFiles: requiredServerFilesManifest.files,
         })
       }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -98,6 +98,17 @@ export type AdapterOutputs = Array<{
      * matchers are the configured matchers for middleware
      */
     matchers?: MiddlewareMatcher[]
+
+    /**
+     * bypassToken is the generated token that signals a prerender cache
+     * should be bypassed
+     */
+    bypassToken?: string
+
+    /**
+     * postponed is the PPR state when it postponed and is used for resuming
+     */
+    postponed?: string
   }
   /**
    * For prerenders the parent output is the originating

--- a/test/production/adapter-config/adapter-config.test.ts
+++ b/test/production/adapter-config/adapter-config.test.ts
@@ -87,6 +87,25 @@ describe('adapter-config', () => {
       expect(fs.existsSync(output.filePath)).toBe(true)
     }
 
+    for (const prerenderOutput of prerenderOutputs) {
+      try {
+        expect(prerenderOutput.parentOutputId).toBeTruthy()
+        if (prerenderOutput.fallback) {
+          expect(await fs.existsSync(prerenderOutput.fallback.filePath)).toBe(
+            true
+          )
+          expect(prerenderOutput.fallback.initialRevalidate).toBeDefined()
+        }
+
+        expect(typeof prerenderOutput.config.bypassToken).toBe('string')
+        expect(Array.isArray(prerenderOutput.config.allowHeader)).toBe(true)
+        expect(Array.isArray(prerenderOutput.config.allowQuery)).toBe(true)
+      } catch (err) {
+        require('console').error(`invalid prerender ${prerenderOutput.id}`, err)
+        throw err
+      }
+    }
+
     expect(buildContext.routes).toEqual({
       dynamicRoutes: expect.toBeArray(),
       rewrites: expect.toBeObject(),

--- a/test/production/adapter-config/pages/isr-pages-fallback-true/[slug]/index.tsx
+++ b/test/production/adapter-config/pages/isr-pages-fallback-true/[slug]/index.tsx
@@ -7,6 +7,9 @@ export function getStaticPaths() {
       {
         params: { slug: 'second' },
       },
+      {
+        params: { slug: 'not-found' },
+      },
     ],
     fallback: true,
   }

--- a/test/production/adapter-config/pages/isr-pages/[slug]/index.tsx
+++ b/test/production/adapter-config/pages/isr-pages/[slug]/index.tsx
@@ -16,6 +16,12 @@ export function getStaticPaths() {
 }
 
 export function getStaticProps({ params }) {
+  if (params.slug === 'not-found') {
+    return {
+      notFound: true,
+    }
+  }
+
   return {
     props: {
       params,


### PR DESCRIPTION
This continues the `build-complete` handling for the adapters config adding additional prerender logic including PPR fields and expanding test coverage ensuring correct outputs. 