### PR TITLE
feat: add a codemod to migrate from the deprecated "next lint" command

### DIFF
--- a/docs/01-app/02-guides/upgrading/codemods.mdx
+++ b/docs/01-app/02-guides/upgrading/codemods.mdx
@@ -24,6 +24,73 @@ Replacing `<transform>` and `<path>` with appropriate values.
 
 ## Codemods
 
+### 16.0
+
+#### Migrate from `next lint` to ESLint CLI
+
+##### `next-lint-to-eslint-cli`
+
+```bash filename="Terminal"
+npx @next/codemod@canary next-lint-to-eslint-cli .
+```
+
+This codemod migrates projects from using `next lint` to using the ESLint CLI with your local ESLint config. It:
+
+- Creates an `eslint.config.mjs` file with Next.js recommended configurations
+- Updates `package.json` scripts to use `eslint .` instead of `next lint`
+- Adds necessary ESLint dependencies to `package.json`
+- Preserves existing ESLint configurations when found
+
+For example:
+
+```json filename="package.json"
+{
+  "scripts": {
+    "lint": "next lint"
+  }
+}
+```
+
+Becomes:
+
+```json filename="package.json"
+{
+  "scripts": {
+    "lint": "eslint ."
+  }
+}
+```
+
+And creates:
+
+```js filename="eslint.config.mjs"
+import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { FlatCompat } from '@eslint/eslintrc'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+})
+
+const eslintConfig = [
+  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  {
+    ignores: [
+      'node_modules/**',
+      '.next/**',
+      'out/**',
+      'build/**',
+      'next-env.d.ts',
+    ],
+  },
+]
+
+export default eslintConfig
+```
+
 ### 15.0
 
 #### Transform App Router Route Segment Config `runtime` value from `experimental-edge` to `edge`

--- a/packages/next-codemod/bin/transform.ts
+++ b/packages/next-codemod/bin/transform.ts
@@ -113,6 +113,11 @@ export async function runTransform(
     return require(transformerPath).default(filesExpanded, options)
   }
 
+  if (transformer === 'next-lint-to-eslint-cli') {
+    // next-lint-to-eslint-cli transform doesn't use jscodeshift directly
+    return require(transformerPath).default(filesExpanded, options)
+  }
+
   let args = []
 
   const { dry, print, runInBand, jscodeshift, verbose } = options

--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -31,6 +31,8 @@ export function getPkgManager(baseDir: string): PackageManager {
           return 'npm'
       }
     }
+    // No lock file found, default to npm
+    return 'npm'
   } catch {
     return 'npm'
   }

--- a/packages/next-codemod/lib/utils.ts
+++ b/packages/next-codemod/lib/utils.ts
@@ -121,4 +121,9 @@ export const TRANSFORMER_INQUIRER_CHOICES = [
     value: 'next-experimental-turbo-to-turbopack',
     version: '10.0.0',
   },
+  {
+    title: 'Migrate from `next lint` to the ESLint CLI',
+    value: 'next-lint-to-eslint-cli',
+    version: '16.0.0',
+  },
 ]

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/basic.input.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/basic.input.json
@@ -1,0 +1,22 @@
+{
+  "name": "my-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "next": "15.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19"
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/basic.output.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/basic.output.json
@@ -1,0 +1,25 @@
+{
+  "name": "my-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "next": "15.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "15.0.0",
+    "@eslint/eslintrc": "^3"
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/cjs-flat-config.eslint.cjs
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/cjs-flat-config.eslint.cjs
@@ -1,0 +1,8 @@
+module.exports = [
+  {
+    rules: {
+      "quotes": ["error", "double"],
+      "indent": ["error", 2]
+    }
+  }
+]

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/complex-scripts.input.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/complex-scripts.input.json
@@ -1,0 +1,18 @@
+{
+  "name": "complex-scripts-app",
+  "version": "1.0.0",
+  "scripts": {
+    "lint": "next lint --fix --dir src --dir pages",
+    "lint:strict": "next lint --strict",
+    "lint:ci": "next lint --quiet --output-file lint-results.json",
+    "precommit": "next lint --fix && npm test",
+    "test": "jest && next lint",
+    "complex": "npm run build && next lint --dir . --ext .js,.jsx,.ts,.tsx 2>/dev/null",
+    "pipe": "next lint | tee lint.log",
+    "redirect": "next lint > output.txt 2>&1",
+    "multi": "next lint; next build; next lint --fix"
+  },
+  "dependencies": {
+    "next": "15.0.0"
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/complex-scripts.output.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/complex-scripts.output.json
@@ -1,0 +1,23 @@
+{
+  "name": "complex-scripts-app",
+  "version": "1.0.0",
+  "scripts": {
+    "lint": "eslint --fix src pages",
+    "lint:strict": "eslint --max-warnings 0 .",
+    "lint:ci": "eslint --quiet --output-file lint-results.json .",
+    "precommit": "eslint --fix . && npm test",
+    "test": "jest && eslint .",
+    "complex": "npm run build && eslint . 2>/dev/null",
+    "pipe": "eslint . | tee lint.log",
+    "redirect": "eslint . > output.txt 2>&1",
+    "multi": "eslint .; next build; eslint --fix ."
+  },
+  "dependencies": {
+    "next": "15.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^9",
+    "eslint-config-next": "15.0.0",
+    "@eslint/eslintrc": "^3"
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-eslint.input.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-eslint.input.json
@@ -1,0 +1,20 @@
+{
+  "name": "my-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "next": "15.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^8.0.0",
+    "eslint-config-next": "15.0.0"
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-eslint.output.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-eslint.output.json
@@ -1,0 +1,21 @@
+{
+  "name": "my-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "next": "15.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^8.0.0",
+    "eslint-config-next": "15.0.0",
+    "@eslint/eslintrc": "^3"
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-flat-config.eslint.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-flat-config.eslint.js
@@ -1,0 +1,14 @@
+export default [
+  {
+    rules: {
+      "no-console": "warn",
+      "semi": ["error", "always"]
+    }
+  },
+  {
+    files: ["**/*.test.js"],
+    rules: {
+      "no-console": "off"
+    }
+  }
+]

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-flat-config.input.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-flat-config.input.json
@@ -1,0 +1,11 @@
+{
+  "name": "app-with-flat-config",
+  "version": "1.0.0",
+  "scripts": {
+    "lint": "next lint",
+    "lint:fix": "next lint --fix"
+  },
+  "dependencies": {
+    "next": "15.0.0"
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-flat-config.output.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-flat-config.output.json
@@ -1,0 +1,16 @@
+{
+  "name": "app-with-flat-config",
+  "version": "1.0.0",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix ."
+  },
+  "dependencies": {
+    "next": "15.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^9",
+    "eslint-config-next": "15.0.0",
+    "@eslint/eslintrc": "^3"
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-ignores.eslint.js
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-ignores.eslint.js
@@ -1,0 +1,10 @@
+export default [
+  {
+    ignores: ["dist/**", "coverage/**"]
+  },
+  {
+    rules: {
+      "no-unused-vars": "warn"
+    }
+  }
+]

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/no-scripts.input.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/no-scripts.input.json
@@ -1,0 +1,7 @@
+{
+  "name": "app-without-scripts",
+  "version": "1.0.0",
+  "dependencies": {
+    "next": "15.0.0"
+  }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/no-scripts.output.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/no-scripts.output.json
@@ -1,0 +1,13 @@
+{
+  "name": "app-without-scripts",
+  "version": "1.0.0",
+  "scripts": {},
+  "dependencies": {
+    "next": "15.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^9",
+    "eslint-config-next": "15.0.0",
+    "@eslint/eslintrc": "^3"
+  }
+}

--- a/packages/next-codemod/transforms/__tests__/next-lint-to-eslint-cli.test.js
+++ b/packages/next-codemod/transforms/__tests__/next-lint-to-eslint-cli.test.js
@@ -1,0 +1,491 @@
+/* global jest */
+jest.autoMockOff()
+const fs = require('fs')
+const path = require('path')
+const { tmpdir } = require('os')
+const transformer = require('../next-lint-to-eslint-cli').default
+
+describe('next-lint-to-eslint-cli', () => {
+  let tempDir
+
+  beforeEach(() => {
+    // Create a unique temp directory for each test
+    tempDir = fs.mkdtempSync(path.join(tmpdir(), 'codemod-test-'))
+  })
+
+  afterEach(() => {
+    // Clean up temp directory
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test('transforms correctly using basic data', () => {
+    // Read input fixture
+    const inputPath = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/basic.input.json')
+    const expectedOutputPath = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/basic.output.json')
+    
+    const inputContent = fs.readFileSync(inputPath, 'utf8')
+    const expectedOutput = fs.readFileSync(expectedOutputPath, 'utf8')
+
+    // Set up test project
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    const tsConfigPath = path.join(tempDir, 'tsconfig.json')
+    
+    fs.writeFileSync(packageJsonPath, inputContent)
+    fs.writeFileSync(tsConfigPath, '{}') // Create tsconfig.json to indicate TypeScript project
+
+    // Run transformer
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    // Check package.json was updated correctly
+    const actualPackageJson = fs.readFileSync(packageJsonPath, 'utf8')
+    expect(JSON.parse(actualPackageJson)).toEqual(JSON.parse(expectedOutput))
+
+    // Check eslint.config.mjs was created
+    const eslintConfigPath = path.join(tempDir, 'eslint.config.mjs')
+    expect(fs.existsSync(eslintConfigPath)).toBe(true)
+    
+    const eslintConfig = fs.readFileSync(eslintConfigPath, 'utf8')
+    expect(eslintConfig).toContain('next/core-web-vitals')
+    expect(eslintConfig).toContain('next/typescript')
+    expect(eslintConfig).toContain('ignores:')
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('transforms correctly using existing-eslint data', () => {
+    // Read input fixture
+    const inputPath = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/existing-eslint.input.json')
+    const expectedOutputPath = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/existing-eslint.output.json')
+    
+    const inputContent = fs.readFileSync(inputPath, 'utf8')
+    const expectedOutput = fs.readFileSync(expectedOutputPath, 'utf8')
+
+    // Set up test project
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    const existingEslintPath = path.join(tempDir, '.eslintrc.json')
+    
+    fs.writeFileSync(packageJsonPath, inputContent)
+    fs.writeFileSync(existingEslintPath, '{"extends": ["next"]}') // Create existing ESLint config
+
+    // Run transformer
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    // Check package.json was updated correctly
+    const actualPackageJson = fs.readFileSync(packageJsonPath, 'utf8')
+    expect(JSON.parse(actualPackageJson)).toEqual(JSON.parse(expectedOutput))
+
+    // Check that no new eslint.config.mjs was created (existing config should be preserved)
+    const eslintConfigPath = path.join(tempDir, 'eslint.config.mjs')
+    expect(fs.existsSync(eslintConfigPath)).toBe(false)
+
+    // Check that existing config still exists
+    expect(fs.existsSync(existingEslintPath)).toBe(true)
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('handles complex script patterns correctly', () => {
+    const inputPath = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/complex-scripts.input.json')
+    const expectedOutputPath = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/complex-scripts.output.json')
+    
+    const inputContent = fs.readFileSync(inputPath, 'utf8')
+    const expectedOutput = fs.readFileSync(expectedOutputPath, 'utf8')
+
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    fs.writeFileSync(packageJsonPath, inputContent)
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    const actualPackageJson = fs.readFileSync(packageJsonPath, 'utf8')
+    expect(JSON.parse(actualPackageJson)).toEqual(JSON.parse(expectedOutput))
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('updates existing ES module flat config with AST manipulation', () => {
+    const inputPath = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/existing-flat-config.input.json')
+    const expectedOutputPath = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/existing-flat-config.output.json')
+    const eslintConfigFixture = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/existing-flat-config.eslint.js')
+    
+    const inputContent = fs.readFileSync(inputPath, 'utf8')
+    const expectedOutput = fs.readFileSync(expectedOutputPath, 'utf8')
+    const eslintConfigContent = fs.readFileSync(eslintConfigFixture, 'utf8')
+
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    const eslintConfigPath = path.join(tempDir, 'eslint.config.js')
+    
+    fs.writeFileSync(packageJsonPath, inputContent)
+    fs.writeFileSync(eslintConfigPath, eslintConfigContent)
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    // Check package.json was updated
+    const actualPackageJson = fs.readFileSync(packageJsonPath, 'utf8')
+    expect(JSON.parse(actualPackageJson)).toEqual(JSON.parse(expectedOutput))
+
+    // Check that existing config was updated with Next.js configs
+    const updatedConfig = fs.readFileSync(eslintConfigPath, 'utf8')
+    expect(updatedConfig).toContain('FlatCompat')
+    expect(updatedConfig).toContain('next/core-web-vitals')
+    expect(updatedConfig).toContain('no-console') // Original rule should be preserved
+    expect(updatedConfig).toContain('semi') // Original rule should be preserved
+    expect(updatedConfig).toContain('ignores') // Should add ignores section
+    expect(updatedConfig).toContain('.next/**') // Should include Next.js build directory
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('updates existing CommonJS flat config with AST manipulation', () => {
+    const inputPath = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/existing-flat-config.input.json')
+    const expectedOutputPath = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/existing-flat-config.output.json')
+    const eslintConfigFixture = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/cjs-flat-config.eslint.cjs')
+    
+    const inputContent = fs.readFileSync(inputPath, 'utf8')
+    const expectedOutput = fs.readFileSync(expectedOutputPath, 'utf8')
+    const eslintConfigContent = fs.readFileSync(eslintConfigFixture, 'utf8')
+
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    const eslintConfigPath = path.join(tempDir, 'eslint.config.cjs')
+    
+    fs.writeFileSync(packageJsonPath, inputContent)
+    fs.writeFileSync(eslintConfigPath, eslintConfigContent)
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    // Check package.json was updated
+    const actualPackageJson = fs.readFileSync(packageJsonPath, 'utf8')
+    expect(JSON.parse(actualPackageJson)).toEqual(JSON.parse(expectedOutput))
+
+    // Check that existing config was updated with Next.js configs
+    const updatedConfig = fs.readFileSync(eslintConfigPath, 'utf8')
+    expect(updatedConfig).toContain('FlatCompat')
+    expect(updatedConfig).toContain('require')
+    expect(updatedConfig).toContain('next/core-web-vitals')
+    expect(updatedConfig).toContain('quotes') // Original rule should be preserved
+    expect(updatedConfig).toContain('indent') // Original rule should be preserved
+    expect(updatedConfig).toContain('ignores') // Should add ignores section
+    expect(updatedConfig).toContain('node_modules/**') // Should include common ignores
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('handles package.json without scripts section', () => {
+    const inputPath = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/no-scripts.input.json')
+    const expectedOutputPath = path.join(__dirname, '../__testfixtures__/next-lint-to-eslint-cli/no-scripts.output.json')
+    
+    const inputContent = fs.readFileSync(inputPath, 'utf8')
+    const expectedOutput = fs.readFileSync(expectedOutputPath, 'utf8')
+
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    fs.writeFileSync(packageJsonPath, inputContent)
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    // Check package.json was updated with dependencies only
+    const actualPackageJson = fs.readFileSync(packageJsonPath, 'utf8')
+    expect(JSON.parse(actualPackageJson)).toEqual(JSON.parse(expectedOutput))
+
+    // Check that eslint.config.mjs was created
+    const eslintConfigPath = path.join(tempDir, 'eslint.config.mjs')
+    expect(fs.existsSync(eslintConfigPath)).toBe(true)
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('preserves existing eslint dependencies', () => {
+    const packageJson = {
+      name: 'app-with-eslint',
+      scripts: {
+        lint: 'next lint'
+      },
+      dependencies: {
+        next: '15.0.0'
+      },
+      devDependencies: {
+        eslint: '^8.57.0',
+        'eslint-config-next': '14.2.0'
+      }
+    }
+
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    const actualPackageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+    
+    // Should preserve existing eslint versions
+    expect(actualPackageJson.devDependencies.eslint).toBe('^8.57.0')
+    expect(actualPackageJson.devDependencies['eslint-config-next']).toBe('14.2.0')
+    // Should add missing @eslint/eslintrc
+    expect(actualPackageJson.devDependencies['@eslint/eslintrc']).toBe('^3')
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('handles TypeScript config files', () => {
+    const packageJson = {
+      name: 'app-with-ts-config',
+      scripts: {
+        lint: 'next lint'
+      },
+      dependencies: {
+        next: '15.0.0'
+      }
+    }
+
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    const eslintConfigPath = path.join(tempDir, 'eslint.config.ts')
+    
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
+    fs.writeFileSync(eslintConfigPath, 'export default []')
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    // Should log that TypeScript configs require manual migration
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('TypeScript config files require manual migration')
+    )
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+    consoleWarnSpy.mockRestore()
+  })
+
+  test('handles missing package.json gracefully', () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error: package.json not found in the specified directory')
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('handles missing directory argument', () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([], { skipInstall: true })
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error: Please specify a directory path')
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('creates JavaScript config for non-TypeScript projects', () => {
+    const packageJson = {
+      name: 'js-app',
+      scripts: {
+        lint: 'next lint'
+      },
+      dependencies: {
+        next: '15.0.0',
+        react: '^18.0.0'
+      }
+    }
+
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    // Check that eslint.config.mjs was created without TypeScript config
+    const eslintConfigPath = path.join(tempDir, 'eslint.config.mjs')
+    const eslintConfig = fs.readFileSync(eslintConfigPath, 'utf8')
+    
+    expect(eslintConfig).toContain('next/core-web-vitals')
+    expect(eslintConfig).not.toContain('next/typescript')
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('adds ignores even when Next.js configs are already present', () => {
+    const existingConfig = `
+import { FlatCompat } from "@eslint/eslintrc"
+const compat = new FlatCompat({ baseDirectory: __dirname })
+export default [
+  ...compat.extends("next/core-web-vitals"),
+  { rules: { "no-console": "warn" } }
+]`
+
+    const packageJson = {
+      name: 'app-with-next-config',
+      scripts: {
+        lint: 'next lint'
+      },
+      dependencies: {
+        next: '15.0.0'
+      }
+    }
+
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    const eslintConfigPath = path.join(tempDir, 'eslint.config.js')
+    
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
+    fs.writeFileSync(eslintConfigPath, existingConfig)
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    // Should still add ignores even though Next.js configs are present
+    const updatedConfig = fs.readFileSync(eslintConfigPath, 'utf8')
+    expect(updatedConfig).toContain('ignores')
+    expect(updatedConfig).toContain('.next/**')
+    expect(updatedConfig).toContain('node_modules/**')
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('handles scripts with paths containing spaces', () => {
+    const packageJson = {
+      name: 'app-with-spaces',
+      scripts: {
+        lint: 'next lint --dir "src/my components" --file "test file.js"'
+      },
+      dependencies: {
+        next: '15.0.0'
+      }
+    }
+
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    const actualPackageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+    expect(actualPackageJson.scripts.lint).toBe('eslint "src/my components" "test file.js"')
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('does not duplicate ignores if already present', () => {
+    const packageJson = {
+      name: 'app-with-existing-ignores',
+      scripts: {
+        lint: 'next lint'
+      },
+      dependencies: {
+        next: '15.0.0'
+      }
+    }
+
+    const existingConfig = `export default [
+  {
+    ignores: ["dist/**", "coverage/**"]
+  },
+  {
+    rules: {
+      "no-unused-vars": "warn"
+    }
+  }
+]`
+
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    const eslintConfigPath = path.join(tempDir, 'eslint.config.js')
+    
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
+    fs.writeFileSync(eslintConfigPath, existingConfig)
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    const updatedConfig = fs.readFileSync(eslintConfigPath, 'utf8')
+    
+    // Should add Next.js extends
+    expect(updatedConfig).toContain('next/core-web-vitals')
+    
+    // Should preserve existing ignores
+    expect(updatedConfig).toContain('dist/**')
+    expect(updatedConfig).toContain('coverage/**')
+    
+    // Check that Next.js ignores are added to existing ignores
+    expect(updatedConfig).toContain('.next/**') // Next.js build dir added
+    expect(updatedConfig).toContain('node_modules/**') // Common ignore added
+    
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+
+  test('handles unsupported flags with warnings', () => {
+    const packageJson = {
+      name: 'app-with-unsupported-flags',
+      scripts: {
+        lint: 'next lint --rulesdir ./custom-rules --ext .js,.jsx'
+      },
+      dependencies: {
+        next: '15.0.0'
+      }
+    }
+
+    const packageJsonPath = path.join(tempDir, 'package.json')
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    
+    transformer([tempDir], { skipInstall: true })
+
+    // Should show warnings about unsupported flags
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('--rulesdir is not supported in ESLint v9'))
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('--ext is not needed in ESLint v9'))
+
+    // Script should be updated without the unsupported flags
+    const actualPackageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+    expect(actualPackageJson.scripts.lint).toBe('eslint .')
+
+    consoleSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+  })
+})

--- a/packages/next-codemod/transforms/next-lint-to-eslint-cli.ts
+++ b/packages/next-codemod/transforms/next-lint-to-eslint-cli.ts
@@ -1,0 +1,900 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { getPkgManager, installPackages } from '../lib/handle-package'
+import { createParserFromPath } from '../lib/parser'
+import { white, bold, red, yellow, green, magenta } from 'picocolors'
+
+export const prefixes = {
+  wait: white(bold('○')),
+  error: red(bold('⨯')),
+  warn: yellow(bold('⚠')),
+  ready: '▲', // no color
+  info: white(bold(' ')),
+  event: green(bold('✓')),
+  trace: magenta(bold('»')),
+} as const
+
+interface TransformerOptions {
+  skipInstall?: boolean
+  [key: string]: unknown
+}
+
+const ESLINT_CONFIG_TEMPLATE_TYPESCRIPT = `\
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    ignores: [
+      "node_modules/**",
+      ".next/**",
+      "out/**",
+      "build/**",
+      "next-env.d.ts",
+    ],
+  },
+];
+
+export default eslintConfig;
+`
+
+const ESLINT_CONFIG_TEMPLATE_JAVASCRIPT = `import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals"),
+  {
+    ignores: [
+      "node_modules/**",
+      ".next/**",
+      "out/**",
+      "build/**",
+      "next-env.d.ts",
+    ],
+  },
+];
+
+export default eslintConfig;
+`
+
+function detectTypeScript(projectRoot: string): boolean {
+  return existsSync(path.join(projectRoot, 'tsconfig.json'))
+}
+
+function findExistingEslintConfig(projectRoot: string): {
+  exists: boolean
+  path?: string
+  isFlat?: boolean
+} {
+  const flatConfigs = [
+    'eslint.config.js',
+    'eslint.config.mjs',
+    'eslint.config.cjs',
+    'eslint.config.ts',
+    'eslint.config.mts',
+    'eslint.config.cts',
+  ]
+
+  const legacyConfigs = [
+    '.eslintrc.js',
+    '.eslintrc.cjs',
+    '.eslintrc.yaml',
+    '.eslintrc.yml',
+    '.eslintrc.json',
+    '.eslintrc',
+  ]
+
+  // Check for flat configs first (preferred for v9+)
+  for (const config of flatConfigs) {
+    const configPath = path.join(projectRoot, config)
+    if (existsSync(configPath)) {
+      return { exists: true, path: configPath, isFlat: true }
+    }
+  }
+
+  // Check for legacy configs
+  for (const config of legacyConfigs) {
+    const configPath = path.join(projectRoot, config)
+    if (existsSync(configPath)) {
+      return { exists: true, path: configPath, isFlat: false }
+    }
+  }
+
+  return { exists: false }
+}
+
+function updateExistingFlatConfig(
+  configPath: string,
+  isTypeScript: boolean
+): boolean {
+  let configContent: string
+  try {
+    configContent = readFileSync(configPath, 'utf8')
+  } catch (error) {
+    console.error(`   Error reading config file: ${error}`)
+    return false
+  }
+
+  // Check if Next.js configs are already imported
+  const hasNextConfigs =
+    configContent.includes('next/core-web-vitals') ||
+    configContent.includes('next/typescript')
+
+  // TypeScript config files need special handling
+  if (
+    configPath.endsWith('.ts') ||
+    configPath.endsWith('.mts') ||
+    configPath.endsWith('.cts')
+  ) {
+    console.warn(
+      prefixes.warn,
+      '   TypeScript config files require manual migration'
+    )
+    console.log('   Please add the following to your config:')
+    console.log('   - Import: import { FlatCompat } from "@eslint/eslintrc"')
+    console.log(
+      '   - Extend: ...compat.extends("next/core-web-vitals"' +
+        (isTypeScript ? ', "next/typescript"' : '') +
+        ')'
+    )
+    return false
+  }
+
+  // Parse the file using jscodeshift
+  const j = createParserFromPath(configPath)
+  const root = j(configContent)
+
+  // Determine if it's CommonJS or ES modules
+  let isCommonJS = false
+
+  if (configPath.endsWith('.cjs')) {
+    isCommonJS = true
+  } else if (configPath.endsWith('.mjs')) {
+    isCommonJS = false
+  } else if (configPath.endsWith('.js')) {
+    // For .js files, check package.json type field
+    const projectRoot = path.dirname(configPath)
+    const packageJsonPath = path.join(projectRoot, 'package.json')
+
+    try {
+      if (existsSync(packageJsonPath)) {
+        const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+        isCommonJS = packageJson.type !== 'module'
+      } else {
+        // Default to CommonJS if no package.json found
+        isCommonJS = true
+      }
+    } catch {
+      // Default to CommonJS if package.json can't be read
+      isCommonJS = true
+    }
+
+    // Always check file syntax to override package.json detection if needed
+    // This handles cases where package.json doesn't specify type but file uses ES modules
+    const hasESModuleSyntax =
+      root.find(j.ExportDefaultDeclaration).size() > 0 ||
+      root.find(j.ExportNamedDeclaration).size() > 0 ||
+      root.find(j.ImportDeclaration).size() > 0
+
+    const hasCommonJSSyntax =
+      root
+        .find(j.AssignmentExpression, {
+          left: {
+            type: 'MemberExpression',
+            object: { name: 'module' },
+            property: { name: 'exports' },
+          },
+        })
+        .size() > 0
+
+    // Override package.json detection based on actual syntax
+    if (hasESModuleSyntax && !hasCommonJSSyntax) {
+      isCommonJS = false
+    } else if (hasCommonJSSyntax && !hasESModuleSyntax) {
+      isCommonJS = true
+    }
+    // If both or neither are found, keep the package.json-based detection
+  } else {
+    // For other extensions (.ts, .mts, .cts), assume based on extension
+    isCommonJS = configPath.endsWith('.cts')
+  }
+
+  // Find the exported array
+  let exportedArray = null
+  let exportNode = null
+
+  if (isCommonJS) {
+    // Look for module.exports = [...]
+    const moduleExports = root.find(j.AssignmentExpression, {
+      left: {
+        type: 'MemberExpression',
+        object: { name: 'module' },
+        property: { name: 'exports' },
+      },
+      right: { type: 'ArrayExpression' },
+    })
+
+    if (moduleExports.size() > 0) {
+      exportNode = moduleExports.at(0)
+      exportedArray = exportNode.get('right')
+    }
+  } else {
+    // Look for export default [...]
+    const defaultExports = root.find(j.ExportDefaultDeclaration, {
+      declaration: { type: 'ArrayExpression' },
+    })
+
+    if (defaultExports.size() > 0) {
+      exportNode = defaultExports.at(0)
+      exportedArray = exportNode.get('declaration')
+    } else {
+      // Look for const variable = [...]; export default variable
+      const defaultExportIdentifier = root.find(j.ExportDefaultDeclaration, {
+        declaration: { type: 'Identifier' },
+      })
+
+      if (defaultExportIdentifier.size() > 0) {
+        const declarationNode = defaultExportIdentifier.at(0).get('declaration')
+        if (!declarationNode.value) {
+          return false
+        }
+        const varName = declarationNode.value.name
+        const varDeclaration = root.find(j.VariableDeclarator, {
+          id: { name: varName },
+          init: { type: 'ArrayExpression' },
+        })
+
+        if (varDeclaration.size() > 0) {
+          exportedArray = varDeclaration.at(0).get('init')
+        }
+      }
+    }
+  }
+
+  if (!exportedArray) {
+    console.warn(
+      prefixes.warn,
+      '   Config does not export an array. Manual migration required.'
+    )
+    console.warn(
+      prefixes.warn,
+      '   ESLint flat configs must export an array of configuration objects.'
+    )
+    return false
+  }
+
+  // Check if FlatCompat is already imported
+  const hasFlatCompat = isCommonJS
+    ? root
+        .find(j.CallExpression, {
+          callee: { name: 'require' },
+          arguments: [{ value: '@eslint/eslintrc' }],
+        })
+        .size() > 0
+    : root
+        .find(j.ImportDeclaration, {
+          source: { value: '@eslint/eslintrc' },
+        })
+        .size() > 0
+
+  // Add necessary imports if not present and if we're adding Next.js extends
+  if (!hasFlatCompat && !hasNextConfigs) {
+    if (isCommonJS) {
+      // Add CommonJS requires at the top
+      const firstNode = root.find(j.Program).get('body', 0)
+      const compatRequire = j.variableDeclaration('const', [
+        j.variableDeclarator(
+          j.objectPattern([
+            j.property(
+              'init',
+              j.identifier('FlatCompat'),
+              j.identifier('FlatCompat')
+            ),
+          ]),
+          j.callExpression(j.identifier('require'), [
+            j.literal('@eslint/eslintrc'),
+          ])
+        ),
+      ])
+      const pathRequire = j.variableDeclaration('const', [
+        j.variableDeclarator(
+          j.identifier('path'),
+          j.callExpression(j.identifier('require'), [j.literal('path')])
+        ),
+      ])
+      const compatNew = j.variableDeclaration('const', [
+        j.variableDeclarator(
+          j.identifier('compat'),
+          j.newExpression(j.identifier('FlatCompat'), [
+            j.objectExpression([
+              j.property(
+                'init',
+                j.identifier('baseDirectory'),
+                j.identifier('__dirname')
+              ),
+            ]),
+          ])
+        ),
+      ])
+
+      j(firstNode).insertBefore(compatRequire)
+      j(firstNode).insertBefore(pathRequire)
+      j(firstNode).insertBefore(compatNew)
+    } else {
+      // Add ES module imports
+      const firstImport = root.find(j.ImportDeclaration).at(0)
+      const insertPoint =
+        firstImport.size() > 0
+          ? firstImport
+          : root.find(j.Program).get('body', 0)
+
+      const imports = [
+        j.importDeclaration(
+          [j.importSpecifier(j.identifier('dirname'))],
+          j.literal('path')
+        ),
+        j.importDeclaration(
+          [j.importSpecifier(j.identifier('fileURLToPath'))],
+          j.literal('url')
+        ),
+        j.importDeclaration(
+          [j.importSpecifier(j.identifier('FlatCompat'))],
+          j.literal('@eslint/eslintrc')
+        ),
+      ]
+
+      const setupVars = [
+        j.variableDeclaration('const', [
+          j.variableDeclarator(
+            j.identifier('__filename'),
+            j.callExpression(j.identifier('fileURLToPath'), [
+              j.memberExpression(
+                j.memberExpression(
+                  j.identifier('import'),
+                  j.identifier('meta')
+                ),
+                j.identifier('url')
+              ),
+            ])
+          ),
+        ]),
+        j.variableDeclaration('const', [
+          j.variableDeclarator(
+            j.identifier('__dirname'),
+            j.callExpression(j.identifier('dirname'), [
+              j.identifier('__filename'),
+            ])
+          ),
+        ]),
+        j.variableDeclaration('const', [
+          j.variableDeclarator(
+            j.identifier('compat'),
+            j.newExpression(j.identifier('FlatCompat'), [
+              j.objectExpression([
+                j.property(
+                  'init',
+                  j.identifier('baseDirectory'),
+                  j.identifier('__dirname')
+                ),
+              ]),
+            ])
+          ),
+        ]),
+      ]
+
+      if (firstImport.size() > 0) {
+        // Insert after the last import
+        const lastImportPath = root.find(j.ImportDeclaration).at(-1).get()
+        if (!lastImportPath) {
+          // Fallback to inserting at the beginning
+          const fallbackInsertPoint = root.find(j.Program).get('body', 0)
+          imports.forEach((imp) => j(fallbackInsertPoint).insertBefore(imp))
+          setupVars.forEach((v) => j(fallbackInsertPoint).insertBefore(v))
+        } else {
+          imports.forEach((imp) => j(lastImportPath).insertAfter(imp))
+          setupVars.forEach((v) => j(lastImportPath).insertAfter(v))
+        }
+      } else {
+        // Insert at the beginning
+        imports.forEach((imp) => j(insertPoint).insertBefore(imp))
+        setupVars.forEach((v) => j(insertPoint).insertBefore(v))
+      }
+    }
+  }
+
+  // Create ignores configuration object
+  const ignoresConfig = j.objectExpression([
+    j.property(
+      'init',
+      j.identifier('ignores'),
+      j.arrayExpression([
+        j.literal('node_modules/**'),
+        j.literal('.next/**'),
+        j.literal('out/**'),
+        j.literal('build/**'),
+        j.literal('next-env.d.ts'),
+      ])
+    ),
+  ])
+
+  // Only add Next.js extends if they're not already present
+  if (!hasNextConfigs) {
+    // Add Next.js configs to the array
+    const nextExtends = isTypeScript
+      ? ['next/core-web-vitals', 'next/typescript']
+      : ['next/core-web-vitals']
+
+    const spreadElement = j.spreadElement(
+      j.callExpression(
+        j.memberExpression(j.identifier('compat'), j.identifier('extends')),
+        nextExtends.map((ext) => j.literal(ext))
+      )
+    )
+
+    // Insert Next.js extends at the beginning of the array
+    if (!exportedArray.value.elements) {
+      exportedArray.value.elements = []
+    }
+    exportedArray.value.elements.unshift(spreadElement)
+  }
+
+  // Check if ignores already exist in the config and merge if needed
+  let existingIgnoresIndex = -1
+  if (exportedArray.value.elements) {
+    for (let i = 0; i < exportedArray.value.elements.length; i++) {
+      const element = exportedArray.value.elements[i]
+      if (
+        element &&
+        element.type === 'ObjectExpression' &&
+        element.properties &&
+        element.properties.some(
+          (prop) =>
+            prop.type === 'Property' &&
+            prop.key &&
+            prop.key.type === 'Identifier' &&
+            prop.key.name === 'ignores'
+        )
+      ) {
+        existingIgnoresIndex = i
+        break
+      }
+    }
+  }
+
+  if (existingIgnoresIndex === -1) {
+    // No existing ignores, add our own at appropriate position
+    const insertIndex = hasNextConfigs ? 0 : 1
+    exportedArray.value.elements.splice(insertIndex, 0, ignoresConfig)
+  } else {
+    // Merge with existing ignores
+    const existingIgnoresObj =
+      exportedArray.value.elements[existingIgnoresIndex]
+    const ignoresProp = existingIgnoresObj.properties.find(
+      (prop) =>
+        prop.type === 'Property' &&
+        prop.key &&
+        prop.key.type === 'Identifier' &&
+        prop.key.name === 'ignores'
+    )
+
+    if (
+      ignoresProp &&
+      ignoresProp.value &&
+      ignoresProp.value.type === 'ArrayExpression'
+    ) {
+      // Add our ignores to the existing array if they're not already there
+      const nextIgnores = [
+        'node_modules/**',
+        '.next/**',
+        'out/**',
+        'build/**',
+        'next-env.d.ts',
+      ]
+
+      const existingIgnores = ignoresProp.value.elements
+        .map((el) => (el.type === 'Literal' ? el.value : null))
+        .filter(Boolean)
+
+      for (const ignore of nextIgnores) {
+        if (!existingIgnores.includes(ignore)) {
+          ignoresProp.value.elements.push(j.literal(ignore))
+        }
+      }
+    }
+  }
+
+  // Generate the updated code
+  const updatedContent = root.toSource()
+
+  if (updatedContent !== configContent) {
+    try {
+      writeFileSync(configPath, updatedContent)
+    } catch (error) {
+      console.error(`   Error writing config file: ${error}`)
+      return false
+    }
+
+    if (hasNextConfigs) {
+      console.log(
+        `   Updated ${path.basename(configPath)} with Next.js ignores configuration`
+      )
+    } else {
+      console.log(
+        `   Updated ${path.basename(configPath)} with Next.js ESLint configs`
+      )
+    }
+    return true
+  }
+
+  // If nothing changed but Next.js configs were already present, that's still success
+  if (hasNextConfigs) {
+    console.log('   Next.js ESLint configs already present in flat config')
+    return true
+  }
+
+  return false
+}
+
+function updatePackageJsonScripts(packageJsonContent: string): {
+  updated: boolean
+  content: string
+} {
+  try {
+    const packageJson = JSON.parse(packageJsonContent)
+    let needsUpdate = false
+
+    if (!packageJson.scripts) {
+      packageJson.scripts = {}
+    }
+
+    // Process all scripts that contain "next lint"
+    for (const scriptName in packageJson.scripts) {
+      const scriptValue = packageJson.scripts[scriptName]
+      if (
+        typeof scriptValue === 'string' &&
+        scriptValue.includes('next lint')
+      ) {
+        // Replace "next lint" with "eslint" and handle special arguments
+        const updatedScript = scriptValue.replace(
+          /\bnext\s+lint\b([^&|;]*)/gi,
+          (_match, args = '') => {
+            // Track whether we need a trailing space before operators
+            let trailingSpace = ''
+            if (args.endsWith(' ')) {
+              trailingSpace = ' '
+              args = args.trimEnd()
+            }
+
+            // Check for redirects (2>, 1>, etc.) and preserve them
+            let redirect = ''
+            const redirectMatch = args.match(/\s+(\d*>[>&]?.*)$/)
+            if (redirectMatch) {
+              redirect = ` ${redirectMatch[1]}`
+              args = args.substring(0, redirectMatch.index)
+            }
+
+            // Parse arguments - handle quoted strings properly
+            const argTokens = []
+            let current = ''
+            let inQuotes = false
+            let quoteChar = ''
+
+            for (let j = 0; j < args.length; j++) {
+              const char = args[j]
+              if (
+                (char === '"' || char === "'") &&
+                (j === 0 || args[j - 1] !== '\\')
+              ) {
+                if (!inQuotes) {
+                  inQuotes = true
+                  quoteChar = char
+                  current += char
+                } else if (char === quoteChar) {
+                  inQuotes = false
+                  quoteChar = ''
+                  current += char
+                } else {
+                  current += char
+                }
+              } else if (char === ' ' && !inQuotes) {
+                if (current) {
+                  argTokens.push(current)
+                  current = ''
+                }
+              } else {
+                current += char
+              }
+            }
+            if (current) {
+              argTokens.push(current)
+            }
+
+            const eslintArgs = []
+            const paths = []
+
+            for (let i = 0; i < argTokens.length; i++) {
+              const token = argTokens[i]
+
+              if (token === '--strict') {
+                eslintArgs.push('--max-warnings', '0')
+              } else if (token === '--dir' && i + 1 < argTokens.length) {
+                paths.push(argTokens[++i])
+              } else if (token === '--file' && i + 1 < argTokens.length) {
+                paths.push(argTokens[++i])
+              } else if (token === '--rulesdir' && i + 1 < argTokens.length) {
+                // Skip rulesdir and its value
+                i++
+              } else if (token === '--ext' && i + 1 < argTokens.length) {
+                // Skip ext and its value
+                i++
+              } else if (token.startsWith('--')) {
+                // Keep other flags and their values
+                eslintArgs.push(token)
+                if (
+                  i + 1 < argTokens.length &&
+                  !argTokens[i + 1].startsWith('--')
+                ) {
+                  eslintArgs.push(argTokens[++i])
+                }
+              } else {
+                // Positional arguments (paths)
+                paths.push(token)
+              }
+            }
+
+            // Build the result
+            let result = 'eslint'
+            if (eslintArgs.length > 0) {
+              result += ` ${eslintArgs.join(' ')}`
+            }
+
+            // Add paths or default to .
+            if (paths.length > 0) {
+              result += ` ${paths.join(' ')}`
+            } else {
+              result += ' .'
+            }
+
+            // Add redirect if present
+            result += redirect
+
+            // Add back trailing space if we had one
+            result += trailingSpace
+
+            return result
+          }
+        )
+
+        if (updatedScript !== scriptValue) {
+          packageJson.scripts[scriptName] = updatedScript
+          needsUpdate = true
+          console.log(
+            `   Updated script "${scriptName}": "${scriptValue}" → "${updatedScript}"`
+          )
+
+          // Note about unsupported flags
+          if (scriptValue.includes('--rulesdir')) {
+            console.log(`   Note: --rulesdir is not supported in ESLint v9`)
+          }
+          if (scriptValue.includes('--ext')) {
+            console.log(`   Note: --ext is not needed in ESLint v9 flat config`)
+          }
+        }
+      }
+    }
+
+    // Ensure required devDependencies exist
+    if (!packageJson.devDependencies) {
+      packageJson.devDependencies = {}
+    }
+
+    // Check if eslint exists in either dependencies or devDependencies
+    if (
+      !packageJson.devDependencies.eslint &&
+      !packageJson.dependencies?.eslint
+    ) {
+      packageJson.devDependencies.eslint = '^9'
+      needsUpdate = true
+    }
+
+    // Check if eslint-config-next exists in either dependencies or devDependencies
+    if (
+      !packageJson.devDependencies['eslint-config-next'] &&
+      !packageJson.dependencies?.['eslint-config-next']
+    ) {
+      // Use the same version as next if available
+      const nextVersion =
+        packageJson.dependencies?.next || packageJson.devDependencies?.next
+      packageJson.devDependencies['eslint-config-next'] =
+        nextVersion || 'latest'
+      needsUpdate = true
+    }
+
+    // Check if @eslint/eslintrc exists in either dependencies or devDependencies
+    if (
+      !packageJson.devDependencies['@eslint/eslintrc'] &&
+      !packageJson.dependencies?.['@eslint/eslintrc']
+    ) {
+      packageJson.devDependencies['@eslint/eslintrc'] = '^3'
+      needsUpdate = true
+    }
+
+    const updatedContent = `${JSON.stringify(packageJson, null, 2)}\n`
+    return { updated: needsUpdate, content: updatedContent }
+  } catch (error) {
+    console.error('Error updating package.json:', error)
+    return { updated: false, content: packageJsonContent }
+  }
+}
+
+export default function transformer(
+  files: string[],
+  options: TransformerOptions = {}
+): void {
+  // The codemod CLI passes arguments as an array for consistency with file-based transforms,
+  // but project-level transforms like this one only process a single directory.
+  // Usage: npx @next/codemod next-lint-to-eslint-cli <project-directory>
+  const dir = files[0]
+  if (!dir) {
+    console.error('Error: Please specify a directory path')
+    return
+  }
+
+  // Allow skipping installation via option
+  const skipInstall = options.skipInstall === true
+
+  const projectRoot = path.resolve(dir)
+  const packageJsonPath = path.join(projectRoot, 'package.json')
+
+  if (!existsSync(packageJsonPath)) {
+    console.error('Error: package.json not found in the specified directory')
+    return
+  }
+
+  const isTypeScript = detectTypeScript(projectRoot)
+
+  console.log('Migrating from next lint to the ESLint CLI...')
+
+  // Check for existing ESLint config
+  const existingConfig = findExistingEslintConfig(projectRoot)
+
+  if (existingConfig.exists) {
+    if (existingConfig.isFlat) {
+      // Try to update existing flat config
+      if (existingConfig.path) {
+        console.log(
+          `   Found existing flat config: ${path.basename(existingConfig.path)}`
+        )
+        const updated = updateExistingFlatConfig(
+          existingConfig.path,
+          isTypeScript
+        )
+
+        if (!updated) {
+          console.log(
+            '   Could not automatically update the existing flat config.'
+          )
+          console.log(
+            '   Please manually ensure your ESLint config extends "next/core-web-vitals"'
+          )
+          if (isTypeScript) {
+            console.log('   and "next/typescript" for TypeScript projects.')
+          }
+        }
+      }
+    } else {
+      // Legacy config exists
+      if (existingConfig.path) {
+        console.log(
+          `   Found legacy ESLint config: ${path.basename(existingConfig.path)}`
+        )
+        console.log(
+          '   Legacy .eslintrc configs are not automatically migrated.'
+        )
+        console.log(
+          '   Please migrate to flat config format (eslint.config.js) and ensure it extends:'
+        )
+        console.log('   - "next/core-web-vitals"')
+        if (isTypeScript) {
+          console.log('   - "next/typescript"')
+        }
+        console.log(
+          '   Learn more: https://eslint.org/docs/latest/use/configure/migration-guide'
+        )
+      }
+    }
+  } else {
+    // Create new ESLint flat config
+    const eslintConfigPath = path.join(projectRoot, 'eslint.config.mjs')
+    const template = isTypeScript
+      ? ESLINT_CONFIG_TEMPLATE_TYPESCRIPT
+      : ESLINT_CONFIG_TEMPLATE_JAVASCRIPT
+
+    try {
+      writeFileSync(eslintConfigPath, template)
+      console.log(`   Created ${path.basename(eslintConfigPath)}`)
+    } catch (error) {
+      console.error('   Error creating ESLint config:', error)
+    }
+  }
+
+  // Update package.json
+  const packageJsonContent = readFileSync(packageJsonPath, 'utf8')
+  const result = updatePackageJsonScripts(packageJsonContent)
+
+  if (result.updated) {
+    try {
+      writeFileSync(packageJsonPath, result.content)
+      console.log('Updated package.json scripts and dependencies')
+
+      // Parse the updated package.json to find new dependencies
+      const updatedPackageJson = JSON.parse(result.content)
+      const originalPackageJson = JSON.parse(packageJsonContent)
+
+      const newDependencies: string[] = []
+
+      // Check for new devDependencies
+      if (updatedPackageJson.devDependencies) {
+        for (const [pkg, version] of Object.entries(
+          updatedPackageJson.devDependencies
+        )) {
+          if (
+            !originalPackageJson.devDependencies?.[pkg] &&
+            !originalPackageJson.dependencies?.[pkg]
+          ) {
+            newDependencies.push(`${pkg}@${version}`)
+          }
+        }
+      }
+
+      // Install new dependencies if any were added
+      if (newDependencies.length > 0) {
+        if (skipInstall) {
+          console.log('\nNew dependencies added to package.json:')
+          newDependencies.forEach((dep) => console.log(`   - ${dep}`))
+          console.log(`Please run: ${getPkgManager(projectRoot)} install`)
+        } else {
+          console.log('\nInstalling new dependencies...')
+          try {
+            const packageManager = getPkgManager(projectRoot)
+            console.log(`   Using ${packageManager}...`)
+
+            installPackages(newDependencies, {
+              packageManager,
+              dev: true,
+              silent: false,
+            })
+
+            console.log('   Dependencies installed successfully!')
+          } catch (_error) {
+            console.error('   Failed to install dependencies automatically.')
+            console.error(
+              `   Please run: ${getPkgManager(projectRoot)} install`
+            )
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Error writing package.json:', error)
+    }
+  }
+
+  console.log('\nMigration complete! Your project now uses the ESLint CLI.')
+}

--- a/packages/next/src/cli/next-lint.ts
+++ b/packages/next/src/cli/next-lint.ts
@@ -70,9 +70,9 @@ const nextLint = async (options: NextLintOptions, directory?: string) => {
       'For new projects, use ' +
       bold('create-next-app') +
       ' to choose your preferred linter.\n' +
-      'For existing projects, migrate to explicit ESLint configuration and update your package.json scripts to use ' +
-      bold('"eslint"') +
-      ' instead.\n'
+      'For existing projects, migrate to the ESLint CLI:\n' +
+      bold('npx @next/codemod@canary next-lint-to-eslint-cli .') +
+      '\n'
   )
 
   const baseDir = getProjectDir(directory)


### PR DESCRIPTION
## Add codemod to migrate from `next lint` to ESLint CLI

This PR introduces a new codemod `next-lint-to-eslint-cli` that helps users migrate away from the deprecated `next lint` command to using ESLint directly, in preparation for Next.js 16 where `next lint` will be removed.

### What it does

The codemod automates the migration process by:

1. **Updating package.json scripts** - Replaces all `next lint` commands with `eslint` equivalents
   - Maps Next.js-specific flags (`--strict` → `--max-warnings 0`, `--dir`/`--file` → paths)
   - Preserves other ESLint-compatible flags
   - Handles complex scripts with pipes, redirects, and multiple commands

2. **Managing ESLint configuration**
   - Creates a new flat config (`eslint.config.mjs`) if none exists
   - Updates existing flat configs to include Next.js rules
   - Provides guidance for legacy configs that need manual migration

3. **Installing dependencies automatically**
   - Adds required packages: `eslint`, `eslint-config-next`, `@eslint/eslintrc`
   - Detects and uses the project's package manager (npm/yarn/pnpm/bun)
   - Falls back to manual instructions if installation fails

### Usage

```bash
npx @next/codemod@latest next-lint-to-eslint-cli .
```

### Example transformations

```json
// Before
{
  "scripts": {
    "lint": "next lint",
    "lint:fix": "next lint --fix",
    "lint:strict": "next lint --strict --dir src"
  }
}

// After
{
  "scripts": {
    "lint": "eslint .",
    "lint:fix": "eslint --fix .",
    "lint:strict": "eslint --max-warnings 0 src"
  }
}
```

### Why this change?

- `next lint` is being deprecated and will be removed in Next.js 16
- ESLint v9+ flat config is becoming the standard
- Direct ESLint usage provides more flexibility and better ecosystem compatibility
- Reduces Next.js maintenance burden of wrapping ESLint functionality

The codemod ensures a smooth transition path for existing Next.js projects while following ESLint best practices.