### PR TITLE
fix: Combine the hrtime tuple to get a better seconds representation

### DIFF
--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -44,6 +44,11 @@ import { durationToString } from '../duration-to-string'
 
 const debug = origDebug('next:build:webpack-build')
 
+function hrtimeToSeconds(hrtime: [number, number]): number {
+  // hrtime is a tuple of [seconds, nanoseconds]
+  return hrtime[0] + hrtime[1] / 1e9
+}
+
 type CompilerResult = {
   errors: webpack.StatsError[]
   warnings: webpack.StatsError[]
@@ -333,7 +338,7 @@ export async function webpackBuildImpl(
     err.code = 'WEBPACK_ERRORS'
     throw err
   } else {
-    const duration = webpackBuildEnd[0]
+    const duration = hrtimeToSeconds(webpackBuildEnd)
     const durationString = durationToString(duration)
 
     if (result.warnings.length > 0) {
@@ -345,7 +350,7 @@ export async function webpackBuildImpl(
     }
 
     return {
-      duration: webpackBuildEnd[0],
+      duration,
       buildTraceContext: traceEntryPointsPlugin?.buildTraceContext,
       pluginState: getPluginState(),
       telemetryState: {


### PR DESCRIPTION
When building w/ webpack to calculate duration, we use `process.hrtime` which is a tuple of integers [seconds, nanoseconds] - which means that for sub second compiler runs, we end up showing total 0ms, or 1000ms (I think)

- https://nodejs.org/api/process.html#processhrtimetime

With this PR we combine the seconds and nanoseconds into a float. 

### Before:

```console
   ▲ Next.js 15.4.6
   - Environments: .env.production

   Creating an optimized production build ...
 ✓ Compiled successfully in 0ms
   Skipping validation of types
```

### After

```console
   ▲ Next.js 15.4.6
   - Environments: .env.production

   Creating an optimized production build ...
 ✓ Compiled successfully in 813ms
   Skipping validation of types
```