### PR TITLE
fix(test-proxy): handle Basic Auth credentials in URLs

### DIFF
--- a/packages/next/src/experimental/testmode/proxy/fetch-api.ts
+++ b/packages/next/src/experimental/testmode/proxy/fetch-api.ts
@@ -16,9 +16,33 @@ export type FetchHandler = (
 function buildRequest(req: ProxyFetchRequest): Request {
   const { request: proxyRequest } = req
   const { url, headers, body, ...options } = proxyRequest
-  return new Request(url, {
+
+  // Extract credentials from URL and convert to Authorization header
+  let cleanUrl = url
+  const requestHeaders = new Headers(headers)
+
+  try {
+    const u = new URL(url)
+    const hasCreds = u.username !== '' || u.password !== ''
+    if (hasCreds) {
+      if (!requestHeaders.has('Authorization')) {
+        const token = Buffer.from(
+          `${u.username}:${u.password}`,
+          'utf-8'
+        ).toString('base64')
+        requestHeaders.set('Authorization', `Basic ${token}`)
+      }
+      u.username = ''
+      u.password = ''
+      cleanUrl = u.toString()
+    }
+  } catch {
+    // Use original URL if parsing fails
+  }
+
+  return new Request(cleanUrl, {
     ...options,
-    headers: new Headers(headers),
+    headers: requestHeaders,
     body: body ? Buffer.from(body, 'base64') : null,
   })
 }


### PR DESCRIPTION
### What?
Fixes #82611. When `experimental.testProxy` is enabled, axios requests that include Basic Auth credentials in the URL (`user:pass@host`) fail with: “Request cannot be constructed from a URL that includes credential”.

This change sanitizes the URL and forwards credentials via the `Authorization: Basic …` header before constructing the `Request`.

### Why?
The Fetch/Request constructor rejects URLs that embed credentials. The proxy was passing the URL through as-is, so `new Request(url, …)` failed under testProxy even though the same axios call works when testProxy is disabled.

### How?
- In `packages/next/src/experimental/testmode/proxy/fetch-api.ts`:
  - Parse the URL.
  - **Always** strip credentials from the URL (clear `username`/`password`) before calling `new Request(cleanUrl, …)`.
  - If there is **no existing** `Authorization` header, base64-encode `username:password`  using `Buffer.from(...).toString('base64')` and set `Authorization: Basic …`.
  - Preserve any existing `Authorization` header.

### Behavior (Before / After)
- **Before:** `experimental.testProxy: true` + `https://user:pass@host/...`
  → Request construction error.
- **After:** Request builds successfully; URL no longer contains credentials and the `Authorization` header is present.

### Testing
- Manually verified with a minimal reproduction (axios http adapter):
  - URL credentials are removed in the forwarded `Request`.
  - `Authorization: Basic dXNlcjpwYXNzd29yZA==` is set for `user:password`.
- Happy to add an automated test under `/test/development` if preferred.

### Risk / Compatibility
- No change for requests without URL credentials.
- Does not override a user-provided `Authorization` header.
- Uses Node `Buffer` (already used in this file) for Base64 encoding.

Fixes #82611
