### PR TITLE
fix(turbopack) Fix handling of intercept route segments

### DIFF
--- a/test/development/app-dir/hmr-intercept-routes/app/intercept/page.js
+++ b/test/development/app-dir/hmr-intercept-routes/app/intercept/page.js
@@ -1,0 +1,3 @@
+export default function InterceptPage() {
+  return <h1>I'm the intercept page</h1>
+}

--- a/test/development/app-dir/hmr-intercept-routes/app/layout.js
+++ b/test/development/app-dir/hmr-intercept-routes/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/hmr-intercept-routes/app/page.js
+++ b/test/development/app-dir/hmr-intercept-routes/app/page.js
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Main Page</h1>
+      <Link id="to-intercept" href="/intercept">
+        Goto Intercept
+      </Link>
+    </div>
+  )
+}

--- a/test/development/app-dir/hmr-intercept-routes/fixtures/@intercept/(.)intercept/page.js
+++ b/test/development/app-dir/hmr-intercept-routes/fixtures/@intercept/(.)intercept/page.js
@@ -1,0 +1,3 @@
+export default function Intercept() {
+  return <h1 id="intercept">I'm the intercept</h1>
+}

--- a/test/development/app-dir/hmr-intercept-routes/fixtures/@intercept/default.js
+++ b/test/development/app-dir/hmr-intercept-routes/fixtures/@intercept/default.js
@@ -1,0 +1,3 @@
+export default function Default() {
+  return <h1 id="default-intercept">I'm the default intercept</h1>
+}

--- a/test/development/app-dir/hmr-intercept-routes/fixtures/layout.js
+++ b/test/development/app-dir/hmr-intercept-routes/fixtures/layout.js
@@ -1,0 +1,10 @@
+export default function RootLayout({ children, intercept }) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        {intercept}
+      </body>
+    </html>
+  )
+}

--- a/test/development/app-dir/hmr-intercept-routes/hmr-intercept-routes.test.ts
+++ b/test/development/app-dir/hmr-intercept-routes/hmr-intercept-routes.test.ts
@@ -1,0 +1,55 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// This only works for Turbopack HMR builds
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'hmr-intercept-routes',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+    })
+
+    it('should update intercept routes via HMR', async () => {
+      const browser = await next.browser('/')
+      expect(await browser.elementByCss('h1').text()).toBe('Main Page')
+
+      const parallelDefaultContent = await next.readFile(
+        'fixtures/@intercept/default.js'
+      )
+
+      const parallelInterceptContent = await next.readFile(
+        'fixtures/@intercept/(.)intercept/page.js'
+      )
+
+      // Write the fixture files to the associated output location
+      await next.patchFile('app/@intercept/default.js', parallelDefaultContent)
+      await next.patchFile(
+        'app/@intercept/(.)intercept/page.js',
+        parallelInterceptContent
+      )
+
+      // Read the original code of the root layout page
+      const rootLayoutContent = await next.readFile('app/layout.js')
+      const fixtureLayoutContent = await next.readFile('fixtures/layout.js')
+
+      // Update the root layout file with the fixture layout which includes the new parallel routes
+      await next.patchFile('app/layout.js', fixtureLayoutContent)
+
+      // Check to make sure that the main page now has the correct layout changes
+      await browser.waitForElementByCss('#default-intercept')
+      expect(await browser.elementById('default-intercept').text()).toBe(
+        "I'm the default intercept"
+      )
+
+      // Go to the intercept route and check that the intercept worked correctly
+      await browser.elementById('to-intercept').click()
+      await browser.waitForElementByCss('#intercept')
+      expect(await browser.elementById('intercept').text()).toBe(
+        "I'm the intercept"
+      )
+
+      // Reset the file statuses
+      await next.patchFile('app/layout.js', rootLayoutContent)
+      await next.deleteFile('app/@intercept')
+    })
+  }
+)

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -2539,6 +2539,13 @@
     "flakey": [],
     "runtimeError": false
   },
+  "test/development/app-dir/hmr-intercept-routes/hmr-intercept-routes.test.ts": {
+    "passed": ["hmr-intercept-routes should update intercept routes via HMR"],
+    "failed": [],
+    "pending": [],
+    "flakey": [],
+    "runtimeError": false
+  },
   "test/development/app-dir/hmr-move-file/hmr-move-file.test.ts": {
     "passed": [
       "HMR Move File should work when moving a component to another directory"


### PR DESCRIPTION
## Fix handling of intercept route segments in HMR

### What?
- Made the routes in `resolve-routes.ts` get lazily initialized, and only recalculated in development mode to preserve
   performance
- Added a test case for HMR with intercept routes

### Why?
This change ensures that intercept route segments (and any other changed elements of routes), will be recalculated correctly during the development proecess.

Fixes PACK-5190

Closes PACK-5354