### PR TITLE
enable browser debug info in terminal by default

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -314,7 +314,9 @@ export function getDefineEnv({
       : {}),
 
     'process.env.__NEXT_BROWSER_DEBUG_INFO_IN_TERMINAL': JSON.stringify(
-      config.experimental.browserDebugInfoInTerminal || false
+      config.experimental?.browserDebugInfoInTerminal ??
+        config.browserDebugInfoInTerminal ??
+        true
     ),
 
     // The devtools need to know whether or not to show an option to clear the

--- a/packages/next/src/next-devtools/shared/console-patch.ts
+++ b/packages/next/src/next-devtools/shared/console-patch.ts
@@ -96,9 +96,9 @@ export function patchConsoleMethod<T extends keyof Console>(
        * This script is from Next.js console patching.
        *
        * You're seeing this because Next.js patches console methods to send logs
-       * to your terminal. 
-       * 
-       * To see the original location, set browserDebugInfoInTerminal to false 
+       * to your terminal.
+       *
+       * To see the original location, set browserDebugInfoInTerminal to false
        * in your next.config file.
        */
       originalMethod.apply(this, args)

--- a/packages/next/src/next-devtools/shared/console-patch.ts
+++ b/packages/next/src/next-devtools/shared/console-patch.ts
@@ -1,3 +1,7 @@
+/**
+ * Do not haphazardly change the name of this file, users that do not have ignore
+ * listing configured will see the name of this source file in chrome devtools console
+ */
 export type LogMethod =
   | 'log'
   | 'info'
@@ -93,13 +97,11 @@ export function patchConsoleMethod<T extends keyof Console>(
       wrapper(methodName, ...args)
 
       /*
-       * This script is from Next.js console patching.
+       * Your console call is being intercepted by Next.js, which makes your dev tools show the wrong source location.
        *
-       * You're seeing this because Next.js patches console methods to send logs
-       * to your terminal.
-       *
-       * To see the original location, set browserDebugInfoInTerminal to false
-       * in your next.config file.
+       * To see the true source location of the console method call, you can do one of the following:
+       * - open your browser's DevTools before the log happens (ensure you have ignore listing on https://developer.chrome.com/docs/devtools/settings/ignore-list)
+       * - set browserDebugInfoInTerminal to false in your next.config file.
        */
       originalMethod.apply(this, args)
     }

--- a/packages/next/src/next-devtools/shared/console-patch.ts
+++ b/packages/next/src/next-devtools/shared/console-patch.ts
@@ -93,17 +93,13 @@ export function patchConsoleMethod<T extends keyof Console>(
       wrapper(methodName, ...args)
 
       /*
-       * This script is from Next.js.
-       * You're likely here because you thought this script sent an error or warning
-       * to the console. Next.js patches the console to send logs to your terminal
-       * output, so this file appears as a source. However, the console call actually
-       * came from another script.
+       * This script is from Next.js console patching.
        *
-       * To remove this script from stack traces, open your browser's DevTools before
-       * these console calls happen.
-       *
-       * Or, to prevent Next.js from patching the console, go to your next.config file
-       * and set browserDebugInfoInTerminal to false.
+       * You're seeing this because Next.js patches console methods to send logs
+       * to your terminal. 
+       * 
+       * To see the original location, set browserDebugInfoInTerminal to false 
+       * in your next.config file.
        */
       originalMethod.apply(this, args)
     }

--- a/packages/next/src/next-devtools/shared/log-patch.ts
+++ b/packages/next/src/next-devtools/shared/log-patch.ts
@@ -92,6 +92,19 @@ export function patchConsoleMethod<T extends keyof Console>(
     ) {
       wrapper(methodName, ...args)
 
+      /*
+       * This script is from Next.js.
+       * You're likely here because you thought this script sent an error or warning
+       * to the console. Next.js patches the console to send logs to your terminal
+       * output, so this file appears as a source. However, the console call actually
+       * came from another script.
+       *
+       * To remove this script from stack traces, open your browser's DevTools before
+       * these console calls happen.
+       *
+       * Or, to prevent Next.js from patching the console, go to your next.config file
+       * and set browserDebugInfoInTerminal to false.
+       */
       originalMethod.apply(this, args)
     }
     if (originalName) {

--- a/packages/next/src/next-devtools/userspace/app/forward-logs.test.ts
+++ b/packages/next/src/next-devtools/userspace/app/forward-logs.test.ts
@@ -1,4 +1,4 @@
-import { UNDEFINED_MARKER } from '../../shared/log-patch'
+import { UNDEFINED_MARKER } from '../../shared/console-patch'
 import {
   preLogSerializationClone,
   PROMISE_MARKER,

--- a/packages/next/src/next-devtools/userspace/app/forward-logs.test.ts
+++ b/packages/next/src/next-devtools/userspace/app/forward-logs.test.ts
@@ -1,4 +1,4 @@
-import { UNDEFINED_MARKER } from '../../shared/forward-logs-shared'
+import { UNDEFINED_MARKER } from '../../shared/log-patch'
 import {
   preLogSerializationClone,
   PROMISE_MARKER,

--- a/packages/next/src/next-devtools/userspace/app/forward-logs.ts
+++ b/packages/next/src/next-devtools/userspace/app/forward-logs.ts
@@ -16,7 +16,7 @@ import {
   type LogMethod,
   patchConsoleMethod,
   UNDEFINED_MARKER,
-} from '../../shared/log-patch'
+} from '../../shared/console-patch'
 
 const terminalLoggingConfig = getTerminalLoggingConfig()
 export const PROMISE_MARKER = 'Promise {}'

--- a/packages/next/src/next-devtools/userspace/app/forward-logs.ts
+++ b/packages/next/src/next-devtools/userspace/app/forward-logs.ts
@@ -16,7 +16,7 @@ import {
   type LogMethod,
   patchConsoleMethod,
   UNDEFINED_MARKER,
-} from '../../shared/forward-logs-shared'
+} from '../../shared/log-patch'
 
 const terminalLoggingConfig = getTerminalLoggingConfig()
 export const PROMISE_MARKER = 'Promise {}'

--- a/packages/next/src/next-devtools/userspace/app/terminal-logging-config.ts
+++ b/packages/next/src/next-devtools/userspace/app/terminal-logging-config.ts
@@ -11,7 +11,7 @@ export function getTerminalLoggingConfig():
       process.env.__NEXT_BROWSER_DEBUG_INFO_IN_TERMINAL || 'true'
     )
   } catch {
-    return false
+    return true
   }
 }
 

--- a/packages/next/src/next-devtools/userspace/app/terminal-logging-config.ts
+++ b/packages/next/src/next-devtools/userspace/app/terminal-logging-config.ts
@@ -8,7 +8,7 @@ export function getTerminalLoggingConfig():
     } {
   try {
     return JSON.parse(
-      process.env.__NEXT_BROWSER_DEBUG_INFO_IN_TERMINAL || 'false'
+      process.env.__NEXT_BROWSER_DEBUG_INFO_IN_TERMINAL || 'true'
     )
   } catch {
     return false

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -312,6 +312,16 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         z.literal(false),
       ])
       .optional(),
+    browserDebugInfoInTerminal: z
+      .union([
+        z.boolean(),
+        z.object({
+          depthLimit: z.number().int().positive().optional(),
+          edgeLimit: z.number().int().positive().optional(),
+          showSourceLocation: z.boolean().optional(),
+        }),
+      ])
+      .optional(),
     distDir: z.string().min(1).optional(),
     env: z.record(z.string(), z.union([z.string(), z.undefined()])).optional(),
     eslint: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -770,23 +770,25 @@ export interface ExperimentalConfig {
 
   /**
    * Enable debug information to be forwarded from browser to dev server stdout/stderr
+   * @deprecated Use top-level `browserDebugInfoInTerminal` instead
    */
   browserDebugInfoInTerminal?:
     | boolean
     | {
         /**
-         * Option to limit stringification at a specific nesting depth when logging circular objects.
+         * Limit stringification depth for nested objects/arrays
          * @default 5
          */
         depthLimit?: number
 
         /**
-         * Maximum number of properties/elements to stringify when logging objects/arrays with circular references.
+         * Max number of properties or elements to include per object or array
          * @default 100
          */
         edgeLimit?: number
         /**
          * Whether to include source location information in debug output when available
+         * @default false
          */
         showSourceLocation?: boolean
       }
@@ -1040,6 +1042,33 @@ export interface NextConfig extends Record<string, any> {
          * @default "bottom-left"
          * */
         position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+      }
+
+  /**
+   * Enable debug information to be forwarded from browser to dev server stdout/stderr
+   * @default true
+   * @see [Browser Debug Info](https://nextjs.org/docs/app/api-reference/config/next-config-js/browserDebugInfoInTerminal)
+   */
+  browserDebugInfoInTerminal?:
+    | boolean
+    | {
+        /**
+         * Limit stringification depth for nested objects/arrays
+         * @default 5
+         */
+        depthLimit?: number
+
+        /**
+         * Max number of properties or elements to include per object or array.
+         * @default 100
+         */
+        edgeLimit?: number
+
+        /**
+         * Whether to include source location information in debug output when available
+         * @default false
+         */
+        showSourceLocation?: boolean
       }
 
   /**
@@ -1327,6 +1356,7 @@ export const defaultConfig = Object.freeze({
   devIndicators: {
     position: 'bottom-left',
   },
+  browserDebugInfoInTerminal: true,
   onDemandEntries: {
     maxInactiveAge: 60 * 1000,
     pagesBufferLength: 5,

--- a/packages/next/src/server/dev/browser-logs/receive-logs.ts
+++ b/packages/next/src/server/dev/browser-logs/receive-logs.ts
@@ -73,7 +73,7 @@ const forwardConsole: typeof console = {
         // of test failures that require non trivial updates. Because we only omit
         // logging to stdout/stderr by default, but still perform the entire log collection
         // pipeline we wont be missing out on any important coverage, unless the code guarded here
-        // is bugged
+        // is bugged (but this should be test by the explicit NEXT_TEST_BROWSER_LOGS tests)
         if (
           process.env.__NEXT_TEST_MODE &&
           !process.env.NEXT_TEST_BROWSER_LOGS

--- a/packages/next/src/server/dev/browser-logs/receive-logs.ts
+++ b/packages/next/src/server/dev/browser-logs/receive-logs.ts
@@ -69,6 +69,11 @@ const forwardConsole: typeof console = {
     methods.map((method) => [
       method,
       (...args: Array<any>) => {
+        // we don't actually log to stdout/stderr because that causes a significant amount
+        // of test failures that require non trivial updates. Because we only omit
+        // logging to stdout/stderr by default, but still perform the entire log collection
+        // pipeline we wont be missing out on any important coverage, unless the code guarded here
+        // is bugged
         if (
           process.env.__NEXT_TEST_MODE &&
           !process.env.NEXT_TEST_BROWSER_LOGS

--- a/packages/next/src/server/dev/browser-logs/receive-logs.ts
+++ b/packages/next/src/server/dev/browser-logs/receive-logs.ts
@@ -12,7 +12,7 @@ import {
   type LogMethod,
   type ConsoleEntry,
   UNDEFINED_MARKER,
-} from '../../../next-devtools/shared/log-patch'
+} from '../../../next-devtools/shared/console-patch'
 import type { NextConfigComplete } from '../../config-shared'
 
 export function getDisplayedSourceLocation(

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -857,7 +857,11 @@ export async function createHotReloaderTurbopack(
               // TODO
               break
             case 'browser-logs': {
-              if (nextConfig.experimental.browserDebugInfoInTerminal) {
+              const browserDebugConfig =
+                nextConfig.experimental?.browserDebugInfoInTerminal ??
+                nextConfig.browserDebugInfoInTerminal ??
+                true
+              if (browserDebugConfig) {
                 await receiveBrowserLogsTurbopack({
                   entries: parsedData.entries,
                   router: parsedData.router,
@@ -865,7 +869,7 @@ export async function createHotReloaderTurbopack(
                   project,
                   projectPath,
                   distDir,
-                  config: nextConfig.experimental.browserDebugInfoInTerminal,
+                  config: browserDebugConfig,
                 })
               }
               break

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -560,7 +560,11 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
               break
             }
             case 'browser-logs': {
-              if (this.config.experimental.browserDebugInfoInTerminal) {
+              const browserDebugConfig =
+                this.config.experimental?.browserDebugInfoInTerminal ??
+                this.config.browserDebugInfoInTerminal ??
+                true
+              if (browserDebugConfig) {
                 await receiveBrowserLogsWebpack({
                   entries: payload.entries,
                   router: payload.router,
@@ -570,7 +574,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
                   edgeServerStats: () => this.edgeServerStats,
                   rootDirectory: this.dir,
                   distDir: this.distDir,
-                  config: this.config.experimental.browserDebugInfoInTerminal,
+                  config: browserDebugConfig,
                 })
               }
               break

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -81,11 +81,11 @@ describe('pages/ error recovery', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "  x Expected '>', got '<eof>'",
+         "description": "  x Unexpected eof",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js
-       Error:   x Expected '>', got '<eof>'
+       Error:   x Unexpected eof
           ,----
         1 | export default () => <div/
           \`----
@@ -168,6 +168,8 @@ describe('pages/ error recovery', () => {
           |           ^",
        "stack": [
          "Index.useCallback[increment] index.js (7:11)",
+         "button <anonymous>",
+         "Index index.js (12:7)",
        ],
      }
     `)
@@ -305,6 +307,7 @@ describe('pages/ error recovery', () => {
              |         ^",
            "stack": [
              "Child child.js (3:9)",
+             "Index index.js (6:7)",
            ],
          }
         `)
@@ -733,6 +736,7 @@ describe('pages/ error recovery', () => {
              |   ^",
            "stack": [
              "Foo Foo.js (3:3)",
+             "FunctionDefault index.js (4:10)",
            ],
          }
         `)

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -81,11 +81,11 @@ describe('pages/ error recovery', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "  x Unexpected eof",
+         "description": "  x Expected '>', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js
-       Error:   x Unexpected eof
+       Error:   x Expected '>', got '<eof>'
           ,----
         1 | export default () => <div/
           \`----

--- a/test/development/browser-logs/browser-logs.test.ts
+++ b/test/development/browser-logs/browser-logs.test.ts
@@ -40,6 +40,21 @@ function setupLogCapture() {
 }
 
 describe(`Terminal Logging (${bundlerName})`, () => {
+  let originalBrowserLogsEnv: string | undefined
+
+  beforeAll(() => {
+    originalBrowserLogsEnv = process.env.NEXT_TEST_BROWSER_LOGS
+    process.env.NEXT_TEST_BROWSER_LOGS = 'true'
+  })
+
+  afterAll(() => {
+    if (originalBrowserLogsEnv === undefined) {
+      delete process.env.NEXT_TEST_BROWSER_LOGS
+    } else {
+      process.env.NEXT_TEST_BROWSER_LOGS = originalBrowserLogsEnv
+    }
+  })
+
   describe('Pages Router', () => {
     let next: NextInstance
     let logs: string[] = []

--- a/test/development/browser-logs/browser-logs.test.ts
+++ b/test/development/browser-logs/browser-logs.test.ts
@@ -53,13 +53,6 @@ describe(`Terminal Logging (${bundlerName})`, () => {
       next = await createNext({
         files: {
           pages: new FileRef(join(__dirname, 'fixtures/pages')),
-          'next.config.js': `
-            module.exports = {
-              experimental: {
-                browserDebugInfoInTerminal: true
-              }
-            }
-          `,
         },
       })
     })
@@ -162,13 +155,6 @@ describe(`Terminal Logging (${bundlerName})`, () => {
       next = await createNext({
         files: {
           app: new FileRef(join(__dirname, 'fixtures/app')),
-          'next.config.js': `
-            module.exports = {
-              experimental: {
-                browserDebugInfoInTerminal: true
-              }
-            }
-          `,
         },
       })
     })
@@ -226,13 +212,6 @@ describe(`Terminal Logging (${bundlerName})`, () => {
       next = await createNext({
         files: {
           app: new FileRef(join(__dirname, 'fixtures/app')),
-          'next.config.js': `
-            module.exports = {
-              experimental: {
-                browserDebugInfoInTerminal: true
-              }
-            }
-          `,
         },
       })
     })
@@ -292,13 +271,6 @@ describe(`Terminal Logging (${bundlerName})`, () => {
       next = await createNext({
         files: {
           app: new FileRef(join(__dirname, 'fixtures/app')),
-          'next.config.js': `
-            module.exports = {
-              experimental: {
-                browserDebugInfoInTerminal: true
-              }
-            }
-          `,
         },
       })
     })
@@ -341,15 +313,6 @@ describe(`Terminal Logging (${bundlerName})`, () => {
         next = await createNext({
           files: {
             pages: new FileRef(join(__dirname, 'fixtures/pages')),
-            'next.config.js': `
-              module.exports = {
-                experimental: {
-                  browserDebugInfoInTerminal: {
-                    showSourceLocation: false
-                  }
-                }
-              }
-            `,
           },
         })
       })


### PR DESCRIPTION
- Enables browser debug info in terminal by default
- source locations are now by default off ( `[browser] hello world (app/page.tsx:10:20)` <--- this)
  - source locations are too noisy when paths are long
  - there are cases source mapping fails but we still show the un source mapped location to the user, NEXT-4684
 