### PR TITLE
fix(turbopack): webpack-loaders failed to resolve relative path

### DIFF
--- a/test/e2e/app-dir/webpack-loader-binary/next.config.js
+++ b/test/e2e/app-dir/webpack-loader-binary/next.config.js
@@ -5,7 +5,7 @@ const nextConfig = {
   turbopack: {
     rules: {
       '*.txt': {
-        loaders: [require.resolve('./test-file-loader.js')],
+        loaders: ['./test-file-loader.js'],
         as: '*.js',
       },
       '*.mp4': {
@@ -17,7 +17,7 @@ const nextConfig = {
   webpack(config) {
     config.module.rules.push({
       test: /\.txt/,
-      use: require.resolve('./test-file-loader.js'),
+      use: './test-file-loader.js',
     })
     config.module.rules.push({
       test: /\.mp4/,

--- a/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -428,7 +428,7 @@ const transform = (
 
         loaders: loadersWithOptions.map((loader) => ({
           loader: __turbopack_external_require__.resolve(loader.loader, {
-            paths: [resourceDir],
+            paths: [contextDir, resourceDir],
           }),
           options: loader.options,
         })),


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

fixed: #82106 

The error was cause by the follow reason, when pass:

```ts
const nextConfig: NextConfig = {
  /* config options here */
  turbopack: {
    rules: {
      '*.txt': {
        loaders: ['./test-file-loader.js'],
        as: '*.js',
      },
    }
  }
};
```

and the project directory as follows:

```bash
src
 |_ app
      |_ index.tsx
      |_ text.txt
```

The loader will deal the `text.txt` under `src/app`, then the loader will resolve path like:

```ts
require.resolve('./test-file-loader.js', paths: ['/Users/next-app/src/app'])
```

Because the resource dir the `dirname(resoucePath)`, and the resourcePath is `/Users/next-app/src/app/text.txt`, this will never resolve the right loader path here.

So I just add a more `path` param(which is `contextDir`) for the require.resolve function, it will help the loader to find the right path here.