### PR TITLE
[turbopack] Remove a debug assertions in client references endpoint

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -730,27 +730,7 @@ impl GlobalBuildInformation {
             let result = if let [graph] = &self.client_references[..] {
                 // Just a single graph, no need to merge results  This also naturally aggregates
                 // server components and server utilities in the correct order
-                let result = graph.get_client_references_for_endpoint(entry);
-                #[cfg(debug_assertions)]
-                {
-                    let result = result.await?;
-                    if has_layout_segments {
-                        use rustc_hash::FxHashSet;
-
-                        let ServerEntries {
-                            server_utils,
-                            server_component_entries,
-                        } = &*find_server_entries(entry, include_traced).await?;
-                        // order of server utils doesn't matter, so just ensure that they match
-                        assert_eq!(
-                            FxHashSet::from_iter(result.server_utils.iter()),
-                            FxHashSet::from_iter(server_utils.iter())
-                        );
-                        // The order of server_components does matter, enforce it is identical
-                        assert_eq!(&result.server_component_entries, server_component_entries);
-                    }
-                }
-                result
+                graph.get_client_references_for_endpoint(entry)
             } else {
                 let results = self
                     .client_references


### PR DESCRIPTION
Remove a debug assertion code in the `GlobalBuildInformation` implementation that was validating client references for endpoints.  This was inserted as a sanity check that two traversals were doing the same thing, but this is overkill and can be trigged accidentally by an eventual consistency condition.  Just drop them.

If an application is edited during this computation it is possible that the module graph that GlobalBuildInformation has access to is different than the set of references that `find_server_entries` will identified, this transient condition could trigger the panic.

Closes PACK-5271