### PR TITLE
Turbopack: fix race condition in test case

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/tests/read_ref_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/read_ref_cell.rs
@@ -2,7 +2,7 @@
 #![feature(arbitrary_self_types_pointers)]
 #![allow(clippy::needless_return)] // clippy bug causes false positive
 
-use std::sync::Mutex;
+use std::{collections::HashSet, mem::take, sync::Mutex};
 
 use anyhow::Result;
 use turbo_tasks::{Invalidator, ReadRef, Vc, get_invalidator};
@@ -14,7 +14,7 @@ static REGISTRATION: Registration = register!();
 async fn read_ref() {
     run(&REGISTRATION, || async {
         let counter = Counter::cell(Counter {
-            value: Mutex::new((0, None)),
+            value: Mutex::new((0, Default::default())),
         });
 
         let counter_value = counter.get_value();
@@ -55,14 +55,14 @@ struct CounterValue(usize);
 #[turbo_tasks::value(serialization = "none", cell = "new", eq = "manual")]
 struct Counter {
     #[turbo_tasks(debug_ignore, trace_ignore)]
-    value: Mutex<(usize, Option<Invalidator>)>,
+    value: Mutex<(usize, HashSet<Invalidator>)>,
 }
 
 impl Counter {
     fn incr(&self) {
         let mut lock = self.value.lock().unwrap();
         lock.0 += 1;
-        if let Some(i) = lock.1.take() {
+        for i in take(&mut lock.1) {
             i.invalidate();
         }
     }
@@ -73,7 +73,7 @@ impl Counter {
     #[turbo_tasks::function]
     fn get_value(&self) -> Result<Vc<CounterValue>> {
         let mut lock = self.value.lock().unwrap();
-        lock.1 = Some(get_invalidator());
+        lock.1.insert(get_invalidator());
         Ok(Vc::cell(lock.0))
     }
 }


### PR DESCRIPTION
### What?

Fixes a race condition in the test case.

Since we are using a single value for multiple Vcs (via ReadRef::cell) the counter can have multiple invalidators.

Closes PACK-5267