### PR TITLE
Turbopack: Skip loading react-loadable-manifest in App Router

### DIFF
--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -100,20 +100,6 @@ export async function loadManifestWithRetries<T extends object>(
 }
 
 /**
- * Load manifest file with retries, defaults to 3 attempts, or return undefined.
- */
-export async function tryLoadManifestWithRetries<T extends object>(
-  manifestPath: string,
-  attempts = 3
-) {
-  try {
-    return await loadManifestWithRetries<T>(manifestPath, attempts)
-  } catch (err) {
-    return undefined
-  }
-}
-
-/**
  * Load manifest file with retries, defaults to 3 attempts.
  */
 export async function evalManifestWithRetries<T extends object>(
@@ -216,10 +202,13 @@ async function loadComponentsImpl<N = any>({
       join(distDir, BUILD_MANIFEST),
       manifestLoadAttempts
     ),
-    tryLoadManifestWithRetries<ReactLoadableManifest>(
-      reactLoadableManifestPath,
-      manifestLoadAttempts
-    ),
+    // We don't need to load the react-loadable-manifest for app paths.
+    isAppPath
+      ? undefined
+      : loadManifestWithRetries<ReactLoadableManifest>(
+          reactLoadableManifestPath,
+          manifestLoadAttempts
+        ),
     // This manifest will only exist in Pages dir && Production && Webpack.
     isAppPath || process.env.TURBOPACK
       ? undefined

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -794,15 +794,17 @@ export class TurbopackManifestLoader {
     productionRewrites: CustomRoutes['rewrites'] | undefined
     entrypoints: Entrypoints
   }) {
-    await this.writeActionManifest()
-    await this.writeAppBuildManifest()
-    await this.writeAppPathsManifest()
-    await this.writeBuildManifest(entrypoints, devRewrites, productionRewrites)
-    await this.writeFallbackBuildManifest()
-    await this.writeMiddlewareManifest()
-    await this.writeClientMiddlewareManifest()
-    await this.writeNextFontManifest()
-    await this.writePagesManifest()
+    await Promise.all([
+      this.writeActionManifest(),
+      this.writeAppBuildManifest(),
+      this.writeAppPathsManifest(),
+      this.writeBuildManifest(entrypoints, devRewrites, productionRewrites),
+      this.writeFallbackBuildManifest(),
+      this.writeMiddlewareManifest(),
+      this.writeClientMiddlewareManifest(),
+      this.writeNextFontManifest(),
+      this.writePagesManifest(),
+    ])
 
     if (process.env.TURBOPACK_STATS != null) {
       await this.writeWebpackStats()


### PR DESCRIPTION
Before:

```
GET /favicon.ico 200 in 249ms
```

After:

```
GET /favicon.ico 200 in 14ms
```

The `tryLoadManifestWithRetries` logic would try to load the `react-loadable-manifest.json` but this doesn't exist for App Router.


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes PACK-5270