### PR TITLE
Turbopack: Skip loading react-loadable-manifest for Route Handlers

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1868,7 +1868,6 @@ export default async function build(
                 distDir,
                 runtimeEnvConfig,
                 checkingApp: false,
-                sriEnabled,
               }))
           )
 
@@ -1902,7 +1901,6 @@ export default async function build(
             distDir,
             runtimeEnvConfig,
             checkingApp: true,
-            sriEnabled,
           }
         )
 
@@ -1910,7 +1908,6 @@ export default async function build(
           page: appPageToCheck,
           distDir,
           runtimeEnvConfig,
-          sriEnabled,
         })
 
         // eslint-disable-next-line @typescript-eslint/no-shadow

--- a/packages/next/src/build/templates/pages-api.ts
+++ b/packages/next/src/build/templates/pages-api.ts
@@ -21,7 +21,7 @@ export default hoist(userland, 'default')
 export const config = hoist(userland, 'config')
 
 // Create and export the route module that will be consumed.
-const routeModule = new PagesAPIRouteModule({
+export const routeModule = new PagesAPIRouteModule({
   definition: {
     kind: RouteKind.PAGES_API,
     page: 'VAR_DEFINITION_PAGE',

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -56,7 +56,7 @@ import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
 import { findPageFile } from '../server/lib/find-page-file'
 import { isEdgeRuntime } from '../lib/is-edge-runtime'
 import * as Log from './output/log'
-import { loadComponents } from '../server/load-components'
+import { getComponentMod, loadComponents } from '../server/load-components'
 import type { LoadComponentsReturnType } from '../server/load-components'
 import { trace } from '../trace'
 import { setHttpClientAndAgentOptions } from '../server/setup-http-agent-env'
@@ -1383,26 +1383,18 @@ export async function hasCustomGetInitialProps({
   distDir,
   runtimeEnvConfig,
   checkingApp,
-  sriEnabled,
 }: {
   page: string
   distDir: string
   runtimeEnvConfig: any
   checkingApp: boolean
-  sriEnabled: boolean
 }): Promise<boolean> {
   ;(
     require('../shared/lib/runtime-config.external') as typeof import('../shared/lib/runtime-config.external')
   ).setConfig(runtimeEnvConfig)
+  const ComponentMod = await getComponentMod(page, distDir, false)
 
-  const components = await loadComponents({
-    distDir,
-    page: page,
-    isAppPath: false,
-    isDev: false,
-    sriEnabled,
-  })
-  let mod = components.ComponentMod
+  let mod = ComponentMod
 
   if (checkingApp) {
     mod = (await mod._app) || mod.default || mod
@@ -1417,26 +1409,18 @@ export async function getDefinedNamedExports({
   page,
   distDir,
   runtimeEnvConfig,
-  sriEnabled,
 }: {
   page: string
   distDir: string
   runtimeEnvConfig: any
-  sriEnabled: boolean
 }): Promise<ReadonlyArray<string>> {
   ;(
     require('../shared/lib/runtime-config.external') as typeof import('../shared/lib/runtime-config.external')
   ).setConfig(runtimeEnvConfig)
-  const components = await loadComponents({
-    distDir,
-    page: page,
-    isAppPath: false,
-    isDev: false,
-    sriEnabled,
-  })
+  const ComponentMod = await getComponentMod(page, distDir, false)
 
-  return Object.keys(components.ComponentMod).filter((key) => {
-    return typeof components.ComponentMod[key] !== 'undefined'
+  return Object.keys(ComponentMod).filter((key) => {
+    return typeof ComponentMod[key] !== 'undefined'
   })
 }
 

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -100,20 +100,6 @@ export async function loadManifestWithRetries<T extends object>(
 }
 
 /**
- * Load manifest file with retries, defaults to 3 attempts, or return undefined.
- */
-export async function tryLoadManifestWithRetries<T extends object>(
-  manifestPath: string,
-  attempts = 3
-) {
-  try {
-    return await loadManifestWithRetries<T>(manifestPath, attempts)
-  } catch (err) {
-    return undefined
-  }
-}
-
-/**
  * Load manifest file with retries, defaults to 3 attempts.
  */
 export async function evalManifestWithRetries<T extends object>(
@@ -216,10 +202,13 @@ async function loadComponentsImpl<N = any>({
       join(distDir, BUILD_MANIFEST),
       manifestLoadAttempts
     ),
-    tryLoadManifestWithRetries<ReactLoadableManifest>(
-      reactLoadableManifestPath,
-      manifestLoadAttempts
-    ),
+    // We don't need to load the react-loadable-manifest for app paths.
+    isAppPath
+      ? undefined
+      : loadManifestWithRetries<ReactLoadableManifest>(
+          reactLoadableManifestPath,
+          manifestLoadAttempts
+        ),
     // This manifest will only exist in Pages dir && Production && Webpack.
     isAppPath || process.env.TURBOPACK
       ? undefined

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -134,6 +134,18 @@ async function tryLoadClientReferenceManifest(
   }
 }
 
+/**
+ * This function returns either the module or a static html string.
+ */
+export async function getComponentMod(
+  page: string,
+  distDir: string,
+  isAppPath: boolean
+) {
+  const ComponentMod = await requirePage(page, distDir, isAppPath)
+  return ComponentMod
+}
+
 async function loadComponentsImpl<N = any>({
   distDir,
   page,
@@ -249,8 +261,7 @@ async function loadComponentsImpl<N = any>({
     })
   }
 
-  const ComponentMod = await requirePage(page, distDir, isAppPath)
-
+  const ComponentMod = await getComponentMod(page, distDir, isAppPath)
   const Component = interopDefault(ComponentMod)
   const Document = interopDefault(DocumentMod)
   const App = interopDefault(AppMod)

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -194,9 +194,9 @@ async function loadComponentsImpl<N = any>({
   // Make sure to avoid loading the manifest for static metadata routes for better performance.
   // TODO: We should not rely on the `page` in order to determine route type. `definition.kind` has this information for each bundle. The problem with ClientReferenceManifest is that it's used in `setReferenceManifestsSingleton` which has to run before the route itself is required.
   const hasClientManifest =
-    !isStaticMetadataRoute(page) ||
+    !isStaticMetadataRoute(page) &&
     // Temporary hack to exclude loading the clientReferenceManifest for Route Handlers.
-    page.endsWith('/route')
+    !page.endsWith('/route')
 
   // Load the manifest files first
   //

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -275,7 +275,7 @@ async function loadComponentsImpl<N = any>({
 
   const reactLoadableManifest =
     // APP_ROUTE does not have a react-loadable-manifest.
-    !isStaticHTML && routeModule.definition.kind === RouteKind.APP_ROUTE
+    isStaticHTML || routeModule.definition.kind === RouteKind.APP_ROUTE
       ? undefined
       : await loadManifestWithRetries<ReactLoadableManifest>(
           reactLoadableManifestPath,

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -262,6 +262,9 @@ async function loadComponentsImpl<N = any>({
   }
 
   const ComponentMod = await getComponentMod(page, distDir, isAppPath)
+
+  const isStaticHTML = typeof ComponentMod === 'string'
+
   const Component = interopDefault(ComponentMod)
   const Document = interopDefault(DocumentMod)
   const App = interopDefault(AppMod)
@@ -272,7 +275,7 @@ async function loadComponentsImpl<N = any>({
 
   const reactLoadableManifest =
     // APP_ROUTE does not have a react-loadable-manifest.
-    routeModule.definition.kind === RouteKind.APP_ROUTE
+    !isStaticHTML && routeModule.definition.kind === RouteKind.APP_ROUTE
       ? undefined
       : await loadManifestWithRetries<ReactLoadableManifest>(
           reactLoadableManifestPath,

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -794,15 +794,17 @@ export class TurbopackManifestLoader {
     productionRewrites: CustomRoutes['rewrites'] | undefined
     entrypoints: Entrypoints
   }) {
-    await this.writeActionManifest()
-    await this.writeAppBuildManifest()
-    await this.writeAppPathsManifest()
-    await this.writeBuildManifest(entrypoints, devRewrites, productionRewrites)
-    await this.writeFallbackBuildManifest()
-    await this.writeMiddlewareManifest()
-    await this.writeClientMiddlewareManifest()
-    await this.writeNextFontManifest()
-    await this.writePagesManifest()
+    await Promise.all([
+      this.writeActionManifest(),
+      this.writeAppBuildManifest(),
+      this.writeAppPathsManifest(),
+      this.writeBuildManifest(entrypoints, devRewrites, productionRewrites),
+      this.writeFallbackBuildManifest(),
+      this.writeMiddlewareManifest(),
+      this.writeClientMiddlewareManifest(),
+      this.writeNextFontManifest(),
+      this.writePagesManifest(),
+    ])
 
     if (process.env.TURBOPACK_STATS != null) {
       await this.writeWebpackStats()


### PR DESCRIPTION
Before:

```
GET /favicon.ico 200 in 249ms
```

After:

```
GET /favicon.ico 200 in 14ms
```

The `tryLoadManifestWithRetries` logic would try to load the `react-loadable-manifest.json` but this doesn't exist for Route Handlers in App Router. It does exist for the other cases.

Removed the `try` case as it's a footgun that can introduce 200ms latency (as shown here).

While investigating this we (@sokra, @mischnic, and I) also found that manifests can be written in parallel.

Closes PACK-5396