### PR TITLE
[Cache Components] Faster partial hydration in PPR resumes

### DIFF
--- a/packages/next/src/server/app-render/postponed-state.test.ts
+++ b/packages/next/src/server/app-render/postponed-state.test.ts
@@ -8,6 +8,7 @@ import {
   getDynamicDataPostponedState,
   getDynamicHTMLPostponedState,
   parsePostponedState,
+  DynamicHTMLPreludeState,
 } from './postponed-state'
 
 describe('getDynamicHTMLPostponedState', () => {
@@ -30,6 +31,7 @@ describe('getDynamicHTMLPostponedState', () => {
 
     const state = await getDynamicHTMLPostponedState(
       { [key]: key, nested: { [key]: key } },
+      DynamicHTMLPreludeState.Full,
       fallbackRouteParams,
       prerenderResumeDataCache
     )
@@ -37,12 +39,15 @@ describe('getDynamicHTMLPostponedState', () => {
     const parsed = parsePostponedState(state, { slug: '123' })
     expect(parsed).toMatchInlineSnapshot(`
      {
-       "data": {
-         "123": "123",
-         "nested": {
+       "data": [
+         1,
+         {
            "123": "123",
+           "nested": {
+             "123": "123",
+           },
          },
-       },
+       ],
        "renderResumeDataCache": {
          "cache": Map {
            "1" => Promise {},
@@ -65,10 +70,11 @@ describe('getDynamicHTMLPostponedState', () => {
   it('serializes a HTML postponed state without fallback params', async () => {
     const state = await getDynamicHTMLPostponedState(
       { key: 'value' },
+      DynamicHTMLPreludeState.Full,
       null,
       createPrerenderResumeDataCache()
     )
-    expect(state).toMatchInlineSnapshot(`"15:{"key":"value"}null"`)
+    expect(state).toMatchInlineSnapshot(`"19:[1,{"key":"value"}]null"`)
   })
 
   it('can serialize and deserialize a HTML postponed state with fallback params', async () => {
@@ -76,6 +82,7 @@ describe('getDynamicHTMLPostponedState', () => {
     const fallbackRouteParams = new Map([['slug', key]])
     const state = await getDynamicHTMLPostponedState(
       { [key]: key },
+      DynamicHTMLPreludeState.Full,
       fallbackRouteParams,
       createPrerenderResumeDataCache()
     )
@@ -85,7 +92,7 @@ describe('getDynamicHTMLPostponedState', () => {
     const parsed = parsePostponedState(state, params)
     expect(parsed).toEqual({
       type: DynamicState.HTML,
-      data: { [value]: value },
+      data: [1, { [value]: value }],
       renderResumeDataCache: createPrerenderResumeDataCache(),
     })
 
@@ -105,7 +112,7 @@ describe('getDynamicDataPostponedState', () => {
 
 describe('parsePostponedState', () => {
   it('parses a HTML postponed state with fallback params', () => {
-    const state = `2589:39[["slug","%%drp:slug:e9615126684e5%%"]]{"t":2,"d":{"nextSegmentId":2,"rootFormatContext":{"insertionMode":0,"selectedValue":null,"tagScope":0},"progressiveChunkSize":12800,"resumableState":{"idPrefix":"","nextFormID":0,"streamingFormat":0,"instructions":0,"hasBody":true,"hasHtml":true,"unknownResources":{},"dnsResources":{},"connectResources":{"default":{},"anonymous":{},"credentials":{}},"imageResources":{},"styleResources":{},"scriptResources":{"/_next/static/chunks/webpack-6b2534a6458c6fe5.js":null,"/_next/static/chunks/f5e865f6-5e04edf75402c5e9.js":null,"/_next/static/chunks/9440-26a4cfbb73347735.js":null,"/_next/static/chunks/main-app-315ef55d588dbeeb.js":null,"/_next/static/chunks/8630-8e01a4bea783c651.js":null,"/_next/static/chunks/app/layout-1b900e1a3caf3737.js":null},"moduleUnknownResources":{},"moduleScriptResources":{"/_next/static/chunks/webpack-6b2534a6458c6fe5.js":null}},"replayNodes":[["oR",0,[["Context.Provider",0,[["ServerInsertedHTMLProvider",0,[["Context.Provider",0,[["n7",0,[["nU",0,[["nF",0,[["n9",0,[["Fragment",0,[["Context.Provider",2,[["Context.Provider",0,[["Context.Provider",0,[["Context.Provider",0,[["Context.Provider",0,[["Context.Provider",0,[["nY",0,[["nX",0,[["Fragment","c",[["Fragment",0,[["html",1,[["body",0,[["main",3,[["j",0,[["Fragment",0,[["Context.Provider","validation",[["i",2,[["Fragment",0,[["E",0,[["R",0,[["h",0,[["Fragment",0,[["O",0,[["Fragment",0,[["s",0,[["c",0,[["s",0,[["c",0,[["v",0,[["Context.Provider",0,[["Fragment","c",[["j",1,[["Fragment",0,[["Context.Provider","slug|%%drp:slug:e9615126684e5%%|d",[["i",2,[["Fragment",0,[["E",0,[["R",0,[["h",0,[["Fragment",0,[["O",0,[["Fragment",0,[["s",0,[["Fragment",0,[["s",0,[["c",0,[["v",0,[["Context.Provider",0,[["Fragment","c",[["j",1,[["Fragment",0,[["Context.Provider","__PAGE__",[["i",2,[["Fragment",0,[["E",0,[["R",0,[["h",0,[["Fragment",0,[["O",0,[["Suspense",0,[["s",0,[["Fragment",0,[["s",0,[["c",0,[["v",0,[["Context.Provider",0,[["Fragment","c",[["Fragment",0,[],{"1":1}]],null]],null]],null]],null]],null]],null]],null]],null,["Suspense Fallback",0,[],null],0]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],"replaySlots":null}}null`
+    const state = `2593:39[["slug","%%drp:slug:e9615126684e5%%"]][1,{"t":2,"d":{"nextSegmentId":2,"rootFormatContext":{"insertionMode":0,"selectedValue":null,"tagScope":0},"progressiveChunkSize":12800,"resumableState":{"idPrefix":"","nextFormID":0,"streamingFormat":0,"instructions":0,"hasBody":true,"hasHtml":true,"unknownResources":{},"dnsResources":{},"connectResources":{"default":{},"anonymous":{},"credentials":{}},"imageResources":{},"styleResources":{},"scriptResources":{"/_next/static/chunks/webpack-6b2534a6458c6fe5.js":null,"/_next/static/chunks/f5e865f6-5e04edf75402c5e9.js":null,"/_next/static/chunks/9440-26a4cfbb73347735.js":null,"/_next/static/chunks/main-app-315ef55d588dbeeb.js":null,"/_next/static/chunks/8630-8e01a4bea783c651.js":null,"/_next/static/chunks/app/layout-1b900e1a3caf3737.js":null},"moduleUnknownResources":{},"moduleScriptResources":{"/_next/static/chunks/webpack-6b2534a6458c6fe5.js":null}},"replayNodes":[["oR",0,[["Context.Provider",0,[["ServerInsertedHTMLProvider",0,[["Context.Provider",0,[["n7",0,[["nU",0,[["nF",0,[["n9",0,[["Fragment",0,[["Context.Provider",2,[["Context.Provider",0,[["Context.Provider",0,[["Context.Provider",0,[["Context.Provider",0,[["Context.Provider",0,[["nY",0,[["nX",0,[["Fragment","c",[["Fragment",0,[["html",1,[["body",0,[["main",3,[["j",0,[["Fragment",0,[["Context.Provider","validation",[["i",2,[["Fragment",0,[["E",0,[["R",0,[["h",0,[["Fragment",0,[["O",0,[["Fragment",0,[["s",0,[["c",0,[["s",0,[["c",0,[["v",0,[["Context.Provider",0,[["Fragment","c",[["j",1,[["Fragment",0,[["Context.Provider","slug|%%drp:slug:e9615126684e5%%|d",[["i",2,[["Fragment",0,[["E",0,[["R",0,[["h",0,[["Fragment",0,[["O",0,[["Fragment",0,[["s",0,[["Fragment",0,[["s",0,[["c",0,[["v",0,[["Context.Provider",0,[["Fragment","c",[["j",1,[["Fragment",0,[["Context.Provider","__PAGE__",[["i",2,[["Fragment",0,[["E",0,[["R",0,[["h",0,[["Fragment",0,[["O",0,[["Suspense",0,[["s",0,[["Fragment",0,[["s",0,[["c",0,[["v",0,[["Context.Provider",0,[["Fragment","c",[["Fragment",0,[],{"1":1}]],null]],null]],null]],null]],null]],null]],null]],null,["Suspense Fallback",0,[],null],0]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],null]],"replaySlots":null}}]null`
     const params = {
       slug: Math.random().toString(16).slice(3),
     }

--- a/test/e2e/app-dir/ppr-partial-hydration/app/hydration-indicator.tsx
+++ b/test/e2e/app-dir/ppr-partial-hydration/app/hydration-indicator.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export function HydrationIndicator({ id }: { id?: string }) {
+  const [isMounted, setIsMounted] = useState(false)
+  useEffect(() => {
+    setIsMounted(true)
+    return () => setIsMounted(false)
+  }, [])
+  return (
+    <div id={id} data-is-hydrated={isMounted ? 'true' : 'false'}>
+      {isMounted ? '🟢 Hydrated' : '⚪ Not hydrated yet'}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-partial-hydration/app/with-shell/layout.tsx
+++ b/test/e2e/app-dir/ppr-partial-hydration/app/with-shell/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/ppr-partial-hydration/app/with-shell/with-streaming-metadata/page.tsx
+++ b/test/e2e/app-dir/ppr-partial-hydration/app/with-shell/with-streaming-metadata/page.tsx
@@ -1,0 +1,40 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import { setTimeout } from 'timers/promises'
+import { HydrationIndicator } from '../../hydration-indicator'
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  await connection()
+  return {
+    title: 'Resume test',
+  }
+}
+
+export default function Page() {
+  return (
+    <main id="shell">
+      <h1>This is a page with static shell + streaming metadata</h1>
+      <div>
+        <p>Static shell</p>
+        <HydrationIndicator id="shell-hydrated" />
+        <hr />
+        <Suspense fallback={<div id="dynamic-fallback">Loading...</div>}>
+          <SlowServerComponent delay={500} />
+        </Suspense>
+      </div>
+    </main>
+  )
+}
+
+async function SlowServerComponent({ delay }: { delay: number }) {
+  await connection()
+  await setTimeout(delay)
+  const randomValue = Math.floor(Math.random() * 1000)
+  return (
+    <div id="dynamic">
+      <div>{`Random value: ${randomValue}`}</div>
+      <HydrationIndicator id="dynamic-hydrated" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-partial-hydration/app/with-shell/without-metadata/page.tsx
+++ b/test/e2e/app-dir/ppr-partial-hydration/app/with-shell/without-metadata/page.tsx
@@ -1,0 +1,32 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import { setTimeout } from 'timers/promises'
+import { HydrationIndicator } from '../../hydration-indicator'
+
+export default function Page() {
+  return (
+    <main id="shell">
+      <h1>This is a page with static shell + no streaming metadata</h1>
+      <div>
+        <p>Static shell</p>
+        <HydrationIndicator id="shell-hydrated" />
+        <hr />
+        <Suspense fallback={<div id="dynamic-fallback">Loading...</div>}>
+          <SlowServerComponent delay={500} />
+        </Suspense>
+      </div>
+    </main>
+  )
+}
+
+async function SlowServerComponent({ delay }: { delay: number }) {
+  await connection()
+  await setTimeout(delay)
+  const randomValue = Math.floor(Math.random() * 1000)
+  return (
+    <div id="dynamic">
+      <div>{`Random value: ${randomValue}`}</div>
+      <HydrationIndicator id="dynamic-hydrated" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-partial-hydration/app/without-shell/layout.tsx
+++ b/test/e2e/app-dir/ppr-partial-hydration/app/without-shell/layout.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <Suspense>
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/ppr-partial-hydration/app/without-shell/with-streaming-metadata/page.tsx
+++ b/test/e2e/app-dir/ppr-partial-hydration/app/without-shell/with-streaming-metadata/page.tsx
@@ -1,0 +1,43 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import { setTimeout } from 'timers/promises'
+import { HydrationIndicator } from '../../hydration-indicator'
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  await connection()
+  return {
+    title: 'Resume test',
+  }
+}
+
+export default async function Page() {
+  // Trigger the Suspense-around-body in the root layout so that no static shell is produced
+  await connection()
+
+  return (
+    <main id="shell">
+      <h1>This is a page with no static shell + with streaming metadata</h1>
+      <div>
+        <p>Dynamic shell</p>
+        <HydrationIndicator id="shell-hydrated" />
+        <hr />
+        <Suspense fallback={<div id="dynamic-fallback">Loading...</div>}>
+          <SlowServerComponent delay={500} />
+        </Suspense>
+      </div>
+    </main>
+  )
+}
+
+async function SlowServerComponent({ delay }: { delay: number }) {
+  await connection()
+  await setTimeout(delay)
+  const randomValue = Math.floor(Math.random() * 1000)
+  return (
+    <div id="dynamic">
+      <div>{`Random value: ${randomValue}`}</div>
+      <HydrationIndicator id="dynamic-hydrated" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-partial-hydration/app/without-shell/without-metadata/page.tsx
+++ b/test/e2e/app-dir/ppr-partial-hydration/app/without-shell/without-metadata/page.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import { setTimeout } from 'timers/promises'
+import { HydrationIndicator } from '../../hydration-indicator'
+
+export default async function Page() {
+  // Trigger the Suspense-around-body in the root layout so that no static shell is produced
+  await connection()
+
+  return (
+    <main id="shell">
+      <h1>This is a page with no static shell + no streaming metadata</h1>
+      <div>
+        <p>Dynamic shell</p>
+        <HydrationIndicator id="shell-hydrated" />
+        <hr />
+        <Suspense fallback={<div id="dynamic-fallback">Loading...</div>}>
+          <SlowServerComponent delay={500} />
+        </Suspense>
+      </div>
+    </main>
+  )
+}
+
+async function SlowServerComponent({ delay }: { delay: number }) {
+  await connection()
+  await setTimeout(delay)
+  const randomValue = Math.floor(Math.random() * 1000)
+  return (
+    <div id="dynamic">
+      <div>{`Random value: ${randomValue}`}</div>
+      <HydrationIndicator id="dynamic-hydrated" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/ppr-partial-hydration/next.config.ts
+++ b/test/e2e/app-dir/ppr-partial-hydration/next.config.ts
@@ -1,0 +1,11 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    ppr: true,
+    // until the flags are merged, test both `ppr` and `cacheComponents`
+    // cacheComponents: true,
+  },
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
+++ b/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
@@ -1,0 +1,139 @@
+// CASES:
+// shell + no metadata
+// shell + streaming metadata
+// no shell + no metadata
+// no shell + streaming metadata
+
+import { nextTestSetup } from '../../../lib/e2e-utils'
+import { retry } from '../../../lib/next-test-utils'
+
+describe('PPR - partial hydration', () => {
+  const { next, isNextDev } = nextTestSetup({ files: __dirname })
+  if (isNextDev) {
+    it.skip('only testable in production', () => {})
+    return
+  }
+
+  describe.each([
+    {
+      description: 'Static shell, no streaming metadata',
+      path: '/with-shell/without-metadata',
+    },
+    {
+      // Streaming metadata shouldn't affect streaming order, because if we have a static shell,
+      // then RSC scripts (and thus hydration) don't need to wait for any HTML to be rendered.
+      // I'm including it here for completeness.
+      description: 'Static shell, streaming metadata',
+      path: '/with-shell/with-streaming-metadata',
+    },
+    {
+      description: 'No static shell, no streaming metadata',
+      path: '/without-shell/without-metadata',
+    },
+    {
+      // Streaming metadata is relevant, because it can affect how the HTML and RSC streams are interleaved.
+      // If we have no static shell, RSC script tags won't be sent until the first SSR HTML chunk is sent.
+      // Streaming metadata results in a HTML chunk, and thus it can affect this.
+      description: 'No static shell, streaming metadata',
+      path: '/without-shell/with-streaming-metadata',
+    },
+  ])('$description', ({ path }) => {
+    it('should hydrate the shell without waiting for slow suspense boundaries', async () => {
+      const browser = await next.browser(path, {
+        waitHydration: false,
+        waitUntil: 'commit', // do not wait for "load", we want to inspect the page as it streams in
+      })
+
+      // Initially, only the shell should be visible
+      await retry(
+        async () => {
+          // The shell should be hydrated as soon as possible,
+          // without waiting for the dynamic content
+          expect(
+            await browser
+              .elementByCssInstant('#shell-hydrated', { state: 'visible' })
+              .getAttribute('data-is-hydrated')
+          ).toBe('true')
+
+          // The dynamic content hasn't streamed in yet, we should only see the fallback
+          expect(await browser.elementsByCss('main #dynamic')).toHaveLength(0)
+          expect(
+            await browser
+              .elementByCssInstant('#dynamic-fallback', { state: 'visible' })
+              .text()
+          ).toContain('Loading...')
+        },
+        1000,
+        50
+      )
+
+      // Then, the slow content should stream in and hydrate
+      await retry(async () => {
+        // The shell is already hydrated, this shouldn't change
+        expect(
+          await browser
+            .elementByCssInstant('#shell-hydrated', { state: 'visible' })
+            .getAttribute('data-is-hydrated')
+        ).toBe('true')
+
+        // The dynamic content should be visible and hydrated
+        expect(
+          await browser
+            .elementByCssInstant('#dynamic', { state: 'visible' })
+            .text()
+        ).toMatch(/Random value: \d+/)
+        expect(
+          await browser
+            .elementByCssInstant('#dynamic-hydrated', { state: 'visible' })
+            .getAttribute('data-is-hydrated')
+        ).toBe('true')
+      })
+
+      // If the HTML and RSC streams were interleaved correctly, we shouldn't be in quirks mode
+      // (we would be happen if an RSC script was sent before `<!DOCTYPE html>`)
+      expect(await browser.eval(() => document.compatMode)).not.toBe(
+        'BackCompat'
+      )
+    })
+
+    it('should produce a valid HTML document', async () => {
+      // This test is meant to check if we're interleaving the HTML and RSC streams correctly.
+      // In particular, RSC script tags should never appear before the initial HTML
+      // (which could happen if we e.g. have no static shell and don't wait for it to be rendered before sending them)
+      const response = await next.fetch(path)
+      expect(response.status).toBe(200)
+      const text = await response
+        .text()
+        // Ignore the sentinel. For pages with no static shell, it ends up at the front
+        // and messes up the assertion.
+        .then((s) => s.replace('<!-- PPR_BOUNDARY_SENTINEL -->', ''))
+
+      expect(text).toStartWith('<!DOCTYPE html>')
+      expect(text).toEndWith('</body></html>')
+    })
+
+    it('should display the shell without JS', async () => {
+      const browser = await next.browser(path, {
+        disableJavaScript: true,
+        waitUntil: 'load', // Unlike the previous test, we want the page to load fully
+      })
+      expect(await browser.elementByCss('#shell').text()).toContain(
+        'This is a page'
+      )
+      expect(
+        await browser
+          .elementByCss('#shell-hydrated', { state: 'visible' })
+          .getAttribute('data-is-hydrated')
+      ).toBe('false')
+
+      // The dynamic content can't be inserted into the document because we disabled JS,
+      // so we should only see the fallback
+      expect(await browser.elementsByCss('main #dynamic')).toHaveLength(0)
+      expect(
+        await browser
+          .elementByCss('#dynamic-fallback', { state: 'visible' })
+          .text()
+      ).toContain('Loading...')
+    })
+  })
+})


### PR DESCRIPTION
This PR fixes some HTML/RSC stream interleaving logic that, under some circumstances, resulted in hydration of a resumed page being delayed unnecessarily.

Fixes NAR-284

---

When SSRing a page, we're mixing two streams -- the HTML stream, and the RSC stream (containing scripts with RSC data, used for hydration). In a regular (non-PPR) render, we need to wait for react to flush the first HTML chunk (containing `<html><body>...`) before we can send the first RSC script. This was implemented in `createMergedTransformStream`. 

The problem was that `createMergedTransformStream` was also re-used when rendering a PPR `resume()`. In that case, we're only outputting  the dynamic portion of HTML, and the shell is sent separately (either by the next server, outside of `app-render`, or by infrastructure), meaning that is _not_ part of the stream that `createMergedTransformStream` receives. But the "wait for the first html chunk" logic was still there, and thus, we were accidentally delaying sending any RSC scripts until the first piece of dynamic HTML was rendered even if they had no connection to each other. In particular, this also prevented us from sending hydration data for the static shell.

There's one edge case here -- if we didn't produce a static shell (e.g. for suspense-above-body), we should still apply the html-waiting logic, otherwise we'd end up sending scripts before the body is rendered. But if we have a shell, we shouldn't wait for the HTML at all.

This is now solved as follows:
1. During the prerender, we track whether or not a shell (aka "prelude") was produced, and store that information in the postponed state object
2. When resuming, we check whether the prerender had a shell, and if it does, we don't wait for HTML (under the assumption that it was already sent separately, outside the dynamic render)

To test this, I've had to extend our testing setup a bit -- with the default settings, playwright would wait until `load` is fired, which seems to fire after all the HTML finished streaming and thus doesn't let us inspect whether partial hydration is working correctly. We're also waiting for `load` in `elementByCss` (apparently, for compatibility with tests written before playwright) so i've had to work around that as well.