### PR TITLE
`create-next-app`: use Turbopack for both dev and build

### DIFF
--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -29,7 +29,7 @@ Would you like to use ESLint? No / Yes
 Would you like to use Tailwind CSS? No / Yes
 Would you like your code inside a `src/` directory? No / Yes
 Would you like to use App Router? (recommended) No / Yes
-Would you like to use Turbopack for `next dev`?  No / Yes
+Would you like to use Turbopack? (recommended) No / Yes
 Would you like to customize the import alias (`@/*` by default)? No / Yes
 What import alias would you like configured? @/*
 ```

--- a/docs/01-app/03-api-reference/06-cli/create-next-app.mdx
+++ b/docs/01-app/03-api-reference/06-cli/create-next-app.mdx
@@ -62,7 +62,7 @@ Would you like to use ESLint?  No / Yes
 Would you like to use Tailwind CSS?  No / Yes
 Would you like your code inside a `src/` directory?  No / Yes
 Would you like to use App Router? (recommended)  No / Yes
-Would you like to use Turbopack for `next dev`?  No / Yes
+Would you like to use Turbopack? (recommended)  No / Yes
 Would you like to customize the import alias (`@/*` by default)?  No / Yes
 ```
 

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -362,7 +362,7 @@ async function run(): Promise<void> {
           onState: onPromptState,
           type: 'toggle',
           name: 'turbopack',
-          message: `Would you like to use ${styledTurbo} for \`next dev\`?`,
+          message: `Would you like to use ${styledTurbo}? (recommended)`,
           initial: getPrefOrDefault('turbopack'),
           active: 'Yes',
           inactive: 'No',

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -189,7 +189,7 @@ export const installTemplate = async ({
     private: true,
     scripts: {
       dev: `next dev${turbopack ? " --turbopack" : ""}`,
-      build: "next build",
+      build: `next build${turbopack ? " --turbopack" : ""}`,
       start: "next start",
       lint: "next lint",
     },


### PR DESCRIPTION
Previously, we asked users if they want to use Turbopack for `next dev`. Now, we ask if they want to use Turbopack, and if they do, we use it for both dev and build. It’s also listed as `(recommended)` like App Router.

Test Plan: `pnpm build`, `./node_modules/.bin/create-next-app ~/path/to/app`. Choose the Turbopack option. Verify the app uses Turbopack for both dev and build.


Closes PACK-5278