### PR TITLE
docs: correct Node.js runtime support version in middleware (15.4.2-canary.47)

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
@@ -180,7 +180,8 @@ Middleware will be invoked for **every route in your project**. Given this, it's
 
 ## Runtime
 
-Middleware defaults to using the Edge runtime. As of v15.2.0, we have experimental support for using the Node.js runtime. To enable, in your middleware file, set the runtime to `nodejs` in the `config` object:
+Middleware defaults to using the Edge runtime. As of v15.5, we have support for using the Node.js runtime. 
+To enable, in your middleware file, set the runtime to `nodejs` in the `config` object:
 
 ```js highlight={2} filename="middleware.js" switcher
 export const config = {

--- a/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
@@ -180,7 +180,7 @@ Middleware will be invoked for **every route in your project**. Given this, it's
 
 ## Runtime
 
-Middleware defaults to using the Edge runtime. As of v15.4.2-canary.47, we have support for using the Node.js runtime. To enable, in your middleware file, set the runtime to `nodejs` in the `config` object:
+Middleware defaults to using the Edge runtime. As of v15.2.0, we have experimental support for using the Node.js runtime. To enable, in your middleware file, set the runtime to `nodejs` in the `config` object:
 
 ```js highlight={2} filename="middleware.js" switcher
 export const config = {

--- a/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
@@ -180,7 +180,7 @@ Middleware will be invoked for **every route in your project**. Given this, it's
 
 ## Runtime
 
-Middleware defaults to using the Edge runtime. As of v15.5, we have support for using the Node.js runtime. To enable, in your middleware file, set the runtime to `nodejs` in the `config` object:
+Middleware defaults to using the Edge runtime. As of v15.4.2-canary.47, we have support for using the Node.js runtime. To enable, in your middleware file, set the runtime to `nodejs` in the `config` object:
 
 ```js highlight={2} filename="middleware.js" switcher
 export const config = {


### PR DESCRIPTION
This PR fixes a documentation issue where the version was incorrectly stated as v15.5. 
Updated it to v15.4.2-canary.47, which is the version that first introduced Node.js runtime support for middleware.

Fixes #82662

---

ℹ️ Maintainers: please confirm if you prefer referencing the canary version (15.4.2-canary.47) or the stable release (15.5).