### PR TITLE
fix: make sure validator.ts uses relative paths for imports

### DIFF
--- a/packages/next/src/server/lib/router-utils/route-types-utils.ts
+++ b/packages/next/src/server/lib/router-utils/route-types-utils.ts
@@ -179,29 +179,50 @@ export async function createRouteTypesManifest({
     appRouteHandlerRoutes: {},
     redirectRoutes: {},
     rewriteRoutes: {},
-    appRouteHandlers: new Set(appRouteHandlers.map(({ filePath }) => filePath)),
-    pageApiRoutes: new Set(pageApiRoutes.map(({ filePath }) => filePath)),
-    appPagePaths: new Set(appRoutes.map(({ filePath }) => filePath)),
-    pagesRouterPagePaths: new Set(pageRoutes.map(({ filePath }) => filePath)),
-    layoutPaths: new Set(layoutRoutes.map(({ filePath }) => filePath)),
+    appRouteHandlers: new Set(
+      appRouteHandlers.map(({ filePath }) => getRelativePath(filePath))
+    ),
+    pageApiRoutes: new Set(
+      pageApiRoutes.map(({ filePath }) => getRelativePath(filePath))
+    ),
+    appPagePaths: new Set(
+      appRoutes.map(({ filePath }) => getRelativePath(filePath))
+    ),
+    pagesRouterPagePaths: new Set(
+      pageRoutes.map(({ filePath }) => getRelativePath(filePath))
+    ),
+    layoutPaths: new Set(
+      layoutRoutes.map(({ filePath }) => getRelativePath(filePath))
+    ),
     filePathToRoute: new Map([
       ...appRoutes.map(
         ({ route, filePath }) =>
-          [filePath, resolveInterceptingRoute(route)] as [string, string]
+          [getRelativePath(filePath), resolveInterceptingRoute(route)] as [
+            string,
+            string,
+          ]
       ),
       ...layoutRoutes.map(
         ({ route, filePath }) =>
-          [filePath, resolveInterceptingRoute(route)] as [string, string]
+          [getRelativePath(filePath), resolveInterceptingRoute(route)] as [
+            string,
+            string,
+          ]
       ),
       ...appRouteHandlers.map(
         ({ route, filePath }) =>
-          [filePath, resolveInterceptingRoute(route)] as [string, string]
+          [getRelativePath(filePath), resolveInterceptingRoute(route)] as [
+            string,
+            string,
+          ]
       ),
       ...pageRoutes.map(
-        ({ route, filePath }) => [filePath, route] as [string, string]
+        ({ route, filePath }) =>
+          [getRelativePath(filePath), route] as [string, string]
       ),
       ...pageApiRoutes.map(
-        ({ route, filePath }) => [filePath, route] as [string, string]
+        ({ route, filePath }) =>
+          [getRelativePath(filePath), route] as [string, string]
       ),
     ]),
   }


### PR DESCRIPTION
Previously, `.next/types/validator.ts` looked like this after a build:

```typescript
// Validate /Users/you/code/next.js/test/e2e/app-dir/typed-routes/app/dashboard/@team/page.tsx
{
  const handler = {} as typeof import("/Users/you/code/next.js/test/e2e/app-dir/typed-routes/app/dashboard/@team/page.js")
  handler satisfies AppPageConfig<"/dashboard">
}
```

Now, it looks like this:

```typescript
// Validate ../../app/dashboard/@team/page.tsx
{
  const handler = {} as typeof import("../../app/dashboard/@team/page.js")
  handler satisfies AppPageConfig<"/dashboard">
}
```

This can be important for security reasons.