### PR TITLE
Turbopack: Define built-in webpack conditions using an enum and typescript union

### DIFF
--- a/crates/next-core/src/mode.rs
+++ b/crates/next-core/src/mode.rs
@@ -1,5 +1,8 @@
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::TaskInput;
 use turbopack_ecmascript_runtime::RuntimeType;
+
+use crate::next_shared::webpack_rules::WebpackBuiltinCondition;
 
 /// The mode in which Next.js is running.
 #[turbo_tasks::value(shared)]
@@ -20,12 +23,23 @@ impl NextMode {
         }
     }
 
-    /// Returns the exports condition for the current mode.
-    pub fn condition(&self) -> &'static str {
+    /// Returns conditions that can be used in the Next.js config's turbopack "rules" section for
+    /// defining webpack loader configuration.
+    pub fn webpack_loader_conditions(&self) -> impl Iterator<Item = WebpackBuiltinCondition> {
         match self {
-            NextMode::Development => "development",
-            NextMode::Build => "production",
+            NextMode::Development => [WebpackBuiltinCondition::Development],
+            NextMode::Build => [WebpackBuiltinCondition::Production],
         }
+        .into_iter()
+    }
+
+    /// Returns conditions used by `ResolveOptionsContext`.
+    pub fn custom_resolve_conditions(&self) -> impl Iterator<Item = RcStr> {
+        match self {
+            NextMode::Development => [rcstr!("development")],
+            NextMode::Build => [rcstr!("production")],
+        }
+        .into_iter()
     }
 
     /// Returns true if the development React runtime should be used.

--- a/crates/next-core/src/mode.rs
+++ b/crates/next-core/src/mode.rs
@@ -2,7 +2,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::TaskInput;
 use turbopack_ecmascript_runtime::RuntimeType;
 
-use crate::next_shared::webpack_rules::WebpackBuiltinCondition;
+use crate::next_shared::webpack_rules::WebpackLoaderBuiltinCondition;
 
 /// The mode in which Next.js is running.
 #[turbo_tasks::value(shared)]
@@ -25,10 +25,10 @@ impl NextMode {
 
     /// Returns conditions that can be used in the Next.js config's turbopack "rules" section for
     /// defining webpack loader configuration.
-    pub fn webpack_loader_conditions(&self) -> impl Iterator<Item = WebpackBuiltinCondition> {
+    pub fn webpack_loader_conditions(&self) -> impl Iterator<Item = WebpackLoaderBuiltinCondition> {
         match self {
-            NextMode::Development => [WebpackBuiltinCondition::Development],
-            NextMode::Build => [WebpackBuiltinCondition::Production],
+            NextMode::Development => [WebpackLoaderBuiltinCondition::Development],
+            NextMode::Build => [WebpackLoaderBuiltinCondition::Production],
         }
         .into_iter()
     }

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -58,7 +58,7 @@ use crate::{
             styled_jsx::get_styled_jsx_transform_rule,
             swc_ecma_transform_plugins::get_swc_ecma_transform_plugin_rule,
         },
-        webpack_rules::{WebpackBuiltinCondition, webpack_loader_options},
+        webpack_rules::{WebpackLoaderBuiltinCondition, webpack_loader_options},
     },
     transform_options::{
         get_decorators_transform_options, get_jsx_transform_options,
@@ -238,21 +238,21 @@ pub async fn get_client_module_options_context(
     .to_resolved()
     .await?;
 
-    let mut conditions = BTreeSet::new();
-    conditions.insert(WebpackBuiltinCondition::Browser);
-    conditions.extend(mode.await?.webpack_loader_conditions());
+    let mut loader_conditions = BTreeSet::new();
+    loader_conditions.insert(WebpackLoaderBuiltinCondition::Browser);
+    loader_conditions.extend(mode.await?.webpack_loader_conditions());
 
     // A separate webpack rules will be applied to codes matching foreign_code_context_condition.
     // This allows to import codes from node_modules that requires webpack loaders, which next-dev
     // implicitly does by default.
-    let mut foreign_conditions = conditions.clone();
-    foreign_conditions.insert(WebpackBuiltinCondition::Foreign);
+    let mut foreign_conditions = loader_conditions.clone();
+    foreign_conditions.insert(WebpackLoaderBuiltinCondition::Foreign);
     let foreign_enable_webpack_loaders =
         webpack_loader_options(project_path.clone(), next_config, true, foreign_conditions).await?;
 
     // Now creates a webpack rules that applies to all code.
     let enable_webpack_loaders =
-        webpack_loader_options(project_path.clone(), next_config, false, conditions).await?;
+        webpack_loader_options(project_path.clone(), next_config, false, loader_conditions).await?;
 
     let tree_shaking_mode_for_user_code = *next_config
         .tree_shaking_mode_for_user_code(next_mode.is_development())

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -1,4 +1,4 @@
-use std::iter::once;
+use std::collections::BTreeSet;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -58,7 +58,7 @@ use crate::{
             styled_jsx::get_styled_jsx_transform_rule,
             swc_ecma_transform_plugins::get_swc_ecma_transform_plugin_rule,
         },
-        webpack_rules::webpack_loader_options,
+        webpack_rules::{WebpackBuiltinCondition, webpack_loader_options},
     },
     transform_options::{
         get_decorators_transform_options, get_jsx_transform_options,
@@ -150,7 +150,7 @@ pub async fn get_client_resolve_options_context(
         get_next_client_resolved_map(project_path.clone(), project_path.clone(), *mode.await?)
             .to_resolved()
             .await?;
-    let custom_conditions = vec![mode.await?.condition().into()];
+    let custom_conditions = mode.await?.custom_resolve_conditions().collect();
     let resolve_options_context = ResolveOptionsContext {
         enable_node_modules: Some(project_path.root().owned().await?),
         custom_conditions,
@@ -238,24 +238,19 @@ pub async fn get_client_module_options_context(
     .to_resolved()
     .await?;
 
-    // A separate webpack rules will be applied to codes matching
-    // foreign_code_context_condition. This allows to import codes from
-    // node_modules that requires webpack loaders, which next-dev implicitly
-    // does by default.
-    let conditions = vec![rcstr!("browser"), mode.await?.condition().into()];
-    let foreign_enable_webpack_loaders = webpack_loader_options(
-        project_path.clone(),
-        next_config,
-        true,
-        conditions
-            .iter()
-            .cloned()
-            .chain(once(rcstr!("foreign")))
-            .collect(),
-    )
-    .await?;
+    let mut conditions = BTreeSet::new();
+    conditions.insert(WebpackBuiltinCondition::Browser);
+    conditions.extend(mode.await?.webpack_loader_conditions());
 
-    // Now creates a webpack rules that applies to all codes.
+    // A separate webpack rules will be applied to codes matching foreign_code_context_condition.
+    // This allows to import codes from node_modules that requires webpack loaders, which next-dev
+    // implicitly does by default.
+    let mut foreign_conditions = conditions.clone();
+    foreign_conditions.insert(WebpackBuiltinCondition::Foreign);
+    let foreign_enable_webpack_loaders =
+        webpack_loader_options(project_path.clone(), next_config, true, foreign_conditions).await?;
+
+    // Now creates a webpack rules that applies to all code.
     let enable_webpack_loaders =
         webpack_loader_options(project_path.clone(), next_config, false, conditions).await?;
 

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -32,7 +32,7 @@ use crate::{
     mode::NextMode,
     next_import_map::mdx_import_source_file,
     next_shared::{
-        transforms::ModularizeImportPackageConfig, webpack_rules::WebpackBuiltinCondition,
+        transforms::ModularizeImportPackageConfig, webpack_rules::WebpackLoaderBuiltinCondition,
     },
 };
 
@@ -1285,7 +1285,7 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub async fn webpack_rules(
         &self,
-        active_conditions: BTreeSet<WebpackBuiltinCondition>,
+        active_conditions: BTreeSet<WebpackLoaderBuiltinCondition>,
         project_path: FileSystemPath,
     ) -> Result<Vc<OptionWebpackRules>> {
         let Some(turbo_rules) = self.turbopack.as_ref().and_then(|t| t.rules.as_ref()) else {
@@ -1317,15 +1317,15 @@ impl NextConfig {
             }
             fn find_rule<'a>(
                 rule: &'a RuleConfigItem,
-                active_conditions: &BTreeSet<WebpackBuiltinCondition>,
+                active_conditions: &BTreeSet<WebpackLoaderBuiltinCondition>,
             ) -> FindRuleResult<'a> {
                 match rule {
                     RuleConfigItem::Options(rule) => FindRuleResult::Found(rule),
                     RuleConfigItem::Conditional(map) => {
                         for (condition, rule) in map.iter() {
-                            let condition = WebpackBuiltinCondition::from_str(condition);
+                            let condition = WebpackLoaderBuiltinCondition::from_str(condition);
                             if let Ok(condition) = condition
-                                && (condition == WebpackBuiltinCondition::Default
+                                && (condition == WebpackLoaderBuiltinCondition::Default
                                     || active_conditions.contains(&condition))
                             {
                                 match find_rule(rule, active_conditions) {

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1,3 +1,5 @@
+use std::{collections::BTreeSet, str::FromStr};
+
 use anyhow::{Context, Result, bail};
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -27,8 +29,11 @@ use turbopack_ecmascript_plugins::transform::{
 use turbopack_node::transforms::webpack::{WebpackLoaderItem, WebpackLoaderItems};
 
 use crate::{
-    mode::NextMode, next_import_map::mdx_import_source_file,
-    next_shared::transforms::ModularizeImportPackageConfig,
+    mode::NextMode,
+    next_import_map::mdx_import_source_file,
+    next_shared::{
+        transforms::ModularizeImportPackageConfig, webpack_rules::WebpackBuiltinCondition,
+    },
 };
 
 #[turbo_tasks::value]
@@ -1280,7 +1285,7 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub async fn webpack_rules(
         &self,
-        active_conditions: Vec<RcStr>,
+        active_conditions: BTreeSet<WebpackBuiltinCondition>,
         project_path: FileSystemPath,
     ) -> Result<Vc<OptionWebpackRules>> {
         let Some(turbo_rules) = self.turbopack.as_ref().and_then(|t| t.rules.as_ref()) else {
@@ -1289,7 +1294,6 @@ impl NextConfig {
         if turbo_rules.is_empty() {
             return Ok(Vc::cell(None));
         }
-        let active_conditions = active_conditions.into_iter().collect::<FxHashSet<_>>();
         let mut rules = FxIndexMap::default();
         for (ext, rule) in turbo_rules.iter() {
             fn transform_loaders(loaders: &[LoaderItem]) -> ResolvedVc<WebpackLoaderItems> {
@@ -1313,13 +1317,17 @@ impl NextConfig {
             }
             fn find_rule<'a>(
                 rule: &'a RuleConfigItem,
-                active_conditions: &FxHashSet<RcStr>,
+                active_conditions: &BTreeSet<WebpackBuiltinCondition>,
             ) -> FindRuleResult<'a> {
                 match rule {
                     RuleConfigItem::Options(rule) => FindRuleResult::Found(rule),
                     RuleConfigItem::Conditional(map) => {
                         for (condition, rule) in map.iter() {
-                            if condition == "default" || active_conditions.contains(condition) {
+                            let condition = WebpackBuiltinCondition::from_str(condition);
+                            if let Ok(condition) = condition
+                                && (condition == WebpackBuiltinCondition::Default
+                                    || active_conditions.contains(&condition))
+                            {
                                 match find_rule(rule, active_conditions) {
                                     FindRuleResult::Found(rule) => {
                                         return FindRuleResult::Found(rule);

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -147,14 +147,8 @@ pub async fn get_edge_resolve_options_context(
     )];
 
     // https://github.com/vercel/next.js/blob/bf52c254973d99fed9d71507a2e818af80b8ade7/packages/next/src/build/webpack-config.ts#L96-L102
-    let mut custom_conditions = vec![mode.await?.condition().into()];
-    custom_conditions.extend(
-        NextRuntime::Edge
-            .conditions()
-            .iter()
-            .map(ToString::to_string)
-            .map(RcStr::from),
-    );
+    let mut custom_conditions: Vec<_> = mode.await?.custom_resolve_conditions().collect();
+    custom_conditions.extend(NextRuntime::Edge.custom_resolve_conditions());
 
     if ty.should_use_react_server_condition() {
         custom_conditions.push(rcstr!("react-server"));

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1,4 +1,4 @@
-use std::iter::once;
+use std::collections::BTreeSet;
 
 use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
@@ -66,7 +66,7 @@ use crate::{
             styled_jsx::get_styled_jsx_transform_rule,
             swc_ecma_transform_plugins::get_swc_ecma_transform_plugin_rule,
         },
-        webpack_rules::webpack_loader_options,
+        webpack_rules::{WebpackBuiltinCondition, webpack_loader_options},
     },
     transform_options::{
         get_decorators_transform_options, get_jsx_transform_options,
@@ -211,14 +211,8 @@ pub async fn get_server_resolve_options_context(
     .to_resolved()
     .await?;
 
-    let mut custom_conditions = vec![mode.await?.condition().to_string().into()];
-    custom_conditions.extend(
-        NextRuntime::NodeJs
-            .conditions()
-            .iter()
-            .map(ToString::to_string)
-            .map(RcStr::from),
-    );
+    let mut custom_conditions: Vec<_> = mode.await?.custom_resolve_conditions().collect();
+    custom_conditions.extend(NextRuntime::NodeJs.custom_resolve_conditions());
 
     if ty.should_use_react_server_condition() {
         custom_conditions.push(rcstr!("react-server"));
@@ -489,32 +483,19 @@ pub async fn get_server_module_options_context(
     let enable_postcss_transform = Some(postcss_transform_options.resolved_cell());
     let enable_foreign_postcss_transform = Some(postcss_foreign_transform_options.resolved_cell());
 
-    let mut conditions = vec![mode.await?.condition().into()];
-    conditions.extend(
-        next_runtime
-            .conditions()
-            .iter()
-            .map(ToString::to_string)
-            .map(RcStr::from),
-    );
+    let mut conditions = BTreeSet::new();
+    conditions.extend(mode.await?.webpack_loader_conditions());
+    conditions.extend(next_runtime.webpack_loader_conditions());
 
-    // A separate webpack rules will be applied to codes matching
-    // foreign_code_context_condition. This allows to import codes from
-    // node_modules that requires webpack loaders, which next-dev implicitly
-    // does by default.
-    let foreign_enable_webpack_loaders = webpack_loader_options(
-        project_path.clone(),
-        next_config,
-        true,
-        conditions
-            .iter()
-            .cloned()
-            .chain(once(rcstr!("foreign")))
-            .collect(),
-    )
-    .await?;
+    // A separate webpack rules will be applied to codes matching foreign_code_context_condition.
+    // This allows to import codes from node_modules that requires webpack loaders, which next-dev
+    // implicitly does by default.
+    let mut foreign_conditions = conditions.clone();
+    foreign_conditions.insert(WebpackBuiltinCondition::Foreign);
+    let foreign_enable_webpack_loaders =
+        webpack_loader_options(project_path.clone(), next_config, true, foreign_conditions).await?;
 
-    // Now creates a webpack rules that applies to all codes.
+    // Now creates a webpack rules that applies to all code.
     let enable_webpack_loaders =
         webpack_loader_options(project_path.clone(), next_config, false, conditions).await?;
 

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -66,7 +66,7 @@ use crate::{
             styled_jsx::get_styled_jsx_transform_rule,
             swc_ecma_transform_plugins::get_swc_ecma_transform_plugin_rule,
         },
-        webpack_rules::{WebpackBuiltinCondition, webpack_loader_options},
+        webpack_rules::{WebpackLoaderBuiltinCondition, webpack_loader_options},
     },
     transform_options::{
         get_decorators_transform_options, get_jsx_transform_options,
@@ -483,21 +483,21 @@ pub async fn get_server_module_options_context(
     let enable_postcss_transform = Some(postcss_transform_options.resolved_cell());
     let enable_foreign_postcss_transform = Some(postcss_foreign_transform_options.resolved_cell());
 
-    let mut conditions = BTreeSet::new();
-    conditions.extend(mode.await?.webpack_loader_conditions());
-    conditions.extend(next_runtime.webpack_loader_conditions());
+    let mut loader_conditions = BTreeSet::new();
+    loader_conditions.extend(mode.await?.webpack_loader_conditions());
+    loader_conditions.extend(next_runtime.webpack_loader_conditions());
 
     // A separate webpack rules will be applied to codes matching foreign_code_context_condition.
     // This allows to import codes from node_modules that requires webpack loaders, which next-dev
     // implicitly does by default.
-    let mut foreign_conditions = conditions.clone();
-    foreign_conditions.insert(WebpackBuiltinCondition::Foreign);
+    let mut foreign_conditions = loader_conditions.clone();
+    foreign_conditions.insert(WebpackLoaderBuiltinCondition::Foreign);
     let foreign_enable_webpack_loaders =
         webpack_loader_options(project_path.clone(), next_config, true, foreign_conditions).await?;
 
     // Now creates a webpack rules that applies to all code.
     let enable_webpack_loaders =
-        webpack_loader_options(project_path.clone(), next_config, false, conditions).await?;
+        webpack_loader_options(project_path.clone(), next_config, false, loader_conditions).await?;
 
     let tree_shaking_mode_for_user_code = *next_config
         .tree_shaking_mode_for_user_code(next_mode.is_development())

--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -40,7 +40,7 @@ pub(crate) mod sass;
     TraceRawVcs,
     NonLocalValue,
 )]
-pub enum WebpackBuiltinCondition {
+pub enum WebpackLoaderBuiltinCondition {
     /// Treated as always-present.
     Default,
     /// Client-side code.
@@ -59,7 +59,7 @@ pub enum WebpackBuiltinCondition {
     EdgeLight,
 }
 
-impl WebpackBuiltinCondition {
+impl WebpackLoaderBuiltinCondition {
     fn as_str(self) -> &'static str {
         match self {
             Self::Default => "default",
@@ -73,7 +73,7 @@ impl WebpackBuiltinCondition {
     }
 }
 
-impl FromStr for WebpackBuiltinCondition {
+impl FromStr for WebpackLoaderBuiltinCondition {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -90,8 +90,8 @@ impl FromStr for WebpackBuiltinCondition {
     }
 }
 
-impl PartialEq<WebpackBuiltinCondition> for &str {
-    fn eq(&self, other: &WebpackBuiltinCondition) -> bool {
+impl PartialEq<WebpackLoaderBuiltinCondition> for &str {
+    fn eq(&self, other: &WebpackLoaderBuiltinCondition) -> bool {
         *self == other.as_str()
     }
 }
@@ -100,7 +100,7 @@ pub async fn webpack_loader_options(
     project_path: FileSystemPath,
     next_config: Vc<NextConfig>,
     foreign: bool,
-    loader_conditions: BTreeSet<WebpackBuiltinCondition>,
+    loader_conditions: BTreeSet<WebpackLoaderBuiltinCondition>,
 ) -> Result<Option<ResolvedVc<WebpackLoadersOptions>>> {
     let rules = *next_config
         .webpack_rules(loader_conditions, project_path.clone())

--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -1,6 +1,9 @@
+use std::{collections::BTreeSet, str::FromStr};
+
 use anyhow::Result;
-use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Vc};
+use serde::{Deserialize, Serialize};
+use turbo_rcstr::rcstr;
+use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::WebpackLoadersOptions;
 use turbopack_core::resolve::{ExternalTraced, ExternalType, options::ImportMapping};
@@ -11,14 +14,96 @@ use crate::next_config::NextConfig;
 pub(crate) mod babel;
 pub(crate) mod sass;
 
+/// Built-in conditions provided by the Next.js Turbopack integration for configuring webpack
+/// loaders. These can be used in the `next.config.js` `turbopack.rules` section.
+///
+/// These are different from than the user-configurable "conditions" field.
+//
+// Note: If you add a field here, make sure to also add it in:
+// - The typescript definition in `packages/next/src/server/config-shared.ts`
+// - The zod schema in `packages/next/src/server/config-schema.ts`
+//
+// Note: Sets of conditions could be stored more efficiently as a bitset, but it's probably not used
+// in enough places for it to matter.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    TaskInput,
+    TraceRawVcs,
+    NonLocalValue,
+)]
+pub enum WebpackBuiltinCondition {
+    /// Treated as always-present.
+    Default,
+    /// Client-side code.
+    Browser,
+    /// Code in `node_modules` that should typically not be modified by webpack loaders.
+    Foreign,
+
+    // These are provided by NextMode:
+    Development,
+    Production,
+
+    // These are provided by NextRuntime:
+    /// Server code on the Node.js runtime.
+    Node,
+    /// Server code on the edge runtime.
+    EdgeLight,
+}
+
+impl WebpackBuiltinCondition {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Browser => "browser",
+            Self::Foreign => "foreign",
+            Self::Development => "development",
+            Self::Production => "production",
+            Self::Node => "node",
+            Self::EdgeLight => "edge-light",
+        }
+    }
+}
+
+impl FromStr for WebpackBuiltinCondition {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "default" => Ok(Self::Default),
+            "browser" => Ok(Self::Browser),
+            "foreign" => Ok(Self::Foreign),
+            "development" => Ok(Self::Development),
+            "production" => Ok(Self::Production),
+            "node" => Ok(Self::Node),
+            "edge-light" => Ok(Self::EdgeLight),
+            _ => Err(()),
+        }
+    }
+}
+
+impl PartialEq<WebpackBuiltinCondition> for &str {
+    fn eq(&self, other: &WebpackBuiltinCondition) -> bool {
+        *self == other.as_str()
+    }
+}
+
 pub async fn webpack_loader_options(
     project_path: FileSystemPath,
     next_config: Vc<NextConfig>,
     foreign: bool,
-    condition_strs: Vec<RcStr>,
+    loader_conditions: BTreeSet<WebpackBuiltinCondition>,
 ) -> Result<Option<ResolvedVc<WebpackLoadersOptions>>> {
     let rules = *next_config
-        .webpack_rules(condition_strs, project_path.clone())
+        .webpack_rules(loader_conditions, project_path.clone())
         .await?;
     let rules = *maybe_add_sass_loader(next_config.sass_config(), rules.map(|v| *v)).await?;
     let rules = if foreign {

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -40,7 +40,7 @@ use crate::{
     next_config::{NextConfig, RouteHas},
     next_import_map::get_next_package,
     next_manifests::MiddlewareMatcher,
-    next_shared::webpack_rules::WebpackBuiltinCondition,
+    next_shared::webpack_rules::WebpackLoaderBuiltinCondition,
 };
 
 const NEXT_TEMPLATE_PATH: &str = "dist/esm/build/templates";
@@ -231,10 +231,10 @@ pub enum NextRuntime {
 impl NextRuntime {
     /// Returns conditions that can be used in the Next.js config's turbopack "rules" section for
     /// defining webpack loader configuration.
-    pub fn webpack_loader_conditions(&self) -> impl Iterator<Item = WebpackBuiltinCondition> {
+    pub fn webpack_loader_conditions(&self) -> impl Iterator<Item = WebpackLoaderBuiltinCondition> {
         match self {
-            NextRuntime::NodeJs => [WebpackBuiltinCondition::Node],
-            NextRuntime::Edge => [WebpackBuiltinCondition::EdgeLight],
+            NextRuntime::NodeJs => [WebpackLoaderBuiltinCondition::Node],
+            NextRuntime::Edge => [WebpackLoaderBuiltinCondition::EdgeLight],
         }
         .into_iter()
     }

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -40,6 +40,7 @@ use crate::{
     next_config::{NextConfig, RouteHas},
     next_import_map::get_next_package,
     next_manifests::MiddlewareMatcher,
+    next_shared::webpack_rules::WebpackBuiltinCondition,
 };
 
 const NEXT_TEMPLATE_PATH: &str = "dist/esm/build/templates";
@@ -228,11 +229,23 @@ pub enum NextRuntime {
 }
 
 impl NextRuntime {
-    pub fn conditions(&self) -> &'static [&'static str] {
+    /// Returns conditions that can be used in the Next.js config's turbopack "rules" section for
+    /// defining webpack loader configuration.
+    pub fn webpack_loader_conditions(&self) -> impl Iterator<Item = WebpackBuiltinCondition> {
         match self {
-            NextRuntime::NodeJs => &["node"],
-            NextRuntime::Edge => &["edge-light"],
+            NextRuntime::NodeJs => [WebpackBuiltinCondition::Node],
+            NextRuntime::Edge => [WebpackBuiltinCondition::EdgeLight],
         }
+        .into_iter()
+    }
+
+    /// Returns conditions used by `ResolveOptionsContext`.
+    pub fn custom_resolve_conditions(&self) -> impl Iterator<Item = RcStr> {
+        match self {
+            NextRuntime::NodeJs => [rcstr!("node")],
+            NextRuntime::Edge => [rcstr!("edge-light")],
+        }
+        .into_iter()
     }
 }
 

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -879,7 +879,7 @@ function bindingToApi(
     nextConfigSerializable.exportPathMap = {}
     nextConfigSerializable.webpack = nextConfig.webpack && {}
 
-    if (nextConfigSerializable.experimental?.turbo?.rules) {
+    if (nextConfigSerializable.turbopack?.rules) {
       ensureLoadersHaveSerializableOptions(
         nextConfigSerializable.turbopack?.rules
       )
@@ -974,10 +974,9 @@ function bindingToApi(
       if ('loaders' in rule) {
         checkLoaderItems((rule as TurbopackRuleConfigItemOptions).loaders, glob)
       } else {
-        for (const key in rule) {
-          const inner = rule[key]
-          if (typeof inner === 'object' && inner) {
-            checkConfigItem(inner, glob)
+        for (const value of Object.values(rule)) {
+          if (typeof value === 'object' && value) {
+            checkConfigItem(value, glob)
           }
         }
       }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -14,6 +14,7 @@ import type {
   TurbopackRuleConfigItemOptions,
   TurbopackRuleConfigItemOrShortcut,
   TurbopackRuleCondition,
+  TurbopackRuleBuiltinCondition,
 } from './config-shared'
 import type {
   Header,
@@ -102,7 +103,7 @@ const zHeader: zod.ZodType<Header> = z.object({
   internal: z.boolean().optional(),
 })
 
-const zTurboLoaderItem: zod.ZodType<TurbopackLoaderItem> = z.union([
+const zTurbopackLoaderItem: zod.ZodType<TurbopackLoaderItem> = z.union([
   z.string(),
   z.object({
     loader: z.string(),
@@ -111,31 +112,42 @@ const zTurboLoaderItem: zod.ZodType<TurbopackLoaderItem> = z.union([
   }),
 ])
 
-const zTurboRuleConfigItemOptions: zod.ZodType<TurbopackRuleConfigItemOptions> =
+const zTurbopackRuleConfigItemOptions: zod.ZodType<TurbopackRuleConfigItemOptions> =
   z.object({
-    loaders: z.array(zTurboLoaderItem),
+    loaders: z.array(zTurbopackLoaderItem),
     as: z.string().optional(),
   })
 
-const zTurboRuleConfigItem: zod.ZodType<TurbopackRuleConfigItem> = z.union([
+const zTurbopackBuiltinCondition: zod.ZodType<TurbopackRuleBuiltinCondition> =
+  z.union([
+    z.literal('default'),
+    z.literal('browser'),
+    z.literal('foreign'),
+    z.literal('development'),
+    z.literal('production'),
+    z.literal('node'),
+    z.literal('edge-light'),
+  ])
+
+const zTurbopackRuleConfigItem: zod.ZodType<TurbopackRuleConfigItem> = z.union([
   z.literal(false),
   z.record(
-    z.string(),
-    z.lazy(() => zTurboRuleConfigItem)
+    zTurbopackBuiltinCondition,
+    z.lazy(() => zTurbopackRuleConfigItem)
   ),
-  zTurboRuleConfigItemOptions,
+  zTurbopackRuleConfigItemOptions,
 ])
-const zTurboRuleConfigItemOrShortcut: zod.ZodType<TurbopackRuleConfigItemOrShortcut> =
-  z.union([z.array(zTurboLoaderItem), zTurboRuleConfigItem])
+const zTurbopackRuleConfigItemOrShortcut: zod.ZodType<TurbopackRuleConfigItemOrShortcut> =
+  z.union([z.array(zTurbopackLoaderItem), zTurbopackRuleConfigItem])
 
-const zTurboCondition: zod.ZodType<TurbopackRuleCondition> = z.object({
+const zTurbopackCondition: zod.ZodType<TurbopackRuleCondition> = z.object({
   path: z.union([z.string(), z.instanceof(RegExp)]).optional(),
   content: z.instanceof(RegExp).optional(),
 })
 
 const zTurbopackConfig: zod.ZodType<TurbopackOptions> = z.strictObject({
-  rules: z.record(z.string(), zTurboRuleConfigItemOrShortcut).optional(),
-  conditions: z.record(z.string(), zTurboCondition).optional(),
+  rules: z.record(z.string(), zTurbopackRuleConfigItemOrShortcut).optional(),
+  conditions: z.record(z.string(), zTurbopackCondition).optional(),
   resolveAlias: z
     .record(
       z.string(),
@@ -155,8 +167,8 @@ const zTurbopackConfig: zod.ZodType<TurbopackOptions> = z.strictObject({
 // properties are duplicated here as `ZodType`s do not export `extend()`.
 const zDeprecatedExperimentalTurboConfig: zod.ZodType<DeprecatedExperimentalTurboOptions> =
   z.strictObject({
-    loaders: z.record(z.string(), z.array(zTurboLoaderItem)).optional(),
-    rules: z.record(z.string(), zTurboRuleConfigItemOrShortcut).optional(),
+    loaders: z.record(z.string(), z.array(zTurbopackLoaderItem)).optional(),
+    rules: z.record(z.string(), zTurbopackRuleConfigItemOrShortcut).optional(),
     resolveAlias: z
       .record(
         z.string(),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -14,7 +14,7 @@ import type {
   TurbopackRuleConfigItemOptions,
   TurbopackRuleConfigItemOrShortcut,
   TurbopackRuleCondition,
-  TurbopackRuleBuiltinCondition,
+  TurbopackLoaderBuiltinCondition,
 } from './config-shared'
 import type {
   Header,
@@ -118,7 +118,7 @@ const zTurbopackRuleConfigItemOptions: zod.ZodType<TurbopackRuleConfigItemOption
     as: z.string().optional(),
   })
 
-const zTurbopackBuiltinCondition: zod.ZodType<TurbopackRuleBuiltinCondition> =
+const zTurbopackLoaderBuiltinCondition: zod.ZodType<TurbopackLoaderBuiltinCondition> =
   z.union([
     z.literal('default'),
     z.literal('browser'),
@@ -132,7 +132,7 @@ const zTurbopackBuiltinCondition: zod.ZodType<TurbopackRuleBuiltinCondition> =
 const zTurbopackRuleConfigItem: zod.ZodType<TurbopackRuleConfigItem> = z.union([
   z.literal(false),
   z.record(
-    zTurbopackBuiltinCondition,
+    zTurbopackLoaderBuiltinCondition,
     z.lazy(() => zTurbopackRuleConfigItem)
   ),
   zTurbopackRuleConfigItemOptions,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -261,7 +261,7 @@ export type TurbopackLoaderItem =
       options: Record<string, JSONValue>
     }
 
-export type TurbopackRuleBuiltinCondition =
+export type TurbopackLoaderBuiltinCondition =
   | 'default'
   | 'browser'
   | 'foreign'
@@ -286,7 +286,7 @@ export type TurbopackRuleConfigItemOptions = {
 
 export type TurbopackRuleConfigItem =
   | TurbopackRuleConfigItemOptions
-  | { [condition in TurbopackRuleBuiltinCondition]?: TurbopackRuleConfigItem }
+  | { [condition in TurbopackLoaderBuiltinCondition]?: TurbopackRuleConfigItem }
   | false
 
 export interface TurbopackOptions {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -261,6 +261,15 @@ export type TurbopackLoaderItem =
       options: Record<string, JSONValue>
     }
 
+export type TurbopackRuleBuiltinCondition =
+  | 'default'
+  | 'browser'
+  | 'foreign'
+  | 'development'
+  | 'production'
+  | 'node'
+  | 'edge-light'
+
 export type TurbopackRuleCondition = {
   path?: string | RegExp
   content?: RegExp
@@ -277,7 +286,7 @@ export type TurbopackRuleConfigItemOptions = {
 
 export type TurbopackRuleConfigItem =
   | TurbopackRuleConfigItemOptions
-  | { [condition: string]: TurbopackRuleConfigItem }
+  | { [condition in TurbopackRuleBuiltinCondition]?: TurbopackRuleConfigItem }
   | false
 
 export interface TurbopackOptions {


### PR DESCRIPTION
## Context

We have some publicly documented syntax for configuring webpack loaders here: https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#configuring-webpack-loaders

However, we also have some undocumented features. Specifically, we have two different "condition" concepts, both of which are shown here: https://github.com/vercel/next.js/blob/1766a1aba6a7c92a03c08073114652d61da1a388/packages/next/src/build/swc/index.ts#L836-L860

1. The `conditions` field in the `turbopack` object of the config can be used to specify predicates (defined by file name glob, regex, or content of file) that can be referenced by rules.
2. There are special built-in internal "conditions" that can be matched by passing an object to a `rule` that does not contain a `loader` field. These special conditions allow us to match on some things we couldn't otherwise declare conditions for.

This is about improving the current state of #2, which I'm calling here to "webpack loader built-in conditions".

Confusingly, there are also very similar conditions used by the resolver context. I'm not changing those, but I've done a tiny bit of work in this PR to better clarify the difference with naming and types.

## This PR

- Instead of using an `RcStr`, for these conditions, use an enum. Theoretically that gives us less flexibility, but it makes it way easier to discover, document, and keep track of what built-in conditions we support. I feel that it's very important that we do this because this enum is effectively a public API, and I'd like to document some version of this API in a subsequent PR.
- Use the exact union of supported fields in the zod schema and typescript definitions.
- Represent the collection of conditions as a set instead of a vec. In reality, this doesn't have much impact because the set is small and always constructed in the same order, but the intent is clearer. Implemented `TaskInput` for `BTreeSet`.
- Some minor consistency cleanup between `next_server` and `next_client`.
- Get rid of some extra type conversions using the `rcstr!()` macro.

Closes PACK-5283