### PR TITLE
[Cache Components] Fix HMR for nested pages

### DIFF
--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -389,7 +389,7 @@ function processMessage(
 
       // Store the latest hash in a session cookie so that it's sent back to the
       // server with any subsequent requests.
-      document.cookie = `${NEXT_HMR_REFRESH_HASH_COOKIE}=${obj.hash}`
+      document.cookie = `${NEXT_HMR_REFRESH_HASH_COOKIE}=${obj.hash};path=/`
 
       if (RuntimeErrorHandler.hadRuntimeError) {
         if (reloading) return

--- a/test/e2e/app-dir/use-cache-dev/app/page.tsx
+++ b/test/e2e/app-dir/use-cache-dev/app/page.tsx
@@ -1,4 +1,5 @@
 import { revalidatePath } from 'next/cache'
+import Link from 'next/link'
 
 async function getRandomValue() {
   'use cache'
@@ -36,6 +37,9 @@ export default async function Page() {
       >
         <button id="revalidate">Revalidate</button>
       </form>
+      <p>
+        <Link href="/some/path">Go to /some/path</Link>
+      </p>
     </>
   )
 }

--- a/test/e2e/app-dir/use-cache-dev/app/some/path/page.tsx
+++ b/test/e2e/app-dir/use-cache-dev/app/some/path/page.tsx
@@ -1,0 +1,5 @@
+export default async function Page() {
+  'use cache'
+
+  return <p id="greeting">Hi</p>
+}


### PR DESCRIPTION
To bypass existing caches when editing server components, we store an HMR hash in a session cookie. The cookie is sent to the server when refetching the RSC, and included in the cache key of all `'use cache'` functions (see #75474).

Before this fix, we weren't setting the cookie path properly, which led to multiple cookies for different paths being written and sent to the server. This caused stale values to be used for nested pages, which resulted in stale components being displayed after edits.

Now, we set the cookie path to `/`, ensuring that the same cookie is used for all nested pages.

closes NAR-204
resolves #81538