### PR TITLE
Turbopack: pass cache handler path as relative path to Rust

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -885,26 +885,25 @@ function bindingToApi(
       )
     }
 
-    nextConfigSerializable.modularizeImports =
-      nextConfigSerializable.modularizeImports
-        ? Object.fromEntries(
-            Object.entries<any>(nextConfigSerializable.modularizeImports).map(
-              ([mod, config]) => [
-                mod,
-                {
-                  ...config,
-                  transform:
-                    typeof config.transform === 'string'
-                      ? config.transform
-                      : Object.entries(config.transform).map(([key, value]) => [
-                          key,
-                          value,
-                        ]),
-                },
-              ]
-            )
-          )
-        : undefined
+    if (nextConfigSerializable.modularizeImports) {
+      nextConfigSerializable.modularizeImports = Object.fromEntries(
+        Object.entries<any>(nextConfigSerializable.modularizeImports).map(
+          ([mod, config]) => [
+            mod,
+            {
+              ...config,
+              transform:
+                typeof config.transform === 'string'
+                  ? config.transform
+                  : Object.entries(config.transform).map(([key, value]) => [
+                      key,
+                      value,
+                    ]),
+            },
+          ]
+        )
+      )
+    }
 
     // loaderFile is an absolute path, we need it to be relative for turbopack.
     if (nextConfigSerializable.images.loaderFile) {
@@ -923,13 +922,16 @@ function bindingToApi(
 
     // cacheHandler can be an absolute path, we need it to be relative for turbopack.
     if (nextConfigSerializable.experimental?.cacheHandlers) {
-      nextConfigSerializable.experimental.cacheHandlers = Object.fromEntries(
-        Object.entries(
-          nextConfig.experimental.cacheHandlers as Record<string, string>
-        )
-          .filter(([_, value]) => value != null)
-          .map(([key, value]) => [key, path.relative(projectPath, value)])
-      )
+      nextConfigSerializable.experimental = {
+        ...nextConfigSerializable.experimental,
+        cacheHandlers: Object.fromEntries(
+          Object.entries(
+            nextConfig.experimental.cacheHandlers as Record<string, string>
+          )
+            .filter(([_, value]) => value != null)
+            .map(([key, value]) => [key, path.relative(projectPath, value)])
+        ),
+      }
     }
 
     const conditions: (typeof nextConfig)['turbopack']['conditions'] =

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -929,7 +929,10 @@ function bindingToApi(
             nextConfig.experimental.cacheHandlers as Record<string, string>
           )
             .filter(([_, value]) => value != null)
-            .map(([key, value]) => [key, path.relative(projectPath, value)])
+            .map(([key, value]) => [
+              key,
+              './' + path.relative(projectPath, value),
+            ])
         ),
       }
     }

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -915,10 +915,11 @@ function bindingToApi(
     // cacheHandler can be an absolute path, we need it to be relative for turbopack.
     if (nextConfigSerializable.cacheHandler) {
       nextConfigSerializable.cacheHandler =
-        './' + path.relative(projectPath, nextConfigSerializable.cacheHandler)
+        './' +
+        (path.isAbsolute(nextConfigSerializable.cacheHandler)
+          ? path.relative(projectPath, nextConfigSerializable.cacheHandler)
+          : nextConfigSerializable.cacheHandler)
     }
-
-    // cacheHandler can be an absolute path, we need it to be relative for turbopack.
     if (nextConfigSerializable.experimental?.cacheHandlers) {
       nextConfigSerializable.experimental = {
         ...nextConfigSerializable.experimental,
@@ -932,7 +933,10 @@ function bindingToApi(
             .filter(([_, value]) => value != null)
             .map(([key, value]) => [
               key,
-              './' + path.relative(projectPath, value),
+              './' +
+                (path.isAbsolute(value)
+                  ? path.relative(projectPath, value)
+                  : value),
             ])
         ),
       }

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -873,11 +873,11 @@ function bindingToApi(
     let nextConfigSerializable = augmentNextConfig(nextConfig, projectPath)
 
     nextConfigSerializable.generateBuildId =
-      await nextConfig.generateBuildId?.()
+      await nextConfigSerializable.generateBuildId?.()
 
     // TODO: these functions takes arguments, have to be supported in a different way
     nextConfigSerializable.exportPathMap = {}
-    nextConfigSerializable.webpack = nextConfig.webpack && {}
+    nextConfigSerializable.webpack = nextConfigSerializable.webpack && {}
 
     if (nextConfigSerializable.turbopack?.rules) {
       ensureLoadersHaveSerializableOptions(
@@ -908,16 +908,17 @@ function bindingToApi(
     // loaderFile is an absolute path, we need it to be relative for turbopack.
     if (nextConfigSerializable.images.loaderFile) {
       nextConfigSerializable.images = {
-        ...nextConfig.images,
+        ...nextConfigSerializable.images,
         loaderFile:
-          './' + path.relative(projectPath, nextConfig.images.loaderFile),
+          './' +
+          path.relative(projectPath, nextConfigSerializable.images.loaderFile),
       }
     }
 
     // cacheHandler can be an absolute path, we need it to be relative for turbopack.
     if (nextConfigSerializable.cacheHandler) {
       nextConfigSerializable.cacheHandler =
-        './' + path.relative(projectPath, nextConfig.cacheHandler)
+        './' + path.relative(projectPath, nextConfigSerializable.cacheHandler)
     }
 
     // cacheHandler can be an absolute path, we need it to be relative for turbopack.
@@ -926,7 +927,10 @@ function bindingToApi(
         ...nextConfigSerializable.experimental,
         cacheHandlers: Object.fromEntries(
           Object.entries(
-            nextConfig.experimental.cacheHandlers as Record<string, string>
+            nextConfigSerializable.experimental.cacheHandlers as Record<
+              string,
+              string
+            >
           )
             .filter(([_, value]) => value != null)
             .map(([key, value]) => [

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -915,6 +915,23 @@ function bindingToApi(
       }
     }
 
+    // cacheHandler can be an absolute path, we need it to be relative for turbopack.
+    if (nextConfigSerializable.cacheHandler) {
+      nextConfigSerializable.cacheHandler =
+        './' + path.relative(projectPath, nextConfig.cacheHandler)
+    }
+
+    // cacheHandler can be an absolute path, we need it to be relative for turbopack.
+    if (nextConfigSerializable.experimental?.cacheHandlers) {
+      nextConfigSerializable.experimental.cacheHandlers = Object.fromEntries(
+        Object.entries(
+          nextConfig.experimental.cacheHandlers as Record<string, string>
+        )
+          .filter(([_, value]) => value != null)
+          .map(([key, value]) => [key, path.relative(projectPath, value)])
+      )
+    }
+
     const conditions: (typeof nextConfig)['turbopack']['conditions'] =
       nextConfigSerializable.turbopack?.conditions
     if (conditions) {

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -895,10 +895,7 @@ function bindingToApi(
               transform:
                 typeof config.transform === 'string'
                   ? config.transform
-                  : Object.entries(config.transform).map(([key, value]) => [
-                      key,
-                      value,
-                    ]),
+                  : Object.entries(config.transform),
             },
           ]
         )

--- a/test/e2e/app-dir/app-static/app-static-custom-handler.test.ts
+++ b/test/e2e/app-dir/app-static/app-static-custom-handler.test.ts
@@ -1,2 +1,2 @@
-process.env.CUSTOM_CACHE_HANDLER = require.resolve('./cache-handler.js')
+process.env.CUSTOM_CACHE_HANDLER = '1'
 require('./app-static.test')

--- a/test/e2e/app-dir/app-static/next.config.js
+++ b/test/e2e/app-dir/app-static/next.config.js
@@ -3,7 +3,9 @@ module.exports = {
   logging: {
     fetches: {},
   },
-  cacheHandler: process.env.CUSTOM_CACHE_HANDLER,
+  cacheHandler: process.env.CUSTOM_CACHE_HANDLER
+    ? require.resolve('./cache-handler.js')
+    : undefined,
 
   rewrites: async () => {
     return {

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -1,5 +1,4 @@
 import { nextTestSetup } from 'e2e-utils'
-import { NextConfig } from 'next'
 import {
   assertHasRedbox,
   assertNoRedbox,
@@ -11,17 +10,6 @@ import stripAnsi from 'strip-ansi'
 import { createSandbox } from 'development-sandbox'
 
 const isRspack = !!process.env.NEXT_RSPACK
-
-const nextConfigWithCacheHandler: NextConfig = {
-  experimental: {
-    cacheComponents: true,
-    cacheHandlers: {
-      custom: require.resolve(
-        'next/dist/server/lib/cache-handlers/default.external'
-      ),
-    },
-  },
-}
 
 describe('use-cache-unknown-cache-kind', () => {
   const { next, isNextStart, isTurbopack, skipped } = nextTestSetup({
@@ -191,7 +179,16 @@ describe('use-cache-unknown-cache-kind', () => {
 
       await session.patch(
         'next.config.js',
-        `module.exports = ${JSON.stringify(nextConfigWithCacheHandler)}`
+        `module.exports = {
+          experimental: {
+            cacheComponents: true,
+            cacheHandlers: {
+              custom: require.resolve(
+                'next/dist/server/lib/cache-handlers/default.external'
+              ),
+            },
+          },
+        }`
       )
 
       await retry(async () => {


### PR DESCRIPTION
Preparation for using this as an entry for NFT tracing from the Rust side. This simplifies the path handling on the Rust side.
We do the same for the `images.loaderFile` already.

Closes PACK-5287