### PR TITLE
[devtools] Shim overlay on server

### DIFF
--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -806,6 +806,14 @@ async fn insert_next_server_special_aliases(
         ),
     );
 
+    import_map.insert_exact_alias(
+        rcstr!("next/dist/compiled/next-devtools"),
+        request_to_import_mapping(
+            project_path.clone(),
+            rcstr!("next/dist/next-devtools/dev-overlay.shim.js"),
+        ),
+    );
+
     Ok(())
 }
 

--- a/packages/next/src/build/create-compiler-aliases.ts
+++ b/packages/next/src/build/create-compiler-aliases.ts
@@ -126,6 +126,10 @@ export function createWebpackAliases({
     'styled-jsx/style$': defaultOverrides['styled-jsx/style'],
     'styled-jsx$': defaultOverrides['styled-jsx'],
 
+    'next/dist/compiled/next-devtools': isClient
+      ? 'next/dist/compiled/next-devtools'
+      : 'next/dist/next-devtools/dev-overlay.shim.js',
+
     ...customAppAliases,
     ...customDocumentAliases,
 


### PR DESCRIPTION
That huge module isn't needed for SSR.

Mirror what Webpack does:
https://github.com/vercel/next.js/blob/b07a315ca945c12e60dae7caa02dcbc924452945/packages/next/next-runtime.webpack-config.js#L82-L83

Before:
<img width="2055" height="386" alt="Bildschirmfoto 2025-08-19 um 18 13 39" src="https://github.com/user-attachments/assets/f9bbbcc7-4030-4889-ae39-49d25d5a6651" />

After:
<img width="2123" height="332" alt="Bildschirmfoto 2025-08-19 um 18 12 50" src="https://github.com/user-attachments/assets/d7e3b96d-7908-41ad-be60-5bae1354e658" />


Closes PACK-5286