### PR TITLE
fix: don't fail with amp config in JS

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -475,7 +475,7 @@ export function generateValidatorFile(
    * Validated at build-time by parsePagesSegmentConfig.
    */
   config?: {
-    amp?: boolean | 'hybrid'
+    amp?: boolean | 'hybrid' | string // necessary for JS
     maxDuration?: number
     runtime?: 'edge' | 'experimental-edge' | 'nodejs' | string // necessary unless config is exported as const
     regions?: string[]

--- a/test/integration/amphtml/pages/use-amp-hook.tsx
+++ b/test/integration/amphtml/pages/use-amp-hook.tsx
@@ -1,0 +1,8 @@
+import { useAmp } from 'next/amp'
+
+export const config = { amp: 'hybrid' }
+
+export default () => {
+  const isAmp = useAmp()
+  return `Hello ${isAmp ? 'AMP' : 'others'}`
+}

--- a/test/integration/api-support/pages/api/big-parse.ts
+++ b/test/integration/api-support/pages/api/big-parse.ts
@@ -1,0 +1,13 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '5mb',
+    },
+  },
+}
+
+export default (req: NextApiRequest, res: NextApiResponse) => {
+  res.status(200).json(req.body)
+}


### PR DESCRIPTION
Because tsc doesn't infer string literal types in JS files