### PR TITLE
Turbopack: add a CLI to NFT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9896,6 +9896,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "turbopack-nft"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "console-subscriber",
+ "rustc-hash 2.1.1",
+ "serde",
+ "swc_core",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "turbo-rcstr",
+ "turbo-tasks",
+ "turbo-tasks-backend",
+ "turbo-tasks-build",
+ "turbo-tasks-env",
+ "turbo-tasks-fs",
+ "turbo-tasks-malloc",
+ "turbopack",
+ "turbopack-cli-utils",
+ "turbopack-core",
+ "turbopack-resolve",
+ "turbopack-trace-utils",
+]
+
+[[package]]
 name = "turbopack-node"
 version = "0.1.0"
 dependencies = [

--- a/turbopack/crates/turbopack-nft/Cargo.toml
+++ b/turbopack/crates/turbopack-nft/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "turbopack-nft"
+version = "0.1.0"
+description = "TBD"
+license = "MIT"
+edition = "2024"
+autobenches = false
+
+[[bin]]
+name = "turbopack-nft"
+path = "src/main.rs"
+bench = false
+
+[lib]
+bench = false
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true, features = ["backtrace"] }
+clap = { workspace = true, features = ["derive", "env"] }
+console-subscriber = { workspace = true, optional = true }
+rustc-hash = { workspace = true }
+serde = { workspace = true }
+swc_core = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["json"] }
+turbo-rcstr = { workspace = true }
+turbo-tasks = { workspace = true }
+turbo-tasks-backend = { workspace = true }
+turbo-tasks-env = { workspace = true }
+turbo-tasks-fs = { workspace = true }
+turbo-tasks-malloc = { workspace = true, default-features = false, features = [
+    "custom_allocator"
+] }
+turbopack = { workspace = true }
+turbopack-cli-utils = { workspace = true }
+turbopack-core = { workspace = true }
+turbopack-resolve = { workspace = true }
+turbopack-trace-utils = { workspace = true }
+
+[build-dependencies]
+turbo-tasks-build = { workspace = true }

--- a/turbopack/crates/turbopack-nft/build.rs
+++ b/turbopack/crates/turbopack-nft/build.rs
@@ -1,0 +1,5 @@
+use turbo_tasks_build::generate_register;
+
+fn main() {
+    generate_register();
+}

--- a/turbopack/crates/turbopack-nft/src/README.md
+++ b/turbopack/crates/turbopack-nft/src/README.md
@@ -1,0 +1,72 @@
+# turbopack-nft
+
+A CLI to test the NFT implementation, similar to `@vercel/nft`'s `nft print index.js` CLI.
+
+## Usage
+
+```
+Usage: turbopack-nft [OPTIONS] <ENTRY>
+
+Arguments:
+  <ENTRY>
+
+Options:
+      --graph
+      --show-issues
+  -h, --help         Print help
+  -V, --version      Print version
+```
+
+Use no arguments to print a list of all files referenced (but not necessarily bundled!) by the entry.
+
+```
+$ cargo run -p turbopack-nft bench/heavy-npm-deps/app/page.js
+FILELIST:
+bench/heavy-npm-deps/app/page.js
+bench/heavy-npm-deps/components/lodash.js
+bench/heavy-npm-deps/node_modules/lodash-es
+bench/heavy-npm-deps/package.json
+node_modules/.pnpm/lodash-es@4.17.21/node_modules/lodash-es/_DataView.js
+node_modules/.pnpm/lodash-es@4.17.21/node_modules/lodash-es/_Hash.js
+node_modules/.pnpm/lodash-es@4.17.21/node_modules/lodash-es/_LazyWrapper.js
+node_modules/.pnpm/lodash-es@4.17.21/node_modules/lodash-es/_ListCache.js
+node_modules/.pnpm/lodash-es@4.17.21/node_modules/lodash-es/_LodashWrapper.js
+node_modules/.pnpm/lodash-es@4.17.21/node_modules/lodash-es/_Map.js
+```
+
+Use `--graph` to print a crude visualization of the module graph to determine why certain files were included:
+```
+$ cargo run -p turbopack-nft bench/heavy-npm-deps/app/page.js --graph
+FILELIST:
+[workspace]/bench/heavy-npm-deps/app/page.js
+  [workspace]/bench/heavy-npm-deps/components/lodash.js
+    [workspace]/node_modules/.pnpm/lodash-es@4.17.21/node_modules/lodash-es/package.json
+    [workspace]/bench/heavy-npm-deps/node_modules/lodash-es
+    [workspace]/node_modules/.pnpm/lodash-es@4.17.21/node_modules/lodash-es/lodash.js
+      [workspace]/node_modules/.pnpm/lodash-es@4.17.21/node_modules/lodash-es/add.js
+        [workspace]/node_modules/.pnpm/lodash-es@4.17.21/node_modules/lodash-es/_createMathOperation.js
+```
+
+
+By default, no warnings and errors are printed (aligning with the Next.js Turbopack behavior which silences any tracing warnings in node_modules as they are non-actionable anyway), but can be enabled with `--show-issues`:
+```
+$ cargo run -p turbopack-nft ... --show-issues
+[workspace]/packages/next/dist/build/jest/jest.js
+  [workspace]/packages/next/dist/build/jest/jest.js:101:15  Module not found: Can't resolve <dynamic>
+
+      97 |         });
+      98 |     }
+      99 |     var mainPath = attempts === 1 ? './' : Array(attempts).join('../');
+      100 |     try {
+          +                v------------------------------------------------------v
+      101 +         return require((0, _path.join)(dir, mainPath + 'package.json'));
+          +                ^------------------------------------------------------^
+      102 |     } catch (e) {
+      103 |         return loadClosestPackageJson(dir, attempts + 1);
+      104 |     }
+      105 | }
+
+
+FILELIST:
+...
+```

--- a/turbopack/crates/turbopack-nft/src/lib.rs
+++ b/turbopack/crates/turbopack-nft/src/lib.rs
@@ -1,0 +1,12 @@
+#![feature(future_join)]
+#![feature(min_specialization)]
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+
+pub mod nft;
+
+pub fn register() {
+    turbopack::register();
+    turbopack_resolve::register();
+    include!(concat!(env!("OUT_DIR"), "/register.rs"));
+}

--- a/turbopack/crates/turbopack-nft/src/main.rs
+++ b/turbopack/crates/turbopack-nft/src/main.rs
@@ -1,7 +1,7 @@
 #![feature(future_join)]
 #![feature(min_specialization)]
 
-use std::{cell::RefCell, env::current_dir, time::Instant};
+use std::env::current_dir;
 
 use anyhow::Result;
 use clap::Parser;
@@ -37,27 +37,8 @@ pub struct Arguments {
 static ALLOC: TurboMalloc = TurboMalloc;
 
 fn main() {
-    thread_local! {
-        static LAST_SWC_ATOM_GC_TIME: RefCell<Option<Instant>> = const { RefCell::new(None) };
-    }
-
     let mut rt = tokio::runtime::Builder::new_multi_thread();
-    rt.enable_all()
-        .on_thread_stop(|| {
-            TurboMalloc::thread_stop();
-        })
-        .on_thread_park(|| {
-            LAST_SWC_ATOM_GC_TIME.with_borrow_mut(|cell| {
-                use std::time::Duration;
-
-                if cell.is_none_or(|t| t.elapsed() > Duration::from_secs(2)) {
-                    swc_core::ecma::atoms::hstr::global_atom_store_gc();
-                    *cell = Some(Instant::now());
-                }
-            });
-        });
-
-    rt.disable_lifo_slot();
+    rt.enable_all().disable_lifo_slot();
 
     let args = Arguments::parse();
     rt.build().unwrap().block_on(main_inner(args)).unwrap();

--- a/turbopack/crates/turbopack-nft/src/main.rs
+++ b/turbopack/crates/turbopack-nft/src/main.rs
@@ -1,13 +1,15 @@
 #![feature(future_join)]
 #![feature(min_specialization)]
 
-use std::{cell::RefCell, path::Path, time::Instant};
+use std::{cell::RefCell, env::current_dir, time::Instant};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Parser;
 use tracing_subscriber::{Registry, layer::SubscriberExt, util::SubscriberInitExt};
+use turbo_tasks::{ReadConsistency, TurboTasks};
+use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_malloc::TurboMalloc;
-use turbopack_cli::{arguments::Arguments, register};
+use turbopack_nft::{nft::node_file_trace, register};
 use turbopack_trace_utils::{
     exit::ExitHandler,
     filter_layer::FilterLayer,
@@ -17,6 +19,19 @@ use turbopack_trace_utils::{
         TRACING_OVERVIEW_TARGETS, TRACING_TURBO_TASKS_TARGETS, TRACING_TURBOPACK_TARGETS,
     },
 };
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about, long_about = None)]
+pub struct Arguments {
+    #[clap(value_parser)]
+    pub entry: String,
+
+    #[clap(long)]
+    pub graph: bool,
+
+    #[clap(long)]
+    pub show_issues: bool,
+}
 
 #[global_allocator]
 static ALLOC: TurboMalloc = TurboMalloc;
@@ -42,7 +57,6 @@ fn main() {
             });
         });
 
-    #[cfg(not(codspeed))]
     rt.disable_lifo_slot();
 
     let args = Arguments::parse();
@@ -72,14 +86,7 @@ async fn main_inner(args: Arguments) -> Result<()> {
 
         let subscriber = subscriber.with(FilterLayer::try_new(&trace).unwrap());
 
-        let internal_dir = args
-            .dir()
-            .unwrap_or_else(|| Path::new("."))
-            .join(".turbopack");
-        std::fs::create_dir_all(&internal_dir)
-            .context("Unable to create .turbopack directory")
-            .unwrap();
-        let trace_file = internal_dir.join("trace.log");
+        let trace_file = current_dir()?.join("turbopack.log");
         let trace_writer = std::fs::File::create(trace_file).unwrap();
         let (trace_writer, guard) = TraceWriter::new(trace_writer);
         let subscriber = subscriber.with(RawTraceLayer::new(trace_writer));
@@ -92,8 +99,32 @@ async fn main_inner(args: Arguments) -> Result<()> {
 
     register();
 
-    match args {
-        Arguments::Build(args) => turbopack_cli::build::build(&args).await,
-        Arguments::Dev(args) => turbopack_cli::dev::start_server(&args).await,
-    }
+    let tt = TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions {
+            dependency_tracking: false,
+            storage_mode: None,
+            ..Default::default()
+        },
+        noop_backing_storage(),
+    ));
+
+    let task = tt.spawn_once_task::<(), _>(async move {
+        node_file_trace(
+            current_dir()?.to_str().unwrap().into(),
+            args.entry.into(),
+            args.graph,
+            args.show_issues,
+        )
+        .await?;
+        Ok(Default::default())
+    });
+
+    tt.wait_task_completion(task, ReadConsistency::Strong)
+        .await?;
+
+    // Intentionally leak this `Arc`. Otherwise we'll waste time during process exit performing a
+    // ton of drop calls.
+    std::mem::forget(tt);
+
+    Ok(())
 }

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -30,7 +30,7 @@ pub async fn node_file_trace(
     show_issues: bool,
 ) -> Result<()> {
     let op = node_file_trace_operation(project_root.clone(), input.clone(), graph);
-    op.resolve_strongly_consistent().await?;
+    let result = op.resolve_strongly_consistent().await?;
 
     if show_issues {
         let issue_reporter: Vc<Box<dyn IssueReporter>> =
@@ -45,11 +45,20 @@ pub async fn node_file_trace(
         handle_issues(op, issue_reporter, IssueSeverity::Error, None, None).await?;
     }
 
+    println!("FILELIST:");
+    for a in result.await? {
+        println!("{a}");
+    }
+
     Ok(())
 }
 
 #[turbo_tasks::function(operation)]
-async fn node_file_trace_operation(project_root: RcStr, input: RcStr, graph: bool) -> Result<()> {
+async fn node_file_trace_operation(
+    project_root: RcStr,
+    input: RcStr,
+    graph: bool,
+) -> Result<Vc<Vec<RcStr>>> {
     let workspace_fs: Vc<Box<dyn FileSystem>> = Vc::upcast(DiskFileSystem::new(
         rcstr!("workspace"),
         project_root.clone(),
@@ -63,9 +72,8 @@ async fn node_file_trace_operation(project_root: RcStr, input: RcStr, graph: boo
     ));
     let module_asset_context = ModuleAssetContext::new(
         Default::default(),
-        // TODO These test cases should move into the `node-file-trace` crate and use the same
-        // config.
-        // It's easy to make a mistake here as this should match the config in the binary from
+        // This config should be kept in sync with
+        // turbopack/crates/turbopack/tests/node-file-trace.rs and
         // turbopack/crates/turbopack/src/lib.rs
         CompileTimeInfo::new(environment),
         ModuleOptionsContext {
@@ -98,17 +106,14 @@ async fn node_file_trace_operation(project_root: RcStr, input: RcStr, graph: boo
 
     let asset = TracedAsset::new(module).to_resolved().await?;
 
-    if graph {
-        print_graph(ResolvedVc::upcast(asset)).await?;
+    Ok(Vc::cell(if graph {
+        to_graph(ResolvedVc::upcast(asset)).await?
     } else {
-        println!("FILELIST:");
-        print_list(ResolvedVc::upcast(asset)).await?;
-    }
-
-    Ok(())
+        to_list(ResolvedVc::upcast(asset)).await?
+    }))
 }
 
-async fn print_list(asset: ResolvedVc<Box<dyn OutputAsset>>) -> Result<()> {
+async fn to_list(asset: ResolvedVc<Box<dyn OutputAsset>>) -> Result<Vec<RcStr>> {
     let mut assets = all_assets_from_entries(Vc::cell(vec![asset]))
         .await?
         .iter()
@@ -118,17 +123,15 @@ async fn print_list(asset: ResolvedVc<Box<dyn OutputAsset>>) -> Result<()> {
     assets.sort();
     assets.dedup();
 
-    for a in assets {
-        println!("{a}");
-    }
-
-    Ok(())
+    Ok(assets)
 }
 
-async fn print_graph(asset: ResolvedVc<Box<dyn OutputAsset>>) -> Result<()> {
+async fn to_graph(asset: ResolvedVc<Box<dyn OutputAsset>>) -> Result<Vec<RcStr>> {
     let mut visited = HashSet::new();
     let mut queue = Vec::new();
     queue.push((0, asset));
+
+    let mut result = vec![];
     while let Some((depth, asset)) = queue.pop() {
         let references = asset.references().await?;
         let mut indent = String::new();
@@ -139,12 +142,12 @@ async fn print_graph(asset: ResolvedVc<Box<dyn OutputAsset>>) -> Result<()> {
             for &asset in references.iter().rev() {
                 queue.push((depth + 1, asset));
             }
-            println!("{}{}", indent, asset.path().to_string().await?);
+            result.push(format!("{}{}", indent, asset.path().to_string().await?).into());
         } else if references.is_empty() {
-            println!("{}{} *", indent, asset.path().to_string().await?);
+            result.push(format!("{}{} *", indent, asset.path().to_string().await?).into());
         } else {
-            println!("{}{} *...", indent, asset.path().to_string().await?);
+            result.push(format!("{}{} *...", indent, asset.path().to_string().await?).into());
         }
     }
-    Ok(())
+    Ok(result)
 }

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -1,0 +1,150 @@
+use std::{collections::HashSet, env::current_dir, path::PathBuf};
+
+use anyhow::Result;
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::{ResolvedVc, TransientInstance, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks_fs::{DiskFileSystem, FileSystem};
+use turbopack::{
+    ModuleAssetContext,
+    module_options::{CssOptionsContext, EcmascriptOptionsContext, ModuleOptionsContext},
+};
+use turbopack_cli_utils::issue::{ConsoleUi, LogOptions};
+use turbopack_core::{
+    compile_time_info::CompileTimeInfo,
+    context::AssetContext,
+    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
+    file_source::FileSource,
+    ident::Layer,
+    issue::{IssueReporter, IssueSeverity, handle_issues},
+    output::OutputAsset,
+    reference::all_assets_from_entries,
+    reference_type::ReferenceType,
+    traced_asset::TracedAsset,
+};
+use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
+
+pub async fn node_file_trace(
+    project_root: RcStr,
+    input: RcStr,
+    graph: bool,
+    show_issues: bool,
+) -> Result<()> {
+    let op = node_file_trace_operation(project_root.clone(), input.clone(), graph);
+    op.resolve_strongly_consistent().await?;
+
+    if show_issues {
+        let issue_reporter: Vc<Box<dyn IssueReporter>> =
+            Vc::upcast(ConsoleUi::new(TransientInstance::new(LogOptions {
+                project_dir: PathBuf::from(project_root),
+                current_dir: current_dir().unwrap(),
+                show_all: true,
+                log_detail: false,
+                log_level: IssueSeverity::Hint,
+            })));
+
+        handle_issues(op, issue_reporter, IssueSeverity::Error, None, None).await?;
+    }
+
+    Ok(())
+}
+
+#[turbo_tasks::function(operation)]
+async fn node_file_trace_operation(project_root: RcStr, input: RcStr, graph: bool) -> Result<()> {
+    let workspace_fs: Vc<Box<dyn FileSystem>> = Vc::upcast(DiskFileSystem::new(
+        rcstr!("workspace"),
+        project_root.clone(),
+    ));
+    let input_dir = workspace_fs.root().owned().await?;
+    let input = input_dir.join(&format!("{input}"))?;
+
+    let source = FileSource::new(input);
+    let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
+        NodeJsEnvironment::default().resolved_cell(),
+    ));
+    let module_asset_context = ModuleAssetContext::new(
+        Default::default(),
+        // TODO These test cases should move into the `node-file-trace` crate and use the same
+        // config.
+        // It's easy to make a mistake here as this should match the config in the binary from
+        // turbopack/crates/turbopack/src/lib.rs
+        CompileTimeInfo::new(environment),
+        ModuleOptionsContext {
+            ecmascript: EcmascriptOptionsContext {
+                ..Default::default()
+            },
+            css: CssOptionsContext {
+                enable_raw_css: true,
+                ..Default::default()
+            },
+            // Environment is not passed in order to avoid downleveling JS / CSS for
+            // node-file-trace.
+            environment: None,
+            ..Default::default()
+        }
+        .cell(),
+        ResolveOptionsContext {
+            enable_node_native_modules: true,
+            enable_node_modules: Some(input_dir.clone()),
+            custom_conditions: vec![rcstr!("node")],
+            loose_errors: true,
+            ..Default::default()
+        }
+        .cell(),
+        Layer::new(rcstr!("test")),
+    );
+    let module = module_asset_context
+        .process(Vc::upcast(source), ReferenceType::Undefined)
+        .module();
+
+    let asset = TracedAsset::new(module).to_resolved().await?;
+
+    if graph {
+        print_graph(ResolvedVc::upcast(asset)).await?;
+    } else {
+        println!("FILELIST:");
+        print_list(ResolvedVc::upcast(asset)).await?;
+    }
+
+    Ok(())
+}
+
+async fn print_list(asset: ResolvedVc<Box<dyn OutputAsset>>) -> Result<()> {
+    let mut assets = all_assets_from_entries(Vc::cell(vec![asset]))
+        .await?
+        .iter()
+        .map(async |a| Ok(a.path().await?.path.clone()))
+        .try_join()
+        .await?;
+    assets.sort();
+    assets.dedup();
+
+    for a in assets {
+        println!("{a}");
+    }
+
+    Ok(())
+}
+
+async fn print_graph(asset: ResolvedVc<Box<dyn OutputAsset>>) -> Result<()> {
+    let mut visited = HashSet::new();
+    let mut queue = Vec::new();
+    queue.push((0, asset));
+    while let Some((depth, asset)) = queue.pop() {
+        let references = asset.references().await?;
+        let mut indent = String::new();
+        for _ in 0..depth {
+            indent.push_str("  ");
+        }
+        if visited.insert(asset) {
+            for &asset in references.iter().rev() {
+                queue.push((depth + 1, asset));
+            }
+            println!("{}{}", indent, asset.path().to_string().await?);
+        } else if references.is_empty() {
+            println!("{}{} *", indent, asset.path().to_string().await?);
+        } else {
+            println!("{}{} *...", indent, asset.path().to_string().await?);
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Mostly copied from the node-file-trace.rs unit test file

Similar to `@vercel/nft`'s `nft print index.mjs`


Usage:
```
.../target/debug/turbopack-nft index.mjs
.../target/debug/turbopack-nft index.mjs --graph
.../target/debug/turbopack-nft index.mjs --graph --show-issues
```

Closes PACK-5313