### PR TITLE
Turbopack: fix circular import with scope hoisting

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/entry1.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/entry1.js
@@ -1,0 +1,1 @@
+import './shared.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/entry2.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/entry2.js
@@ -1,0 +1,5 @@
+import { z } from './library/index.js'
+
+import './shared.js'
+
+z.any()

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/index.js
@@ -1,0 +1,4 @@
+it('should work', async () => {
+  await import('./entry1.js')
+  await import('./entry2.js')
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/index.js
@@ -1,0 +1,3 @@
+import * as z from './src/index.js'
+export { RealError } from './src/index.js'
+export { z }

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/package.json
@@ -1,3 +1,4 @@
 {
+  "type": "module",
   "sideEffects": false
 }

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/errors.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/errors.js
@@ -1,0 +1,1 @@
+export const RealError = 'RealError'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/index.js
@@ -1,0 +1,2 @@
+export { any } from './schemas.js'
+export { RealError } from './errors.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/iso.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/iso.js
@@ -1,0 +1,7 @@
+import * as schemas from './schemas.js'
+export const datetimeBase = () => {
+  schemas.anyBase.init()
+}
+export function datetime() {
+  return datetimeBase
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/parse.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/parse.js
@@ -1,0 +1,2 @@
+import { RealError } from './errors.js'
+export const parse = () => RealError

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/parse.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/parse.js
@@ -1,2 +1,0 @@
-import { RealError } from './errors.js'
-export const parse = () => RealError

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/schemas.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/schemas.js
@@ -1,0 +1,10 @@
+import * as iso from './iso.js'
+import * as parse from './parse.js'
+
+parse.parse()
+iso.datetime()
+
+export const anyBase = 1234
+export function any() {
+  return anyBase
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/schemas.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/library/src/schemas.js
@@ -1,7 +1,7 @@
 import * as iso from './iso.js'
-import * as parse from './parse.js'
+import { RealError } from './errors.js'
 
-parse.parse()
+RealError
 iso.datetime()
 
 export const anyBase = 1234

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/shared.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-2/input/shared.js
@@ -1,0 +1,5 @@
+import { RealError } from './library/index.js'
+import { z } from './library/index.js'
+
+z.any()
+RealError

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/entry1.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/entry1.js
@@ -1,0 +1,1 @@
+import './shared.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/entry2.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/entry2.js
@@ -1,0 +1,5 @@
+import { z } from './library/index.js'
+
+import './shared.js'
+
+z.any()

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/index.js
@@ -1,0 +1,4 @@
+it('should work', async () => {
+  await import('./entry1.js')
+  await import('./entry2.js')
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/library/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/library/index.js
@@ -1,0 +1,3 @@
+import * as z from './src/index.js'
+export { RealError } from './src/index.js'
+export { z }

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/library/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/library/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "sideEffects": false
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/library/src/errors.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/library/src/errors.js
@@ -1,0 +1,1 @@
+export const RealError = 'RealError'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/library/src/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/library/src/index.js
@@ -1,0 +1,2 @@
+export { any } from './schemas.js'
+export { RealError } from './errors.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/library/src/iso.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/library/src/iso.js
@@ -1,0 +1,7 @@
+import * as schemas from './schemas.js'
+export const datetimeBase = () => {
+  schemas.anyBase.init()
+}
+export function datetime() {
+  return datetimeBase
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/library/src/schemas.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/library/src/schemas.js
@@ -1,0 +1,10 @@
+import * as iso from './iso.js'
+import { RealError } from './errors.js'
+
+RealError
+iso.datetime()
+
+export const anyBase = 1234
+export function any() {
+  return anyBase
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/shared.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/input/shared.js
@@ -1,0 +1,6 @@
+console.log('exec shared')
+import { RealError } from './library/index.js'
+import { z } from './library/index.js'
+
+z.any()
+RealError

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/circular-import-3/options.json
@@ -1,0 +1,3 @@
+{
+  "scopeHoisting": false
+}


### PR DESCRIPTION
- [x] Add test
- [ ] Fix

This is the problematic situation:

```
a.js:
    esmImport("y.js")


x.js, y.js:
    esmExport({...}, "x.js")

    esmImport("a.js")

    esmExport({...}, "y.js")


entry:
    esmImport("x.js")
```

`entry` and then `x.js, y.js` starts executing, then it imports `a.js`, which imports a module would only come later in the same merged module. This causes the module factory to be executed a second time (because `esmExport({...}, "y.js")` hasn't happened yet, so `y.js` isn't in the module cache yet)

It looks like we will have to better track that `y.js` is effectly already being executed here, to prevent the second execution.

Closes PACK-5289
Closes #82723