### PR TITLE
[test] fix cache components build error in next-form tests

### DIFF
--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -33,10 +33,11 @@
       ]
     },
     "test/e2e/next-form/default/next-form-prefetch.test.ts": {
-      "passed": [],
-      "failed": [
-        "app dir - form prefetching should not prefetch when prefetch is set to false`",
+      "passed": [
         "app dir - form prefetching should prefetch a loading state for the form's target"
+      ],
+      "failed": [
+        "app dir - form prefetching should not prefetch when prefetch is set to false`"
       ]
     }
   },

--- a/test/e2e/next-form/default/app/forms/button-formaction-unsupported/page.tsx
+++ b/test/e2e/next-form/default/app/forms/button-formaction-unsupported/page.tsx
@@ -1,14 +1,13 @@
 'use client'
-import * as React from 'react'
+
+import React, { Suspense } from 'react'
 import Form from 'next/form'
 
-type AnySearchParams = { [key: string]: string | Array<string> | undefined }
+type AnySearchParams = Promise<{
+  [key: string]: string | Array<string> | undefined
+}>
 
-export default function Home({
-  searchParams,
-}: {
-  searchParams: Promise<AnySearchParams>
-}) {
+function Home({ searchParams }: { searchParams: AnySearchParams }) {
   const attribute = React.use(searchParams).attribute
   return (
     <div
@@ -37,5 +36,17 @@ export default function Home({
         </button>
       </Form>
     </div>
+  )
+}
+
+export default function Page({
+  searchParams,
+}: {
+  searchParams: AnySearchParams
+}) {
+  return (
+    <Suspense fallback={<div>Page is loading...</div>}>
+      <Home searchParams={searchParams} />
+    </Suspense>
   )
 }

--- a/test/e2e/next-form/default/app/redirected-from-action/page.tsx
+++ b/test/e2e/next-form/default/app/redirected-from-action/page.tsx
@@ -1,6 +1,27 @@
 import * as React from 'react'
+import { Suspense } from 'react'
 
-export default async function RedirectedPage({ searchParams }) {
+type AnySearchParams = Promise<{
+  [key: string]: string | Array<string> | undefined
+}>
+
+async function RedirectedPage({
+  searchParams,
+}: {
+  searchParams: AnySearchParams
+}) {
   const query = (await searchParams).query as string
   return <div id="redirected-results">query: {JSON.stringify(query)}</div>
+}
+
+export default function Page({
+  searchParams,
+}: {
+  searchParams: AnySearchParams
+}) {
+  return (
+    <Suspense fallback={<div>Page is loading...</div>}>
+      <RedirectedPage searchParams={searchParams} />
+    </Suspense>
+  )
 }


### PR DESCRIPTION
Add suspense boundary above the async request API to avoid build error with cache components test suite