### PR TITLE
[types] refactor shared types

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -17,7 +17,7 @@ import {
   createMutableActionQueue,
 } from './components/app-router-instance'
 import AppRouter from './components/app-router'
-import type { InitialRSCPayload } from '../server/app-render/types'
+import type { InitialRSCPayload } from '../shared/lib/app-router-types'
 import { createInitialRouterState } from './components/router-reducer/create-initial-router-state'
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
 import { setAppBuildId } from './app-build-id'

--- a/packages/next/src/client/components/app-router-announcer.tsx
+++ b/packages/next/src/client/components/app-router-announcer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import type { FlightRouterState } from '../../server/app-render/types'
+import type { FlightRouterState } from '../../shared/lib/app-router-types'
 
 const ANNOUNCER_TYPE = 'next-route-announcer'
 const ANNOUNCER_ID = '__next-route-announcer__'

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -29,7 +29,7 @@ import type {
   PrefetchOptions,
 } from '../../shared/lib/app-router-context.shared-runtime'
 import { setLinkForCurrentNavigation, type LinkInstance } from './links'
-import type { FlightRouterState } from '../../server/app-render/types'
+import type { FlightRouterState } from '../../shared/lib/app-router-types'
 import type { ClientInstrumentationHooks } from '../app-index'
 import type { GlobalErrorComponent } from './builtin/global-error'
 

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -12,7 +12,7 @@ import {
   LayoutRouterContext,
   GlobalLayoutRouterContext,
 } from '../../shared/lib/app-router-context.shared-runtime'
-import type { CacheNode } from '../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../shared/lib/app-router-types'
 import { ACTION_RESTORE } from './router-reducer/router-reducer-types'
 import type { AppRouterState } from './router-reducer/router-reducer-types'
 import { createHrefFromUrl } from './router-reducer/create-href-from-url'
@@ -31,7 +31,7 @@ import { unresolvedThenable } from './unresolved-thenable'
 import { removeBasePath } from '../remove-base-path'
 import { hasBasePath } from '../has-base-path'
 import { getSelectedParams } from './router-reducer/compute-changed-path'
-import type { FlightRouterState } from '../../server/app-render/types'
+import type { FlightRouterState } from '../../shared/lib/app-router-types'
 import { useNavFailureHandler } from './nav-failure-handler'
 import {
   dispatchTraverseAction,

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -12,7 +12,10 @@ import {
   LayoutRouterContext,
   GlobalLayoutRouterContext,
 } from '../../shared/lib/app-router-context.shared-runtime'
-import type { CacheNode } from '../../shared/lib/app-router-types'
+import type {
+  CacheNode,
+  FlightRouterState,
+} from '../../shared/lib/app-router-types'
 import { ACTION_RESTORE } from './router-reducer/router-reducer-types'
 import type { AppRouterState } from './router-reducer/router-reducer-types'
 import { createHrefFromUrl } from './router-reducer/create-href-from-url'
@@ -31,7 +34,6 @@ import { unresolvedThenable } from './unresolved-thenable'
 import { removeBasePath } from '../remove-base-path'
 import { hasBasePath } from '../has-base-path'
 import { getSelectedParams } from './router-reducer/compute-changed-path'
-import type { FlightRouterState } from '../../shared/lib/app-router-types'
 import { useNavFailureHandler } from './nav-failure-handler'
 import {
   dispatchTraverseAction,

--- a/packages/next/src/client/components/bfcache.ts
+++ b/packages/next/src/client/components/bfcache.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from '../../server/app-render/types'
+import type { FlightRouterState } from '../../shared/lib/app-router-types'
 import { useState } from 'react'
 
 // When the flag is disabled, only track the currently active tree

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -3,12 +3,12 @@
 import type {
   CacheNode,
   LazyCacheNode,
-  LoadingModuleData,
-} from '../../shared/lib/app-router-context.shared-runtime'
+} from '../../shared/lib/app-router-types'
+import type { LoadingModuleData } from '../../shared/lib/app-router-types'
 import type {
   FlightRouterState,
   FlightSegmentPath,
-} from '../../server/app-render/types'
+} from '../../shared/lib/app-router-types'
 import type { ErrorComponent } from './error-boundary'
 import {
   ACTION_SERVER_PATCH,

--- a/packages/next/src/client/components/links.ts
+++ b/packages/next/src/client/components/links.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from '../../server/app-render/types'
+import type { FlightRouterState } from '../../shared/lib/app-router-types'
 import type { AppRouterInstance } from '../../shared/lib/app-router-context.shared-runtime'
 import { getCurrentAppRouterState } from './app-router-instance'
 import { createPrefetchURL } from './app-router'

--- a/packages/next/src/client/components/match-segments.ts
+++ b/packages/next/src/client/components/match-segments.ts
@@ -1,4 +1,4 @@
-import type { Segment } from '../../server/app-render/types'
+import type { Segment } from '../../shared/lib/app-router-types'
 
 export const matchSegment = (
   existingSegment: Segment,

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from '../../server/app-render/types'
+import type { FlightRouterState } from '../../shared/lib/app-router-types'
 import type { Params } from '../../server/request/params'
 
 import { useContext, useMemo } from 'react'

--- a/packages/next/src/client/components/router-reducer/aliased-prefetch-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/aliased-prefetch-navigations.ts
@@ -1,8 +1,8 @@
 import type {
   CacheNodeSeedData,
   FlightRouterState,
-} from '../../../server/app-render/types'
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
+} from '../../../shared/lib/app-router-types'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
 import {
   addSearchParamsIfPageSegment,
   PAGE_SEGMENT_KEY,

--- a/packages/next/src/client/components/router-reducer/apply-flight-data.ts
+++ b/packages/next/src/client/components/router-reducer/apply-flight-data.ts
@@ -1,4 +1,4 @@
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
 import { fillCacheWithNewSubTreeData } from './fill-cache-with-new-subtree-data'
 import type { PrefetchCacheEntry } from './router-reducer-types'

--- a/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.test.tsx
+++ b/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import type {
   FlightData,
   FlightRouterState,
-} from '../../../server/app-render/types'
+} from '../../../shared/lib/app-router-types'
 import { applyRouterStatePatchToTree } from './apply-router-state-patch-to-tree'
 
 const getInitialRouterStateTree = (): FlightRouterState => [

--- a/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
+++ b/packages/next/src/client/components/router-reducer/apply-router-state-patch-to-tree.ts
@@ -1,7 +1,7 @@
 import type {
   FlightRouterState,
   FlightSegmentPath,
-} from '../../../server/app-render/types'
+} from '../../../shared/lib/app-router-types'
 import { DEFAULT_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { getNextFlightSegmentPath } from '../../flight-data-helpers'
 import { matchSegment } from '../match-segments'

--- a/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.test.tsx
+++ b/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { clearCacheNodeDataForSegmentPath } from './clear-cache-node-data-for-segment-path'
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
 
 const navigatedAt = -1
 

--- a/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.ts
+++ b/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.ts
@@ -1,5 +1,7 @@
-import type { FlightSegmentPath } from '../../../shared/lib/app-router-types'
-import type { CacheNode } from '../../../shared/lib/app-router-types'
+import type {
+  FlightSegmentPath,
+  CacheNode,
+} from '../../../shared/lib/app-router-types'
 import { getNextFlightSegmentPath } from '../../flight-data-helpers'
 import { createRouterCacheKey } from './create-router-cache-key'
 

--- a/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.ts
+++ b/packages/next/src/client/components/router-reducer/clear-cache-node-data-for-segment-path.ts
@@ -1,5 +1,5 @@
-import type { FlightSegmentPath } from '../../../server/app-render/types'
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
+import type { FlightSegmentPath } from '../../../shared/lib/app-router-types'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
 import { getNextFlightSegmentPath } from '../../flight-data-helpers'
 import { createRouterCacheKey } from './create-router-cache-key'
 

--- a/packages/next/src/client/components/router-reducer/compute-changed-path.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.ts
@@ -1,7 +1,7 @@
 import type {
   FlightRouterState,
   Segment,
-} from '../../../server/app-render/types'
+} from '../../../shared/lib/app-router-types'
 import { INTERCEPTION_ROUTE_MARKERS } from '../../../shared/lib/router/utils/interception-routes'
 import type { Params } from '../../../server/request/params'
 import {

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import type { FlightRouterState } from '../../../server/app-render/types'
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
+import type { FlightRouterState } from '../../../shared/lib/app-router-types'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
 import { createInitialRouterState } from './create-initial-router-state'
 import { PrefetchCacheEntryStatus, PrefetchKind } from './router-reducer-types'
 

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import type { FlightRouterState } from '../../../shared/lib/app-router-types'
-import type { CacheNode } from '../../../shared/lib/app-router-types'
+import type {
+  FlightRouterState,
+  CacheNode,
+} from '../../../shared/lib/app-router-types'
 import { createInitialRouterState } from './create-initial-router-state'
 import { PrefetchCacheEntryStatus, PrefetchKind } from './router-reducer-types'
 

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -1,5 +1,5 @@
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
-import type { FlightDataPath } from '../../../server/app-render/types'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
+import type { FlightDataPath } from '../../../shared/lib/app-router-types'
 
 import { createHrefFromUrl } from './create-href-from-url'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -1,5 +1,7 @@
-import type { CacheNode } from '../../../shared/lib/app-router-types'
-import type { FlightDataPath } from '../../../shared/lib/app-router-types'
+import type {
+  CacheNode,
+  FlightDataPath,
+} from '../../../shared/lib/app-router-types'
 
 import { createHrefFromUrl } from './create-href-from-url'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'

--- a/packages/next/src/client/components/router-reducer/create-router-cache-key.ts
+++ b/packages/next/src/client/components/router-reducer/create-router-cache-key.ts
@@ -1,4 +1,4 @@
-import type { Segment } from '../../../server/app-render/types'
+import type { Segment } from '../../../shared/lib/app-router-types'
 import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 
 export function createRouterCacheKey(

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -7,7 +7,7 @@ import { createFromReadableStream as createFromReadableStreamBrowser } from 'rea
 import type {
   FlightRouterState,
   NavigationFlightResponse,
-} from '../../../server/app-render/types'
+} from '../../../shared/lib/app-router-types'
 
 import type { NEXT_ROUTER_SEGMENT_PREFETCH_HEADER } from '../app-router-headers'
 import {

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.test.tsx
@@ -1,5 +1,5 @@
 import { fillCacheWithNewSubTreeData } from './fill-cache-with-new-subtree-data'
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
 import type { NormalizedFlightData } from '../../flight-data-helpers'
 
 const getFlightData = (): NormalizedFlightData[] => {

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -1,5 +1,5 @@
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
-import type { Segment } from '../../../server/app-render/types'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
+import type { Segment } from '../../../shared/lib/app-router-types'
 import { invalidateCacheByRouterState } from './invalidate-cache-by-router-state'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
 import { createRouterCacheKey } from './create-router-cache-key'

--- a/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
+++ b/packages/next/src/client/components/router-reducer/fill-cache-with-new-subtree-data.ts
@@ -1,5 +1,4 @@
-import type { CacheNode } from '../../../shared/lib/app-router-types'
-import type { Segment } from '../../../shared/lib/app-router-types'
+import type { CacheNode, Segment } from '../../../shared/lib/app-router-types'
 import { invalidateCacheByRouterState } from './invalidate-cache-by-router-state'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
 import { createRouterCacheKey } from './create-router-cache-key'

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
-import type { FlightData } from '../../../server/app-render/types'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
+import type { FlightData } from '../../../shared/lib/app-router-types'
 
 const getFlightData = (): FlightData => {
   return [

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
-import type { CacheNode } from '../../../shared/lib/app-router-types'
-import type { FlightData } from '../../../shared/lib/app-router-types'
+import type {
+  CacheNode,
+  FlightData,
+} from '../../../shared/lib/app-router-types'
 
 const getFlightData = (): FlightData => {
   return [

--- a/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
+++ b/packages/next/src/client/components/router-reducer/fill-lazy-items-till-leaf-with-head.ts
@@ -1,8 +1,8 @@
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
 import type {
   FlightRouterState,
   CacheNodeSeedData,
-} from '../../../server/app-render/types'
+} from '../../../shared/lib/app-router-types'
 import { createRouterCacheKey } from './create-router-cache-key'
 import {
   PrefetchCacheEntryStatus,

--- a/packages/next/src/client/components/router-reducer/handle-segment-mismatch.ts
+++ b/packages/next/src/client/components/router-reducer/handle-segment-mismatch.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from '../../../server/app-render/types'
+import type { FlightRouterState } from '../../../shared/lib/app-router-types'
 import { handleExternalUrl } from './reducers/navigate-reducer'
 import type {
   ReadonlyReducerState,

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { invalidateCacheBelowFlightSegmentPath } from './invalidate-cache-below-flight-segmentpath'
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
 import { fillCacheWithNewSubTreeData } from './fill-cache-with-new-subtree-data'
 import type { NormalizedFlightData } from '../../flight-data-helpers'
 

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
@@ -1,5 +1,7 @@
-import type { CacheNode } from '../../../shared/lib/app-router-types'
-import type { FlightSegmentPath } from '../../../shared/lib/app-router-types'
+import type {
+  CacheNode,
+  FlightSegmentPath,
+} from '../../../shared/lib/app-router-types'
 import { createRouterCacheKey } from './create-router-cache-key'
 import { getNextFlightSegmentPath } from '../../flight-data-helpers'
 

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-below-flight-segmentpath.ts
@@ -1,5 +1,5 @@
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
-import type { FlightSegmentPath } from '../../../server/app-render/types'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
+import type { FlightSegmentPath } from '../../../shared/lib/app-router-types'
 import { createRouterCacheKey } from './create-router-cache-key'
 import { getNextFlightSegmentPath } from '../../flight-data-helpers'
 

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
@@ -1,6 +1,8 @@
 import { invalidateCacheByRouterState } from './invalidate-cache-by-router-state'
-import type { CacheNode } from '../../../shared/lib/app-router-types'
-import type { FlightRouterState } from '../../../shared/lib/app-router-types'
+import type {
+  CacheNode,
+  FlightRouterState,
+} from '../../../shared/lib/app-router-types'
 
 const navigatedAt = -1
 

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.test.tsx
@@ -1,6 +1,6 @@
 import { invalidateCacheByRouterState } from './invalidate-cache-by-router-state'
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
-import type { FlightRouterState } from '../../../server/app-render/types'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
+import type { FlightRouterState } from '../../../shared/lib/app-router-types'
 
 const navigatedAt = -1
 

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.ts
@@ -1,5 +1,5 @@
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
-import type { FlightRouterState } from '../../../server/app-render/types'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
+import type { FlightRouterState } from '../../../shared/lib/app-router-types'
 import { createRouterCacheKey } from './create-router-cache-key'
 
 /**

--- a/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/invalidate-cache-by-router-state.ts
@@ -1,5 +1,7 @@
-import type { CacheNode } from '../../../shared/lib/app-router-types'
-import type { FlightRouterState } from '../../../shared/lib/app-router-types'
+import type {
+  CacheNode,
+  FlightRouterState,
+} from '../../../shared/lib/app-router-types'
 import { createRouterCacheKey } from './create-router-cache-key'
 
 /**

--- a/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.test.ts
+++ b/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.test.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from '../../../server/app-render/types'
+import type { FlightRouterState } from '../../../shared/lib/app-router-types'
 import { isNavigatingToNewRootLayout } from './is-navigating-to-new-root-layout'
 
 describe('isNavigatingToNewRootLayout', () => {

--- a/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.ts
+++ b/packages/next/src/client/components/router-reducer/is-navigating-to-new-root-layout.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from '../../../server/app-render/types'
+import type { FlightRouterState } from '../../../shared/lib/app-router-types'
 
 export function isNavigatingToNewRootLayout(
   currentTree: FlightRouterState,

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -3,14 +3,16 @@ import type {
   FlightRouterState,
   FlightSegmentPath,
   Segment,
-} from '../../../server/app-render/types'
+} from '../../../shared/lib/app-router-types'
 import type {
   CacheNode,
   ChildSegmentMap,
+  ReadyCacheNode,
+} from '../../../shared/lib/app-router-types'
+import type {
   HeadData,
   LoadingModuleData,
-  ReadyCacheNode,
-} from '../../../shared/lib/app-router-context.shared-runtime'
+} from '../../../shared/lib/app-router-types'
 import { DEFAULT_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { matchSegment } from '../match-segments'
 import { createRouterCacheKey } from './create-router-cache-key'

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
@@ -1,5 +1,7 @@
-import type { FlightRouterState } from '../../../../shared/lib/app-router-types'
-import type { CacheNode } from '../../../../shared/lib/app-router-types'
+import type {
+  FlightRouterState,
+  CacheNode,
+} from '../../../../shared/lib/app-router-types'
 import { findHeadInCache } from './find-head-in-cache'
 
 const navigatedAt = -1

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
@@ -1,5 +1,5 @@
-import type { FlightRouterState } from '../../../../server/app-render/types'
-import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
+import type { FlightRouterState } from '../../../../shared/lib/app-router-types'
+import type { CacheNode } from '../../../../shared/lib/app-router-types'
 import { findHeadInCache } from './find-head-in-cache'
 
 const navigatedAt = -1

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
@@ -1,5 +1,7 @@
-import type { FlightRouterState } from '../../../../shared/lib/app-router-types'
-import type { CacheNode } from '../../../../shared/lib/app-router-types'
+import type {
+  FlightRouterState,
+  CacheNode,
+} from '../../../../shared/lib/app-router-types'
 import { DEFAULT_SEGMENT_KEY } from '../../../../shared/lib/segment'
 import { createRouterCacheKey } from '../create-router-cache-key'
 

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.ts
@@ -1,5 +1,5 @@
-import type { FlightRouterState } from '../../../../server/app-render/types'
-import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
+import type { FlightRouterState } from '../../../../shared/lib/app-router-types'
+import type { CacheNode } from '../../../../shared/lib/app-router-types'
 import { DEFAULT_SEGMENT_KEY } from '../../../../shared/lib/segment'
 import { createRouterCacheKey } from '../create-router-cache-key'
 

--- a/packages/next/src/client/components/router-reducer/reducers/get-segment-value.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/get-segment-value.ts
@@ -1,4 +1,4 @@
-import type { Segment } from '../../../../server/app-render/types'
+import type { Segment } from '../../../../shared/lib/app-router-types'
 
 export function getSegmentValue(segment: Segment) {
   return Array.isArray(segment) ? segment[1] : segment

--- a/packages/next/src/client/components/router-reducer/reducers/has-interception-route-in-current-tree.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/has-interception-route-in-current-tree.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from '../../../../server/app-render/types'
+import type { FlightRouterState } from '../../../../shared/lib/app-router-types'
 import { isInterceptionRouteAppPath } from '../../../../shared/lib/router/utils/interception-routes'
 
 export function hasInterceptionRouteInCurrentTree([

--- a/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
@@ -11,7 +11,7 @@ import type {
 import { handleExternalUrl } from './navigate-reducer'
 import { handleMutable } from '../handle-mutable'
 import { applyFlightData } from '../apply-flight-data'
-import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../../../shared/lib/app-router-types'
 import { createEmptyCacheNode } from '../../app-router'
 import { handleSegmentMismatch } from '../handle-segment-mismatch'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -1,8 +1,8 @@
-import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../../../shared/lib/app-router-types'
 import type {
   FlightRouterState,
   FlightSegmentPath,
-} from '../../../../server/app-render/types'
+} from '../../../../shared/lib/app-router-types'
 import { fetchServerResponse } from '../fetch-server-response'
 import { createHrefFromUrl } from '../create-href-from-url'
 import { invalidateCacheBelowFlightSegmentPath } from '../invalidate-cache-below-flight-segmentpath'

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -10,7 +10,7 @@ import type {
 } from '../router-reducer-types'
 import { handleExternalUrl } from './navigate-reducer'
 import { handleMutable } from '../handle-mutable'
-import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../../../shared/lib/app-router-types'
 import { fillLazyItemsTillLeafWithHead } from '../fill-lazy-items-till-leaf-with-head'
 import { createEmptyCacheNode } from '../../app-router'
 import { handleSegmentMismatch } from '../handle-segment-mismatch'

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -1,7 +1,7 @@
 import type {
   ActionFlightResponse,
   ActionResult,
-} from '../../../../server/app-render/types'
+} from '../../../../shared/lib/app-router-types'
 import { callServer } from '../../../app-call-server'
 import { findSourceMapURL } from '../../../app-find-source-map-url'
 import {
@@ -34,7 +34,7 @@ import { createHrefFromUrl } from '../create-href-from-url'
 import { handleExternalUrl } from './navigate-reducer'
 import { applyRouterStatePatchToTree } from '../apply-router-state-patch-to-tree'
 import { isNavigatingToNewRootLayout } from '../is-navigating-to-new-root-layout'
-import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../../../shared/lib/app-router-types'
 import { handleMutable } from '../handle-mutable'
 import { fillLazyItemsTillLeafWithHead } from '../fill-lazy-items-till-leaf-with-head'
 import { createEmptyCacheNode } from '../../app-router'

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -10,7 +10,7 @@ import type {
 import { handleExternalUrl } from './navigate-reducer'
 import { applyFlightData } from '../apply-flight-data'
 import { handleMutable } from '../handle-mutable'
-import type { CacheNode } from '../../../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../../../shared/lib/app-router-types'
 import { createEmptyCacheNode } from '../../app-router'
 
 export function serverPatchReducer(

--- a/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
+++ b/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
@@ -1,5 +1,7 @@
-import type { FlightRouterState } from '../../../shared/lib/app-router-types'
-import type { CacheNode } from '../../../shared/lib/app-router-types'
+import type {
+  FlightRouterState,
+  CacheNode,
+} from '../../../shared/lib/app-router-types'
 import type { AppRouterState } from './router-reducer-types'
 import { applyFlightData } from './apply-flight-data'
 import { fetchServerResponse } from './fetch-server-response'

--- a/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
+++ b/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
@@ -1,5 +1,5 @@
-import type { FlightRouterState } from '../../../server/app-render/types'
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
+import type { FlightRouterState } from '../../../shared/lib/app-router-types'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
 import type { AppRouterState } from './router-reducer-types'
 import { applyFlightData } from './apply-flight-data'
 import { fetchServerResponse } from './fetch-server-response'

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -1,8 +1,8 @@
-import type { CacheNode } from '../../../shared/lib/app-router-context.shared-runtime'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
 import type {
   FlightRouterState,
   FlightSegmentPath,
-} from '../../../server/app-render/types'
+} from '../../../shared/lib/app-router-types'
 import type { FetchServerResponseResult } from './fetch-server-response'
 
 export const ACTION_REFRESH = 'refresh'

--- a/packages/next/src/client/components/router-reducer/should-hard-navigate.test.tsx
+++ b/packages/next/src/client/components/router-reducer/should-hard-navigate.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import type {
   FlightData,
   FlightRouterState,
-} from '../../../server/app-render/types'
+} from '../../../shared/lib/app-router-types'
 import { shouldHardNavigate } from './should-hard-navigate'
 
 describe('shouldHardNavigate', () => {

--- a/packages/next/src/client/components/router-reducer/should-hard-navigate.ts
+++ b/packages/next/src/client/components/router-reducer/should-hard-navigate.ts
@@ -2,7 +2,7 @@ import type {
   FlightRouterState,
   FlightDataPath,
   Segment,
-} from '../../../server/app-render/types'
+} from '../../../shared/lib/app-router-types'
 import { getNextFlightSegmentPath } from '../../flight-data-helpers'
 import { matchSegment } from '../match-segments'
 

--- a/packages/next/src/client/components/segment-cache-impl/cache.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache.ts
@@ -6,13 +6,13 @@ import type {
 import type {
   HeadData,
   LoadingModuleData,
-} from '../../../shared/lib/app-router-context.shared-runtime'
+} from '../../../shared/lib/app-router-types'
 import type {
   CacheNodeSeedData,
   DynamicParamTypesShort,
   Segment as FlightRouterStateSegment,
-} from '../../../server/app-render/types'
-import { HasLoadingBoundary } from '../../../server/app-render/types'
+} from '../../../shared/lib/app-router-types'
+import { HasLoadingBoundary } from '../../../shared/lib/app-router-types'
 import {
   NEXT_DID_POSTPONE_HEADER,
   NEXT_ROUTER_PREFETCH_HEADER,
@@ -70,7 +70,7 @@ import {
 import type {
   FlightRouterState,
   NavigationFlightResponse,
-} from '../../../server/app-render/types'
+} from '../../../shared/lib/app-router-types'
 import { normalizeFlightData } from '../../flight-data-helpers'
 import { STATIC_STALETIME_MS } from '../router-reducer/prefetch-cache-utils'
 import { pingVisibleLinks } from '../links'

--- a/packages/next/src/client/components/segment-cache-impl/navigation.ts
+++ b/packages/next/src/client/components/segment-cache-impl/navigation.ts
@@ -2,12 +2,12 @@ import type {
   CacheNodeSeedData,
   FlightRouterState,
   FlightSegmentPath,
-} from '../../../server/app-render/types'
+} from '../../../shared/lib/app-router-types'
+import type { CacheNode } from '../../../shared/lib/app-router-types'
 import type {
-  CacheNode,
   HeadData,
   LoadingModuleData,
-} from '../../../shared/lib/app-router-context.shared-runtime'
+} from '../../../shared/lib/app-router-types'
 import type { NormalizedFlightData } from '../../flight-data-helpers'
 import { fetchServerResponse } from '../router-reducer/fetch-server-response'
 import {

--- a/packages/next/src/client/components/segment-cache-impl/prefetch.ts
+++ b/packages/next/src/client/components/segment-cache-impl/prefetch.ts
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from '../../../server/app-render/types'
+import type { FlightRouterState } from '../../../shared/lib/app-router-types'
 import { createPrefetchURL } from '../app-router'
 import { createCacheKey } from './cache-key'
 import { schedulePrefetchTask } from './scheduler'

--- a/packages/next/src/client/components/segment-cache-impl/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache-impl/scheduler.ts
@@ -2,8 +2,8 @@ import type {
   FlightRouterState,
   Segment as FlightRouterStateSegment,
   Segment,
-} from '../../../server/app-render/types'
-import { HasLoadingBoundary } from '../../../server/app-render/types'
+} from '../../../shared/lib/app-router-types'
+import { HasLoadingBoundary } from '../../../shared/lib/app-router-types'
 import { matchSegment } from '../match-segments'
 import {
   readOrCreateRouteCacheEntry,

--- a/packages/next/src/client/flight-data-helpers.test.ts
+++ b/packages/next/src/client/flight-data-helpers.test.ts
@@ -1,6 +1,6 @@
 import { prepareFlightRouterStateForRequest } from './flight-data-helpers'
-import type { FlightRouterState } from '../server/app-render/types'
-import { HasLoadingBoundary } from '../server/app-render/types'
+import type { FlightRouterState } from '../shared/lib/app-router-types'
+import { HasLoadingBoundary } from '../shared/lib/app-router-types'
 
 describe('prepareFlightRouterStateForRequest', () => {
   describe('HMR refresh handling', () => {

--- a/packages/next/src/client/flight-data-helpers.test.ts
+++ b/packages/next/src/client/flight-data-helpers.test.ts
@@ -1,6 +1,8 @@
 import { prepareFlightRouterStateForRequest } from './flight-data-helpers'
-import type { FlightRouterState } from '../shared/lib/app-router-types'
-import { HasLoadingBoundary } from '../shared/lib/app-router-types'
+import {
+  HasLoadingBoundary,
+  type FlightRouterState,
+} from '../shared/lib/app-router-types'
 
 describe('prepareFlightRouterStateForRequest', () => {
   describe('HMR refresh handling', () => {

--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -5,8 +5,8 @@ import type {
   FlightRouterState,
   FlightSegmentPath,
   Segment,
-} from '../server/app-render/types'
-import type { HeadData } from '../shared/lib/app-router-context.shared-runtime'
+} from '../shared/lib/app-router-types'
+import type { HeadData } from '../shared/lib/app-router-types'
 import { PAGE_SEGMENT_KEY } from '../shared/lib/segment'
 
 export type NormalizedFlightData = {

--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -5,8 +5,8 @@ import type {
   FlightRouterState,
   FlightSegmentPath,
   Segment,
+  HeadData,
 } from '../shared/lib/app-router-types'
-import type { HeadData } from '../shared/lib/app-router-types'
 import { PAGE_SEGMENT_KEY } from '../shared/lib/segment'
 
 export type NormalizedFlightData = {

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -1,4 +1,4 @@
-import type { DynamicParamTypesShort } from '../server/app-render/types'
+import type { DynamicParamTypesShort } from '../shared/lib/app-router-types'
 import {
   addSearchParamsIfPageSegment,
   DEFAULT_SEGMENT_KEY,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1,16 +1,15 @@
+import type { RenderOpts, PreloadCallbacks } from './types'
 import type {
   ActionResult,
   DynamicParamTypesShort,
   FlightRouterState,
-  RenderOpts,
   Segment,
   CacheNodeSeedData,
-  PreloadCallbacks,
   RSCPayload,
   FlightData,
   InitialRSCPayload,
   FlightDataPath,
-} from './types'
+} from '../../shared/lib/app-router-types'
 import {
   workAsyncStorage,
   type WorkStore,

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -3,6 +3,8 @@ import type {
   FlightRouterState,
   InitialRSCPayload,
   DynamicParamTypesShort,
+  HeadData,
+  LoadingModuleData,
 } from '../../shared/lib/app-router-types'
 import type { ManifestNode } from '../../build/webpack/plugins/flight-manifest-plugin'
 
@@ -16,10 +18,6 @@ import {
   streamToBuffer,
 } from '../stream-utils/node-web-streams-helper'
 import { waitAtLeastOneReactRenderTask } from '../../lib/scheduler'
-import type {
-  HeadData,
-  LoadingModuleData,
-} from '../../shared/lib/app-router-types'
 import {
   type SegmentRequestKey,
   createSegmentRequestKeyPart,

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -3,7 +3,7 @@ import type {
   FlightRouterState,
   InitialRSCPayload,
   DynamicParamTypesShort,
-} from './types'
+} from '../../shared/lib/app-router-types'
 import type { ManifestNode } from '../../build/webpack/plugins/flight-manifest-plugin'
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -19,7 +19,7 @@ import { waitAtLeastOneReactRenderTask } from '../../lib/scheduler'
 import type {
   HeadData,
   LoadingModuleData,
-} from '../../shared/lib/app-router-context.shared-runtime'
+} from '../../shared/lib/app-router-types'
 import {
   type SegmentRequestKey,
   createSegmentRequestKeyPart,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -1,4 +1,5 @@
-import type { CacheNodeSeedData, PreloadCallbacks } from './types'
+import type { CacheNodeSeedData } from '../../shared/lib/app-router-types'
+import type { PreloadCallbacks } from './types'
 import React from 'react'
 import {
   isClientReference,
@@ -17,7 +18,7 @@ import { PARALLEL_ROUTE_DEFAULT_PATH } from '../../client/components/builtin/def
 import { getTracer } from '../lib/trace/tracer'
 import { NextNodeServerSpan } from '../lib/trace/constants'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
-import type { LoadingModuleData } from '../../shared/lib/app-router-context.shared-runtime'
+import type { LoadingModuleData } from '../../shared/lib/app-router-types'
 import type { Params } from '../request/params'
 import { workUnitAsyncStorage } from './work-unit-async-storage.external'
 import { OUTLET_BOUNDARY_NAME } from '../../lib/framework/boundary-constants'

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -1,4 +1,7 @@
-import type { CacheNodeSeedData } from '../../shared/lib/app-router-types'
+import type {
+  CacheNodeSeedData,
+  LoadingModuleData,
+} from '../../shared/lib/app-router-types'
 import type { PreloadCallbacks } from './types'
 import React from 'react'
 import {
@@ -18,7 +21,6 @@ import { PARALLEL_ROUTE_DEFAULT_PATH } from '../../client/components/builtin/def
 import { getTracer } from '../lib/trace/tracer'
 import { NextNodeServerSpan } from '../lib/trace/constants'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
-import type { LoadingModuleData } from '../../shared/lib/app-router-types'
 import type { Params } from '../request/params'
 import { workUnitAsyncStorage } from './work-unit-async-storage.external'
 import { OUTLET_BOUNDARY_NAME } from '../../lib/framework/boundary-constants'

--- a/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-flight-router-state-from-loader-tree.ts
@@ -1,5 +1,8 @@
 import type { LoaderTree } from '../lib/app-dir-module'
-import { HasLoadingBoundary, type FlightRouterState } from './types'
+import {
+  HasLoadingBoundary,
+  type FlightRouterState,
+} from '../../shared/lib/app-router-types'
 import type { GetDynamicParamFromSegment } from './app-render'
 import { addSearchParamsIfPageSegment } from '../../shared/lib/segment'
 

--- a/packages/next/src/server/app-render/get-segment-param.tsx
+++ b/packages/next/src/server/app-render/get-segment-param.tsx
@@ -1,5 +1,5 @@
 import { INTERCEPTION_ROUTE_MARKERS } from '../../shared/lib/router/utils/interception-routes'
-import type { DynamicParamTypes } from './types'
+import type { DynamicParamTypes } from '../../shared/lib/app-router-types'
 
 /**
  * Parse dynamic route segment to type of parameter

--- a/packages/next/src/server/app-render/get-short-dynamic-param-type.tsx
+++ b/packages/next/src/server/app-render/get-short-dynamic-param-type.tsx
@@ -1,4 +1,7 @@
-import type { DynamicParamTypes, DynamicParamTypesShort } from './types'
+import type {
+  DynamicParamTypes,
+  DynamicParamTypesShort,
+} from '../../shared/lib/app-router-types'
 
 export const dynamicParamTypes: Record<
   DynamicParamTypes,

--- a/packages/next/src/server/app-render/parse-and-validate-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/parse-and-validate-flight-router-state.tsx
@@ -1,4 +1,4 @@
-import type { FlightRouterState } from './types'
+import type { FlightRouterState } from '../../shared/lib/app-router-types'
 import { flightRouterStateSchema } from './types'
 import { assert } from 'next/dist/compiled/superstruct'
 

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -8,10 +8,6 @@ import type { ClientReferenceManifest } from '../../build/webpack/plugins/flight
 import type { NextFontManifest } from '../../build/webpack/plugins/next-font-manifest-plugin'
 import type { ParsedUrlQuery } from 'querystring'
 import type { AppPageModule } from '../route-modules/app-page/module'
-import type {
-  HeadData,
-  LoadingModuleData,
-} from '../../shared/lib/app-router-context.shared-runtime'
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
 import type { __ApiPreviewProps } from '../api-utils'
 
@@ -23,16 +19,7 @@ import type { BaseNextRequest } from '../base-http'
 import type { IncomingMessage } from 'http'
 import type { RenderResumeDataCache } from '../resume-data-cache/resume-data-cache'
 
-export type DynamicParamTypes =
-  | 'catchall'
-  | 'catchall-intercepted'
-  | 'optional-catchall'
-  | 'dynamic'
-  | 'dynamic-intercepted'
-
 const dynamicParamTypesSchema = s.enums(['c', 'ci', 'oc', 'd', 'di'])
-
-export type DynamicParamTypesShort = s.Infer<typeof dynamicParamTypesSchema>
 
 const segmentSchema = s.union([
   s.string(),
@@ -51,8 +38,6 @@ const segmentSchema = s.union([
     dynamicParamTypesSchema,
   ]),
 ])
-
-export type Segment = s.Infer<typeof segmentSchema>
 
 // unfortunately the tuple is not understood well by Describe so we have to
 // use any here. This does not have any impact on the runtime type since the validation
@@ -76,124 +61,6 @@ export const flightRouterStateSchema: s.Describe<any> = s.tuple([
   ),
   s.optional(s.boolean()),
 ])
-
-/**
- * Router state
- */
-export type FlightRouterState = [
-  segment: Segment,
-  parallelRoutes: { [parallelRouterKey: string]: FlightRouterState },
-  url?: string | null,
-  /**
-   * "refresh" and "refetch", despite being similarly named, have different
-   * semantics:
-   * - "refetch" is used during a request to inform the server where rendering
-   *   should start from.
-   *
-   * - "refresh" is used by the client to mark that a segment should re-fetch the
-   *   data from the server for the current segment. It uses the "url" property
-   *   above to determine where to fetch from.
-   *
-   * - "inside-shared-layout" is used during a prefetch request to inform the
-   *   server that even if the segment matches, it should be treated as if it's
-   *   within the "new" part of a navigation — inside the shared layout. If
-   *   the segment doesn't match, then it has no effect, since it would be
-   *   treated as new regardless. If it does match, though, the server does not
-   *   need to render it, because the client already has it.
-   *
-   * - "metadata-only" instructs the server to skip rendering the segments and
-   *   only send the head data.
-   *
-   *   A bit confusing, but that's because it has only one extremely narrow use
-   *   case — during a non-PPR prefetch, the server uses it to find the first
-   *   loading boundary beneath a shared layout.
-   *
-   *   TODO: We should rethink the protocol for dynamic requests. It might not
-   *   make sense for the client to send a FlightRouterState, since this type is
-   *   overloaded with concerns.
-   */
-  refresh?:
-    | 'refetch'
-    | 'refresh'
-    | 'inside-shared-layout'
-    | 'metadata-only'
-    | null,
-  isRootLayout?: boolean,
-  /**
-   * Only present when responding to a tree prefetch request. Indicates whether
-   * there is a loading boundary somewhere in the tree. The client cache uses
-   * this to determine if it can skip the data prefetch request.
-   */
-  hasLoadingBoundary?: HasLoadingBoundary,
-]
-
-export const enum HasLoadingBoundary {
-  // There is a loading boundary in this particular segment
-  SegmentHasLoadingBoundary = 1,
-  // There is a loading boundary somewhere in the subtree (but not in
-  // this segment)
-  SubtreeHasLoadingBoundary = 2,
-  // There is no loading boundary in this segment or any of its descendants
-  SubtreeHasNoLoadingBoundary = 3,
-}
-
-/**
- * Individual Flight response path
- */
-export type FlightSegmentPath =
-  // Uses `any` as repeating pattern can't be typed.
-  | any[]
-  // Looks somewhat like this
-  | [
-      segment: Segment,
-      parallelRouterKey: string,
-      segment: Segment,
-      parallelRouterKey: string,
-      segment: Segment,
-      parallelRouterKey: string,
-    ]
-
-/**
- * Represents a tree of segments and the Flight data (i.e. React nodes) that
- * correspond to each one. The tree is isomorphic to the FlightRouterState;
- * however in the future we want to be able to fetch arbitrary partial segments
- * without having to fetch all its children. So this response format will
- * likely change.
- */
-export type CacheNodeSeedData = [
-  segment: Segment,
-  node: React.ReactNode | null,
-  parallelRoutes: {
-    [parallelRouterKey: string]: CacheNodeSeedData | null
-  },
-  loading: LoadingModuleData | Promise<LoadingModuleData>,
-  isPartial: boolean,
-]
-
-export type FlightDataSegment = [
-  /* segment of the rendered slice: */ Segment,
-  /* treePatch */ FlightRouterState,
-  /* cacheNodeSeedData */ CacheNodeSeedData | null, // Can be null during prefetch if there's no loading component
-  /* head: viewport */ HeadData,
-  /* isHeadPartial */ boolean,
-]
-
-export type FlightDataPath =
-  // Uses `any` as repeating pattern can't be typed.
-  | any[]
-  // Looks somewhat like this
-  | [
-      // Holds full path to the segment.
-      ...FlightSegmentPath[],
-      ...FlightDataSegment,
-    ]
-
-/**
- * The Flight response data
- */
-export type FlightData = Array<FlightDataPath> | string
-
-export type ActionResult = Promise<any>
 
 export type ServerOnInstrumentationRequestError = (
   error: unknown,
@@ -321,49 +188,3 @@ export type RenderOpts = LoadComponentsReturnType<AppPageModule> &
   RequestLifecycleOpts
 
 export type PreloadCallbacks = (() => void)[]
-
-export type InitialRSCPayload = {
-  /** buildId */
-  b: string
-  /** assetPrefix */
-  p: string
-  /** initialCanonicalUrlParts */
-  c: string[]
-  /** couldBeIntercepted */
-  i: boolean
-  /** initialFlightData */
-  f: FlightDataPath[]
-  /** missingSlots */
-  m: Set<string> | undefined
-  /** GlobalError */
-  G: [React.ComponentType<any>, React.ReactNode | undefined]
-  /** postponed */
-  s: boolean
-  /** prerendered */
-  S: boolean
-}
-
-// Response from `createFromFetch` for normal rendering
-export type NavigationFlightResponse = {
-  /** buildId */
-  b: string
-  /** flightData */
-  f: FlightData
-  /** prerendered */
-  S: boolean
-}
-
-// Response from `createFromFetch` for server actions. Action's flight data can be null
-export type ActionFlightResponse = {
-  /** actionResult */
-  a: ActionResult
-  /** buildId */
-  b: string
-  /** flightData */
-  f: FlightData
-}
-
-export type RSCPayload =
-  | InitialRSCPayload
-  | NavigationFlightResponse
-  | ActionFlightResponse

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -3,6 +3,7 @@ import type {
   FlightDataSegment,
   FlightRouterState,
   Segment,
+  HeadData,
 } from '../../shared/lib/app-router-types'
 import type { PreloadCallbacks } from './types'
 import { matchSegment } from '../../client/components/match-segments'
@@ -20,7 +21,6 @@ import {
   addSearchParamsIfPageSegment,
 } from '../../shared/lib/segment'
 import { createComponentTree } from './create-component-tree'
-import type { HeadData } from '../../shared/lib/app-router-types'
 import { getSegmentParam } from './get-segment-param'
 
 /**

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -2,9 +2,9 @@ import type {
   FlightDataPath,
   FlightDataSegment,
   FlightRouterState,
-  PreloadCallbacks,
   Segment,
-} from './types'
+} from '../../shared/lib/app-router-types'
+import type { PreloadCallbacks } from './types'
 import { matchSegment } from '../../client/components/match-segments'
 import type { LoaderTree } from '../lib/app-dir-module'
 import { getLinkAndScriptTags } from './get-css-inlined-link-tags'
@@ -20,7 +20,7 @@ import {
   addSearchParamsIfPageSegment,
 } from '../../shared/lib/segment'
 import { createComponentTree } from './create-component-tree'
-import type { HeadData } from '../../shared/lib/app-router-context.shared-runtime'
+import type { HeadData } from '../../shared/lib/app-router-types'
 import { getSegmentParam } from './get-segment-param'
 
 /**

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -5,7 +5,7 @@ import type {
   DynamicParamTypesShort,
   FlightRouterState,
   FlightSegmentPath,
-} from '../app-render/types'
+} from '../../shared/lib/app-router-types'
 import type { CompilerNameValues } from '../../shared/lib/constants'
 import type { RouteDefinition } from '../route-definitions/route-definition'
 import type HotReloaderWebpack from './hot-reloader-webpack'

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -4,8 +4,11 @@ import type {
   FocusAndScrollRef,
   PrefetchKind,
 } from '../../client/components/router-reducer/router-reducer-types'
-import type { FlightRouterState, FlightSegmentPath } from './app-router-types'
-import type { CacheNode } from './app-router-types'
+import type {
+  FlightRouterState,
+  FlightSegmentPath,
+  CacheNode,
+} from './app-router-types'
 import React from 'react'
 
 export interface NavigateOptions {

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -1,120 +1,12 @@
 'use client'
 
-import type { FetchServerResponseResult } from '../../client/components/router-reducer/fetch-server-response'
 import type {
   FocusAndScrollRef,
   PrefetchKind,
 } from '../../client/components/router-reducer/router-reducer-types'
-import type {
-  FlightRouterState,
-  FlightSegmentPath,
-} from '../../server/app-render/types'
+import type { FlightRouterState, FlightSegmentPath } from './app-router-types'
+import type { CacheNode } from './app-router-types'
 import React from 'react'
-
-export type ChildSegmentMap = Map<string, CacheNode>
-
-/**
- * Cache node used in app-router / layout-router.
- */
-export type CacheNode = ReadyCacheNode | LazyCacheNode
-
-export type LoadingModuleData =
-  | [React.JSX.Element, React.ReactNode, React.ReactNode]
-  | null
-
-/** viewport metadata node */
-export type HeadData = React.ReactNode
-
-export type LazyCacheNode = {
-  /**
-   * When rsc is null, this is a lazily-initialized cache node.
-   *
-   * If the app attempts to render it, it triggers a lazy data fetch,
-   * postpones the render, and schedules an update to a new tree.
-   *
-   * TODO: This mechanism should not be used when PPR is enabled, though it
-   * currently is in some cases until we've implemented partial
-   * segment fetching.
-   */
-  rsc: null
-
-  /**
-   * A prefetched version of the segment data. See explanation in corresponding
-   * field of ReadyCacheNode (below).
-   *
-   * Since LazyCacheNode mostly only exists in the non-PPR implementation, this
-   * will usually be null, but it could have been cloned from a previous
-   * CacheNode that was created by the PPR implementation. Eventually we want
-   * to migrate everything away from LazyCacheNode entirely.
-   */
-  prefetchRsc: React.ReactNode
-
-  /**
-   * A pending response for the lazy data fetch. If this is not present
-   * during render, it is lazily created.
-   */
-  lazyData: Promise<FetchServerResponseResult> | null
-
-  prefetchHead: HeadData | null
-
-  head: HeadData
-
-  loading: LoadingModuleData | Promise<LoadingModuleData>
-
-  /**
-   * Child parallel routes.
-   */
-  parallelRoutes: Map<string, ChildSegmentMap>
-
-  /**
-   * The timestamp of the navigation that last updated the CacheNode's data. If
-   * a CacheNode is reused from a previous navigation, this value is not
-   * updated. Used to track the staleness of the data.
-   */
-  navigatedAt: number
-}
-
-export type ReadyCacheNode = {
-  /**
-   * When rsc is not null, it represents the RSC data for the
-   * corresponding segment.
-   *
-   * `null` is a valid React Node but because segment data is always a
-   * <LayoutRouter> component, we can use `null` to represent empty.
-   *
-   * TODO: For additional type safety, update this type to
-   * Exclude<React.ReactNode, null>. Need to update createEmptyCacheNode to
-   * accept rsc as an argument, or just inline the callers.
-   */
-  rsc: React.ReactNode
-
-  /**
-   * Represents a static version of the segment that can be shown immediately,
-   * and may or may not contain dynamic holes. It's prefetched before a
-   * navigation occurs.
-   *
-   * During rendering, we will choose whether to render `rsc` or `prefetchRsc`
-   * with `useDeferredValue`. As with the `rsc` field, a value of `null` means
-   * no value was provided. In this case, the LayoutRouter will go straight to
-   * rendering the `rsc` value; if that one is also missing, it will suspend and
-   * trigger a lazy fetch.
-   */
-  prefetchRsc: React.ReactNode
-
-  /**
-   * There should never be a lazy data request in this case.
-   */
-  lazyData: null
-  prefetchHead: HeadData | null
-
-  head: HeadData
-
-  loading: LoadingModuleData | Promise<LoadingModuleData>
-
-  parallelRoutes: Map<string, ChildSegmentMap>
-
-  navigatedAt: number
-}
 
 export interface NavigateOptions {
   scroll?: boolean

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -1,0 +1,302 @@
+/**
+ * App Router types - Client-safe types for the Next.js App Router
+ *
+ * This file contains type definitions that can be safely imported
+ * by both client-side and server-side code without circular dependencies.
+ */
+import type { FetchServerResponseResult } from '../../client/components/router-reducer/fetch-server-response'
+import type React from 'react'
+
+export type LoadingModuleData =
+  | [React.JSX.Element, React.ReactNode, React.ReactNode]
+  | null
+
+/** viewport metadata node */
+export type HeadData = React.ReactNode
+
+export type ChildSegmentMap = Map<string, CacheNode>
+
+/**
+ * Cache node used in app-router / layout-router.
+ */
+export type CacheNode = ReadyCacheNode | LazyCacheNode
+
+export type LazyCacheNode = {
+  /**
+   * When rsc is null, this is a lazily-initialized cache node.
+   *
+   * If the app attempts to render it, it triggers a lazy data fetch,
+   * postpones the render, and schedules an update to a new tree.
+   *
+   * TODO: This mechanism should not be used when PPR is enabled, though it
+   * currently is in some cases until we've implemented partial
+   * segment fetching.
+   */
+  rsc: null
+
+  /**
+   * A prefetched version of the segment data. See explanation in corresponding
+   * field of ReadyCacheNode (below).
+   *
+   * Since LazyCacheNode mostly only exists in the non-PPR implementation, this
+   * will usually be null, but it could have been cloned from a previous
+   * CacheNode that was created by the PPR implementation. Eventually we want
+   * to migrate everything away from LazyCacheNode entirely.
+   */
+  prefetchRsc: React.ReactNode
+
+  /**
+   * A pending response for the lazy data fetch. If this is not present
+   * during render, it is lazily created.
+   */
+  lazyData: Promise<FetchServerResponseResult> | null
+
+  prefetchHead: HeadData | null
+
+  head: HeadData
+
+  loading: LoadingModuleData | Promise<LoadingModuleData>
+
+  /**
+   * Child parallel routes.
+   */
+  parallelRoutes: Map<string, ChildSegmentMap>
+
+  /**
+   * The timestamp of the navigation that last updated the CacheNode's data. If
+   * a CacheNode is reused from a previous navigation, this value is not
+   * updated. Used to track the staleness of the data.
+   */
+  navigatedAt: number
+}
+
+export type ReadyCacheNode = {
+  /**
+   * When rsc is not null, it represents the RSC data for the
+   * corresponding segment.
+   *
+   * `null` is a valid React Node but because segment data is always a
+   * <LayoutRouter> component, we can use `null` to represent empty.
+   *
+   * TODO: For additional type safety, update this type to
+   * Exclude<React.ReactNode, null>. Need to update createEmptyCacheNode to
+   * accept rsc as an argument, or just inline the callers.
+   */
+  rsc: React.ReactNode
+
+  /**
+   * Represents a static version of the segment that can be shown immediately,
+   * and may or may not contain dynamic holes. It's prefetched before a
+   * navigation occurs.
+   *
+   * During rendering, we will choose whether to render `rsc` or `prefetchRsc`
+   * with `useDeferredValue`. As with the `rsc` field, a value of `null` means
+   * no value was provided. In this case, the LayoutRouter will go straight to
+   * rendering the `rsc` value; if that one is also missing, it will suspend and
+   * trigger a lazy fetch.
+   */
+  prefetchRsc: React.ReactNode
+
+  /**
+   * There should never be a lazy data request in this case.
+   */
+  lazyData: null
+  prefetchHead: HeadData | null
+
+  head: HeadData
+
+  loading: LoadingModuleData | Promise<LoadingModuleData>
+
+  parallelRoutes: Map<string, ChildSegmentMap>
+
+  navigatedAt: number
+}
+
+export type DynamicParamTypes =
+  | 'catchall'
+  | 'catchall-intercepted'
+  | 'optional-catchall'
+  | 'dynamic'
+  | 'dynamic-intercepted'
+
+export type DynamicParamTypesShort = 'c' | 'ci' | 'oc' | 'd' | 'di'
+
+export type Segment =
+  | string
+  | [
+      // Param name
+      string,
+      // Param cache key (almost the same as the value, but arrays are
+      // concatenated into strings)
+      // TODO: We should change this to just be the value. Currently we convert
+      // it back to a value when passing to useParams. It only needs to be
+      // a string when converted to a a cache key, but that doesn't mean we
+      // need to store it as that representation.
+      string,
+      // Dynamic param type
+      DynamicParamTypesShort,
+    ]
+
+/**
+ * Router state
+ */
+export type FlightRouterState = [
+  segment: Segment,
+  parallelRoutes: { [parallelRouterKey: string]: FlightRouterState },
+  url?: string | null,
+  /**
+   * "refresh" and "refetch", despite being similarly named, have different
+   * semantics:
+   * - "refetch" is used during a request to inform the server where rendering
+   *   should start from.
+   *
+   * - "refresh" is used by the client to mark that a segment should re-fetch the
+   *   data from the server for the current segment. It uses the "url" property
+   *   above to determine where to fetch from.
+   *
+   * - "inside-shared-layout" is used during a prefetch request to inform the
+   *   server that even if the segment matches, it should be treated as if it's
+   *   within the "new" part of a navigation — inside the shared layout. If
+   *   the segment doesn't match, then it has no effect, since it would be
+   *   treated as new regardless. If it does match, though, the server does not
+   *   need to render it, because the client already has it.
+   *
+   * - "metadata-only" instructs the server to skip rendering the segments and
+   *   only send the head data.
+   *
+   *   A bit confusing, but that's because it has only one extremely narrow use
+   *   case — during a non-PPR prefetch, the server uses it to find the first
+   *   loading boundary beneath a shared layout.
+   *
+   *   TODO: We should rethink the protocol for dynamic requests. It might not
+   *   make sense for the client to send a FlightRouterState, since this type is
+   *   overloaded with concerns.
+   */
+  refresh?:
+    | 'refetch'
+    | 'refresh'
+    | 'inside-shared-layout'
+    | 'metadata-only'
+    | null,
+  isRootLayout?: boolean,
+  /**
+   * Only present when responding to a tree prefetch request. Indicates whether
+   * there is a loading boundary somewhere in the tree. The client cache uses
+   * this to determine if it can skip the data prefetch request.
+   */
+  hasLoadingBoundary?: HasLoadingBoundary,
+]
+
+export const enum HasLoadingBoundary {
+  // There is a loading boundary in this particular segment
+  SegmentHasLoadingBoundary = 1,
+  // There is a loading boundary somewhere in the subtree (but not in
+  // this segment)
+  SubtreeHasLoadingBoundary = 2,
+  // There is no loading boundary in this segment or any of its descendants
+  SubtreeHasNoLoadingBoundary = 3,
+}
+
+/**
+ * Individual Flight response path
+ */
+export type FlightSegmentPath =
+  // Uses `any` as repeating pattern can't be typed.
+  | any[]
+  // Looks somewhat like this
+  | [
+      segment: Segment,
+      parallelRouterKey: string,
+      segment: Segment,
+      parallelRouterKey: string,
+      segment: Segment,
+      parallelRouterKey: string,
+    ]
+
+/**
+ * Represents a tree of segments and the Flight data (i.e. React nodes) that
+ * correspond to each one. The tree is isomorphic to the FlightRouterState;
+ * however in the future we want to be able to fetch arbitrary partial segments
+ * without having to fetch all its children. So this response format will
+ * likely change.
+ */
+export type CacheNodeSeedData = [
+  segment: Segment,
+  node: React.ReactNode | null,
+  parallelRoutes: {
+    [parallelRouterKey: string]: CacheNodeSeedData | null
+  },
+  loading: LoadingModuleData | Promise<LoadingModuleData>,
+  isPartial: boolean,
+]
+
+export type FlightDataSegment = [
+  /* segment of the rendered slice: */ Segment,
+  /* treePatch */ FlightRouterState,
+  /* cacheNodeSeedData */ CacheNodeSeedData | null, // Can be null during prefetch if there's no loading component
+  /* head: viewport */ HeadData,
+  /* isHeadPartial */ boolean,
+]
+
+export type FlightDataPath =
+  // Uses `any` as repeating pattern can't be typed.
+  | any[]
+  // Looks somewhat like this
+  | [
+      // Holds full path to the segment.
+      ...FlightSegmentPath[],
+      ...FlightDataSegment,
+    ]
+
+/**
+ * The Flight response data
+ */
+export type FlightData = Array<FlightDataPath> | string
+
+export type ActionResult = Promise<any>
+
+export type InitialRSCPayload = {
+  /** buildId */
+  b: string
+  /** assetPrefix */
+  p: string
+  /** initialCanonicalUrlParts */
+  c: string[]
+  /** couldBeIntercepted */
+  i: boolean
+  /** initialFlightData */
+  f: FlightDataPath[]
+  /** missingSlots */
+  m: Set<string> | undefined
+  /** GlobalError */
+  G: [React.ComponentType<any>, React.ReactNode | undefined]
+  /** postponed */
+  s: boolean
+  /** prerendered */
+  S: boolean
+}
+
+// Response from `createFromFetch` for normal rendering
+export type NavigationFlightResponse = {
+  /** buildId */
+  b: string
+  /** flightData */
+  f: FlightData
+  /** prerendered */
+  S: boolean
+}
+
+// Response from `createFromFetch` for server actions. Action's flight data can be null
+export type ActionFlightResponse = {
+  /** actionResult */
+  a: ActionResult
+  /** buildId */
+  b: string
+  /** flightData */
+  f: FlightData
+}
+
+export type RSCPayload =
+  | InitialRSCPayload
+  | NavigationFlightResponse
+  | ActionFlightResponse

--- a/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
+++ b/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
@@ -1,5 +1,5 @@
 import type { DynamicParam } from '../../../../server/app-render/app-render'
-import type { DynamicParamTypesShort } from '../../../../server/app-render/types'
+import type { DynamicParamTypesShort } from '../../app-router-types'
 import type { FallbackRouteParams } from '../../../../server/request/fallback-params'
 
 /**

--- a/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
@@ -1,5 +1,5 @@
 import { PAGE_SEGMENT_KEY } from '../segment'
-import type { Segment as FlightRouterStateSegment } from '../../../server/app-render/types'
+import type { Segment as FlightRouterStateSegment } from '../app-router-types'
 
 // TypeScript trick to simulate opaque types, like in Flow.
 type Opaque<K, T> = T & { __brand: K }

--- a/packages/next/src/shared/lib/segment.ts
+++ b/packages/next/src/shared/lib/segment.ts
@@ -1,4 +1,4 @@
-import type { Segment } from '../../server/app-render/types'
+import type { Segment } from './app-router-types'
 
 export function isGroupSegment(segment: string) {
   // Use array[0] for performant purpose

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -27,10 +27,11 @@
       ]
     },
     "test/production/app-dir/browser-chunks/browser-chunks.test.ts": {
-      "passed": [],
-      "failed": [
-        "browser-chunks must not bundle any server modules into browser chunks"
-      ]
+      "passed": [
+        "browser-chunks must not bundle any server modules into browser chunks",
+        "browser-chunks must not bundle any dev overlay into browser chunks"
+      ],
+      "failed": []
     },
     "test/e2e/next-form/default/next-form-prefetch.test.ts": {
       "passed": [


### PR DESCRIPTION
This only changed the paths of types.

The types that can both used for client/server are moved to `/shared/lib/app-router-types`, the server types are still kept in `/server/app-render/types`. Currently `browser-chunks.test.ts` is failing due to `app-render/types` is included into client chunk. After this change not anymore, the client side types are from `shared/`.

This will unblock `test/production/app-dir/browser-chunks/browser-chunks.test.ts` running with cache components. 