### PR TITLE
[turbopack] Track the scope in which variables are assigned

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -18,7 +18,7 @@ use turbopack_core::{
     target::CompileTarget,
 };
 use turbopack_ecmascript::analyzer::{
-    graph::{EvalContext, VarGraph, create_graph},
+    graph::{EvalContext, VarGraph, VarMeta, create_graph},
     imports::ImportAttributes,
     linker::link,
     test_utils::{early_visitor, visitor},
@@ -98,7 +98,7 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
 
     b.to_async(rt).iter(|| async {
         let var_cache = Default::default();
-        for val in input.var_graph.values.values() {
+        for VarMeta { value, .. } in input.var_graph.values.values() {
             VcStorage::with(async {
                 let compile_time_info = CompileTimeInfo::builder(
                     Environment::new(ExecutionEnvironment::NodeJsLambda(
@@ -116,7 +116,7 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
                 .await?;
                 link(
                     &input.var_graph,
-                    val.clone(),
+                    value.clone(),
                     &early_visitor,
                     &(|val| visitor(val, compile_time_info, ImportAttributes::empty_ref())),
                     &Default::default(),

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -247,31 +247,31 @@ impl Effect {
     }
 }
 
-pub enum AssignmentKind {
-    InRootScope,
-    InFunction,
+pub enum AssignmentScope {
+    ModuleEval,
+    Function,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum AssignmentKinds {
-    AllInRootScope,
-    AllInFunction,
+pub enum AssignmentScopes {
+    AllInModuleEvalScope,
+    AllInFunctionScopes,
     Mixed,
 }
-impl AssignmentKinds {
-    fn new(initial: AssignmentKind) -> Self {
+impl AssignmentScopes {
+    fn new(initial: AssignmentScope) -> Self {
         match initial {
-            AssignmentKind::InRootScope => AssignmentKinds::AllInRootScope,
-            AssignmentKind::InFunction => AssignmentKinds::AllInFunction,
+            AssignmentScope::ModuleEval => AssignmentScopes::AllInModuleEvalScope,
+            AssignmentScope::Function => AssignmentScopes::AllInFunctionScopes,
         }
     }
 
-    fn merge(self, other: AssignmentKind) -> Self {
+    fn merge(self, other: AssignmentScope) -> Self {
         // If the other assignment kind is the same as the current one, return the current one.
         if self == Self::new(other) {
             self
         } else {
-            AssignmentKinds::Mixed
+            AssignmentScopes::Mixed
         }
     }
 }
@@ -280,18 +280,18 @@ impl AssignmentKinds {
 pub struct VarMeta {
     pub value: JsValue,
     // Tracks the locations where this was assigned to:
-    // - [AssignmentKinds::AllInRootScope] if it was assigned only in the root scope
-    // - [AssignmentKinds::AllInFunction] if it was assigned in function scopes
-    // - [AssignmentKinds::Mixed] if it was assigned in both
+    // - [AssignmentScopes::AllInModuleEvalScope] if it was assigned only in the root scope
+    // - [AssignmentScopes::AllInFunctionScopes] if it was assigned in any set of function scopes
+    // - [AssignmentScopes::Mixed] if it was assigned in both
     // This is used to track the _liveness_ of exports.
-    pub assignment_kinds: AssignmentKinds,
+    pub assignment_scopes: AssignmentScopes,
 }
 
 impl VarMeta {
-    pub fn new(value: JsValue, kind: AssignmentKind) -> Self {
+    pub fn new(value: JsValue, kind: AssignmentScope) -> Self {
         Self {
             value,
-            assignment_kinds: AssignmentKinds::new(kind),
+            assignment_scopes: AssignmentScopes::new(kind),
         }
     }
 
@@ -299,9 +299,9 @@ impl VarMeta {
         self.value.normalize();
     }
 
-    fn add_alt(&mut self, value: JsValue, kind: AssignmentKind) {
+    fn add_alt(&mut self, value: JsValue, kind: AssignmentScope) {
         self.value.add_alt(value);
-        self.assignment_kinds = self.assignment_kinds.merge(kind);
+        self.assignment_scopes = self.assignment_scopes.merge(kind);
     }
 }
 
@@ -1087,9 +1087,9 @@ impl Analyzer<'_> {
         }
 
         let kind = if self.is_in_fn() {
-            AssignmentKind::InFunction
+            AssignmentScope::Function
         } else {
-            AssignmentKind::InRootScope
+            AssignmentScope::ModuleEval
         };
         if let Some(prev) = self.data.values.get_mut(&id) {
             prev.add_alt(value, kind);

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -284,6 +284,7 @@ pub struct VarMeta {
     /// - [`AssignmentScopes::AllInFunctionScopes`] if it was assigned in any set of function
     ///   scopes
     /// - [`AssignmentScopes::Mixed`] if it was assigned in both
+    ///
     /// This is used to track the _liveness_ of exports.
     pub assignment_scopes: AssignmentScopes,
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -281,7 +281,8 @@ pub struct VarMeta {
     pub value: JsValue,
     /// Tracks the locations where this was assigned to:
     /// - [`AssignmentScopes::AllInModuleEvalScope`] if it was assigned only in the root scope
-    /// - [`AssignmentScopes::AllInFunctionScopes`] if it was assigned in any set of function scopes
+    /// - [`AssignmentScopes::AllInFunctionScopes`] if it was assigned in any set of function
+    ///   scopes
     /// - [`AssignmentScopes::Mixed`] if it was assigned in both
     /// This is used to track the _liveness_ of exports.
     pub assignment_scopes: AssignmentScopes,

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -247,10 +247,69 @@ impl Effect {
     }
 }
 
+pub enum AssignmentKind {
+    InRootScope,
+    InFunction,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum AssignmentKinds {
+    AllInRootScope,
+    AllInFunction,
+    Mixed,
+}
+impl AssignmentKinds {
+    fn new(initial: AssignmentKind) -> Self {
+        match initial {
+            AssignmentKind::InRootScope => AssignmentKinds::AllInRootScope,
+            AssignmentKind::InFunction => AssignmentKinds::AllInFunction,
+        }
+    }
+
+    fn merge(self, other: AssignmentKind) -> Self {
+        // If the other assignment kind is the same as the current one, return the current one.
+        if self == Self::new(other) {
+            self
+        } else {
+            AssignmentKinds::Mixed
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct VarMeta {
+    pub value: JsValue,
+    // Tracks the locations where this was assigned to:
+    // - [AssignmentKinds::AllInRootScope] if it was assigned only in the root scope
+    // - [AssignmentKinds::AllInFunction] if it was assigned in function scopes
+    // - [AssignmentKinds::Mixed] if it was assigned in both
+    // This is used to track the _liveness_ of exports.
+    pub assignment_kinds: AssignmentKinds,
+}
+
+impl VarMeta {
+    pub fn new(value: JsValue, kind: AssignmentKind) -> Self {
+        Self {
+            value,
+            assignment_kinds: AssignmentKinds::new(kind),
+        }
+    }
+
+    pub fn normalize(&mut self) {
+        self.value.normalize();
+    }
+
+    fn add_alt(&mut self, value: JsValue, kind: AssignmentKind) {
+        self.value.add_alt(value);
+        self.assignment_kinds = self.assignment_kinds.merge(kind);
+    }
+}
+
 #[derive(Debug)]
 pub struct VarGraph {
-    pub values: FxHashMap<Id, JsValue>,
+    pub values: FxHashMap<Id, VarMeta>,
     /// Map FreeVar names to their Id to facilitate lookups into [values]
+    /// Doesn't necessarily contain every FreeVar, just those who have non trivial values.
     pub free_var_ids: FxHashMap<Atom, Id>,
 
     pub effects: Vec<Effect>,
@@ -1027,10 +1086,15 @@ impl Analyzer<'_> {
             self.data.free_var_ids.insert(id.0.clone(), id.clone());
         }
 
-        if let Some(prev) = self.data.values.get_mut(&id) {
-            prev.add_alt(value);
+        let kind = if self.is_in_fn() {
+            AssignmentKind::InFunction
         } else {
-            self.data.values.insert(id, value);
+            AssignmentKind::InRootScope
+        };
+        if let Some(prev) = self.data.values.get_mut(&id) {
+            prev.add_alt(value, kind);
+        } else {
+            self.data.values.insert(id, VarMeta::new(value, kind));
         }
         // TODO(kdy1): We may need to report an error for this.
         // Variables declared with `var` are hoisted, but using undefined as its

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -279,11 +279,11 @@ impl AssignmentScopes {
 #[derive(Debug, Clone)]
 pub struct VarMeta {
     pub value: JsValue,
-    // Tracks the locations where this was assigned to:
-    // - [AssignmentScopes::AllInModuleEvalScope] if it was assigned only in the root scope
-    // - [AssignmentScopes::AllInFunctionScopes] if it was assigned in any set of function scopes
-    // - [AssignmentScopes::Mixed] if it was assigned in both
-    // This is used to track the _liveness_ of exports.
+    /// Tracks the locations where this was assigned to:
+    /// - [`AssignmentScopes::AllInModuleEvalScope`] if it was assigned only in the root scope
+    /// - [`AssignmentScopes::AllInFunctionScopes`] if it was assigned in any set of function scopes
+    /// - [`AssignmentScopes::Mixed`] if it was assigned in both
+    /// This is used to track the _liveness_ of exports.
     pub assignment_scopes: AssignmentScopes,
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -6,6 +6,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::ecma::ast::Id;
 
 use super::{JsValue, graph::VarGraph};
+use crate::analyzer::graph::VarMeta;
 
 pub async fn link<'a, B, RB, F, RF>(
     graph: &VarGraph,
@@ -122,11 +123,11 @@ where
                     if let Some(val) = var_cache_lock.as_deref().and_then(|cache| cache.get(&var)) {
                         total_nodes += val.total_nodes();
                         done.push(val.clone());
-                    } else if let Some(val) = graph.values.get(&var) {
+                    } else if let Some(VarMeta { value, .. }) = graph.values.get(&var) {
                         cycle_stack.insert(var.clone());
                         work_queue_stack.push(Step::LeaveVar(var));
-                        total_nodes += val.total_nodes();
-                        work_queue_stack.push(Step::Enter(val.clone()));
+                        total_nodes += value.total_nodes();
+                        work_queue_stack.push(Step::Enter(value.clone()));
                     } else {
                         total_nodes += 1;
                         done.push(JsValue::unknown(

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3813,7 +3813,10 @@ mod tests {
         graph::{ConditionalKind, Effect, EffectArg, EvalContext, VarGraph, create_graph},
         linker::link,
     };
-    use crate::analyzer::imports::ImportAttributes;
+    use crate::analyzer::{
+        graph::{AssignmentKinds, VarMeta},
+        imports::ImportAttributes,
+    };
 
     #[fixture("tests/analyzer/graph/**/input.js")]
     fn fixture(input: PathBuf) {
@@ -3873,13 +3876,17 @@ mod tests {
                 named_values.sort_by(|a, b| a.0.cmp(&b.0));
 
                 fn explain_all<'a>(
-                    values: impl IntoIterator<Item = (&'a String, &'a JsValue)>,
+                    values: impl IntoIterator<Item = (&'a String, &'a JsValue, Option<AssignmentKinds>)>,
                 ) -> String {
                     values
                         .into_iter()
-                        .map(|(id, value)| {
+                        .map(|(id, value, assignment_kinds)| {
+                            let non_root_assignments = match assignment_kinds {
+                                Some(AssignmentKinds::AllInRootScope) => " (const after eval)",
+                                _ => "",
+                            };
                             let (explainer, hints) = value.explain(10, 5);
-                            format!("{id} = {explainer}{hints}")
+                            format!("{id}{non_root_assignments} = {explainer}{hints}")
                         })
                         .collect::<Vec<_>>()
                         .join("\n\n")
@@ -3895,15 +3902,24 @@ mod tests {
                             "{:#?}",
                             named_values
                                 .iter()
-                                .map(|(name, (_, value))| (name, value))
+                                .map(|(name, (_, VarMeta {value, ..}))| (name, value))
                                 .collect::<Vec<_>>()
                         ))
                         .compare_to_file(&graph_snapshot_path)
                         .unwrap();
                     }
-                    NormalizedOutput::from(explain_all(
-                        named_values.iter().map(|(name, (_, value))| (name, value)),
-                    ))
+                    NormalizedOutput::from(explain_all(named_values.iter().map(
+                        |(
+                            name,
+                            (
+                                _,
+                                VarMeta {
+                                    value,
+                                    assignment_kinds,
+                                },
+                            ),
+                        )| (name, value, Some(*assignment_kinds)),
+                    )))
                     .compare_to_file(&graph_explained_snapshot_path)
                     .unwrap();
                     if !large {
@@ -3947,7 +3963,8 @@ mod tests {
                     }
 
                     let start = Instant::now();
-                    let explainer = explain_all(resolved.iter().map(|(name, value)| (name, value)));
+                    let explainer =
+                        explain_all(resolved.iter().map(|(name, value)| (name, value, None)));
                     let time = start.elapsed();
                     if time.as_millis() > 1 {
                         println!(
@@ -4175,7 +4192,8 @@ mod tests {
                     }
 
                     let start = Instant::now();
-                    let explainer = explain_all(resolved.iter().map(|(name, value)| (name, value)));
+                    let explainer =
+                        explain_all(resolved.iter().map(|(name, value)| (name, value, None)));
                     let time = start.elapsed();
                     if time.as_millis() > 1 {
                         println!(

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3814,7 +3814,7 @@ mod tests {
         linker::link,
     };
     use crate::analyzer::{
-        graph::{AssignmentKinds, VarMeta},
+        graph::{AssignmentScopes, VarMeta},
         imports::ImportAttributes,
     };
 
@@ -3876,13 +3876,17 @@ mod tests {
                 named_values.sort_by(|a, b| a.0.cmp(&b.0));
 
                 fn explain_all<'a>(
-                    values: impl IntoIterator<Item = (&'a String, &'a JsValue, Option<AssignmentKinds>)>,
+                    values: impl IntoIterator<
+                        Item = (&'a String, &'a JsValue, Option<AssignmentScopes>),
+                    >,
                 ) -> String {
                     values
                         .into_iter()
-                        .map(|(id, value, assignment_kinds)| {
-                            let non_root_assignments = match assignment_kinds {
-                                Some(AssignmentKinds::AllInRootScope) => " (const after eval)",
+                        .map(|(id, value, assignment_scopes)| {
+                            let non_root_assignments = match assignment_scopes {
+                                Some(AssignmentScopes::AllInModuleEvalScope) => {
+                                    " (const after eval)"
+                                }
                                 _ => "",
                             };
                             let (explainer, hints) = value.explain(10, 5);
@@ -3902,7 +3906,7 @@ mod tests {
                             "{:#?}",
                             named_values
                                 .iter()
-                                .map(|(name, (_, VarMeta {value, ..}))| (name, value))
+                                .map(|(name, (_, VarMeta { value, .. }))| (name, value))
                                 .collect::<Vec<_>>()
                         ))
                         .compare_to_file(&graph_snapshot_path)
@@ -3915,10 +3919,10 @@ mod tests {
                                 _,
                                 VarMeta {
                                     value,
-                                    assignment_kinds,
+                                    assignment_scopes,
                                 },
                             ),
-                        )| (name, value, Some(*assignment_kinds)),
+                        )| (name, value, Some(*assignment_scopes)),
                     )))
                     .compare_to_file(&graph_explained_snapshot_path)
                     .unwrap();

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph-explained.snapshot
@@ -1,8 +1,8 @@
-a = (...) => undefined
+a (const after eval) = (...) => undefined
 
-b = (...) => undefined
+b (const after eval) = (...) => undefined
 
-c = (...) => undefined
+c (const after eval) = (...) => undefined
 
 x = (1 | `${y}.js`)
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/2/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/2/graph-explained.snapshot
@@ -1,5 +1,5 @@
-x = (1 | y)
+x (const after eval) = (1 | y)
 
-y = x
+y (const after eval) = x
 
-z = x
+z (const after eval) = x

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/graph-explained.snapshot
@@ -1,16 +1,16 @@
-*anonymous function 170* = (...) => [file]
+*anonymous function 170* (const after eval) = (...) => [file]
 
-*anonymous function 254* = (...) => FreeVar(require)["resolve"](file)
+*anonymous function 254* (const after eval) = (...) => FreeVar(require)["resolve"](file)
 
-*anonymous function 88* = (...) => file
+*anonymous function 88* (const after eval) = (...) => file
 
-a = ["../lib/a.js", "../lib/b.js"]
+a (const after eval) = ["../lib/a.js", "../lib/b.js"]
 
-b = ["../lib/a.js", "../lib/b.js"]["map"](*anonymous function 88*)
+b (const after eval) = ["../lib/a.js", "../lib/b.js"]["map"](*anonymous function 88*)
 
-c = ["../lib/a.js", "../lib/b.js"]["map"](*anonymous function 170*)
+c (const after eval) = ["../lib/a.js", "../lib/b.js"]["map"](*anonymous function 170*)
 
-d = ["../lib/a.js", "../lib/b.js"]["map"](*anonymous function 254*)
+d (const after eval) = ["../lib/a.js", "../lib/b.js"]["map"](*anonymous function 254*)
 
 file#3 = arguments[0]
 
@@ -20,4 +20,4 @@ file#5 = arguments[0]
 
 file#6 = arguments[0]
 
-func = (...) => FreeVar(require)["resolve"](file)
+func (const after eval) = (...) => FreeVar(require)["resolve"](file)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph-explained.snapshot
@@ -1,17 +1,17 @@
-a = 1
+a (const after eval) = 1
 
-b = "foo"
+b (const after eval) = "foo"
 
-c = [1, "foo"][FreeVar(global)["index"]]
+c (const after eval) = [1, "foo"][FreeVar(global)["index"]]
 
-d1 = [1, "foo"]
+d1 (const after eval) = [1, "foo"]
 
-d2 = d1[FreeVar(global)["index"]]
+d2 (const after eval) = d1[FreeVar(global)["index"]]
 
-d3 = d1[1]
+d3 (const after eval) = d1[1]
 
-d4 = d1[2]
+d4 (const after eval) = d1[2]
 
-value#3 = Iterated(d1)
+value#3 (const after eval) = Iterated(d1)
 
-value#5 = Iterated([])
+value#5 (const after eval) = Iterated([])

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/arrow/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/arrow/graph-explained.snapshot
@@ -1,8 +1,8 @@
-*anonymous function 116* = (...) => 3
+*anonymous function 116* (const after eval) = (...) => 3
 
 *anonymous function 339* = (...) => 3
 
-*arrow function 11* = (...) => 1
+*arrow function 11* (const after eval) = (...) => 1
 
 *arrow function 214* = (...) => 1
 
@@ -12,27 +12,27 @@
 
 *arrow function 299* = (...) => 2
 
-*arrow function 30* = (...) => 2
+*arrow function 30* (const after eval) = (...) => 2
 
-*arrow function 50* = (...) => 1
+*arrow function 50* (const after eval) = (...) => 1
 
-*arrow function 83* = (...) => 2
+*arrow function 83* (const after eval) = (...) => 2
 
-a = *arrow function 11*
+a (const after eval) = *arrow function 11*
 
-b = *arrow function 30*
+b (const after eval) = *arrow function 30*
 
-c = *arrow function 50*
+c (const after eval) = *arrow function 50*
 
-d = *arrow function 83*
+d (const after eval) = *arrow function 83*
 
-e#2 = *anonymous function 116*
+e#2 (const after eval) = *anonymous function 116*
 
-e#6 = (...) => 4
+e#6 (const after eval) = (...) => 4
 
-f = e
+f (const after eval) = e
 
-x = (...) => undefined
+x (const after eval) = (...) => undefined
 
 xa = *arrow function 214*
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph-explained.snapshot
@@ -1,15 +1,15 @@
-a = ("" | `${a}x`)
+a (const after eval) = ("" | `${a}x`)
 
-b = (0 | ???*0*)
+b (const after eval) = (0 | ???*0*)
 - *0* unsupported assign operation
   ⚠️  This value might have side effects
 
-c = (0 | ???*0*)
+c (const after eval) = (0 | ???*0*)
 - *0* updated with update expression
   ⚠️  This value might have side effects
 
-d = (0 | 1)
+d (const after eval) = (0 | 1)
 
-e = (1 | 2)
+e (const after eval) = (1 | 2)
 
-f = (1 | 2)
+f (const after eval) = (1 | 2)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/async-lazy-init/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/async-lazy-init/graph-explained.snapshot
@@ -1,10 +1,10 @@
-computeAsyncValue = (...) => Promise<"async result">
+computeAsyncValue (const after eval) = (...) => Promise<"async result">
 
-ensureAsyncProcessStarted = (...) => lasyInitAsyncProcess
+ensureAsyncProcessStarted (const after eval) = (...) => lasyInitAsyncProcess
 
-getLasyInitAsyncValue = (...) => lasyInitAsyncValue
+getLasyInitAsyncValue (const after eval) = (...) => lasyInitAsyncValue
 
-initLasyInitAsyncProcess = (...) => Promise<undefined>
+initLasyInitAsyncProcess (const after eval) = (...) => Promise<undefined>
 
 lasyInitAsyncProcess = (null | initLasyInitAsyncProcess())
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/graph-explained.snapshot
@@ -1,10 +1,10 @@
 *arrow function 138* = (...) => undefined
 
-BaseClass = ???*0*
+BaseClass (const after eval) = ???*0*
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-SubClass = ???*0*
+SubClass (const after eval) = ???*0*
 - *0* unsupported expression
   ⚠️  This value might have side effects
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/concat/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/concat/graph-explained.snapshot
@@ -1,7 +1,7 @@
-a = ""
+a (const after eval) = ""
 
-b = "hello"
+b (const after eval) = "hello"
 
-c = "--service=0.14.12"
+c (const after eval) = "--service=0.14.12"
 
-d = "--service=0.14.12"
+d (const after eval) = "--service=0.14.12"

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/conditional-import/graph-explained.snapshot
@@ -1,13 +1,13 @@
-a = FreeVar(import)("a")
+a (const after eval) = FreeVar(import)("a")
 
-b = (???*0* | FreeVar(import)("a") | FreeVar(import)("b"))
+b (const after eval) = (???*0* | FreeVar(import)("a") | FreeVar(import)("b"))
 - *0* b
   ⚠️  pattern without value
 
-c = FreeVar(import)(
+c (const after eval) = FreeVar(import)(
     ((FreeVar(process)["env"]["NEXT_RUNTIME"] === "edge") ? "next/dist/compiled/@vercel/og/index.edge.js" : "next/dist/compiled/@vercel/og/index.node.js")
 )
 
-earlyExit = (...) => (hoisted | undefined)
+earlyExit (const after eval) = (...) => (hoisted | undefined)
 
 hoisted = (...) => undefined

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph-explained.snapshot
@@ -1,4 +1,4 @@
-*arrow function 425* = (...) => *arrow function 431*
+*arrow function 425* (const after eval) = (...) => *arrow function 431*
 
 *arrow function 431* = (...) => *arrow function 437*
 
@@ -8,7 +8,7 @@
 
 *arrow function 449* = (...) => 1
 
-*arrow function 468* = (...) => *arrow function 474*
+*arrow function 468* (const after eval) = (...) => *arrow function 474*
 
 *arrow function 474* = (...) => *arrow function 480*
 
@@ -18,7 +18,7 @@
 
 *arrow function 492* = (...) => 2
 
-*arrow function 511* = (...) => *arrow function 517*
+*arrow function 511* (const after eval) = (...) => *arrow function 517*
 
 *arrow function 517* = (...) => *arrow function 523*
 
@@ -28,7 +28,7 @@
 
 *arrow function 535* = (...) => 2
 
-*arrow function 554* = (...) => *arrow function 560*
+*arrow function 554* (const after eval) = (...) => *arrow function 560*
 
 *arrow function 560* = (...) => *arrow function 566*
 
@@ -38,13 +38,13 @@
 
 *arrow function 578* = (...) => 1
 
-a = (1 | 2 | 3 | b)
+a (const after eval) = (1 | 2 | 3 | b)
 
-b = (4 | 5 | 6 | c)
+b (const after eval) = (4 | 5 | 6 | c)
 
-c = (7 | 8 | 9 | a)
+c (const after eval) = (7 | 8 | 9 | a)
 
-d = (
+d (const after eval) = (
   | f11
   | f22
   | f32
@@ -68,122 +68,122 @@ d = (
   | fl2
 )
 
-f11 = (*arrow function 425* | *arrow function 468*)
+f11 (const after eval) = (*arrow function 425* | *arrow function 468*)
 
-f12 = (*arrow function 511* | *arrow function 554*)
+f12 (const after eval) = (*arrow function 511* | *arrow function 554*)
 
-f21 = (f11 | f12)
+f21 (const after eval) = (f11 | f12)
 
-f22 = (f12 | f11)
+f22 (const after eval) = (f12 | f11)
 
-f31 = (f21 | f22)
+f31 (const after eval) = (f21 | f22)
 
-f32 = (f22 | f21)
+f32 (const after eval) = (f22 | f21)
 
-f41 = (f31 | f32)
+f41 (const after eval) = (f31 | f32)
 
-f42 = (f32 | f31)
+f42 (const after eval) = (f32 | f31)
 
-f51 = (f41 | f42)
+f51 (const after eval) = (f41 | f42)
 
-f52 = (f42 | f41)
+f52 (const after eval) = (f42 | f41)
 
-f61 = (f51 | f52)
+f61 (const after eval) = (f51 | f52)
 
-f62 = (f52 | f51)
+f62 (const after eval) = (f52 | f51)
 
-f71 = (f61 | f62)
+f71 (const after eval) = (f61 | f62)
 
-f72 = (f62 | f61)
+f72 (const after eval) = (f62 | f61)
 
-f81 = (f71 | f72)
+f81 (const after eval) = (f71 | f72)
 
-f82 = (f72 | f71)
+f82 (const after eval) = (f72 | f71)
 
-f91 = (f81 | f82)
+f91 (const after eval) = (f81 | f82)
 
-f92 = (f82 | f81)
+f92 (const after eval) = (f82 | f81)
 
-fa1 = (f91 | f92)
+fa1 (const after eval) = (f91 | f92)
 
-fa2 = (f92 | f91)
+fa2 (const after eval) = (f92 | f91)
 
-fb1 = (fa1 | fa2)
+fb1 (const after eval) = (fa1 | fa2)
 
-fb2 = (fa2 | fa1)
+fb2 (const after eval) = (fa2 | fa1)
 
-fc1 = (fb1 | fb2)
+fc1 (const after eval) = (fb1 | fb2)
 
-fc2 = (fb2 | fb1)
+fc2 (const after eval) = (fb2 | fb1)
 
-fd1 = (fc1 | fc2)
+fd1 (const after eval) = (fc1 | fc2)
 
-fd2 = (fc2 | fc1)
+fd2 (const after eval) = (fc2 | fc1)
 
-fe1 = (fd1 | fd2)
+fe1 (const after eval) = (fd1 | fd2)
 
-fe2 = (fd2 | fd1)
+fe2 (const after eval) = (fd2 | fd1)
 
-ff1 = (fe1 | fe2)
+ff1 (const after eval) = (fe1 | fe2)
 
-ff2 = (fe2 | fe1)
+ff2 (const after eval) = (fe2 | fe1)
 
-fg1 = (ff1 | ff2)
+fg1 (const after eval) = (ff1 | ff2)
 
-fg2 = (ff2 | ff1)
+fg2 (const after eval) = (ff2 | ff1)
 
-fh1 = (fg1 | fg2)
+fh1 (const after eval) = (fg1 | fg2)
 
-fh2 = (fg2 | fg1)
+fh2 (const after eval) = (fg2 | fg1)
 
-fi1 = (fh1 | fh2)
+fi1 (const after eval) = (fh1 | fh2)
 
-fi2 = (fh2 | fh1)
+fi2 (const after eval) = (fh2 | fh1)
 
-fj1 = (fi1 | fi2)
+fj1 (const after eval) = (fi1 | fi2)
 
-fj2 = (fi2 | fi1)
+fj2 (const after eval) = (fi2 | fi1)
 
-fk1 = (fj1 | fj2)
+fk1 (const after eval) = (fj1 | fj2)
 
-fk2 = (fj2 | fj1)
+fk2 (const after eval) = (fj2 | fj1)
 
-fl1 = (fk1 | fk2)
+fl1 (const after eval) = (fk1 | fk2)
 
-fl2 = (fk2 | fk1)
+fl2 (const after eval) = (fk2 | fk1)
 
-x = (a | b | c)
+x (const after eval) = (a | b | c)
 
-x1 = (x1 | x2 | x3 | x4 | x5 | x6)
+x1 (const after eval) = (x1 | x2 | x3 | x4 | x5 | x6)
 
-x2 = (x1 | x2 | x3 | x4 | x5 | x6)
+x2 (const after eval) = (x1 | x2 | x3 | x4 | x5 | x6)
 
-x3 = (x1 | x2 | x3 | x4 | x5 | x6)
+x3 (const after eval) = (x1 | x2 | x3 | x4 | x5 | x6)
 
-x4 = (x1 | x2 | x3 | x4 | x5 | x6)
+x4 (const after eval) = (x1 | x2 | x3 | x4 | x5 | x6)
 
-x5 = (x1 | x2 | x3 | x4 | x5 | x6)
+x5 (const after eval) = (x1 | x2 | x3 | x4 | x5 | x6)
 
-x6 = (x1 | x2 | x3 | x4 | x5 | x6)
+x6 (const after eval) = (x1 | x2 | x3 | x4 | x5 | x6)
 
-y = (a | b | c | x)
+y (const after eval) = (a | b | c | x)
 
-z = (a | b | c | y)
+z (const after eval) = (a | b | c | y)
 
-z1 = z
+z1 (const after eval) = z
 
-z2 = z1
+z2 (const after eval) = z1
 
-z3 = z2
+z3 (const after eval) = z2
 
-z4 = z3
+z4 (const after eval) = z3
 
-z5 = z4
+z5 (const after eval) = z4
 
-z6 = z5
+z6 (const after eval) = z5
 
-z7 = z6
+z7 (const after eval) = z6
 
-z8 = z7
+z8 (const after eval) = z7
 
-z9 = z8
+z9 (const after eval) = z8

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph-explained.snapshot
@@ -1,25 +1,25 @@
-*anonymous function 25* = (...) => undefined
+*anonymous function 25* (const after eval) = (...) => undefined
 
-a = (...) => undefined
+a (const after eval) = (...) => undefined
 
-aa = a
+aa (const after eval) = a
 
-b = *anonymous function 25*
+b (const after eval) = *anonymous function 25*
 
-bb = b
+bb (const after eval) = b
 
-c = 123
+c (const after eval) = 123
 
-cc = c
+cc (const after eval) = c
 
-d = "hello"
+d (const after eval) = "hello"
 
-dd = d
+dd (const after eval) = d
 
-e = ???*0*
+e (const after eval) = ???*0*
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-ee = e
+ee (const after eval) = e
 
-ff = FreeVar(f)
+ff (const after eval) = FreeVar(f)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph-explained.snapshot
@@ -1,8 +1,8 @@
-*arrow function 105* = (...) => value2
+*arrow function 105* (const after eval) = (...) => value2
 
-Fun = (...) => value
+Fun (const after eval) = (...) => value
 
-Fun2 = *arrow function 105*
+Fun2 (const after eval) = *arrow function 105*
 
 value = (arguments[0]["value"] | module<./module.js, {}>["named"])
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/early-return/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/early-return/graph-explained.snapshot
@@ -1,22 +1,22 @@
-a = (...) => undefined
+a (const after eval) = (...) => undefined
 
-b = (...) => undefined
+b (const after eval) = (...) => undefined
 
-c = (...) => undefined
+c (const after eval) = (...) => undefined
 
-d = (...) => undefined
+d (const after eval) = (...) => undefined
 
-e = (...) => undefined
+e (const after eval) = (...) => undefined
 
-f = (...) => undefined
+f (const after eval) = (...) => undefined
 
-g = (...) => undefined
+g (const after eval) = (...) => undefined
 
-h = (...) => undefined
+h (const after eval) = (...) => undefined
 
-i = (...) => (FreeVar(i1)() | FreeVar(i2)())
+i (const after eval) = (...) => (FreeVar(i1)() | FreeVar(i2)())
 
-j#2 = (...) => (FreeVar(i1)() | FreeVar(i2)())
+j#2 (const after eval) = (...) => (FreeVar(i1)() | FreeVar(i2)())
 
 j#25 = arguments[0]
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild-reduced/graph-explained.snapshot
@@ -6,17 +6,17 @@ e = ???*0*
 - *0* e
   ⚠️  pattern without value
 
-generateBinPath = (...) => binPath
+generateBinPath (const after eval) = (...) => binPath
 
-knownWindowsPackages = {
+knownWindowsPackages (const after eval) = {
     "win32 arm64 LE": "esbuild-windows-arm64",
     "win32 ia32 LE": "esbuild-windows-32",
     "win32 x64 LE": "esbuild-windows-64"
 }
 
-path = FreeVar(require)("path")
+path (const after eval) = FreeVar(require)("path")
 
-path2 = FreeVar(require)("path")
+path2 (const after eval) = FreeVar(require)("path")
 
 pkg#3 = (???*0* | knownWindowsPackages[FreeVar(platformKey)])
 - *0* pkg
@@ -24,7 +24,7 @@ pkg#3 = (???*0* | knownWindowsPackages[FreeVar(platformKey)])
 
 pkg#4 = pkgAndSubpathForCurrentPlatform()["pkg"]
 
-pkgAndSubpathForCurrentPlatform = (...) => {"pkg": pkg, "subpath": subpath}
+pkgAndSubpathForCurrentPlatform (const after eval) = (...) => {"pkg": pkg, "subpath": subpath}
 
 subpath#3 = (???*0* | "esbuild.exe")
 - *0* subpath
@@ -32,4 +32,4 @@ subpath#3 = (???*0* | "esbuild.exe")
 
 subpath#4 = pkgAndSubpathForCurrentPlatform()["subpath"]
 
-x = generateBinPath()
+x (const after eval) = generateBinPath()

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph-explained.snapshot
@@ -1,4 +1,4 @@
-*arrow function 2666* = (...) => (
+*arrow function 2666* (const after eval) = (...) => (
   | [
         "node",
         [
@@ -8,7 +8,7 @@
   | [generateBinPath(), []]
 )
 
-args = esbuildCommandAndArgs()[1]
+args (const after eval) = esbuildCommandAndArgs()[1]
 
 binPath = (
   | ???*0*
@@ -20,7 +20,7 @@ binPath = (
 
 binTargetPath = path["join"](esbuildLibDir, `pnpapi-${pkg}-${path["basename"](subpath)}`)
 
-command = esbuildCommandAndArgs()[0]
+command (const after eval) = esbuildCommandAndArgs()[0]
 
 e#10 = ???*0*
 - *0* e
@@ -30,15 +30,15 @@ e#15 = ???*0*
 - *0* e
   ⚠️  pattern without value
 
-esbuildCommandAndArgs = *arrow function 2666*
+esbuildCommandAndArgs (const after eval) = *arrow function 2666*
 
 esbuildLibDir = path["dirname"](FreeVar(require)["resolve"]("esbuild"))
 
-generateBinPath = (...) => (FreeVar(ESBUILD_BINARY_PATH) | binTargetPath | binPath)
+generateBinPath (const after eval) = (...) => (FreeVar(ESBUILD_BINARY_PATH) | binTargetPath | binPath)
 
 isYarnPnP = (false | true)
 
-knownUnixlikePackages = {
+knownUnixlikePackages (const after eval) = {
     "android arm64 LE": "esbuild-android-arm64",
     "darwin arm64 LE": "esbuild-darwin-arm64",
     "darwin x64 LE": "esbuild-darwin-64",
@@ -56,17 +56,17 @@ knownUnixlikePackages = {
     "sunos x64 LE": "esbuild-sunos-64"
 }
 
-knownWindowsPackages = {
+knownWindowsPackages (const after eval) = {
     "win32 arm64 LE": "esbuild-windows-arm64",
     "win32 ia32 LE": "esbuild-windows-32",
     "win32 x64 LE": "esbuild-windows-64"
 }
 
-os = FreeVar(require)("os")
+os (const after eval) = FreeVar(require)("os")
 
-path = FreeVar(require)("path")
+path (const after eval) = FreeVar(require)("path")
 
-path2 = FreeVar(require)("path")
+path2 (const after eval) = FreeVar(require)("path")
 
 pkg#3 = (???*0* | knownWindowsPackages[platformKey] | knownUnixlikePackages[platformKey])
 - *0* pkg
@@ -74,7 +74,7 @@ pkg#3 = (???*0* | knownWindowsPackages[platformKey] | knownUnixlikePackages[plat
 
 pkg#7 = pkgAndSubpathForCurrentPlatform()["pkg"]
 
-pkgAndSubpathForCurrentPlatform = (...) => {"pkg": pkg, "subpath": subpath}
+pkgAndSubpathForCurrentPlatform (const after eval) = (...) => {"pkg": pkg, "subpath": subpath}
 
 platformKey = `${FreeVar(process)["platform"]} ${os["arch"]()} ${os["endianness"]()}`
 
@@ -84,4 +84,4 @@ subpath#3 = (???*0* | "esbuild.exe" | "bin/esbuild")
 
 subpath#7 = pkgAndSubpathForCurrentPlatform()["subpath"]
 
-x = args["concat"]("--service=0.14.12", "--ping")
+x (const after eval) = args["concat"]("--service=0.14.12", "--ping")

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph-explained.snapshot
@@ -2,12 +2,12 @@ a = arguments[0]
 
 b = arguments[1]
 
-c = (...) => [`${a}${x}`, a]
+c (const after eval) = (...) => [`${a}${x}`, a]
 
-d = c("1", "2")
+d (const after eval) = c("1", "2")
 
-e = d[0]
+e (const after eval) = d[0]
 
-f = d[1]
+f (const after eval) = d[1]
 
 x = b

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph-explained.snapshot
@@ -2,10 +2,10 @@ a = arguments[0]
 
 b = arguments[1]
 
-c = (...) => [`${a}${b}`, a]
+c (const after eval) = (...) => [`${a}${b}`, a]
 
-d = c("1", "2")
+d (const after eval) = c("1", "2")
 
-e = d[0]
+e (const after eval) = d[0]
 
-f = d[1]
+f (const after eval) = d[1]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/free-vars/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/free-vars/graph-explained.snapshot
@@ -1,1 +1,1 @@
-buf = FreeVar(Buffer)["from"]("Hello World")
+buf (const after eval) = FreeVar(Buffer)["from"]("Hello World")

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife-2/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife-2/graph-explained.snapshot
@@ -1,4 +1,4 @@
-_ = (...) => parent
+_ (const after eval) = (...) => parent
 
 i = (0 | ???*0*)
 - *0* updated with update expression
@@ -14,4 +14,4 @@ parent = arguments[2]
 
 path = arguments[1]
 
-root = {}
+root (const after eval) = {}

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife/graph-explained.snapshot
@@ -1,4 +1,4 @@
-a = FreeVar(require)
+a (const after eval) = FreeVar(require)
 
 b = a
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/import-meta-prop/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/import-meta-prop/graph-explained.snapshot
@@ -1,2 +1,2 @@
-x = import.meta*0*["prop"]
+x (const after eval) = import.meta*0*["prop"]
 - *0* import.meta: The import.meta object

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/imports/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/imports/graph-explained.snapshot
@@ -1,5 +1,5 @@
-aa = module<x2, {}>["a"]
+aa (const after eval) = module<x2, {}>["a"]
 
-xx = module<x1, {}>["default"]
+xx (const after eval) = module<x1, {}>["default"]
 
-yy = module<x3, {}>
+yy (const after eval) = module<x3, {}>

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-75938/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-75938/graph-explained.snapshot
@@ -4,11 +4,11 @@
 
 *arrow function 471* = (...) => undefined
 
-HelloWorld = ???*0*
+HelloWorld (const after eval) = ???*0*
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-Home = (...) => module<https://esm.sh/preact/jsx-runtime, {}>["jsx"](
+Home (const after eval) = (...) => module<https://esm.sh/preact/jsx-runtime, {}>["jsx"](
     "button",
     {"onClick": *arrow function 362*, "children": "Click me"}
 )

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-77083/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-77083/graph-explained.snapshot
@@ -1,1 +1,1 @@
-runGetClassesOrUseCache = (...) => ("value a" | "value b")
+runGetClassesOrUseCache (const after eval) = (...) => ("value a" | "value b")

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-77126/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-77126/graph-explained.snapshot
@@ -1,7 +1,7 @@
-*arrow function 19* = (...) => false
+*arrow function 19* (const after eval) = (...) => false
 
-run = (...) => ("should not run" | "should run")
+run (const after eval) = (...) => ("should not run" | "should run")
 
-shouldRun = *arrow function 19*
+shouldRun (const after eval) = *arrow function 19*
 
 x = (true | undefined)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph-explained.snapshot
@@ -1,29 +1,29 @@
-a = (x && y)
+a (const after eval) = (x && y)
 
-b = (x || y)
+b (const after eval) = (x || y)
 
-c = (x ?? y)
+c (const after eval) = (x ?? y)
 
-chain1 = (1 && 2 && 3 && FreeVar(global))
+chain1 (const after eval) = (1 && 2 && 3 && FreeVar(global))
 
-chain2 = ((1 && 2 && FreeVar(global)) || 3 || 4)
+chain2 (const after eval) = ((1 && 2 && FreeVar(global)) || 3 || 4)
 
-d = !(x)
+d (const after eval) = !(x)
 
-e = !(!(x))
+e (const after eval) = !(!(x))
 
-resolve1 = (1 && 2 && FreeVar(global) && 3 && 4)
+resolve1 (const after eval) = (1 && 2 && FreeVar(global) && 3 && 4)
 
-resolve2 = (1 && 2 && 0 && FreeVar(global) && 4)
+resolve2 (const after eval) = (1 && 2 && 0 && FreeVar(global) && 4)
 
-resolve3 = (FreeVar(global) || true)
+resolve3 (const after eval) = (FreeVar(global) || true)
 
-resolve4 = (true || FreeVar(global))
+resolve4 (const after eval) = (true || FreeVar(global))
 
-resolve5 = (FreeVar(global) && false)
+resolve5 (const after eval) = (FreeVar(global) && false)
 
-resolve6 = (false && FreeVar(global))
+resolve6 (const after eval) = (false && FreeVar(global))
 
-x = true
+x (const after eval) = true
 
-y = false
+y (const after eval) = false

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-explained.snapshot
@@ -74,7 +74,7 @@ i = (???*0* | 0 | (i + 16))
 
 len = arguments[1]
 
-md5cmn = (...) => FreeVar(safeAdd)(
+md5cmn (const after eval) = (...) => FreeVar(safeAdd)(
     FreeVar(bitRotateLeft)(
         FreeVar(safeAdd)(FreeVar(safeAdd)(a, q), FreeVar(safeAdd)(x, t)),
         s
@@ -82,7 +82,7 @@ md5cmn = (...) => FreeVar(safeAdd)(
     b
 )
 
-md5ff = (...) => md5cmn(???*0*, a, b, x, s, t)
+md5ff (const after eval) = (...) => md5cmn(???*0*, a, b, x, s, t)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
@@ -112,7 +112,7 @@ t#5 = arguments[5]
 
 t#6 = arguments[6]
 
-wordsToMd5 = (...) => [a, b, c, d]
+wordsToMd5 (const after eval) = (...) => [a, b, c, d]
 
 x#3 = arguments[0]
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5/graph-explained.snapshot
@@ -106,13 +106,13 @@ b#7 = (
 - *12* unsupported expression
   ⚠️  This value might have side effects
 
-bitRotateLeft = (...) => ???*0*
+bitRotateLeft (const after eval) = (...) => ???*0*
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
 bytes = (arguments[0] | new FreeVar(Array)(msg["length"]))
 
-bytesToWords = (...) => output
+bytesToWords (const after eval) = (...) => output
 
 c#15 = arguments[2]
 
@@ -272,30 +272,30 @@ lsw = (???*0* + ???*1*)
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-md5 = (...) => md5ToHexEncodedArray(wordsToMd5(bytesToWords(bytes), ???*0*))
+md5 (const after eval) = (...) => md5ToHexEncodedArray(wordsToMd5(bytesToWords(bytes), ???*0*))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-md5ToHexEncodedArray = (...) => output
+md5ToHexEncodedArray (const after eval) = (...) => output
 
-md5cmn = (...) => safeAdd(
+md5cmn (const after eval) = (...) => safeAdd(
     bitRotateLeft(safeAdd(safeAdd(a, q), safeAdd(x, t)), s),
     b
 )
 
-md5ff = (...) => md5cmn(???*0*, a, b, x, s, t)
+md5ff (const after eval) = (...) => md5cmn(???*0*, a, b, x, s, t)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-md5gg = (...) => md5cmn(???*0*, a, b, x, s, t)
+md5gg (const after eval) = (...) => md5cmn(???*0*, a, b, x, s, t)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-md5hh = (...) => md5cmn(???*0*, a, b, x, s, t)
+md5hh (const after eval) = (...) => md5cmn(???*0*, a, b, x, s, t)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-md5ii = (...) => md5cmn(???*0*, a, b, x, s, t)
+md5ii (const after eval) = (...) => md5cmn(???*0*, a, b, x, s, t)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
@@ -346,7 +346,7 @@ s#17 = arguments[5]
 
 s#18 = arguments[5]
 
-safeAdd = (...) => ???*0*
+safeAdd (const after eval) = (...) => ???*0*
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
@@ -360,7 +360,7 @@ t#17 = arguments[6]
 
 t#18 = arguments[6]
 
-wordsToMd5 = (...) => [a, b, c, d]
+wordsToMd5 (const after eval) = (...) => [a, b, c, d]
 
 x#12 = arguments[0]
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph-explained.snapshot
@@ -1,15 +1,15 @@
-array = [1, 2, 3]
+array (const after eval) = [1, 2, 3]
 
-arrays = ([1, 2, 3] | [4, 5, 6])
+arrays (const after eval) = ([1, 2, 3] | [4, 5, 6])
 
-concatenated_array = array["concat"](4, 5, 6, [7, 8, 9], `hello ${item}`)
+concatenated_array (const after eval) = array["concat"](4, 5, 6, [7, 8, 9], `hello ${item}`)
 
-concatenated_array_options = array["concat"]([7, 8, 9])
+concatenated_array_options (const after eval) = array["concat"]([7, 8, 9])
 
-item = array[1]
+item (const after eval) = array[1]
 
-item_options = arrays[1]
+item_options (const after eval) = arrays[1]
 
-pick_array1 = [[1, 2, 3]][0]["concat"]([4, 5, 6, FreeVar(unknown)])
+pick_array1 (const after eval) = [[1, 2, 3]][0]["concat"]([4, 5, 6, FreeVar(unknown)])
 
-pick_array2 = [[1, 2, 3]][0]["concat"](4, 5, 6, FreeVar(unknown))
+pick_array2 (const after eval) = [[1, 2, 3]][0]["concat"](4, 5, 6, FreeVar(unknown))

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/mongoose-reduced/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/mongoose-reduced/graph-explained.snapshot
@@ -1,5 +1,5 @@
-Collection = FreeVar(require)(`${driver}/collection`)
+Collection (const after eval) = FreeVar(require)(`${driver}/collection`)
 
-Connection = FreeVar(require)(`${driver}/connection`)
+Connection (const after eval) = FreeVar(require)(`${driver}/connection`)
 
-driver = (FreeVar(global)["MONGOOSE_DRIVER_PATH"] || "./drivers/node-mongodb-native")
+driver (const after eval) = (FreeVar(global)["MONGOOSE_DRIVER_PATH"] || "./drivers/node-mongodb-native")

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph-explained.snapshot
@@ -10,16 +10,16 @@ b#5 = arguments[0]
 
 inner = (...) => (a + b)
 
-outer = (...) => inner("b")
+outer (const after eval) = (...) => inner("b")
 
-r = (...) => (a | (r((a + 1)) + 1))
+r (const after eval) = (...) => (a | (r((a + 1)) + 1))
 
-v1 = x(1)(2)
+v1 (const after eval) = x(1)(2)
 
-v2 = r(2)
+v2 (const after eval) = r(2)
 
-v3 = outer("a")
+v3 (const after eval) = outer("a")
 
-x = (...) => y
+x (const after eval) = (...) => y
 
 y = (...) => (a + b)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested/graph-explained.snapshot
@@ -1,22 +1,22 @@
-*anonymous function 66* = (...) => undefined
+*anonymous function 66* (const after eval) = (...) => undefined
 
-*arrow function 118* = (...) => undefined
+*arrow function 118* (const after eval) = (...) => undefined
 
-*arrow function 229* = (...) => undefined
+*arrow function 229* (const after eval) = (...) => undefined
 
-a = (...) => undefined
+a (const after eval) = (...) => undefined
 
-b = *anonymous function 66*
+b (const after eval) = *anonymous function 66*
 
-c = *arrow function 118*
+c (const after eval) = *arrow function 118*
 
-d = ???*0*
+d (const after eval) = ???*0*
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-e = (...) => undefined
+e (const after eval) = (...) => undefined
 
-f = e
+f (const after eval) = e
 
 x#3 = 1
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/new-url/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/new-url/graph-explained.snapshot
@@ -1,2 +1,2 @@
-asset = new FreeVar(URL)("./worker.ts", import.meta*0*["url"])
+asset (const after eval) = new FreeVar(URL)("./worker.ts", import.meta*0*["url"])
 - *0* import.meta: The import.meta object

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-effects.snapshot
@@ -1,0 +1,225 @@
+[
+    FreeVar {
+        var: FreeVar(
+            "d1",
+        ),
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    3,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                For,
+            ),
+            ForStmt(
+                Body,
+            ),
+            Stmt(
+                Block,
+            ),
+            BlockStmt(
+                Stmts(
+                    0,
+                ),
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Assign,
+            ),
+            AssignExpr(
+                Left,
+            ),
+            AssignTarget(
+                Simple,
+            ),
+            SimpleAssignTarget(
+                Ident,
+            ),
+            BindingIdent(
+                Id,
+            ),
+        ],
+        span: 342..344,
+        in_try: false,
+    },
+    FreeVar {
+        var: FreeVar(
+            "e4",
+        ),
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    9,
+                ),
+            ),
+            ModuleItem(
+                ModuleDecl,
+            ),
+            ModuleDecl(
+                ExportNamed,
+            ),
+            NamedExport(
+                Specifiers(
+                    0,
+                ),
+            ),
+            ExportSpecifier(
+                Named,
+            ),
+            ExportNamedSpecifier(
+                Exported,
+            ),
+            ModuleExportName(
+                Ident,
+            ),
+        ],
+        span: 814..816,
+        in_try: false,
+    },
+    FreeVar {
+        var: FreeVar(
+            "setTimeout",
+        ),
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    11,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+            CallExpr(
+                Callee,
+            ),
+            Callee(
+                Expr,
+            ),
+            Expr(
+                Ident,
+            ),
+        ],
+        span: 896..906,
+        in_try: false,
+    },
+    Call {
+        func: FreeVar(
+            "setTimeout",
+        ),
+        args: [
+            Closure(
+                Variable(
+                    (
+                        "*arrow function 907*",
+                        #0,
+                    ),
+                ),
+                EffectsBlock {
+                    effects: [],
+                    range: Exact(
+                        [
+                            Program(
+                                Module,
+                            ),
+                            Module(
+                                Body(
+                                    11,
+                                ),
+                            ),
+                            ModuleItem(
+                                Stmt,
+                            ),
+                            Stmt(
+                                Expr,
+                            ),
+                            ExprStmt(
+                                Expr,
+                            ),
+                            Expr(
+                                Call,
+                            ),
+                            CallExpr(
+                                Args(
+                                    0,
+                                ),
+                            ),
+                            ExprOrSpread(
+                                Expr,
+                            ),
+                            Expr(
+                                Arrow,
+                            ),
+                            ArrowExpr(
+                                Body,
+                            ),
+                            BlockStmtOrExpr(
+                                BlockStmt,
+                            ),
+                        ],
+                    ),
+                },
+            ),
+            Value(
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            1.0,
+                        ),
+                    ),
+                ),
+            ),
+        ],
+        ast_path: [
+            Program(
+                Module,
+            ),
+            Module(
+                Body(
+                    11,
+                ),
+            ),
+            ModuleItem(
+                Stmt,
+            ),
+            Stmt(
+                Expr,
+            ),
+            ExprStmt(
+                Expr,
+            ),
+            Expr(
+                Call,
+            ),
+        ],
+        span: 896..964,
+        in_try: false,
+        new: false,
+    },
+]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-effects.snapshot
@@ -1,8 +1,6 @@
 [
     FreeVar {
-        var: FreeVar(
-            "d1",
-        ),
+        var: "d1",
         ast_path: [
             Program(
                 Module,
@@ -52,12 +50,9 @@
             ),
         ],
         span: 342..344,
-        in_try: false,
     },
     FreeVar {
-        var: FreeVar(
-            "e4",
-        ),
+        var: "e4",
         ast_path: [
             Program(
                 Module,
@@ -89,12 +84,9 @@
             ),
         ],
         span: 814..816,
-        in_try: false,
     },
     FreeVar {
-        var: FreeVar(
-            "setTimeout",
-        ),
+        var: "setTimeout",
         ast_path: [
             Program(
                 Module,
@@ -127,7 +119,6 @@
             ),
         ],
         span: 896..906,
-        in_try: false,
     },
     Call {
         func: FreeVar(

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-explained.snapshot
@@ -1,0 +1,27 @@
+*arrow function 907* (const after eval) = (...) => undefined
+
+ConstAfterEvalClass (const after eval) = ???*0*
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+
+d1 (const after eval) = 2
+
+default_function_export_const_after_eval (const after eval) = (...) => undefined
+
+i (const after eval) = (0 | ???*0*)
+- *0* updated with update expression
+  ⚠️  This value might have side effects
+
+named_const_export_const_after_eval (const after eval) = 3
+
+named_function_export_const_after_eval (const after eval) = ((...) => undefined | 2)
+
+named_let_export_const_after_eval (const after eval) = 2
+
+named_let_export_const_after_eval_2 (const after eval) = (???*0* | 5)
+- *0* named_let_export_const_after_eval_2
+  ⚠️  pattern without value
+
+named_let_export_not_const_after_eval = (1 | 5)
+
+named_let_export_not_const_after_eval_2 = (1 | 3)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph.snapshot
@@ -1,0 +1,178 @@
+[
+    (
+        "*arrow function 907*",
+        Function(
+            2,
+            907,
+            Constant(
+                Undefined,
+            ),
+        ),
+    ),
+    (
+        "ConstAfterEvalClass",
+        Unknown {
+            original_value: None,
+            reason: "unsupported expression",
+            has_side_effects: true,
+        },
+    ),
+    (
+        "d1",
+        Constant(
+            Num(
+                ConstantNumber(
+                    2.0,
+                ),
+            ),
+        ),
+    ),
+    (
+        "default_function_export_const_after_eval",
+        Function(
+            2,
+            251,
+            Constant(
+                Undefined,
+            ),
+        ),
+    ),
+    (
+        "i",
+        Alternatives {
+            total_nodes: 3,
+            values: [
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            0.0,
+                        ),
+                    ),
+                ),
+                Unknown {
+                    original_value: None,
+                    reason: "updated with update expression",
+                    has_side_effects: true,
+                },
+            ],
+            logical_property: None,
+        },
+    ),
+    (
+        "named_const_export_const_after_eval",
+        Constant(
+            Num(
+                ConstantNumber(
+                    3.0,
+                ),
+            ),
+        ),
+    ),
+    (
+        "named_function_export_const_after_eval",
+        Alternatives {
+            total_nodes: 4,
+            values: [
+                Function(
+                    2,
+                    65,
+                    Constant(
+                        Undefined,
+                    ),
+                ),
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            2.0,
+                        ),
+                    ),
+                ),
+            ],
+            logical_property: None,
+        },
+    ),
+    (
+        "named_let_export_const_after_eval",
+        Constant(
+            Num(
+                ConstantNumber(
+                    2.0,
+                ),
+            ),
+        ),
+    ),
+    (
+        "named_let_export_const_after_eval_2",
+        Alternatives {
+            total_nodes: 3,
+            values: [
+                Unknown {
+                    original_value: Some(
+                        Variable(
+                            (
+                                "named_let_export_const_after_eval_2",
+                                #2,
+                            ),
+                        ),
+                    ),
+                    reason: "pattern without value",
+                    has_side_effects: false,
+                },
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            5.0,
+                        ),
+                    ),
+                ),
+            ],
+            logical_property: None,
+        },
+    ),
+    (
+        "named_let_export_not_const_after_eval",
+        Alternatives {
+            total_nodes: 3,
+            values: [
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            1.0,
+                        ),
+                    ),
+                ),
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            5.0,
+                        ),
+                    ),
+                ),
+            ],
+            logical_property: None,
+        },
+    ),
+    (
+        "named_let_export_not_const_after_eval_2",
+        Alternatives {
+            total_nodes: 3,
+            values: [
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            1.0,
+                        ),
+                    ),
+                ),
+                Constant(
+                    Num(
+                        ConstantNumber(
+                            3.0,
+                        ),
+                    ),
+                ),
+            ],
+            logical_property: None,
+        },
+    ),
+]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/input.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/input.js
@@ -1,0 +1,41 @@
+// should be inferred as not having non-root assignments
+export function named_function_export_const_after_eval() {
+}
+
+if (true) {
+  named_function_export_const_after_eval = 2
+}
+// should be inferred as not having non-root assignments
+export default function default_function_export_const_after_eval() {
+
+}
+
+for (let i = 0; i < 10; i++) {
+  d1 = 2
+}
+// should be inferred as not having non-root assignments
+export let named_let_export_const_after_eval = 2
+
+// ditto
+export const named_const_export_const_after_eval = 3
+
+// should be inferred as not having non-root assignments
+let named_let_export_const_after_eval_2
+// should be inferred as having non-root assignments
+let named_let_export_not_const_after_eval = 1
+let named_let_export_not_const_after_eval_2 = 1
+export {named_let_export_not_const_after_eval as e4, named_let_export_const_after_eval_2}
+
+named_let_export_const_after_eval_2 = 5
+setTimeout(() => {
+  named_let_export_not_const_after_eval = 5
+}, 1);
+
+export class ConstAfterEvalClass {
+  named_class_method_export_const_after_eval() {
+    named_let_export_not_const_after_eval_2=3
+  }
+}
+
+
+

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/resolved-effects.snapshot
@@ -1,0 +1,10 @@
+0 -> 1 free var = FreeVar(d1)
+
+0 -> 2 free var = FreeVar(e4)
+
+0 -> 3 free var = FreeVar(setTimeout)
+
+0 -> 4 call = ???*0*((...) => undefined, 1)
+- *0* FreeVar(setTimeout)
+  ⚠️  unknown global
+  ⚠️  This value might have side effects

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/resolved-explained.snapshot
@@ -1,0 +1,27 @@
+*arrow function 907* = (...) => undefined
+
+ConstAfterEvalClass = ???*0*
+- *0* unsupported expression
+  ⚠️  This value might have side effects
+
+d1 = 2
+
+default_function_export_const_after_eval = (...) => undefined
+
+i = (0 | ???*0*)
+- *0* updated with update expression
+  ⚠️  This value might have side effects
+
+named_const_export_const_after_eval = 3
+
+named_function_export_const_after_eval = ((...) => undefined | 2)
+
+named_let_export_const_after_eval = 2
+
+named_let_export_const_after_eval_2 = (???*0* | 5)
+- *0* named_let_export_const_after_eval_2
+  ⚠️  pattern without value
+
+named_let_export_not_const_after_eval = (1 | 5)
+
+named_let_export_not_const_after_eval_2 = (1 | 3)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph-explained.snapshot
@@ -1,63 +1,63 @@
-a = object["a"]
+a (const after eval) = object["a"]
 
-a1 = object["a"]
+a1 (const after eval) = object["a"]
 
-a2 = object["a"]
+a2 (const after eval) = object["a"]
 
-a3 = object_spread["a"]
+a3 (const after eval) = object_spread["a"]
 
-a4 = object["a"]
+a4 (const after eval) = object["a"]
 
-a5 = unknown_spread["a"]
+a5 (const after eval) = unknown_spread["a"]
 
-a6 = object2["a"]
+a6 (const after eval) = object2["a"]
 
-b = object["b"]
+b (const after eval) = object["b"]
 
-b1 = object["b"]
+b1 (const after eval) = object["b"]
 
-b2 = object["b"]
+b2 (const after eval) = object["b"]
 
-b3 = object_spread["b"]
+b3 (const after eval) = object_spread["b"]
 
-b4 = object["b"]
+b4 (const after eval) = object["b"]
 
-b5 = unknown_spread["b"]
+b5 (const after eval) = unknown_spread["b"]
 
-b6 = object2["b"]
+b6 (const after eval) = object2["b"]
 
-c = object["c"]
+c (const after eval) = object["c"]
 
-c1 = object["c"]
+c1 (const after eval) = object["c"]
 
-c2 = object["c"]
+c2 (const after eval) = object["c"]
 
-c3 = object_spread["c"]
+c3 (const after eval) = object_spread["c"]
 
-c4 = object["c"]
+c4 (const after eval) = object["c"]
 
-c5 = unknown_spread["c"]
+c5 (const after eval) = unknown_spread["c"]
 
-c6 = object2["c"]
+c6 (const after eval) = object2["c"]
 
-d = object["d"]
+d (const after eval) = object["d"]
 
-d1 = object["d"]
+d1 (const after eval) = object["d"]
 
-d2 = object["d"]
+d2 (const after eval) = object["d"]
 
-d3 = object_spread["d"]
+d3 (const after eval) = object_spread["d"]
 
-d4 = object["d"]
+d4 (const after eval) = object["d"]
 
-d6 = object2["d"]
+d6 (const after eval) = object2["d"]
 
-e6 = object2["e"]
+e6 (const after eval) = object2["e"]
 
-object = {"a": 1, "b": 2, "c": 3}
+object (const after eval) = {"a": 1, "b": 2, "c": 3}
 
-object2 = {"a": 1, FreeVar(global): 2, "c": 3, FreeVar(global): 4, "e": 5}
+object2 (const after eval) = {"a": 1, FreeVar(global): 2, "c": 3, FreeVar(global): 4, "e": 5}
 
-object_spread = {"a": 11, ...object, "b": 22}
+object_spread (const after eval) = {"a": 11, ...object, "b": 22}
 
-unknown_spread = {"a": 1, ...FreeVar(global), "b": 2}
+unknown_spread (const after eval) = {"a": 1, ...FreeVar(global), "b": 2}

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph-explained.snapshot
@@ -12,7 +12,7 @@ clientComponentLoadTimes = (0 | (clientComponentLoadTimes + ???*0*))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-getClientComponentLoaderMetrics = (...) => metrics
+getClientComponentLoaderMetrics (const after eval) = (...) => metrics
 
 metrics = ((clientComponentLoadTimes === 0) ? undefined : {
     "clientComponentLoadTimes": clientComponentLoadTimes
@@ -24,4 +24,4 @@ options = ???*0*
 
 startTime = FreeVar(performance)["now"]()
 
-wrapClientComponentLoader = (...) => {"loadChunk": *arrow function 173*}
+wrapClientComponentLoader (const after eval) = (...) => {"loadChunk": *arrow function 173*}

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/other-free-vars/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/other-free-vars/graph-explained.snapshot
@@ -1,5 +1,5 @@
-O = FreeVar(Object)
+O (const after eval) = FreeVar(Object)
 
-a = FreeVar(Object)["keys"](O)
+a (const after eval) = FreeVar(Object)["keys"](O)
 
-b = O["keys"](FreeVar(Object))
+b (const after eval) = O["keys"](FreeVar(Object))

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2236/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2236/graph-explained.snapshot
@@ -1,1 +1,1 @@
-Redis = ((typeof(FreeVar(EdgeRuntime)) === "undefined") ? FreeVar(require)("ioredis") : module<@upstash/redis, {}>["Redis"])
+Redis (const after eval) = ((typeof(FreeVar(EdgeRuntime)) === "undefined") ? FreeVar(require)("ioredis") : module<@upstash/redis, {}>["Redis"])

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2521/graph-explained.snapshot
@@ -1,22 +1,22 @@
-err = ???*0*
+err (const after eval) = ???*0*
 - *0* err
   ⚠️  pattern without value
 
-errors = []
+errors (const after eval) = []
 
-path = Iterated(paths)
+path (const after eval) = Iterated(paths)
 
-paths = [
+paths (const after eval) = [
     `../src/build/Release/sharp-${runtimePlatform}.node`,
     "../src/build/Release/sharp-wasm32.node",
     `@img/sharp-${runtimePlatform}/sharp.node`,
     "@img/sharp-wasm32/sharp.node"
 ]
 
-runtimePlatform = runtimePlatformArch()
+runtimePlatform (const after eval) = runtimePlatformArch()
 
-runtimePlatformArch = FreeVar(require)("./libvips")["runtimePlatformArch"]
+runtimePlatformArch (const after eval) = FreeVar(require)("./libvips")["runtimePlatformArch"]
 
-sharp = (???*0* | FreeVar(require)(path))
+sharp (const after eval) = (???*0* | FreeVar(require)(path))
 - *0* sharp
   ⚠️  pattern without value

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/graph-explained.snapshot
@@ -1,12 +1,12 @@
-*arrow function 24* = (...) => FreeVar(JSON)["stringify"](
+*arrow function 24* (const after eval) = (...) => FreeVar(JSON)["stringify"](
     {
         "condition": (variable === "true"),
         "buggedConditionalCheck": ((variable === "true") ? "true" : "false")
     }
 )
 
-BuggyArguments = *arrow function 24*
+BuggyArguments (const after eval) = *arrow function 24*
 
-res = BuggyArguments({"variable": "false"})
+res (const after eval) = BuggyArguments({"variable": "false"})
 
 variable = (arguments[0]["variable"] | "true")

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/path-join/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/path-join/graph-explained.snapshot
@@ -1,23 +1,23 @@
-a = FreeVar(require)("foo")
+a (const after eval) = FreeVar(require)("foo")
 
-p1 = FreeVar(require)("path")
+p1 (const after eval) = FreeVar(require)("path")
 
-path = FreeVar(require)("path")
+path (const after eval) = FreeVar(require)("path")
 
-path_join1 = p1["join"]
+path_join1 (const after eval) = p1["join"]
 
-path_join2 = module<path, {}>["default"]["join"]
+path_join2 (const after eval) = module<path, {}>["default"]["join"]
 
-path_join3 = module<path, {}>["join"]
+path_join3 (const after eval) = module<path, {}>["join"]
 
-path_join4 = await(FreeVar(import)("path"))["join"]
+path_join4 (const after eval) = await(FreeVar(import)("path"))["join"]
 
-z1_joined = path["join"]("foo", "bar")
+z1_joined (const after eval) = path["join"]("foo", "bar")
 
-z2_joined = path["join"]("foo/", "bar")
+z2_joined (const after eval) = path["join"]("foo/", "bar")
 
-z3_joined = path["join"]("foo", "/bar")
+z3_joined (const after eval) = path["join"]("foo", "/bar")
 
-z4_joined = path["join"]("foo/", "/bar")
+z4_joined (const after eval) = path["join"]("foo/", "/bar")
 
-z5_joined = path["join"]("foo", "bar", "..", "baz", FreeVar(global), "..", "foo")
+z5_joined (const after eval) = path["join"]("foo", "bar", "..", "baz", FreeVar(global), "..", "foo")

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pattern-assignment/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pattern-assignment/graph-explained.snapshot
@@ -1,7 +1,7 @@
-arrPatternBool = (true | false)
+arrPatternBool (const after eval) = (true | false)
 
-nestedPatternBool = ({"inner": [true]}["inner"][0] | {"inner": [false]}["inner"][0])
+nestedPatternBool (const after eval) = ({"inner": [true]}["inner"][0] | {"inner": [false]}["inner"][0])
 
-objPatternBool = ({"objPatternBool": true}["objPatternBool"] | {"objPatternBool": false}["objPatternBool"])
+objPatternBool (const after eval) = ({"objPatternBool": true}["objPatternBool"] | {"objPatternBool": false}["objPatternBool"])
 
-singleAssignBool = {"singleAssignBool": true}["singleAssignBool"]
+singleAssignBool (const after eval) = {"singleAssignBool": true}["singleAssignBool"]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/graph-explained.snapshot
@@ -140,7 +140,7 @@
 
 *anonymous function 5936* = (...) => {"type": "sort_expression", "expression": expression, "order": order}
 
-*anonymous function 625* = (...) => `Expected ${describeExpected(expected)} but ${describeFound(found)} found.`
+*anonymous function 625* (const after eval) = (...) => `Expected ${describeExpected(expected)} but ${describeFound(found)} found.`
 
 *anonymous function 6287* = (...) => {"type": "scalar_function_expression", "name": name, "arguments": args, "udf": true}
 
@@ -483,7 +483,7 @@ parts = arguments[0]
 
 peg$FAILED = {}
 
-peg$SyntaxError = (...) => undefined
+peg$SyntaxError (const after eval) = (...) => undefined
 
 peg$anyExpectation = (...) => {"type": "any"}
 
@@ -1083,7 +1083,7 @@ peg$maxFailPos = (0 | peg$currPos)
 
 peg$otherExpectation = (...) => {"type": "other", "description": description}
 
-peg$parse = (...) => (peg$result | undefined)
+peg$parse (const after eval) = (...) => (peg$result | undefined)
 
 peg$parse_ = (...) => s0
 
@@ -1364,7 +1364,7 @@ peg$startRuleFunction = (peg$parsesql | peg$startRuleFunctions[options["startRul
 
 peg$startRuleFunctions = {"sql": peg$parsesql}
 
-peg$subclass = (...) => undefined
+peg$subclass (const after eval) = (...) => undefined
 
 pos = arguments[0]
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/process-and-os/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/process-and-os/graph-explained.snapshot
@@ -1,31 +1,31 @@
-arch = FreeVar(require)("os")["arch"]
+arch (const after eval) = FreeVar(require)("os")["arch"]
 
-binding1 = FreeVar(require)(
+binding1 (const after eval) = FreeVar(require)(
     `esbuild-${FreeVar(process)["arch"]}-${platform()}-${endianness()}`
 )
 
-binding2 = FreeVar(require)(`esbuild-${arch()}-${platform()}-${endianness()}`)
+binding2 (const after eval) = FreeVar(require)(`esbuild-${arch()}-${platform()}-${endianness()}`)
 
-binding3 = FreeVar(require)(
+binding3 (const after eval) = FreeVar(require)(
     `esbuild-${arch()}-${FreeVar(process)["platform"]}-${endianness()}`
 )
 
-binding4 = FreeVar(require)(
+binding4 (const after eval) = FreeVar(require)(
     `esbuild-${FreeVar(process)["arch"]}-${FreeVar(process)["platform"]}-${endianness()}`
 )
 
-binding5 = FreeVar(require)(
+binding5 (const after eval) = FreeVar(require)(
     `esbuild-${p["arch"]}-${p["platform"]}-${endianness()}`
 )
 
-binding6 = FreeVar(require)(
+binding6 (const after eval) = FreeVar(require)(
     `esbuild-${p["arch"]}-${processPlatform}-${endianness()}`
 )
 
-endianness = FreeVar(require)("os")["endianness"]
+endianness (const after eval) = FreeVar(require)("os")["endianness"]
 
-p = FreeVar(process)
+p (const after eval) = FreeVar(process)
 
-platform = FreeVar(require)("os")["platform"]
+platform (const after eval) = FreeVar(require)("os")["platform"]
 
-processPlatform = FreeVar(require)("process")["platform"]
+processPlatform (const after eval) = FreeVar(require)("process")["platform"]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/graph-explained.snapshot
@@ -2,19 +2,19 @@ $a = (???*0* | nd() | he(c) | (ce ? je(a, c) : ke(a, c)))
 - *0* $a
   ⚠️  pattern without value
 
-$b = (...) => (a | b | null)
+$b (const after eval) = (...) => (a | b | null)
 
-$c = (...) => undefined
+$c (const after eval) = (...) => undefined
 
-$d = [9, 13, 27, 32]
+$d (const after eval) = [9, 13, 27, 32]
 
-$e = Ze("animationend")
+$e (const after eval) = Ze("animationend")
 
-$f = (...) => undefined
+$f (const after eval) = (...) => undefined
 
 $g = (!(1) | !(0))
 
-$h = {
+$h (const after eval) = {
     "readContext": Vg,
     "useCallback": Bi,
     "useContext": Vg,
@@ -35,9 +35,9 @@ $h = {
     "unstable_isNewReconciler": !(1)
 }
 
-$i = (...) => (null | b["child"])
+$i (const after eval) = (...) => (null | b["child"])
 
-$k = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
+$k (const after eval) = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 10089* = (...) => d
 
@@ -51,7 +51,7 @@ $k = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 114743* = (...) => null
 
-*anonymous function 117815* = (...) => (
+*anonymous function 117815* (const after eval) = (...) => (
   | zj(a, b, c)
   | b
   | ???*0*
@@ -65,15 +65,15 @@ $k = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-*anonymous function 126145* = (...) => undefined
+*anonymous function 126145* (const after eval) = (...) => undefined
 
-*anonymous function 126252* = (...) => undefined
+*anonymous function 126252* (const after eval) = (...) => undefined
 
-*anonymous function 126382* = (...) => undefined
+*anonymous function 126382* (const after eval) = (...) => undefined
 
 *anonymous function 126480* = (...) => undefined
 
-*anonymous function 126604* = (...) => undefined
+*anonymous function 126604* (const after eval) = (...) => undefined
 
 *anonymous function 127055* = (...) => undefined
 
@@ -83,37 +83,37 @@ $k = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 127571* = (...) => undefined
 
-*anonymous function 127654* = (...) => undefined
+*anonymous function 127654* (const after eval) = (...) => undefined
 
 *anonymous function 127846* = (...) => undefined
 
-*anonymous function 127923* = (...) => undefined
+*anonymous function 127923* (const after eval) = (...) => undefined
 
-*anonymous function 128036* = (...) => undefined
+*anonymous function 128036* (const after eval) = (...) => undefined
 
-*anonymous function 128133* = (...) => C
+*anonymous function 128133* (const after eval) = (...) => C
 
-*anonymous function 128157* = (...) => (b() | undefined)
+*anonymous function 128157* (const after eval) = (...) => (b() | undefined)
 
-*anonymous function 128216* = (...) => undefined
+*anonymous function 128216* (const after eval) = (...) => undefined
 
-*anonymous function 129223* = (...) => ((null === a) ? null : a["stateNode"])
+*anonymous function 129223* (const after eval) = (...) => ((null === a) ? null : a["stateNode"])
 
-*anonymous function 129753* = (...) => dl(a, b, null, c)
+*anonymous function 129753* (const after eval) = (...) => dl(a, b, null, c)
 
-*anonymous function 129905* = (...) => new ml(b)
+*anonymous function 129905* (const after eval) = (...) => new ml(b)
 
-*anonymous function 130256* = (...) => (null | a)
+*anonymous function 130256* (const after eval) = (...) => (null | a)
 
-*anonymous function 130523* = (...) => Sk(a)
+*anonymous function 130523* (const after eval) = (...) => Sk(a)
 
-*anonymous function 130565* = (...) => sl(null, a, b, !(0), c)
+*anonymous function 130565* (const after eval) = (...) => sl(null, a, b, !(0), c)
 
-*anonymous function 130658* = (...) => new nl(b)
+*anonymous function 130658* (const after eval) = (...) => new nl(b)
 
-*anonymous function 131212* = (...) => sl(null, a, b, !(1), c)
+*anonymous function 131212* (const after eval) = (...) => sl(null, a, b, !(1), c)
 
-*anonymous function 131315* = (...) => (a["_reactRootContainer"] ? ???*0* : !(1))
+*anonymous function 131315* (const after eval) = (...) => (a["_reactRootContainer"] ? ???*0* : !(1))
 - *0* !(0)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -122,31 +122,31 @@ $k = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 131418* = (...) => undefined
 
-*anonymous function 131559* = (...) => sl(a, b, c, !(1), d)
+*anonymous function 131559* (const after eval) = (...) => sl(a, b, c, !(1), d)
 
 *anonymous function 13525* = (...) => undefined
 
 *anonymous function 13573* = (...) => a(b, c, d, e)
 
-*anonymous function 13608* = (...) => undefined
+*anonymous function 13608* (const after eval) = (...) => undefined
 
-*anonymous function 14731* = (...) => undefined
+*anonymous function 14731* (const after eval) = (...) => undefined
 
 *anonymous function 14754* = (...) => undefined
 
-*anonymous function 17157* = (...) => undefined
+*anonymous function 17157* (const after eval) = (...) => undefined
 
-*anonymous function 17435* = (...) => undefined
+*anonymous function 17435* (const after eval) = (...) => undefined
 
-*anonymous function 2285* = (...) => undefined
+*anonymous function 2285* (const after eval) = (...) => undefined
 
 *anonymous function 23424* = (...) => undefined
 
-*anonymous function 2443* = (...) => undefined
+*anonymous function 2443* (const after eval) = (...) => undefined
 
-*anonymous function 2564* = (...) => undefined
+*anonymous function 2564* (const after eval) = (...) => undefined
 
-*anonymous function 2705* = (...) => undefined
+*anonymous function 2705* (const after eval) = (...) => undefined
 
 *anonymous function 27645* = (...) => undefined
 
@@ -154,21 +154,21 @@ $k = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 28013* = (...) => undefined
 
-*anonymous function 28108* = (...) => (a["timeStamp"] || FreeVar(Date)["now"]())
+*anonymous function 28108* (const after eval) = (...) => (a["timeStamp"] || FreeVar(Date)["now"]())
 
-*anonymous function 28404* = (...) => ((undefined === a["relatedTarget"]) ? ((a["fromElement"] === a["srcElement"]) ? a["toElement"] : a["fromElement"]) : a["relatedTarget"])
+*anonymous function 28404* (const after eval) = (...) => ((undefined === a["relatedTarget"]) ? ((a["fromElement"] === a["srcElement"]) ? a["toElement"] : a["fromElement"]) : a["relatedTarget"])
 
-*anonymous function 28530* = (...) => (a["movementX"] | wd)
+*anonymous function 28530* (const after eval) = (...) => (a["movementX"] | wd)
 
-*anonymous function 28699* = (...) => (???*0* ? a["movementY"] : xd)
+*anonymous function 28699* (const after eval) = (...) => (???*0* ? a["movementY"] : xd)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-*anonymous function 28936* = (...) => (???*0* ? a["clipboardData"] : FreeVar(window)["clipboardData"])
+*anonymous function 28936* (const after eval) = (...) => (???*0* ? a["clipboardData"] : FreeVar(window)["clipboardData"])
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-*anonymous function 29891* = (...) => (
+*anonymous function 29891* (const after eval) = (...) => (
   | b
   | (("keypress" === a["type"]) ? ???*0* : ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? (Nd[a["keyCode"]] || "Unidentified") : ""))
 )
@@ -176,15 +176,15 @@ $k = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-*anonymous function 3008* = (...) => undefined
+*anonymous function 3008* (const after eval) = (...) => undefined
 
-*anonymous function 30217* = (...) => (("keypress" === a["type"]) ? od(a) : 0)
+*anonymous function 30217* (const after eval) = (...) => (("keypress" === a["type"]) ? od(a) : 0)
 
-*anonymous function 30272* = (...) => ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0)
+*anonymous function 30272* (const after eval) = (...) => ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0)
 
-*anonymous function 30346* = (...) => (("keypress" === a["type"]) ? od(a) : ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0))
+*anonymous function 30346* (const after eval) = (...) => (("keypress" === a["type"]) ? od(a) : ((("keydown" === a["type"]) || ("keyup" === a["type"])) ? a["keyCode"] : 0))
 
-*anonymous function 30803* = (...) => (???*0* ? a["deltaX"] : (???*1* ? ???*2* : 0))
+*anonymous function 30803* (const after eval) = (...) => (???*0* ? a["deltaX"] : (???*1* ? ???*2* : 0))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
@@ -192,7 +192,7 @@ $k = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
-*anonymous function 30887* = (...) => (???*0* ? a["deltaY"] : (???*1* ? ???*2* : (???*3* ? ???*4* : 0)))
+*anonymous function 30887* (const after eval) = (...) => (???*0* ? a["deltaY"] : (???*1* ? ???*2* : (???*3* ? ???*4* : 0)))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
@@ -204,39 +204,39 @@ $k = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 - *4* unsupported expression
   ⚠️  This value might have side effects
 
-*anonymous function 3119* = (...) => undefined
+*anonymous function 3119* (const after eval) = (...) => undefined
 
-*anonymous function 3196* = (...) => undefined
+*anonymous function 3196* (const after eval) = (...) => undefined
 
-*anonymous function 3280* = (...) => undefined
+*anonymous function 3280* (const after eval) = (...) => undefined
 
-*anonymous function 3354* = (...) => undefined
+*anonymous function 3354* (const after eval) = (...) => undefined
 
 *anonymous function 39904* = (...) => undefined
 
 *anonymous function 40883* = (...) => undefined
 
-*anonymous function 4580* = (...) => undefined
+*anonymous function 4580* (const after eval) = (...) => undefined
 
-*anonymous function 45964* = (...) => Hf["resolve"](null)["then"](a)["catch"](If)
+*anonymous function 45964* (const after eval) = (...) => Hf["resolve"](null)["then"](a)["catch"](If)
 
 *anonymous function 46048* = (...) => undefined
 
-*anonymous function 4744* = (...) => undefined
+*anonymous function 4744* (const after eval) = (...) => undefined
 
-*anonymous function 4883* = (...) => undefined
+*anonymous function 4883* (const after eval) = (...) => undefined
 
-*anonymous function 5021* = (...) => undefined
+*anonymous function 5021* (const after eval) = (...) => undefined
 
-*anonymous function 5213* = (...) => undefined
+*anonymous function 5213* (const after eval) = (...) => undefined
 
-*anonymous function 55504* = (...) => (a["_reactInternals"] ? (Vb(a) === a) : !(1))
+*anonymous function 55504* (const after eval) = (...) => (a["_reactInternals"] ? (Vb(a) === a) : !(1))
 
-*anonymous function 55574* = (...) => undefined
+*anonymous function 55574* (const after eval) = (...) => undefined
 
-*anonymous function 55754* = (...) => undefined
+*anonymous function 55754* (const after eval) = (...) => undefined
 
-*anonymous function 55941* = (...) => undefined
+*anonymous function 55941* (const after eval) = (...) => undefined
 
 *anonymous function 58064* = (...) => undefined
 
@@ -254,41 +254,41 @@ $k = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 69089* = (...) => undefined
 
-*anonymous function 71076* = (...) => a
+*anonymous function 71076* (const after eval) = (...) => a
 
-*anonymous function 71188* = (...) => ti(4194308, 4, yi["bind"](null, b, a), c)
+*anonymous function 71188* (const after eval) = (...) => ti(4194308, 4, yi["bind"](null, b, a), c)
 
-*anonymous function 71305* = (...) => ti(4194308, 4, a, b)
+*anonymous function 71305* (const after eval) = (...) => ti(4194308, 4, a, b)
 
-*anonymous function 71364* = (...) => ti(4, 2, a, b)
+*anonymous function 71364* (const after eval) = (...) => ti(4, 2, a, b)
 
-*anonymous function 71406* = (...) => a
+*anonymous function 71406* (const after eval) = (...) => a
 
-*anonymous function 71500* = (...) => [d["memoizedState"], a]
+*anonymous function 71500* (const after eval) = (...) => [d["memoizedState"], a]
 
-*anonymous function 71750* = (...) => a
+*anonymous function 71750* (const after eval) = (...) => a
 
-*anonymous function 71860* = (...) => a
+*anonymous function 71860* (const after eval) = (...) => a
 
-*anonymous function 71915* = (...) => [b, a]
+*anonymous function 71915* (const after eval) = (...) => [b, a]
 
-*anonymous function 72018* = (...) => undefined
+*anonymous function 72018* (const after eval) = (...) => undefined
 
-*anonymous function 72052* = (...) => c
+*anonymous function 72052* (const after eval) = (...) => c
 
-*anonymous function 72352* = (...) => b
+*anonymous function 72352* (const after eval) = (...) => b
 
-*anonymous function 72781* = (...) => fi(ei)
+*anonymous function 72781* (const after eval) = (...) => fi(ei)
 
-*anonymous function 72842* = (...) => Di(b, O["memoizedState"], a)
+*anonymous function 72842* (const after eval) = (...) => Di(b, O["memoizedState"], a)
 
-*anonymous function 72911* = (...) => [a, b]
+*anonymous function 72911* (const after eval) = (...) => [a, b]
 
-*anonymous function 73223* = (...) => gi(ei)
+*anonymous function 73223* (const after eval) = (...) => gi(ei)
 
-*anonymous function 73283* = (...) => ((null === O) ? a : Di(b, O["memoizedState"], a))
+*anonymous function 73283* (const after eval) = (...) => ((null === O) ? a : Di(b, O["memoizedState"], a))
 
-*anonymous function 73380* = (...) => [a, b]
+*anonymous function 73380* (const after eval) = (...) => [a, b]
 
 *anonymous function 73860* = (...) => undefined
 
@@ -300,13 +300,13 @@ $k = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 74327* = (...) => undefined
 
-*anonymous function 86042* = (...) => undefined
+*anonymous function 86042* (const after eval) = (...) => undefined
 
-*anonymous function 86340* = (...) => undefined
+*anonymous function 86340* (const after eval) = (...) => undefined
 
-*anonymous function 86357* = (...) => undefined
+*anonymous function 86357* (const after eval) = (...) => undefined
 
-*anonymous function 87803* = (...) => undefined
+*anonymous function 87803* (const after eval) = (...) => undefined
 
 *anonymous function 9947* = (...) => e["call"](???*0*)
 - *0* unsupported expression
@@ -314,15 +314,15 @@ $k = (...) => ((bj(a) ? 1 : 0) | 11 | 14 | 2)
 
 *anonymous function 9983* = (...) => undefined
 
-A = FreeVar(Object)["assign"]
+A (const after eval) = FreeVar(Object)["assign"]
 
-Aa = FreeVar(Symbol)["for"]("react.profiler")
+Aa (const after eval) = FreeVar(Symbol)["for"]("react.profiler")
 
 Ab = (null | [a])
 
-Ac = (...) => undefined
+Ac (const after eval) = (...) => undefined
 
-Ad = A(
+Ad (const after eval) = A(
     {},
     ud,
     {
@@ -345,43 +345,43 @@ Ad = A(
     }
 )
 
-Ae = (...) => undefined
+Ae (const after eval) = (...) => undefined
 
-Af = (...) => undefined
+Af (const after eval) = (...) => undefined
 
-Ag = (...) => undefined
+Ag (const after eval) = (...) => undefined
 
-Ah = (...) => a
+Ah (const after eval) = (...) => a
 
-Ai = (...) => undefined
+Ai (const after eval) = (...) => undefined
 
-Aj = (???*0* | *anonymous function 86042*)
+Aj (const after eval) = (???*0* | *anonymous function 86042*)
 - *0* Aj
   ⚠️  pattern without value
 
 Ak = (null | a)
 
-B = ca["unstable_now"]
+B (const after eval) = ca["unstable_now"]
 
-Ba = FreeVar(Symbol)["for"]("react.provider")
+Ba (const after eval) = FreeVar(Symbol)["for"]("react.provider")
 
-Bb = (...) => undefined
+Bb (const after eval) = (...) => undefined
 
-Bc = (...) => undefined
+Bc (const after eval) = (...) => undefined
 
-Bd = rd(Ad)
+Bd (const after eval) = rd(Ad)
 
-Be = (...) => undefined
+Be (const after eval) = (...) => undefined
 
-Bf = (...) => undefined
+Bf (const after eval) = (...) => undefined
 
-Bg = (...) => new al(a, b, c, d)
+Bg (const after eval) = (...) => new al(a, b, c, d)
 
-Bh = vh(!(0))
+Bh (const after eval) = vh(!(0))
 
-Bi = (...) => (d[0] | a)
+Bi (const after eval) = (...) => (d[0] | a)
 
-Bj = (???*0* | *anonymous function 86340*)
+Bj (const after eval) = (???*0* | *anonymous function 86340*)
 - *0* Bj
   ⚠️  pattern without value
 
@@ -411,22 +411,22 @@ C = (
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-Ca = FreeVar(Symbol)["for"]("react.context")
+Ca (const after eval) = FreeVar(Symbol)["for"]("react.context")
 
-Cb = (...) => ((
+Cb (const after eval) = (...) => ((
  || !(a)
  || ((5 !== a["tag"]) && (6 !== a["tag"]) && (13 !== a["tag"]) && (3 !== a["tag"]))
 ) ? null : a)
 
-Cc = (...) => undefined
+Cc (const after eval) = (...) => undefined
 
-Cd = A({}, Ad, {"dataTransfer": 0})
+Cd (const after eval) = A({}, Ad, {"dataTransfer": 0})
 
-Ce = (...) => undefined
+Ce (const after eval) = (...) => undefined
 
 Cf = (null | dd)
 
-Cg = (...) => (
+Cg (const after eval) = (...) => (
   | ((null !== b) ? ???*0* : !(1))
   | ((null !== b) ? !(0) : !(1))
   | ((null !== b) ? ???*1* : !(1))
@@ -440,23 +440,23 @@ Cg = (...) => (
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-Ch = vh(!(1))
+Ch (const after eval) = vh(!(1))
 
-Ci = (...) => (d[0] | a)
+Ci (const after eval) = (...) => (d[0] | a)
 
-Cj = (???*0* | *anonymous function 86357*)
+Cj (const after eval) = (???*0* | *anonymous function 86357*)
 - *0* Cj
   ⚠️  pattern without value
 
 Ck = (0 | yc())
 
-D = (...) => undefined
+D (const after eval) = (...) => undefined
 
-Da = FreeVar(Symbol)["for"]("react.forward_ref")
+Da (const after eval) = FreeVar(Symbol)["for"]("react.forward_ref")
 
-Db = (...) => (a[Pf] || null)
+Db (const after eval) = (...) => (a[Pf] || null)
 
-Dc = (...) => (???*0* ? (???*1* ? ((0 !== ???*2*) ? 16 : 536870912) : 4) : 1)
+Dc (const after eval) = (...) => (???*0* ? (???*1* ? ((0 !== ???*2*) ? 16 : 536870912) : 4) : 1)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
@@ -464,43 +464,43 @@ Dc = (...) => (???*0* ? (???*1* ? ((0 !== ???*2*) ? 16 : 536870912) : 4) : 1)
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
-Dd = rd(Cd)
+Dd (const after eval) = rd(Cd)
 
-De = (...) => (te(qe) | undefined)
+De (const after eval) = (...) => (te(qe) | undefined)
 
 Df = (null | {"focusedElem": a, "selectionRange": c})
 
-Dg = (...) => ((0 !== ???*0*) && (0 === ???*1*))
+Dg (const after eval) = (...) => ((0 !== ???*0*) && (0 === ???*1*))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-Dh = {}
+Dh (const after eval) = {}
 
-Di = (...) => (c | b)
+Di (const after eval) = (...) => (c | b)
 
-Dj = (???*0* | *anonymous function 87803*)
+Dj (const after eval) = (???*0* | *anonymous function 87803*)
 - *0* Dj
   ⚠️  pattern without value
 
-Dk = (...) => undefined
+Dk (const after eval) = (...) => undefined
 
-E = (...) => undefined
+E (const after eval) = (...) => undefined
 
-Ea = FreeVar(Symbol)["for"]("react.suspense")
+Ea (const after eval) = FreeVar(Symbol)["for"]("react.suspense")
 
-Eb = (...) => undefined
+Eb (const after eval) = (...) => undefined
 
-Ec = (???*0* | *anonymous function 127654*)
+Ec (const after eval) = (???*0* | *anonymous function 127654*)
 - *0* Ec
   ⚠️  pattern without value
 
-Ed = A({}, ud, {"relatedTarget": 0})
+Ed (const after eval) = A({}, ud, {"relatedTarget": 0})
 
-Ee = (...) => (te(b) | undefined)
+Ee (const after eval) = (...) => (te(b) | undefined)
 
-Ef = (...) => (
+Ef (const after eval) = (...) => (
  || ("textarea" === a)
  || ("noscript" === a)
  || ("string" === typeof(b["children"]))
@@ -512,15 +512,15 @@ Ef = (...) => (
     )
 )
 
-Eg = (...) => undefined
+Eg (const after eval) = (...) => undefined
 
-Eh = Uf(Dh)
+Eh (const after eval) = Uf(Dh)
 
-Ei = (...) => undefined
+Ei (const after eval) = (...) => undefined
 
-Ej = (...) => undefined
+Ej (const after eval) = (...) => undefined
 
-Ek = (...) => undefined
+Ek (const after eval) = (...) => undefined
 
 F#292 = (u["stateNode"] | undefined | Kb(w, x) | "onMouseLeave" | "onPointerLeave" | null | t | x | vf(F))
 
@@ -536,129 +536,129 @@ F#843 = (Ri(f, h, b) | undefined)
 
 F#883 = (h["sibling"] | undefined)
 
-Fa = FreeVar(Symbol)["for"]("react.suspense_list")
+Fa (const after eval) = FreeVar(Symbol)["for"]("react.suspense_list")
 
-Fb = (...) => undefined
+Fb (const after eval) = (...) => undefined
 
-Fc = (???*0* | *anonymous function 127923*)
+Fc (const after eval) = (???*0* | *anonymous function 127923*)
 - *0* Fc
   ⚠️  pattern without value
 
-Fd = rd(Ed)
+Fd (const after eval) = rd(Ed)
 
-Fe = (...) => (te(b) | undefined)
+Fe (const after eval) = (...) => (te(b) | undefined)
 
-Ff = (("function" === typeof(FreeVar(setTimeout))) ? FreeVar(setTimeout) : undefined)
+Ff (const after eval) = (("function" === typeof(FreeVar(setTimeout))) ? FreeVar(setTimeout) : undefined)
 
-Fg = (...) => undefined
+Fg (const after eval) = (...) => undefined
 
-Fh = Uf(Dh)
+Fh (const after eval) = Uf(Dh)
 
-Fi = (...) => di()["memoizedState"]
+Fi (const after eval) = (...) => di()["memoizedState"]
 
-Fj = (...) => (???*0* | null | (???*1* ? b : null) | b | b["child"] | undefined)
+Fj (const after eval) = (...) => (???*0* | null | (???*1* ? b : null) | b | b["child"] | undefined)
 - *0* null
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-Fk = (...) => (???*0* | null)
+Fk (const after eval) = (...) => (???*0* | null)
 - *0* null
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-G = (...) => undefined
+G (const after eval) = (...) => undefined
 
-Ga = FreeVar(Symbol)["for"]("react.memo")
+Ga (const after eval) = FreeVar(Symbol)["for"]("react.memo")
 
-Gb = ((...) => a(b) | Rk)
+Gb (const after eval) = ((...) => a(b) | Rk)
 
-Gc = (???*0* | *anonymous function 128036*)
+Gc (const after eval) = (???*0* | *anonymous function 128036*)
 - *0* Gc
   ⚠️  pattern without value
 
-Gd = A(
+Gd (const after eval) = A(
     {},
     sd,
     {"animationName": 0, "elapsedTime": 0, "pseudoElement": 0}
 )
 
-Ge = (...) => (((a === b) && ((0 !== a) || (???*0* === ???*1*))) || ((a !== a) && (b !== b)))
+Ge (const after eval) = (...) => (((a === b) && ((0 !== a) || (???*0* === ???*1*))) || ((a !== a) && (b !== b)))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-Gf = (("function" === typeof(FreeVar(clearTimeout))) ? FreeVar(clearTimeout) : undefined)
+Gf (const after eval) = (("function" === typeof(FreeVar(clearTimeout))) ? FreeVar(clearTimeout) : undefined)
 
-Gg = (...) => (!(1) | ???*0* | !(0))
+Gg (const after eval) = (...) => (!(1) | ???*0* | !(0))
 - *0* !(1)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-Gh = Uf(Dh)
+Gh (const after eval) = Uf(Dh)
 
-Gi = (...) => undefined
+Gi (const after eval) = (...) => undefined
 
-Gj = (...) => undefined
+Gj (const after eval) = (...) => undefined
 
-Gk = (...) => ac(a, b)
+Gk (const after eval) = (...) => ac(a, b)
 
-H = Uf(Vf)
+H (const after eval) = Uf(Vf)
 
-Ha = FreeVar(Symbol)["for"]("react.lazy")
+Ha (const after eval) = FreeVar(Symbol)["for"]("react.lazy")
 
-Hb = ((...) => undefined | Sk)
+Hb (const after eval) = ((...) => undefined | Sk)
 
-Hc = (???*0* | *anonymous function 128133*)
+Hc (const after eval) = (???*0* | *anonymous function 128133*)
 - *0* Hc
   ⚠️  pattern without value
 
-Hd = rd(Gd)
+Hd (const after eval) = rd(Gd)
 
-He = (("function" === typeof(FreeVar(Object)["is"])) ? FreeVar(Object)["is"] : Ge)
+He (const after eval) = (("function" === typeof(FreeVar(Object)["is"])) ? FreeVar(Object)["is"] : Ge)
 
-Hf = (("function" === typeof(FreeVar(Promise))) ? FreeVar(Promise) : undefined)
+Hf (const after eval) = (("function" === typeof(FreeVar(Promise))) ? FreeVar(Promise) : undefined)
 
-Hg = (...) => undefined
+Hg (const after eval) = (...) => undefined
 
-Hh = (...) => a
+Hh (const after eval) = (...) => a
 
-Hi = (...) => ((a === N) || ((null !== b) && (b === N)))
+Hi (const after eval) = (...) => ((a === N) || ((null !== b) && (b === N)))
 
 Hj = (inf | (B() + 500))
 
-Hk = (...) => (
+Hk (const after eval) = (...) => (
   | null
   | ((a["callbackNode"] === c) ? Hk["bind"](null, a) : null)
 )
 
 I = (!(1) | !(0))
 
-Ia = FreeVar(Symbol)["for"]("react.offscreen")
+Ia (const after eval) = FreeVar(Symbol)["for"]("react.offscreen")
 
 Ib = (!(1) | !(0))
 
-Ic = (???*0* | *anonymous function 128157*)
+Ic (const after eval) = (???*0* | *anonymous function 128157*)
 - *0* Ic
   ⚠️  pattern without value
 
-Id = A({}, sd, {"clipboardData": *anonymous function 28936*})
+Id (const after eval) = A({}, sd, {"clipboardData": *anonymous function 28936*})
 
-Ie = (...) => (!(0) | !(1))
+Ie (const after eval) = (...) => (!(0) | !(1))
 
-If = (...) => undefined
+If (const after eval) = (...) => undefined
 
-Ig = (...) => undefined
+Ig (const after eval) = (...) => undefined
 
-Ih = (...) => undefined
+Ih (const after eval) = (...) => undefined
 
-Ii = (...) => undefined
+Ii (const after eval) = (...) => undefined
 
-Ij = (...) => undefined
+Ij (const after eval) = (...) => undefined
 
-Ik = (...) => (d | !(1))
+Ik (const after eval) = (...) => (d | !(1))
 
 J#292 = ((!(t) && ("scroll" === a)) | undefined | Vb(n) | ((null == k) ? h : ue(k)) | F)
 
@@ -679,25 +679,25 @@ J#843 = (Vi(g) | undefined)
 
 J#883 = (t["sibling"] | undefined)
 
-Ja = FreeVar(Symbol)["iterator"]
+Ja (const after eval) = FreeVar(Symbol)["iterator"]
 
-Jb = (...) => (a(b, c) | Gb(a, b, c) | undefined)
+Jb (const after eval) = (...) => (a(b, c) | Gb(a, b, c) | undefined)
 
 Jc = (!(1) | !(0))
 
-Jd = rd(Id)
+Jd (const after eval) = rd(Id)
 
-Je = (...) => a
+Je (const after eval) = (...) => a
 
-Jf = (("function" === typeof(FreeVar(queueMicrotask))) ? FreeVar(queueMicrotask) : (("undefined" !== typeof(Hf)) ? *anonymous function 45964* : Ff))
+Jf (const after eval) = (("function" === typeof(FreeVar(queueMicrotask))) ? FreeVar(queueMicrotask) : (("undefined" !== typeof(Hf)) ? *anonymous function 45964* : Ff))
 
-Jg = (...) => undefined
+Jg (const after eval) = (...) => undefined
 
-Jh = (...) => undefined
+Jh (const after eval) = (...) => undefined
 
-Ji = (...) => undefined
+Ji (const after eval) = (...) => undefined
 
-Jj = (...) => (???*0* | (???*3* ? ???*4* : null) | null | undefined)
+Jj (const after eval) = (...) => (???*0* | (???*3* ? ???*4* : null) | null | undefined)
 - *0* (???*1* ? ???*2* : null)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -712,37 +712,37 @@ Jj = (...) => (???*0* | (???*3* ? ???*4* : null) | null | undefined)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-Jk = (...) => T
+Jk (const after eval) = (...) => T
 
 K = (0 | ???*0* | e | c | b | c | h | e)
 - *0* unsupported assign operation
   ⚠️  This value might have side effects
 
-Ka = (...) => (null | (("function" === typeof(a)) ? a : null))
+Ka (const after eval) = (...) => (null | (("function" === typeof(a)) ? a : null))
 
-Kb = (...) => (null | c)
+Kb (const after eval) = (...) => (null | c)
 
-Kc = []
+Kc (const after eval) = []
 
-Kd = A({}, sd, {"data": 0})
+Kd (const after eval) = A({}, sd, {"data": 0})
 
-Ke = (...) => ({"node": c, "offset": ???*0*} | undefined)
+Ke (const after eval) = (...) => ({"node": c, "offset": ???*0*} | undefined)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-Kf = (...) => undefined
+Kf (const after eval) = (...) => undefined
 
-Kg = ua["ReactCurrentBatchConfig"]
+Kg (const after eval) = ua["ReactCurrentBatchConfig"]
 
-Kh = (...) => undefined
+Kh (const after eval) = (...) => undefined
 
-Ki = (...) => {"value": a, "source": b, "stack": e, "digest": null}
+Ki (const after eval) = (...) => {"value": a, "source": b, "stack": e, "digest": null}
 
 Kj = (!(1) | g | h)
 
-Kk = (...) => ((null === a) ? ai : a)
+Kk (const after eval) = (...) => ((null === a) ? ai : a)
 
-L = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : B()))
+L (const after eval) = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : B()))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
@@ -756,36 +756,36 @@ Lb = (!(1) | !(0))
 
 Lc = (null | Tc(Lc, a, b, c, d, e))
 
-Ld = rd(Kd)
+Ld (const after eval) = rd(Kd)
 
-Le = (...) => ((a && b) ? ((a === b) ? !(0) : ((a && (3 === a["nodeType"])) ? !(1) : ((b && (3 === b["nodeType"])) ? Le(a, b["parentNode"]) : (???*0* ? a["contains"](b) : (a["compareDocumentPosition"] ? !(!(???*1*)) : !(1)))))) : !(1))
+Le (const after eval) = (...) => ((a && b) ? ((a === b) ? !(0) : ((a && (3 === a["nodeType"])) ? !(1) : ((b && (3 === b["nodeType"])) ? Le(a, b["parentNode"]) : (???*0* ? a["contains"](b) : (a["compareDocumentPosition"] ? !(!(???*1*)) : !(1)))))) : !(1))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-Lf = (...) => (null | a)
+Lf (const after eval) = (...) => (null | a)
 
-Lg = (...) => b
+Lg (const after eval) = (...) => b
 
-Lh = (...) => undefined
+Lh (const after eval) = (...) => undefined
 
-Li = (...) => {"value": a, "source": null, "stack": ((null != c) ? c : null), "digest": ((null != b) ? b : null)}
+Li (const after eval) = (...) => {"value": a, "source": null, "stack": ((null != c) ? c : null), "digest": ((null != b) ? b : null)}
 
-Lj = (("function" === typeof(FreeVar(WeakSet))) ? FreeVar(WeakSet) : FreeVar(Set))
+Lj (const after eval) = (("function" === typeof(FreeVar(WeakSet))) ? FreeVar(WeakSet) : FreeVar(Set))
 
-Lk = (...) => a
+Lk (const after eval) = (...) => a
 
-M = Uf(0)
+M (const after eval) = Uf(0)
 
-Ma = (...) => `
+Ma (const after eval) = (...) => `
 ${La}${a}`
 
-Mb = ({} | undefined)
+Mb (const after eval) = ({} | undefined)
 
 Mc = (null | Tc(Mc, a, b, c, d, e))
 
-Md = {
+Md (const after eval) = {
     "Esc": "Escape",
     "Spacebar": " ",
     "Left": "ArrowLeft",
@@ -800,29 +800,29 @@ Md = {
     "MozPrintableKey": "Unidentified"
 }
 
-Me = (...) => b
+Me (const after eval) = (...) => b
 
-Mf = (...) => (a | null)
+Mf (const after eval) = (...) => (a | null)
 
-Mg = Uf(null)
+Mg (const after eval) = Uf(null)
 
-Mh = (...) => (b | null)
+Mh (const after eval) = (...) => (b | null)
 
-Mi = (...) => undefined
+Mi (const after eval) = (...) => undefined
 
-Mj = (...) => undefined
+Mj (const after eval) = (...) => undefined
 
-Mk = (...) => undefined
+Mk (const after eval) = (...) => undefined
 
 N = (null | b)
 
 Na = (!(1) | !(0))
 
-Nb = (...) => undefined
+Nb (const after eval) = (...) => undefined
 
 Nc = (null | Tc(Nc, a, b, c, d, e))
 
-Nd = {
+Nd (const after eval) = {
     8: "Backspace",
     9: "Tab",
     12: "Clear",
@@ -861,7 +861,7 @@ Nd = {
     224: "Meta"
 }
 
-Ne = (...) => (
+Ne (const after eval) = (...) => (
  && b
  && (
      || (
@@ -879,21 +879,21 @@ Ne = (...) => (
     )
 )
 
-Nf = FreeVar(Math)["random"]()["toString"](36)["slice"](2)
+Nf (const after eval) = FreeVar(Math)["random"]()["toString"](36)["slice"](2)
 
 Ng = (null | a)
 
-Nh = []
+Nh (const after eval) = []
 
-Ni = (("function" === typeof(FreeVar(WeakMap))) ? FreeVar(WeakMap) : FreeVar(Map))
+Ni (const after eval) = (("function" === typeof(FreeVar(WeakMap))) ? FreeVar(WeakMap) : FreeVar(Map))
 
-Nj = (...) => undefined
+Nj (const after eval) = (...) => undefined
 
-Nk = (...) => undefined
+Nk (const after eval) = (...) => undefined
 
 O = (null | a)
 
-Oa = (...) => (
+Oa (const after eval) = (...) => (
   | ""
   | k
   | ((a ? (a["displayName"] || a["name"]) : "") ? Ma(a) : "")
@@ -901,58 +901,58 @@ Oa = (...) => (
 
 Ob = (!(1) | !(0))
 
-Oc = new FreeVar(Map)()
+Oc (const after eval) = new FreeVar(Map)()
 
-Od = {"Alt": "altKey", "Control": "ctrlKey", "Meta": "metaKey", "Shift": "shiftKey"}
+Od (const after eval) = {"Alt": "altKey", "Control": "ctrlKey", "Meta": "metaKey", "Shift": "shiftKey"}
 
-Oe = (...) => undefined
+Oe (const after eval) = (...) => undefined
 
-Of = `__reactFiber$${Nf}`
+Of (const after eval) = `__reactFiber$${Nf}`
 
 Og = (null | a)
 
-Oh = (...) => undefined
+Oh (const after eval) = (...) => undefined
 
-Oi = (...) => c
+Oi (const after eval) = (...) => c
 
 Oj = !(1)
 
-Ok = (...) => a
+Ok (const after eval) = (...) => a
 
 P = (null | a | b | a)
 
-Pa = (...) => (Ma(a["type"]) | Ma("Lazy") | Ma("Suspense") | Ma("SuspenseList") | ???*0* | "" | undefined)
+Pa (const after eval) = (...) => (Ma(a["type"]) | Ma("Lazy") | Ma("Suspense") | Ma("SuspenseList") | ???*0* | "" | undefined)
 - *0* a
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
 Pb = (null | a)
 
-Pc = new FreeVar(Map)()
+Pc (const after eval) = new FreeVar(Map)()
 
-Pd = (...) => (b["getModifierState"] ? b["getModifierState"](a) : (Od[a] ? !(!(b[a])) : !(1)))
+Pd (const after eval) = (...) => (b["getModifierState"] ? b["getModifierState"](a) : (Od[a] ? !(!(b[a])) : !(1)))
 
-Pe = (ia && ???*0* && ???*1*)
+Pe (const after eval) = (ia && ???*0* && ???*1*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-Pf = `__reactProps$${Nf}`
+Pf (const after eval) = `__reactProps$${Nf}`
 
 Pg = null
 
-Ph = ua["ReactCurrentDispatcher"]
+Ph (const after eval) = ua["ReactCurrentDispatcher"]
 
 Pi = (!(0) | !(1))
 
-Pj = (...) => n
+Pj (const after eval) = (...) => n
 
-Pk = (...) => (!(1) | !(0))
+Pk (const after eval) = (...) => (!(1) | !(0))
 
-Q = (...) => undefined
+Q (const after eval) = (...) => undefined
 
-Qa = (...) => (
+Qa (const after eval) = (...) => (
   | null
   | (a["displayName"] || a["name"] || null)
   | a
@@ -970,9 +970,9 @@ Qa = (...) => (
 
 Qb = (!(1) | !(0))
 
-Qc = []
+Qc (const after eval) = []
 
-Qd = A(
+Qd (const after eval) = A(
     {},
     ud,
     {
@@ -994,21 +994,21 @@ Qd = A(
 
 Qe = (null | xa)
 
-Qf = `__reactListeners$${Nf}`
+Qf (const after eval) = `__reactListeners$${Nf}`
 
-Qg = (...) => undefined
+Qg (const after eval) = (...) => undefined
 
-Qh = ua["ReactCurrentBatchConfig"]
+Qh (const after eval) = ua["ReactCurrentBatchConfig"]
 
 Qi = (d | null)
 
-Qj = (...) => undefined
+Qj (const after eval) = (...) => undefined
 
-Qk = (...) => null
+Qk (const after eval) = (...) => null
 
 R = (null | a)
 
-Ra = (...) => (
+Ra (const after eval) = (...) => (
   | "Cache"
   | `${(b["displayName"] || "Context")}.Consumer`
   | `${(b["_context"]["displayName"] || "Context")}.Provider`
@@ -1033,33 +1033,33 @@ Ra = (...) => (
 
 Rb = (null | l)
 
-Rc = "mousedown mouseup touchcancel touchend touchstart auxclick dblclick pointercancel pointerdown pointerup dragend dragstart drop compositionend compositionstart keydown keypress keyup input textInput copy cut paste click change contextmenu reset submit"["split"](" ")
+Rc (const after eval) = "mousedown mouseup touchcancel touchend touchstart auxclick dblclick pointercancel pointerdown pointerup dragend dragstart drop compositionend compositionstart keydown keypress keyup input textInput copy cut paste click change contextmenu reset submit"["split"](" ")
 
-Rd = rd(Qd)
+Rd (const after eval) = rd(Qd)
 
 Re = (null | d)
 
-Rf = `__reactHandles$${Nf}`
+Rf (const after eval) = `__reactHandles$${Nf}`
 
-Rg = (...) => undefined
+Rg (const after eval) = (...) => undefined
 
 Rh = (0 | f)
 
-Ri = (...) => c
+Ri (const after eval) = (...) => c
 
-Rj = (...) => undefined
+Rj (const after eval) = (...) => undefined
 
-Rk = (...) => (a(b) | undefined)
+Rk (const after eval) = (...) => (a(b) | undefined)
 
-S = (...) => b
+S (const after eval) = (...) => b
 
-Sa = (...) => (a | "" | undefined)
+Sa (const after eval) = (...) => (a | "" | undefined)
 
-Sb = {"onError": *anonymous function 17435*}
+Sb (const after eval) = {"onError": *anonymous function 17435*}
 
-Sc = (...) => undefined
+Sc (const after eval) = (...) => undefined
 
-Sd = A(
+Sd (const after eval) = A(
     {},
     Ad,
     {
@@ -1078,9 +1078,9 @@ Sd = A(
 
 Se = (null | d)
 
-Sf = []
+Sf (const after eval) = []
 
-Sg = (...) => undefined
+Sg (const after eval) = (...) => undefined
 
 Sh = (!(1) | !(0))
 
@@ -1088,22 +1088,22 @@ Si = (new FreeVar(Set)([???*0*]) | null)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-Sj = (...) => undefined
+Sj (const after eval) = (...) => undefined
 
-Sk = (...) => (a() | undefined)
+Sk (const after eval) = (...) => (a() | undefined)
 
 T = (3 | 0 | 1 | 2 | 4 | 6 | 5)
 
-Ta = (...) => (a["nodeName"] && ("input" === a["toLowerCase"]()) && (("checkbox" === b) || ("radio" === b)))
+Ta (const after eval) = (...) => (a["nodeName"] && ("input" === a["toLowerCase"]()) && (("checkbox" === b) || ("radio" === b)))
 
-Tb = (...) => undefined
+Tb (const after eval) = (...) => undefined
 
-Tc = (...) => (???*0* | a)
+Tc (const after eval) = (...) => (???*0* | a)
 - *0* a
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-Td = rd(Sd)
+Td (const after eval) = rd(Sd)
 
 Te = (!(1) | !(0))
 
@@ -1113,19 +1113,19 @@ Tf = (???*0* | ???*1*)
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
-Tg = (...) => undefined
+Tg (const after eval) = (...) => undefined
 
 Th = (!(1) | !(0))
 
-Ti = (...) => undefined
+Ti (const after eval) = (...) => undefined
 
-Tj = (...) => undefined
+Tj (const after eval) = (...) => undefined
 
-Tk = (...) => undefined
+Tk (const after eval) = (...) => undefined
 
 U = (!(1) | (U || (null !== c["memoizedState"])) | d | (U || m) | l | k | l)
 
-Ua = (...) => (
+Ua (const after eval) = (...) => (
   | {
         "getValue": *anonymous function 10089*,
         "setValue": *anonymous function 10119*,
@@ -1134,14 +1134,14 @@ Ua = (...) => (
   | undefined
 )
 
-Ub = (...) => undefined
+Ub (const after eval) = (...) => undefined
 
-Uc = (...) => (???*0* | !(0) | !(1))
+Uc (const after eval) = (...) => (???*0* | !(0) | !(1))
 - *0* !(0)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-Ud = A(
+Ud (const after eval) = A(
     {},
     ud,
     {
@@ -1156,9 +1156,9 @@ Ud = A(
     }
 )
 
-Ue = (...) => undefined
+Ue (const after eval) = (...) => undefined
 
-Uf = (...) => {"current": a}
+Uf (const after eval) = (...) => {"current": a}
 
 Ug = (!(0) | !(1) | ((0 !== ???*0*) ? !(0) : !(1)))
 - *0* unsupported expression
@@ -1168,11 +1168,11 @@ Uh = (0 | ???*0*)
 - *0* updated with update expression
   ⚠️  This value might have side effects
 
-Ui = (...) => undefined
+Ui (const after eval) = (...) => undefined
 
-Uj = (...) => ((5 === a["tag"]) || (3 === a["tag"]) || (4 === a["tag"]))
+Uj (const after eval) = (...) => ((5 === a["tag"]) || (3 === a["tag"]) || (4 === a["tag"]))
 
-Uk = (...) => undefined
+Uk (const after eval) = (...) => undefined
 
 V = (
   | null
@@ -1207,101 +1207,101 @@ V = (
   | h["return"]
 )
 
-Va = (...) => undefined
+Va (const after eval) = (...) => undefined
 
-Vb = (...) => ((3 === b["tag"]) ? c : null)
+Vb (const after eval) = (...) => ((3 === b["tag"]) ? c : null)
 
-Vc = (...) => undefined
+Vc (const after eval) = (...) => undefined
 
-Vd = rd(Ud)
+Vd (const after eval) = rd(Ud)
 
-Ve = (...) => c
+Ve (const after eval) = (...) => c
 
-Vf = {}
+Vf (const after eval) = {}
 
-Vg = (...) => b
+Vg (const after eval) = (...) => b
 
 Vh = (0 | ???*0*)
 - *0* updated with update expression
   ⚠️  This value might have side effects
 
-Vi = (...) => (a | null)
+Vi (const after eval) = (...) => (a | null)
 
-Vj = (...) => (null | a["stateNode"] | undefined)
+Vj (const after eval) = (...) => (null | a["stateNode"] | undefined)
 
-Vk = (...) => undefined
+Vk (const after eval) = (...) => undefined
 
-W = (...) => undefined
+W (const after eval) = (...) => undefined
 
-Wa = (...) => (!(1) | !(0) | ((a !== c) ? ???*0* : !(1)))
+Wa (const after eval) = (...) => (!(1) | !(0) | ((a !== c) ? ???*0* : !(1)))
 - *0* !(0)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-Wb = (...) => (b["dehydrated"] | null)
+Wb (const after eval) = (...) => (b["dehydrated"] | null)
 
-Wc = (...) => (b | c | null)
+Wc (const after eval) = (...) => (b | c | null)
 
-Wd = A(
+Wd (const after eval) = A(
     {},
     sd,
     {"propertyName": 0, "elapsedTime": 0, "pseudoElement": 0}
 )
 
-We = {
+We (const after eval) = {
     "animationend": Ve("Animation", "AnimationEnd"),
     "animationiteration": Ve("Animation", "AnimationIteration"),
     "animationstart": Ve("Animation", "AnimationStart"),
     "transitionend": Ve("Transition", "TransitionEnd")
 }
 
-Wf = Uf(!(1))
+Wf (const after eval) = Uf(!(1))
 
 Wg = (null | [a])
 
-Wh = (...) => (!(1) | !(0))
+Wh (const after eval) = (...) => (!(1) | !(0))
 
-Wi = (...) => (???*0* | a)
+Wi (const after eval) = (...) => (???*0* | a)
 - *0* a
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-Wj = (...) => undefined
+Wj (const after eval) = (...) => undefined
 
-Wk = (???*0* | *anonymous function 117815*)
+Wk (const after eval) = (???*0* | *anonymous function 117815*)
 - *0* Wk
   ⚠️  pattern without value
 
 X = (null | d | c["stateNode"]["containerInfo"] | h["stateNode"] | h["stateNode"]["containerInfo"])
 
-Xa = (...) => (null | (a["activeElement"] || a["body"]) | a["body"] | undefined)
+Xa (const after eval) = (...) => (null | (a["activeElement"] || a["body"]) | a["body"] | undefined)
 
-Xb = (...) => undefined
+Xb (const after eval) = (...) => undefined
 
-Xc = (...) => (!(1) | ???*0* | !(0))
+Xc (const after eval) = (...) => (!(1) | ???*0* | !(0))
 - *0* !(1)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-Xd = rd(Wd)
+Xd (const after eval) = rd(Wd)
 
-Xe = {}
+Xe (const after eval) = {}
 
 Xf = (Vf | H["current"])
 
-Xg = (...) => undefined
+Xg (const after eval) = (...) => undefined
 
-Xh = (...) => a
+Xh (const after eval) = (...) => a
 
-Xi = ua["ReactCurrentOwner"]
+Xi (const after eval) = ua["ReactCurrentOwner"]
 
-Xj = (...) => undefined
+Xj (const after eval) = (...) => undefined
 
-Xk = (...) => null
+Xk (const after eval) = (...) => null
 
 Y = (null | wh(a["current"], null) | c["return"] | b | c | b | a)
 
-Ya = (...) => A(
+Ya (const after eval) = (...) => A(
     {},
     b,
     {
@@ -1312,18 +1312,18 @@ Ya = (...) => A(
     }
 )
 
-Yb = (...) => (((b !== a) ? null : a) | ???*0* | ((c["stateNode"]["current"] === c) ? a : b))
+Yb (const after eval) = (...) => (((b !== a) ? null : a) | ???*0* | ((c["stateNode"]["current"] === c) ? a : b))
 - *0* a
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-Yc = (...) => (
+Yc (const after eval) = (...) => (
   | a
   | ((3 === b["tag"]) ? b["stateNode"]["containerInfo"] : null)
   | null
 )
 
-Yd = A(
+Yd (const after eval) = A(
     {},
     Ad,
     {
@@ -1334,13 +1334,13 @@ Yd = A(
     }
 )
 
-Ye = ({} | FreeVar(document)["createElement"]("div")["style"])
+Ye (const after eval) = ({} | FreeVar(document)["createElement"]("div")["style"])
 
-Yf = (...) => (Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)
+Yf (const after eval) = (...) => (Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)
 
-Yg = (...) => Zg(a, d)
+Yg (const after eval) = (...) => Zg(a, d)
 
-Yh = {
+Yh (const after eval) = {
     "readContext": Vg,
     "useCallback": *anonymous function 71076*,
     "useContext": Vg,
@@ -1361,29 +1361,29 @@ Yh = {
     "unstable_isNewReconciler": !(1)
 }
 
-Yi = (...) => undefined
+Yi (const after eval) = (...) => undefined
 
 Yj = (!(1) | e | !(0))
 
-Yk = (...) => undefined
+Yk (const after eval) = (...) => undefined
 
 Z = (0 | b)
 
-Za = (...) => undefined
+Za (const after eval) = (...) => undefined
 
-Zb = (...) => ((null !== a) ? $b(a) : null)
+Zb (const after eval) = (...) => ((null !== a) ? $b(a) : null)
 
-Zc = (...) => undefined
+Zc (const after eval) = (...) => undefined
 
-Zd = rd(Yd)
+Zd (const after eval) = rd(Yd)
 
-Ze = (...) => (Xe[a] | a | b[c])
+Ze (const after eval) = (...) => (Xe[a] | a | b[c])
 
-Zf = (...) => ((null !== a) && (undefined !== a))
+Zf (const after eval) = (...) => ((null !== a) && (undefined !== a))
 
-Zg = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)
+Zg (const after eval) = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)
 
-Zh = {
+Zh (const after eval) = {
     "readContext": Vg,
     "useCallback": Bi,
     "useContext": Vg,
@@ -1404,14 +1404,14 @@ Zh = {
     "unstable_isNewReconciler": !(1)
 }
 
-Zi = (...) => (???*0* | b["child"])
+Zi (const after eval) = (...) => (???*0* | b["child"])
 - *0* $i(a, b, e)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-Zj = (...) => undefined
+Zj (const after eval) = (...) => undefined
 
-Zk = (...) => undefined
+Zk (const after eval) = (...) => undefined
 
 a#10 = arguments[0]
 
@@ -1423,7 +1423,7 @@ a#1008 = (arguments[0] | Zb(a))
 
 a#101 = arguments[0]
 
-a#1011 = ???*0*
+a#1011 (const after eval) = ???*0*
 - *0* a
   ⚠️  pattern without value
 
@@ -1482,7 +1482,7 @@ a#119 = (arguments[0] | a["type"] | !(d) | !(1))
 
 a#12 = arguments[0]
 
-a#122 = ???*0*
+a#122 (const after eval) = ???*0*
 - *0* a
   ⚠️  pattern without value
 
@@ -2421,25 +2421,25 @@ a#994 = arguments[0]
 
 a#997 = arguments[0]
 
-aa = FreeVar(require)("react")
+aa (const after eval) = FreeVar(require)("react")
 
-ab = (...) => undefined
+ab (const after eval) = (...) => undefined
 
-ac = ca["unstable_scheduleCallback"]
+ac (const after eval) = ca["unstable_scheduleCallback"]
 
-ad = (...) => undefined
+ad (const after eval) = (...) => undefined
 
-ae = (ia && ???*0*)
+ae (const after eval) = (ia && ???*0*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-af = Ze("animationiteration")
+af (const after eval) = Ze("animationiteration")
 
-ag = (...) => undefined
+ag (const after eval) = (...) => undefined
 
-ah = (...) => undefined
+ah (const after eval) = (...) => undefined
 
-ai = {
+ai (const after eval) = {
     "readContext": Vg,
     "useCallback": Q,
     "useContext": Q,
@@ -2460,11 +2460,11 @@ ai = {
     "unstable_isNewReconciler": !(1)
 }
 
-aj = (...) => (cj(a, b, f, d, e) | a | $i(a, b, e))
+aj (const after eval) = (...) => (cj(a, b, f, d, e) | a | $i(a, b, e))
 
-ak = (...) => undefined
+ak (const after eval) = (...) => undefined
 
-al = (...) => undefined
+al (const after eval) = (...) => undefined
 
 b#100 = (
   | arguments[0]
@@ -3246,27 +3246,27 @@ ba = (
   | new Ld(ba, a, null, c, e)
 )
 
-bb = (...) => undefined
+bb (const after eval) = (...) => undefined
 
-bc = ca["unstable_cancelCallback"]
+bc (const after eval) = ca["unstable_cancelCallback"]
 
-bd = (...) => undefined
+bd (const after eval) = (...) => undefined
 
-be = (null | FreeVar(document)["documentMode"])
+be (const after eval) = (null | FreeVar(document)["documentMode"])
 
-bf = Ze("animationstart")
+bf (const after eval) = Ze("animationstart")
 
-bg = (...) => (c | A({}, c, d))
+bg (const after eval) = (...) => (c | A({}, c, d))
 
-bh = (...) => undefined
+bh (const after eval) = (...) => undefined
 
-bi = (...) => a
+bi (const after eval) = (...) => a
 
-bj = (...) => !((!(a) || !(a["isReactComponent"])))
+bj (const after eval) = (...) => !((!(a) || !(a["isReactComponent"])))
 
-bk = (...) => undefined
+bk (const after eval) = (...) => undefined
 
-bl = (...) => undefined
+bl (const after eval) = (...) => undefined
 
 c#1001 = C
 
@@ -3881,31 +3881,31 @@ c#994 = (L() | undefined)
 
 c#997 = (Zg(a, b) | undefined)
 
-ca = FreeVar(require)("scheduler")
+ca (const after eval) = FreeVar(require)("scheduler")
 
-cb = (...) => undefined
+cb (const after eval) = (...) => undefined
 
-cc = ca["unstable_shouldYield"]
+cc (const after eval) = ca["unstable_shouldYield"]
 
-cd = ua["ReactCurrentBatchConfig"]
+cd (const after eval) = ua["ReactCurrentBatchConfig"]
 
-ce = (ia && ???*0* && !(be))
+ce (const after eval) = (ia && ???*0* && !(be))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-cf = Ze("transitionend")
+cf (const after eval) = Ze("transitionend")
 
-cg = (...) => !(0)
+cg (const after eval) = (...) => !(0)
 
-ch = (...) => {"eventTime": a, "lane": b, "tag": 0, "payload": null, "callback": null, "next": null}
+ch (const after eval) = (...) => {"eventTime": a, "lane": b, "tag": 0, "payload": null, "callback": null, "next": null}
 
-ci = (...) => P
+ci (const after eval) = (...) => P
 
-cj = (...) => ($i(a, b, e) | dj(a, b, c, d, e))
+cj (const after eval) = (...) => ($i(a, b, e) | dj(a, b, c, d, e))
 
-ck = (...) => undefined
+ck (const after eval) = (...) => undefined
 
-cl = (...) => a
+cl (const after eval) = (...) => a
 
 d#1004 = (c[b] | undefined)
 
@@ -4398,36 +4398,36 @@ d#986 = arguments[3]
 
 d#997 = (L() | undefined)
 
-da = new FreeVar(Set)()
+da (const after eval) = new FreeVar(Set)()
 
-db = (...) => undefined
+db (const after eval) = (...) => undefined
 
-dc = ca["unstable_requestPaint"]
+dc (const after eval) = ca["unstable_requestPaint"]
 
 dd = (!(0) | !(1) | !(!(Cf)))
 
-de = (ia && (!(ae) || (be && ???*0* && ???*1*)))
+de (const after eval) = (ia && (!(ae) || (be && ???*0* && ???*1*)))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-df = new FreeVar(Map)()
+df (const after eval) = new FreeVar(Map)()
 
-dg = (...) => undefined
+dg (const after eval) = (...) => undefined
 
-dh = (...) => (null | Zg(a, c))
+dh (const after eval) = (...) => (null | Zg(a, c))
 
-di = (...) => P
+di (const after eval) = (...) => P
 
-dj = (...) => (???*0* | b["child"])
+dj (const after eval) = (...) => (???*0* | b["child"])
 - *0* $i(a, b, e)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-dk = (...) => undefined
+dk (const after eval) = (...) => undefined
 
-dl = (...) => {
+dl (const after eval) = (...) => {
     "$$typeof": wa,
     "key": ((null == d) ? null : `${d}`),
     "children": a,
@@ -4721,32 +4721,32 @@ e#979 = (arguments[4] | a["lastChild"])
 
 e#986 = (arguments[4] | *anonymous function 127571*)
 
-ea = {}
+ea (const after eval) = {}
 
-eb = FreeVar(Array)["isArray"]
+eb (const after eval) = FreeVar(Array)["isArray"]
 
-ec = ca["unstable_getCurrentPriorityLevel"]
+ec (const after eval) = ca["unstable_getCurrentPriorityLevel"]
 
-ed = (...) => undefined
+ed (const after eval) = (...) => undefined
 
-ee = FreeVar(String)["fromCharCode"](32)
+ee (const after eval) = FreeVar(String)["fromCharCode"](32)
 
-ef = "abort auxClick cancel canPlay canPlayThrough click close contextMenu copy cut drag dragEnd dragEnter dragExit dragLeave dragOver dragStart drop durationChange emptied encrypted ended error gotPointerCapture input invalid keyDown keyPress keyUp load loadedData loadedMetadata loadStart lostPointerCapture mouseDown mouseMove mouseOut mouseOver mouseUp paste pause play playing pointerCancel pointerDown pointerMove pointerOut pointerOver pointerUp progress rateChange reset resize seeked seeking stalled submit suspend timeUpdate touchCancel touchEnd touchStart volumeChange scroll toggle touchMove waiting wheel"["split"](" ")
+ef (const after eval) = "abort auxClick cancel canPlay canPlayThrough click close contextMenu copy cut drag dragEnd dragEnter dragExit dragLeave dragOver dragStart drop durationChange emptied encrypted ended error gotPointerCapture input invalid keyDown keyPress keyUp load loadedData loadedMetadata loadStart lostPointerCapture mouseDown mouseMove mouseOut mouseOver mouseUp paste pause play playing pointerCancel pointerDown pointerMove pointerOut pointerOver pointerUp progress rateChange reset resize seeked seeking stalled submit suspend timeUpdate touchCancel touchEnd touchStart volumeChange scroll toggle touchMove waiting wheel"["split"](" ")
 
 eg = (null | [a] | eg["slice"]((a + 1)))
 
-eh = (...) => undefined
+eh (const after eval) = (...) => undefined
 
-ei = (...) => (("function" === typeof(b)) ? b(a) : b)
+ei (const after eval) = (...) => (("function" === typeof(b)) ? b(a) : b)
 
-ej = (...) => (???*0* | b["child"])
+ej (const after eval) = (...) => (???*0* | b["child"])
 - *0* null
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-ek = (...) => undefined
+ek (const after eval) = (...) => undefined
 
-el = (...) => (Vf | bg(a, c, b) | b)
+el (const after eval) = (...) => (Vf | bg(a, c, b) | b)
 
 f#1018 = ("" | c["identifierPrefix"])
 
@@ -4980,29 +4980,29 @@ f#979 = (d | undefined)
 
 f#986 = c["_reactRootContainer"]
 
-fa = (...) => undefined
+fa (const after eval) = (...) => undefined
 
-fb = (...) => undefined
+fb (const after eval) = (...) => undefined
 
-fc = ca["unstable_ImmediatePriority"]
+fc (const after eval) = ca["unstable_ImmediatePriority"]
 
-fd = (...) => undefined
+fd (const after eval) = (...) => undefined
 
 fe = (!(1) | !(0))
 
-ff = (...) => undefined
+ff (const after eval) = (...) => undefined
 
 fg = (!(1) | !(0))
 
-fh = (...) => undefined
+fh (const after eval) = (...) => undefined
 
-fi = (...) => [b["memoizedState"], c["dispatch"]]
+fi (const after eval) = (...) => [b["memoizedState"], c["dispatch"]]
 
-fj = Uf(0)
+fj (const after eval) = Uf(0)
 
-fk = (...) => undefined
+fk (const after eval) = (...) => undefined
 
-fl = (...) => a
+fl (const after eval) = (...) => a
 
 g#1018 = (ll | c["onRecoverableError"])
 
@@ -5189,7 +5189,7 @@ g#979 = (fl(b, d, a, 0, null, !(1), !(1), "", ql) | undefined)
 
 g#986 = (f | undefined | rl(c, b, a, e, d))
 
-gb = (...) => A(
+gb (const after eval) = (...) => A(
     {},
     b,
     {
@@ -5199,23 +5199,23 @@ gb = (...) => A(
     }
 )
 
-gc = ca["unstable_UserBlockingPriority"]
+gc (const after eval) = ca["unstable_UserBlockingPriority"]
 
-gd = (...) => undefined
+gd (const after eval) = (...) => undefined
 
-ge = (...) => ((???*0* !== $d["indexOf"](b["keyCode"])) | (229 !== b["keyCode"]) | !(0) | !(1) | undefined)
+ge (const after eval) = (...) => ((???*0* !== $d["indexOf"](b["keyCode"])) | (229 !== b["keyCode"]) | !(0) | !(1) | undefined)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-gf = (0 | ???*0*)
+gf (const after eval) = (0 | ???*0*)
 - *0* updated with update expression
   ⚠️  This value might have side effects
 
 gg = (!(1) | !(0))
 
-gh = (...) => undefined
+gh (const after eval) = (...) => undefined
 
-gi = (...) => [f, d]
+gi (const after eval) = (...) => [f, d]
 
 gj = (???*0* | 0 | fj["current"] | b)
 - *0* unsupported assign operation
@@ -5223,7 +5223,7 @@ gj = (???*0* | 0 | fj["current"] | b)
 
 gk = (B() | 0)
 
-gl = (...) => g
+gl (const after eval) = (...) => g
 
 h#123 = arguments[7]
 
@@ -5355,83 +5355,83 @@ h#979 = (d | undefined)
 
 h#986 = (e | undefined)
 
-ha = (...) => undefined
+ha (const after eval) = (...) => undefined
 
-hb = (...) => undefined
+hb (const after eval) = (...) => undefined
 
-hc = ca["unstable_NormalPriority"]
+hc (const after eval) = ca["unstable_NormalPriority"]
 
-hd = (...) => undefined
+hd (const after eval) = (...) => undefined
 
-he = (...) => ((("object" === typeof(a)) && ???*0*) ? a["data"] : null)
+he (const after eval) = (...) => ((("object" === typeof(a)) && ???*0*) ? a["data"] : null)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-hf = (ef[gf] | undefined)
+hf (const after eval) = (ef[gf] | undefined)
 
-hg = (...) => undefined
+hg (const after eval) = (...) => undefined
 
 hh = (???*0* | 0)
 - *0* unsupported assign operation
   ⚠️  This value might have side effects
 
-hi = (...) => undefined
+hi (const after eval) = (...) => undefined
 
-hj = (...) => undefined
+hj (const after eval) = (...) => undefined
 
-hk = (...) => undefined
+hk (const after eval) = (...) => undefined
 
-hl = (...) => (null | a["child"]["stateNode"] | undefined)
+hl (const after eval) = (...) => (null | a["child"]["stateNode"] | undefined)
 
-ia = !((
+ia (const after eval) = !((
  || ("undefined" === typeof(FreeVar(window)))
  || ("undefined" === typeof(FreeVar(window)["document"]))
  || ("undefined" === typeof(FreeVar(window)["document"]["createElement"]))
 ))
 
-ib = (...) => undefined
+ib (const after eval) = (...) => undefined
 
-ic = ca["unstable_LowPriority"]
+ic (const after eval) = ca["unstable_LowPriority"]
 
 id = (null | a)
 
 ie = (!(1) | !(0))
 
-ig = (...) => undefined
+ig (const after eval) = (...) => undefined
 
-ih = (...) => undefined
+ih (const after eval) = (...) => undefined
 
-ii = (...) => e
+ii (const after eval) = (...) => e
 
-ij = (...) => kj(a, b, c, d, f, e)
+ij (const after eval) = (...) => kj(a, b, c, d, f, e)
 
-ik = (...) => undefined
+ik (const after eval) = (...) => undefined
 
-il = (...) => undefined
+il (const after eval) = (...) => undefined
 
-ja = FreeVar(Object)["prototype"]["hasOwnProperty"]
+ja (const after eval) = FreeVar(Object)["prototype"]["hasOwnProperty"]
 
-jb = (...) => undefined
+jb (const after eval) = (...) => undefined
 
-jc = ca["unstable_IdlePriority"]
+jc (const after eval) = ca["unstable_IdlePriority"]
 
-jd = (...) => (1 | 4 | 16 | 536870912 | undefined)
+jd (const after eval) = (...) => (1 | 4 | 16 | 536870912 | undefined)
 
-je = (...) => (he(b) | null | ee | (((a === ee) && fe) ? null : a) | undefined)
+je (const after eval) = (...) => (he(b) | null | ee | (((a === ee) && fe) ? null : a) | undefined)
 
-jf = (hf["toLowerCase"]() | undefined)
+jf (const after eval) = (hf["toLowerCase"]() | undefined)
 
-jg = (...) => null
+jg (const after eval) = (...) => null
 
-jh = new aa["Component"]()["refs"]
+jh (const after eval) = new aa["Component"]()["refs"]
 
-ji = (...) => ui(2048, 8, a, b)
+ji (const after eval) = (...) => ui(2048, 8, a, b)
 
-jj = (...) => undefined
+jj (const after eval) = (...) => undefined
 
-jk = (...) => undefined
+jk (const after eval) = (...) => undefined
 
-jl = (...) => undefined
+jl (const after eval) = (...) => undefined
 
 k#123 = arguments[8]
 
@@ -5577,20 +5577,20 @@ k#960 = arguments[8]
 
 k#979 = cl(a, 0, !(1), null, null, !(1), !(1), "", ql)
 
-ka = /^[:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$/
+ka (const after eval) = /^[:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$/
 
-kb = (...) => (
+kb (const after eval) = (...) => (
   | "http://www.w3.org/2000/svg"
   | "http://www.w3.org/1998/Math/MathML"
   | "http://www.w3.org/1999/xhtml"
   | undefined
 )
 
-kc = (null | wl["inject"](vl))
+kc (const after eval) = (null | wl["inject"](vl))
 
 kd = (null | e)
 
-ke = (...) => (
+ke (const after eval) = (...) => (
   | ((("compositionend" === a) || (!(ae) && ge(a, b))) ? ???*0* : null)
   | null
   | b["char"]
@@ -5602,22 +5602,22 @@ ke = (...) => (
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-kf = ((hf[0]["toUpperCase"]() + hf["slice"](1)) | undefined)
+kf (const after eval) = ((hf[0]["toUpperCase"]() + hf["slice"](1)) | undefined)
 
-kg = []
+kg (const after eval) = []
 
-kh = (...) => undefined
+kh (const after eval) = (...) => undefined
 
-ki = (...) => c(*anonymous function 67764*)
+ki (const after eval) = (...) => c(*anonymous function 67764*)
 
-kj = (...) => (???*0* | b["child"])
+kj (const after eval) = (...) => (???*0* | b["child"])
 - *0* $i(a, b, f)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-kk = (...) => undefined
+kk (const after eval) = (...) => undefined
 
-kl = (...) => null
+kl (const after eval) = (...) => null
 
 l#123 = FreeVar(Array)["prototype"]["slice"]["call"](FreeVar(arguments), 3)
 
@@ -5695,17 +5695,17 @@ l#883 = (h[k] | undefined)
 
 l#919 = (f["updateQueue"] | undefined | l["shared"])
 
-la = {}
+la (const after eval) = {}
 
-lb = (...) => (((null == a) || ("http://www.w3.org/1999/xhtml" === a)) ? kb(b) : ((("http://www.w3.org/2000/svg" === a) && ("foreignObject" === b)) ? "http://www.w3.org/1999/xhtml" : a))
+lb (const after eval) = (...) => (((null == a) || ("http://www.w3.org/1999/xhtml" === a)) ? kb(b) : ((("http://www.w3.org/2000/svg" === a) && ("foreignObject" === b)) ? "http://www.w3.org/1999/xhtml" : a))
 
-lc = (null | wl)
+lc (const after eval) = (null | wl)
 
 ld = (null | (???*0* ? kd["value"] : kd["textContent"]))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-le = {
+le (const after eval) = {
     "color": !(0),
     "date": !(0),
     "datetime": !(0),
@@ -5723,26 +5723,26 @@ le = {
     "week": !(0)
 }
 
-lf = "abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting"["split"](" ")
+lf (const after eval) = "abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting"["split"](" ")
 
 lg = (0 | ???*0*)
 - *0* updated with update expression
   ⚠️  This value might have side effects
 
-lh = (...) => (1 | ???*0* | ???*1* | a)
+lh (const after eval) = (...) => (1 | ???*0* | ???*1* | a)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-li = (...) => a
+li (const after eval) = (...) => a
 
-lj = (...) => undefined
+lj (const after eval) = (...) => undefined
 
-lk = (...) => undefined
+lk (const after eval) = (...) => undefined
 
-ll = (("function" === typeof(FreeVar(reportError))) ? FreeVar(reportError) : *anonymous function 126145*)
+ll (const after eval) = (("function" === typeof(FreeVar(reportError))) ? FreeVar(reportError) : *anonymous function 126145*)
 
 m#125 = ???*0*
 - *0* m
@@ -5806,13 +5806,13 @@ m#883 = (V | undefined)
 
 m#919 = (l["pending"] | undefined)
 
-ma = {}
+ma (const after eval) = {}
 
 mb = (???*0* | (mb || FreeVar(document)["createElement"]("div")))
 - *0* mb
   ⚠️  pattern without value
 
-mc = (...) => undefined
+mc (const after eval) = (...) => undefined
 
 md = (null | e["slice"](a, (???*0* ? ???*1* : undefined)))
 - *0* unsupported expression
@@ -5820,9 +5820,9 @@ md = (null | e["slice"](a, (???*0* ? ???*1* : undefined)))
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-me = (...) => (("input" === b) ? !(!(le[a["type"]])) : (("textarea" === b) ? !(0) : !(1)))
+me (const after eval) = (...) => (("input" === b) ? !(!(le[a["type"]])) : (("textarea" === b) ? !(0) : !(1)))
 
-mf = new FreeVar(Set)(
+mf (const after eval) = new FreeVar(Set)(
     "cancel close invalid load scroll toggle"["split"](" ")["concat"](lf)
 )
 
@@ -5830,15 +5830,15 @@ mg = (null | a | kg[???*0*])
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-mh = (...) => undefined
+mh (const after eval) = (...) => undefined
 
-mi = (...) => undefined
+mi (const after eval) = (...) => undefined
 
-mj = (...) => b["child"]
+mj (const after eval) = (...) => b["child"]
 
-mk = FreeVar(Math)["ceil"]
+mk (const after eval) = FreeVar(Math)["ceil"]
 
-ml = (...) => undefined
+ml (const after eval) = (...) => undefined
 
 n#292 = (
   | a
@@ -5887,75 +5887,75 @@ na#907 = ???*0*
 - *0* na
   ⚠️  pattern without value
 
-nb = *anonymous function 13449*(*anonymous function 13608*)
+nb (const after eval) = *anonymous function 13449*(*anonymous function 13608*)
 
-nc = (...) => ((0 === a) ? 32 : ???*0*)
+nc (const after eval) = (...) => ((0 === a) ? 32 : ???*0*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-nd = (...) => (md | e["slice"](a, (???*0* ? ???*1* : undefined)))
+nd (const after eval) = (...) => (md | e["slice"](a, (???*0* ? ???*1* : undefined)))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-ne = (...) => undefined
+ne (const after eval) = (...) => undefined
 
-nf = (...) => undefined
+nf (const after eval) = (...) => undefined
 
 ng = (0 | b | kg[???*0*])
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-nh = {
+nh (const after eval) = {
     "isMounted": *anonymous function 55504*,
     "enqueueSetState": *anonymous function 55574*,
     "enqueueReplaceState": *anonymous function 55754*,
     "enqueueForceUpdate": *anonymous function 55941*
 }
 
-ni = (...) => undefined
+ni (const after eval) = (...) => undefined
 
-nj = {"dehydrated": null, "treeContext": null, "retryLane": 0}
+nj (const after eval) = {"dehydrated": null, "treeContext": null, "retryLane": 0}
 
-nk = ua["ReactCurrentDispatcher"]
+nk (const after eval) = ua["ReactCurrentDispatcher"]
 
-nl = (...) => undefined
+nl (const after eval) = (...) => undefined
 
-oa = (...) => (!(0) | !(1))
+oa (const after eval) = (...) => (!(0) | !(1))
 
-ob = (...) => undefined
+ob (const after eval) = (...) => undefined
 
-oc = (FreeVar(Math)["clz32"] ? FreeVar(Math)["clz32"] : nc)
+oc (const after eval) = (FreeVar(Math)["clz32"] ? FreeVar(Math)["clz32"] : nc)
 
-od = (...) => ((???*0* || (13 === a)) ? a : 0)
+od (const after eval) = (...) => ((???*0* || (13 === a)) ? a : 0)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-oe = (...) => d
+oe (const after eval) = (...) => d
 
-of = `__reactEvents$${Nf}`
+of (const after eval) = `__reactEvents$${Nf}`
 
-og = []
+og (const after eval) = []
 
-oh = (...) => (("function" === typeof(a["shouldComponentUpdate"])) ? a["shouldComponentUpdate"](d, f, g) : ((b["prototype"] && b["prototype"]["isPureReactComponent"]) ? (!(Ie(c, d)) || !(Ie(e, f))) : !(0)))
+oh (const after eval) = (...) => (("function" === typeof(a["shouldComponentUpdate"])) ? a["shouldComponentUpdate"](d, f, g) : ((b["prototype"] && b["prototype"]["isPureReactComponent"]) ? (!(Ie(c, d)) || !(Ie(e, f))) : !(0)))
 
-oi = (...) => (!(He(a, c)) | !(0) | undefined)
+oi (const after eval) = (...) => (!(He(a, c)) | !(0) | undefined)
 
-oj = (...) => {"baseLanes": a, "cachePool": null, "transitions": null}
+oj (const after eval) = (...) => {"baseLanes": a, "cachePool": null, "transitions": null}
 
-ok = ua["ReactCurrentOwner"]
+ok (const after eval) = ua["ReactCurrentOwner"]
 
-ol = (...) => !((
+ol (const after eval) = (...) => !((
  || !(a)
  || ((1 !== a["nodeType"]) && (9 !== a["nodeType"]) && (11 !== a["nodeType"]))
 ))
 
-p = (...) => `Minified React error #${a}; visit ${b} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`
+p (const after eval) = (...) => `Minified React error #${a}; visit ${b} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`
 
-pa = (...) => (!(1) | !(0) | !(c["acceptsBooleans"]) | (("data-" !== a) && ("aria-" !== a)) | undefined)
+pa (const after eval) = (...) => (!(1) | !(0) | !(c["acceptsBooleans"]) | (("data-" !== a) && ("aria-" !== a)) | undefined)
 
-pb = {
+pb (const after eval) = {
     "animationIterationCount": !(0),
     "aspectRatio": !(0),
     "borderImageOutset": !(0),
@@ -6001,23 +6001,23 @@ pb = {
     "strokeWidth": !(0)
 }
 
-pc = FreeVar(Math)["log"]
+pc (const after eval) = FreeVar(Math)["log"]
 
-pd = (...) => !(0)
+pd (const after eval) = (...) => !(0)
 
 pe = (null | b)
 
-pf = (...) => undefined
+pf (const after eval) = (...) => undefined
 
 pg = (0 | ???*0*)
 - *0* updated with update expression
   ⚠️  This value might have side effects
 
-ph = (...) => b
+ph (const after eval) = (...) => b
 
-pi = (...) => undefined
+pi (const after eval) = (...) => undefined
 
-pj = (...) => (???*0* | (f ? ???*1* : rj(b, g)) | sj(a, b, g, d, h, e, c) | d)
+pj (const after eval) = (...) => (???*0* | (f ? ???*1* : rj(b, g)) | sj(a, b, g, d, h, e, c) | d)
 - *0* null
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -6025,9 +6025,9 @@ pj = (...) => (???*0* | (f ? ???*1* : rj(b, g)) | sj(a, b, g, d, h, e, c) | d)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-pk = ua["ReactCurrentBatchConfig"]
+pk (const after eval) = ua["ReactCurrentBatchConfig"]
 
-pl = (...) => !((
+pl (const after eval) = (...) => !((
  || !(a)
  || (
      && (1 !== a["nodeType"])
@@ -6077,33 +6077,33 @@ q#843 = (m["tag"] | undefined)
 
 q#883 = (m["child"] | undefined)
 
-qa = (...) => (!(0) | !(1) | !(b) | (!(1) === b) | FreeVar(isNaN)(b) | (FreeVar(isNaN)(b) || ???*0*))
+qa (const after eval) = (...) => (!(0) | !(1) | !(b) | (!(1) === b) | FreeVar(isNaN)(b) | (FreeVar(isNaN)(b) || ???*0*))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-qb = ["Webkit", "ms", "Moz", "O"]
+qb (const after eval) = ["Webkit", "ms", "Moz", "O"]
 
-qc = FreeVar(Math)["LN2"]
+qc (const after eval) = FreeVar(Math)["LN2"]
 
-qd = (...) => !(1)
+qd (const after eval) = (...) => !(1)
 
 qe = (null | c)
 
-qf = (...) => undefined
+qf (const after eval) = (...) => undefined
 
 qg = (null | a | og[???*0*] | b)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-qh = (...) => undefined
+qh (const after eval) = (...) => undefined
 
-qi = (...) => [b["memoizedState"], a]
+qi (const after eval) = (...) => [b["memoizedState"], a]
 
-qj = (...) => a
+qj (const after eval) = (...) => a
 
 qk = (null | b)
 
-ql = (...) => undefined
+ql (const after eval) = (...) => undefined
 
 r#404 = (
   | h["lane"]
@@ -6137,19 +6137,19 @@ r#843 = (m["alternate"] | undefined)
 
 r#883 = (m["sibling"] | undefined)
 
-ra = /[\-:]([a-z])/g
+ra (const after eval) = /[\-:]([a-z])/g
 
-rb = (...) => (((null == b) || ("boolean" === typeof(b)) || ("" === b)) ? "" : ((c || ("number" !== typeof(b)) || (0 === b) || (pb["hasOwnProperty"](a) && pb[a])) ? `${b}`["trim"]() : `${b}px`))
+rb (const after eval) = (...) => (((null == b) || ("boolean" === typeof(b)) || ("" === b)) ? "" : ((c || ("number" !== typeof(b)) || (0 === b) || (pb["hasOwnProperty"](a) && pb[a])) ? `${b}`["trim"]() : `${b}px`))
 
 rc = (64 | ???*0*)
 - *0* unsupported assign operation
   ⚠️  This value might have side effects
 
-rd = (...) => b
+rd (const after eval) = (...) => b
 
-re = (...) => undefined
+re (const after eval) = (...) => undefined
 
-rf = `_reactListening${FreeVar(Math)["random"]()["toString"](36)["slice"](2)}`
+rf (const after eval) = `_reactListening${FreeVar(Math)["random"]()["toString"](36)["slice"](2)}`
 
 rg = (1 | ???*0* | og[???*1*] | a["id"])
 - *0* unsupported expression
@@ -6157,27 +6157,27 @@ rg = (1 | ???*0* | og[???*1*] | a["id"])
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-rh = (...) => undefined
+rh (const after eval) = (...) => undefined
 
-ri = (...) => undefined
+ri (const after eval) = (...) => undefined
 
-rj = (...) => b
+rj (const after eval) = (...) => b
 
 rk = (0 | ???*0*)
 - *0* unsupported assign operation
   ⚠️  This value might have side effects
 
-rl = (...) => (g | k)
+rl (const after eval) = (...) => (g | k)
 
-sa = (...) => a[1]["toUpperCase"]()
+sa (const after eval) = (...) => a[1]["toUpperCase"]()
 
-sb = (...) => undefined
+sb (const after eval) = (...) => undefined
 
 sc = (4194304 | ???*0*)
 - *0* unsupported assign operation
   ⚠️  This value might have side effects
 
-sd = {
+sd (const after eval) = {
     "eventPhase": 0,
     "bubbles": 0,
     "cancelable": 0,
@@ -6186,19 +6186,19 @@ sd = {
     "isTrusted": 0
 }
 
-se = (...) => undefined
+se (const after eval) = (...) => undefined
 
-sf = (...) => undefined
+sf (const after eval) = (...) => undefined
 
 sg = ("" | (f + a) | a | og[???*0*] | a["overflow"])
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-sh = (...) => (b["ref"] | b | a)
+sh (const after eval) = (...) => (b["ref"] | b | a)
 
-si = (...) => di()["memoizedState"]
+si (const after eval) = (...) => di()["memoizedState"]
 
-sj = (...) => (???*0* | null | f | tj(a, b, g, null) | tj(a, b, g, d) | b)
+sj (const after eval) = (...) => (???*0* | null | f | tj(a, b, g, null) | tj(a, b, g, d) | b)
 - *0* tj(a, b, g, d)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -6207,7 +6207,7 @@ sk = (0 | ???*0*)
 - *0* unsupported assign operation
   ⚠️  This value might have side effects
 
-sl = (...) => hl(g)
+sl (const after eval) = (...) => hl(g)
 
 t#292 = ((0 !== ???*0*) | undefined | [] | Bd | Td | new t(x, `${w}enter`, n, c, e) | k | vf(t) | null)
 - *0* unsupported expression
@@ -6264,9 +6264,9 @@ t#843 = (new FreeVar(Set)() | undefined)
 
 t#883 = (n["child"] | undefined | J)
 
-ta = (...) => undefined
+ta (const after eval) = (...) => undefined
 
-tb = A(
+tb (const after eval) = A(
     {"menuitem": !(0)},
     {
         "area": !(0),
@@ -6287,27 +6287,27 @@ tb = A(
     }
 )
 
-tc = (...) => (1 | 2 | 4 | 8 | 16 | 32 | ???*0* | 134217728 | 268435456 | 536870912 | 1073741824 | a | undefined)
+tc (const after eval) = (...) => (1 | 2 | 4 | 8 | 16 | 32 | ???*0* | 134217728 | 268435456 | 536870912 | 1073741824 | a | undefined)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-td = rd(sd)
+td (const after eval) = rd(sd)
 
-te = (...) => (a | undefined)
+te (const after eval) = (...) => (a | undefined)
 
-tf = (...) => {"instance": a, "listener": b, "currentTarget": c}
+tf (const after eval) = (...) => {"instance": a, "listener": b, "currentTarget": c}
 
-tg = (...) => undefined
+tg (const after eval) = (...) => undefined
 
-th = (...) => undefined
+th (const after eval) = (...) => undefined
 
-ti = (...) => undefined
+ti (const after eval) = (...) => undefined
 
-tj = (...) => a
+tj (const after eval) = (...) => a
 
 tk = (null | [f])
 
-tl = {"usingClientEntryPoint": !(1), "Events": [Cb, ue, Db, Eb, Fb, Rk]}
+tl (const after eval) = {"usingClientEntryPoint": !(1), "Events": [Cb, ue, Db, Eb, Fb, Rk]}
 
 u#292 = (???*0* | w | F | ((null == n) ? h : ue(n)) | t | vf(u) | 0 | ???*1*)
 - *0* u
@@ -6325,62 +6325,62 @@ u#843 = (f["stateNode"] | undefined)
 
 u#883 = (g["child"] | undefined)
 
-ua = aa["__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"]
+ua (const after eval) = aa["__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"]
 
-ub = (...) => undefined
+ub (const after eval) = (...) => undefined
 
-uc = (...) => (0 | b | d)
+uc (const after eval) = (...) => (0 | b | d)
 
-ud = A({}, sd, {"view": 0, "detail": 0})
+ud (const after eval) = A({}, sd, {"view": 0, "detail": 0})
 
-ue = (...) => (a["stateNode"] | undefined)
+ue (const after eval) = (...) => (a["stateNode"] | undefined)
 
-uf = `__reactContainer$${Nf}`
+uf (const after eval) = `__reactContainer$${Nf}`
 
-ug = (...) => undefined
+ug (const after eval) = (...) => undefined
 
-uh = (...) => b(a["_payload"])
+uh (const after eval) = (...) => b(a["_payload"])
 
-ui = (...) => undefined
+ui (const after eval) = (...) => undefined
 
-uj = (...) => undefined
+uj (const after eval) = (...) => undefined
 
 uk = (null | c | a)
 
-ul = {
+ul (const after eval) = {
     "findFiberByHostInstance": Wc,
     "bundleType": 0,
     "version": "18.2.0",
     "rendererPackageName": "react-dom"
 }
 
-v = (...) => undefined
+v (const after eval) = (...) => undefined
 
-va = FreeVar(Symbol)["for"]("react.element")
+va (const after eval) = FreeVar(Symbol)["for"]("react.element")
 
-vb = (...) => (("string" === typeof(b["is"])) | !(1) | !(0) | undefined)
+vb (const after eval) = (...) => (("string" === typeof(b["is"])) | !(1) | !(0) | undefined)
 
-vc = (...) => ((b + 250) | (b + 5000) | ???*0* | undefined)
+vc (const after eval) = (...) => ((b + 250) | (b + 5000) | ???*0* | undefined)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-vd = rd(ud)
+vd (const after eval) = rd(ud)
 
-ve = (...) => (b | undefined)
+ve (const after eval) = (...) => (b | undefined)
 
-vf = (...) => (null | (a ? a : null))
+vf (const after eval) = (...) => (null | (a ? a : null))
 
-vg = (...) => undefined
+vg (const after eval) = (...) => undefined
 
-vh = (...) => J
+vh (const after eval) = (...) => J
 
-vi = (...) => ti(8390656, 8, a, b)
+vi (const after eval) = (...) => ti(8390656, 8, a, b)
 
-vj = (...) => undefined
+vj (const after eval) = (...) => undefined
 
 vk = null
 
-vl = {
+vl (const after eval) = {
     "bundleType": ul["bundleType"],
     "version": ul["version"],
     "rendererPackageName": ul["rendererPackageName"],
@@ -6429,11 +6429,11 @@ w#843 = (f["type"] | undefined)
 
 w#883 = (a["current"] | undefined)
 
-wa = FreeVar(Symbol)["for"]("react.portal")
+wa (const after eval) = FreeVar(Symbol)["for"]("react.portal")
 
 wb = (null | d)
 
-wc = (...) => undefined
+wc (const after eval) = (...) => undefined
 
 wd = (???*0* | ???*1* | 0)
 - *0* wd
@@ -6441,26 +6441,26 @@ wd = (???*0* | ???*1* | 0)
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-we = (
+we (const after eval) = (
   | !(1)
   | (xe && (!(FreeVar(document)["documentMode"]) || ???*0*))
 )
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-wf = (...) => undefined
+wf (const after eval) = (...) => undefined
 
-wg = (...) => undefined
+wg (const after eval) = (...) => undefined
 
-wh = (...) => c
+wh (const after eval) = (...) => c
 
-wi = (...) => ui(4, 2, a, b)
+wi (const after eval) = (...) => ui(4, 2, a, b)
 
-wj = (...) => undefined
+wj (const after eval) = (...) => undefined
 
 wk = (!(1) | !(0))
 
-wl = (FreeVar(__REACT_DEVTOOLS_GLOBAL_HOOK__) | undefined)
+wl (const after eval) = (FreeVar(__REACT_DEVTOOLS_GLOBAL_HOOK__) | undefined)
 
 x#292 = (
   | (t ? ((null !== h) ? `${h}Capture` : null) : h)
@@ -6483,9 +6483,9 @@ x#883 = (f["sibling"] | undefined)
 
 xa = (Ce | undefined | h["_wrapperState"] | (d ? ue(d) : FreeVar(window)) | oe(d, ba))
 
-xb = (...) => ((3 === a["nodeType"]) ? a["parentNode"] : a)
+xb (const after eval) = (...) => ((3 === a["nodeType"]) ? a["parentNode"] : a)
 
-xc = (...) => ((0 !== a) ? a : (???*0* ? 1073741824 : 0))
+xc (const after eval) = (...) => ((0 !== a) ? a : (???*0* ? 1073741824 : 0))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
@@ -6495,19 +6495,19 @@ xd = (???*0* | ???*1* | 0)
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
-xe = (???*0* | ye | !(1))
+xe (const after eval) = (???*0* | ye | !(1))
 - *0* xe
   ⚠️  pattern without value
 
-xf = /\r\n?/g
+xf (const after eval) = /\r\n?/g
 
 xg = (null | a | a | a | b | b)
 
-xh = (...) => a
+xh (const after eval) = (...) => a
 
-xi = (...) => ui(4, 4, a, b)
+xi (const after eval) = (...) => ui(4, 4, a, b)
 
-xj = (...) => undefined
+xj (const after eval) = (...) => undefined
 
 xk = (null | a)
 
@@ -6542,21 +6542,21 @@ y#843 = (Vi(g) | undefined)
 
 y#883 = (m["return"] | undefined)
 
-ya = FreeVar(Symbol)["for"]("react.fragment")
+ya (const after eval) = FreeVar(Symbol)["for"]("react.fragment")
 
-yb = (null | *anonymous function 128216*)
+yb (const after eval) = (null | *anonymous function 128216*)
 
-yc = (...) => a
+yc (const after eval) = (...) => a
 
 yd = (???*0* | a)
 - *0* yd
   ⚠️  pattern without value
 
-ye = (???*0* | undefined | ("function" === typeof(ze["oninput"])))
+ye (const after eval) = (???*0* | undefined | ("function" === typeof(ze["oninput"])))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 
-yf = /\u0000|\uFFFD/g
+yf (const after eval) = /\u0000|\uFFFD/g
 
 yg = (
   | null
@@ -6567,41 +6567,41 @@ yg = (
   | Lf(b["stateNode"]["containerInfo"]["firstChild"])
 )
 
-yh = (...) => (Ah(c["children"], e, f, b) | ???*0* | qj(c, e, f, b) | b)
+yh (const after eval) = (...) => (Ah(c["children"], e, f, b) | ???*0* | qj(c, e, f, b) | b)
 - *0* a
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-yi = (...) => (???*0* | undefined)
+yi (const after eval) = (...) => (???*0* | undefined)
 - *0* *anonymous function 69020*
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 
-yj = (...) => b["child"]
+yj (const after eval) = (...) => b["child"]
 
 yk = (0 | e)
 
-z = {}
+z (const after eval) = {}
 
-za = FreeVar(Symbol)["for"]("react.strict_mode")
+za (const after eval) = FreeVar(Symbol)["for"]("react.strict_mode")
 
 zb = (null | a)
 
-zc = (...) => b
+zc (const after eval) = (...) => b
 
-zd = (...) => Pd
+zd (const after eval) = (...) => Pd
 
-ze = (FreeVar(document)["createElement"]("div") | undefined)
+ze (const after eval) = (FreeVar(document)["createElement"]("div") | undefined)
 
-zf = (...) => (("string" === typeof(a)) ? a : `${a}`)["replace"](xf, "\n")["replace"](yf, "")
+zf (const after eval) = (...) => (("string" === typeof(a)) ? a : `${a}`)["replace"](xf, "\n")["replace"](yf, "")
 
 zg = (null | [a])
 
-zh = (...) => b
+zh (const after eval) = (...) => b
 
-zi = (...) => ui(4, 4, yi["bind"](null, b, a), c)
+zi (const after eval) = (...) => ui(4, 4, yi["bind"](null, b, a), c)
 
-zj = (...) => (
+zj (const after eval) = (...) => (
   | ???*0*
   | pj(a, b, c)
   | ((null !== a) ? a["sibling"] : null)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/require-context/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/require-context/graph-explained.snapshot
@@ -1,9 +1,9 @@
-a = context["resolve"]("./a")
+a (const after eval) = context["resolve"]("./a")
 
-context = FreeVar(require)["context"]("./test", false, /\.test\.js$/)
+context (const after eval) = FreeVar(require)["context"]("./test", false, /\.test\.js$/)
 
-importAll = (...) => r["keys"]()["map"](r)
+importAll (const after eval) = (...) => r["keys"]()["map"](r)
 
-items = importAll(context)
+items (const after eval) = importAll(context)
 
 r = arguments[0]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/sequences/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/sequences/graph-explained.snapshot
@@ -1,8 +1,8 @@
-x = (1 | ???*0*)
+x (const after eval) = (1 | ???*0*)
 - *0* updated with update expression
   ⚠️  This value might have side effects
 
-y = ???*0*
+y (const after eval) = ???*0*
 - *0* 2
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/try/graph-explained.snapshot
@@ -1,7 +1,7 @@
-e = ???*0*
+e (const after eval) = ???*0*
 - *0* e
   ⚠️  pattern without value
 
-pkg = (???*0* | FreeVar(require)("packages/not-found") | FreeVar(require)("packages/found"))
+pkg (const after eval) = (???*0* | FreeVar(require)("packages/not-found") | FreeVar(require)("packages/found"))
 - *0* pkg
   ⚠️  pattern without value

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/turbopack-ignore/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/turbopack-ignore/graph-explained.snapshot
@@ -1,14 +1,14 @@
-exported_t_r = FreeVar(require)("exported_t_r")
+exported_t_r (const after eval) = FreeVar(require)("exported_t_r")
 
-t_i = await(FreeVar(import)("t_i"))
+t_i (const after eval) = await(FreeVar(import)("t_i"))
 
-t_r = (
+t_r (const after eval) = (
   | FreeVar(require)("w_i_f")
   | FreeVar(require)("t_i_f")
   | FreeVar(require)("t_r_t")
   | FreeVar(require)("t_r_f")
 )
 
-w_i = await(FreeVar(import)("w_i"))
+w_i (const after eval) = await(FreeVar(import)("w_i"))
 
-w_r = (FreeVar(require)("w_r_t") | FreeVar(require)("w_r_f"))
+w_r (const after eval) = (FreeVar(require)("w_r_t") | FreeVar(require)("w_r_f"))

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/graph-explained.snapshot
@@ -1,7 +1,7 @@
-A = (...) => undefined
+A (const after eval) = (...) => undefined
 
-B = (...) => undefined
+B (const after eval) = (...) => undefined
 
-C = (...) => undefined
+C (const after eval) = (...) => undefined
 
 v = arguments[0]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable/graph-explained.snapshot
@@ -1,24 +1,24 @@
 *arrow function 567* = (...) => undefined
 
-a = (...) => undefined
+a (const after eval) = (...) => undefined
 
-b = (...) => undefined
+b (const after eval) = (...) => undefined
 
-c = (...) => undefined
+c (const after eval) = (...) => undefined
 
-d = (...) => undefined
+d (const after eval) = (...) => undefined
 
 e#16 = ???*0*
 - *0* e
   ⚠️  pattern without value
 
-e#2 = (...) => undefined
+e#2 (const after eval) = (...) => undefined
 
-f = (...) => undefined
+f (const after eval) = (...) => undefined
 
-g = (...) => undefined
+g (const after eval) = (...) => undefined
 
-h = (...) => undefined
+h (const after eval) = (...) => undefined
 
 x#10 = ???*0*
 - *0* for-in variable currently not analyzed

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/worker/graph-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/worker/graph-explained.snapshot
@@ -1,2 +1,2 @@
-workerUrl = new FreeVar(URL)("./worker.ts", import.meta*0*["url"])
+workerUrl (const after eval) = new FreeVar(URL)("./worker.ts", import.meta*0*["url"])
 - *0* import.meta: The import.meta object


### PR DESCRIPTION
Track where variable assignments occur for all variables.

Right now we only care to identify variables that are _only_ assigned in the 'module evaluation' scope which can later flow into analysis of esm exports.


Closes PACK-5515