### PR TITLE
Fix hasMiddleware prop to trigger getStaticProps on back nav

### DIFF
--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -2025,7 +2025,7 @@ export default class Router implements BaseRouter {
           asPath: isNotFound ? '/404' : resolvedAs,
           locale,
         }),
-        hasMiddleware: true,
+        hasMiddleware,
         isServerRender: this.isSsr,
         parseJSON: true,
         inflightCache: isBackground ? this.sbc : this.sdc,

--- a/test/e2e/middleware-rewrites/app/pages/index.js
+++ b/test/e2e/middleware-rewrites/app/pages/index.js
@@ -1,11 +1,12 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
-export default function Home() {
+export default function Home({ now }) {
   const router = useRouter()
   return (
     <div>
       <p className="title">Home Page</p>
+      <p className="now">{now}</p>
       <div />
       <Link href="/article/foo/bar/123" id="to-article-rewrite">
         to /article/foo/bar/123

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -151,6 +151,34 @@ describe('Middleware Rewrite', () => {
       expect(await browser.eval('next.router.asPath')).toBe('/param-1')
     })
 
+    it('should trigger getServerSideProps on back navigation when middleware is present', async () => {
+      const home1 = await fetchViaHTTP(next.url, '/')
+      expect(home1.status).toBe(200)
+
+      const home1Text = await home1.text()
+      const home1Timestamp = home1Text.match(/now.*?(\d+)/)?.[1]
+      expect(home1Timestamp).toBeDefined()
+
+      const rewritten = await fetchViaHTTP(
+        next.url,
+        '/fallback-true-blog/rewritten'
+      )
+      expect(rewritten.status).toBe(200)
+
+      const rewrittenText = await rewritten.text()
+      expect(rewrittenText).toContain('About Page')
+
+      const home2 = await fetchViaHTTP(next.url, '/')
+      expect(home2.status).toBe(200)
+
+      const home2Text = await home2.text()
+      const home2Timestamp = home2Text.match(/now.*?(\d+)/)?.[1]
+      expect(home2Timestamp).toBeDefined()
+
+      expect(home1Timestamp).not.toBe(home2Timestamp)
+      expect(parseInt(home2Timestamp)).toBeGreaterThan(parseInt(home1Timestamp))
+    })
+
     it('should have props for afterFiles rewrite to SSG page', async () => {
       // TODO: investigate test failure during client navigation
       // on deployment

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -152,31 +152,30 @@ describe('Middleware Rewrite', () => {
     })
 
     it('should trigger getServerSideProps on back navigation when middleware is present', async () => {
-      const home1 = await fetchViaHTTP(next.url, '/')
-      expect(home1.status).toBe(200)
+      const browser = await webdriver(next.url, '/')
 
-      const home1Text = await home1.text()
-      const home1Timestamp = home1Text.match(/now.*?(\d+)/)?.[1]
+      const home1Timestamp = await browser.eval(
+        'document.querySelector(".now")?.textContent'
+      )
       expect(home1Timestamp).toBeDefined()
 
-      const rewritten = await fetchViaHTTP(
-        next.url,
-        '/fallback-true-blog/rewritten'
+      await browser.elementByCss('a[href="/ssg"]').click()
+      await browser.waitForElementByCss('h1')
+      const ssgText = await browser.eval('document.body.innerText')
+      expect(ssgText).toContain('SSG Page')
+
+      await browser.back()
+      await browser.waitForElementByCss('.now')
+
+      const home2Timestamp = await browser.eval(
+        'document.querySelector(".now")?.textContent'
       )
-      expect(rewritten.status).toBe(200)
-
-      const rewrittenText = await rewritten.text()
-      expect(rewrittenText).toContain('About Page')
-
-      const home2 = await fetchViaHTTP(next.url, '/')
-      expect(home2.status).toBe(200)
-
-      const home2Text = await home2.text()
-      const home2Timestamp = home2Text.match(/now.*?(\d+)/)?.[1]
       expect(home2Timestamp).toBeDefined()
 
       expect(home1Timestamp).not.toBe(home2Timestamp)
       expect(parseInt(home2Timestamp)).toBeGreaterThan(parseInt(home1Timestamp))
+
+      await browser.close()
     })
 
     it('should have props for afterFiles rewrite to SSG page', async () => {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


**What?**
Fix `fetchNextDataParams` so browser back navigation fetches the latest data correctly.

**Why?**
Back button navigation didn’t always reload data when middleware and rewrites were used.

**How?**
Use the hasMiddleware value from props instead of hardcoding `true`.


Closes NEXT-
Fixes https://github.com/vercel/next.js/issues/82829