### PR TITLE
fix: update the config.api.responseLimit type

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -526,7 +526,7 @@ export function generateValidatorFile(
   config?: {
     api?: {
       bodyParser?: boolean | { sizeLimit?: string }
-      responseLimit?: string | number
+      responseLimit?: string | number | boolean
       externalResolver?: boolean
     }
     runtime?: 'edge' | 'experimental-edge' | 'nodejs' | string // necessary unless config is exported as const


### PR DESCRIPTION
`config.api.responseLimit` can also be [set to `false`](https://github.com/vercel/next.js/issues/82842#issuecomment-3207638164). Because of the limitations of type inference on JS files, we need to set the type to `boolean`.

See https://github.com/vercel/next.js/issues/82842#issuecomment-3207638164