### PR TITLE
Turbopack: Add new webpack loader rule/condition syntax in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9482,6 +9482,7 @@ dependencies = [
  "anyhow",
  "codspeed-criterion-compat",
  "difference",
+ "either",
  "regex",
  "rstest",
  "rstest_reuse",

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -248,11 +248,11 @@ pub async fn get_client_module_options_context(
     let mut foreign_conditions = loader_conditions.clone();
     foreign_conditions.insert(WebpackLoaderBuiltinCondition::Foreign);
     let foreign_enable_webpack_loaders =
-        webpack_loader_options(project_path.clone(), next_config, true, foreign_conditions).await?;
+        webpack_loader_options(project_path.clone(), next_config, foreign_conditions).await?;
 
     // Now creates a webpack rules that applies to all code.
     let enable_webpack_loaders =
-        webpack_loader_options(project_path.clone(), next_config, false, loader_conditions).await?;
+        webpack_loader_options(project_path.clone(), next_config, loader_conditions).await?;
 
     let tree_shaking_mode_for_user_code = *next_config
         .tree_shaking_mode_for_user_code(next_mode.is_development())

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -493,11 +493,11 @@ pub async fn get_server_module_options_context(
     let mut foreign_conditions = loader_conditions.clone();
     foreign_conditions.insert(WebpackLoaderBuiltinCondition::Foreign);
     let foreign_enable_webpack_loaders =
-        webpack_loader_options(project_path.clone(), next_config, true, foreign_conditions).await?;
+        webpack_loader_options(project_path.clone(), next_config, foreign_conditions).await?;
 
     // Now creates a webpack rules that applies to all code.
     let enable_webpack_loaders =
-        webpack_loader_options(project_path.clone(), next_config, false, loader_conditions).await?;
+        webpack_loader_options(project_path.clone(), next_config, loader_conditions).await?;
 
     let tree_shaking_mode_for_user_code = *next_config
         .tree_shaking_mode_for_user_code(next_mode.is_development())

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -97,6 +97,7 @@ pub async fn maybe_add_babel_loader(
                         LoaderRuleItem {
                             loaders: ResolvedVc::cell(vec![loader]),
                             rename_as: Some(rcstr!("*")),
+                            condition: None,
                         },
                     );
                 }

--- a/crates/next-core/src/next_shared/webpack_rules/sass.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/sass.rs
@@ -87,6 +87,7 @@ pub async fn maybe_add_sass_loader(
                 LoaderRuleItem {
                     loaders: ResolvedVc::cell(vec![resolve_url_loader, sass_loader]),
                     rename_as: Some(format!("*{rename}").into()),
+                    condition: None,
                 },
             );
         }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -259,7 +259,7 @@ export type TurbopackLoaderItem =
   | {
       loader: string
       // At the moment, Turbopack options must be JSON-serializable, so restrict values.
-      options: Record<string, JSONValue>
+      options?: Record<string, JSONValue>
     }
 
 export type TurbopackLoaderBuiltinCondition =
@@ -271,24 +271,30 @@ export type TurbopackLoaderBuiltinCondition =
   | 'node'
   | 'edge-light'
 
-export type TurbopackRuleCondition = {
-  path?: string | RegExp
-  content?: RegExp
-}
-
-export type TurbopackRuleConfigItemOrShortcut =
-  | TurbopackLoaderItem[]
-  | TurbopackRuleConfigItem
+export type TurbopackRuleCondition =
+  | { all: TurbopackRuleCondition[] }
+  | { any: TurbopackRuleCondition[] }
+  | { not: TurbopackRuleCondition }
+  | TurbopackLoaderBuiltinCondition
+  | {
+      path?: string | RegExp
+      content?: RegExp
+    }
 
 export type TurbopackRuleConfigItemOptions = {
   loaders: TurbopackLoaderItem[]
   as?: string
+  condition?: TurbopackRuleCondition
 }
 
 export type TurbopackRuleConfigItem =
   | TurbopackRuleConfigItemOptions
   | { [condition in TurbopackLoaderBuiltinCondition]?: TurbopackRuleConfigItem }
   | false
+
+export type TurbopackRuleConfigItemOrShortcut =
+  | TurbopackLoaderItem[]
+  | TurbopackRuleConfigItem
 
 export interface TurbopackOptions {
   /**
@@ -320,7 +326,7 @@ export interface TurbopackOptions {
    *
    * @see [Turbopack Loaders](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders)
    */
-  conditions?: Record<string, TurbopackRuleCondition>
+  conditions?: Record<`#${string}`, TurbopackRuleCondition>
 
   /**
    * The module ID strategy to use for Turbopack.

--- a/test/e2e/turbopack-loader-config/app/api/route.ts
+++ b/test/e2e/turbopack-loader-config/app/api/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import foo from '../../foo.js'
+import bar from '../../bar.js'
+
+export async function GET(_req) {
+  return NextResponse.json(
+    {
+      foo,
+      bar,
+    },
+    { status: 200 }
+  )
+}

--- a/test/e2e/turbopack-loader-config/bar.js
+++ b/test/e2e/turbopack-loader-config/bar.js
@@ -1,0 +1,1 @@
+export default 'untransformed bar'

--- a/test/e2e/turbopack-loader-config/foo.js
+++ b/test/e2e/turbopack-loader-config/foo.js
@@ -1,0 +1,1 @@
+export default 'untransformed foo'

--- a/test/e2e/turbopack-loader-config/index.test.ts
+++ b/test/e2e/turbopack-loader-config/index.test.ts
@@ -1,0 +1,23 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('turbopack-loader-config', () => {
+  const { next, isTurbopack, isNextDev } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    // we can't set `nextConfig` inline because it contains regexes that fail to serialize, it needs
+    // to be set in a separate module (`next.config.ts`)
+  })
+
+  if (!isTurbopack) {
+    it('should only run the test in turbopack', () => {})
+    return
+  }
+
+  it('should replace modules with their loader-generated versions', async () => {
+    const response = JSON.parse(await next.render('/api'))
+    expect(response).toEqual({
+      foo: 'default return value',
+      bar: 'has export substring' + (isNextDev ? ' on dev' : ' on prod'),
+    })
+  })
+})

--- a/test/e2e/turbopack-loader-config/next.config.ts
+++ b/test/e2e/turbopack-loader-config/next.config.ts
@@ -1,0 +1,62 @@
+export default {
+  turbopack: {
+    rules: {
+      // an empty condition should match
+      'foo.js': {
+        condition: {},
+        // use the shorthand syntax
+        loaders: ['./webpack-loader-replace-with-stub.cjs'],
+      },
+      // this condition should not match
+      'bar.js': {
+        condition: 'foreign',
+        loaders: [
+          {
+            loader: './webpack-loader-replace-with-stub.cjs',
+            options: { returnValue: 'foreign' },
+          },
+        ],
+      },
+      // this condition should not match
+      '{bar}.js': {
+        condition: {
+          not: { content: /export/ },
+        },
+        loaders: [
+          {
+            loader: './webpack-loader-replace-with-stub.cjs',
+            options: { returnValue: 'missing export' },
+          },
+        ],
+      },
+      // this should match on dev
+      '{bar.js}': {
+        condition: {
+          any: [
+            {
+              all: ['development', { not: { not: { content: /export/ } } }],
+            },
+          ],
+        },
+        loaders: [
+          {
+            loader: './webpack-loader-replace-with-stub.cjs',
+            options: { returnValue: 'has export substring on dev' },
+          },
+        ],
+      },
+      // this should match on production
+      'bar.{js}': {
+        condition: {
+          all: [{ not: 'development' }, { content: /export/ }],
+        },
+        loaders: [
+          {
+            loader: './webpack-loader-replace-with-stub.cjs',
+            options: { returnValue: 'has export substring on prod' },
+          },
+        ],
+      },
+    },
+  },
+}

--- a/test/e2e/turbopack-loader-config/webpack-loader-replace-with-stub.cjs
+++ b/test/e2e/turbopack-loader-config/webpack-loader-replace-with-stub.cjs
@@ -1,0 +1,8 @@
+module.exports = function (content, _map, _meta) {
+  const options = this.getOptions()
+  if (!content.includes('untransformed')) {
+    throw new Error('loader matched multiple times')
+  }
+  const returnValue = options?.returnValue ?? 'default return value'
+  return `export default ${JSON.stringify(returnValue)}`
+}

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -88,6 +88,7 @@ struct WebpackLoadersProcessingResult {
 )]
 pub struct WebpackLoaderItem {
     pub loader: RcStr,
+    #[serde(default)]
     pub options: serde_json::Map<String, serde_json::Value>,
 }
 

--- a/turbopack/crates/turbopack/Cargo.toml
+++ b/turbopack/crates/turbopack/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+either = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 smallvec = { workspace = true }

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -11,7 +11,7 @@ pub use module_options_context::*;
 pub use module_rule::*;
 pub use rule_condition::*;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::{IntoTraitRef, ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::{
     FileSystemPath,
     glob::{Glob, GlobOptions},
@@ -27,7 +27,10 @@ use turbopack_ecmascript::{
     EcmascriptInputTransform, EcmascriptInputTransforms, EcmascriptOptions, SpecifiedModuleType,
 };
 use turbopack_mdx::MdxTransform;
-use turbopack_node::transforms::{postcss::PostCssTransform, webpack::WebpackLoaders};
+use turbopack_node::{
+    execution_context::ExecutionContext,
+    transforms::{postcss::PostCssTransform, webpack::WebpackLoaders},
+};
 use turbopack_wasm::source::WebAssemblySourceType;
 
 use crate::{
@@ -58,6 +61,80 @@ fn package_import_map_from_context(
         ImportMapping::PrimaryAlternative(package_name, Some(context_path)).resolved_cell(),
     );
     import_map.cell()
+}
+
+async fn rule_condition_from_webpack_condition_glob(
+    execution_context: ResolvedVc<ExecutionContext>,
+    glob: &RcStr,
+) -> Result<RuleCondition> {
+    Ok(if glob.contains('/') {
+        RuleCondition::ResourcePathGlob {
+            base: execution_context.project_path().owned().await?,
+            glob: Glob::new(glob.clone(), GlobOptions::default()).await?,
+        }
+    } else {
+        RuleCondition::ResourceBasePathGlob(Glob::new(glob.clone(), GlobOptions::default()).await?)
+    })
+}
+
+async fn rule_condition_from_webpack_condition(
+    execution_context: ResolvedVc<ExecutionContext>,
+    builtin_conditions: &dyn WebpackLoaderBuiltinConditionSet,
+    webpack_loader_condition: &ConditionItem,
+) -> Result<RuleCondition> {
+    Ok(match webpack_loader_condition {
+        ConditionItem::All(conds) => RuleCondition::All(
+            conds
+                .iter()
+                .map(|c| {
+                    rule_condition_from_webpack_condition(execution_context, builtin_conditions, c)
+                })
+                .try_join()
+                .await?,
+        ),
+        ConditionItem::Any(conds) => RuleCondition::Any(
+            conds
+                .iter()
+                .map(|c| {
+                    rule_condition_from_webpack_condition(execution_context, builtin_conditions, c)
+                })
+                .try_join()
+                .await?,
+        ),
+        ConditionItem::Not(cond) => RuleCondition::Not(Box::new(
+            Box::pin(rule_condition_from_webpack_condition(
+                execution_context,
+                builtin_conditions,
+                cond,
+            ))
+            .await?,
+        )),
+        ConditionItem::Builtin(name) => match builtin_conditions.match_condition(name) {
+            WebpackLoaderBuiltinConditionSetMatch::Matched => RuleCondition::True,
+            WebpackLoaderBuiltinConditionSetMatch::Unmatched => RuleCondition::False,
+            WebpackLoaderBuiltinConditionSetMatch::Invalid => {
+                // We don't expect the user to hit this because whatever deserailizes the user
+                // configuration should validate conditions itself
+                anyhow::bail!("{name:?} is not a valid built-in condition")
+            }
+        },
+        ConditionItem::Base { path, content } => {
+            let mut rule_conditions = Vec::new();
+            match &path {
+                Some(ConditionPath::Glob(glob)) => rule_conditions.push(
+                    rule_condition_from_webpack_condition_glob(execution_context, glob).await?,
+                ),
+                Some(ConditionPath::Regex(regex)) => {
+                    rule_conditions.push(RuleCondition::ResourcePathEsRegex(regex.await?));
+                }
+                None => {}
+            }
+            if let Some(content) = content {
+                rule_conditions.push(RuleCondition::ResourceContentEsRegex(content.await?));
+            }
+            RuleCondition::All(rule_conditions)
+        }
+    })
 }
 
 #[turbo_tasks::value(cell = "new", eq = "manual")]
@@ -493,9 +570,17 @@ impl ModuleOptions {
                         .context("need_path in ModuleOptions::new is incorrect")?,
                 )
             };
+            let builtin_conditions = webpack_loaders_options
+                .builtin_conditions
+                .into_trait_ref()
+                .await?;
             for (key, rule) in webpack_loaders_options.rules.await?.iter() {
                 let mut rule_conditions = Vec::new();
+
                 if key.starts_with("#") {
+                    // Legacy (undocumented) condition reference syntax:
+                    // https://www.notion.so/vercel/Turbopack-loader-rule-syntax-254e06b059c4809096d1e7c9afad278c
+                    //
                     // This is a custom marker requiring a corresponding condition entry
                     let conditions = (*webpack_loaders_options.conditions.await?)
                         .context(
@@ -508,65 +593,63 @@ impl ModuleOptions {
                         "Expected a condition entry for the webpack loader rule matching {key}.",
                     )?;
 
-                    let ConditionItem { path, content } = &condition;
-
-                    match &path {
-                        Some(ConditionPath::Glob(glob)) => {
-                            if glob.contains('/') {
-                                rule_conditions.push(RuleCondition::ResourcePathGlob {
-                                    base: execution_context.project_path().owned().await?,
-                                    glob: Glob::new(glob.clone(), GlobOptions::default()).await?,
-                                });
-                            } else {
-                                rule_conditions.push(RuleCondition::ResourceBasePathGlob(
-                                    Glob::new(glob.clone(), GlobOptions::default()).await?,
-                                ));
-                            }
-                        }
-                        Some(ConditionPath::Regex(regex)) => {
-                            rule_conditions.push(RuleCondition::ResourcePathEsRegex(regex.await?));
-                        }
-                        None => {}
-                    }
-                    if let Some(content) = content {
-                        rule_conditions.push(RuleCondition::ResourceContentEsRegex(content.await?));
-                    }
-                } else if key.contains('/') {
-                    rule_conditions.push(RuleCondition::ResourcePathGlob {
-                        base: execution_context.project_path().owned().await?,
-                        glob: Glob::new(key.clone(), GlobOptions::default()).await?,
-                    });
+                    rule_conditions.push(
+                        rule_condition_from_webpack_condition(
+                            execution_context,
+                            &*builtin_conditions,
+                            condition,
+                        )
+                        .await?,
+                    )
                 } else {
-                    rule_conditions.push(RuleCondition::ResourceBasePathGlob(
-                        Glob::new(key.clone(), GlobOptions::default()).await?,
-                    ));
+                    // prefer to add this condition ahead of the user-defined `condition` field,
+                    // because we know it's cheap to check
+                    rule_conditions.push(
+                        rule_condition_from_webpack_condition_glob(execution_context, key).await?,
+                    )
                 };
+
+                if let Some(condition) = &rule.condition {
+                    rule_conditions.push(
+                        rule_condition_from_webpack_condition(
+                            execution_context,
+                            &*builtin_conditions,
+                            condition,
+                        )
+                        .await?,
+                    )
+                }
+
                 rule_conditions.push(RuleCondition::not(RuleCondition::ResourceIsVirtualSource));
                 rule_conditions.push(module_css_external_transform_conditions.clone());
 
-                rules.push(ModuleRule::new(
-                    RuleCondition::All(rule_conditions),
-                    vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
-                        ResolvedVc::upcast(
-                            WebpackLoaders::new(
-                                node_evaluate_asset_context(
+                let mut all_rule_condition = RuleCondition::All(rule_conditions);
+                all_rule_condition.flatten();
+                if !matches!(all_rule_condition, RuleCondition::False) {
+                    rules.push(ModuleRule::new(
+                        all_rule_condition,
+                        vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
+                            ResolvedVc::upcast(
+                                WebpackLoaders::new(
+                                    node_evaluate_asset_context(
+                                        *execution_context,
+                                        Some(import_map),
+                                        None,
+                                        Layer::new(rcstr!("webpack_loaders")),
+                                        false,
+                                    ),
                                     *execution_context,
-                                    Some(import_map),
-                                    None,
-                                    Layer::new(rcstr!("webpack_loaders")),
-                                    false,
-                                ),
-                                *execution_context,
-                                *rule.loaders,
-                                rule.rename_as.clone(),
-                                resolve_options_context,
-                                matches!(ecmascript_source_maps, SourceMapsType::Full),
-                            )
-                            .to_resolved()
-                            .await?,
-                        ),
-                    ]))],
-                ));
+                                    *rule.loaders,
+                                    rule.rename_as.clone(),
+                                    resolve_options_context,
+                                    matches!(ecmascript_source_maps, SourceMapsType::Full),
+                                )
+                                .to_resolved()
+                                .await?,
+                            ),
+                        ]))],
+                    ));
+                }
             }
         }
 


### PR DESCRIPTION
# This PR:

- [x] Allow a condition to be specified inline within a `rule`
- [x] Support `all`/`any`/`not` for conditions
- [x] Simple flattening/optimization logic for the generated `RuleCondition` objects
  - [x] Unit test coverage of flattening logic
- [x] Allow builtin conditions (see https://github.com/vercel/next.js/pull/82765) to be specified in condition objects, instead of requiring a separate syntax for them
- [x] Update regex serialization logic in `packages/next/src/build/swc/index.ts`
- [x] Make sure the updated syntax is fully reflected in the config schema and typedefs
- [x] Emit collectibles for configuration issues instead of hard-failing with anyhow
- [x] e2e test coverage

# Remaining Work for Subsequent PRs

- [x] Remove the legacy `conditions` field from the `turbopack` config object: https://github.com/vercel/next.js/pull/83237
- [x] Remove the legacy built-in condition object syntax from rules: https://github.com/vercel/next.js/pull/83068
- [x] Allow array values in the `turbopack.rules` object: https://github.com/vercel/next.js/pull/83138
- [x] Update user-facing documentation: https://github.com/vercel/next.js/pull/83246

This PR is the bulk of the work towards implementing the proposed new loader rule syntax:
https://www.notion.so/vercel/Turbopack-loader-rule-syntax-254e06b059c4809096d1e7c9afad278c
*(copied below)*

# Loader Syntax Proposal

## Today (documented)

[https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#configuring-webpack-loaders](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#configuring-webpack-loaders)

```javascript
module.exports = {
  turbopack: {
    rules: {
      // all matched rules apply, adding their loaders in order
      '*.svg': {
        loaders: ['@svgr/webpack'],
        as: '*.js',
      },
    },
  },
}
```

## Today (undocumented) - User-defined conditions

You can define custom `#`-prefixed “conditions” that can act as filters for rules.

```javascript
module.exports = {
  turbopack: {
    rules: {
      '#svg-file': {
        loaders: ['@svgr/webpack'],
        // `as` is incompatible! There's no obvious glob to match against!
      },
    },
    conditions: {
      "#svg-file": {
        // this is an implicit "and"/"all": both path and content must match
        path: '*.svg', // can also be a RegExp
        content: /\<svg[^\>]*\>/, // can match the contents of the file!
      },
    },
  },
}
```

## Today (undocumented) - Built-in Conditions

These use a different syntax, and are provided by Next.js / Turbopack (are not user-defined).

```javascript
module.exports = {
  turbopack: {
    rules: {
      // This will match svg files in the project that aren't from `node_modules`
      '*.svg': {
        // These object properties are evaluated in order, and the first match
        // used. The supported keys can be found here:
        // https://github.com/vercel/next.js/pull/82765
        foreign: false, // causes us to bail out if node_modules are matched
        default: {
          loaders: ['@svgr/webpack'],
          as: '*.js',
        }
      },
    },
  },
}
```

## Proposed

- Remove (minor breaking change in Next 16, was undocumented) the `conditions` field from the `turbopack` config object. The benefit of a separate `conditions` field was that named conditions could be re-used across rules. But, there’s not much value in allowing condition re-use as the configuration file is JS and could implement re-use with local variables or functions.
    - The separate `conditions` field was also incompatible with the `as` field.
- Add an optional `condition` field to each rule object.
    - Rules must be matched by a glob first (can be `*`) before the condition is checked.
    - This allows compatibility with `as`, since there’s always an obvious glob for that to match against.
- Maintain support for `path` and `content` properties in `condition` objects.
    - These can be used with each other (as an implicit `all`)
- Extend `condition` object with `{all: [...]}`, `{any: [...]}` , and `{not: ...}`.
    - Similar to webpack’s `{and: [...]}`, `{or: [...]}` and `{not: ...}` syntax: https://webpack.js.org/configuration/module/#condition
    - Our underlying `RuleCondition` enum already supports this, it’s just a matter of translating it from the JS object.
- Allow conditions to be an object or a string. If it’s a string, require it to be a built-in condition (like `'foreign'` or `'browser'`).
- Allow values in the rules object to either be objects (what we support today) or an array of objects.

```javascript
module.exports = {
  turbopack: {
    rules: {
      // all matched rules apply, adding their loaders in order
      '*.svg': [
        // this optionally can be an array of objects (shown here), or just an object
        {
          // this condition is matched after the glob
          condition: {
            all: [
              { not: 'foreign' }, // excludes `node_modules`
              { path: /app\/.*\.svg/, content: /\<svg[^\>]*\>/ },
            ],
          },
          loaders: ['@svgr/webpack'],
          as: '*.js',
        },
      ],
    },
  },
}
```

Closes PACK-5369