### PR TITLE
[Cache Components] Don't propagate tags/life for omitted caches

### DIFF
--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -244,7 +244,10 @@ export async function exportAppPage(
       cacheControl,
       fetchMetrics,
       renderResumeDataCache: renderResumeDataCache
-        ? await stringifyResumeDataCache(renderResumeDataCache)
+        ? await stringifyResumeDataCache(
+            renderResumeDataCache,
+            renderOpts.experimental.cacheComponents
+          )
         : undefined,
     }
   } catch (err) {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3929,12 +3929,15 @@ async function prerenderToStream(
               ? DynamicHTMLPreludeState.Empty
               : DynamicHTMLPreludeState.Full,
             fallbackRouteParams,
-            resumeDataCache
+            resumeDataCache,
+            experimental.cacheComponents
           )
         } else {
           // Dynamic Data case
-          metadata.postponed =
-            await getDynamicDataPostponedState(resumeDataCache)
+          metadata.postponed = await getDynamicDataPostponedState(
+            resumeDataCache,
+            experimental.cacheComponents
+          )
         }
         reactServerResult.consume()
         return {
@@ -4152,12 +4155,14 @@ async function prerenderToStream(
               ? DynamicHTMLPreludeState.Empty
               : DynamicHTMLPreludeState.Full,
             fallbackRouteParams,
-            prerenderResumeDataCache
+            prerenderResumeDataCache,
+            experimental.cacheComponents
           )
         } else {
           // Dynamic Data case.
           metadata.postponed = await getDynamicDataPostponedState(
-            prerenderResumeDataCache
+            prerenderResumeDataCache,
+            experimental.cacheComponents
           )
         }
         // Regardless of whether this is the Dynamic HTML or Dynamic Data case we need to ensure we include
@@ -4182,7 +4187,8 @@ async function prerenderToStream(
       } else if (fallbackRouteParams && fallbackRouteParams.size > 0) {
         // Rendering the fallback case.
         metadata.postponed = await getDynamicDataPostponedState(
-          prerenderResumeDataCache
+          prerenderResumeDataCache,
+          experimental.cacheComponents
         )
 
         return {

--- a/packages/next/src/server/app-render/postponed-state.test.ts
+++ b/packages/next/src/server/app-render/postponed-state.test.ts
@@ -21,6 +21,9 @@ export function createMockOpaqueFallbackRouteParams(
   return new Map(Object.entries(params))
 }
 
+const isCacheComponentsEnabled =
+  process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true'
+
 describe('getDynamicHTMLPostponedState', () => {
   it('serializes a HTML postponed state with fallback params', async () => {
     const key = '%%drp:slug:e9615126684e5%%'
@@ -36,8 +39,8 @@ describe('getDynamicHTMLPostponedState', () => {
         tags: [],
         stale: 0,
         timestamp: 0,
-        expire: 0,
-        revalidate: 0,
+        expire: 300,
+        revalidate: 1,
       })
     )
 
@@ -45,10 +48,12 @@ describe('getDynamicHTMLPostponedState', () => {
       { [key]: key, nested: { [key]: key } },
       DynamicHTMLPreludeState.Full,
       fallbackRouteParams,
-      prerenderResumeDataCache
+      prerenderResumeDataCache,
+      isCacheComponentsEnabled
     )
 
     const parsed = parsePostponedState(state, '/blog/[slug]', { slug: '123' })
+
     expect(parsed).toMatchInlineSnapshot(`
      {
        "data": [
@@ -84,7 +89,8 @@ describe('getDynamicHTMLPostponedState', () => {
       { key: 'value' },
       DynamicHTMLPreludeState.Full,
       null,
-      createPrerenderResumeDataCache()
+      createPrerenderResumeDataCache(),
+      isCacheComponentsEnabled
     )
     expect(state).toMatchInlineSnapshot(`"19:[1,{"key":"value"}]null"`)
   })
@@ -98,7 +104,8 @@ describe('getDynamicHTMLPostponedState', () => {
       { [key]: key },
       DynamicHTMLPreludeState.Full,
       fallbackRouteParams,
-      createPrerenderResumeDataCache()
+      createPrerenderResumeDataCache(),
+      isCacheComponentsEnabled
     )
 
     const value = 'hello'
@@ -113,14 +120,15 @@ describe('getDynamicHTMLPostponedState', () => {
     // The replacements have been replaced.
     expect(JSON.stringify(parsed)).not.toMatch(key)
   })
-})
 
-describe('getDynamicDataPostponedState', () => {
-  it('serializes a data postponed state with fallback params', async () => {
-    const state = await getDynamicDataPostponedState(
-      createPrerenderResumeDataCache()
-    )
-    expect(state).toMatchInlineSnapshot(`"4:nullnull"`)
+  describe('getDynamicDataPostponedState', () => {
+    it('serializes a data postponed state with fallback params', async () => {
+      const state = await getDynamicDataPostponedState(
+        createPrerenderResumeDataCache(),
+        isCacheComponentsEnabled
+      )
+      expect(state).toMatchInlineSnapshot(`"4:nullnull"`)
+    })
   })
 })
 

--- a/packages/next/src/server/app-render/postponed-state.test.ts
+++ b/packages/next/src/server/app-render/postponed-state.test.ts
@@ -120,15 +120,15 @@ describe('getDynamicHTMLPostponedState', () => {
     // The replacements have been replaced.
     expect(JSON.stringify(parsed)).not.toMatch(key)
   })
+})
 
-  describe('getDynamicDataPostponedState', () => {
-    it('serializes a data postponed state with fallback params', async () => {
-      const state = await getDynamicDataPostponedState(
-        createPrerenderResumeDataCache(),
-        isCacheComponentsEnabled
-      )
-      expect(state).toMatchInlineSnapshot(`"4:nullnull"`)
-    })
+describe('getDynamicDataPostponedState', () => {
+  it('serializes a data postponed state with fallback params', async () => {
+    const state = await getDynamicDataPostponedState(
+      createPrerenderResumeDataCache(),
+      isCacheComponentsEnabled
+    )
+    expect(state).toMatchInlineSnapshot(`"4:nullnull"`)
   })
 })
 

--- a/packages/next/src/server/app-render/postponed-state.ts
+++ b/packages/next/src/server/app-render/postponed-state.ts
@@ -79,7 +79,8 @@ export async function getDynamicHTMLPostponedState(
   postponed: ReactPostponed,
   preludeState: DynamicHTMLPreludeState,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
-  resumeDataCache: PrerenderResumeDataCache | RenderResumeDataCache
+  resumeDataCache: PrerenderResumeDataCache | RenderResumeDataCache,
+  isCacheComponentsEnabled: boolean
 ): Promise<string> {
   const data: DynamicHTMLPostponedState['data'] = [preludeState, postponed]
   const dataString = JSON.stringify(data)
@@ -89,7 +90,8 @@ export async function getDynamicHTMLPostponedState(
   if (!fallbackRouteParams || fallbackRouteParams.size === 0) {
     // Serialized as `<postponedString.length>:<postponedString><renderResumeDataCache>`
     return `${dataString.length}:${dataString}${await stringifyResumeDataCache(
-      createRenderResumeDataCache(resumeDataCache)
+      createRenderResumeDataCache(resumeDataCache),
+      isCacheComponentsEnabled
     )}`
   }
 
@@ -102,13 +104,14 @@ export async function getDynamicHTMLPostponedState(
   const postponedString = `${replacementsString.length}${replacementsString}${dataString}`
 
   // Serialized as `<postponedString.length>:<postponedString><renderResumeDataCache>`
-  return `${postponedString.length}:${postponedString}${await stringifyResumeDataCache(resumeDataCache)}`
+  return `${postponedString.length}:${postponedString}${await stringifyResumeDataCache(resumeDataCache, isCacheComponentsEnabled)}`
 }
 
 export async function getDynamicDataPostponedState(
-  resumeDataCache: PrerenderResumeDataCache | RenderResumeDataCache
+  resumeDataCache: PrerenderResumeDataCache | RenderResumeDataCache,
+  isCacheComponentsEnabled: boolean
 ): Promise<string> {
-  return `4:null${await stringifyResumeDataCache(createRenderResumeDataCache(resumeDataCache))}`
+  return `4:null${await stringifyResumeDataCache(createRenderResumeDataCache(resumeDataCache), isCacheComponentsEnabled)}`
 }
 
 export function parsePostponedState(

--- a/packages/next/src/server/resume-data-cache/cache-store.ts
+++ b/packages/next/src/server/resume-data-cache/cache-store.ts
@@ -93,13 +93,17 @@ export function parseUseCacheCacheStore(
  * @returns A promise that resolves to an array of key-value pairs with serialized values
  */
 export async function serializeUseCacheCacheStore(
-  entries: IterableIterator<[string, Promise<CacheEntry>]>
+  entries: IterableIterator<[string, Promise<CacheEntry>]>,
+  isCacheComponentsEnabled: boolean
 ): Promise<Array<[string, UseCacheCacheStoreSerialized] | null>> {
   return Promise.all(
     Array.from(entries).map(([key, value]) => {
       return value
         .then(async (entry) => {
-          if (entry.revalidate === 0 || entry.expire < DYNAMIC_EXPIRE) {
+          if (
+            isCacheComponentsEnabled &&
+            (entry.revalidate === 0 || entry.expire < DYNAMIC_EXPIRE)
+          ) {
             // The entry was omitted from the prerender result, and subsequently
             // does not need to be included in the serialized RDC.
             return null

--- a/packages/next/src/server/resume-data-cache/cache-store.ts
+++ b/packages/next/src/server/resume-data-cache/cache-store.ts
@@ -4,6 +4,7 @@ import {
 } from '../app-render/encryption-utils'
 import type { CacheEntry } from '../lib/cache-handlers/types'
 import type { CachedFetchValue } from '../response-cache/types'
+import { DYNAMIC_EXPIRE } from '../use-cache/constants'
 
 /**
  * A generic cache store type that provides a subset of Map functionality
@@ -98,6 +99,12 @@ export async function serializeUseCacheCacheStore(
     Array.from(entries).map(([key, value]) => {
       return value
         .then(async (entry) => {
+          if (entry.revalidate === 0 || entry.expire < DYNAMIC_EXPIRE) {
+            // The entry was omitted from the prerender result, and subsequently
+            // does not need to be included in the serialized RDC.
+            return null
+          }
+
           const [left, right] = entry.value.tee()
           entry.value = right
 

--- a/packages/next/src/server/resume-data-cache/resume-data-cache.test.ts
+++ b/packages/next/src/server/resume-data-cache/resume-data-cache.test.ts
@@ -6,8 +6,10 @@ import { createPrerenderResumeDataCache } from './resume-data-cache'
 import { streamFromString } from '../stream-utils/node-web-streams-helper'
 import { inflateSync } from 'node:zlib'
 
-function createCacheWithSingleEntry() {
+function createMockedCache() {
   const cache = createPrerenderResumeDataCache()
+
+  // Should be included during serialization.
   cache.cache.set(
     'success',
     Promise.resolve({
@@ -15,7 +17,33 @@ function createCacheWithSingleEntry() {
       tags: [],
       stale: 0,
       timestamp: 0,
-      expire: 0,
+      expire: 300,
+      revalidate: 1,
+    })
+  )
+
+  // Should be omitted during serialization.
+  cache.cache.set(
+    'dynamic-expire',
+    Promise.resolve({
+      value: streamFromString('value'),
+      tags: [],
+      stale: 0,
+      timestamp: 0,
+      expire: 299,
+      revalidate: 1,
+    })
+  )
+
+  // Should be omitted during serialization.
+  cache.cache.set(
+    'zero-revalidate',
+    Promise.resolve({
+      value: streamFromString('value'),
+      tags: [],
+      stale: 0,
+      timestamp: 0,
+      expire: 300,
       revalidate: 0,
     })
   )
@@ -23,8 +51,8 @@ function createCacheWithSingleEntry() {
   return cache
 }
 
-function createCacheWithSingleEntryThatFails() {
-  const cache = createCacheWithSingleEntry()
+function createMockedCacheWithEntryThatFails() {
+  const cache = createMockedCache()
   cache.cache.set('fail', Promise.reject(new Error('Failed to serialize')))
 
   return cache
@@ -36,8 +64,8 @@ describe('stringifyResumeDataCache', () => {
     expect(await stringifyResumeDataCache(cache)).toBe('null')
   })
 
-  it('serializes a cache with a single entry', async () => {
-    const cache = createCacheWithSingleEntry()
+  it('only serializes cache entries that were not excluded from the prerender result', async () => {
+    const cache = createMockedCache()
     const compressed = await stringifyResumeDataCache(cache)
 
     // We have to decompress the output because the compressed string is not
@@ -48,12 +76,12 @@ describe('stringifyResumeDataCache', () => {
     ).toString('utf-8')
 
     expect(decompressed).toMatchInlineSnapshot(
-      `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":0,"revalidate":0}},"encryptedBoundArgs":{}}}"`
+      `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1}},"encryptedBoundArgs":{}}}"`
     )
   })
 
-  it('serializes a cache with a single entry that fails', async () => {
-    const cache = createCacheWithSingleEntryThatFails()
+  it('serializes a cache with an entry that fails', async () => {
+    const cache = createMockedCacheWithEntryThatFails()
     const compressed = await stringifyResumeDataCache(cache)
 
     // We have to decompress the output because the compressed string is not
@@ -66,7 +94,7 @@ describe('stringifyResumeDataCache', () => {
     // We expect that the cache will still contain the successful entry but the
     // failed entry will be ignored and omitted from the output.
     expect(decompressed).toMatchInlineSnapshot(
-      `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":0,"revalidate":0}},"encryptedBoundArgs":{}}}"`
+      `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1}},"encryptedBoundArgs":{}}}"`
     )
   })
 })
@@ -79,7 +107,7 @@ describe('parseResumeDataCache', () => {
   })
 
   it('parses a cache with a single entry', async () => {
-    const cache = createCacheWithSingleEntry()
+    const cache = createMockedCache()
     const serialized = await stringifyResumeDataCache(cache)
 
     const parsed = createRenderResumeDataCache(serialized)

--- a/packages/next/src/server/resume-data-cache/resume-data-cache.test.ts
+++ b/packages/next/src/server/resume-data-cache/resume-data-cache.test.ts
@@ -6,6 +6,9 @@ import { createPrerenderResumeDataCache } from './resume-data-cache'
 import { streamFromString } from '../stream-utils/node-web-streams-helper'
 import { inflateSync } from 'node:zlib'
 
+const isCacheComponentsEnabled =
+  process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true'
+
 function createMockedCache() {
   const cache = createPrerenderResumeDataCache()
 
@@ -59,90 +62,85 @@ function createMockedCacheWithEntryThatFails() {
 }
 
 describe('stringifyResumeDataCache', () => {
-  describe.each([true, false])(
-    'cacheComponents: %s',
-    (isCacheComponentsEnabled) => {
-      it('serializes an empty cache', async () => {
-        const cache = createPrerenderResumeDataCache()
-        expect(
-          await stringifyResumeDataCache(cache, isCacheComponentsEnabled)
-        ).toBe('null')
-      })
+  it('serializes an empty cache', async () => {
+    const cache = createPrerenderResumeDataCache()
+    expect(
+      await stringifyResumeDataCache(cache, isCacheComponentsEnabled)
+    ).toBe('null')
+  })
 
-      it('only serializes cache entries that were not excluded from the prerender result', async () => {
-        const cache = createMockedCache()
+  it('only serializes cache entries that were not excluded from the prerender result', async () => {
+    const cache = createMockedCache()
 
-        const compressed = await stringifyResumeDataCache(
-          cache,
-          isCacheComponentsEnabled
-        )
+    const compressed = await stringifyResumeDataCache(
+      cache,
+      isCacheComponentsEnabled
+    )
 
-        // We have to decompress the output because the compressed string is not
-        // deterministic. If it fails here it's because the compressed string is
-        // different.
-        const decompressed = inflateSync(
-          Buffer.from(compressed, 'base64')
-        ).toString('utf-8')
+    // We have to decompress the output because the compressed string is not
+    // deterministic. If it fails here it's because the compressed string is
+    // different.
+    const decompressed = inflateSync(
+      Buffer.from(compressed, 'base64')
+    ).toString('utf-8')
 
-        if (isCacheComponentsEnabled) {
-          expect(decompressed).toMatchInlineSnapshot(
-            `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1}},"encryptedBoundArgs":{}}}"`
-          )
-        } else {
-          expect(decompressed).toMatchInlineSnapshot(
-            `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1},"dynamic-expire":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":299,"revalidate":1},"zero-revalidate":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":0}},"encryptedBoundArgs":{}}}"`
-          )
-        }
-      })
-
-      it('serializes a cache with an entry that fails', async () => {
-        const cache = createMockedCacheWithEntryThatFails()
-
-        const compressed = await stringifyResumeDataCache(
-          cache,
-          isCacheComponentsEnabled
-        )
-
-        // We have to decompress the output because the compressed string is not
-        // deterministic. If it fails here it's because the compressed string is
-        // different.
-        const decompressed = inflateSync(
-          Buffer.from(compressed, 'base64')
-        ).toString('utf-8')
-
-        // We expect that the cache will still contain the successful entries
-        // but the failed entry will be ignored and omitted from the output.
-        if (isCacheComponentsEnabled) {
-          expect(decompressed).toMatchInlineSnapshot(
-            `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1}},"encryptedBoundArgs":{}}}"`
-          )
-        } else {
-          expect(decompressed).toMatchInlineSnapshot(
-            `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1},"dynamic-expire":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":299,"revalidate":1},"zero-revalidate":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":0}},"encryptedBoundArgs":{}}}"`
-          )
-        }
-      })
-
-      describe('parseResumeDataCache', () => {
-        it('parses an empty cache', () => {
-          expect(createRenderResumeDataCache('null')).toEqual(
-            createPrerenderResumeDataCache()
-          )
-        })
-
-        it('parses a filled cache', async () => {
-          const cache = createMockedCache()
-          const serialized = await stringifyResumeDataCache(
-            cache,
-            isCacheComponentsEnabled
-          )
-
-          const parsed = createRenderResumeDataCache(serialized)
-
-          expect(parsed.cache.size).toBe(isCacheComponentsEnabled ? 1 : 3)
-          expect(parsed.fetch.size).toBe(0)
-        })
-      })
+    if (isCacheComponentsEnabled) {
+      expect(decompressed).toMatchInlineSnapshot(
+        `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1}},"encryptedBoundArgs":{}}}"`
+      )
+    } else {
+      expect(decompressed).toMatchInlineSnapshot(
+        `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1},"dynamic-expire":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":299,"revalidate":1},"zero-revalidate":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":0}},"encryptedBoundArgs":{}}}"`
+      )
     }
-  )
+  })
+
+  it('serializes a cache with an entry that fails', async () => {
+    const cache = createMockedCacheWithEntryThatFails()
+
+    const compressed = await stringifyResumeDataCache(
+      cache,
+      isCacheComponentsEnabled
+    )
+
+    // We have to decompress the output because the compressed string is not
+    // deterministic. If it fails here it's because the compressed string is
+    // different.
+    const decompressed = inflateSync(
+      Buffer.from(compressed, 'base64')
+    ).toString('utf-8')
+
+    // We expect that the cache will still contain the successful entries
+    // but the failed entry will be ignored and omitted from the output.
+    if (isCacheComponentsEnabled) {
+      expect(decompressed).toMatchInlineSnapshot(
+        `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1}},"encryptedBoundArgs":{}}}"`
+      )
+    } else {
+      expect(decompressed).toMatchInlineSnapshot(
+        `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1},"dynamic-expire":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":299,"revalidate":1},"zero-revalidate":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":0}},"encryptedBoundArgs":{}}}"`
+      )
+    }
+  })
+})
+
+describe('parseResumeDataCache', () => {
+  it('parses an empty cache', () => {
+    expect(createRenderResumeDataCache('null')).toEqual(
+      createPrerenderResumeDataCache()
+    )
+  })
+
+  it('parses a filled cache', async () => {
+    const cache = createMockedCache()
+    const serialized = await stringifyResumeDataCache(
+      cache,
+      isCacheComponentsEnabled
+    )
+
+    const parsed = createRenderResumeDataCache(serialized)
+
+    expect(parsed.cache.size).toBe(isCacheComponentsEnabled ? 1 : 3)
+    expect(parsed.fetch.size).toBe(0)
+  })
 })

--- a/packages/next/src/server/resume-data-cache/resume-data-cache.test.ts
+++ b/packages/next/src/server/resume-data-cache/resume-data-cache.test.ts
@@ -59,60 +59,90 @@ function createMockedCacheWithEntryThatFails() {
 }
 
 describe('stringifyResumeDataCache', () => {
-  it('serializes an empty cache', async () => {
-    const cache = createPrerenderResumeDataCache()
-    expect(await stringifyResumeDataCache(cache)).toBe('null')
-  })
+  describe.each([true, false])(
+    'cacheComponents: %s',
+    (isCacheComponentsEnabled) => {
+      it('serializes an empty cache', async () => {
+        const cache = createPrerenderResumeDataCache()
+        expect(
+          await stringifyResumeDataCache(cache, isCacheComponentsEnabled)
+        ).toBe('null')
+      })
 
-  it('only serializes cache entries that were not excluded from the prerender result', async () => {
-    const cache = createMockedCache()
-    const compressed = await stringifyResumeDataCache(cache)
+      it('only serializes cache entries that were not excluded from the prerender result', async () => {
+        const cache = createMockedCache()
 
-    // We have to decompress the output because the compressed string is not
-    // deterministic. If it fails here it's because the compressed string is
-    // different.
-    const decompressed = inflateSync(
-      Buffer.from(compressed, 'base64')
-    ).toString('utf-8')
+        const compressed = await stringifyResumeDataCache(
+          cache,
+          isCacheComponentsEnabled
+        )
 
-    expect(decompressed).toMatchInlineSnapshot(
-      `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1}},"encryptedBoundArgs":{}}}"`
-    )
-  })
+        // We have to decompress the output because the compressed string is not
+        // deterministic. If it fails here it's because the compressed string is
+        // different.
+        const decompressed = inflateSync(
+          Buffer.from(compressed, 'base64')
+        ).toString('utf-8')
 
-  it('serializes a cache with an entry that fails', async () => {
-    const cache = createMockedCacheWithEntryThatFails()
-    const compressed = await stringifyResumeDataCache(cache)
+        if (isCacheComponentsEnabled) {
+          expect(decompressed).toMatchInlineSnapshot(
+            `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1}},"encryptedBoundArgs":{}}}"`
+          )
+        } else {
+          expect(decompressed).toMatchInlineSnapshot(
+            `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1},"dynamic-expire":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":299,"revalidate":1},"zero-revalidate":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":0}},"encryptedBoundArgs":{}}}"`
+          )
+        }
+      })
 
-    // We have to decompress the output because the compressed string is not
-    // deterministic. If it fails here it's because the compressed string is
-    // different.
-    const decompressed = inflateSync(
-      Buffer.from(compressed, 'base64')
-    ).toString('utf-8')
+      it('serializes a cache with an entry that fails', async () => {
+        const cache = createMockedCacheWithEntryThatFails()
 
-    // We expect that the cache will still contain the successful entry but the
-    // failed entry will be ignored and omitted from the output.
-    expect(decompressed).toMatchInlineSnapshot(
-      `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1}},"encryptedBoundArgs":{}}}"`
-    )
-  })
-})
+        const compressed = await stringifyResumeDataCache(
+          cache,
+          isCacheComponentsEnabled
+        )
 
-describe('parseResumeDataCache', () => {
-  it('parses an empty cache', () => {
-    expect(createRenderResumeDataCache('null')).toEqual(
-      createPrerenderResumeDataCache()
-    )
-  })
+        // We have to decompress the output because the compressed string is not
+        // deterministic. If it fails here it's because the compressed string is
+        // different.
+        const decompressed = inflateSync(
+          Buffer.from(compressed, 'base64')
+        ).toString('utf-8')
 
-  it('parses a cache with a single entry', async () => {
-    const cache = createMockedCache()
-    const serialized = await stringifyResumeDataCache(cache)
+        // We expect that the cache will still contain the successful entries
+        // but the failed entry will be ignored and omitted from the output.
+        if (isCacheComponentsEnabled) {
+          expect(decompressed).toMatchInlineSnapshot(
+            `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1}},"encryptedBoundArgs":{}}}"`
+          )
+        } else {
+          expect(decompressed).toMatchInlineSnapshot(
+            `"{"store":{"fetch":{},"cache":{"success":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":1},"dynamic-expire":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":299,"revalidate":1},"zero-revalidate":{"value":"dmFsdWU=","tags":[],"stale":0,"timestamp":0,"expire":300,"revalidate":0}},"encryptedBoundArgs":{}}}"`
+          )
+        }
+      })
 
-    const parsed = createRenderResumeDataCache(serialized)
+      describe('parseResumeDataCache', () => {
+        it('parses an empty cache', () => {
+          expect(createRenderResumeDataCache('null')).toEqual(
+            createPrerenderResumeDataCache()
+          )
+        })
 
-    expect(parsed.cache.size).toBe(1)
-    expect(parsed.fetch.size).toBe(0)
-  })
+        it('parses a filled cache', async () => {
+          const cache = createMockedCache()
+          const serialized = await stringifyResumeDataCache(
+            cache,
+            isCacheComponentsEnabled
+          )
+
+          const parsed = createRenderResumeDataCache(serialized)
+
+          expect(parsed.cache.size).toBe(isCacheComponentsEnabled ? 1 : 3)
+          expect(parsed.fetch.size).toBe(0)
+        })
+      })
+    }
+  )
 })

--- a/packages/next/src/server/resume-data-cache/resume-data-cache.ts
+++ b/packages/next/src/server/resume-data-cache/resume-data-cache.ts
@@ -100,7 +100,8 @@ type ResumeStoreSerialized = {
  * 'null' if empty
  */
 export async function stringifyResumeDataCache(
-  resumeDataCache: RenderResumeDataCache | PrerenderResumeDataCache
+  resumeDataCache: RenderResumeDataCache | PrerenderResumeDataCache,
+  isCacheComponentsEnabled: boolean
 ): Promise<string> {
   if (process.env.NEXT_RUNTIME === 'edge') {
     throw new InvariantError(
@@ -116,7 +117,10 @@ export async function stringifyResumeDataCache(
         fetch: Object.fromEntries(Array.from(resumeDataCache.fetch.entries())),
         cache: Object.fromEntries(
           (
-            await serializeUseCacheCacheStore(resumeDataCache.cache.entries())
+            await serializeUseCacheCacheStore(
+              resumeDataCache.cache.entries(),
+              isCacheComponentsEnabled
+            )
           ).filter(
             (entry): entry is [string, UseCacheCacheStoreSerialized] =>
               entry !== null

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -378,7 +378,7 @@ function propagateCacheLifeAndTags(
 }
 
 async function collectResult(
-  savedStream: ReadableStream,
+  savedStream: ReadableStream<Uint8Array>,
   workStore: WorkStore,
   cacheContext: CacheContext,
   innerCacheStore: UseCacheStore,
@@ -398,7 +398,7 @@ async function collectResult(
   // that the stream might also error for other reasons anyway such as losing
   // connection.
 
-  const buffer: any[] = []
+  const buffer: Uint8Array[] = []
   const reader = savedStream.getReader()
 
   try {
@@ -410,7 +410,7 @@ async function collectResult(
   }
 
   let idx = 0
-  const bufferStream = new ReadableStream({
+  const bufferStream = new ReadableStream<Uint8Array>({
     pull(controller) {
       if (workStore.invalidDynamicUsageError) {
         controller.error(workStore.invalidDynamicUsageError)

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -451,17 +451,39 @@ async function collectResult(
     tags: collectedTags === null ? [] : collectedTags,
   }
 
-  // Propagate tags/revalidate to the parent context.
-  if (cacheContext) {
-    propagateCacheLifeAndTags(cacheContext, entry)
-  }
+  if (cacheContext.outerWorkUnitStore) {
+    const outerWorkUnitStore = cacheContext.outerWorkUnitStore
 
-  const cacheSignal = cacheContext.outerWorkUnitStore
-    ? getCacheSignal(cacheContext.outerWorkUnitStore)
-    : null
+    // Propagate tags/revalidate to the parent context if appropriate.
+    switch (outerWorkUnitStore.type) {
+      case 'prerender':
+      case 'prerender-runtime': {
+        // If we've just created a cache result, then we're filling caches for a Cache Components prerender.
+        // We don't want to propagate cache life/tags yet in case the entry ends up being omitted from
+        // the final render due to short expire/stale times --
+        // if it's omitted, then it shouldn't have any effects on the prerender.
+        // We'll decide whether or not this cache should have its tags/life propagated
+        // when we read it in the final render.
+        break
+      }
+      case 'request':
+      case 'private-cache':
+      case 'cache':
+      case 'unstable-cache':
+      case 'prerender-legacy':
+      case 'prerender-ppr': {
+        propagateCacheLifeAndTags(cacheContext, entry)
+        break
+      }
+      default: {
+        outerWorkUnitStore satisfies never
+      }
+    }
 
-  if (cacheSignal) {
-    cacheSignal.endRead()
+    const cacheSignal = getCacheSignal(outerWorkUnitStore)
+    if (cacheSignal) {
+      cacheSignal.endRead()
+    }
   }
 
   return entry
@@ -1160,8 +1182,6 @@ export function cache(
         const cachedEntry = renderResumeDataCache.cache.get(serializedCacheKey)
         if (cachedEntry !== undefined) {
           const existingEntry = await cachedEntry
-          propagateCacheLifeAndTags(cacheContext, existingEntry)
-
           if (workUnitStore !== undefined && existingEntry !== undefined) {
             if (
               existingEntry.revalidate === 0 ||
@@ -1231,6 +1251,10 @@ export function cache(
               }
             }
           }
+
+          // We want to make sure we only propagate cache life / tags if the entry *wasn't* omitted from the prerender,
+          // so we only do this after the above early returns.
+          propagateCacheLifeAndTags(cacheContext, existingEntry)
 
           const [streamA, streamB] = existingEntry.value.tee()
           existingEntry.value = streamB

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -454,16 +454,17 @@ async function collectResult(
   if (cacheContext.outerWorkUnitStore) {
     const outerWorkUnitStore = cacheContext.outerWorkUnitStore
 
-    // Propagate tags/revalidate to the parent context if appropriate.
+    // Propagate cache life & tags to the parent context if appropriate.
     switch (outerWorkUnitStore.type) {
       case 'prerender':
       case 'prerender-runtime': {
-        // If we've just created a cache result, then we're filling caches for a Cache Components prerender.
-        // We don't want to propagate cache life/tags yet in case the entry ends up being omitted from
-        // the final render due to short expire/stale times --
-        // if it's omitted, then it shouldn't have any effects on the prerender.
-        // We'll decide whether or not this cache should have its tags/life propagated
-        // when we read it in the final render.
+        // If we've just created a cache result, and we're filling caches for a
+        // Cache Components prerender, then we don't want to propagate cache
+        // life & tags yet, in case the entry ends up being omitted from the
+        // final prerender due to short expire/stale times. If it is omitted,
+        // then it shouldn't have any effects on the prerender. We'll decide
+        // whether or not this cache should have its life & tags propagated when
+        // we read the entry in the final prerender from the resume data cache.
         break
       }
       case 'request':
@@ -1190,11 +1191,11 @@ export function cache(
               switch (workUnitStore.type) {
                 case 'prerender':
                   // In a Dynamic I/O prerender, if the cache entry has
-                  // revalidate: 0 or if the expire time is under 5 minutes, then
-                  // we consider this cache entry dynamic as it's not worth
-                  // generating static pages for such data. It's better to leave a
-                  // PPR hole that can be filled in dynamically with a potentially
-                  // cached entry.
+                  // revalidate: 0 or if the expire time is under 5 minutes,
+                  // then we consider this cache entry dynamic as it's not worth
+                  // generating static pages for such data. It's better to leave
+                  // a dynamic hole that can be filled in during the resume with
+                  // a potentially cached entry.
                   if (cacheSignal) {
                     cacheSignal.endRead()
                   }
@@ -1204,7 +1205,8 @@ export function cache(
                     'dynamic "use cache"'
                   )
                 case 'prerender-runtime': {
-                  // In a runtime prerender, we have to make sure that APIs that would hang during a static prerender
+                  // In the final phase of a runtime prerender, we have to make
+                  // sure that APIs that would hang during a static prerender
                   // are resolved with a delay, in the runtime stage.
                   if (workUnitStore.runtimeStagePromise) {
                     await workUnitStore.runtimeStagePromise
@@ -1226,10 +1228,10 @@ export function cache(
             if (existingEntry.stale < RUNTIME_PREFETCH_DYNAMIC_STALE) {
               switch (workUnitStore.type) {
                 case 'prerender-runtime':
-                  // In a runtime prerender, if the cache entry will become stale in less then 30 seconds,
-                  // we consider this cache entry dynamic as it's not worth prefetching.
-                  // It's better to leave a PPR hole that can be filled in dynamically
-                  // with a potentially cached entry.
+                  // In a runtime prerender, if the cache entry will become
+                  // stale in less then 30 seconds, we consider this cache entry
+                  // dynamic as it's not worth prefetching. It's better to leave
+                  // a dynamic hole that can be filled during the navigation.
                   if (cacheSignal) {
                     cacheSignal.endRead()
                   }
@@ -1252,8 +1254,9 @@ export function cache(
             }
           }
 
-          // We want to make sure we only propagate cache life / tags if the entry *wasn't* omitted from the prerender,
-          // so we only do this after the above early returns.
+          // We want to make sure we only propagate cache life & tags if the
+          // entry was *not* omitted from the prerender. So we only do this
+          // after the above early returns.
           propagateCacheLifeAndTags(cacheContext, existingEntry)
 
           const [streamA, streamB] = existingEntry.value.tee()
@@ -1385,8 +1388,9 @@ export function cache(
               // In a Dynamic I/O prerender, if the cache entry has revalidate:
               // 0 or if the expire time is under 5 minutes, then we consider
               // this cache entry dynamic as it's not worth generating static
-              // pages for such data. It's better to leave a PPR hole that can
-              // be filled in dynamically with a potentially cached entry.
+              // pages for such data. It's better to leave a dynamic hole that
+              // can be filled in during the resume with a potentially cached
+              // entry.
               if (cacheSignal) {
                 cacheSignal.endRead()
               }
@@ -1396,12 +1400,6 @@ export function cache(
                 'dynamic "use cache"'
               )
             case 'prerender-runtime':
-              // In a runtime prerender, we have to make sure that APIs that would hang during a static prerender
-              // are resolved with a delay, in the runtime stage.
-              if (workUnitStore.runtimeStagePromise) {
-                await workUnitStore.runtimeStagePromise
-              }
-              break
             case 'prerender-ppr':
             case 'prerender-legacy':
             case 'request':

--- a/test/e2e/app-dir/segment-cache/staleness/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/page.tsx
@@ -33,6 +33,11 @@ export default function Page() {
         <li>
           <LinkAccordion href="/dynamic">Page with dynamic data</LinkAccordion>
         </li>
+        <li>
+          <LinkAccordion href="/seconds">
+            Page with cached data with <code>cacheLife("seconds")</code>
+          </LinkAccordion>
+        </li>
       </ul>
     </>
   )

--- a/test/e2e/app-dir/segment-cache/staleness/app/seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/seconds/page.tsx
@@ -1,0 +1,32 @@
+import { Suspense } from 'react'
+import { unstable_cacheLife } from 'next/cache'
+
+export default function Page() {
+  return (
+    <main>
+      <p>
+        Caches that use the 'seconds' profile will be omitted from static
+        prerenders, making this essentially dynamic. If we omit it, it should
+        not affect the cache life of the prerender.
+      </p>
+      <Suspense fallback="Loading...">
+        <ShortLivedContent />
+      </Suspense>
+      <br />
+      <p>Longer lived caches should still affect the cache life of the page.</p>
+      <LongerLivedContent />
+    </main>
+  )
+}
+
+async function ShortLivedContent() {
+  'use cache'
+  unstable_cacheLife('seconds')
+  return <div>Short-lived cached content</div>
+}
+
+async function LongerLivedContent() {
+  'use cache'
+  unstable_cacheLife('minutes')
+  return <div>Longer-lived cached content</div>
+}

--- a/test/e2e/app-dir/use-cache-custom-handler/app/prerender/page.tsx
+++ b/test/e2e/app-dir/use-cache-custom-handler/app/prerender/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react'
+import { unstable_cacheLife as cacheLife } from 'next/cache'
+
+// The id prop is just used to assert on the logged cache key in tests.
+async function DynamicCache({ id }: { id: string }) {
+  'use cache'
+  cacheLife('seconds')
+  return <p>{new Date().toISOString()}</p>
+}
+
+export default function Page() {
+  return (
+    <p>
+      This page uses a short-lived "use cache", which is omitted from the
+      prerender, but should still be saved in the cache handler.
+      <Suspense>
+        <DynamicCache id="dynamic-cache" />
+      </Suspense>
+    </p>
+  )
+}

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -4,7 +4,7 @@ import { retry } from 'next-test-utils'
 const isoDateRegExp = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
 
 describe('use-cache-custom-handler', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next, skipped, isNextStart } = nextTestSetup({
     files: __dirname,
     // Skip deployment so we can test the custom cache handlers log output
     skipDeployment: true,
@@ -184,4 +184,12 @@ describe('use-cache-custom-handler', () => {
       )
     })
   })
+
+  if (isNextStart) {
+    it('should save a short-lived cache during prerendering at buildtime', async () => {
+      expect(next.cliOutput).toMatch(
+        /ModernCustomCacheHandler::set \["[A-Za-z0-9_-]{21}","([0-9a-f]{2})+",\[{"id":"dynamic-cache"},"\$undefined"\]\]/
+      )
+    })
+  }
 })

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/cache-life-with-dynamic/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/cache-life-with-dynamic/page.tsx
@@ -1,4 +1,5 @@
 import { unstable_cacheLife as cacheLife } from 'next/cache'
+import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 async function getCachedRandom() {
@@ -9,8 +10,13 @@ async function getCachedRandom() {
 
 async function DynamicCache() {
   'use cache'
-  cacheLife('seconds')
+  cacheLife({ revalidate: 99, expire: 299 })
   return <p id="y">{new Date().toISOString()}</p>
+}
+
+async function Dynamic() {
+  await connection()
+  return null
 }
 
 export default async function Page() {
@@ -21,6 +27,9 @@ export default async function Page() {
       <p id="x">{x}</p>
       <Suspense fallback={<p id="y">Loading...</p>}>
         <DynamicCache />
+      </Suspense>
+      <Suspense>
+        <Dynamic />
       </Suspense>
     </>
   )

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/cache-life-with-dynamic/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/cache-life-with-dynamic/page.tsx
@@ -10,7 +10,7 @@ async function getCachedRandom() {
 
 async function DynamicCache() {
   'use cache'
-  cacheLife({ revalidate: 99, expire: 299 })
+  cacheLife({ revalidate: 99, expire: 299, stale: 18 })
   return <p id="y">{new Date().toISOString()}</p>
 }
 

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/cache-life-with-dynamic/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/cache-life-with-dynamic/page.tsx
@@ -1,0 +1,27 @@
+import { unstable_cacheLife as cacheLife } from 'next/cache'
+import { Suspense } from 'react'
+
+async function getCachedRandom() {
+  'use cache'
+  cacheLife('frequent')
+  return Math.random()
+}
+
+async function DynamicCache() {
+  'use cache'
+  cacheLife('seconds')
+  return <p id="y">{new Date().toISOString()}</p>
+}
+
+export default async function Page() {
+  const x = await getCachedRandom()
+
+  return (
+    <>
+      <p id="x">{x}</p>
+      <Suspense fallback={<p id="y">Loading...</p>}>
+        <DynamicCache />
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/cache-life/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/cache-life/page.tsx
@@ -1,4 +1,5 @@
 import { unstable_cacheLife as cacheLife } from 'next/cache'
+import { Suspense } from 'react'
 
 async function getCachedRandom() {
   'use cache'
@@ -6,7 +7,21 @@ async function getCachedRandom() {
   return Math.random()
 }
 
+async function DynamicCache() {
+  'use cache'
+  cacheLife('seconds')
+  return <p id="y">{new Date().toISOString()}</p>
+}
+
 export default async function Page() {
   const x = await getCachedRandom()
-  return <p id="x">{x}</p>
+
+  return (
+    <>
+      <p id="x">{x}</p>
+      <Suspense fallback={<p id="y">Loading...</p>}>
+        <DynamicCache />
+      </Suspense>
+    </>
+  )
 }

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/cache-life/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/cache-life/page.tsx
@@ -1,5 +1,4 @@
 import { unstable_cacheLife as cacheLife } from 'next/cache'
-import { Suspense } from 'react'
 
 async function getCachedRandom() {
   'use cache'
@@ -7,21 +6,7 @@ async function getCachedRandom() {
   return Math.random()
 }
 
-async function DynamicCache() {
-  'use cache'
-  cacheLife('seconds')
-  return <p id="y">{new Date().toISOString()}</p>
-}
-
 export default async function Page() {
   const x = await getCachedRandom()
-
-  return (
-    <>
-      <p id="x">{x}</p>
-      <Suspense fallback={<p id="y">Loading...</p>}>
-        <DynamicCache />
-      </Suspense>
-    </>
-  )
+  return <p id="x">{x}</p>
 }

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/rdc/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/rdc/page.tsx
@@ -1,3 +1,4 @@
+import { unstable_cacheLife } from 'next/cache'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
@@ -16,18 +17,35 @@ async function innermost(id: string) {
   return id
 }
 
+async function Short({ id }: { id: string }) {
+  'use cache'
+  unstable_cacheLife('seconds')
+  return id
+}
+
 async function Dynamic() {
   await connection()
   return null
 }
 
-export default async function Page() {
+async function CachedStuff() {
   await outermost('outer')
   await innermost('inner')
 
   return (
     <Suspense>
-      <Dynamic />
+      <Short id="short" />
     </Suspense>
+  )
+}
+
+export default function Page() {
+  return (
+    <div>
+      <CachedStuff />
+      <Suspense>
+        <Dynamic />
+      </Suspense>
+    </div>
   )
 }

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry } from 'next-test-utils'
+import { assertNoConsoleErrors, retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 import { format } from 'util'
 import { Playwright } from 'next-webdriver'
@@ -482,7 +482,6 @@ describe('use-cache', () => {
           '/cache-fetch',
           '/cache-fetch-no-store',
           '/cache-life',
-          !withCacheComponents && '/cache-life-with-dynamic',
           '/cache-tag',
           '/directive-in-node-modules/with-handler',
           '/directive-in-node-modules/without-handler',
@@ -531,8 +530,10 @@ describe('use-cache', () => {
         // (including PPR).
         expect(
           routes['/cache-life-with-dynamic'].initialRevalidateSeconds
-        ).toBe(1)
-        expect(routes['/cache-life-with-dynamic'].initialExpireSeconds).toBe(60)
+        ).toBe(99)
+        expect(routes['/cache-life-with-dynamic'].initialExpireSeconds).toBe(
+          299
+        )
       }
 
       // default expireTime
@@ -580,13 +581,27 @@ describe('use-cache', () => {
 
     if (withCacheComponents) {
       it('should omit dynamic caches from prerendered shells', async () => {
-        let browser = await next.browser('/cache-life-with-dynamic', {
+        const browser = await next.browser('/cache-life-with-dynamic', {
           disableJavaScript: true,
         })
 
         expect(await browser.elementById('y').text()).toBe('Loading...')
       })
     }
+
+    it('should not have hydration errors when resuming a partial shell with dynamic caches', async () => {
+      const browser = await next.browser('/cache-life-with-dynamic', {
+        pushErrorAsConsoleLog: true,
+      })
+
+      await retry(async () => {
+        expect(await browser.elementById('y').text()).not.toBe('Loading...')
+      })
+
+      // There should be no hydration errors due to a buildtime date being
+      // replaced by a new runtime date.
+      await assertNoConsoleErrors(browser)
+    })
 
     it('should propagate unstable_cache tags correctly', async () => {
       const meta = JSON.parse(
@@ -1012,10 +1027,15 @@ describe('use-cache', () => {
       // following expectation is matching on the full list. If any additional
       // keys are found, the test will fail and print the unexpected keys.
       expect(cacheKeys).toMatchObject([
-        // Note: We're matching on the "id" args that are encoded into the
-        // respective cache keys.
+        // Note: We're matching on the args that are encoded into the respective
+        // cache keys.
         expect.stringContaining('["outer"]'),
         expect.stringContaining('["inner"]'),
+        ...(withCacheComponents
+          ? []
+          : // With legacy PPR, the "short" cache is included in the prerendered
+            // shell.
+            [expect.stringContaining('[{"id":"short"},"$undefined"]]')]),
       ])
     })
   }

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -525,9 +525,8 @@ describe('use-cache', () => {
         expect(routes['/cache-life-with-dynamic'].initialExpireSeconds).toBe(
           300
         )
-      } else {
-        // We don't exclude dynamic caches for the legacy prerendering
-        // (including PPR).
+      } else if (withPPR) {
+        // We don't exclude dynamic caches for the legacy PPR prerendering.
         expect(
           routes['/cache-life-with-dynamic'].initialRevalidateSeconds
         ).toBe(99)
@@ -543,7 +542,7 @@ describe('use-cache', () => {
       // config for the page.
       expect(routes['/cache-tag'].initialRevalidateSeconds).toBe(42)
 
-      if (process.env.__NEXT_EXPERIMENTAL_PPR === 'true') {
+      if (withPPR) {
         // cache life profile "weeks"
         expect(dynamicRoutes['/[id]'].fallbackRevalidate).toBe(604800)
         expect(dynamicRoutes['/[id]'].fallbackExpire).toBe(2592000)
@@ -1021,7 +1020,7 @@ describe('use-cache', () => {
     })
   }
 
-  if (isNextStart && process.env.__NEXT_EXPERIMENTAL_PPR === 'true') {
+  if (isNextStart && withPPR) {
     it('should exclude inner caches and omitted caches from the resume data cache (RDC)', async () => {
       await next.fetch('/rdc')
 

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -556,10 +556,22 @@ describe('use-cache', () => {
       )
       expect(cacheLifeMeta.headers['x-nextjs-stale-time']).toBe('19')
 
-      const cacheLifeWithDynamicMeta = JSON.parse(
-        await next.readFile('.next/server/app/cache-life-with-dynamic.meta')
-      )
-      expect(cacheLifeWithDynamicMeta.headers['x-nextjs-stale-time']).toBe('19')
+      if (withCacheComponents) {
+        const cacheLifeWithDynamicMeta = JSON.parse(
+          await next.readFile('.next/server/app/cache-life-with-dynamic.meta')
+        )
+        expect(cacheLifeWithDynamicMeta.headers['x-nextjs-stale-time']).toBe(
+          '19'
+        )
+      } else if (withPPR) {
+        const cacheLifeWithDynamicMeta = JSON.parse(
+          await next.readFile('.next/server/app/cache-life-with-dynamic.meta')
+        )
+        // We don't exclude dynamic caches for the legacy PPR prerendering.
+        expect(cacheLifeWithDynamicMeta.headers['x-nextjs-stale-time']).toBe(
+          '18'
+        )
+      }
     })
 
     it('should send an SWR cache-control header based on the revalidate and expire values', async () => {

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -482,6 +482,7 @@ describe('use-cache', () => {
           '/cache-fetch',
           '/cache-fetch-no-store',
           '/cache-life',
+          !withCacheComponents && '/cache-life-with-dynamic',
           '/cache-tag',
           '/directive-in-node-modules/with-handler',
           '/directive-in-node-modules/without-handler',
@@ -517,10 +518,22 @@ describe('use-cache', () => {
       // custom cache life profile "frequent"
       expect(routes['/cache-life'].initialRevalidateSeconds).toBe(100)
       expect(routes['/cache-life'].initialExpireSeconds).toBe(300)
-      expect(routes['/cache-life-with-dynamic'].initialRevalidateSeconds).toBe(
-        100
-      )
-      expect(routes['/cache-life-with-dynamic'].initialExpireSeconds).toBe(300)
+
+      if (withCacheComponents) {
+        expect(
+          routes['/cache-life-with-dynamic'].initialRevalidateSeconds
+        ).toBe(100)
+        expect(routes['/cache-life-with-dynamic'].initialExpireSeconds).toBe(
+          300
+        )
+      } else {
+        // We don't exclude dynamic caches for the legacy prerendering
+        // (including PPR).
+        expect(
+          routes['/cache-life-with-dynamic'].initialRevalidateSeconds
+        ).toBe(1)
+        expect(routes['/cache-life-with-dynamic'].initialExpireSeconds).toBe(60)
+      }
 
       // default expireTime
       expect(routes['/cache-fetch'].initialExpireSeconds).toBe(31536000)

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -963,7 +963,7 @@ describe('use-cache', () => {
   }
 
   if (isNextStart && process.env.__NEXT_EXPERIMENTAL_PPR === 'true') {
-    it('should exclude inner caches from the resume data cache (RDC)', async () => {
+    it('should exclude inner caches and omitted caches from the resume data cache (RDC)', async () => {
       await next.fetch('/rdc')
 
       const resumeDataCache = extractResumeDataCacheFromPostponedState(
@@ -974,9 +974,14 @@ describe('use-cache', () => {
 
       // There should be no cache entry for the "middle" cache function, because
       // it's only used inside another cache scope ("outer"). Whereas "inner" is
-      // also used inside a prerender scope (the page). Note: We're matching on
-      // the "id" args that are encoded into the respective cache keys.
+      // also used inside a prerender scope (the page). Additionally, there
+      // should also be no cache entry for "short", because it has a short
+      // lifetime and is subsequently omitted from the prerendered shell. The
+      // following expectation is matching on the full list. If any additional
+      // keys are found, the test will fail and print the unexpected keys.
       expect(cacheKeys).toMatchObject([
+        // Note: We're matching on the "id" args that are encoded into the
+        // respective cache keys.
         expect.stringContaining('["outer"]'),
         expect.stringContaining('["inner"]'),
       ])

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -481,6 +481,7 @@ describe('use-cache', () => {
           expect.stringMatching(/\/b\d/),
           '/cache-fetch',
           '/cache-fetch-no-store',
+          '/cache-life',
           '/cache-tag',
           '/directive-in-node-modules/with-handler',
           '/directive-in-node-modules/without-handler',
@@ -516,6 +517,10 @@ describe('use-cache', () => {
       // custom cache life profile "frequent"
       expect(routes['/cache-life'].initialRevalidateSeconds).toBe(100)
       expect(routes['/cache-life'].initialExpireSeconds).toBe(300)
+      expect(routes['/cache-life-with-dynamic'].initialRevalidateSeconds).toBe(
+        100
+      )
+      expect(routes['/cache-life-with-dynamic'].initialExpireSeconds).toBe(300)
 
       // default expireTime
       expect(routes['/cache-fetch'].initialExpireSeconds).toBe(31536000)
@@ -532,10 +537,15 @@ describe('use-cache', () => {
     })
 
     it('should match the expected stale config in the page header', async () => {
-      const meta = JSON.parse(
+      const cacheLifeMeta = JSON.parse(
         await next.readFile('.next/server/app/cache-life.meta')
       )
-      expect(meta.headers['x-nextjs-stale-time']).toBe('19')
+      expect(cacheLifeMeta.headers['x-nextjs-stale-time']).toBe('19')
+
+      const cacheLifeWithDynamicMeta = JSON.parse(
+        await next.readFile('.next/server/app/cache-life-with-dynamic.meta')
+      )
+      expect(cacheLifeWithDynamicMeta.headers['x-nextjs-stale-time']).toBe('19')
     })
 
     it('should send an SWR cache-control header based on the revalidate and expire values', async () => {
@@ -557,7 +567,7 @@ describe('use-cache', () => {
 
     if (withCacheComponents) {
       it('should omit dynamic caches from prerendered shells', async () => {
-        let browser = await next.browser('/cache-life', {
+        let browser = await next.browser('/cache-life-with-dynamic', {
           disableJavaScript: true,
         })
 

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -12,6 +12,11 @@ import { PrerenderManifest } from 'next/dist/build'
 const GENERIC_RSC_ERROR =
   'An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.'
 
+const withPPR = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+
+const withCacheComponents =
+  process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true'
+
 describe('use-cache', () => {
   const { next, isNextDev, isNextDeploy, isNextStart, skipped } = nextTestSetup(
     {
@@ -444,11 +449,6 @@ describe('use-cache', () => {
         await next.readFile('.next/prerender-manifest.json')
       ) as PrerenderManifest
 
-      const withPPR = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
-
-      const withCacheComponents =
-        process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true'
-
       let prerenderedRoutes = Object.entries(prerenderManifest.routes)
 
       if (withPPR || withCacheComponents) {
@@ -481,7 +481,6 @@ describe('use-cache', () => {
           expect.stringMatching(/\/b\d/),
           '/cache-fetch',
           '/cache-fetch-no-store',
-          '/cache-life',
           '/cache-tag',
           '/directive-in-node-modules/with-handler',
           '/directive-in-node-modules/without-handler',
@@ -555,6 +554,16 @@ describe('use-cache', () => {
         's-maxage=900, stale-while-revalidate=31535100'
       )
     })
+
+    if (withCacheComponents) {
+      it('should omit dynamic caches from prerendered shells', async () => {
+        let browser = await next.browser('/cache-life', {
+          disableJavaScript: true,
+        })
+
+        expect(await browser.elementById('y').text()).toBe('Loading...')
+      })
+    }
 
     it('should propagate unstable_cache tags correctly', async () => {
       const meta = JSON.parse(


### PR DESCRIPTION
Caches with staleness/expiration below certain thresholds are not included in static prerenders and are treated as dynamic. However, the logic for propagating life/tags did not factor this in, meaning that a prerender could get `cacheLife("seconds")`, making it expire (both on the server and in the client router cache) much earlier than necessary. This PR fixes that.

Closes NAR-271

### Implementation notes

The solution relies on the fact that in a Cache Components prerender, we'll first fill the caches in the prospective render, and then read them again in the final prerender. Previously, we'd propagate cache life/tags in the prospective render, when the cache was filled, but this didn't factor in the fact that the final render might decide to omit the cache, leading to the problem described earlier. After this change, we'll be relying on the fact that the entry will be read in the final prerender, at which point we decide if it should be included or not, and then propagate cache life/tags if it is.

Additionally, we filter the omitted cache entries from the resume data cache (RDC). Otherwise they would be available during the resume, which they should not be.

To be honest, this feels a bit brittle, and perhaps we should take a look at how we're handling this and make it cleaner, but it should work for now.