### PR TITLE
Turbopack: run more unit tests in multi thread runtime

### DIFF
--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -398,7 +398,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_relativize_glob_normal_patterns() {
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
             BackendOptions::default(),
@@ -425,7 +425,7 @@ mod tests {
         .unwrap();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_relativize_glob_current_directory_prefix() {
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
             BackendOptions::default(),
@@ -454,7 +454,7 @@ mod tests {
         .unwrap();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_relativize_glob_parent_directory_navigation() {
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
             BackendOptions::default(),
@@ -484,7 +484,7 @@ mod tests {
         .unwrap();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_relativize_glob_mixed_prefixes() {
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
             BackendOptions::default(),
@@ -514,7 +514,7 @@ mod tests {
         .unwrap();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_relativize_glob_error_navigation_out_of_root() {
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
             BackendOptions::default(),

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -2423,7 +2423,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn with_extension() {
         crate::register();
 
@@ -2460,7 +2460,7 @@ mod tests {
         .unwrap()
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn file_stem() {
         crate::register();
 

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -240,7 +240,7 @@ pub mod tests {
         DirectoryEntry, DiskFileSystem, FileContent, FileSystem, FileSystemPath, glob::Glob,
     };
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn read_glob_basic() {
         crate::register();
         let scratch = tempfile::tempdir().unwrap();
@@ -304,7 +304,7 @@ pub mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn read_glob_symlinks() {
         crate::register();
         let scratch = tempfile::tempdir().unwrap();
@@ -407,7 +407,7 @@ pub mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn track_glob_invalidations() {
         use std::os::unix::fs::symlink;
         crate::register();
@@ -494,7 +494,7 @@ pub mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn track_glob_symlinks_loop() {
         crate::register();
         let scratch = tempfile::tempdir().unwrap();
@@ -552,7 +552,7 @@ pub mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn read_glob_symlinks_loop() {
         crate::register();
         let scratch = tempfile::tempdir().unwrap();

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/task_input.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/task_input.rs
@@ -18,7 +18,7 @@ fn one_unnamed_field(input: OneUnnamedField) -> Vc<Completion> {
     Completion::immutable()
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn tests() {
     run(&REGISTRATION, || async {
         assert!(ReadRef::ptr_eq(

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value_debug.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value_debug.rs
@@ -5,7 +5,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn ignored_indexes() {
     #[allow(dead_code)]
     #[derive(ValueDebugFormat)]

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1877,7 +1877,7 @@ pub mod tests {
         resolve::ExportUsage,
     };
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn traverse_dfs_from_entries_diamond() {
         run_graph_test(
             vec![rcstr!("a.js")],
@@ -1939,7 +1939,7 @@ pub mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn traverse_dfs_from_entries_cycle() {
         run_graph_test(
             vec![rcstr!("a.js")],
@@ -1999,7 +1999,7 @@ pub mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn traverse_edges_from_entries_fixed_point_cycle() {
         run_graph_test(
             vec![rcstr!("a.js")],

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -425,7 +425,7 @@ pub mod test {
         ResolveSourceRequestResult::NotFound.cell()
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_get_content_fn() {
         crate::register();
         let tt = TurboTasks::new(TurboTasksBackend::new(

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -240,7 +240,7 @@ pub mod tests {
 
     use super::*;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_rule_condition_leaves() {
         crate::register();
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
@@ -374,7 +374,7 @@ pub mod tests {
         anyhow::Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_rule_condition_tree() {
         crate::register();
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(


### PR DESCRIPTION
### What?

We want to run all unit tests in multi thread runtime, otherwise they would panic on block_in_place.

Closes PACK-5307