### PR TITLE
Turbopack: run all unit tests with a fixed amount of worker threads to avoid overloading with many CPUs

### DIFF
--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -431,7 +431,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_relativize_glob_normal_patterns() {
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
             BackendOptions::default(),
@@ -458,7 +458,7 @@ mod tests {
         .unwrap();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_relativize_glob_current_directory_prefix() {
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
             BackendOptions::default(),
@@ -487,7 +487,7 @@ mod tests {
         .unwrap();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_relativize_glob_parent_directory_navigation() {
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
             BackendOptions::default(),
@@ -517,7 +517,7 @@ mod tests {
         .unwrap();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_relativize_glob_mixed_prefixes() {
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
             BackendOptions::default(),
@@ -547,7 +547,7 @@ mod tests {
         .unwrap();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_relativize_glob_error_navigation_out_of_root() {
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
             BackendOptions::default(),

--- a/turbopack/crates/turbo-tasks-backend/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/all_in_one.rs
@@ -9,7 +9,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn all_in_one() {
     run(&REGISTRATION, || async {
         let a: Vc<u32> = Vc::cell(4242);

--- a/turbopack/crates/turbo-tasks-backend/tests/basic.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/basic.rs
@@ -8,7 +8,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn basic() {
     run(&REGISTRATION, || async {
         let output1 = func_without_args();

--- a/turbopack/crates/turbo-tasks-backend/tests/bug.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/bug.rs
@@ -24,7 +24,7 @@ struct TaskSpec {
 #[turbo_tasks::value(transparent)]
 struct TasksSpec(Vec<TaskSpec>);
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn graph_bug() {
     // see https://github.com/vercel/next.js/pull/79451
     run(&REGISTRATION, || async {

--- a/turbopack/crates/turbo-tasks-backend/tests/bug2.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/bug2.rs
@@ -33,7 +33,7 @@ pub struct TaskSpec {
 #[turbo_tasks::value(transparent)]
 struct Iteration(State<usize>);
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn graph_bug() {
     run(&REGISTRATION, move || async move {
         let spec = vec![

--- a/turbopack/crates/turbo-tasks-backend/tests/call_types.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/call_types.rs
@@ -8,7 +8,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn functions() {
     run(&REGISTRATION, || async {
         assert_eq!(*fn_plain().await?, 42);
@@ -53,7 +53,7 @@ async fn async_fn_vc_arg(n: Vc<u32>) -> Result<Vc<u32>> {
     Ok(Vc::cell(*n.await?))
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn methods() {
     run(&REGISTRATION, || async {
         assert_eq!(*Value::static_method().await?, 42);
@@ -106,7 +106,7 @@ impl Value {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn trait_methods() {
     run(&REGISTRATION, || async {
         assert_eq!(*Value::static_trait_method().await?, 42);

--- a/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
@@ -14,7 +14,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn transitive_emitting() {
     run(&REGISTRATION, || async {
         let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
@@ -32,7 +32,7 @@ async fn transitive_emitting() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn transitive_emitting_indirect() {
     run(&REGISTRATION, || async {
         let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
@@ -50,7 +50,7 @@ async fn transitive_emitting_indirect() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn multi_emitting() {
     run(&REGISTRATION, || async {
         let result_op = my_multi_emitting_function();
@@ -68,7 +68,7 @@ async fn multi_emitting() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn taking_collectibles() {
     run(&REGISTRATION, || async {
         let result_op = my_collecting_function();
@@ -84,7 +84,7 @@ async fn taking_collectibles() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn taking_collectibles_extra_layer() {
     run(&REGISTRATION, || async {
         let result_op = my_collecting_function_indirect();
@@ -100,7 +100,7 @@ async fn taking_collectibles_extra_layer() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn taking_collectibles_parallel() {
     run(&REGISTRATION, || async {
         let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!("a"));
@@ -142,7 +142,7 @@ async fn taking_collectibles_parallel() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn taking_collectibles_with_resolve() {
     run(&REGISTRATION, || async {
         let result_op = my_transitive_emitting_function_with_resolve(rcstr!("resolve"));

--- a/turbopack/crates/turbo-tasks-backend/tests/debug.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/debug.rs
@@ -9,7 +9,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn primitive_debug() {
     run(&REGISTRATION, || async {
         let a: Vc<u32> = Vc::cell(42);
@@ -20,7 +20,7 @@ async fn primitive_debug() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn transparent_debug() {
     run(&REGISTRATION, || async {
         let a: Vc<Transparent> = Transparent(42).cell();
@@ -32,7 +32,7 @@ async fn transparent_debug() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn enum_none_debug() {
     run(&REGISTRATION, || async {
         let a: Vc<Enum> = Enum::None.cell();
@@ -44,7 +44,7 @@ async fn enum_none_debug() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn enum_transparent_debug() {
     run(&REGISTRATION, || async {
         let a: Vc<Enum> = Enum::Transparent(Transparent(42).resolved_cell()).cell();
@@ -60,7 +60,7 @@ async fn enum_transparent_debug() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn enum_inner_vc_debug() {
     run(&REGISTRATION, || async {
         let a: Vc<Enum> = Enum::Enum(Enum::None.resolved_cell()).cell();
@@ -76,7 +76,7 @@ async fn enum_inner_vc_debug() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn struct_unit_debug() {
     run(&REGISTRATION, || async {
         let a: Vc<StructUnit> = StructUnit.cell();
@@ -87,7 +87,7 @@ async fn struct_unit_debug() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn struct_transparent_debug() {
     run(&REGISTRATION, || async {
         let a: Vc<StructWithTransparent> = StructWithTransparent {
@@ -106,7 +106,7 @@ async fn struct_transparent_debug() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn struct_vec_debug() {
     run(&REGISTRATION, || async {
         let a: Vc<StructWithVec> = StructWithVec { vec: vec![] }.cell();
@@ -135,7 +135,7 @@ async fn struct_vec_debug() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn struct_ignore_debug() {
     run(&REGISTRATION, || async {
         let a: Vc<StructWithIgnore> = StructWithIgnore {

--- a/turbopack/crates/turbo-tasks-backend/tests/detached.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/detached.rs
@@ -15,7 +15,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_spawns_detached() -> anyhow::Result<()> {
     run(&REGISTRATION, || async {
         // HACK: The watch channel we use has an incorrect implementation of `TraceRawVcs`, just
@@ -82,7 +82,7 @@ async fn spawns_detached(
     Vc::cell(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_spawns_detached_changing() -> anyhow::Result<()> {
     run(&REGISTRATION, || async {
         // HACK: The watch channel we use has an incorrect implementation of `TraceRawVcs`

--- a/turbopack/crates/turbo-tasks-backend/tests/dirty_in_progress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/dirty_in_progress.rs
@@ -11,7 +11,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn dirty_in_progress() {
     run(&REGISTRATION, || async {
         let cases = [

--- a/turbopack/crates/turbo-tasks-backend/tests/emptied_cells.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/emptied_cells.rs
@@ -8,7 +8,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recompute() {
     run(&REGISTRATION, || async {
         let input = ChangingInput {

--- a/turbopack/crates/turbo-tasks-backend/tests/filter_unused_args.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/filter_unused_args.rs
@@ -8,7 +8,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn filtered_trait_method_args() -> Result<()> {
     run(&REGISTRATION, || async {
         let uses_arg = UsesArg.cell();

--- a/turbopack/crates/turbo-tasks-backend/tests/immutable.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/immutable.rs
@@ -8,7 +8,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn hidden_mutate() {
     run(&REGISTRATION, || async {
         let input = create_input().resolve().await?;

--- a/turbopack/crates/turbo-tasks-backend/tests/local_tasks.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/local_tasks.rs
@@ -8,7 +8,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_local_task_id() -> Result<()> {
     run(&REGISTRATION, || async {
         let local_vc = get_local_task_id();

--- a/turbopack/crates/turbo-tasks-backend/tests/operation_vc.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/operation_vc.rs
@@ -26,7 +26,7 @@ fn use_operations() -> Vc<i32> {
     forty_two.connect()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_use_operations() -> Result<()> {
     run(&REGISTRATION, || async {
         assert_eq!(*use_operations().await?, 42);

--- a/turbopack/crates/turbo-tasks-backend/tests/panics.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/panics.rs
@@ -25,7 +25,7 @@ static FILE_PATH_REGEX: LazyLock<Regex> =
 //
 // This test depends on the process-wide global panic handler. This test must be run in its own
 // process in isolation of any other tests.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_panic_hook() {
     let prev_hook = take_hook();
     set_hook(Box::new(move |info| {

--- a/turbopack/crates/turbo-tasks-backend/tests/performance.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/performance.rs
@@ -142,7 +142,7 @@ fn check_skip() -> bool {
     false
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn many_calls_to_many_children() {
     if check_skip() {
         return;
@@ -157,7 +157,7 @@ async fn many_calls_to_many_children() {
     .unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn many_calls_to_uncached_many_children() {
     if check_skip() {
         return;
@@ -189,7 +189,7 @@ fn run_big_graph_test(counts: Vec<u32>) -> impl Future<Output = Result<()>> + Se
     )
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn many_calls_to_big_graph_1() {
     if check_skip() {
         return;
@@ -199,7 +199,7 @@ async fn many_calls_to_big_graph_1() {
         .unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn many_calls_to_big_graph_2() {
     if check_skip() {
         return;
@@ -211,7 +211,7 @@ async fn many_calls_to_big_graph_2() {
     .unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn many_calls_to_big_graph_3() {
     if check_skip() {
         return;
@@ -221,7 +221,7 @@ async fn many_calls_to_big_graph_3() {
         .unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn many_calls_to_big_graph_4() {
     if check_skip() {
         return;
@@ -231,7 +231,7 @@ async fn many_calls_to_big_graph_4() {
         .unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn many_calls_to_big_graph_5() {
     if check_skip() {
         return;
@@ -243,7 +243,7 @@ async fn many_calls_to_big_graph_5() {
     .unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn many_calls_to_big_graph_6() {
     if check_skip() {
         return;
@@ -255,7 +255,7 @@ async fn many_calls_to_big_graph_6() {
     .unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn many_calls_to_big_graph_7() {
     if check_skip() {
         return;
@@ -270,7 +270,7 @@ async fn many_calls_to_big_graph_7() {
     .unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn many_calls_to_big_graph_8() {
     if check_skip() {
         return;
@@ -282,7 +282,7 @@ async fn many_calls_to_big_graph_8() {
     .unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn many_calls_to_big_graph_9() {
     if check_skip() {
         return;

--- a/turbopack/crates/turbo-tasks-backend/tests/random_change.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/random_change.rs
@@ -9,7 +9,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn random_change() {
     run(&REGISTRATION, || async {
         let state = make_state();

--- a/turbopack/crates/turbo-tasks-backend/tests/read_ref_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/read_ref_cell.rs
@@ -10,7 +10,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn read_ref() {
     run(&REGISTRATION, || async {
         let counter = Counter::cell(Counter {

--- a/turbopack/crates/turbo-tasks-backend/tests/recompute.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/recompute.rs
@@ -8,7 +8,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recompute() {
     run(&REGISTRATION, || async {
         let input = ChangingInput {
@@ -58,7 +58,7 @@ async fn recompute() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn immutable_analysis() {
     run(&REGISTRATION, || async {
         let input = ChangingInput {

--- a/turbopack/crates/turbo-tasks-backend/tests/recompute_collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/recompute_collectibles.rs
@@ -9,7 +9,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recompute() {
     run(&REGISTRATION, || async {
         let input = ChangingInput::new(1).resolve().await?;

--- a/turbopack/crates/turbo-tasks-backend/tests/resolved_vc.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/resolved_vc.rs
@@ -23,7 +23,7 @@ fn assert_resolved(input: ResolvedVc<u32>) {
     assert!(input_vc.is_resolved());
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_conversion() -> Result<()> {
     run(&REGISTRATION, || async {
         let unresolved: Vc<u32> = Vc::cell(42);
@@ -38,7 +38,7 @@ async fn test_conversion() -> Result<()> {
     .await
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_cell_construction() -> Result<()> {
     run(&REGISTRATION, || async {
         let a: ResolvedVc<u32> = ResolvedVc::cell(42);
@@ -50,7 +50,7 @@ async fn test_cell_construction() -> Result<()> {
     .await
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_resolved_vc_as_arg() -> Result<()> {
     run(&REGISTRATION, || async {
         let unresolved: Vc<u32> = returns_int(42);
@@ -62,7 +62,7 @@ async fn test_resolved_vc_as_arg() -> Result<()> {
     .await
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_into_future() -> Result<()> {
     run(&REGISTRATION, || async {
         let mut resolved = ResolvedVc::cell(42);
@@ -78,7 +78,7 @@ async fn test_into_future() -> Result<()> {
     .await
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_sidecast() -> Result<()> {
     run(&REGISTRATION, || async {
         let concrete_value = ImplementsAAndB.resolved_cell();

--- a/turbopack/crates/turbo-tasks-backend/tests/scope_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/scope_stress.rs
@@ -8,7 +8,7 @@ use turbo_tasks_testing::{Registration, register, run_with_tt};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn rectangle_stress() -> Result<()> {
     let size = std::env::var("TURBOPACK_TEST_RECTANGLE_STRESS_SIZE")
         .map(|size| size.parse().unwrap())

--- a/turbopack/crates/turbo-tasks-backend/tests/shrink_to_fit.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/shrink_to_fit.rs
@@ -11,7 +11,7 @@ static REGISTRATION: Registration = register!();
 #[turbo_tasks::value(transparent)]
 struct Wrapper(Vec<u32>);
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_shrink_to_fit() -> Result<()> {
     run(&REGISTRATION, || async {
         // `Vec::shrink_to_fit` is implicitly called when a cell is constructed.

--- a/turbopack/crates/turbo-tasks-backend/tests/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/task_statistics.rs
@@ -13,7 +13,7 @@ use turbo_tasks_testing::{Registration, register, run_without_cache_check};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_simple_task() -> Result<()> {
     run_without_cache_check(&REGISTRATION, async move {
         enable_stats();
@@ -39,7 +39,7 @@ async fn test_simple_task() -> Result<()> {
     .await
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_await_same_vc_multiple_times() -> Result<()> {
     run_without_cache_check(&REGISTRATION, async move {
         enable_stats();
@@ -61,7 +61,7 @@ async fn test_await_same_vc_multiple_times() -> Result<()> {
     .await
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_vc_receiving_task() -> Result<()> {
     run_without_cache_check(&REGISTRATION, async move {
         enable_stats();
@@ -93,7 +93,7 @@ async fn test_vc_receiving_task() -> Result<()> {
     .await
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trait_methods() -> Result<()> {
     run_without_cache_check(&REGISTRATION, async move {
         enable_stats();
@@ -130,7 +130,7 @@ async fn test_trait_methods() -> Result<()> {
     .await
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_dyn_trait_methods() -> Result<()> {
     run_without_cache_check(&REGISTRATION, async move {
         enable_stats();
@@ -174,7 +174,7 @@ async fn test_dyn_trait_methods() -> Result<()> {
 }
 
 // creates Vcs, but doesn't ever execute them
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_no_execution() -> Result<()> {
     run_without_cache_check(&REGISTRATION, async move {
         enable_stats();

--- a/turbopack/crates/turbo-tasks-backend/tests/trace_transient.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trace_transient.rs
@@ -18,7 +18,7 @@ Adder::add_method (read cell of type turbo-tasks@TODO::::primitives::u64)
     unknown transient task (read cell of type turbo-tasks@TODO::::primitives::u16)
     unknown transient task (read cell of type turbo-tasks@TODO::::primitives::u32)";
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trace_transient() {
     let result = run_without_cache_check(&REGISTRATION, async {
         read_incorrect_task_input_operation(IncorrectTaskInput(

--- a/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell.rs
@@ -10,7 +10,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn trait_ref() {
     run(&REGISTRATION, || async {
         let counter = Counter::cell(Counter {

--- a/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell_mode.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell_mode.rs
@@ -9,7 +9,7 @@ static REGISTRATION: Registration = register!();
 
 // Test that with `cell = "shared"`, the cell will be re-used as long as the
 // value is equal.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trait_ref_shared_cell_mode() {
     run(&REGISTRATION, || async {
         let input = CellIdSelector {
@@ -44,7 +44,7 @@ async fn test_trait_ref_shared_cell_mode() {
 
 // Test that with `cell = "new"`, the cell will is never re-used, even if the
 // value is equal.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trait_ref_new_cell_mode() {
     run(&REGISTRATION, || async {
         let input = CellIdSelector {

--- a/turbopack/crates/turbo-tasks-backend/tests/transient_collectible.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/transient_collectible.rs
@@ -10,7 +10,7 @@ static REGISTRATION: Registration = register!();
 const EXPECTED_MSG: &str =
     "Collectible is transient, transient collectibles cannot be emitted from persistent tasks";
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_transient_emit_from_persistent() {
     let result = run_without_cache_check(&REGISTRATION, async {
         emit_incorrect_task_input_operation(IncorrectTaskInput(U32Wrapper(123).resolved_cell()))

--- a/turbopack/crates/turbo-tasks-backend/tests/transient_vc.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/transient_vc.rs
@@ -7,7 +7,7 @@ use turbo_tasks_testing::{Registration, register, run_without_cache_check};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_transient_vc() -> Result<()> {
     run_without_cache_check(&REGISTRATION, async {
         test_transient_operation(TransientValue::new(123))

--- a/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -18,7 +18,7 @@ static REGISTRATION: Registration = register!(turbo_tasks_fetch::register);
 /// acquire and hold this lock to prevent potential flakiness.
 static GLOBAL_TEST_LOCK: TokioMutex<()> = TokioMutex::const_new(());
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn basic_get() {
     let _guard = GLOBAL_TEST_LOCK.lock().await;
     run(&REGISTRATION, || async {
@@ -49,7 +49,7 @@ async fn basic_get() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sends_user_agent() {
     let _guard = GLOBAL_TEST_LOCK.lock().await;
     run(&REGISTRATION, || async {
@@ -85,7 +85,7 @@ async fn sends_user_agent() {
 
 // This is temporary behavior.
 // TODO: Implement invalidation that respects Cache-Control headers.
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn invalidation_does_not_invalidate() {
     let _guard = GLOBAL_TEST_LOCK.lock().await;
     run(&REGISTRATION, || async {
@@ -130,7 +130,7 @@ fn get_issue_context() -> Vc<FileSystemPath> {
     DiskFileSystem::new(rcstr!("root"), rcstr!("/")).root()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn errors_on_failed_connection() {
     let _guard = GLOBAL_TEST_LOCK.lock().await;
     run(&REGISTRATION, || async {
@@ -161,7 +161,7 @@ async fn errors_on_failed_connection() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn errors_on_404() {
     let _guard = GLOBAL_TEST_LOCK.lock().await;
     run(&REGISTRATION, || async {
@@ -196,7 +196,7 @@ async fn errors_on_404() {
     .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn client_cache() {
     // a simple fetch that should always succeed
     async fn simple_fetch(path: &str, client: FetchClient) -> anyhow::Result<()> {

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -2423,7 +2423,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn with_extension() {
         crate::register();
 
@@ -2460,7 +2460,7 @@ mod tests {
         .unwrap()
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn file_stem() {
         crate::register();
 

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -240,7 +240,7 @@ pub mod tests {
         DirectoryEntry, DiskFileSystem, FileContent, FileSystem, FileSystemPath, glob::Glob,
     };
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn read_glob_basic() {
         crate::register();
         let scratch = tempfile::tempdir().unwrap();
@@ -304,7 +304,7 @@ pub mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn read_glob_symlinks() {
         crate::register();
         let scratch = tempfile::tempdir().unwrap();
@@ -407,7 +407,7 @@ pub mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn track_glob_invalidations() {
         use std::os::unix::fs::symlink;
         crate::register();
@@ -494,7 +494,7 @@ pub mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn track_glob_symlinks_loop() {
         crate::register();
         let scratch = tempfile::tempdir().unwrap();
@@ -552,7 +552,7 @@ pub mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn read_glob_symlinks_loop() {
         crate::register();
         let scratch = tempfile::tempdir().unwrap();

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/task_input.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/task_input.rs
@@ -18,7 +18,7 @@ fn one_unnamed_field(input: OneUnnamedField) -> Vc<Completion> {
     Completion::immutable()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn tests() {
     run(&REGISTRATION, || async {
         assert!(ReadRef::ptr_eq(

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value_debug.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value_debug.rs
@@ -5,7 +5,7 @@ use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn ignored_indexes() {
     #[allow(dead_code)]
     #[derive(ValueDebugFormat)]

--- a/turbopack/crates/turbo-tasks/src/parallel.rs
+++ b/turbopack/crates/turbo-tasks/src/parallel.rs
@@ -216,7 +216,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_parallel_for_each() {
         let input = vec![1, 2, 3, 4, 5];
         let sum = AtomicI32::new(0);
@@ -226,7 +226,7 @@ mod tests {
         assert_eq!(sum.load(Ordering::SeqCst), 15);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_parallel_try_for_each() {
         let input = vec![1, 2, 3, 4, 5];
         let result = try_for_each(&input, |&x| {
@@ -240,7 +240,7 @@ mod tests {
         assert_eq!(result.unwrap_err(), "Odd number 1 encountered");
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_parallel_try_for_each_mut() {
         let mut input = vec![1, 2, 3, 4, 5];
         let result = try_for_each_mut(&mut input, |x| {
@@ -256,7 +256,7 @@ mod tests {
         assert_eq!(input, vec![11, 12, 13, 14, 15]);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_parallel_for_each_owned() {
         let input = vec![1, 2, 3, 4, 5];
         let sum = AtomicI32::new(0);
@@ -266,28 +266,28 @@ mod tests {
         assert_eq!(sum.load(Ordering::SeqCst), 15);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_parallel_map_collect() {
         let input = vec![1, 2, 3, 4, 5];
         let result: Vec<_> = map_collect(&input, |&x| x * 2);
         assert_eq!(result, vec![2, 4, 6, 8, 10]);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_parallel_map_collect_owned() {
         let input = vec![1, 2, 3, 4, 5];
         let result: Vec<_> = map_collect_owned(input, |x| x * 2);
         assert_eq!(result, vec![2, 4, 6, 8, 10]);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_parallel_map_collect_owned_many() {
         let input = vec![1; 1000];
         let result: Vec<_> = map_collect_owned(input, |x| x * 2);
         assert_eq!(result, vec![2; 1000]);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_panic_in_scope() {
         let result = catch_unwind(AssertUnwindSafe(|| {
             let mut input = vec![1; 1000];

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -191,7 +191,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_scope() {
         let results = scope_and_block(1000, |scope| {
             for i in 0..1000 {
@@ -203,7 +203,7 @@ mod tests {
         });
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_empty_scope() {
         let results = scope_and_block(0, |scope| {
             if false {
@@ -213,7 +213,7 @@ mod tests {
         assert_eq!(results.count(), 0);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_single_task() {
         let results = scope_and_block(1, |scope| {
             scope.spawn(async move { 42 });
@@ -222,7 +222,7 @@ mod tests {
         assert_eq!(results, vec![42]);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_task_finish_before_scope() {
         let results = scope_and_block(1, |scope| {
             scope.spawn(async move { 42 });
@@ -232,7 +232,7 @@ mod tests {
         assert_eq!(results, vec![42]);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_task_finish_after_scope() {
         let results = scope_and_block(1, |scope| {
             scope.spawn(async move {
@@ -244,7 +244,7 @@ mod tests {
         assert_eq!(results, vec![42]);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_panic_in_scope_factory() {
         let result = catch_unwind(AssertUnwindSafe(|| {
             let _results = scope_and_block(1000, |scope| {
@@ -262,7 +262,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_panic_in_scope_task() {
         let result = catch_unwind(AssertUnwindSafe(|| {
             let _results = scope_and_block(1000, |scope| {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1877,7 +1877,7 @@ pub mod tests {
         resolve::ExportUsage,
     };
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn traverse_dfs_from_entries_diamond() {
         run_graph_test(
             vec![rcstr!("a.js")],
@@ -1939,7 +1939,7 @@ pub mod tests {
         .await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn traverse_dfs_from_entries_cycle() {
         run_graph_test(
             vec![rcstr!("a.js")],
@@ -1999,7 +1999,7 @@ pub mod tests {
         .await;
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn traverse_edges_from_entries_fixed_point_cycle() {
         run_graph_test(
             vec![rcstr!("a.js")],

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -425,7 +425,7 @@ pub mod test {
         ResolveSourceRequestResult::NotFound.cell()
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_get_content_fn() {
         crate::register();
         let tt = TurboTasks::new(TurboTasksBackend::new(

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -240,7 +240,7 @@ pub mod tests {
 
     use super::*;
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_rule_condition_leaves() {
         crate::register();
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
@@ -374,7 +374,7 @@ pub mod tests {
         anyhow::Ok(())
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_rule_condition_tree() {
         crate::register();
         let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(


### PR DESCRIPTION
### What?

To avoid overwelming the CPU when one has many core, we limit the number of worker thread in unit tests.

Unit tests already run multi-threaded, so we don't want to create N * N threads here....

Closes PACK-5310