### PR TITLE
fix(manifest): parent page chunk was loaded in child page

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -235,6 +235,7 @@ export class ClientReferenceManifestPlugin {
 
   createAsset(compilation: webpack.Compilation, context: string) {
     const manifestsPerGroup = new Map<string, ClientReferenceManifest[]>()
+    const manifestsPerPage = new Map<string, ClientReferenceManifest[]>()
     const manifestEntryFiles: string[] = []
 
     const configuredCrossOriginLoading =
@@ -543,12 +544,7 @@ export class ClientReferenceManifestPlugin {
 
       recordChunkGroup(entrypoint)
 
-      // A page's entry name can have extensions. For example, these are both valid:
-      // - app/foo/page
-      // - app/foo/page.page
-      if (/\/page(\.[^/]+)?$/.test(entryName)) {
-        manifestEntryFiles.push(entryName.replace(/\/page(\.[^/]+)?$/, '/page'))
-      }
+      const groupName = entryNameToGroupName(entryName)
 
       // We also need to create manifests for route handler entrypoints to
       // enable `'use cache'`.
@@ -556,11 +552,24 @@ export class ClientReferenceManifestPlugin {
         manifestEntryFiles.push(entryName)
       }
 
-      const groupName = entryNameToGroupName(entryName)
-      if (!manifestsPerGroup.has(groupName)) {
-        manifestsPerGroup.set(groupName, [])
+      // A page's entry name can have extensions. For example, these are both valid:
+      // - app/foo/page
+      // - app/foo/page.page
+      if (/\/page(\.[^/]+)?$/.test(entryName)) {
+        manifestEntryFiles.push(entryName.replace(/\/page(\.[^/]+)?$/, '/page'))
+
+        if (!manifestsPerPage.has(groupName)) {
+          manifestsPerPage.set(groupName, [])
+        }
+        manifestsPerPage.get(groupName)!.push(manifest)
       }
-      manifestsPerGroup.get(groupName)!.push(manifest)
+      // For other entries, we use the global group
+      else {
+        if (!manifestsPerGroup.has(groupName)) {
+          manifestsPerGroup.set(groupName, [])
+        }
+        manifestsPerGroup.get(groupName)!.push(manifest)
+      }
     }
 
     // Generate per-page manifests.
@@ -584,6 +593,13 @@ export class ClientReferenceManifestPlugin {
         for (const manifest of manifestsPerGroup.get(group) || []) {
           mergeManifest(mergedManifest, manifest)
         }
+
+        if (segment === 'page') {
+          for (const manifest of manifestsPerPage.get(group) || []) {
+            mergeManifest(mergedManifest, manifest)
+          }
+        }
+
         group += (group ? '/' : '') + segment
       }
 

--- a/test/e2e/app-dir/page-manifest-bug/app/abc/page.tsx
+++ b/test/e2e/app-dir/page-manifest-bug/app/abc/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function Abc() {
+  return (
+    <>
+      <h1 id="page-title-abc">ABC Page</h1>
+      <p>
+        <Link href="/" prefetch={false}>
+          go to home page
+        </Link>
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/page-manifest-bug/app/layout.tsx
+++ b/test/e2e/app-dir/page-manifest-bug/app/layout.tsx
@@ -1,0 +1,13 @@
+import Script from 'next/script'
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <head />
+      <body>
+        {children}
+        <Script id="next-script-layout" />
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/page-manifest-bug/app/page.tsx
+++ b/test/e2e/app-dir/page-manifest-bug/app/page.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+import Script from 'next/script'
+
+export default function Home() {
+  return (
+    <>
+      <h1 id="page-title-home">Home page</h1>
+      <p>
+        <Link href="/abc" prefetch={false}>
+          go to ABC page
+        </Link>
+      </p>
+      <Script id="next-script-home" />
+    </>
+  )
+}

--- a/test/e2e/app-dir/page-manifest-bug/next.config.js
+++ b/test/e2e/app-dir/page-manifest-bug/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/page-manifest-bug/page-manifest-bug.test.ts
+++ b/test/e2e/app-dir/page-manifest-bug/page-manifest-bug.test.ts
@@ -1,0 +1,35 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('route-page-manifest-bug', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should work when loading the child page', async () => {
+    const browser = await next.browser('/')
+    await browser.waitForElementByCss('#page-title-home')
+    await browser.waitForIdleNetwork()
+
+    expect(await browser.elementById('next-script-layout')).toBeDefined()
+    const pageScriptElement = await browser.eval(
+      `document.querySelector('script[src*="/_next/static/chunks/app/page"]')`
+    )
+    expect(pageScriptElement).not.toBeNull()
+
+    // go to child page
+    await browser.eval('window.location.href = "/abc"')
+    await browser.waitForElementByCss('#page-title-abc')
+    await browser.refresh()
+    await browser.waitForIdleNetwork()
+
+    expect(await browser.elementById('next-script-layout')).toBeDefined()
+    const childPageScriptElement = await browser.eval(
+      `document.querySelector('script[src*="/_next/static/chunks/app/abc/page"]')`
+    )
+    expect(childPageScriptElement).not.toBeNull()
+    const parentPageScriptElement = await browser.eval(
+      `document.querySelector('script[src*="/_next/static/chunks/app/page"]')`
+    )
+    expect(parentPageScriptElement).toBeNull()
+  })
+})


### PR DESCRIPTION
# What 

Once the  manifest of a page is generated, it should not be associated to the segment group, otherwise a child page could have the parent page chunk to load.

FIXES #82787

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
