### PR TITLE
Remove experimental appDocumentPreloading

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -321,7 +321,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         adapterPath: z.string().optional(),
         useSkewCookie: z.boolean().optional(),
         after: z.boolean().optional(),
-        appDocumentPreloading: z.boolean().optional(),
         appNavFailHandling: z.boolean().optional(),
         preloadEntriesOnStart: z.boolean().optional(),
         allowedRevalidateHeaderKeys: z.array(z.string()).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -446,7 +446,6 @@ export interface ExperimentalConfig {
   clientSegmentCache?: boolean | 'client-only'
   clientParamParsing?: boolean
   dynamicOnHover?: boolean
-  appDocumentPreloading?: boolean
   preloadEntriesOnStart?: boolean
   clientRouterFilter?: boolean
   clientRouterFilterRedirects?: boolean
@@ -1521,7 +1520,6 @@ export const defaultConfig = Object.freeze({
     clientSegmentCache: false,
     clientParamParsing: false,
     dynamicOnHover: false,
-    appDocumentPreloading: undefined,
     preloadEntriesOnStart: true,
     clientRouterFilter: true,
     clientRouterFilterRedirects: false,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -292,32 +292,6 @@ export default class NextNodeServer extends BaseServer<
       this.imageResponseCache = new ResponseCache(this.minimalMode)
     }
 
-    const { appDocumentPreloading } = this.nextConfig.experimental
-    const isDefaultEnabled = typeof appDocumentPreloading === 'undefined'
-
-    if (
-      !options.dev &&
-      (appDocumentPreloading === true ||
-        !(this.minimalMode && isDefaultEnabled))
-    ) {
-      // pre-warm _document and _app as these will be
-      // needed for most requests
-      loadComponents({
-        distDir: this.distDir,
-        page: '/_document',
-        isAppPath: false,
-        isDev: this.isDev,
-        sriEnabled: this.sriEnabled,
-      }).catch(() => {})
-      loadComponents({
-        distDir: this.distDir,
-        page: '/_app',
-        isAppPath: false,
-        isDev: this.isDev,
-        sriEnabled: this.sriEnabled,
-      }).catch(() => {})
-    }
-
     if (
       !options.dev &&
       !this.minimalMode &&


### PR DESCRIPTION
## What?

This functionality has been succeeded by experimental.preloadEntriesOnStart which is enabled by default. `preloadEntriesOnStart` can likely also be removed as an option given that it's `true` since 16 months ago. But that's for another PR.

Closes PACK-5309