### PR TITLE
Update prettier project dependency from 3.2.5 to 3.6.2

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -72,3 +72,18 @@ test/e2e/async-modules/amp-validator-wasm.js
 /turbopack/crates/turbopack-tests/tests/**/static
 
 /apps/docs/.source/*
+
+# Symlink files
+readme.md
+test/development/app-dir/hmr-symlink/app/symlink-chain/page.tsx
+test/development/app-dir/hmr-symlink/app/symlink-link/page.tsx
+test/development/app-dir/ssr-in-rsc/node_modules/random-react-library
+test/integration/build-trace-extra-entries/app/node_modules/pkg-behind-symlink
+test/integration/edge-runtime-configurable-guards/node_modules/lib
+test/production/app-dir/symbolic-file-links/src/i18n.ts
+test/production/app-dir/symbolic-file-links/src/app/layout.tsx
+test/production/app-dir/symbolic-file-links/src/app/page.tsx
+turbopack/crates/turbopack/tests/node-file-trace/integration/pnpm/node_modules/foo
+turbopack/crates/turbopack/tests/node-file-trace/integration/pnpm/node_modules/.pnpm/foo@2.1.0/node_modules/lodash-pnpm-test
+turbopack/crates/turbopack/tests/node-file-trace/integration/symlink-to-file/linked.js
+turbopack/crates/turbopack-tests/tests/snapshot/swc_transforms/mono_transforms/input/node_modules/component

--- a/docs/01-app/02-guides/progressive-web-apps.mdx
+++ b/docs/01-app/02-guides/progressive-web-apps.mdx
@@ -331,7 +331,8 @@ function InstallPrompt() {
           <span role="img" aria-label="plus icon">
             {' '}
             ➕{' '}
-          </span>.
+          </span>
+          .
         </p>
       )}
     </div>

--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -890,7 +890,6 @@ This `next/image` component uses browser native [lazy loading](https://caniuse.c
   - Use CSS `@supports (font: -apple-system-body) and (-webkit-appearance: none) { img[loading="lazy"] { clip-path: inset(0.6px) } }`
   - Use [`priority`](#priority) if the image is above the fold
 - [Firefox 67+](https://bugzilla.mozilla.org/show_bug.cgi?id=1556156) displays a white background while loading. Possible solutions:
-
   - Enable [AVIF `formats`](#formats)
   - Use [`placeholder`](#placeholder)
 

--- a/docs/01-app/03-api-reference/03-file-conventions/route-segment-config.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/route-segment-config.mdx
@@ -52,7 +52,6 @@ export const dynamic = 'auto'
 
 - **`'auto'`** (default): The default option to cache as much as possible without preventing any components from opting into dynamic behavior.
 - **`'force-dynamic'`**: Force [dynamic rendering](/docs/app/getting-started/partial-prerendering#dynamic-rendering), which will result in routes being rendered for each user at request time. This option is equivalent to:
-
   - Setting the option of every `fetch()` request in a layout or page to `{ cache: 'no-store', next: { revalidate: 0 } }`.
   - Setting the segment config to `export const fetchCache = 'force-no-store'`
 

--- a/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
@@ -115,7 +115,6 @@ For type completion of `params` and `searchParams`, you can type the first argum
 `generateMetadata` function accepts the following parameters:
 
 - `props` - An object containing the parameters of the current route:
-
   - `params` - An object containing the [dynamic route parameters](/docs/app/api-reference/file-conventions/dynamic-routes) object from the root segment down to the segment `generateMetadata` is called from. Examples:
 
     | Route                           | URL         | `params`                  |
@@ -232,11 +231,9 @@ export const metadata = {
 > **Good to know**:
 >
 > - `title.template` applies to **child** route segments and **not** the segment it's defined in. This means:
->
 >   - `title.default` is **required** when you add a `title.template`.
 >   - `title.template` defined in `layout.js` will not apply to a `title` defined in a `page.js` of the same route segment.
 >   - `title.template` defined in `page.js` has no effect because a page is always the terminating segment (it doesn't have any children route segments).
->
 > - `title.template` has **no effect** if a route has not defined a `title` or `title.default`.
 
 ##### `absolute`
@@ -286,11 +283,9 @@ export const metadata = {
 > **Good to know**:
 >
 > - `layout.js`
->
 >   - `title` (string) and `title.default` define the default title for child segments (that do not define their own `title`). It will augment `title.template` from the closest parent segment if it exists.
 >   - `title.absolute` defines the default title for child segments. It ignores `title.template` from parent segments.
 >   - `title.template` defines a new title template for child segments.
->
 > - `page.js`
 >   - If a page does not define its own title the closest parents resolved title will be used.
 >   - `title` (string) defines the routes title. It will augment `title.template` from the closest parent segment if it exists.

--- a/errors/css-global.mdx
+++ b/errors/css-global.mdx
@@ -21,8 +21,9 @@ Consider the stylesheet named [`styles.css`](/docs/app/getting-started/css)
 
 ```css filename="styles.css"
 body {
-  font-family: 'SF Pro Text', 'SF Pro Icons', 'Helvetica Neue', 'Helvetica',
-    'Arial', sans-serif;
+  font-family:
+    'SF Pro Text', 'SF Pro Icons', 'Helvetica Neue', 'Helvetica', 'Arial',
+    sans-serif;
   padding: 20px 20px 60px;
   max-width: 680px;
   margin: 0 auto;

--- a/errors/no-styled-jsx-in-document.mdx
+++ b/errors/no-styled-jsx-in-document.mdx
@@ -16,8 +16,9 @@ For example, consider the following stylesheet named `styles.css`:
 
 ```css filename="styles.css"
 body {
-  font-family: 'SF Pro Text', 'SF Pro Icons', 'Helvetica Neue', 'Helvetica',
-    'Arial', sans-serif;
+  font-family:
+    'SF Pro Text', 'SF Pro Icons', 'Helvetica Neue', 'Helvetica', 'Arial',
+    sans-serif;
   padding: 20px 20px 60px;
   max-width: 680px;
   margin: 0 auto;

--- a/examples/auth0/components/layout.tsx
+++ b/examples/auth0/components/layout.tsx
@@ -30,8 +30,9 @@ const Layout = ({ user, loading = false, children }: LayoutProps) => {
         body {
           margin: 0;
           color: #333;
-          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-            Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+          font-family:
+            -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+            Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
         }
       `}</style>
     </>

--- a/examples/cms-sitecore-xmcloud/src/lib/extract-path/index.ts
+++ b/examples/cms-sitecore-xmcloud/src/lib/extract-path/index.ts
@@ -19,7 +19,7 @@ export class PathExtractor {
     }
     let path = Array.isArray(params.path)
       ? params.path.join("/")
-      : params.path ?? "/";
+      : (params.path ?? "/");
 
     // Ensure leading '/'
     if (!path.startsWith("/")) {

--- a/examples/cms-wordpress/src/utils/nextSlugToWpSlug.ts
+++ b/examples/cms-wordpress/src/utils/nextSlugToWpSlug.ts
@@ -1,2 +1,2 @@
 export const nextSlugToWpSlug = (nextSlug: string) =>
-  nextSlug && Array.isArray(nextSlug) ? nextSlug.join("/") : nextSlug ?? "/";
+  nextSlug && Array.isArray(nextSlug) ? nextSlug.join("/") : (nextSlug ?? "/");

--- a/examples/convex/styles/globals.css
+++ b/examples/convex/styles/globals.css
@@ -7,8 +7,8 @@
 }
 
 body {
-  font-family: system-ui, "Segoe UI", Roboto, "Helvetica Neue", helvetica,
-    sans-serif;
+  font-family:
+    system-ui, "Segoe UI", Roboto, "Helvetica Neue", helvetica, sans-serif;
 }
 
 main {

--- a/examples/mdx/app/globals.css
+++ b/examples/mdx/app/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+  --font-mono:
+    ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 

--- a/examples/next-forms/app/global.css
+++ b/examples/next-forms/app/global.css
@@ -1,6 +1,7 @@
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/examples/with-apollo-and-redux/components/Layout.js
+++ b/examples/with-apollo-and-redux/components/Layout.js
@@ -7,7 +7,8 @@ const Layout = ({ children }) => (
     {children}
     <style jsx global>{`
       * {
-        font-family: Menlo, Monaco, "Lucida Console", "Liberation Mono",
+        font-family:
+          Menlo, Monaco, "Lucida Console", "Liberation Mono",
           "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New",
           monospace, serif;
       }

--- a/examples/with-apollo/src/app/globals.css
+++ b/examples/with-apollo/src/app/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+  --font-mono:
+    ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 

--- a/examples/with-clerk/styles/Home.module.css
+++ b/examples/with-clerk/styles/Home.module.css
@@ -74,11 +74,8 @@
 
 .card:empty {
   padding: 2em;
-  background-image: radial-gradient(
-      circle 14px at 46px 46px,
-      #f2f2f2 99%,
-      transparent 0
-    ),
+  background-image:
+    radial-gradient(circle 14px at 46px 46px, #f2f2f2 99%, transparent 0),
     linear-gradient(
       100deg,
       rgba(255, 255, 255, 0),

--- a/examples/with-edgedb/components/Layout.tsx
+++ b/examples/with-edgedb/components/Layout.tsx
@@ -24,8 +24,9 @@ const Layout: React.FC<Props> = (props) => (
         margin: 0;
         padding: 0;
         font-size: 16px;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-          Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+          Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
           "Segoe UI Symbol";
         background: rgba(0, 0, 0, 0);
       }

--- a/examples/with-elasticsearch/styles/globals.css
+++ b/examples/with-elasticsearch/styles/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+  --font-mono:
+    ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 

--- a/examples/with-fingerprintjs-pro/styles/globals.css
+++ b/examples/with-fingerprintjs-pro/styles/globals.css
@@ -1,14 +1,14 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: rgba(0, 0, 0, 0.87);
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
+  font-family:
+    source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }

--- a/examples/with-graphql-hooks/src/app/globals.css
+++ b/examples/with-graphql-hooks/src/app/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+  --font-mono:
+    ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 

--- a/examples/with-sentry/styles/globals.css
+++ b/examples/with-sentry/styles/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+  --font-mono:
+    ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 

--- a/examples/with-storybook/app/globals.css
+++ b/examples/with-storybook/app/globals.css
@@ -1,7 +1,8 @@
 :root {
   --max-width: 1100px;
   --border-radius: 12px;
-  --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
+  --font-mono:
+    ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 

--- a/examples/with-stripe-typescript/styles.css
+++ b/examples/with-stripe-typescript/styles.css
@@ -3,8 +3,8 @@
   --body-color: #fcfdfe;
   --checkout-color: #8f6ed5;
   --elements-color: #6772e5;
-  --body-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    sans-serif;
+  --body-font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --h1-color: #1a1f36;
   --h2-color: #7b818a;
   --h3-color: #a3acb9;

--- a/examples/with-xata/styles/root.css
+++ b/examples/with-xata/styles/root.css
@@ -1,7 +1,7 @@
 html {
-  --system-fonts: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-    "Segoe UI Symbol";
+  --system-fonts:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   --xata-accent: rgb(255, 0, 117);
   --xata-accent-faded: rgba(255, 0, 117, 0.4);
   --transition-duration: 350ms;

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "postcss-pseudoelements": "5.0.0",
     "postcss-short-size": "4.0.0",
     "postcss-trolling": "0.1.7",
-    "prettier": "3.2.5",
+    "prettier": "3.6.2",
     "pretty-bytes": "5.3.0",
     "pretty-ms": "7.0.0",
     "random-seed": "0.3.0",

--- a/packages/font/src/local/loader.ts
+++ b/packages/font/src/local/loader.ts
@@ -73,10 +73,10 @@ const nextFontLocalFontLoader: FontLoader = async ({
         ...(hasCustomFontFamily ? [] : [['font-family', variableName]]),
         ['src', `url(${fontUrl + qs}) format('${format}')`],
         ['font-display', display],
-        ...(weight ?? defaultWeight
+        ...((weight ?? defaultWeight)
           ? [['font-weight', weight ?? defaultWeight]]
           : []),
-        ...(style ?? defaultStyle
+        ...((style ?? defaultStyle)
           ? [['font-style', style ?? defaultStyle]]
           : []),
       ]

--- a/packages/next/src/build/babel/loader/get-config.ts
+++ b/packages/next/src/build/babel/loader/get-config.ts
@@ -326,7 +326,7 @@ async function getFreshConfig(
   })()
 
   const reactCompilerPluginsIfEnabled = hasReactCompiler
-    ? loaderOptions.reactCompilerPlugins ?? []
+    ? (loaderOptions.reactCompilerPlugins ?? [])
     : []
 
   let { isServer, pagesDir, srcDir, development } = loaderOptions

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -243,7 +243,7 @@ export function getDefineEnv({
     'process.env.__NEXT_DEV_INDICATOR_POSITION':
       config.devIndicators === false
         ? 'bottom-left' // This will not be used as the indicator is disabled.
-        : config.devIndicators.position ?? 'bottom-left',
+        : (config.devIndicators.position ?? 'bottom-left'),
     'process.env.__NEXT_STRICT_MODE':
       config.reactStrictMode === null ? false : config.reactStrictMode,
     'process.env.__NEXT_STRICT_MODE_APP':

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -277,7 +277,7 @@ export function calculateFallbackMode(
       // perform a blocking static render.
       fallbackRootParams.length > 0
       ? FallbackMode.BLOCKING_STATIC_RENDER
-      : baseFallbackMode ?? FallbackMode.NOT_FOUND
+      : (baseFallbackMode ?? FallbackMode.NOT_FOUND)
     : FallbackMode.NOT_FOUND
 }
 

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -683,7 +683,7 @@ export async function printTreeView(
 
     const sharedFiles = process.env.__NEXT_PRIVATE_DETERMINISTIC_BUILD_OUTPUT
       ? []
-      : stats.router[routerType]?.common.files ?? []
+      : (stats.router[routerType]?.common.files ?? [])
 
     messages.push([
       '+ First Load JS shared by all',

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -411,9 +411,9 @@ async function createTreeCodeFromPath(
       if (isNotFoundRoute) {
         if (normalizedParallelKey === 'children') {
           const matchedGlobalNotFound = isGlobalNotFoundEnabled
-            ? definedFilePaths.find(
+            ? (definedFilePaths.find(
                 ([type]) => type === GLOBAL_NOT_FOUND_FILE_TYPE
-              )?.[1] ?? defaultGlobalNotFoundPath
+              )?.[1] ?? defaultGlobalNotFoundPath)
             : undefined
 
           // If custom global-not-found.js is defined, use global-not-found.js

--- a/packages/next/src/client/components/router-reducer/handle-mutable.ts
+++ b/packages/next/src/client/components/router-reducer/handle-mutable.ts
@@ -70,7 +70,7 @@ export function handleMutable(
         : // If shouldScroll is false then we should not apply scroll and focus management.
           null,
       segmentPaths: shouldScroll
-        ? mutable?.scrollableSegments ?? state.focusAndScrollRef.segmentPaths
+        ? (mutable?.scrollableSegments ?? state.focusAndScrollRef.segmentPaths)
         : // If shouldScroll is false then we should not apply scroll and focus management.
           [],
     },

--- a/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.css
+++ b/packages/next/src/next-devtools/dev-overlay/components/overview/segment-boundary-trigger.css
@@ -55,7 +55,8 @@
   min-width: 120px;
   user-select: none;
   cursor: default;
-  box-shadow: 0px 4px 8px -4px color-mix(in srgb, var(--color-gray-900) 4%, transparent);
+  box-shadow: 0px 4px 8px -4px
+    color-mix(in srgb, var(--color-gray-900) 4%, transparent);
 }
 
 .segment-boundary-dropdown-positioner {

--- a/packages/next/src/next-devtools/dev-overlay/font/font-styles.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/font/font-styles.tsx
@@ -12,10 +12,10 @@ export const FontStyles = () => {
         font-weight: 400 600;
         font-display: swap;
         src: url(/__nextjs_font/geist-latin-ext.woff2) format('woff2');
-        unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7,
-          U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F,
-          U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
-          U+A720-A7FF;
+        unicode-range:
+          U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
+          U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
+          U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
       }
       /* latin-ext */
       @font-face {
@@ -24,10 +24,10 @@ export const FontStyles = () => {
         font-weight: 400 600;
         font-display: swap;
         src: url(/__nextjs_font/geist-mono-latin-ext.woff2) format('woff2');
-        unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7,
-          U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F,
-          U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
-          U+A720-A7FF;
+        unicode-range:
+          U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF,
+          U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
+          U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
       }
       /* latin */
       @font-face {
@@ -36,9 +36,10 @@ export const FontStyles = () => {
         font-weight: 400 600;
         font-display: swap;
         src: url(/__nextjs_font/geist-latin.woff2) format('woff2');
-        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
-          U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
-          U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+        unicode-range:
+          U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+          U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+          U+2212, U+2215, U+FEFF, U+FFFD;
       }
       /* latin */
       @font-face {
@@ -47,9 +48,10 @@ export const FontStyles = () => {
         font-weight: 400 600;
         font-display: swap;
         src: url(/__nextjs_font/geist-mono-latin.woff2) format('woff2');
-        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6,
-          U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122,
-          U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+        unicode-range:
+          U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+          U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+          U+2212, U+2215, U+FEFF, U+FFFD;
       }
     `
     document.head.appendChild(style)

--- a/packages/next/src/next-devtools/dev-overlay/normalize.css
+++ b/packages/next/src/next-devtools/dev-overlay/normalize.css
@@ -40,9 +40,10 @@ section {
 
 :host {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
   font-size: 16px;
   font-weight: 400;
   line-height: 1.5;
@@ -173,8 +174,9 @@ pre,
 code,
 kbd,
 samp {
-  font-family: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
-    'Courier New', monospace;
+  font-family:
+    SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
   font-size: 1em;
 }
 

--- a/packages/next/src/next-devtools/dev-overlay/styles/default-theme.css
+++ b/packages/next/src/next-devtools/dev-overlay/styles/default-theme.css
@@ -19,10 +19,11 @@
   --color-accents-2: #222222;
   --color-accents-3: #404040;
 
-  --font-stack-monospace: '__nextjs-Geist Mono', 'Geist Mono', 'SFMono-Regular',
-    Consolas, 'Liberation Mono', Menlo, Courier, monospace;
-  --font-stack-sans: '__nextjs-Geist', 'Geist', -apple-system, 'Source Sans Pro',
-    sans-serif;
+  --font-stack-monospace:
+    '__nextjs-Geist Mono', 'Geist Mono', 'SFMono-Regular', Consolas,
+    'Liberation Mono', Menlo, Courier, monospace;
+  --font-stack-sans:
+    '__nextjs-Geist', 'Geist', -apple-system, 'Source Sans Pro', sans-serif;
 
   font-family: var(--font-stack-sans);
   font-variant-ligatures: none;
@@ -31,17 +32,18 @@
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1),
-    0 4px 6px -4px rgb(0 0 0 / 0.1);
-  --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1),
-    0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --shadow-lg:
+    0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --shadow-xl:
+    0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
   --shadow-2xl: 0 25px 50px -12px rgb(0 0 0 / 0.25);
   --shadow-inner: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);
   --shadow-none: 0 0 #0000;
 
   --shadow-small: 0px 2px 2px rgba(0, 0, 0, 0.04);
-  --shadow-menu: 0px 1px 1px rgba(0, 0, 0, 0.02),
-    0px 4px 8px -4px rgba(0, 0, 0, 0.04), 0px 16px 24px -8px rgba(0, 0, 0, 0.06);
+  --shadow-menu:
+    0px 1px 1px rgba(0, 0, 0, 0.02), 0px 4px 8px -4px rgba(0, 0, 0, 0.04),
+    0px 16px 24px -8px rgba(0, 0, 0, 0.06);
 
   --focus-color: var(--color-blue-800);
   --focus-ring: 2px solid var(--focus-color);

--- a/packages/next/src/server/web/spec-extension/response.ts
+++ b/packages/next/src/server/web/spec-extension/response.ts
@@ -115,7 +115,7 @@ export class NextResponse<Body = unknown> extends Response {
   }
 
   static redirect(url: string | NextURL | URL, init?: number | ResponseInit) {
-    const status = typeof init === 'number' ? init : init?.status ?? 307
+    const status = typeof init === 'number' ? init : (init?.status ?? 307)
     if (!REDIRECTS.has(status)) {
       throw new RangeError(
         'Failed to execute "redirect" on "response": Invalid status code'

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -424,7 +424,7 @@ const manualScrollRestoration =
     try {
       let v = '__next'
       // eslint-disable-next-line no-sequences
-      return sessionStorage.setItem(v, v), sessionStorage.removeItem(v), true
+      return (sessionStorage.setItem(v, v), sessionStorage.removeItem(v), true)
     } catch (n) {}
   })()
 

--- a/packages/next/src/telemetry/events/version.ts
+++ b/packages/next/src/telemetry/events/version.ts
@@ -148,11 +148,11 @@ export function eventCliSession(
     reactCompiler: Boolean(nextConfig.experimental.reactCompiler),
     reactCompilerCompilationMode:
       typeof nextConfig.experimental.reactCompiler !== 'boolean'
-        ? nextConfig.experimental.reactCompiler?.compilationMode ?? null
+        ? (nextConfig.experimental.reactCompiler?.compilationMode ?? null)
         : null,
     reactCompilerPanicThreshold:
       typeof nextConfig.experimental.reactCompiler !== 'boolean'
-        ? nextConfig.experimental.reactCompiler?.panicThreshold ?? null
+        ? (nextConfig.experimental.reactCompiler?.panicThreshold ?? null)
         : null,
   }
   return [{ eventName: EVENT_VERSION, payload }]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,8 +473,8 @@ importers:
         specifier: 0.1.7
         version: 0.1.7
       prettier:
-        specifier: 3.2.5
-        version: 3.2.5
+        specifier: 3.6.2
+        version: 3.6.2
       pretty-bytes:
         specifier: 5.3.0
         version: 5.3.0
@@ -837,7 +837,7 @@ importers:
         version: 1.0.0
       prettier-plugin-tailwindcss:
         specifier: 0.6.2
-        version: 0.6.2(prettier@3.3.3)
+        version: 0.6.2(prettier@3.6.2)
       prompts:
         specifier: 2.4.2
         version: 2.4.2
@@ -1074,31 +1074,31 @@ importers:
         version: 1.4.5(@swc/helpers@0.5.15)
       '@storybook/addon-a11y':
         specifier: 8.6.0
-        version: 8.6.0(storybook@8.6.0(prettier@3.3.3))
+        version: 8.6.0(storybook@8.6.0(prettier@3.6.2))
       '@storybook/addon-essentials':
         specifier: 8.6.0
-        version: 8.6.0(@types/react@19.1.10)(storybook@8.6.0(prettier@3.3.3))
+        version: 8.6.0(@types/react@19.1.10)(storybook@8.6.0(prettier@3.6.2))
       '@storybook/addon-interactions':
         specifier: 8.6.0
-        version: 8.6.0(storybook@8.6.0(prettier@3.3.3))
+        version: 8.6.0(storybook@8.6.0(prettier@3.6.2))
       '@storybook/addon-webpack5-compiler-swc':
         specifier: 3.0.0
         version: 3.0.0(@swc/helpers@0.5.15)(webpack@5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2))
       '@storybook/blocks':
         specifier: 8.6.0
-        version: 8.6.0(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))
+        version: 8.6.0(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))
       '@storybook/react':
         specifier: 8.6.0
-        version: 8.6.0(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.3.3)))(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))(typescript@5.8.2)
+        version: 8.6.0(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.6.2)))(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))(typescript@5.8.2)
       '@storybook/react-webpack5':
         specifier: 8.6.0
-        version: 8.6.0(@rspack/core@1.4.5(@swc/helpers@0.5.15))(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.3.3)))(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))(typescript@5.8.2)
+        version: 8.6.0(@rspack/core@1.4.5(@swc/helpers@0.5.15))(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.6.2)))(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))(typescript@5.8.2)
       '@storybook/test':
         specifier: 8.6.0
-        version: 8.6.0(storybook@8.6.0(prettier@3.3.3))
+        version: 8.6.0(storybook@8.6.0(prettier@3.6.2))
       '@storybook/test-runner':
         specifier: 0.21.0
-        version: 0.21.0(@swc/helpers@0.5.15)(@types/node@20.17.6(patch_hash=rvl3vkomen3tospgr67bzubfyu))(babel-plugin-macros@3.1.0)(debug@4.1.1)(storybook@8.6.0(prettier@3.3.3))
+        version: 0.21.0(@swc/helpers@0.5.15)(@types/node@20.17.6(patch_hash=rvl3vkomen3tospgr67bzubfyu))(babel-plugin-macros@3.1.0)(debug@4.1.1)(storybook@8.6.0(prettier@3.6.2))
       '@swc/core':
         specifier: 1.11.24
         version: 1.11.24(@swc/helpers@0.5.15)
@@ -1530,7 +1530,7 @@ importers:
         version: 0.1.10(patch_hash=x5tdcojc7b5m2b5ojepbcdl36a)
       storybook:
         specifier: 8.6.0
-        version: 8.6.0(prettier@3.3.3)
+        version: 8.6.0(prettier@3.6.2)
       stream-browserify:
         specifier: 3.0.0
         version: 3.0.0
@@ -13788,13 +13788,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.2.5:
-    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
-    engines: {node: '>=14'}
-    hasBin: true
-
-  prettier@3.3.3:
-    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -20854,99 +20849,99 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@storybook/addon-a11y@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/addon-a11y@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
-      '@storybook/addon-highlight': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/test': 8.6.0(storybook@8.6.0(prettier@3.3.3))
+      '@storybook/addon-highlight': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/test': 8.6.0(storybook@8.6.0(prettier@3.6.2))
       axe-core: 4.10.0
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
 
-  '@storybook/addon-actions@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/addon-actions@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       '@storybook/global': 5.0.0
       '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
       uuid: 9.0.1
 
-  '@storybook/addon-backgrounds@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/addon-backgrounds@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-controls@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/addon-controls@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       '@storybook/global': 5.0.0
       dequal: 2.0.3
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-docs@8.6.0(@types/react@19.1.10)(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/addon-docs@8.6.0(@types/react@19.1.10)(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@19.1.10)(react@19.2.0-canary-03fda05d-20250820)
-      '@storybook/blocks': 8.6.0(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/csf-plugin': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/react-dom-shim': 8.6.0(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))
+      '@storybook/blocks': 8.6.0(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/csf-plugin': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/react-dom-shim': 8.6.0(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))
       react: 19.2.0-canary-03fda05d-20250820
       react-dom: 19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820)
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-essentials@8.6.0(@types/react@19.1.10)(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/addon-essentials@8.6.0(@types/react@19.1.10)(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
-      '@storybook/addon-actions': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/addon-backgrounds': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/addon-controls': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/addon-docs': 8.6.0(@types/react@19.1.10)(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/addon-highlight': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/addon-measure': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/addon-outline': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/addon-toolbars': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/addon-viewport': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      storybook: 8.6.0(prettier@3.3.3)
+      '@storybook/addon-actions': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/addon-backgrounds': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/addon-controls': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/addon-docs': 8.6.0(@types/react@19.1.10)(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/addon-highlight': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/addon-measure': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/addon-outline': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/addon-toolbars': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/addon-viewport': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      storybook: 8.6.0(prettier@3.6.2)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-highlight@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/addon-highlight@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
 
-  '@storybook/addon-interactions@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/addon-interactions@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/test': 8.6.0(storybook@8.6.0(prettier@3.3.3))
+      '@storybook/instrumenter': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/test': 8.6.0(storybook@8.6.0(prettier@3.6.2))
       polished: 4.3.1
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-measure@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/addon-measure@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-outline@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/addon-outline@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-toolbars@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/addon-toolbars@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
 
-  '@storybook/addon-viewport@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/addon-viewport@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       memoizerific: 1.11.3
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
 
   '@storybook/addon-webpack5-compiler-swc@3.0.0(@swc/helpers@0.5.15)(webpack@5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2))':
     dependencies:
@@ -20956,18 +20951,18 @@ snapshots:
       - '@swc/helpers'
       - webpack
 
-  '@storybook/blocks@8.6.0(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/blocks@8.6.0(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       '@storybook/icons': 1.3.0(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 19.2.0-canary-03fda05d-20250820
       react-dom: 19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820)
 
-  '@storybook/builder-webpack5@8.6.0(@rspack/core@1.4.5(@swc/helpers@0.5.15))(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)(storybook@8.6.0(prettier@3.3.3))(typescript@5.8.2)':
+  '@storybook/builder-webpack5@8.6.0(@rspack/core@1.4.5(@swc/helpers@0.5.15))(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)(storybook@8.6.0(prettier@3.6.2))(typescript@5.8.2)':
     dependencies:
-      '@storybook/core-webpack': 8.6.0(storybook@8.6.0(prettier@3.3.3))
+      '@storybook/core-webpack': 8.6.0(storybook@8.6.0(prettier@3.6.2))
       '@types/semver': 7.5.6
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -20981,7 +20976,7 @@ snapshots:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
       style-loader: 3.3.4(webpack@5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2))
       terser-webpack-plugin: 5.3.9(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)(webpack@5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2))
       ts-dedent: 2.2.0
@@ -21001,18 +20996,18 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/components@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/components@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
 
-  '@storybook/core-webpack@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/core-webpack@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
       ts-dedent: 2.2.0
 
-  '@storybook/core@8.6.0(prettier@3.3.3)(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/core@8.6.0(prettier@3.6.2)(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
-      '@storybook/theming': 8.6.0(storybook@8.6.0(prettier@3.3.3))
+      '@storybook/theming': 8.6.0(storybook@8.6.0(prettier@3.6.2))
       better-opn: 3.0.2
       browser-assert: 1.2.1
       esbuild: 0.24.2
@@ -21024,16 +21019,16 @@ snapshots:
       util: 0.12.5
       ws: 8.2.3
     optionalDependencies:
-      prettier: 3.3.3
+      prettier: 3.6.2
     transitivePeerDependencies:
       - bufferutil
       - storybook
       - supports-color
       - utf-8-validate
 
-  '@storybook/csf-plugin@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/csf-plugin@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
       unplugin: 1.16.0
 
   '@storybook/csf@0.1.12':
@@ -21047,20 +21042,20 @@ snapshots:
       react: 19.2.0-canary-03fda05d-20250820
       react-dom: 19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820)
 
-  '@storybook/instrumenter@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/instrumenter@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.8
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
 
-  '@storybook/manager-api@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/manager-api@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
 
-  '@storybook/preset-react-webpack@8.6.0(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.3.3)))(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))(typescript@5.8.2)':
+  '@storybook/preset-react-webpack@8.6.0(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.6.2)))(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))(typescript@5.8.2)':
     dependencies:
-      '@storybook/core-webpack': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/react': 8.6.0(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.3.3)))(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))(typescript@5.8.2)
+      '@storybook/core-webpack': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/react': 8.6.0(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.6.2)))(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))(typescript@5.8.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.8.2)(webpack@5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2))
       '@types/semver': 7.5.6
       find-up: 5.0.0
@@ -21070,7 +21065,7 @@ snapshots:
       react-dom: 19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820)
       resolve: 1.22.10
       semver: 7.6.3
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
       tsconfig-paths: 4.2.0
       webpack: 5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)
     optionalDependencies:
@@ -21083,9 +21078,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/preview-api@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/preview-api@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
 
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.8.2)(webpack@5.98.0(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2))':
     dependencies:
@@ -21101,20 +21096,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@8.6.0(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/react-dom-shim@8.6.0(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       react: 19.2.0-canary-03fda05d-20250820
       react-dom: 19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820)
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
 
-  '@storybook/react-webpack5@8.6.0(@rspack/core@1.4.5(@swc/helpers@0.5.15))(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.3.3)))(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))(typescript@5.8.2)':
+  '@storybook/react-webpack5@8.6.0(@rspack/core@1.4.5(@swc/helpers@0.5.15))(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.6.2)))(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))(typescript@5.8.2)':
     dependencies:
-      '@storybook/builder-webpack5': 8.6.0(@rspack/core@1.4.5(@swc/helpers@0.5.15))(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)(storybook@8.6.0(prettier@3.3.3))(typescript@5.8.2)
-      '@storybook/preset-react-webpack': 8.6.0(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.3.3)))(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))(typescript@5.8.2)
-      '@storybook/react': 8.6.0(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.3.3)))(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))(typescript@5.8.2)
+      '@storybook/builder-webpack5': 8.6.0(@rspack/core@1.4.5(@swc/helpers@0.5.15))(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)(storybook@8.6.0(prettier@3.6.2))(typescript@5.8.2)
+      '@storybook/preset-react-webpack': 8.6.0(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.6.2)))(@swc/core@1.11.24(@swc/helpers@0.5.15))(esbuild@0.24.2)(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))(typescript@5.8.2)
+      '@storybook/react': 8.6.0(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.6.2)))(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))(typescript@5.8.2)
       react: 19.2.0-canary-03fda05d-20250820
       react-dom: 19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820)
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
     optionalDependencies:
       typescript: 5.8.2
     transitivePeerDependencies:
@@ -21126,22 +21121,22 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react@8.6.0(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.3.3)))(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))(typescript@5.8.2)':
+  '@storybook/react@8.6.0(@storybook/test@8.6.0(storybook@8.6.0(prettier@3.6.2)))(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))(typescript@5.8.2)':
     dependencies:
-      '@storybook/components': 8.6.0(storybook@8.6.0(prettier@3.3.3))
+      '@storybook/components': 8.6.0(storybook@8.6.0(prettier@3.6.2))
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/preview-api': 8.6.0(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/react-dom-shim': 8.6.0(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.3.3))
-      '@storybook/theming': 8.6.0(storybook@8.6.0(prettier@3.3.3))
+      '@storybook/manager-api': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/preview-api': 8.6.0(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/react-dom-shim': 8.6.0(react-dom@19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820))(react@19.2.0-canary-03fda05d-20250820)(storybook@8.6.0(prettier@3.6.2))
+      '@storybook/theming': 8.6.0(storybook@8.6.0(prettier@3.6.2))
       react: 19.2.0-canary-03fda05d-20250820
       react-dom: 19.2.0-canary-03fda05d-20250820(react@19.2.0-canary-03fda05d-20250820)
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
     optionalDependencies:
-      '@storybook/test': 8.6.0(storybook@8.6.0(prettier@3.3.3))
+      '@storybook/test': 8.6.0(storybook@8.6.0(prettier@3.6.2))
       typescript: 5.8.2
 
-  '@storybook/test-runner@0.21.0(@swc/helpers@0.5.15)(@types/node@20.17.6(patch_hash=rvl3vkomen3tospgr67bzubfyu))(babel-plugin-macros@3.1.0)(debug@4.1.1)(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/test-runner@0.21.0(@swc/helpers@0.5.15)(@types/node@20.17.6(patch_hash=rvl3vkomen3tospgr67bzubfyu))(babel-plugin-macros@3.1.0)(debug@4.1.1)(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/generator': 7.27.0
@@ -21162,7 +21157,7 @@ snapshots:
       jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@20.17.6(patch_hash=rvl3vkomen3tospgr67bzubfyu))(babel-plugin-macros@3.1.0))
       nyc: 15.1.0
       playwright: 1.48.0
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
     transitivePeerDependencies:
       - '@swc/helpers'
       - '@types/node'
@@ -21172,20 +21167,20 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@storybook/test@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/test@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.0(storybook@8.6.0(prettier@3.3.3))
+      '@storybook/instrumenter': 8.6.0(storybook@8.6.0(prettier@3.6.2))
       '@testing-library/dom': 10.4.0
       '@testing-library/jest-dom': 6.5.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
 
-  '@storybook/theming@8.6.0(storybook@8.6.0(prettier@3.3.3))':
+  '@storybook/theming@8.6.0(storybook@8.6.0(prettier@3.6.2))':
     dependencies:
-      storybook: 8.6.0(prettier@3.3.3)
+      storybook: 8.6.0(prettier@3.6.2)
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
@@ -32039,17 +32034,15 @@ snapshots:
 
   prepend-http@2.0.0: {}
 
-  prettier-plugin-tailwindcss@0.6.2(prettier@3.3.3):
+  prettier-plugin-tailwindcss@0.6.2(prettier@3.6.2):
     dependencies:
-      prettier: 3.3.3
+      prettier: 3.6.2
 
   prettier@2.5.1: {}
 
   prettier@2.8.8: {}
 
-  prettier@3.2.5: {}
-
-  prettier@3.3.3: {}
+  prettier@3.6.2: {}
 
   pretty-bytes@3.0.1:
     dependencies:
@@ -33814,11 +33807,11 @@ snapshots:
     dependencies:
       internal-slot: 1.0.7
 
-  storybook@8.6.0(prettier@3.3.3):
+  storybook@8.6.0(prettier@3.6.2):
     dependencies:
-      '@storybook/core': 8.6.0(prettier@3.3.3)(storybook@8.6.0(prettier@3.3.3))
+      '@storybook/core': 8.6.0(prettier@3.6.2)(storybook@8.6.0(prettier@3.6.2))
     optionalDependencies:
-      prettier: 3.3.3
+      prettier: 3.6.2
     transitivePeerDependencies:
       - bufferutil
       - supports-color

--- a/scripts/release/slack.ts
+++ b/scripts/release/slack.ts
@@ -16,7 +16,7 @@ async function slack() {
   const ping = process.env.SLACK_PING ?? '@nextjs-oncall'
 
   const message =
-    process.env.SLACK_MESSAGE ?? process.env.RELEASE_STATUS === 'true'
+    (process.env.SLACK_MESSAGE ?? process.env.RELEASE_STATUS === 'true')
       ? `Successfully published a new release!\n<https://github.com/vercel/next.js/releases|Releases Link>`
       : `Failed to publish a new release triggered by "${process.env.WORKFLOW_ACTOR}". ${ping}\n<${workflowLink}|Workflow Link>`
 

--- a/test/integration/critical-css/styles/styles.css
+++ b/test/integration/critical-css/styles/styles.css
@@ -1,6 +1,7 @@
 body {
-  font-family: 'SF Pro Text', 'SF Pro Icons', 'Helvetica Neue', 'Helvetica',
-    'Arial', sans-serif;
+  font-family:
+    'SF Pro Text', 'SF Pro Icons', 'Helvetica Neue', 'Helvetica', 'Arial',
+    sans-serif;
   padding: 20px 20px 60px;
   max-width: 680px;
   margin: 0 auto;

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -164,7 +164,7 @@ export async function createNext(
     return await trace('createNext').traceAsyncFn(async (rootSpan) => {
       const useTurbo = !!process.env.NEXT_TEST_WASM
         ? false
-        : opts?.turbo ?? shouldUseTurbopack()
+        : (opts?.turbo ?? shouldUseTurbopack())
 
       if (testMode === 'dev') {
         // next dev

--- a/turbopack/crates/turbopack-node/src/render/error.html
+++ b/turbopack/crates/turbopack-node/src/render/error.html
@@ -30,8 +30,9 @@
 
         .error {
           /* https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css#L38-L52 */
-          font-family: system-ui, 'Segoe UI', Roboto, Helvetica, Arial,
-            sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+          font-family:
+            system-ui, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
+            'Apple Color Emoji', 'Segoe UI Emoji';
           height: 100vh;
           max-height: 100vh;
           overflow: hidden;

--- a/turbopack/crates/turbopack/tests/node-file-trace/integration/webpack-target-node/webpack-api-runtime.js
+++ b/turbopack/crates/turbopack/tests/node-file-trace/integration/webpack-target-node/webpack-api-runtime.js
@@ -132,8 +132,8 @@
       /******/ // arguments: chunkIds, moduleId are deprecated
       /******/ var moduleId = chunkIds
       /******/ if (!fn)
-        (chunkIds = result),
-          (fn = () => __webpack_require__((__webpack_require__.s = moduleId)))
+        ((chunkIds = result),
+          (fn = () => __webpack_require__((__webpack_require__.s = moduleId))))
       /******/ chunkIds.map(__webpack_require__.e, __webpack_require__)
       /******/ var r = fn()
       /******/ return r === undefined ? result : r


### PR DESCRIPTION
What?
This PR updates the dependency "prettier" from version 3.2.5 to version 3.6.2. It also modifies other scripts by using the pnpm run prettier-fix after updating the dependency.

Why?
This is updated to benefit from the changes and fixes introduced in the newer versions of prettier, from versions 3.3 to 3.6.

How?
The package has been updated using pnpm install prettier@latest, and the files other than package.json and pnpm-lock.json have been modified using the script pnpm run prettier-fix.

This PR does only have formatting changes introduced by the updated dependency
This PR is the same as #82719 , with fixes implemented to prevent prettier to modifiy symlink files