### PR TITLE
Do not modify parsedUrl collecting params

### DIFF
--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -116,6 +116,7 @@ export const getHandler = ({
       routerServerContext,
       nextConfig,
       resolvedPathname,
+      encodedResolvedPathname,
     } = prepareResult
 
     const isExperimentalCompile =
@@ -197,8 +198,8 @@ export const getHandler = ({
 
       const resolvedUrl = formatUrl({
         pathname: nextConfig.trailingSlash
-          ? parsedUrl.pathname
-          : removeTrailingSlash(parsedUrl.pathname || '/'),
+          ? `${encodedResolvedPathname}${!encodedResolvedPathname.endsWith('/') && parsedUrl.pathname?.endsWith('/') ? '/' : ''}`
+          : removeTrailingSlash(encodedResolvedPathname || '/'),
         // make sure to only add query values from original URL
         query: hasStaticProps ? {} : originalQuery,
       })


### PR DESCRIPTION
This updates to not modify the parsed URL values when collecting rewrite params inside of the `RouteModule`. This avoids invalid double rewrite cases one at the CDN layer and once again when collecting rewrite params inside the function. 

In the future we should have a de-opt to skip the in function rewrite param parsing when a user has properly configured their CDN to handle their rewrites and pass them down to the function. 

x-ref: [slack thread](https://vercel.slack.com/archives/C04M81FAWE6/p1755806771519109?thread_ts=1755668503.049659&cid=C04M81FAWE6)