### PR TITLE
Route modules: Call setReferenceManifestsSingleton for app-route to match app-page

### DIFF
--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -8,6 +8,8 @@ import { patchFetch as _patchFetch } from '../../server/lib/patch-fetch'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { getRequestMeta } from '../../server/request-meta'
 import { getTracer, type Span, SpanKind } from '../../server/lib/trace/tracer'
+import { setReferenceManifestsSingleton } from '../../server/app-render/encryption-utils'
+import { createServerModuleMap } from '../../server/app-render/action-utils'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { NodeNextRequest, NodeNextResponse } from '../../server/base-http/node'
 import {
@@ -119,6 +121,8 @@ export async function handler(
     isOnDemandRevalidate,
     revalidateOnlyGenerated,
     resolvedPathname,
+    clientReferenceManifest,
+    serverActionsManifest,
   } = prepareResult
 
   const normalizedSrcPage = normalizeAppPath(srcPage)
@@ -159,6 +163,20 @@ export async function handler(
   // it is not a dynamic RSC request then it is a revalidation
   // request.
   const isRevalidate = isIsr && !supportsDynamicResponse
+
+  // Before rendering (which initializes component tree modules), we have to
+  // set the reference manifests to our global store so Server Action's
+  // encryption util can access to them at the top level of the page module.
+  if (serverActionsManifest && clientReferenceManifest) {
+    setReferenceManifestsSingleton({
+      page: srcPage,
+      clientReferenceManifest,
+      serverActionsManifest,
+      serverModuleMap: createServerModuleMap({
+        serverActionsManifest,
+      }),
+    })
+  }
 
   const method = req.method || 'GET'
   const tracer = getTracer()


### PR DESCRIPTION
## What?

The changes in #82903 highlighted some failing tests because `use cache` relies on the global singleton being set which accidentally depended on the `load-components` call to `setReferenceManifestsSingleton`. The `app-page` template did the right thing calling `setReferenceManifestsSingleton` already but `app-route` did not, causing those tests to fail when I removed calling `setReferenceManifestsSingleton` in the PR further in the stack.

Closes PACK-5311