### PR TITLE
Stricter types in the route validation file

### DIFF
--- a/docs/01-app/01-getting-started/06-partial-prerendering.mdx
+++ b/docs/01-app/01-getting-started/06-partial-prerendering.mdx
@@ -230,7 +230,7 @@ import { Suspense } from 'react'
 export default function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ sort: string }>
+  searchParams: Promise<{ sort?: string }>
 }) {
   return (
     <section>
@@ -265,7 +265,7 @@ Inside of the table component, accessing the value from `searchParams` will make
 export async function Table({
   searchParams,
 }: {
-  searchParams: Promise<{ sort: string }>
+  searchParams: Promise<{ sort?: string }>
 }) {
   const sort = (await searchParams).sort === 'true'
   return '...'

--- a/examples/with-supabase/app/auth/error/page.tsx
+++ b/examples/with-supabase/app/auth/error/page.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ error: string }>;
+  searchParams: Promise<{ error?: string }>;
 }) {
   const params = await searchParams;
 

--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -491,16 +491,16 @@ export function generateValidatorFile(
 
   if (appPageValidations) {
     typeDefinitions += `type AppPageConfig<Route extends AppRoutes = AppRoutes> = {
-  default: React.ComponentType<{ params: Promise<ParamMap[Route]> } & any> | ((props: { params: Promise<ParamMap[Route]> } & any) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
+  default: React.ComponentType<PageProps<Route>> | ((props: PageProps<Route>) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
   generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
   generateMetadata?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
+    props: PageProps<Route>,
     parent: ResolvingMetadata
-  ) => Promise<any> | any
+  ) => any
   generateViewport?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
+    props: PageProps<Route>,
     parent: ResolvingViewport
-  ) => Promise<any> | any
+  ) => any
   metadata?: any
   viewport?: any
 }
@@ -511,10 +511,10 @@ export function generateValidatorFile(
   if (pagesRouterPageValidations) {
     typeDefinitions += `type PagesPageConfig = {
   default: React.ComponentType<any> | ((props: any) => React.ReactNode | Promise<React.ReactNode> | never | void)
-  getStaticProps?: (context: any) => Promise<any> | any
-  getStaticPaths?: (context: any) => Promise<any> | any
-  getServerSideProps?: (context: any) => Promise<any> | any
-  getInitialProps?: (context: any) => Promise<any> | any
+  getStaticProps?: (context: any) => any
+  getStaticPaths?: (context: any) => any
+  getServerSideProps?: (context: any) => any
+  getInitialProps?: (context: any) => any
   /**
    * Segment configuration for legacy Pages Router pages.
    * Validated at build-time by parsePagesSegmentConfig.
@@ -535,13 +535,13 @@ export function generateValidatorFile(
   default: React.ComponentType<LayoutProps<Route>> | ((props: LayoutProps<Route>) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
   generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
   generateMetadata?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
+    props: { params: Promise<ParamMap[Route]> },
     parent: ResolvingMetadata
-  ) => Promise<any> | any
+  ) => any
   generateViewport?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
+    props: { params: Promise<ParamMap[Route]> },
     parent: ResolvingViewport
-  ) => Promise<any> | any
+  ) => any
   metadata?: any
   viewport?: any
 }

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -50,7 +50,7 @@ export type SearchParams = { [key: string]: string | string[] | undefined }
  * If refactoring is not possible but you still want to be able to access params directly without typescript errors you can cast the params Promise to this type
  *
  * ```tsx
- * type Props = { searchParams: Promise<{ foo: string }> }
+ * type Props = { searchParams: Promise<{ foo?: string }> }
  *
  * export default async function Page(props: Props) {
  *  const { searchParams } = (props.searchParams as unknown as UnsafeUnwrappedSearchParams<typeof props.searchParams>)

--- a/test/e2e/app-dir/cache-components/app/cases/full_cached/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/full_cached/page.tsx
@@ -5,7 +5,7 @@ import { getSentinelValue } from '../../getSentinelValue'
 export default async function Page({
   searchParams: _unused,
 }: {
-  searchParams: Promise<{ n: string }>
+  searchParams: Promise<{ n?: string }>
 }) {
   return (
     <>

--- a/test/e2e/app-dir/not-found-with-pages-i18n/app/app-dir/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/not-found-with-pages-i18n/app/app-dir/[[...slug]]/page.tsx
@@ -4,7 +4,11 @@ export async function generateStaticParams() {
   return []
 }
 
-async function validateSlug(slug: string[]) {
+async function validateSlug(slug: string[] | undefined) {
+  if (typeof slug === 'undefined') {
+    return false
+  }
+
   try {
     const isValidPath =
       slug.length === 1 && (slug[0] === 'about' || slug[0] === 'contact')
@@ -22,13 +26,12 @@ async function validateSlug(slug: string[]) {
 export default async function CatchAll({
   params,
 }: {
-  params: Promise<{ slug: string[] }>
+  params: Promise<{ slug?: string[] }>
 }) {
   const { slug } = await params
-  const slugArray = Array.isArray(slug) ? slug : [slug]
 
   // Validate the slug
-  const isValid = await validateSlug(slugArray)
+  const isValid = await validateSlug(slug)
 
   // If not valid, show 404
   if (!isValid) {

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/@interception2/(.)[...dynamic]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/@interception2/(.)[...dynamic]/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 export default function Page({
   params,
 }: {
-  params: Promise<{ dynamic: string }>
+  params: Promise<{ dynamic: string[] }>
 }) {
   const router = useRouter()
   return (

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/[...dynamic]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/[...dynamic]/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 export default function Page({
   params,
 }: {
-  params: Promise<{ dynamic: string }>
+  params: Promise<{ dynamic: string[] }>
 }) {
   const router = useRouter()
   return (

--- a/test/e2e/app-dir/revalidatetag-rsc/app/revalidate_via_page/page.tsx
+++ b/test/e2e/app-dir/revalidatetag-rsc/app/revalidate_via_page/page.tsx
@@ -6,7 +6,7 @@ import { unstable_expireTag } from 'next/cache'
 const RevalidateViaPage = async ({
   searchParams,
 }: {
-  searchParams: Promise<{ tag: string }>
+  searchParams: Promise<{ tag?: string }>
 }) => {
   const { tag } = await searchParams
   unstable_expireTag(tag)

--- a/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled-dynamic-head/page.tsx
+++ b/test/e2e/app-dir/segment-cache/incremental-opt-in/app/ppr-disabled-dynamic-head/page.tsx
@@ -5,7 +5,7 @@ import { Metadata } from 'next'
 export async function generateMetadata({
   searchParams,
 }: {
-  searchParams: Promise<{ foo: string }>
+  searchParams: Promise<{ foo?: string }>
 }): Promise<Metadata> {
   const { foo } = await searchParams
   return {

--- a/test/e2e/app-dir/use-cache-private/app/search-params/page.tsx
+++ b/test/e2e/app-dir/use-cache-private/app/search-params/page.tsx
@@ -1,7 +1,7 @@
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ [key: string]: string }>
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }) {
   'use cache: private'
 

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/complex-args/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/complex-args/page.tsx
@@ -10,9 +10,9 @@ async function getCached({ p }) {
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ n: string }>
+  searchParams: Promise<{ n?: string }>
 }) {
-  const n = parseInt((await searchParams).n, 16)
+  const n = parseInt((await searchParams).n ?? '0', 16)
   const p = Promise.resolve(new Uint8Array([n]))
   return <p id="x">{await getCached({ p })}</p>
 }

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/custom-handler/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/custom-handler/page.tsx
@@ -10,9 +10,9 @@ async function getCachedRandom(x: number, children: React.ReactNode) {
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ n: string }>
+  searchParams: Promise<{ n?: string }>
 }) {
-  const n = +(await searchParams).n
+  const n = parseInt((await searchParams).n ?? '0')
   const values = await getCachedRandom(
     n,
     <p id="r">rnd{Math.random()}</p> // This should not invalidate the cache

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/page.tsx
@@ -13,9 +13,9 @@ async function getCachedRandom(x: number, children: React.ReactNode) {
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ n: string }>
+  searchParams: Promise<{ n?: string }>
 }) {
-  const n = +(await searchParams).n
+  const n = parseInt((await searchParams).n ?? '0')
   const values = await getCachedRandom(
     n,
     <p id="r">rnd{Math.random()}</p> // This should not invalidate the cache

--- a/test/production/app-dir/build-output-tree-view/fixtures/mixed/app/ppr/[slug]/page.tsx
+++ b/test/production/app-dir/build-output-tree-view/fixtures/mixed/app/ppr/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import { unstable_cacheLife } from 'next/cache'
 
+// TODO: I think this is an incorrect type (it's an object, not a string)
+// but since we're deprecating this API, we'll leave it as is for now
 type CacheLife = Parameters<typeof unstable_cacheLife>[0]
 
 async function getCachedValue(cacheLife: CacheLife) {
@@ -13,11 +15,11 @@ async function getCachedValue(cacheLife: CacheLife) {
 export default async function Page({
   params,
 }: {
-  params: Promise<{ slug: CacheLife }>
+  params: Promise<{ slug: string }>
 }) {
   const { slug } = await params
 
-  return <p>hello world {await getCachedValue(slug)}</p>
+  return <p>hello world {await getCachedValue(slug as CacheLife)}</p>
 }
 
 export function generateStaticParams() {


### PR DESCRIPTION
This PR makes the TypeScript validation types more strict. The main impact is on typing of `params` and `searchParams` -- in that sense it is a breaking change, and should not be released until Next.js 16.

For example, it will make you mark searchParams as optional (they can be `undefined` in runtime, so this is correct behavior).
 
```diff
- searchParams: Promise<{ sort: string }>
+ searchParams: Promise<{ sort?: string }>
```