### PR TITLE
Add special marker in terminal if all error stack frames are ignore-listed

### DIFF
--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -12,7 +12,7 @@ import {
 import { parseStack, type StackFrame } from './lib/parse-stack'
 import { getOriginalCodeFrame } from '../next-devtools/server/shared'
 import { workUnitAsyncStorage } from './app-render/work-unit-async-storage.external'
-import { dim } from '../lib/picocolors'
+import { dim, italic } from '../lib/picocolors'
 
 type FindSourceMapPayload = (
   sourceURL: string
@@ -414,6 +414,17 @@ function parseAndSourceMap(
           )
         )
     }
+  }
+
+  if (sourceMappedStack === '' && sourceMappedFrames.length > 0) {
+    // The `at` marker is important so that Node.js doesn't add square brackets
+    // around the stringified error i.e. this results in
+    // Error: message
+    //   at <ignore-listed frames>
+    // instead of
+    // [Error: message
+    //   at <ignore-listed frames>]
+    sourceMappedStack = '\n    at ' + italic('<ignore-listed frames>')
   }
 
   return (

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -424,7 +424,7 @@ function parseAndSourceMap(
     // instead of
     // [Error: message
     //   at <ignore-listed frames>]
-    sourceMappedStack = '\n    at ' + italic('<ignore-listed frames>')
+    sourceMappedStack = '\n    at ' + italic('ignore-listed frames')
   }
 
   return (


### PR DESCRIPTION
Can be quite confusing when we ignore-list all stackframes in errors. Especially due to the weird formatting Node.js produces. These should be a bit clearer:
<img width="452" height="196" alt="CleanShot 2025-08-22 at 00 27 01@2x" src="https://github.com/user-attachments/assets/680c9779-6a21-4c29-b488-b82095316111" />


The display is inspired by what Chrome does:
<img width="470" height="128" alt="CleanShot 2025-08-22 at 00 26 09@2x" src="https://github.com/user-attachments/assets/f0099772-603a-4343-ae14-67b3ed241dcf" />


We might add a CLI flag to disable ignore-listing in the terminal. But it's a niche use case since errors with only ignore-listed frames are almost always bugs and bugs are generally unactionable beyond reporting. ignore-listing optimizes for our users not framework devs. The best affordance right now to disable ignore-listing is attaching a debugger which you probably need anyway when investigating bugs.