### PR TITLE
feat: export the StaticRoutes, DynamicRoutes types from 'next'

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -295,6 +295,29 @@ declare module 'next' {
 
   export type Route<T extends string = string> =
     __next_route_internal_types__.RouteImpl<T>
+  
+  /**
+   * All static routes in your application.
+   * @example
+   * \`\`\`ts
+   * import type { StaticRoutes } from 'next'
+   * const route: StaticRoutes = "/about"
+   * \`\`\`
+   */
+  export type StaticRoutes = __next_route_internal_types__.StaticRoutes
+  
+  /**
+   * All dynamic routes in your application.
+   * 
+   * The type parameter T represents the union of all possible values that can fill any dynamic segment in your routes.
+   * @example
+   * \`\`\`ts
+   * import type { DynamicRoutes } from 'next'
+   * // T applies to ALL dynamic segments across ALL routes
+   * const route: DynamicRoutes<"en" | "fr"> = "/en/about"
+   * \`\`\`
+   */
+  export type DynamicRoutes<T extends string = string> = __next_route_internal_types__.DynamicRoutes<T>
 }
 
 declare module 'next/link' {

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -59,6 +59,31 @@ export type { Instrumentation } from './server/instrumentation/types'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type Route<RouteInferType = any> = string & {}
 
+/**
+ * Stub static routes type before `next dev` or `next build` is run.
+ * Will be populated with actual static routes during build.
+ * @example
+ * ```ts
+ * import type { StaticRoutes } from 'next'
+ * const route: StaticRoutes = "/about"
+ * ```
+ */
+export type StaticRoutes = never
+
+/**
+ * Stub dynamic routes type before `next dev` or `next build` is run.
+ * Will be populated with actual dynamic routes during build.
+ *
+ * The type parameter T represents the union of all possible values that can fill any dynamic segment in your routes.
+ * @example
+ * ```ts
+ * import type { DynamicRoutes } from 'next'
+ * // T applies to ALL dynamic segments across ALL routes
+ * const route: DynamicRoutes<"en" | "fr"> = "/en/about"
+ * ```
+ */
+export type DynamicRoutes<_T extends string = string> = never
+
 // Extend the React types with missing properties
 declare module 'react' {
   // <html amp=""> support


### PR DESCRIPTION
See https://github.com/amannn/next-intl/issues/396#issuecomment-3213431328.

These changes would allow i18n or other libraries to create their own customized `<Link>` components with type-safety and autocomplete. I've given an example of what that could look like below.

```typescript
import NextLink from 'next/link'
import type { DynamicRoutes, Route } from 'next'

type Locale = 'en' | 'de'

type SearchOrHash = `?${string}` | `#${string}`
type WithProtocol = `${string}:${string}`

type SafeSlug<S extends string> = S extends `${string}/${string}`
  ? never
  : S extends `${string}${SearchOrHash}`
    ? never
    : S extends ''
      ? never
      : S

type ExtractFirstPart<T> = T extends `/${infer U}/${string}` ? U : never
type RemoveFirstPart<T> = T extends `/${SafeSlug<string>}/${infer U}`
  ? U
  : never
type ExtractValidRoutes<T> = T extends unknown
  ? SafeSlug<string> extends ExtractFirstPart<T>
    ? RemoveFirstPart<T>
    : never
  : never

type ValidRoutes = `/${ExtractValidRoutes<DynamicRoutes>}`

type ValidRoute =
  | ValidRoutes
  | SearchOrHash
  | WithProtocol
  | `${ValidRoutes}${SearchOrHash}`

export function Link({ href, locale }: { href: ValidRoute; locale: Locale }) {
  const base = `/${locale}${href}`
  const normalised = base.endsWith('/') ? base.slice(0, -1) : base
  return <NextLink href={normalised as Route<Locale>} />
}

// Usage
export default function Example() {
  return (
    <div>
      <Link locale="en" href="/docs/api" />
    </div>
  )
}
```

You can test it out by creating a Next.js app, wrapping all of the pages in `[locale]`, and then putting the above code in a `CustomLink` component.