### PR TITLE
Turbopack: remove blocking thread limit to avoid deadlocks

### DIFF
--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -73,7 +73,9 @@ fn init() {
     use std::{
         cell::RefCell,
         panic::{set_hook, take_hook},
+        thread::available_parallelism,
         time::{Duration, Instant},
+        usize,
     };
 
     thread_local! {
@@ -90,6 +92,8 @@ fn init() {
         prev_hook(info);
     }));
 
+    let worker_threads = available_parallelism().map(|n| n.get()).unwrap_or(1);
+
     let rt = Builder::new_multi_thread()
         .enable_all()
         .on_thread_stop(|| {
@@ -103,6 +107,10 @@ fn init() {
                 }
             });
         })
+        .worker_threads(worker_threads)
+        // Avoid a limit on threads to avoid deadlocks due to usage of block_in_place
+        .max_blocking_threads(usize::MAX - worker_threads)
+        // Avoid the extra lifo slot to avoid staling tasks when doing cpu-heavy work
         .disable_lifo_slot()
         .build()
         .unwrap();

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -109,7 +109,7 @@ fn init() {
         .worker_threads(worker_threads)
         // Avoid a limit on threads to avoid deadlocks due to usage of block_in_place
         .max_blocking_threads(usize::MAX - worker_threads)
-        // Avoid the extra lifo slot to avoid staling tasks when doing cpu-heavy work
+        // Avoid the extra lifo slot to avoid stalling tasks when doing cpu-heavy work
         .disable_lifo_slot()
         .build()
         .unwrap();

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -75,7 +75,6 @@ fn init() {
         panic::{set_hook, take_hook},
         thread::available_parallelism,
         time::{Duration, Instant},
-        usize,
     };
 
     thread_local! {

--- a/turbopack/crates/turbopack-cli/src/main.rs
+++ b/turbopack/crates/turbopack-cli/src/main.rs
@@ -1,7 +1,7 @@
 #![feature(future_join)]
 #![feature(min_specialization)]
 
-use std::{cell::RefCell, path::Path, time::Instant};
+use std::{cell::RefCell, path::Path, thread::available_parallelism, time::Instant};
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -41,6 +41,11 @@ fn main() {
                 }
             });
         });
+
+    let worker_threads = available_parallelism().map(|n| n.get()).unwrap_or(1);
+
+    rt.worker_threads(worker_threads);
+    rt.max_blocking_threads(usize::MAX - worker_threads);
 
     #[cfg(not(codspeed))]
     rt.disable_lifo_slot();


### PR DESCRIPTION
### What?

Having a limit of blocking thread can lead to deadlocks the using block_in_place

Closes PACK-5329