### PR TITLE
fix: update validation return type for unknown pages router

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -565,7 +565,7 @@ export function generateValidatorFile(
 
   if (pagesApiRouteValidations) {
     typeDefinitions += `type ApiRouteConfig = {
-  default: (req: any, res: any) => Promise<Response | void> | Response | void
+  default: (req: any, res: any) => Promise<Response | void> | Response | void | unknown
   config?: {
     api?: {
       bodyParser?: boolean | { sizeLimit?: string }


### PR DESCRIPTION
I updated the return type of API routes and route handlers from

Promise<Response> | Response | Promise<void> | void

to

Promise<Response | void> | Response | void | unknown

which fixes https://github.com/vercel/next.js/issues/82877.
for pages router with trpc the type cannot be determined 
```Type error: Type 'typeof import("/home/himanshu77/Desktop/projects/create-t3-app/cli/test/src/pages/api/trpc/[trpc]")' does not satisfy the expected type 'ApiRouteConfig'.
  The types returned by 'default(...)' are incompatible between these types.
    Type 'unknown' is not assignable to type 'void | Response | Promise<void | Response>'.
```
adding unknown fixes this and build work without any issues