### PR TITLE
fix: change "noUnknownAtRules" to "warn" for Biome

### DIFF
--- a/packages/create-next-app/templates/app-tw-empty/js/biome.json
+++ b/packages/create-next-app/templates/app-tw-empty/js/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noUnknownAtRules": "warn"
+      }
     },
     "domains": {
       "next": "recommended",

--- a/packages/create-next-app/templates/app-tw-empty/ts/biome.json
+++ b/packages/create-next-app/templates/app-tw-empty/ts/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noUnknownAtRules": "warn"
+      }
     },
     "domains": {
       "next": "recommended",

--- a/packages/create-next-app/templates/app-tw/js/biome.json
+++ b/packages/create-next-app/templates/app-tw/js/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noUnknownAtRules": "warn"
+      }
     },
     "domains": {
       "next": "recommended",

--- a/packages/create-next-app/templates/app-tw/ts/biome.json
+++ b/packages/create-next-app/templates/app-tw/ts/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noUnknownAtRules": "warn"
+      }
     },
     "domains": {
       "next": "recommended",

--- a/packages/create-next-app/templates/default-tw-empty/js/biome.json
+++ b/packages/create-next-app/templates/default-tw-empty/js/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noUnknownAtRules": "warn"
+      }
     },
     "domains": {
       "next": "recommended",

--- a/packages/create-next-app/templates/default-tw-empty/ts/biome.json
+++ b/packages/create-next-app/templates/default-tw-empty/ts/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noUnknownAtRules": "warn"
+      }
     },
     "domains": {
       "next": "recommended",

--- a/packages/create-next-app/templates/default-tw/js/biome.json
+++ b/packages/create-next-app/templates/default-tw/js/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noUnknownAtRules": "warn"
+      }
     },
     "domains": {
       "next": "recommended",

--- a/packages/create-next-app/templates/default-tw/ts/biome.json
+++ b/packages/create-next-app/templates/default-tw/ts/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noUnknownAtRules": "warn"
+      }
     },
     "domains": {
       "next": "recommended",


### PR DESCRIPTION
Temporary patch for #82826 to get Biome lint working with Tailwind until they release a version with the fix (expected soon).

Note that this will still throw a warning, just not fail the build.