### PR TITLE
fix(ci): standardize Node.js version configuration across workflows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ env.NODE_MAINTENANCE_VERSION }}
       - name: Setup corepack
         run: |
           npm i -g corepack@0.31

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -78,7 +78,7 @@ on:
 env:
   NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.5.5
-  NODE_LTS_VERSION: 20.9.0
+  NODE_LTS_VERSION: 20
   # run-tests.js reads `TEST_CONCURRENCY` if no explicit `--concurrency` or `-c`
   # argument is provided
   TEST_CONCURRENCY: 8

--- a/.github/workflows/code_freeze.yml
+++ b/.github/workflows/code_freeze.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
       - name: Setup corepack
         run: |

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
 
       - name: Clone Next.js repository

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -13,6 +13,10 @@ on:
 
 name: Test examples
 
+env:
+  NODE_MAINTENANCE_VERSION: 18
+  NODE_LTS_VERSION: 20
+
 jobs:
   testExamples:
     # Don't execute using cron on forks
@@ -37,7 +41,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ matrix.node }}
           check-latest: true
       - name: Setup corepack
         run: |

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ env.NODE_LTS_VERSION }}
           check-latest: true
 
       - name: Clone Next.js repository


### PR DESCRIPTION
### Problem
The GitHub Actions workflows had inconsistent Node.js version configurations:
- Some workflows used hardcoded `node-version: 18` instead of environment variables
- `build_reusable.yml` used a specific version `NODE_LTS_VERSION: 20.9.0` while others used `20`
- `test_examples.yml` was missing required environment variable definitions

#### Changes Made:
- **Standardized environment variables**: Changed `NODE_LTS_VERSION: 20.9.0` → `NODE_LTS_VERSION: 20`
- **Replaced hardcoded versions** with environment variables in:
  - `build_and_test.yml`: `node-version: 18` → `${{ env.NODE_MAINTENANCE_VERSION }}`
  - `trigger_release.yml`: `node-version: 18` → `${{ env.NODE_LTS_VERSION }}`
  - `create_release_branch.yml`: `node-version: 18` → `${{ env.NODE_LTS_VERSION }}`
  - `code_freeze.yml`: `node-version: 18` → `${{ env.NODE_LTS_VERSION }}`
- **Added missing env vars** to `test_examples.yml` and used matrix strategy properly
