### PR TITLE
Turbopack: fix route format for NFT globs

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -34,10 +34,7 @@ use next_core::{
     },
     next_server_utility::{NEXT_SERVER_UTILITY_MERGE_TAG, NextServerUtilityTransition},
     parse_segment_config_from_source,
-    util::{
-        NextRuntime, app_middleware_function_name, module_styles_rule_condition,
-        styles_rule_condition,
-    },
+    util::{NextRuntime, app_function_name, module_styles_rule_condition, styles_rule_condition},
 };
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
@@ -1587,7 +1584,7 @@ impl AppEndpoint {
                         files: file_paths_from_root.into_iter().collect(),
                         wasm: wasm_paths_to_bindings(wasm_paths_from_root).await?,
                         assets: paths_to_bindings(all_assets),
-                        name: app_middleware_function_name(&app_entry.original_name).into(),
+                        name: app_function_name(&app_entry.original_name).into(),
                         page: app_entry.original_name.clone(),
                         regions: app_entry
                             .config
@@ -1698,11 +1695,10 @@ impl AppEndpoint {
                     .await?
                     .is_production()
                 {
-                    let page_name = app_entry.pathname.clone();
                     server_assets.insert(ResolvedVc::upcast(
                         NftJsonAsset::new(
                             project,
-                            Some(page_name),
+                            Some(app_function_name(&app_entry.original_name).into()),
                             *rsc_chunk,
                             client_reference_manifest
                                 .iter()

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -35,7 +35,8 @@ pub struct NftJsonAsset {
     /// An example of this is the two-phase approach used by the `ClientReferenceManifest` in
     /// next.js.
     additional_assets: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
-    page_name: Option<RcStr>,
+    // The page name, e.g. `pages/index` or `app/route1`
+    page_name: Option<String>,
 }
 
 #[turbo_tasks::value_impl]
@@ -51,7 +52,7 @@ impl NftJsonAsset {
             chunk,
             project,
             additional_assets,
-            page_name,
+            page_name: page_name.map(|page_name| format!("/{page_name}")),
         }
         .cell()
     }

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -24,8 +24,7 @@ use next_core::{
         PagesDirectoryStructure, PagesStructure, PagesStructureItem, find_pages_structure,
     },
     util::{
-        NextRuntime, get_asset_prefix_from_pathname, pages_middleware_function_name,
-        parse_config_from_source,
+        NextRuntime, get_asset_prefix_from_pathname, pages_function_name, parse_config_from_source,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -1176,7 +1175,7 @@ impl PageEndpoint {
                     ResolvedVc::cell(Some(ResolvedVc::upcast(
                         NftJsonAsset::new(
                             project,
-                            Some(this.original_name.clone()),
+                            Some(pages_function_name(&this.original_name).into()),
                             *ssr_entry_chunk,
                             additional_assets,
                         )
@@ -1585,7 +1584,7 @@ impl PageEndpoint {
                         files: file_paths_from_root.into_iter().collect(),
                         wasm: wasm_paths_to_bindings(wasm_paths_from_root).await?,
                         assets: paths_to_bindings(all_assets),
-                        name: pages_middleware_function_name(&this.original_name).into(),
+                        name: pages_function_name(&this.original_name).into(),
                         page: this.original_name.clone(),
                         regions,
                         matchers: vec![matchers],

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -27,7 +27,7 @@ use crate::{
     next_edge::entry::wrap_edge_entry,
     next_server_component::NextServerComponentTransition,
     parse_segment_config_from_loader_tree,
-    util::{NextRuntime, app_middleware_function_name, file_content_rope, load_next_js_template},
+    util::{NextRuntime, app_function_name, file_content_rope, load_next_js_template},
 };
 
 /// Computes the entry for a Next.js app page.
@@ -186,6 +186,6 @@ async fn wrap_edge_page(
         asset_context,
         project_root,
         wrapped,
-        app_middleware_function_name(&page).into(),
+        app_function_name(&page).into(),
     ))
 }

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -16,7 +16,7 @@ use crate::{
     next_config::{NextConfig, OutputType},
     next_edge::entry::wrap_edge_entry,
     parse_segment_config_from_source,
-    util::{NextRuntime, app_middleware_function_name, load_next_js_template},
+    util::{NextRuntime, app_function_name, load_next_js_template},
 };
 
 /// Computes the entry for a Next.js app route.
@@ -162,6 +162,6 @@ async fn wrap_edge_route(
         asset_context,
         project_root.clone(),
         wrapped,
-        app_middleware_function_name(&page).into(),
+        app_function_name(&page).into(),
     ))
 }

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -19,7 +19,7 @@ use crate::{
     next_config::NextConfig,
     next_edge::entry::wrap_edge_entry,
     pages_structure::{PagesStructure, PagesStructureItem},
-    util::{NextRuntime, file_content_rope, load_next_js_template, pages_middleware_function_name},
+    util::{NextRuntime, file_content_rope, load_next_js_template, pages_function_name},
 };
 
 #[turbo_tasks::value]
@@ -163,7 +163,7 @@ pub async fn create_page_ssr_entry_module(
                 ssr_module_context,
                 project_root,
                 ssr_module,
-                pages_middleware_function_name(&definition_page).into(),
+                pages_function_name(&definition_page).into(),
             );
         }
     }
@@ -288,7 +288,7 @@ async fn wrap_edge_page(
         asset_context,
         project_root,
         wrapped,
-        pages_middleware_function_name(&page).into(),
+        pages_function_name(&page).into(),
     ))
 }
 

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -197,10 +197,10 @@ pub async fn internal_assets_conditions() -> Result<ContextCondition> {
     ]))
 }
 
-pub fn app_middleware_function_name(page: impl Display) -> String {
+pub fn app_function_name(page: impl Display) -> String {
     format!("app{page}")
 }
-pub fn pages_middleware_function_name(page: impl Display) -> String {
+pub fn pages_function_name(page: impl Display) -> String {
     format!("pages{page}")
 }
 

--- a/test/integration/build-trace-extra-entries/app/next.config.js
+++ b/test/integration/build-trace-extra-entries/app/next.config.js
@@ -18,11 +18,13 @@ module.exports = {
     return cfg
   },
   outputFileTracingIncludes: {
-    '/index': ['include-me/**/*'],
-    '/route1': ['./include-me/**/*', 'node_modules/pkg-behind-symlink/*'],
+    // Full path includes "app" or "pages"
+    '/pages/index': ['include-me/**/*'],
+    '/app/route1': ['./include-me/**/*', 'node_modules/pkg-behind-symlink/*'],
     '/*': ['include-me-global.txt'],
   },
   outputFileTracingExcludes: {
+    // Subpaths should also work
     '/index': ['public/exclude-me/**/*'],
     '/route1': ['./public/exclude-me/**/*'],
   },


### PR DESCRIPTION
These are effectively the tests for https://github.com/vercel/next.js/pull/82906

`outputFileTracingIncludes` and `outputFileTracingExcludes` match not against the pathname of the routes, but also include the app/pages prefix, e.g. `app/route1` for `src/app/route1/route.js` (at least the Webpack implementation does, which is what we're replicating here).

Closes PACK-5341