### PR TITLE
Fetch tag before reset for create-release-branch

### DIFF
--- a/scripts/create-release-branch.js
+++ b/scripts/create-release-branch.js
@@ -39,6 +39,10 @@ async function main() {
     stdio: 'inherit',
     shell: true,
   })
+  await execa(`git fetch origin ${tagName}`, {
+    stdio: 'inherit',
+    shell: true,
+  })
   await execa(`git reset --hard ${tagName}`, {
     stdio: 'inherit',
     shell: true,


### PR DESCRIPTION
This ensures we can reset to the tag even if we didn't clone deep enough to include the tag in history 

x-ref: https://github.com/vercel/next.js/actions/runs/17214240270/job/48833696068#step:10:20