### PR TITLE
Ensure tags are fetched for release branch

### DIFF
--- a/scripts/create-release-branch.js
+++ b/scripts/create-release-branch.js
@@ -39,7 +39,7 @@ async function main() {
     stdio: 'inherit',
     shell: true,
   })
-  await execa(`git fetch origin ${tagName}`, {
+  await execa(`git fetch origin ${tagName} --tags`, {
     stdio: 'inherit',
     shell: true,
   })


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/83006 this ensures we actually pull the tag refs otherwise we can't reset to them. 

Verified here: https://github.com/vercel/next.js/actions/runs/17217751382