### PR TITLE
Turbopack: persist when stopping (after build)

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1223,6 +1223,9 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             self.is_idle.store(false, Ordering::Release);
             self.verify_aggregation_graph(turbo_tasks, false);
         }
+        if self.should_persist() {
+            self.snapshot();
+        }
         self.task_cache.drop_contents();
         drop_contents(&self.transient_tasks);
         self.storage.drop_contents();


### PR DESCRIPTION
### What?

Fixes persistent caching with next build.

Need to investigate how this regression passes the test cases...

Closes PACK-5359