### PR TITLE
Turbopack: refactor backend jobs

### DIFF
--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -1,5 +1,4 @@
 use std::{
-    any::Any,
     borrow::Cow,
     error::Error,
     fmt::{self, Debug, Display},
@@ -17,7 +16,6 @@ use serde::{Deserialize, Serialize};
 use tracing::Span;
 use turbo_rcstr::RcStr;
 
-pub use crate::id::BackendJobId;
 use crate::{
     RawVc, ReadCellOptions, ReadRef, SharedReference, TaskId, TaskIdSet, TraitRef, TraitTypeId,
     TurboTasksPanic, ValueTypeId, VcRead, VcValueTrait, VcValueType,
@@ -583,10 +581,11 @@ pub trait Backend: Sync + Send {
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> bool;
 
+    type BackendJob: Send + 'static;
+
     fn run_backend_job<'a>(
         &'a self,
-        id: BackendJobId,
-        data: Option<Box<dyn Any + Send>>,
+        job: Self::BackendJob,
         turbo_tasks: &'a dyn TurboTasksBackendApi<Self>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -115,7 +115,6 @@ macro_rules! define_id {
 define_id!(TaskId: u32, derive(Serialize, Deserialize), serde(transparent));
 define_id!(ValueTypeId: u32);
 define_id!(TraitTypeId: u32);
-define_id!(BackendJobId: u32);
 define_id!(SessionId: u32, derive(Debug, Serialize, Deserialize), serde(transparent));
 define_id!(
     LocalTaskId: u32,

--- a/turbopack/crates/turbo-tasks/src/id_factory.rs
+++ b/turbopack/crates/turbo-tasks/src/id_factory.rs
@@ -121,8 +121,7 @@ where
     }
 }
 
-/// An [`IdFactory`], but extended with a free list to allow for id reuse for ids such as
-/// [`BackendJobId`][crate::backend::BackendJobId].
+/// An [`IdFactory`], but extended with a free list to allow for id reuse.
 ///
 /// If silent untracked re-use of ids is okay, consider using the cheaper
 /// [`IdFactory::wrapping_get`] method.

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     capture_future::CaptureFuture,
     event::{Event, EventListener},
-    id::{BackendJobId, ExecutionId, LocalTaskId, TRANSIENT_TASK_BIT, TraitTypeId},
+    id::{ExecutionId, LocalTaskId, TRANSIENT_TASK_BIT, TraitTypeId},
     id_factory::IdFactoryWithReuse,
     macro_helpers::NativeFunction,
     magic_any::MagicAny,
@@ -250,8 +250,8 @@ pub trait TurboTasksBackendApi<B: Backend + 'static>: TurboTasksCallApi + Sync +
     unsafe fn reuse_transient_task_id(&self, id: Unused<TaskId>);
 
     fn schedule(&self, task: TaskId);
-    fn schedule_backend_background_job(&self, id: BackendJobId, data: Option<Box<dyn Any + Send>>);
-    fn schedule_backend_foreground_job(&self, id: BackendJobId, data: Option<Box<dyn Any + Send>>);
+    fn schedule_backend_background_job(&self, job: B::BackendJob);
+    fn schedule_backend_foreground_job(&self, job: B::BackendJob);
 
     fn try_foreground_done(&self) -> Result<(), EventListener>;
     fn wait_foreground_done_excluding_own<'a>(
@@ -1478,16 +1478,16 @@ impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
     }
 
     #[track_caller]
-    fn schedule_backend_background_job(&self, id: BackendJobId, data: Option<Box<dyn Any + Send>>) {
+    fn schedule_backend_background_job(&self, job: B::BackendJob) {
         self.schedule_background_job(move |this| async move {
-            this.backend.run_backend_job(id, data, &*this).await;
+            this.backend.run_backend_job(job, &*this).await;
         })
     }
 
     #[track_caller]
-    fn schedule_backend_foreground_job(&self, id: BackendJobId, data: Option<Box<dyn Any + Send>>) {
+    fn schedule_backend_foreground_job(&self, job: B::BackendJob) {
         self.schedule_foreground_job(move |this| async move {
-            this.backend.run_backend_job(id, data, &*this).await;
+            this.backend.run_backend_job(job, &*this).await;
         })
     }
 


### PR DESCRIPTION
### What?

Use associated types to avoid Box and Any.

* avoids any casting
* avoid extra vec collecting
* avoid cloning lists for parallelization

Closes PACK-5356