### PR TITLE
Turbopack: Persisting happens in foreground tasks

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1215,7 +1215,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         if self.should_persist() {
             // Schedule the snapshot job
-            turbo_tasks.schedule_backend_background_job(TurboTasksBackendJob::InitialSnapshot);
+            turbo_tasks.schedule_backend_foreground_job(TurboTasksBackendJob::InitialSnapshot);
         }
     }
 
@@ -2212,7 +2212,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                                 Ordering::Relaxed,
                             );
 
-                            turbo_tasks.schedule_backend_background_job(
+                            turbo_tasks.schedule_backend_foreground_job(
                                 TurboTasksBackendJob::FollowUpSnapshot,
                             );
                             return;


### PR DESCRIPTION
### What?

Background tasks will only run when idle, but persisting should also happen when active.

Closes PACK-5363