### PR TITLE
fix: add '.next/types/**/*.ts' to the pages router TSConfig

### DIFF
--- a/packages/create-next-app/templates/default-empty/ts/tsconfig.json
+++ b/packages/create-next-app/templates/default-empty/ts/tsconfig.json
@@ -17,6 +17,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/create-next-app/templates/default-tw-empty/ts/tsconfig.json
+++ b/packages/create-next-app/templates/default-tw-empty/ts/tsconfig.json
@@ -17,6 +17,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/create-next-app/templates/default-tw/ts/tsconfig.json
+++ b/packages/create-next-app/templates/default-tw/ts/tsconfig.json
@@ -17,6 +17,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/create-next-app/templates/default/ts/tsconfig.json
+++ b/packages/create-next-app/templates/default/ts/tsconfig.json
@@ -17,6 +17,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
See #83010

Previously, typed links only worked in App Router. Now they work in Pages Router too, but we forgot to update the templates.
