### PR TITLE
fix: remove redundant type validation of config exports

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -515,16 +515,6 @@ export function generateValidatorFile(
   getStaticPaths?: (context: any) => Promise<any> | any
   getServerSideProps?: (context: any) => Promise<any> | any
   getInitialProps?: (context: any) => Promise<any> | any
-  /**
-   * Segment configuration for legacy Pages Router pages.
-   * Validated at build-time by parsePagesSegmentConfig.
-   */
-  config?: {
-    amp?: boolean | 'hybrid' | string // necessary for JS
-    maxDuration?: number
-    runtime?: 'edge' | 'experimental-edge' | 'nodejs' | string // necessary unless config is exported as const
-    regions?: string[]
-  }
 }
 
 `
@@ -572,8 +562,6 @@ export function generateValidatorFile(
       responseLimit?: string | number | boolean
       externalResolver?: boolean
     }
-    runtime?: 'edge' | 'experimental-edge' | 'nodejs' | string // necessary unless config is exported as const
-    maxDuration?: number
   }
 }
 


### PR DESCRIPTION
Type-checking these exports is unnecessary, since they're already validated in runtime by our Zod schema in `pages-segment-config.ts`.

Also, `export const config` is legacy for Pages Router.