### PR TITLE
Turbopack: add benchmark for JS analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9776,6 +9776,7 @@ dependencies = [
  "turbopack-core",
  "turbopack-resolve",
  "turbopack-swc-utils",
+ "turbopack-test-utils",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9768,6 +9768,7 @@ dependencies = [
  "turbo-esregex",
  "turbo-rcstr",
  "turbo-tasks",
+ "turbo-tasks-backend",
  "turbo-tasks-build",
  "turbo-tasks-fs",
  "turbo-tasks-hash",

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -31,6 +31,7 @@ enum Task {
     Finished(Result<RawVc, SharedError>),
 }
 
+#[derive(Default)]
 pub struct VcStorage {
     this: Weak<Self>,
     cells: Mutex<FxHashMap<(TaskId, CellId), CellContent>>,
@@ -326,19 +327,15 @@ impl TurboTasksApi for VcStorage {
 }
 
 impl VcStorage {
-    pub fn new() -> Arc<Self> {
-        Arc::new_cyclic(|weak| VcStorage {
-            this: weak.clone(),
-            cells: Default::default(),
-            tasks: Default::default(),
-        })
-    }
-
-    pub fn run<T>(self: Arc<Self>, f: impl Future<Output = T>) -> impl Future<Output = T> {
-        with_turbo_tasks_for_testing(self, TaskId::MAX, ExecutionId::MIN, f)
-    }
-
     pub fn with<T>(f: impl Future<Output = T>) -> impl Future<Output = T> {
-        Self::new().run(f)
+        with_turbo_tasks_for_testing(
+            Arc::new_cyclic(|weak| VcStorage {
+                this: weak.clone(),
+                ..Default::default()
+            }),
+            TaskId::MAX,
+            ExecutionId::MIN,
+            f,
+        )
     }
 }

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -31,7 +31,6 @@ enum Task {
     Finished(Result<RawVc, SharedError>),
 }
 
-#[derive(Default)]
 pub struct VcStorage {
     this: Weak<Self>,
     cells: Mutex<FxHashMap<(TaskId, CellId), CellContent>>,
@@ -327,15 +326,19 @@ impl TurboTasksApi for VcStorage {
 }
 
 impl VcStorage {
+    pub fn new() -> Arc<Self> {
+        Arc::new_cyclic(|weak| VcStorage {
+            this: weak.clone(),
+            cells: Default::default(),
+            tasks: Default::default(),
+        })
+    }
+
+    pub fn run<T>(self: Arc<Self>, f: impl Future<Output = T>) -> impl Future<Output = T> {
+        with_turbo_tasks_for_testing(self, TaskId::MAX, ExecutionId::MIN, f)
+    }
+
     pub fn with<T>(f: impl Future<Output = T>) -> impl Future<Output = T> {
-        with_turbo_tasks_for_testing(
-            Arc::new_cyclic(|weak| VcStorage {
-                this: weak.clone(),
-                ..Default::default()
-            }),
-            TaskId::MAX,
-            ExecutionId::MIN,
-            f,
-        )
+        Self::new().run(f)
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -76,6 +76,7 @@ swc_core = { workspace = true, features = [
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
+turbo-tasks-backend = { workspace = true }
 turbo-tasks-malloc = { workspace = true }
 turbo-tasks-testing = { workspace = true }
 turbopack-test-utils = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -78,6 +78,7 @@ swc_core = { workspace = true, features = [
 criterion = { workspace = true, features = ["async_tokio"] }
 turbo-tasks-malloc = { workspace = true }
 turbo-tasks-testing = { workspace = true }
+turbopack-test-utils = { workspace = true }
 
 [build-dependencies]
 turbo-tasks-build = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript/benches/full.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/full.rs
@@ -1,0 +1,111 @@
+use std::{path::PathBuf, sync::Arc};
+
+use criterion::{Bencher, BenchmarkId, Criterion};
+use turbo_rcstr::rcstr;
+use turbo_tasks::ResolvedVc;
+use turbo_tasks_fs::{DiskFileSystem, FileSystem};
+use turbo_tasks_testing::VcStorage;
+use turbopack_core::{
+    compile_time_info::CompileTimeInfo,
+    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
+    file_source::FileSource,
+    ident::Layer,
+};
+use turbopack_ecmascript::{
+    EcmascriptInputTransforms, EcmascriptModuleAsset, EcmascriptOptions, TreeShakingMode,
+    references::analyse_ecmascript_module_internal,
+};
+use turbopack_test_utils::noop_asset_context::NoopAssetContext;
+
+pub fn benchmark(c: &mut Criterion) {
+    turbopack_ecmascript::register();
+    turbopack_test_utils::register();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    let storage = VcStorage::new();
+
+    let cases = rt
+        .block_on(storage.clone().run(async {
+            let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../");
+            let fs = DiskFileSystem::new(rcstr!("project"), root_dir.to_str().unwrap().into());
+
+            let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
+                NodeJsEnvironment::default().resolved_cell(),
+            ))
+            .resolve()
+            .await?;
+            let compile_time_info = CompileTimeInfo::new(environment).to_resolved().await?;
+            let layer = Layer::new(rcstr!("test"));
+            // let module_asset_context = ModuleAssetContext::new(
+            //     Default::default(),
+            //     CompileTimeInfo::new(environment),
+            //     ModuleOptionsContext::value_default(),
+            //     ResolveOptionsContext::value_default(),
+            //     layer,
+            // )
+            // .to_resolved()
+            // .await?;
+            let module_asset_context = NoopAssetContext {
+                compile_time_info,
+                layer,
+            }
+            .resolved_cell();
+
+            let mut cases = vec![];
+            for file in ["packages/next/dist/compiled/babel-packages/packages-bundle.js"] {
+                let module = EcmascriptModuleAsset::builder(
+                    ResolvedVc::upcast(
+                        FileSource::new(fs.root().await?.join(file).unwrap())
+                            .to_resolved()
+                            .await?,
+                    ),
+                    ResolvedVc::upcast(module_asset_context),
+                    EcmascriptInputTransforms::empty().to_resolved().await?,
+                    EcmascriptOptions {
+                        tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
+                        ..Default::default()
+                    }
+                    .resolved_cell(),
+                    compile_time_info,
+                )
+                .build()
+                .to_resolved()
+                .await?;
+
+                let input = BenchInput {
+                    storage: storage.clone(),
+                    module,
+                };
+                cases.push((file, input));
+            }
+            anyhow::Ok(cases)
+        }))
+        .unwrap();
+
+    let mut group = c.benchmark_group("full");
+
+    for case in cases {
+        group.bench_with_input(BenchmarkId::new("full", case.0), &case.1, bench_full);
+    }
+}
+
+struct BenchInput {
+    storage: Arc<VcStorage>,
+    module: ResolvedVc<EcmascriptModuleAsset>,
+}
+
+fn bench_full(b: &mut Bencher, input: &BenchInput) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    b.to_async(rt).iter(|| {
+        input
+            .storage
+            .clone()
+            .run(async { analyse_ecmascript_module_internal(input.module, None).await })
+    });
+}

--- a/turbopack/crates/turbopack-ecmascript/benches/full.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/full.rs
@@ -1,10 +1,12 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use criterion::{Bencher, BenchmarkId, Criterion};
 use turbo_rcstr::rcstr;
-use turbo_tasks::ResolvedVc;
+use turbo_tasks::{ResolvedVc, TurboTasks};
+use turbo_tasks_backend::{
+    BackendOptions, BackingStorage, TurboTasksBackend, noop_backing_storage,
+};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
-use turbo_tasks_testing::VcStorage;
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
@@ -25,29 +27,25 @@ pub fn benchmark(c: &mut Criterion) {
         .build()
         .unwrap();
 
-    let storage = VcStorage::new();
+    let tt = TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions {
+            dependency_tracking: false,
+            storage_mode: None,
+            ..Default::default()
+        },
+        noop_backing_storage(),
+    ));
 
     let cases = rt
-        .block_on(storage.clone().run(async {
+        .block_on(tt.run_once(async {
             let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../");
             let fs = DiskFileSystem::new(rcstr!("project"), root_dir.to_str().unwrap().into());
 
             let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
                 NodeJsEnvironment::default().resolved_cell(),
-            ))
-            .resolve()
-            .await?;
+            ));
             let compile_time_info = CompileTimeInfo::new(environment).to_resolved().await?;
             let layer = Layer::new(rcstr!("test"));
-            // let module_asset_context = ModuleAssetContext::new(
-            //     Default::default(),
-            //     CompileTimeInfo::new(environment),
-            //     ModuleOptionsContext::value_default(),
-            //     ResolveOptionsContext::value_default(),
-            //     layer,
-            // )
-            // .to_resolved()
-            // .await?;
             let module_asset_context = NoopAssetContext {
                 compile_time_info,
                 layer,
@@ -55,7 +53,10 @@ pub fn benchmark(c: &mut Criterion) {
             .resolved_cell();
 
             let mut cases = vec![];
-            for file in ["packages/next/dist/compiled/babel-packages/packages-bundle.js"] {
+            for file in [
+                r#"packages/next/dist/compiled/babel-packages/packages-bundle.js"#,
+                r#"node_modules/.pnpm/react-dom@19.2.0-canary-03fda05d-20250820_react@19.2.0-canary-03fda05d-20250820/node_modules/react-dom/cjs/react-dom-client.development.js"#,
+            ] {
                 let module = EcmascriptModuleAsset::builder(
                     ResolvedVc::upcast(
                         FileSource::new(fs.root().await?.join(file).unwrap())
@@ -75,29 +76,40 @@ pub fn benchmark(c: &mut Criterion) {
                 .to_resolved()
                 .await?;
 
-                let input = BenchInput {
-                    storage: storage.clone(),
-                    module,
-                };
-                cases.push((file, input));
+                cases.push((file, module));
             }
             anyhow::Ok(cases)
         }))
         .unwrap();
 
     let mut group = c.benchmark_group("full");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(20));
 
     for case in cases {
-        group.bench_with_input(BenchmarkId::new("full", case.0), &case.1, bench_full);
+        group.bench_with_input(
+            BenchmarkId::new("full", case.0),
+            &BenchInput {
+                module: case.1,
+                storage: tt.clone(),
+            },
+            bench_full,
+        );
     }
 }
 
-struct BenchInput {
-    storage: Arc<VcStorage>,
+struct BenchInput<B>
+where
+    B: BackingStorage,
+{
+    storage: Arc<TurboTasks<TurboTasksBackend<B>>>,
     module: ResolvedVc<EcmascriptModuleAsset>,
 }
 
-fn bench_full(b: &mut Bencher, input: &BenchInput) {
+fn bench_full<B>(b: &mut Bencher, input: &BenchInput<B>)
+where
+    B: BackingStorage,
+{
     let rt = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap();
@@ -105,7 +117,6 @@ fn bench_full(b: &mut Bencher, input: &BenchInput) {
     b.to_async(rt).iter(|| {
         input
             .storage
-            .clone()
-            .run(async { analyse_ecmascript_module_internal(input.module, None).await })
+            .run_once(analyse_ecmascript_module_internal(input.module, None))
     });
 }

--- a/turbopack/crates/turbopack-ecmascript/benches/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/mod.rs
@@ -3,6 +3,8 @@ extern crate turbo_tasks_malloc;
 use criterion::{criterion_group, criterion_main};
 
 mod analyzer;
+mod full;
 
 criterion_group!(analyzer_benches, analyzer::benchmark);
-criterion_main!(analyzer_benches);
+criterion_group!(full_benches, full::benchmark);
+criterion_main!(analyzer_benches, full_benches);

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -499,7 +499,7 @@ pub(crate) async fn analyse_ecmascript_module(
     }
 }
 
-pub(crate) async fn analyse_ecmascript_module_internal(
+pub async fn analyse_ecmascript_module_internal(
     module: ResolvedVc<EcmascriptModuleAsset>,
     part: Option<ModulePart>,
 ) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {

--- a/turbopack/crates/turbopack-test-utils/src/lib.rs
+++ b/turbopack/crates/turbopack-test-utils/src/lib.rs
@@ -3,4 +3,13 @@
 #![feature(arbitrary_self_types_pointers)]
 
 pub mod jest;
+pub mod noop_asset_context;
 pub mod snapshot;
+
+pub fn register() {
+    turbo_tasks::register();
+    turbo_tasks_fs::register();
+    turbopack_core::register();
+    turbopack_cli_utils::register();
+    include!(concat!(env!("OUT_DIR"), "/register.rs"));
+}

--- a/turbopack/crates/turbopack-test-utils/src/noop_asset_context.rs
+++ b/turbopack/crates/turbopack-test-utils/src/noop_asset_context.rs
@@ -1,0 +1,81 @@
+use anyhow::Result;
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks_fs::{FileSystemPath, glob::Glob};
+use turbopack_core::{
+    compile_time_info::CompileTimeInfo,
+    context::{AssetContext, ProcessResult},
+    ident::Layer,
+    reference_type::ReferenceType,
+    resolve::{ModuleResolveResult, ResolveResult, options::ResolveOptions, parse::Request},
+    source::Source,
+};
+
+#[turbo_tasks::value(shared)]
+pub struct NoopAssetContext {
+    pub compile_time_info: ResolvedVc<CompileTimeInfo>,
+    pub layer: Layer,
+}
+
+#[turbo_tasks::value_impl]
+impl AssetContext for NoopAssetContext {
+    #[turbo_tasks::function]
+    fn compile_time_info(&self) -> Vc<CompileTimeInfo> {
+        *self.compile_time_info
+    }
+
+    fn layer(&self) -> Layer {
+        self.layer.clone()
+    }
+
+    #[turbo_tasks::function]
+    async fn resolve_options(
+        self: Vc<Self>,
+        _origin_path: FileSystemPath,
+        _reference_type: ReferenceType,
+    ) -> Result<Vc<ResolveOptions>> {
+        Ok(ResolveOptions::default().cell())
+    }
+
+    #[turbo_tasks::function]
+    async fn resolve_asset(
+        self: Vc<Self>,
+        _origin_path: FileSystemPath,
+        _request: Vc<Request>,
+        _resolve_options: Vc<ResolveOptions>,
+        _reference_type: ReferenceType,
+    ) -> Result<Vc<ModuleResolveResult>> {
+        Ok(*ModuleResolveResult::unresolvable())
+    }
+
+    #[turbo_tasks::function]
+    async fn process_resolve_result(
+        self: Vc<Self>,
+        _result: Vc<ResolveResult>,
+        _reference_type: ReferenceType,
+    ) -> Result<Vc<ModuleResolveResult>> {
+        Ok(*ModuleResolveResult::unresolvable())
+    }
+
+    #[turbo_tasks::function]
+    async fn process(
+        self: Vc<Self>,
+        _asset: ResolvedVc<Box<dyn Source>>,
+        _reference_type: ReferenceType,
+    ) -> Result<Vc<ProcessResult>> {
+        Ok(ProcessResult::Ignore.cell())
+    }
+
+    #[turbo_tasks::function]
+    async fn with_transition(
+        self: Vc<Self>,
+        _transition: RcStr,
+    ) -> Result<Vc<Box<dyn AssetContext>>> {
+        Ok(Vc::upcast(self))
+    }
+
+    #[turbo_tasks::function]
+    async fn side_effect_free_packages(&self) -> Result<Vc<Glob>> {
+        Ok(Glob::new(rcstr!(""), Default::default()))
+    }
+}


### PR DESCRIPTION
```
full/full/packages/next/dist/compiled/babel-packages/packages-bundle.js
                        time:   [176.60 ms 177.59 ms 178.86 ms]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
full/full/node_modules/.pnpm/react-dom@19.2.0-canary-03fda05d-20250820_react@19.2.0-canary-03fda05d-...
                        time:   [65.679 ms 66.265 ms 67.000 ms]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
```

Closes PACK-5349