### PR TITLE
Enforce navigation hooks are client only

### DIFF
--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -1,3 +1,5 @@
+import 'client-only'
+
 import type { FlightRouterState } from '../../shared/lib/app-router-types'
 import type { Params } from '../../server/request/params'
 


### PR DESCRIPTION
All of our navigation hooks only work in client components. This change adds `import "client-only"` to the hooks implementation to ensure that these modules do not end up in a server context. This is helpful for detecting early whether you have used them in an incorrect way allows us to make certain assumptions around the server rendered scope so we don't have to account for every workUnitStore since only client stores can be in scope.