### PR TITLE
ci: optimize e2e deploy test performance and resource usage

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -64,12 +64,6 @@ jobs:
         name: Extract `next` version
         run: echo 'value=${{ fromJson(steps.nextPackageInfo.outputs.value).version }}' >> "$GITHUB_OUTPUT"
 
-      - name: Setup test project
-        run: |
-          pnpm install
-          pnpm run build
-          node scripts/run-e2e-test-project-reset.mjs
-
   test-deploy:
     name: Run Deploy Tests
     needs: setup
@@ -78,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
+        group: [1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8, 8/8]
     with:
       afterBuild: npm i -g vercel@latest && NEXT_E2E_TEST_TIMEOUT=240000 NEXT_TEST_MODE=deploy NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || 'canary' }}" VERCEL_CLI_VERSION="${{ github.event.inputs.vercelCliVersion || 'vercel@latest' }}" node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
       skipNativeBuild: 'yes'

--- a/.github/workflows/test_e2e_project_reset_cron.yml
+++ b/.github/workflows/test_e2e_project_reset_cron.yml
@@ -1,0 +1,46 @@
+name: test-e2e-project-reset-cron
+
+on:
+  # Run every Sunday at 5AM UTC
+  schedule:
+    - cron: '0 5 * * 0'
+  # Allow manual triggering for emergency resets
+  workflow_dispatch:
+
+env:
+  VERCEL_TEST_TEAM: vtest314-next-e2e-tests
+  VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
+  TURBO_TEAM: 'vercel'
+  TURBO_CACHE: 'remote:rw'
+  TURBO_API: ${{ secrets.HOSTED_TURBO_API }}
+  TURBO_TOKEN: ${{ secrets.HOSTED_TURBO_TOKEN }}
+  NODE_LTS_VERSION: 20
+
+run-name: test-e2e-project-reset (scheduled)
+
+jobs:
+  reset-test-project:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'vercel'
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_LTS_VERSION }}
+          check-latest: true
+
+      - name: Setup pnpm
+        run: |
+          npm i -g corepack@0.31
+          corepack enable
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 25
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Reset test project
+        run: node scripts/run-e2e-test-project-reset.mjs


### PR DESCRIPTION
### What?

Optimize CI workflow performance by moving e2e test project reset to a weekly cron schedule and increasing deploy test parallelization.

### Why?

The current workflow runs project reset on every deploy test execution, making parallel investigations by manual dispatch impossible. Additionally, deploy tests were limited to 6 parallel groups, creating a bottleneck.

### How?

- Created new weekly cron workflow (`test_e2e_project_reset_cron.yml`) that runs every Sunday at 5AM UTC
- Removed inline project reset step from deploy test workflow
- Increased deploy test matrix from 6 to 8 parallel groups for faster execution
- Added manual workflow dispatch option for emergency resets