### PR TITLE
[backport] fix: disable unknownatrules lint rule entirely (#83059)

### DIFF
--- a/packages/create-next-app/templates/app-tw-empty/js/biome.json
+++ b/packages/create-next-app/templates/app-tw-empty/js/biome.json
@@ -19,7 +19,7 @@
     "rules": {
       "recommended": true,
       "suspicious": {
-        "noUnknownAtRules": "warn"
+        "noUnknownAtRules": "off"
       }
     },
     "domains": {

--- a/packages/create-next-app/templates/app-tw-empty/ts/biome.json
+++ b/packages/create-next-app/templates/app-tw-empty/ts/biome.json
@@ -19,7 +19,7 @@
     "rules": {
       "recommended": true,
       "suspicious": {
-        "noUnknownAtRules": "warn"
+        "noUnknownAtRules": "off"
       }
     },
     "domains": {

--- a/packages/create-next-app/templates/app-tw/js/biome.json
+++ b/packages/create-next-app/templates/app-tw/js/biome.json
@@ -19,7 +19,7 @@
     "rules": {
       "recommended": true,
       "suspicious": {
-        "noUnknownAtRules": "warn"
+        "noUnknownAtRules": "off"
       }
     },
     "domains": {

--- a/packages/create-next-app/templates/app-tw/ts/biome.json
+++ b/packages/create-next-app/templates/app-tw/ts/biome.json
@@ -19,7 +19,7 @@
     "rules": {
       "recommended": true,
       "suspicious": {
-        "noUnknownAtRules": "warn"
+        "noUnknownAtRules": "off"
       }
     },
     "domains": {

--- a/packages/create-next-app/templates/default-tw-empty/js/biome.json
+++ b/packages/create-next-app/templates/default-tw-empty/js/biome.json
@@ -19,7 +19,7 @@
     "rules": {
       "recommended": true,
       "suspicious": {
-        "noUnknownAtRules": "warn"
+        "noUnknownAtRules": "off"
       }
     },
     "domains": {

--- a/packages/create-next-app/templates/default-tw-empty/ts/biome.json
+++ b/packages/create-next-app/templates/default-tw-empty/ts/biome.json
@@ -19,7 +19,7 @@
     "rules": {
       "recommended": true,
       "suspicious": {
-        "noUnknownAtRules": "warn"
+        "noUnknownAtRules": "off"
       }
     },
     "domains": {

--- a/packages/create-next-app/templates/default-tw/js/biome.json
+++ b/packages/create-next-app/templates/default-tw/js/biome.json
@@ -19,7 +19,7 @@
     "rules": {
       "recommended": true,
       "suspicious": {
-        "noUnknownAtRules": "warn"
+        "noUnknownAtRules": "off"
       }
     },
     "domains": {

--- a/packages/create-next-app/templates/default-tw/ts/biome.json
+++ b/packages/create-next-app/templates/default-tw/ts/biome.json
@@ -19,7 +19,7 @@
     "rules": {
       "recommended": true,
       "suspicious": {
-        "noUnknownAtRules": "warn"
+        "noUnknownAtRules": "off"
       }
     },
     "domains": {


### PR DESCRIPTION
Biome is close to releasing their fix for Tailwind parsing, but it'll be released in the next minor version.

We want to make sure that linting the template doesn't show any problems arising from Tailwind at-rules in the meantime.

(See #82974 and #82826)