### PR TITLE
revert: add ?dpl to fonts in `/_next/static/media`

### DIFF
--- a/packages/font/src/google/loader.test.ts
+++ b/packages/font/src/google/loader.test.ts
@@ -124,7 +124,6 @@ describe('next/font/google loader', () => {
         mockFetchResource.mockResolvedValue(Buffer.from('OK'))
         const { css } = await nextFontGoogleFontLoader({
           functionName,
-          deploymentId: undefined,
           data: [
             {
               adjustFontFallback: false,

--- a/packages/font/src/local/loader.test.ts
+++ b/packages/font/src/local/loader.test.ts
@@ -5,7 +5,6 @@ describe('next/font/local loader', () => {
     test('Default CSS', async () => {
       const { css } = await nextFontLocalFontLoader({
         functionName: '',
-        deploymentId: undefined,
         data: [{ src: './my-font.woff2' }],
         emitFontFile: () => '/_next/static/media/my-font.woff2',
         resolve: jest.fn(),
@@ -29,37 +28,9 @@ describe('next/font/local loader', () => {
       `)
     })
 
-    test('with dpl query string', async () => {
-      const { css } = await nextFontLocalFontLoader({
-        functionName: '',
-        deploymentId: 'dpl_123',
-        data: [{ src: './my-font.woff2' }],
-        emitFontFile: () => '/_next/static/media/my-font.woff2',
-        resolve: jest.fn(),
-        isDev: false,
-        isServer: true,
-        variableName: 'myFont',
-        loaderContext: {
-          fs: {
-            readFile: (_: string, cb: any) => cb(null, 'fontdata'),
-          },
-        } as any,
-      })
-
-      expect(css).toMatchInlineSnapshot(`
-        "@font-face {
-        font-family: myFont;
-        src: url(/_next/static/media/my-font.woff2?dpl=dpl_123) format('woff2');
-        font-display: swap;
-        }
-        "
-      `)
-    })
-
     test('Weight and style', async () => {
       const { css } = await nextFontLocalFontLoader({
         functionName: '',
-        deploymentId: undefined,
         data: [{ src: './my-font.woff2', weight: '100 900', style: 'italic' }],
         emitFontFile: () => '/_next/static/media/my-font.woff2',
         resolve: jest.fn(),
@@ -88,7 +59,6 @@ describe('next/font/local loader', () => {
     test('Other properties', async () => {
       const { css } = await nextFontLocalFontLoader({
         functionName: '',
-        deploymentId: undefined,
         data: [
           {
             src: './my-font.woff2',
@@ -125,7 +95,6 @@ describe('next/font/local loader', () => {
     test('Multiple weights default style', async () => {
       const { css } = await nextFontLocalFontLoader({
         functionName: '',
-        deploymentId: undefined,
         data: [
           {
             style: 'italic',
@@ -202,7 +171,6 @@ describe('next/font/local loader', () => {
     test('Multiple styles default weight', async () => {
       const { css } = await nextFontLocalFontLoader({
         functionName: '',
-        deploymentId: undefined,
         data: [
           {
             weight: '400',
@@ -265,7 +233,6 @@ describe('next/font/local loader', () => {
     test('Custom font-family in declarations', async () => {
       const { css } = await nextFontLocalFontLoader({
         functionName: '',
-        deploymentId: undefined,
         data: [
           {
             src: './my-font.woff2',

--- a/packages/font/src/local/loader.ts
+++ b/packages/font/src/local/loader.ts
@@ -19,7 +19,6 @@ const nextFontLocalFontLoader: FontLoader = async ({
   data,
   emitFontFile,
   resolve,
-  deploymentId,
   loaderContext,
 }) => {
   const {
@@ -46,10 +45,6 @@ const nextFontLocalFontLoader: FontLoader = async ({
         preload,
         typeof adjustFontFallback === 'undefined' || !!adjustFontFallback
       )
-      // Should match behavior in get-asset-query-string.ts
-      const qs = deploymentId
-        ? `${fontUrl.includes('?') ? '&' : '?'}dpl=${deploymentId}`
-        : ''
 
       // Try to load font metadata from the font file using fontkit.
       // The data is used to calculate the fallback font override values.
@@ -71,7 +66,7 @@ const nextFontLocalFontLoader: FontLoader = async ({
           ? declarations.map(({ prop, value }) => [prop, value])
           : []),
         ...(hasCustomFontFamily ? [] : [['font-family', variableName]]),
-        ['src', `url(${fontUrl + qs}) format('${format}')`],
+        ['src', `url(${fontUrl}) format('${format}')`],
         ['font-display', display],
         ...((weight ?? defaultWeight)
           ? [['font-weight', weight ?? defaultWeight]]

--- a/packages/next/font/index.d.ts
+++ b/packages/next/font/index.d.ts
@@ -19,7 +19,6 @@ export type FontLoader = (options: {
   resolve: (src: string) => string
   isDev: boolean
   isServer: boolean
-  deploymentId: string | undefined
   loaderContext: any
 }) => Promise<{
   css: string

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2451,7 +2451,6 @@ export default async function getBaseWebpackConfig(
     isEdgeRuntime: isEdgeServer,
     targetWeb: isClient || isEdgeServer,
     assetPrefix: config.assetPrefix || '',
-    deploymentId: config.deploymentId,
     sassOptions: config.sassOptions,
     productionBrowserSourceMaps: config.productionBrowserSourceMaps,
     future: config.future,

--- a/packages/next/src/build/webpack/config/blocks/css/loaders/next-font.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/loaders/next-font.ts
@@ -62,7 +62,6 @@ export function getNextFontLoader(
       isDev: ctx.isDevelopment,
       isServer: ctx.isServer,
       assetPrefix: ctx.assetPrefix,
-      deploymentId: ctx.deploymentId,
       fontLoaderPath,
       postcss,
     },

--- a/packages/next/src/build/webpack/config/index.ts
+++ b/packages/next/src/build/webpack/config/index.ts
@@ -19,7 +19,6 @@ export async function buildConfiguration(
     isEdgeRuntime,
     targetWeb,
     assetPrefix,
-    deploymentId,
     sassOptions,
     productionBrowserSourceMaps,
     future,
@@ -37,7 +36,6 @@ export async function buildConfiguration(
     isEdgeRuntime: boolean
     targetWeb: boolean
     assetPrefix: string
-    deploymentId: string | undefined
     sassOptions: any
     productionBrowserSourceMaps: boolean
     transpilePackages: NextConfigComplete['transpilePackages']
@@ -63,7 +61,6 @@ export async function buildConfiguration(
         ? assetPrefix.slice(0, -1)
         : assetPrefix
       : '',
-    deploymentId,
     sassOptions,
     productionBrowserSourceMaps,
     transpilePackages,

--- a/packages/next/src/build/webpack/config/utils.ts
+++ b/packages/next/src/build/webpack/config/utils.ts
@@ -19,7 +19,6 @@ export type ConfigurationContext = {
   targetWeb: boolean
 
   assetPrefix: string
-  deploymentId: string | undefined
 
   sassOptions: any
   productionBrowserSourceMaps: boolean

--- a/packages/next/src/build/webpack/loaders/next-font-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-font-loader/index.ts
@@ -45,7 +45,6 @@ export default async function nextFontLoader(this: any) {
       assetPrefix,
       fontLoaderPath,
       postcss: getPostcss,
-      deploymentId,
     } = this.getOptions()
 
     if (assetPrefix && !/^\/|https?:\/\//.test(assetPrefix)) {
@@ -67,7 +66,7 @@ export default async function nextFontLoader(this: any) {
      * NextFontManifestPlugin uses this to see if fallback fonts are being used.
      * This is used to collect stats on fallback fonts usage by the Google Aurora team.
      */
-    const emitFontFile: Parameters<FontLoader>[0]['emitFontFile'] = (
+    const emitFontFile = (
       content: Buffer,
       ext: string,
       preload: boolean,
@@ -110,7 +109,6 @@ export default async function nextFontLoader(this: any) {
               ),
             isDev,
             isServer,
-            deploymentId,
             loaderContext: this,
           })
         )

--- a/packages/next/src/pages/_document.tsx
+++ b/packages/next/src/pages/_document.tsx
@@ -363,8 +363,7 @@ function getAmpPath(ampPath: string, asPath: string): string {
 function getNextFontLinkTags(
   nextFontManifest: DeepReadonly<NextFontManifest> | undefined,
   dangerousAsPath: string,
-  assetPrefix: string = '',
-  assetQueryString: string = ''
+  assetPrefix: string = ''
 ) {
   if (!nextFontManifest) {
     return {
@@ -404,7 +403,7 @@ function getNextFontLinkTags(
             <link
               key={fontFile}
               rel="preload"
-              href={`${assetPrefix}/_next/${encodeURIPath(fontFile)}${assetQueryString}`}
+              href={`${assetPrefix}/_next/${encodeURIPath(fontFile)}`}
               as="font"
               type={`font/${ext}`}
               crossOrigin="anonymous"
@@ -756,8 +755,7 @@ export class Head extends React.Component<HeadProps> {
     const nextFontLinkTags = getNextFontLinkTags(
       nextFontManifest,
       dangerousAsPath,
-      assetPrefix,
-      this.context.assetQueryString
+      assetPrefix
     )
 
     const tracingMetadata = getTracedMetadata(

--- a/packages/next/src/server/app-render/get-layer-assets.tsx
+++ b/packages/next/src/server/app-render/get-layer-assets.tsx
@@ -46,7 +46,7 @@ export function getLayerAssets({
         const fontFilename = preloadedFontFiles[i]
         const ext = /\.(woff|woff2|eot|ttf|otf)$/.exec(fontFilename)![1]
         const type = `font/${ext}`
-        const href = `${ctx.assetPrefix}/_next/${encodeURIPath(fontFilename)}${getAssetQueryString(ctx, false)}`
+        const href = `${ctx.assetPrefix}/_next/${encodeURIPath(fontFilename)}`
 
         preloadCallbacks.push(() => {
           ctx.componentMod.preloadFont(

--- a/test/production/deployment-id-handling/deployment-id-cookie-handling.test.ts
+++ b/test/production/deployment-id-handling/deployment-id-cookie-handling.test.ts
@@ -45,7 +45,11 @@ describe('deployment-id-handling disabled', () => {
 
       for (const link of links) {
         if (link.attribs.href) {
-          expect(link.attribs.href).not.toContain('dpl=' + deploymentId)
+          if (link.attribs.as === 'font') {
+            expect(link.attribs.href).not.toContain('dpl=' + deploymentId)
+          } else {
+            expect(link.attribs.href).not.toContain('dpl=' + deploymentId)
+          }
         }
       }
 

--- a/test/production/deployment-id-handling/deployment-id-handling.test.ts
+++ b/test/production/deployment-id-handling/deployment-id-handling.test.ts
@@ -39,7 +39,11 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'CUSTOM_DEPLOYMENT_ID'])(
 
         for (const link of links) {
           if (link.attribs.href && link.attribs.rel !== 'expect') {
-            expect(link.attribs.href).toContain('dpl=' + deploymentId)
+            if (link.attribs.as === 'font') {
+              expect(link.attribs.href).not.toContain('dpl=' + deploymentId)
+            } else {
+              expect(link.attribs.href).toContain('dpl=' + deploymentId)
+            }
           }
         }
 
@@ -169,7 +173,11 @@ describe('deployment-id-handling disabled', () => {
 
       for (const link of links) {
         if (link.attribs.href) {
-          expect(link.attribs.href).not.toContain('dpl=' + deploymentId)
+          if (link.attribs.as === 'font') {
+            expect(link.attribs.href).not.toContain('dpl=' + deploymentId)
+          } else {
+            expect(link.attribs.href).not.toContain('dpl=' + deploymentId)
+          }
         }
       }
 


### PR DESCRIPTION
This change is causing double font loading due to CSS loading without a `dpl` while they are preloaded with a `dpl` param. Reverting until a proper fix can be implemented.

Reverts:
- #82384
- #82488