### PR TITLE
Turbopack: Remove undocumented legacy syntax for built-in conditions (e.g. foreign, browser)

### DIFF
--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -5,13 +5,15 @@ use regex::Regex;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{self, FileSystemEntryType, FileSystemPath};
-use turbopack::module_options::LoaderRuleItem;
+use turbopack::module_options::{ConditionItem, LoaderRuleItem};
 use turbopack_core::{
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
     reference_type::{CommonJsReferenceSubType, ReferenceType},
     resolve::{node::node_cjs_resolve_options, parse::Request, pattern::Pattern, resolve},
 };
 use turbopack_node::transforms::webpack::WebpackLoaderItem;
+
+use crate::next_shared::webpack_rules::WebpackLoaderBuiltinCondition;
 
 // https://babeljs.io/docs/config-files
 // TODO: Also support a `babel` key in a package.json file
@@ -89,7 +91,9 @@ pub async fn get_babel_loader_rules(
                 options: Default::default(),
             }]),
             rename_as: Some(rcstr!("*")),
-            condition: None,
+            condition: Some(ConditionItem::Not(Box::new(ConditionItem::Builtin(
+                RcStr::from(WebpackLoaderBuiltinCondition::Foreign.as_str()),
+            )))),
         },
     )])
 }

--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -149,7 +149,7 @@ pub async fn webpack_loader_options(
     builtin_conditions: BTreeSet<WebpackLoaderBuiltinCondition>,
 ) -> Result<Vc<OptionWebpackLoadersOptions>> {
     let mut rules = next_config
-        .webpack_rules(builtin_conditions.clone(), project_path.clone())
+        .webpack_rules(project_path.clone())
         .owned()
         .await?;
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -11,7 +11,6 @@ import type {
   DeprecatedExperimentalTurboOptions,
   TurbopackOptions,
   TurbopackRuleConfigItem,
-  TurbopackRuleConfigItemOptions,
   TurbopackRuleConfigCollection,
   TurbopackRuleCondition,
   TurbopackLoaderBuiltinCondition,
@@ -135,26 +134,17 @@ const zTurbopackCondition: zod.ZodType<TurbopackRuleCondition> = z.union([
   }),
 ])
 
-const zTurbopackRuleConfigItemOptions: zod.ZodType<TurbopackRuleConfigItemOptions> =
+const zTurbopackRuleConfigItem: zod.ZodType<TurbopackRuleConfigItem> =
   z.strictObject({
     loaders: z.array(zTurbopackLoaderItem),
     as: z.string().optional(),
     condition: zTurbopackCondition.optional(),
   })
 
-const zTurbopackRuleConfigItem: zod.ZodType<TurbopackRuleConfigItem> = z.union([
-  z.literal(false),
-  z.record(
-    zTurbopackLoaderBuiltinCondition,
-    z.lazy(() => zTurbopackRuleConfigItem)
-  ),
-  zTurbopackRuleConfigItemOptions,
-])
-
 const zTurbopackRuleConfigCollection: zod.ZodType<TurbopackRuleConfigCollection> =
   z.union([
     zTurbopackRuleConfigItem,
-    z.array(z.union([zTurbopackLoaderItem, zTurbopackRuleConfigItemOptions])),
+    z.array(z.union([zTurbopackLoaderItem, zTurbopackRuleConfigItem])),
   ])
 
 const zTurbopackConfig: zod.ZodType<TurbopackOptions> = z.strictObject({

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -278,16 +278,11 @@ export type TurbopackRuleCondition =
       content?: RegExp
     }
 
-export type TurbopackRuleConfigItemOptions = {
+export type TurbopackRuleConfigItem = {
   loaders: TurbopackLoaderItem[]
   as?: string
   condition?: TurbopackRuleCondition
 }
-
-export type TurbopackRuleConfigItem =
-  | TurbopackRuleConfigItemOptions
-  | { [condition in TurbopackLoaderBuiltinCondition]?: TurbopackRuleConfigItem }
-  | false
 
 /**
  * This can be an object representing a single configuration, or a list of
@@ -300,7 +295,7 @@ export type TurbopackRuleConfigItem =
  */
 export type TurbopackRuleConfigCollection =
   | TurbopackRuleConfigItem
-  | (TurbopackLoaderItem | TurbopackRuleConfigItemOptions)[]
+  | (TurbopackLoaderItem | TurbopackRuleConfigItem)[]
 
 export interface TurbopackOptions {
   /**

--- a/test/e2e/app-dir/webpack-loader-conditions/next.config.js
+++ b/test/e2e/app-dir/webpack-loader-conditions/next.config.js
@@ -4,27 +4,27 @@
 const nextConfig = {
   turbopack: {
     rules: {
-      '*.test-file.js': {
-        browser: {
-          foreign: {
-            loaders: [
-              {
-                loader: require.resolve('./test-file-loader.js'),
-                options: { browser: true, foreign: true },
-              },
-            ],
-          },
-          default: {
-            loaders: [
-              {
-                loader: require.resolve('./test-file-loader.js'),
-                options: { browser: true },
-              },
-            ],
-          },
+      '*.test-file.js': [
+        {
+          condition: { all: ['browser', 'foreign'] },
+          loaders: [
+            {
+              loader: require.resolve('./test-file-loader.js'),
+              options: { browser: true, foreign: true },
+            },
+          ],
         },
-        foreign: false,
-        default: {
+        {
+          condition: { all: ['browser', { not: 'foreign' }] },
+          loaders: [
+            {
+              loader: require.resolve('./test-file-loader.js'),
+              options: { browser: true },
+            },
+          ],
+        },
+        {
+          condition: { not: { any: ['browser', 'foreign'] } },
           loaders: [
             {
               loader: require.resolve('./test-file-loader.js'),
@@ -32,7 +32,7 @@ const nextConfig = {
             },
           ],
         },
-      },
+      ],
     },
   },
 }


### PR DESCRIPTION
- https://github.com/vercel/next.js/pull/82857 provides a better way to do this that we intend to document.
- This syntax was never documented (outside of the types and tests). You wouldn't be able to figure out the built-in conditions without digging through the Turbopack source code.

Closes PACK-5377