### PR TITLE
Turbopack: Un-deprecate the `TurbopackLoaderItem` type

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -251,9 +251,6 @@ type JSONValue =
   | JSONValue[]
   | { [k: string]: JSONValue }
 
-/**
- * @deprecated Use `TurbopackRuleConfigItem` instead.
- */
 export type TurbopackLoaderItem =
   | string
   | {


### PR DESCRIPTION
It looks like this was accidentally deprecated as part of https://github.com/vercel/next.js/pull/77850 ?

- It suggests using `TurbopackRuleConfigItem` instead, but the required `loaders` field on `TurbopackRuleConfigItemOptions` uses it, so the type is unavoidable.
- Perhaps there was intent to deprecate the shortcut version of `TurbopackRuleConfigItemOrShortcut` (the shortcut syntax is undocumented), but it looks like Sentry uses it, so it's probably not worth getting rid of: https://sourcegraph.com/search?q=context:global+/turbopack:%28%5B%5E%7B%7D%5D%7C%5Cn%29*%7B%5B%5E%7B%7D%5D*rules:%5B%5E%7B%7D%5D*%7B%5B%5E%7B%5D*%5C%5B/&patternType=keyword&sm=0

Closes PACK-5370