### PR TITLE
fix: relative paths in dev in validator.ts

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -576,10 +576,7 @@ async function startWatcher(
                   ''
                 )
               ),
-              filePath: path.relative(
-                path.dirname(validatorFilePath),
-                fileName
-              ),
+              filePath: fileName,
             })
           }
 
@@ -606,18 +603,12 @@ async function startWatcher(
           if (validFileMatcher.isAppRouterRoute(fileName)) {
             appRouteHandlers.push({
               route: normalizePathSep(pageName),
-              filePath: path.relative(
-                path.dirname(validatorFilePath),
-                fileName
-              ),
+              filePath: fileName,
             })
           } else {
             appRoutes.push({
               route: normalizePathSep(pageName),
-              filePath: path.relative(
-                path.dirname(validatorFilePath),
-                fileName
-              ),
+              filePath: fileName,
             })
           }
 
@@ -635,18 +626,12 @@ async function startWatcher(
           if (pageName.startsWith('/api/')) {
             pageApiRoutes.push({
               route: normalizePathSep(pageName),
-              filePath: path.relative(
-                path.dirname(validatorFilePath),
-                fileName
-              ),
+              filePath: fileName,
             })
           } else {
             pageRoutes.push({
               route: normalizePathSep(pageName),
-              filePath: path.relative(
-                path.dirname(validatorFilePath),
-                fileName
-              ),
+              filePath: fileName,
             })
           }
         }
@@ -1062,6 +1047,9 @@ async function startWatcher(
             slots,
             redirects: opts.nextConfig.redirects,
             rewrites: opts.nextConfig.rewrites,
+            // Ensure relative paths in validator.ts are computed from validatorFilePath,
+            // matching behavior of build and CLI typegen.
+            validatorFilePath,
             appRouteHandlers,
             pageApiRoutes,
           })


### PR DESCRIPTION
Fixes #83063 

- **Problem**: `next dev` produced overly deep relative imports in `validator.ts` that differed from `next typegen`/`next build`.
- **Cause**: Dev pre-relativized page file paths and didn’t pass `validatorFilePath`, causing incorrect relative path computation.
- **Solution**:
  - Pass `validatorFilePath` to `createRouteTypesManifest` in dev.
  - Stop pre-relativizing file paths; provide absolute `fileName` so the manifest computes paths relative to the validator directory.
- **Result**: `validator.ts` now uses correct, shallow relative imports, matching `next typegen` and `next build`.
- **Verification**: Reproduced with `test/e2e/app-dir/typed-routes-validator`; outputs from `pnpm next dev` and `pnpm next typegen` now match.

### Example
Before (next dev):
```typescript
// Validate ../../../../../../app/page.tsx
{
  const handler = {} as typeof import("../../../../../../app/page.js")
  handler satisfies AppPageConfig<"/">
}
```

After (next dev/typegen/build):
```typescript
// Validate ../../app/page.tsx
{
  const handler = {} as typeof import("../../app/page.js")
  handler satisfies AppPageConfig<"/">
}
```