### PR TITLE
fix dynamic param extraction in edge-ssr-app

### DIFF
--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -24,6 +24,10 @@ import { getBotType } from '../../shared/lib/router/utils/is-bot'
 import { interopDefault } from '../../lib/interop-default'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { checkIsOnDemandRevalidate } from '../../server/api-utils'
+import { addRequestMeta } from '../../server/request-meta'
+import { isDynamicRoute } from '../../shared/lib/router/utils'
+import { getNamedRouteRegex } from '../../shared/lib/router/utils/route-regex'
+import { getRouteMatcher } from '../../shared/lib/router/utils/route-matcher'
 import { CloseController } from '../../server/web/web-on-close'
 
 declare const incrementalCacheHandler: any
@@ -64,6 +68,22 @@ async function requestHandler(
   const relativeUrl = `${req.nextUrl.pathname}${req.nextUrl.search}`
   const baseReq = new WebNextRequest(req)
   const baseRes = new WebNextResponse(undefined)
+
+  // Extract dynamic params if the page is dynamic
+  if (isDynamicRoute(normalizedSrcPage)) {
+    const routeRegex = getNamedRouteRegex(normalizedSrcPage, {
+      prefixRouteKeys: false,
+    })
+    const dynamicRouteMatcher = getRouteMatcher(routeRegex)
+    const pathname = req.nextUrl.pathname
+
+    const matchResult = dynamicRouteMatcher(pathname)
+
+    if (matchResult) {
+      // Add the params to the request metadata so prepare() can access them
+      addRequestMeta(baseReq, 'params', matchResult)
+    }
+  }
 
   const pageRouteModule = pageMod.routeModule as AppPageRouteModule
   const prepareResult = await pageRouteModule.prepare(baseReq, null, {

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -69,7 +69,10 @@ async function requestHandler(
   const baseReq = new WebNextRequest(req)
   const baseRes = new WebNextResponse(undefined)
 
-  // Extract dynamic params if the page is dynamic
+  // Extract and populate dynamic params for edge runtime.
+  // This ensures params are available in request metadata before calling prepare(),
+  // matching the behavior of the node runtime and fixing cases where the fallback
+  // matcher in prepare() fails (e.g., when URL contains literal brackets like /[id]).
   if (isDynamicRoute(normalizedSrcPage)) {
     const routeRegex = getNamedRouteRegex(normalizedSrcPage, {
       prefixRouteKeys: false,
@@ -80,7 +83,6 @@ async function requestHandler(
     const matchResult = dynamicRouteMatcher(pathname)
 
     if (matchResult) {
-      // Add the params to the request metadata so prepare() can access them
       addRequestMeta(baseReq, 'params', matchResult)
     }
   }

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -24,10 +24,6 @@ import { getBotType } from '../../shared/lib/router/utils/is-bot'
 import { interopDefault } from '../../lib/interop-default'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { checkIsOnDemandRevalidate } from '../../server/api-utils'
-import { addRequestMeta } from '../../server/request-meta'
-import { isDynamicRoute } from '../../shared/lib/router/utils'
-import { getNamedRouteRegex } from '../../shared/lib/router/utils/route-regex'
-import { getRouteMatcher } from '../../shared/lib/router/utils/route-matcher'
 import { CloseController } from '../../server/web/web-on-close'
 
 declare const incrementalCacheHandler: any
@@ -68,24 +64,6 @@ async function requestHandler(
   const relativeUrl = `${req.nextUrl.pathname}${req.nextUrl.search}`
   const baseReq = new WebNextRequest(req)
   const baseRes = new WebNextResponse(undefined)
-
-  // Extract and populate dynamic params for edge runtime.
-  // This ensures params are available in request metadata before calling prepare(),
-  // matching the behavior of the node runtime and fixing cases where the fallback
-  // matcher in prepare() fails (e.g., when URL contains literal brackets like /[id]).
-  if (isDynamicRoute(normalizedSrcPage)) {
-    const routeRegex = getNamedRouteRegex(normalizedSrcPage, {
-      prefixRouteKeys: false,
-    })
-    const dynamicRouteMatcher = getRouteMatcher(routeRegex)
-    const pathname = req.nextUrl.pathname
-
-    const matchResult = dynamicRouteMatcher(pathname)
-
-    if (matchResult) {
-      addRequestMeta(baseReq, 'params', matchResult)
-    }
-  }
 
   const pageRouteModule = pageMod.routeModule as AppPageRouteModule
   const prepareResult = await pageRouteModule.prepare(baseReq, null, {

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -598,8 +598,13 @@ export abstract class RouteModule<
       }
     }
 
+    // Normalize the page path for route matching. The srcPage contains the
+    // internal page path (e.g., /app/[slug]/page), but route matchers expect
+    // the pathname format (e.g., /app/[slug]).
+    const normalizedSrcPage = normalizeAppPath(srcPage)
+
     const serverUtils = getServerUtils({
-      page: srcPage,
+      page: normalizedSrcPage,
       i18n,
       basePath,
       rewrites,
@@ -807,7 +812,6 @@ export abstract class RouteModule<
     const nextConfig =
       routerServerContext?.nextConfig || serverFilesManifest.config
 
-    const normalizedSrcPage = normalizeAppPath(srcPage)
     let resolvedPathname =
       getRequestMeta(req, 'rewroteURL') || normalizedSrcPage
 

--- a/test/e2e/app-dir/rsc-basic/app/node/dynamic/[id]/page.js
+++ b/test/e2e/app-dir/rsc-basic/app/node/dynamic/[id]/page.js
@@ -1,0 +1,3 @@
+export default function page() {
+  return 'dynamic route [id] page'
+}

--- a/test/e2e/app-dir/rsc-basic/app/node/dynamic/page.js
+++ b/test/e2e/app-dir/rsc-basic/app/node/dynamic/page.js
@@ -1,0 +1,3 @@
+export default function page() {
+  return 'dynamic route index page'
+}

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -382,6 +382,15 @@ describe('app dir - rsc basics', () => {
     expect(dynamicRouteUrl).toBe(`${next.url}/edge/dynamic/123`)
   })
 
+  describe.each(['node', 'edge'])(`%s`, (runtime) => {
+    it('should handle dynamic routes when URL segment matches the folder bracket syntax', async () => {
+      const browser = await next.browser(`/${runtime}/dynamic/[id]`)
+      expect(await browser.elementByCss('body').text()).toBe(
+        'dynamic route [id] page'
+      )
+    })
+  })
+
   it('should support streaming for flight response', async () => {
     await next
       .fetch(`/?${NEXT_RSC_UNION_QUERY}`, {


### PR DESCRIPTION
Fixes edge runtime pages with dynamic routes returning 500 errors when the URL segment literally contains bracket syntax that matches the folder name (e.g., accessing `/[id]` for a route defined as `/[id]/page.tsx`).

The removal of web-server.ts in #81389 modified how route params were extracted for dynamic routes. The route matcher in prepare() was being created with the full internal page path (e.g., /[id]/page) which generated a regex expecting /page at the end. However, actual URL pathnames don't include the /page suffix, causing the matcher to fail when trying to extract params. This issue specifically manifested when the URL contained literal brackets (like /[id]), as the fallback param extraction would fail and leave params empty, leading to the error. 

This PR normalizes the page path using before creating the route matcher in prepare(). This ensures the regex pattern matches the actual URL pathname format (without /page suffix). 

Fixes NEXT-4698