### PR TITLE
Turbopack: skip codegen effects when tracing

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -64,7 +64,7 @@ pub fn benchmark(c: &mut Criterion) {
                     None,
                     None,
                 );
-                let var_graph = create_graph(&program, &eval_context);
+                let var_graph = create_graph(&program, &eval_context, false);
 
                 let input = BenchInput {
                     program,
@@ -90,7 +90,7 @@ struct BenchInput {
 }
 
 fn bench_create_graph(b: &mut Bencher, input: &BenchInput) {
-    b.iter(|| create_graph(&input.program, &input.eval_context));
+    b.iter(|| create_graph(&input.program, &input.eval_context, false));
 }
 
 fn bench_link(b: &mut Bencher, input: &BenchInput) {

--- a/turbopack/crates/turbopack-ecmascript/benches/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/mod.rs
@@ -3,8 +3,8 @@ extern crate turbo_tasks_malloc;
 use criterion::{criterion_group, criterion_main};
 
 mod analyzer;
-mod full;
+mod references;
 
 criterion_group!(analyzer_benches, analyzer::benchmark);
-criterion_group!(full_benches, full::benchmark);
+criterion_group!(full_benches, references::benchmark);
 criterion_main!(analyzer_benches, full_benches);

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3828,7 +3828,7 @@ mod tests {
                     None,
                 );
 
-                let mut var_graph = create_graph(&m, &eval_context);
+                let mut var_graph = create_graph(&m, &eval_context, false);
                 let var_cache = Default::default();
 
                 let mut named_values = var_graph

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -200,6 +200,9 @@ pub struct EcmascriptOptions {
     /// parsing fails. This is useful to keep the module graph structure intact when syntax errors
     /// are temporarily introduced.
     pub keep_last_successful_parse: bool,
+    /// Whether the modules in this context are never chunked/codegen-ed, but only used for
+    /// tracing.
+    pub is_tracing: bool,
 }
 
 #[turbo_tasks::value]

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -89,6 +89,7 @@ async fn node_file_trace_operation(
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
+            is_tracing: true,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -709,6 +709,7 @@ async fn externals_tracing_module_context(
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
+            is_tracing: true,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -150,6 +150,7 @@ impl ModuleOptions {
             execution_context,
             tree_shaking_mode,
             keep_last_successful_parse,
+            is_tracing,
             ..
         } = *module_options_context.await?;
 
@@ -203,6 +204,7 @@ impl ModuleOptions {
             ignore_dynamic_requests,
             extract_source_map: matches!(ecmascript_source_maps, SourceMapsType::Full),
             keep_last_successful_parse,
+            is_tracing,
             ..Default::default()
         };
         let ecmascript_options_vc = ecmascript_options.resolved_cell();

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -174,6 +174,10 @@ pub struct ModuleOptionsContext {
     /// context paths. The first matching is used.
     pub rules: Vec<(ContextCondition, ResolvedVc<ModuleOptionsContext>)>,
 
+    /// Whether the modules in this context are never chunked/codegen-ed, but only used for
+    /// tracing.
+    pub is_tracing: bool,
+
     pub placeholder_for_future_extensions: (),
 }
 

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -368,6 +368,7 @@ async fn node_file_trace_operation(
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
+            is_tracing: true,
             ..Default::default()
         }
         .cell(),


### PR DESCRIPTION
Skip these effects when in a tracing-only asset context, since we never codegen these modules and these effects cannot add any references (which is the only thing we are interested in this case):

- `Effect::FreeVar`, `Effect::TypeOf`, `Effect::ImportMeta`, `Effect::Unreachable`, `Effect::Member`

Closes PACK-5358