### PR TITLE
Fix flakey multiple-lockfiles tests

### DIFF
--- a/test/development/project-directory-with-styled-jsx-suffix/index.test.ts
+++ b/test/development/project-directory-with-styled-jsx-suffix/index.test.ts
@@ -14,7 +14,7 @@ describe('project directory with styled-jsx suffix', () => {
           } 
         `,
       },
-      dirSuffix: '-styled-jsx',
+      subDir: 'test-styled-jsx',
     })
   })
   afterAll(() => next.destroy())

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
@@ -1,5 +1,4 @@
 import { join } from 'path'
-import { unlink } from 'fs/promises'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('multiple-lockfiles - has-output-file-tracing-root', () => {
@@ -16,17 +15,14 @@ describe('multiple-lockfiles - has-output-file-tracing-root', () => {
         lockfileVersion: 3,
       }),
     },
+    // So that ../package-lock.json doesn't leave the isolated testDir
+    dirSuffix: '/root',
     skipDeployment: true,
   })
 
   if (skipped) {
     return
   }
-
-  afterAll(async () => {
-    // Cleanup to ensure it doesn't affect other tests.
-    await unlink(join(next.testDir, '../package-lock.json'))
-  })
 
   it('should not have multiple lockfiles warnings', async () => {
     expect(next.cliOutput).not.toMatch(

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
@@ -16,7 +16,7 @@ describe('multiple-lockfiles - has-output-file-tracing-root', () => {
       }),
     },
     // So that ../package-lock.json doesn't leave the isolated testDir
-    dirSuffix: '/root',
+    subDir: 'test',
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
@@ -1,5 +1,4 @@
 import { join } from 'path'
-import { unlink } from 'fs/promises'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('multiple-lockfiles - has-turbo-root', () => {
@@ -16,17 +15,14 @@ describe('multiple-lockfiles - has-turbo-root', () => {
         lockfileVersion: 3,
       }),
     },
+    // So that ../package-lock.json doesn't leave the isolated testDir
+    dirSuffix: '/root',
     skipDeployment: true,
   })
 
   if (skipped) {
     return
   }
-
-  afterAll(async () => {
-    // Cleanup to ensure it doesn't affect other tests.
-    await unlink(join(next.testDir, '../package-lock.json'))
-  })
 
   it('should not have multiple lockfiles warnings', async () => {
     expect(next.cliOutput).not.toMatch(

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
@@ -16,7 +16,7 @@ describe('multiple-lockfiles - has-turbo-root', () => {
       }),
     },
     // So that ../package-lock.json doesn't leave the isolated testDir
-    dirSuffix: '/root',
+    subDir: 'test',
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
@@ -14,7 +14,7 @@ describe('multiple-lockfiles', () => {
       }),
     },
     // So that ../package-lock.json doesn't leave the isolated testDir
-    dirSuffix: '/root',
+    subDir: 'test',
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
@@ -1,5 +1,4 @@
 import { join } from 'path'
-import { unlink } from 'fs/promises'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('multiple-lockfiles', () => {
@@ -14,17 +13,14 @@ describe('multiple-lockfiles', () => {
         lockfileVersion: 3,
       }),
     },
+    // So that ../package-lock.json doesn't leave the isolated testDir
+    dirSuffix: '/root',
     skipDeployment: true,
   })
 
   if (skipped) {
     return
   }
-
-  afterAll(async () => {
-    // Cleanup to ensure it doesn't affect other tests.
-    await unlink(join(next.testDir, '../package-lock.json'))
-  })
 
   it('should have multiple lockfiles warnings', async () => {
     expect(next.cliOutput).toMatch(

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -39,7 +39,7 @@ async function installDependencies(cwd, tmpDir) {
  * @param {object | null} [param0.resolutions]
  * @param { ((ctx: { dependencies: { [key: string]: string } }) => string) | string | null} [param0.installCommand]
  * @param {object} [param0.packageJson]
- * @param {string} [param0.dirSuffix]
+ * @param {string} [param0.subDir]
  * @param {boolean} [param0.keepRepoDir]
  * @param {(span: import('@next/telemetry').Span, installDir: string) => Promise<void>} param0.beforeInstall
  * @returns {Promise<{installDir: string, pkgPaths: Map<string, string>, tmpRepoDir: string | undefined}>}
@@ -50,7 +50,7 @@ async function createNextInstall({
   resolutions = null,
   installCommand = null,
   packageJson = {},
-  dirSuffix = '',
+  subDir = '',
   keepRepoDir = false,
   beforeInstall,
 }) {
@@ -62,7 +62,8 @@ async function createNextInstall({
       const origRepoDir = path.join(__dirname, '../../')
       const installDir = path.join(
         tmpDir,
-        `next-install-${randomBytes(32).toString('hex')}${dirSuffix}`
+        `next-install-${randomBytes(32).toString('hex')}`,
+        subDir
       )
       let tmpRepoDir
       require('console').log('Creating next instance in:')
@@ -77,7 +78,8 @@ async function createNextInstall({
       } else {
         tmpRepoDir = path.join(
           tmpDir,
-          `next-repo-${randomBytes(32).toString('hex')}${dirSuffix}`
+          `next-repo-${randomBytes(32).toString('hex')}`,
+          subDir
         )
         require('console').log('Creating temp repo dir', tmpRepoDir)
 

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -40,7 +40,7 @@ export interface NextInstanceOpts {
   startCommand?: string
   startArgs?: string[]
   env?: Record<string, string>
-  dirSuffix?: string
+  subDir?: string
   turbo?: boolean
   forcedPort?: string
   serverReadyPattern?: RegExp
@@ -85,7 +85,7 @@ export class NextInstance {
   protected basePath?: string
   public env: Record<string, string>
   public forcedPort?: string
-  public dirSuffix: string = ''
+  public subDir: string = ''
   public startServerTimeout: number = 10_000 // 10 seconds
   public serverReadyPattern: RegExp = / ✓ Ready in /
   patchFileDelay: number = 0
@@ -201,9 +201,8 @@ export class NextInstance {
           : process.env.NEXT_TEST_DIR || (await fs.realpath(os.tmpdir()))
         this.testDir = path.join(
           tmpDir,
-          `next-test-${Date.now()}-${(Math.random() * 1000) | 0}${
-            this.dirSuffix
-          }`
+          `next-test-${Date.now()}-${(Math.random() * 1000) | 0}`,
+          this.subDir
         )
 
         const reactVersion =
@@ -273,7 +272,7 @@ export class NextInstance {
               resolutions: this.resolutions ?? null,
               installCommand: this.installCommand,
               packageJson: this.packageJson,
-              dirSuffix: this.dirSuffix,
+              subDir: this.subDir,
               keepRepoDir: true,
               beforeInstall: async (span, installDir) => {
                 this.testDir = installDir


### PR DESCRIPTION
Writing to `join(next.testDir, '../package-lock.json')` breaks test isolation.

Closes PACK-5355