### PR TITLE
fix global not found canont static shell with sync io

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1462,15 +1462,8 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                             parallel_routes: FxIndexMap::default(),
                             modules: if use_global_not_found {
                                 // if global-not-found.js is present:
-                                // we use it for the page and no layout, since layout is included in global-not-found.js;
+                                // leaf module only keeps page pointing to empty-stub
                                 AppDirModules {
-                                    layout: match modules.global_not_found {
-                                        Some(v) => Some(v),
-                                        None =>  Some(get_next_package(app_dir.clone())
-                                            .await?
-                                            .join("dist/client/components/builtin/global-not-found.js")?,
-                                        ),
-                                    },
                                     // page is built-in/empty-stub
                                     page: Some(get_next_package(app_dir.clone())
                                         .await?
@@ -1507,7 +1500,14 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                 // Otherwise, we need to compose it with the root layout to compose with
                 // not-found.js boundary.
                 layout: if use_global_not_found {
-                    None
+                    match modules.global_not_found {
+                        Some(v) => Some(v),
+                        None => Some(
+                            get_next_package(app_dir.clone())
+                                .await?
+                                .join("dist/client/components/builtin/global-not-found.js")?,
+                        ),
+                    }
                 } else {
                     modules.layout
                 },
@@ -1515,7 +1515,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
             },
             global_metadata,
         }
-            .resolved_cell();
+        .resolved_cell();
 
         {
             let app_page = app_page

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1464,14 +1464,18 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                                 // if global-not-found.js is present:
                                 // we use it for the page and no layout, since layout is included in global-not-found.js;
                                 AppDirModules {
-                                    layout: None,
-                                    page: match modules.global_not_found {
+                                    layout: match modules.global_not_found {
                                         Some(v) => Some(v),
                                         None =>  Some(get_next_package(app_dir.clone())
                                             .await?
                                             .join("dist/client/components/builtin/global-not-found.js")?,
                                         ),
                                     },
+                                    // page is built-in/empty-stub
+                                    page: Some(get_next_package(app_dir.clone())
+                                        .await?
+                                        .join("dist/client/components/builtin/empty-stub.js")?,
+                                    ),
                                     ..Default::default()
                                 }
                             } else {

--- a/packages/next/src/client/components/builtin/empty-stub.tsx
+++ b/packages/next/src/client/components/builtin/empty-stub.tsx
@@ -1,0 +1,3 @@
+export default function Empty() {
+  return null
+}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -349,7 +349,6 @@ function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
         page: [() => null, 'next/dist/client/components/builtin/empty-stub'],
       }
     : {
-        layout: components['layout'],
         page: components['not-found'],
       }
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -343,16 +343,20 @@ function parseRequestHeaders(
 function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
   const components = loaderTree[2]
   const hasGlobalNotFound = !!components['global-not-found']
+  const notFoundTreeComponents: LoaderTree[2] = hasGlobalNotFound
+    ? {
+        layout: components['global-not-found']!,
+        page: [() => null, 'next/dist/client/components/builtin/empty-stub'],
+      }
+    : {
+        layout: components['layout'],
+        page: components['not-found'],
+      }
+
   return [
     '',
     {
-      children: [
-        PAGE_SEGMENT_KEY,
-        {},
-        {
-          page: components['global-not-found'] ?? components['not-found'],
-        },
-      ],
+      children: [PAGE_SEGMENT_KEY, {}, notFoundTreeComponents],
     },
     // When global-not-found is present, skip layout from components
     hasGlobalNotFound ? components : {},

--- a/test/e2e/app-dir/global-not-found/cache-components/app/action/actions.ts
+++ b/test/e2e/app-dir/global-not-found/cache-components/app/action/actions.ts
@@ -1,0 +1,7 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+
+export async function callNotFoundInAction() {
+  redirect('/not-found')
+}

--- a/test/e2e/app-dir/global-not-found/cache-components/app/action/page.tsx
+++ b/test/e2e/app-dir/global-not-found/cache-components/app/action/page.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useActionState } from 'react'
+import Form from 'next/form'
+
+import { callNotFoundInAction } from './actions'
+
+export default function Home() {
+  const [, submit] = useActionState(callNotFoundInAction, null)
+  return (
+    <>
+      <div>hello</div>
+      <div>
+        <Form action={submit}>
+          <button id="not-found-btn" type="submit">
+            Submit
+          </button>
+        </Form>
+      </div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/global-not-found/cache-components/app/global-not-found.tsx
+++ b/test/e2e/app-dir/global-not-found/cache-components/app/global-not-found.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+import { Year } from './year'
+
+export const metadata: Metadata = {
+  title: 'Global Not Found',
+}
+
+export default function GlobalNotFound() {
+  return (
+    <html lang="en">
+      <body>
+        <h1>Global Not Found</h1>
+        <Suspense>
+          <Year />
+        </Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/global-not-found/cache-components/app/layout.tsx
+++ b/test/e2e/app-dir/global-not-found/cache-components/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/global-not-found/cache-components/app/year.tsx
+++ b/test/e2e/app-dir/global-not-found/cache-components/app/year.tsx
@@ -1,0 +1,6 @@
+'use client'
+import { Suspense } from 'react'
+
+export function Year() {
+  return <Suspense>{new Date().getFullYear()}</Suspense>
+}

--- a/test/e2e/app-dir/global-not-found/cache-components/cache-components.test.ts
+++ b/test/e2e/app-dir/global-not-found/cache-components/cache-components.test.ts
@@ -1,0 +1,28 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('global-not-found - cache-components', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render global-not-found for 404 routes', async () => {
+    await next.fetch('/does-not-exist')
+    expect(next.cliOutput).not.toContain(
+      'did not produce a static shell and Next.js was unable to determine a reason. This is a bug in Next.js'
+    )
+  })
+
+  it('should render not-found boundary when calling notFound() in a page', async () => {
+    const browser = await next.browser('/action')
+    // submit form with #not-found-btn button
+    await browser.elementByCss('#not-found-btn').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('h1').text()).toBe('Global Not Found')
+    })
+    expect(next.cliOutput).not.toContain(
+      'did not produce a static shell and Next.js was unable to determine a reason. This is a bug in Next.js'
+    )
+  })
+})

--- a/test/e2e/app-dir/global-not-found/cache-components/next.config.mjs
+++ b/test/e2e/app-dir/global-not-found/cache-components/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    cacheComponents: true,
+    globalNotFound: true,
+  },
+}
+
+export default nextConfig


### PR DESCRIPTION
Noticed when I use `Date` api in global-not-found then it's triggering an error `Route /_not-found did not produce a static shell and Next.js was unable to determine a reason.`.
It turns out that if we have sync IO in the layout under suspense boundary, it can still successfully postpone and produce the static shell, but for `global-not-found` the entire content was in the page and the suspense causes the prelude to be empty then the static shell is not generated.

This PR changes the tree structure of global-not-found to render the content in `layout` module, and there's an empty `page` stub that ensure the tree can be rendered as a App Router page. In this way the statc shell can be properly generated during prerender.

Closes NAR-326