### PR TITLE
[sourcemaps] Always check for vendor chunks regardless of Node.js version

### DIFF
--- a/packages/next/src/server/lib/source-maps.ts
+++ b/packages/next/src/server/lib/source-maps.ts
@@ -1,14 +1,9 @@
-import type { SourceMap } from 'module'
 import { LRUCache } from './lru-cache'
 
-function noSourceMap(): SourceMap | undefined {
-  return undefined
-}
-
 // Edge runtime does not implement `module`
-const nativeFindSourceMap =
+const findSourceMap =
   process.env.NEXT_RUNTIME === 'edge'
-    ? noSourceMap
+    ? () => undefined
     : (require('module') as typeof import('module')).findSourceMap
 
 /**
@@ -103,13 +98,6 @@ export function findApplicableSourceMapPayload(
 }
 
 const didWarnAboutInvalidSourceMapDEV = new Set<string>()
-
-const findSourceMap: (scriptNameOrSourceURL: string) => SourceMap | undefined =
-  process.env.NEXT_RUNTIME === 'nodejs' &&
-  process.versions.node?.startsWith('18')
-    ? // Node.js 18 has a horribly slow `findSourceMap` implementation
-      noSourceMap
-    : nativeFindSourceMap
 
 export function filterStackFrameDEV(
   sourceURL: string,

--- a/packages/next/src/server/lib/source-maps.ts
+++ b/packages/next/src/server/lib/source-maps.ts
@@ -1,9 +1,14 @@
+import type { SourceMap } from 'module'
 import { LRUCache } from './lru-cache'
+
+function noSourceMap(): SourceMap | undefined {
+  return undefined
+}
 
 // Edge runtime does not implement `module`
 const findSourceMap =
   process.env.NEXT_RUNTIME === 'edge'
-    ? () => undefined
+    ? noSourceMap
     : (require('module') as typeof import('module')).findSourceMap
 
 /**


### PR DESCRIPTION
This PR reverts https://github.com/vercel/next.js/pull/81619 as version 18 gating is no longer necessary.