### PR TITLE
Refactor transpile-config

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -794,5 +794,6 @@
   "793": "No value found for segment key: \"%s\"",
   "794": "Invalid <Link> with <a> child. Please remove <a>.\nLearn more: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor",
   "795": "\\`%s\\` was called from a Server Component. Next.js should be preventing %s from being included in server components statically, but did not in this case.",
-  "796": "Page \"%s\" cannot use \\`export const unstable_prefetch = ...\\` without enabling \\`experimental.cacheComponents\\` and \\`experimental.clientSegmentCache\\`."
+  "796": "Page \"%s\" cannot use \\`export const unstable_prefetch = ...\\` without enabling \\`experimental.cacheComponents\\` and \\`experimental.clientSegmentCache\\`.",
+  "797": "Failed to transpile \"%s\"."
 }

--- a/packages/next/src/build/next-config-ts/transpile-config.ts
+++ b/packages/next/src/build/next-config-ts/transpile-config.ts
@@ -148,6 +148,8 @@ async function handleCJS({
 
     // filename & extension don't matter here
     return requireFromString(code, resolve(cwd, 'next.config.compiled.js'))
+  } catch (error) {
+    throw error
   } finally {
     if (hasRequire) {
       deregisterHook()

--- a/packages/next/src/build/next-config-ts/transpile-config.ts
+++ b/packages/next/src/build/next-config-ts/transpile-config.ts
@@ -11,20 +11,28 @@ function resolveSWCOptions(
   cwd: string,
   compilerOptions: CompilerOptions
 ): SWCOptions {
-  const resolvedBaseUrl = resolve(cwd, compilerOptions.baseUrl ?? '.')
   return {
     jsc: {
       target: 'es5',
       parser: {
         syntax: 'typescript',
       },
-      paths: compilerOptions.paths,
-      baseUrl: resolvedBaseUrl,
+      ...(compilerOptions.paths ? { paths: compilerOptions.paths } : {}),
+      ...(compilerOptions.baseUrl
+        ? // Needs to be an absolute path.
+          { baseUrl: resolve(cwd, compilerOptions.baseUrl) }
+        : {}),
     },
     module: {
       type: 'commonjs',
     },
     isModule: 'unknown',
+    env: {
+      targets: {
+        // Setting the Node.js version can reduce unnecessary code generation.
+        node: process?.versions?.node ?? '20.19.0',
+      },
+    },
   } satisfies SWCOptions
 }
 
@@ -102,14 +110,31 @@ export async function transpileConfig({
   configFileName: string
   cwd: string
 }) {
-  let hasRequire = false
   try {
     // Ensure TypeScript is installed to use the API.
     await verifyTypeScriptSetup(cwd, configFileName)
-
     const compilerOptions = await getTsConfig(cwd)
-    const swcOptions = resolveSWCOptions(cwd, compilerOptions)
 
+    return handleCJS({ cwd, nextConfigPath, compilerOptions })
+  } catch (cause) {
+    throw new Error(`Failed to transpile "${configFileName}".`, {
+      cause,
+    })
+  }
+}
+
+async function handleCJS({
+  cwd,
+  nextConfigPath,
+  compilerOptions,
+}: {
+  cwd: string
+  nextConfigPath: string
+  compilerOptions: CompilerOptions
+}) {
+  const swcOptions = resolveSWCOptions(cwd, compilerOptions)
+  let hasRequire = false
+  try {
     const nextConfigString = await readFile(nextConfigPath, 'utf8')
     // lazy require swc since it loads React before even setting NODE_ENV
     // resulting loading Development React on Production
@@ -124,8 +149,6 @@ export async function transpileConfig({
 
     // filename & extension don't matter here
     return requireFromString(code, resolve(cwd, 'next.config.compiled.js'))
-  } catch (error) {
-    throw error
   } finally {
     if (hasRequire) {
       deregisterHook()

--- a/packages/next/src/build/next-config-ts/transpile-config.ts
+++ b/packages/next/src/build/next-config-ts/transpile-config.ts
@@ -13,7 +13,6 @@ function resolveSWCOptions(
 ): SWCOptions {
   return {
     jsc: {
-      target: 'es5',
       parser: {
         syntax: 'typescript',
       },

--- a/packages/next/src/build/next-config-ts/transpile-config.ts
+++ b/packages/next/src/build/next-config-ts/transpile-config.ts
@@ -20,7 +20,10 @@ function resolveSWCOptions(
       ...(compilerOptions.baseUrl
         ? // Needs to be an absolute path.
           { baseUrl: resolve(cwd, compilerOptions.baseUrl) }
-        : {}),
+        : compilerOptions.paths
+          ? // If paths is given, baseUrl is required.
+            { baseUrl: cwd }
+          : {}),
     },
     module: {
       type: 'commonjs',
@@ -86,7 +89,7 @@ async function getTsConfig(cwd: string): Promise<CompilerOptions> {
 
   if (!tsConfigPath) {
     // It is ok to not return ts.getDefaultCompilerOptions() because
-    // we are only lookfing for paths and baseUrl from tsConfig.
+    // we are only looking for paths and baseUrl from tsConfig.
     return {}
   }
 


### PR DESCRIPTION
Refactors before adding ESM handling of next config ts.

- Add `paths` and `baseUrl` value only when provided
  - Removes SWC unnecessary `baseUrl` handling
- Use `env.targets.node` instead of `jsc.target: es5`
  - Reduces lines of transpiled code

| `jsc.target: es5` | `env.targets.node: 20` |
|--------|--------|
| <img width="1672" height="1604" alt="CleanShot 2025-08-27 at 17 56 36@2x" src="https://github.com/user-attachments/assets/ad1cd018-208d-4a5b-a104-db0c149884a9" /> | <img width="1672" height="1604" alt="CleanShot 2025-08-27 at 17 56 42@2x" src="https://github.com/user-attachments/assets/3554a04a-3bcf-4c22-8e8e-d8da6262e32b" /> | 