### PR TITLE
[Breaking] remove deprecated `devIndicators` options

### DIFF
--- a/crates/next-build-test/nextConfig.json
+++ b/crates/next-build-test/nextConfig.json
@@ -37,7 +37,7 @@
     "unoptimized": false
   },
   "devIndicators": {
-    "buildActivityPosition": "bottom-right"
+    "position": "bottom-right"
   },
   "onDemandEntries": {
     "maxInactiveAge": 60000,

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/devIndicators.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/devIndicators.mdx
@@ -54,5 +54,6 @@ When exporting [`getServerSideProps`](/docs/pages/building-your-application/data
 
 | Version   | Changes                                                                                                                                             |
 | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `v16.0.0` | `appIsrStatus`, `buildActivity`, and `buildActivityPosition` options have been removed.                                                             |
 | `v15.2.0` | Improved on-screen indicator with new `position` option. `appIsrStatus`, `buildActivity`, and `buildActivityPosition` options have been deprecated. |
 | `v15.0.0` | Static on-screen indicator added with `appIsrStatus` option.                                                                                        |

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2301,7 +2301,7 @@ export default async function getBaseWebpackConfig(
     crossOrigin: config.crossOrigin,
     pageExtensions: pageExtensions,
     trailingSlash: config.trailingSlash,
-    buildActivityPosition:
+    devIndicatorsPosition:
       config.devIndicators === false
         ? undefined
         : config.devIndicators.position,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -300,14 +300,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
     devIndicators: z
       .union([
         z.object({
-          buildActivityPosition: z
-            .union([
-              z.literal('bottom-left'),
-              z.literal('bottom-right'),
-              z.literal('top-left'),
-              z.literal('top-right'),
-            ])
-            .optional(),
           position: z
             .union([
               z.literal('bottom-left'),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1146,28 +1146,6 @@ export interface NextConfig extends Record<string, any> {
     | false
     | {
         /**
-         * @deprecated The dev tools indicator has it enabled by default. To disable, set `devIndicators` to `false`.
-         * */
-        appIsrStatus?: boolean
-
-        /**
-         * Show "building..." indicator in development
-         * @deprecated The dev tools indicator has it enabled by default. To disable, set `devIndicators` to `false`.
-         */
-        buildActivity?: boolean
-
-        /**
-         * Position of "building..." indicator in browser
-         * @default "bottom-right"
-         * @deprecated Renamed as `position`.
-         */
-        buildActivityPosition?:
-          | 'top-left'
-          | 'top-right'
-          | 'bottom-left'
-          | 'bottom-right'
-
-        /**
          * Position of the development tools indicator in the browser window.
          * @default "bottom-left"
          * */

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -135,27 +135,6 @@ function checkDeprecations(
     silent
   )
 
-  warnOptionHasBeenDeprecated(
-    userConfig,
-    'devIndicators.appIsrStatus',
-    `\`devIndicators.appIsrStatus\` is deprecated and no longer configurable. Please remove it from ${configFileName}.`,
-    silent
-  )
-
-  warnOptionHasBeenDeprecated(
-    userConfig,
-    'devIndicators.buildActivity',
-    `\`devIndicators.buildActivity\` is deprecated and no longer configurable. Please remove it from ${configFileName}.`,
-    silent
-  )
-
-  warnOptionHasBeenDeprecated(
-    userConfig,
-    'devIndicators.buildActivityPosition',
-    `\`devIndicators.buildActivityPosition\` has been renamed to \`devIndicators.position\`. Please update your ${configFileName} file accordingly.`,
-    silent
-  )
-
   // i18n deprecation for App Router
   if (userConfig.i18n) {
     const hasAppDir = Boolean(findDir(dir, 'app'))
@@ -593,21 +572,6 @@ function assignDefaultsAndValidate(
     configFileName,
     silent
   )
-
-  // Handle buildActivityPosition migration (needs to be done after merging with defaults)
-  if (
-    result.devIndicators &&
-    typeof result.devIndicators === 'object' &&
-    'buildActivityPosition' in result.devIndicators &&
-    result.devIndicators.buildActivityPosition !== result.devIndicators.position
-  ) {
-    if (!silent) {
-      Log.warnOnce(
-        `The \`devIndicators\` option \`buildActivityPosition\` ("${result.devIndicators.buildActivityPosition}") conflicts with \`position\` ("${result.devIndicators.position}"). Using \`buildActivityPosition\` ("${result.devIndicators.buildActivityPosition}") for backward compatibility.`
-      )
-    }
-    result.devIndicators.position = result.devIndicators.buildActivityPosition
-  }
 
   warnOptionHasBeenMovedOutOfExperimental(
     result,

--- a/test/integration/build-indicator/test/index.test.js
+++ b/test/integration/build-indicator/test/index.test.js
@@ -25,7 +25,7 @@ const installCheckVisible = (browser) => {
 }
 
 describe('Build Activity Indicator', () => {
-  it('should validate buildActivityPosition config', async () => {
+  it('should validate position config', async () => {
     let stderr = ''
     const configPath = join(appDir, 'next.config.js')
     await fs.writeFile(
@@ -33,7 +33,7 @@ describe('Build Activity Indicator', () => {
       `
       module.exports = {
         devIndicators: {
-          buildActivityPosition: 'ttop-leff'
+          position: 'ttop-leff'
         }
       }
     `

--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -10451,7 +10451,7 @@
       "Build Activity Indicator Enabled - (app) webpack only Shows the build indicator when a page is built during navigation",
       "Build Activity Indicator Enabled - (pages) Shows build indicator when page is built from modifying",
       "Build Activity Indicator Enabled - (pages) webpack only Shows the build indicator when a page is built during navigation",
-      "Build Activity Indicator should validate buildActivityPosition config"
+      "Build Activity Indicator should validate position config"
     ],
     "failed": [],
     "pending": [],

--- a/test/rspack-dev-tests-manifest.json
+++ b/test/rspack-dev-tests-manifest.json
@@ -12144,7 +12144,7 @@
       "Build Activity Indicator Enabled - (app) webpack only Shows the build indicator when a page is built during navigation",
       "Build Activity Indicator Enabled - (pages) Shows build indicator when page is built from modifying",
       "Build Activity Indicator Enabled - (pages) webpack only Shows the build indicator when a page is built during navigation",
-      "Build Activity Indicator should validate buildActivityPosition config"
+      "Build Activity Indicator should validate position config"
     ],
     "failed": [],
     "pending": [],

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -9754,7 +9754,7 @@
     "passed": [
       "Build Activity Indicator Enabled - (app) Shows build indicator when page is built from modifying",
       "Build Activity Indicator Enabled - (pages) Shows build indicator when page is built from modifying",
-      "Build Activity Indicator should validate buildActivityPosition config"
+      "Build Activity Indicator should validate position config"
     ],
     "failed": [],
     "pending": [

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -13295,7 +13295,7 @@
     "passed": [
       "Build Activity Indicator Enabled - (app) Shows build indicator when page is built from modifying",
       "Build Activity Indicator Enabled - (pages) Shows build indicator when page is built from modifying",
-      "Build Activity Indicator should validate buildActivityPosition config"
+      "Build Activity Indicator should validate position config"
     ],
     "failed": [],
     "pending": [


### PR DESCRIPTION
This PR removed deprecated `devIndicators` options since v15.2.0.