### PR TITLE
Turbopack: Allow arrays to be used as values in `turbopack.rules` config

### DIFF
--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = "0.21.0"
-either = { workspace = true }
+either = { workspace = true, features = ["serde"] }
 once_cell = { workspace = true }
 qstring = { workspace = true }
 regex = { workspace = true }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -12,7 +12,7 @@ import type {
   TurbopackOptions,
   TurbopackRuleConfigItem,
   TurbopackRuleConfigItemOptions,
-  TurbopackRuleConfigItemOrShortcut,
+  TurbopackRuleConfigCollection,
   TurbopackRuleCondition,
   TurbopackLoaderBuiltinCondition,
 } from './config-shared'
@@ -151,11 +151,14 @@ const zTurbopackRuleConfigItem: zod.ZodType<TurbopackRuleConfigItem> = z.union([
   zTurbopackRuleConfigItemOptions,
 ])
 
-const zTurbopackRuleConfigItemOrShortcut: zod.ZodType<TurbopackRuleConfigItemOrShortcut> =
-  z.union([z.array(zTurbopackLoaderItem), zTurbopackRuleConfigItem])
+const zTurbopackRuleConfigCollection: zod.ZodType<TurbopackRuleConfigCollection> =
+  z.union([
+    zTurbopackRuleConfigItem,
+    z.array(z.union([zTurbopackLoaderItem, zTurbopackRuleConfigItemOptions])),
+  ])
 
 const zTurbopackConfig: zod.ZodType<TurbopackOptions> = z.strictObject({
-  rules: z.record(z.string(), zTurbopackRuleConfigItemOrShortcut).optional(),
+  rules: z.record(z.string(), zTurbopackRuleConfigCollection).optional(),
   conditions: z.record(z.string(), zTurbopackCondition).optional(),
   resolveAlias: z
     .record(
@@ -177,7 +180,7 @@ const zTurbopackConfig: zod.ZodType<TurbopackOptions> = z.strictObject({
 const zDeprecatedExperimentalTurboConfig: zod.ZodType<DeprecatedExperimentalTurboOptions> =
   z.strictObject({
     loaders: z.record(z.string(), z.array(zTurbopackLoaderItem)).optional(),
-    rules: z.record(z.string(), zTurbopackRuleConfigItemOrShortcut).optional(),
+    rules: z.record(z.string(), zTurbopackRuleConfigCollection).optional(),
     resolveAlias: z
       .record(
         z.string(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -289,9 +289,18 @@ export type TurbopackRuleConfigItem =
   | { [condition in TurbopackLoaderBuiltinCondition]?: TurbopackRuleConfigItem }
   | false
 
-export type TurbopackRuleConfigItemOrShortcut =
-  | TurbopackLoaderItem[]
+/**
+ * This can be an object representing a single configuration, or a list of
+ * loaders and/or rule configuration objects.
+ *
+ * - A list of loader path strings or objects is the "shorthand" syntax.
+ * - A list of rule configuration objects can be useful when each configuration
+ *   object has different `condition` fields, but still match the same top-level
+ *   path glob.
+ */
+export type TurbopackRuleConfigCollection =
   | TurbopackRuleConfigItem
+  | (TurbopackLoaderItem | TurbopackRuleConfigItemOptions)[]
 
 export interface TurbopackOptions {
   /**
@@ -316,7 +325,7 @@ export interface TurbopackOptions {
    *
    * @see [Turbopack Loaders](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders)
    */
-  rules?: Record<string, TurbopackRuleConfigItemOrShortcut>
+  rules?: Record<string, TurbopackRuleConfigCollection>
 
   /**
    * (`next --turbopack` only) A list of conditions to apply when running webpack loaders with Turbopack.

--- a/test/e2e/turbopack-loader-config/next.config.ts
+++ b/test/e2e/turbopack-loader-config/next.config.ts
@@ -7,56 +7,58 @@ export default {
         // use the shorthand syntax
         loaders: ['./webpack-loader-replace-with-stub.cjs'],
       },
-      // this condition should not match
-      'bar.js': {
-        condition: 'foreign',
-        loaders: [
-          {
-            loader: './webpack-loader-replace-with-stub.cjs',
-            options: { returnValue: 'foreign' },
-          },
-        ],
-      },
-      // this condition should not match
-      '{bar}.js': {
-        condition: {
-          not: { content: /export/ },
-        },
-        loaders: [
-          {
-            loader: './webpack-loader-replace-with-stub.cjs',
-            options: { returnValue: 'missing export' },
-          },
-        ],
-      },
-      // this should match on dev
-      '{bar.js}': {
-        condition: {
-          any: [
+      'bar.js': [
+        // this condition should not match
+        {
+          condition: 'foreign',
+          loaders: [
             {
-              all: ['development', { not: { not: { content: /export/ } } }],
+              loader: './webpack-loader-replace-with-stub.cjs',
+              options: { returnValue: 'foreign' },
             },
           ],
         },
-        loaders: [
-          {
-            loader: './webpack-loader-replace-with-stub.cjs',
-            options: { returnValue: 'has export substring on dev' },
+        // this condition should not match
+        {
+          condition: {
+            not: { content: /export/ },
           },
-        ],
-      },
-      // this should match on production
-      'bar.{js}': {
-        condition: {
-          all: [{ not: 'development' }, { content: /export/ }],
+          loaders: [
+            {
+              loader: './webpack-loader-replace-with-stub.cjs',
+              options: { returnValue: 'missing export' },
+            },
+          ],
         },
-        loaders: [
-          {
-            loader: './webpack-loader-replace-with-stub.cjs',
-            options: { returnValue: 'has export substring on prod' },
+        // this should match on dev
+        {
+          condition: {
+            any: [
+              {
+                all: ['development', { not: { not: { content: /export/ } } }],
+              },
+            ],
           },
-        ],
-      },
+          loaders: [
+            {
+              loader: './webpack-loader-replace-with-stub.cjs',
+              options: { returnValue: 'has export substring on dev' },
+            },
+          ],
+        },
+        // this should match on production
+        {
+          condition: {
+            all: [{ not: 'development' }, { content: /export/ }],
+          },
+          loaders: [
+            {
+              loader: './webpack-loader-replace-with-stub.cjs',
+              options: { returnValue: 'has export substring on prod' },
+            },
+          ],
+        },
+      ],
     },
   },
 }


### PR DESCRIPTION
This implements the last part of the syntax proposal in #82857.

We want to support this syntax:

```javascript
module.exports = {
  turbopack: {
    rules: {
      // all matched rules apply, adding their loaders in order
      '*.svg': [
        // this optionally can be an array of objects (shown here), or just an object
        {
          // this condition is matched after the glob
          condition: {
            all: [
              { not: 'foreign' }, // excludes `node_modules`
              { path: /app\/.*\.svg/, content: /\<svg[^\>]*\>/ },
            ],
          },
          loaders: ['@svgr/webpack'],
          as: '*.js',
        },
      ],
    },
  },
}
```

Prior to this PR, the value of `'*.svg'` in the `turbopack.rules` object had to be a configuration object or an array of shorthand loader syntax. After this PR, it can be an array of "full" configuration objects.

Closes PACK-5372