### PR TITLE
[metadata] refine metadata image error for webpack

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -128,7 +128,10 @@ async function nextMetadataImageLoader(
 
   const imageSize: { width?: number; height?: number } = await getImageSize(
     content
-  ).catch(() => ({ width: undefined, height: undefined }))
+  ).catch((error) => {
+    console.error(`Acquire image size of ${interpolatedName} failed:`, error)
+    return { width: undefined, height: undefined }
+  })
 
   const imageData: Omit<MetadataImageModule, 'url'> = {
     ...(extension in imageExtMimeTypeMap && {

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -126,12 +126,18 @@ async function nextMetadataImageLoader(
     }`
   }
 
+  let imageError
   const imageSize: { width?: number; height?: number } = await getImageSize(
     content
   ).catch((error) => {
-    console.error(`Acquire image size of ${interpolatedName} failed:`, error)
-    return { width: undefined, height: undefined }
+    const message = `Process image "${path.posix.join(segment || '/', interpolatedName)}" failed: ${error}`
+    imageError = new Error(message)
+    return {}
   })
+
+  if (imageError) {
+    throw imageError
+  }
 
   const imageData: Omit<MetadataImageModule, 'url'> = {
     ...(extension in imageExtMimeTypeMap && {

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -128,13 +128,7 @@ async function nextMetadataImageLoader(
 
   const imageSize: { width?: number; height?: number } = await getImageSize(
     content
-  ).catch((err) => err)
-
-  if (imageSize instanceof Error) {
-    const err = imageSize
-    err.name = 'InvalidImageFormatError'
-    throw err
-  }
+  ).catch(() => ({ width: undefined, height: undefined }))
 
   const imageData: Omit<MetadataImageModule, 'url'> = {
     ...(extension in imageExtMimeTypeMap && {

--- a/test/e2e/app-dir/metadata-invalid-image-file/app/favicon.ico
+++ b/test/e2e/app-dir/metadata-invalid-image-file/app/favicon.ico
@@ -1,0 +1,1 @@
+malformed image content

--- a/test/e2e/app-dir/metadata-invalid-image-file/app/layout.tsx
+++ b/test/e2e/app-dir/metadata-invalid-image-file/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/metadata-invalid-image-file/app/page.tsx
+++ b/test/e2e/app-dir/metadata-invalid-image-file/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/metadata-invalid-image-file/metadata-invalid-image-file.test.ts
+++ b/test/e2e/app-dir/metadata-invalid-image-file/metadata-invalid-image-file.test.ts
@@ -1,0 +1,43 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('metadata-invalid-image-file', () => {
+  const { next, isTurbopack, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  if (skipped) return
+
+  it('should error on invalid metadata image file', async () => {
+    // In dev, it needs to render the page first
+    if (isNextDev) {
+      await next.start()
+      await next.fetch('/')
+    } else {
+      await next.build()
+    }
+
+    if (isTurbopack) {
+      // In turbopack the image decoding error is displayed in multiple lines
+      expect(next.cliOutput).toContain('app/favicon.ico')
+      expect(next.cliOutput).toContain('Processing image failed')
+      expect(next.cliOutput).toContain('unable to decode image data')
+    } else {
+      expect(next.cliOutput).toContain(
+        'Error: Process image "/favicon.ico" failed:'
+      )
+    }
+
+    if (!isNextDev) {
+      // `next build` should fail
+      if (isTurbopack) {
+        expect(next.cliOutput).toContain('Build error occurred')
+      } else {
+        expect(next.cliOutput).toContain(
+          'Build failed because of webpack errors'
+        )
+      }
+    }
+  })
+})

--- a/test/e2e/app-dir/metadata-invalid-image-file/next.config.js
+++ b/test/e2e/app-dir/metadata-invalid-image-file/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
We don't need to throw when failed to query the image size, just leave as empty. One case was that image from git LFS which is a virtual file that the size can't be accessed.

The error message was bit vague with webpack build that hard to read and make people think it could be a framework or webpack loader issue
```
Error: Image import "next-metadata-image-loader?type=favicon&segment=&basePath=&pageExtensions=tsx&pageExtensions=ts&pageExtensions=jsx&pageExtensions=js!/.../app/favicon.ico?__next_metadata__" is not a valid image file. The image may be corrupted or an unsupported format.
```

After this change, we'll still log the `image-size` error but with a more reasonable error message
```
Error: Process image "/favicon.ico" failed: <actual error message from `image-size` library>
```

Closes NAR-341