### PR TITLE
next-codemod: Migrate legacy ESLint configs to flat config, upgrade to ESLint v9, and allow installs from custom cwd

### DIFF
--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -83,6 +83,7 @@ export function installPackages(
     packageManager?: PackageManager
     silent?: boolean
     dev?: boolean
+    cwd?: string
   } = {}
 ) {
   if (packageToInstall.length === 0) return
@@ -91,6 +92,7 @@ export function installPackages(
     packageManager = getPkgManager(process.cwd()),
     silent = false,
     dev = false,
+    cwd = process.cwd(),
   } = options
 
   if (!packageManager) throw new Error('Failed to find package manager')
@@ -107,6 +109,7 @@ export function installPackages(
       // Keeping stderr since it'll likely be relevant later when it fails.
       stdio: silent ? ['ignore', 'ignore', 'inherit'] : 'inherit',
       shell: true,
+      cwd,
     })
   } catch (error) {
     throw new Error(

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-eslint.output.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/existing-eslint.output.json
@@ -14,7 +14,7 @@
     "next": "15.0.0"
   },
   "devDependencies": {
-    "eslint": "^8.0.0",
+    "eslint": "^9",
     "eslint-config-next": "15.0.0",
     "@eslint/eslintrc": "^3"
   }


### PR DESCRIPTION
### What & why
- **Modernize ESLint setup**: Smoothly migrate projects using `next lint` and legacy `.eslintrc*` to the ESLint v9 flat config.
- **Reliably install deps**: Ensure package installs run in the correct target folder during codemods.

### Changes
- **Legacy to flat config migration**
  - Generate `eslint.config.mjs` from legacy `.eslintrc*` (JSON and bare), using `FlatCompat`.
  - Preserve existing rules and extend `next/core-web-vitals`.
  - Add sensible `ignores` (e.g. `node_modules/**`).
- **Update existing flat configs (CJS)**
  - If a CommonJS flat config exports an identifier/array, augment it with Next.js configs and `ignores` while preserving original rules.
- **Dependency updates**
  - Upgrade `eslint` to `^9` when older versions are detected.
  - Preserve existing `eslint-config-next` version.
  - Ensure `@eslint/eslintrc` `^3` is present for compat.
- **Installer improvements**
  - `installPackages` now accepts `cwd` and passes it to the underlying process to run installs in the intended directory.
- **Tests/fixtures**
  - Expanded and renamed tests to reflect migration behavior and ESLint v9 upgrade.
  - Updated fixtures to expect `eslint` `^9` and generated flat configs.

### Notes
- Aimed at codemod behavior; no runtime changes to Next.js.
- Helps users migrate to ESLint v9 flat config with minimal manual steps.