### PR TITLE
Update caching.mdx

### DIFF
--- a/docs/01-app/02-guides/caching.mdx
+++ b/docs/01-app/02-guides/caching.mdx
@@ -419,9 +419,9 @@ See the [`useRouter` hook](/docs/app/api-reference/functions/use-router) API ref
 
 ### `fetch`
 
-Data returned from `fetch` is _not_ automatically cached in the Data Cache.
+Data returned from `fetch` is automatically cached in the Data Cache.
 
-The default caching behavior of `fetch` (e.g., when the `cache` option is not specified) is equal to setting the `cache` option to `no-store`:
+The default caching behavior of `fetch` (e.g., when the `cache` option is not specified) is not equal to setting the `cache` option to `no-store`:
 
 ```js
 let data = await fetch('https://api.vercel.app/blog', { cache: 'no-store' })


### PR DESCRIPTION
In the docs it says => ( The default caching behavior of fetch (e.g., when the cache option is not specified) is equal to setting the cache option to no-store )

But when I code, I found that fetch default behaviour and setting the cache option to no-store are different.

After building process ....

When changing routes. default is stored as cache. I see that because there is no new network request when I change route. In setting the cache option to no-store, it is making a new network request as soon as i get back to the page.

so docs and real working one are mismatch.

I also provided how tested with pictures belows.
Please build... and check
Change routes...

<img width="545" height="371" alt="image" src="https://github.com/user-attachments/assets/4931302f-b5ef-4016-b43d-cbbd790c1e11" />

<img width="601" height="409" alt="image" src="https://github.com/user-attachments/assets/3f2b4a79-fa24-466f-8330-0dc8323b6c16" />



<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
