### PR TITLE
test: add CI job to run all prod tests with typedRoutes enabled

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -892,6 +892,7 @@ jobs:
         export __NEXT_EXPERIMENTAL_PPR=true # for compatibility with the existing tests
         export __NEXT_EXPERIMENTAL_CACHE_COMPONENTS=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/experimental-tests-manifest.json"
+        export __NEXT_TYPED_ROUTES=true
 
         node run-tests.js \
           --timings \
@@ -915,6 +916,7 @@ jobs:
         export __NEXT_EXPERIMENTAL_CACHE_COMPONENTS=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/experimental-tests-manifest.json"
         export NEXT_TEST_MODE=dev
+        export __NEXT_TYPED_ROUTES=true
 
         node run-tests.js \
           --timings \
@@ -939,6 +941,7 @@ jobs:
         export __NEXT_EXPERIMENTAL_CACHE_COMPONENTS=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/experimental-tests-manifest.json"
         export NEXT_TEST_MODE=start
+        export __NEXT_TYPED_ROUTES=true
 
         node run-tests.js \
           --timings \

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1198,6 +1198,11 @@ function assignDefaultsAndValidate(
     )
   }
 
+  // Override typedRoutes with CLI flag if provided
+  if (process.env.__NEXT_TYPED_ROUTES === 'true') {
+    result.typedRoutes = true
+  }
+
   return result as NextConfigComplete
 }
 


### PR DESCRIPTION
## Enable Typed Routes in CI Testing

This PR enables typed routes testing across all CI test environments by:

- Adding `__NEXT_TYPED_ROUTES=true` environment variable to experimental test workflows (build, dev, and start modes)
- Implementing CLI flag override in server config to force enable `typedRoutes` when the environment variable is set

This ensures typed routes functionality is properly tested in our continuous integration pipeline alongside other experimental features like PPR and cache components.

**Files changed:**
- `.github/workflows/build_and_test.yml` - Added env var to CI workflows
- `packages/next/src/server/config.ts` - Added env var override logic