### PR TITLE
Turbopack: hide blocking spans in trace server

### DIFF
--- a/turbopack/crates/turbopack-trace-server/src/span.rs
+++ b/turbopack/crates/turbopack-trace-server/src/span.rs
@@ -79,7 +79,7 @@ impl Span {
         self.time_data.get_or_init(|| {
             Box::new(SpanTimeData {
                 self_end: self.start,
-                ignore_self_time: &self.name == "thread",
+                ignore_self_time: &self.name == "thread" || &self.name == "blocking",
                 ..Default::default()
             })
         })


### PR DESCRIPTION
### What?

We annotate `block_in_place` with a `blocking` span to allow hiding the blocking time in the trace.

Closes PACK-5378