### PR TITLE
[cna] For pnpm ignore postinstall from `sharp` and `unrs-resolver`

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -320,14 +320,19 @@ export const installTemplate = async ({
   }
 
   if (packageManager === "pnpm") {
-    // TODO: This is a v9 setting that still works in v10. Use pnpm-workspace.yaml
-    // when v10 is used
-    packageJson.pnpm = {
-      // Sharp has prebuilt binaries for the platforms next-swc has binaries.
-      // If it needs to build binaries from source, next-swc wouldn't work either.
-      // See https://sharp.pixelplumbing.com/install/#:~:text=When%20using%20pnpm%2C%20add%20sharp%20to%20ignoredBuiltDependencies%20to%20silence%20warnings
-      neverBuiltDependencies: ["sharp"],
-    };
+    const pnpmWorkspaceYaml = [
+      // required for v9, v10 doesn't need it anymore
+      "packages:",
+      "  - .",
+      // v10 setting without counterpart in v9
+      "ignoredBuiltDependencies:",
+      "  - sharp",
+      "",
+    ].join(os.EOL);
+    await fs.writeFile(
+      path.join(root, "pnpm-workspace.yaml"),
+      pnpmWorkspaceYaml,
+    );
   }
 
   await fs.writeFile(

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -319,10 +319,14 @@ export const installTemplate = async ({
     packageJson.devDependencies = sorted(packageJson.devDependencies);
   }
 
-  /* For pnpm v10+ x-ref: https://github.com/vercel/next.js/issues/83158 */
   if (packageManager === "pnpm") {
+    // TODO: This is a v9 setting that still works in v10. Use pnpm-workspace.yaml
+    // when v10 is used
     packageJson.pnpm = {
-      onlyBuiltDependencies: ["sharp"],
+      // Sharp has prebuilt binaries for the platforms next-swc has binaries.
+      // If it needs to build binaries from source, next-swc wouldn't work either.
+      // See https://sharp.pixelplumbing.com/install/#:~:text=When%20using%20pnpm%2C%20add%20sharp%20to%20ignoredBuiltDependencies%20to%20silence%20warnings
+      neverBuiltDependencies: ["sharp"],
     };
   }
 

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -319,6 +319,13 @@ export const installTemplate = async ({
     packageJson.devDependencies = sorted(packageJson.devDependencies);
   }
 
+  /* For pnpm v10+ x-ref: https://github.com/vercel/next.js/issues/83158 */
+  if (packageManager === "pnpm") {
+    packageJson.pnpm = {
+      onlyBuiltDependencies: ["sharp"],
+    };
+  }
+
   await fs.writeFile(
     path.join(root, "package.json"),
     JSON.stringify(packageJson, null, 2) + os.EOL,

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -326,7 +326,12 @@ export const installTemplate = async ({
       "  - .",
       // v10 setting without counterpart in v9
       "ignoredBuiltDependencies:",
+      // Sharp has prebuilt binaries for the platforms next-swc has binaries.
+      // If it needs to build binaries from source, next-swc wouldn't work either.
+      // See https://sharp.pixelplumbing.com/install/#:~:text=When%20using%20pnpm%2C%20add%20sharp%20to%20ignoredBuiltDependencies%20to%20silence%20warnings
       "  - sharp",
+      // Not needed for pnpm: https://github.com/unrs/unrs-resolver/issues/193#issuecomment-3295510146
+      "  - unrs-resolver",
       "",
     ].join(os.EOL);
     await fs.writeFile(


### PR DESCRIPTION
Fixes: https://github.com/vercel/next.js/issues/83158

There's still two other postinstall that are ignored if you use tw and eslint's next config (?):

```
╭ Warning ───────────────────────────────────────────────────────────────────────────────────╮
│                                                                                            │
│   Ignored build scripts: @tailwindcss/oxide, unrs-resolver.                                │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.   │
│                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
```