### PR TITLE
[test] Run all dev tests with sourcemaps enabled

### DIFF
--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -35,15 +35,11 @@ export const base = curry(function base(
 
   // https://webpack.js.org/configuration/devtool/#development
   if (ctx.isDevelopment) {
-    if (process.env.__NEXT_TEST_MODE && !process.env.__NEXT_TEST_WITH_DEVTOOL) {
-      config.devtool = false
-    } else {
-      // `eval-source-map` provides full-fidelity source maps for the
-      // original source, including columns and original variable names.
-      // This is desirable so the in-browser debugger can correctly pause
-      // and show scoped variables with their original names.
-      config.devtool = 'eval-source-map'
-    }
+    // `eval-source-map` provides full-fidelity source maps for the
+    // original source, including columns and original variable names.
+    // This is desirable so the in-browser debugger can correctly pause
+    // and show scoped variables with their original names.
+    config.devtool = 'eval-source-map'
   } else {
     if (
       ctx.isEdgeRuntime ||

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -5,7 +5,6 @@ import { nextTestSetup } from 'e2e-utils'
 describe('middleware - development errors', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    env: { __NEXT_TEST_WITH_DEVTOOL: '1' },
     patchFileDelay: 500,
   })
   beforeEach(async () => {

--- a/test/integration/client-navigation-a11y/test/index.test.js
+++ b/test/integration/client-navigation-a11y/test/index.test.js
@@ -29,9 +29,7 @@ const getMainHeadingTitle = async (browser) =>
 describe('Client Navigation accessibility', () => {
   beforeAll(async () => {
     context.appPort = await findPort()
-    context.server = await launchApp(appDir, context.appPort, {
-      env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
-    })
+    context.server = await launchApp(appDir, context.appPort)
 
     const prerender = [
       '/page-with-h1-and-title, /page-with-h1, /page-with-title, /page-without-h1-or-title',

--- a/test/integration/config-devtool-dev/test/index.test.js
+++ b/test/integration/config-devtool-dev/test/index.test.js
@@ -22,7 +22,6 @@ const appDir = join(__dirname, '../')
 
       const appPort = await findPort()
       const app = await launchApp(appDir, appPort, {
-        env: { __NEXT_TEST_WITH_DEVTOOL: true },
         onStderr(msg) {
           stderr += msg || ''
         },

--- a/test/integration/edge-runtime-configurable-guards/test/index.test.js
+++ b/test/integration/edge-runtime-configurable-guards/test/index.test.js
@@ -30,7 +30,6 @@ const context = {
   ),
 }
 const appOption = {
-  env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
   onStdout(msg) {
     context.logs.output += msg
     context.logs.stdout += msg

--- a/test/integration/edge-runtime-dynamic-code/test/index.test.js
+++ b/test/integration/edge-runtime-dynamic-code/test/index.test.js
@@ -30,7 +30,6 @@ describe('Page using eval in development mode', () => {
   beforeAll(async () => {
     context.appPort = await findPort()
     context.app = await launchApp(context.appDir, context.appPort, {
-      env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
       onStdout(msg) {
         output += msg
       },
@@ -84,7 +83,6 @@ describe.each([
         beforeAll(async () => {
           context.appPort = await findPort()
           context.app = await launchApp(context.appDir, context.appPort, {
-            env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
             onStdout(msg) {
               output += msg
             },

--- a/test/integration/edge-runtime-module-errors/test/utils.js
+++ b/test/integration/edge-runtime-module-errors/test/utils.js
@@ -11,7 +11,6 @@ export const context = {
   page: new File(join(__dirname, '../pages/index.js')),
 }
 export const appOption = {
-  env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
   onStdout(msg) {
     context.logs.output += msg
     context.logs.stdout += msg

--- a/test/integration/edge-runtime-response-error/test/index.test.js
+++ b/test/integration/edge-runtime-response-error/test/index.test.js
@@ -24,7 +24,6 @@ const context = {
   page: new File(join(__dirname, '../pages/index.js')),
 }
 const appOption = {
-  env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
   onStdout(msg) {
     context.logs.output += msg
     context.logs.stdout += msg

--- a/test/integration/edge-runtime-streaming-error/test/index.test.ts
+++ b/test/integration/edge-runtime-streaming-error/test/index.test.ts
@@ -57,7 +57,6 @@ describe('development mode', () => {
     context.appPort = await findPort()
     context.app = await launchApp(appDir, context.appPort, {
       ...context.handler,
-      env: { __NEXT_TEST_WITH_DEVTOOL: '1' },
     })
   })
 

--- a/test/integration/edge-runtime-with-node.js-apis/test/index.test.ts
+++ b/test/integration/edge-runtime-with-node.js-apis/test/index.test.ts
@@ -73,7 +73,6 @@ describe.each([
       beforeAll(async () => {
         appPort = await findPort()
         app = await launchApp(appDir, appPort, {
-          env: { __NEXT_TEST_WITH_DEVTOOL: '1' },
           onStdout(msg) {
             output += msg
           },

--- a/test/integration/gssp-redirect-with-rewrites/test/index.test.js
+++ b/test/integration/gssp-redirect-with-rewrites/test/index.test.js
@@ -17,9 +17,7 @@ const context = {}
 describe('getServerSideProps redirects', () => {
   beforeAll(async () => {
     context.appPort = await findPort()
-    context.server = await launchApp(join(__dirname, '../'), context.appPort, {
-      env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
-    })
+    context.server = await launchApp(join(__dirname, '../'), context.appPort)
 
     // pre-build all pages at the start
     await Promise.all([

--- a/test/integration/prerender/test/index.test.js
+++ b/test/integration/prerender/test/index.test.js
@@ -25,9 +25,7 @@ describe('SSG Prerender', () => {
       )
       await fs.remove(join(appDir, '.next'))
       appPort = await findPort()
-      app = await launchApp(appDir, appPort, {
-        env: { __NEXT_TEST_WITH_DEVTOOL: 1 },
-      })
+      app = await launchApp(appDir, appPort)
     })
     afterAll(async () => {
       try {

--- a/test/integration/server-side-dev-errors/test/index.test.js
+++ b/test/integration/server-side-dev-errors/test/index.test.js
@@ -38,9 +38,6 @@ describe('server-side dev errors', () => {
           ''
         )
       },
-      env: {
-        __NEXT_TEST_WITH_DEVTOOL: 1,
-      },
     })
   })
   afterAll(() => killApp(app))

--- a/test/integration/typescript-hmr/test/index.test.js
+++ b/test/integration/typescript-hmr/test/index.test.js
@@ -21,7 +21,6 @@ describe('TypeScript HMR', () => {
     appPort = await findPort()
     app = await launchApp(appDir, appPort, {
       env: {
-        __NEXT_TEST_WITH_DEVTOOL: 1,
         // Events can be finicky in CI. This switches to a more reliable
         // polling method.
         CHOKIDAR_USEPOLLING: 'true',

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -63,7 +63,6 @@ export class NextDevInstance extends NextInstance {
             NODE_ENV: this.env.NODE_ENV || ('' as any),
             PORT: this.forcedPort || '0',
             __NEXT_TEST_MODE: 'e2e',
-            __NEXT_TEST_WITH_DEVTOOL: '1',
           },
         })
 


### PR DESCRIPTION
TL;DR: `__NEXT_TEST_WITH_DEVTOOL=1` is now the default with no way to opt out. 

Unisolated tests used to not produce sourcemaps in development for Webpack to improve test perf and let tests opt-in. This hits a problematic combination with the current sourcemap spec. Node.js tries to find the last `#sourceMappingURL` magic comment and uses that. For bundled code that hasn't produced a sourcemap, this is non-sensical if a bundle module also contains a `sourceMappingURL` magic comment (e.g. 3rd party libraries).

In the future, `#sourceMappingURL` magic comments cannot be followed by code. In that world, Node.js wouldn't even try to crawl up into bundled code and immediately give up.

Now unisolated tests produce sourcemaps in Webpack. The isolated tests already do this. It's also better to test what our users would get now that we integrate deeper with sourcemaps.