### PR TITLE
Turbopack: Redefine Background backend jobs

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1215,7 +1215,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         if self.should_persist() {
             // Schedule the snapshot job
-            turbo_tasks.schedule_backend_background_job(TurboTasksBackendJob::InitialSnapshot);
+            turbo_tasks.schedule_backend_secondary_job(TurboTasksBackendJob::InitialSnapshot);
         }
     }
 
@@ -2215,7 +2215,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                                 Ordering::Relaxed,
                             );
 
-                            turbo_tasks.schedule_backend_background_job(
+                            turbo_tasks.schedule_backend_secondary_job(
                                 TurboTasksBackendJob::FollowUpSnapshot,
                             );
                             return;
@@ -2230,7 +2230,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                             let chunk_size = good_chunk_size(data.len());
                             let chunks = data.len().div_ceil(chunk_size);
                             for i in 0..chunks {
-                                turbo_tasks.schedule_backend_foreground_job(
+                                turbo_tasks.schedule_backend_primary_job(
                                     TurboTasksBackendJob::Prefetch {
                                         data: data.clone(),
                                         range: Some(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1215,7 +1215,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         if self.should_persist() {
             // Schedule the snapshot job
-            turbo_tasks.schedule_backend_secondary_job(TurboTasksBackendJob::InitialSnapshot);
+            turbo_tasks.schedule_backend_background_job(TurboTasksBackendJob::InitialSnapshot);
         }
     }
 
@@ -2215,7 +2215,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                                 Ordering::Relaxed,
                             );
 
-                            turbo_tasks.schedule_backend_secondary_job(
+                            turbo_tasks.schedule_backend_background_job(
                                 TurboTasksBackendJob::FollowUpSnapshot,
                             );
                             return;
@@ -2230,7 +2230,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                             let chunk_size = good_chunk_size(data.len());
                             let chunks = data.len().div_ceil(chunk_size);
                             for i in 0..chunks {
-                                turbo_tasks.schedule_backend_secondary_job(
+                                turbo_tasks.schedule_backend_background_job(
                                     TurboTasksBackendJob::Prefetch {
                                         data: data.clone(),
                                         range: Some(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2230,7 +2230,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                             let chunk_size = good_chunk_size(data.len());
                             let chunks = data.len().div_ceil(chunk_size);
                             for i in 0..chunks {
-                                turbo_tasks.schedule_backend_primary_job(
+                                turbo_tasks.schedule_backend_secondary_job(
                                     TurboTasksBackendJob::Prefetch {
                                         data: data.clone(),
                                         range: Some(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -265,7 +265,7 @@ where
     fn schedule_task(&self, mut task: impl TaskGuard + '_) {
         if let Some(tasks_to_prefetch) = task.prefetch() {
             self.turbo_tasks
-                .schedule_backend_secondary_job(TurboTasksBackendJob::Prefetch {
+                .schedule_backend_background_job(TurboTasksBackendJob::Prefetch {
                     data: Arc::new(tasks_to_prefetch),
                     range: None,
                 });

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -265,7 +265,7 @@ where
     fn schedule_task(&self, mut task: impl TaskGuard + '_) {
         if let Some(tasks_to_prefetch) = task.prefetch() {
             self.turbo_tasks
-                .schedule_backend_primary_job(TurboTasksBackendJob::Prefetch {
+                .schedule_backend_secondary_job(TurboTasksBackendJob::Prefetch {
                     data: Arc::new(tasks_to_prefetch),
                     range: None,
                 });

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -265,7 +265,7 @@ where
     fn schedule_task(&self, mut task: impl TaskGuard + '_) {
         if let Some(tasks_to_prefetch) = task.prefetch() {
             self.turbo_tasks
-                .schedule_backend_foreground_job(TurboTasksBackendJob::Prefetch {
+                .schedule_backend_primary_job(TurboTasksBackendJob::Prefetch {
                     data: Arc::new(tasks_to_prefetch),
                     range: None,
                 });

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -39,6 +39,7 @@
 #![feature(ptr_metadata)]
 #![feature(sync_unsafe_cell)]
 #![feature(vec_into_raw_parts)]
+#![feature(async_fn_traits)]
 
 pub mod backend;
 mod capture_future;

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -249,14 +249,17 @@ pub trait TurboTasksBackendApi<B: Backend + 'static>: TurboTasksCallApi + Sync +
     /// The caller must ensure that the task id is not used anymore.
     unsafe fn reuse_transient_task_id(&self, id: Unused<TaskId>);
 
+    /// Schedule a task for execution.
     fn schedule(&self, task: TaskId);
-    fn schedule_backend_background_job(&self, job: B::BackendJob);
-    fn schedule_backend_foreground_job(&self, job: B::BackendJob);
 
-    fn try_foreground_done(&self) -> Result<(), EventListener>;
-    fn wait_foreground_done_excluding_own<'a>(
-        &'a self,
-    ) -> Option<Pin<Box<dyn Future<Output = ()> + Send + 'a>>>;
+    /// Schedule a primary backend job for execution.
+    fn schedule_backend_primary_job(&self, job: B::BackendJob);
+
+    /// Schedule a secondary backend job for execution.
+    ///
+    /// Secondary jobs are not counted towards activeness of the system. The system is considered
+    /// idle even with active secondary jobs.
+    fn schedule_backend_secondary_job(&self, job: B::BackendJob);
 
     /// Enqueues tasks for notification of changed dependencies. This will
     /// eventually call `invalidate_tasks()` on all tasks.
@@ -369,16 +372,18 @@ pub struct TurboTasks<B: Backend + 'static> {
     transient_task_id_factory: IdFactoryWithReuse<TaskId>,
     execution_id_factory: IdFactory<ExecutionId>,
     stopped: AtomicBool,
-    currently_scheduled_tasks: AtomicUsize,
-    currently_scheduled_foreground_jobs: AtomicUsize,
-    currently_scheduled_background_jobs: AtomicUsize,
+    currently_scheduled_primary_tasks: AtomicUsize,
+    currently_scheduled_secondary_jobs: AtomicUsize,
     scheduled_tasks: AtomicUsize,
     start: Mutex<Option<Instant>>,
     aggregated_update: Mutex<(Option<(Duration, usize)>, InvalidationReasonSet)>,
-    event: Event,
-    event_start: Event,
-    event_foreground: Event,
-    event_background: Event,
+    /// Event that is triggered when currently_scheduled_primary_tasks becomes non-zero
+    event_primary_start: Event,
+    /// Event that is triggered when all primary tasks are done (currently_scheduled_primary_tasks
+    /// becomes zero)
+    event_primary_done: Event,
+    /// Event that is triggered when all secondary tasks are done
+    event_secondary_done: Event,
     program_start: Instant,
     compilation_events: CompilationEventQueue,
 }
@@ -499,16 +504,14 @@ impl<B: Backend + 'static> TurboTasks<B> {
             transient_task_id_factory,
             execution_id_factory,
             stopped: AtomicBool::new(false),
-            currently_scheduled_tasks: AtomicUsize::new(0),
-            currently_scheduled_background_jobs: AtomicUsize::new(0),
-            currently_scheduled_foreground_jobs: AtomicUsize::new(0),
+            currently_scheduled_primary_tasks: AtomicUsize::new(0),
+            currently_scheduled_secondary_jobs: AtomicUsize::new(0),
             scheduled_tasks: AtomicUsize::new(0),
             start: Default::default(),
             aggregated_update: Default::default(),
-            event: Event::new(|| || "TurboTasks::event".to_string()),
-            event_start: Event::new(|| || "TurboTasks::event_start".to_string()),
-            event_foreground: Event::new(|| || "TurboTasks::event_foreground".to_string()),
-            event_background: Event::new(|| || "TurboTasks::event_background".to_string()),
+            event_primary_done: Event::new(|| || "TurboTasks::event_primary_done".to_string()),
+            event_primary_start: Event::new(|| || "TurboTasks::event_primary_start".to_string()),
+            event_secondary_done: Event::new(|| || "TurboTasks::event_secondary_done".to_string()),
             program_start: Instant::now(),
             compilation_events: CompilationEventQueue::default(),
         });
@@ -868,25 +871,19 @@ impl<B: Backend + 'static> TurboTasks<B> {
 
     fn begin_primary_job(&self) {
         if self
-            .currently_scheduled_tasks
+            .currently_scheduled_primary_tasks
             .fetch_add(1, Ordering::AcqRel)
             == 0
         {
             *self.start.lock().unwrap() = Some(Instant::now());
-            self.event_start.notify(usize::MAX);
+            self.event_primary_start.notify(usize::MAX);
             self.backend.idle_end(self);
         }
     }
 
-    fn begin_foreground_job(&self) {
-        self.begin_primary_job();
-        self.currently_scheduled_foreground_jobs
-            .fetch_add(1, Ordering::AcqRel);
-    }
-
     fn finish_primary_job(&self) {
         if self
-            .currently_scheduled_tasks
+            .currently_scheduled_primary_tasks
             .fetch_sub(1, Ordering::AcqRel)
             == 1
         {
@@ -904,44 +901,28 @@ impl<B: Backend + 'static> TurboTasks<B> {
                     *update = Some((start.elapsed(), total));
                 }
             }
-            self.event.notify(usize::MAX);
+            self.event_primary_done.notify(usize::MAX);
         }
     }
 
-    fn finish_foreground_job(&self) {
+    fn begin_secondary_task(&self) {
+        self.currently_scheduled_secondary_jobs
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn finish_secondary_task(&self) {
         if self
-            .currently_scheduled_foreground_jobs
-            .fetch_sub(1, Ordering::AcqRel)
+            .currently_scheduled_secondary_jobs
+            .fetch_sub(1, Ordering::Relaxed)
             == 1
         {
-            self.event_foreground.notify(usize::MAX);
+            self.event_secondary_done.notify(usize::MAX);
         }
-        self.finish_primary_job();
-    }
-
-    pub async fn wait_foreground_done(&self) {
-        if self
-            .currently_scheduled_foreground_jobs
-            .load(Ordering::Acquire)
-            == 0
-        {
-            return;
-        }
-        let listener = self.event_foreground.listen();
-        if self
-            .currently_scheduled_foreground_jobs
-            .load(Ordering::Acquire)
-            == 0
-        {
-            return;
-        }
-        listener
-            .instrument(trace_span!("wait_foreground_done"))
-            .await;
     }
 
     pub fn get_in_progress_count(&self) -> usize {
-        self.currently_scheduled_tasks.load(Ordering::Acquire)
+        self.currently_scheduled_primary_tasks
+            .load(Ordering::Acquire)
     }
 
     /// Waits for the given task to finish executing. This works by performing an untracked read,
@@ -982,7 +963,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
         timeout: Duration,
     ) -> Option<UpdateInfo> {
         let listener = self
-            .event
+            .event_primary_done
             .listen_with_note(|| || "wait for update info".to_string());
         let wait_for_finish = {
             let (update, reason_set) = &mut *self.aggregated_update.lock().unwrap();
@@ -1008,9 +989,13 @@ impl<B: Backend + 'static> TurboTasks<B> {
             } else {
                 // wait for start, then wait for finish or timeout
                 let start_listener = self
-                    .event_start
+                    .event_primary_start
                     .listen_with_note(|| || "wait for update info".to_string());
-                if self.currently_scheduled_tasks.load(Ordering::Acquire) == 0 {
+                if self
+                    .currently_scheduled_primary_tasks
+                    .load(Ordering::Acquire)
+                    == 0
+                {
                     start_listener.await;
                 } else {
                     drop(start_listener);
@@ -1027,7 +1012,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
                     () = tokio::time::sleep(aggregation) => {
                         break;
                     }
-                    () = self.event.listen_with_note(|| || "wait for update info".to_string()) => {
+                    () = self.event_primary_done.listen_with_note(|| || "wait for update info".to_string()) => {
                         // Resets the sleep
                     }
                 }
@@ -1046,10 +1031,10 @@ impl<B: Backend + 'static> TurboTasks<B> {
         }
     }
 
-    pub async fn wait_background_done(&self) {
-        let listener = self.event_background.listen();
+    pub async fn wait_secondary_done(&self) {
+        let listener = self.event_secondary_done.listen();
         if self
-            .currently_scheduled_background_jobs
+            .currently_scheduled_secondary_jobs
             .load(Ordering::Acquire)
             != 0
         {
@@ -1063,16 +1048,20 @@ impl<B: Backend + 'static> TurboTasks<B> {
             self.stopped.store(true, Ordering::Release);
             {
                 let listener = self
-                    .event
+                    .event_primary_done
                     .listen_with_note(|| || "wait for stop".to_string());
-                if self.currently_scheduled_tasks.load(Ordering::Acquire) != 0 {
+                if self
+                    .currently_scheduled_primary_tasks
+                    .load(Ordering::Acquire)
+                    != 0
+                {
                     listener.await;
                 }
             }
             {
-                let listener = self.event_background.listen();
+                let listener = self.event_secondary_done.listen();
                 if self
-                    .currently_scheduled_background_jobs
+                    .currently_scheduled_secondary_jobs
                     .load(Ordering::Acquire)
                     != 0
                 {
@@ -1085,60 +1074,40 @@ impl<B: Backend + 'static> TurboTasks<B> {
     }
 
     #[track_caller]
-    pub(crate) fn schedule_background_job<
-        T: FnOnce(Arc<TurboTasks<B>>) -> F + Send + 'static,
-        F: Future<Output = ()> + Send + 'static,
-    >(
-        &self,
-        func: T,
-    ) {
-        let this = self.pin();
-        self.currently_scheduled_background_jobs
-            .fetch_add(1, Ordering::AcqRel);
+    pub(crate) fn schedule_primary_job<T>(&self, func: T)
+    where
+        T: AsyncFnOnce(Arc<TurboTasks<B>>) -> Arc<TurboTasks<B>> + Send + 'static,
+        T::CallOnceFuture: Send,
+    {
+        let mut this = self.pin();
+        this.begin_primary_job();
         tokio::spawn(
             TURBO_TASKS
                 .scope(this.clone(), async move {
-                    while this.currently_scheduled_tasks.load(Ordering::Acquire) != 0 {
-                        let listener = this.event.listen_with_note(|| {
-                            || "background job waiting for execution".to_string()
-                        });
-                        if this.currently_scheduled_tasks.load(Ordering::Acquire) != 0 {
-                            listener.await;
-                        }
-                    }
-                    let this2 = this.clone();
                     if !this.stopped.load(Ordering::Acquire) {
-                        func(this).await;
+                        this = func(this.clone()).await;
                     }
-                    if this2
-                        .currently_scheduled_background_jobs
-                        .fetch_sub(1, Ordering::AcqRel)
-                        == 1
-                    {
-                        this2.event_background.notify(usize::MAX);
-                    }
+                    this.finish_primary_job();
                 })
                 .in_current_span(),
         );
     }
 
     #[track_caller]
-    pub(crate) fn schedule_foreground_job<
-        T: FnOnce(Arc<TurboTasks<B>>) -> F + Send + 'static,
-        F: Future<Output = ()> + Send + 'static,
-    >(
-        &self,
-        func: T,
-    ) {
-        let this = self.pin();
-        this.begin_foreground_job();
+    pub(crate) fn schedule_secondary_job<T>(&self, func: T)
+    where
+        T: AsyncFnOnce(Arc<TurboTasks<B>>) -> Arc<TurboTasks<B>> + Send + 'static,
+        T::CallOnceFuture: Send,
+    {
+        let mut this = self.pin();
+        self.begin_secondary_task();
         tokio::spawn(
             TURBO_TASKS
                 .scope(this.clone(), async move {
                     if !this.stopped.load(Ordering::Acquire) {
-                        func(this.clone()).await;
+                        this = func(this).await;
                     }
-                    this.finish_foreground_job();
+                    this.finish_secondary_task();
                 })
                 .in_current_span(),
         );
@@ -1478,53 +1447,19 @@ impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
     }
 
     #[track_caller]
-    fn schedule_backend_background_job(&self, job: B::BackendJob) {
-        self.schedule_background_job(move |this| async move {
+    fn schedule_backend_secondary_job(&self, job: B::BackendJob) {
+        self.schedule_secondary_job(async move |this| {
             this.backend.run_backend_job(job, &*this).await;
+            this
         })
     }
 
     #[track_caller]
-    fn schedule_backend_foreground_job(&self, job: B::BackendJob) {
-        self.schedule_foreground_job(move |this| async move {
+    fn schedule_backend_primary_job(&self, job: B::BackendJob) {
+        self.schedule_primary_job(async move |this| {
             this.backend.run_backend_job(job, &*this).await;
+            this
         })
-    }
-
-    fn try_foreground_done(&self) -> Result<(), EventListener> {
-        if self
-            .currently_scheduled_foreground_jobs
-            .load(Ordering::Acquire)
-            == 0
-        {
-            return Ok(());
-        }
-        let listener = self.event_foreground.listen();
-        if self
-            .currently_scheduled_foreground_jobs
-            .load(Ordering::Acquire)
-            == 0
-        {
-            return Ok(());
-        }
-        Err(listener)
-    }
-
-    fn wait_foreground_done_excluding_own<'a>(
-        &'a self,
-    ) -> Option<Pin<Box<dyn Future<Output = ()> + Send + 'a>>> {
-        if self
-            .currently_scheduled_foreground_jobs
-            .load(Ordering::Acquire)
-            == 0
-        {
-            return None;
-        }
-        Some(Box::pin(async {
-            self.finish_foreground_job();
-            self.wait_foreground_done().await;
-            self.begin_foreground_job();
-        }))
     }
 
     /// Enqueues tasks for notification of changed dependencies. This will
@@ -1595,7 +1530,9 @@ impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
     }
 
     fn is_idle(&self) -> bool {
-        self.currently_scheduled_tasks.load(Ordering::Acquire) == 0
+        self.currently_scheduled_primary_tasks
+            .load(Ordering::Acquire)
+            == 0
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -252,14 +252,14 @@ pub trait TurboTasksBackendApi<B: Backend + 'static>: TurboTasksCallApi + Sync +
     /// Schedule a task for execution.
     fn schedule(&self, task: TaskId);
 
-    /// Schedule a primary backend job for execution.
-    fn schedule_backend_primary_job(&self, job: B::BackendJob);
+    /// Schedule a foreground backend job for execution.
+    fn schedule_backend_foreground_job(&self, job: B::BackendJob);
 
-    /// Schedule a secondary backend job for execution.
+    /// Schedule a background backend job for execution.
     ///
-    /// Secondary jobs are not counted towards activeness of the system. The system is considered
-    /// idle even with active secondary jobs.
-    fn schedule_backend_secondary_job(&self, job: B::BackendJob);
+    /// Background jobs are not counted towards activeness of the system. The system is considered
+    /// idle even with active background jobs.
+    fn schedule_backend_background_job(&self, job: B::BackendJob);
 
     /// Enqueues tasks for notification of changed dependencies. This will
     /// eventually call `invalidate_tasks()` on all tasks.
@@ -372,18 +372,18 @@ pub struct TurboTasks<B: Backend + 'static> {
     transient_task_id_factory: IdFactoryWithReuse<TaskId>,
     execution_id_factory: IdFactory<ExecutionId>,
     stopped: AtomicBool,
-    currently_scheduled_primary_tasks: AtomicUsize,
-    currently_scheduled_secondary_jobs: AtomicUsize,
+    currently_scheduled_foreground_tasks: AtomicUsize,
+    currently_scheduled_background_jobs: AtomicUsize,
     scheduled_tasks: AtomicUsize,
     start: Mutex<Option<Instant>>,
     aggregated_update: Mutex<(Option<(Duration, usize)>, InvalidationReasonSet)>,
-    /// Event that is triggered when currently_scheduled_primary_tasks becomes non-zero
-    event_primary_start: Event,
-    /// Event that is triggered when all primary tasks are done (currently_scheduled_primary_tasks
-    /// becomes zero)
-    event_primary_done: Event,
-    /// Event that is triggered when all secondary tasks are done
-    event_secondary_done: Event,
+    /// Event that is triggered when currently_scheduled_foreground_tasks becomes non-zero
+    event_foreground_start: Event,
+    /// Event that is triggered when all foreground tasks are done
+    /// (currently_scheduled_foreground_tasks becomes zero)
+    event_foreground_done: Event,
+    /// Event that is triggered when all background tasks are done
+    event_background_done: Event,
     program_start: Instant,
     compilation_events: CompilationEventQueue,
 }
@@ -504,14 +504,20 @@ impl<B: Backend + 'static> TurboTasks<B> {
             transient_task_id_factory,
             execution_id_factory,
             stopped: AtomicBool::new(false),
-            currently_scheduled_primary_tasks: AtomicUsize::new(0),
-            currently_scheduled_secondary_jobs: AtomicUsize::new(0),
+            currently_scheduled_foreground_tasks: AtomicUsize::new(0),
+            currently_scheduled_background_jobs: AtomicUsize::new(0),
             scheduled_tasks: AtomicUsize::new(0),
             start: Default::default(),
             aggregated_update: Default::default(),
-            event_primary_done: Event::new(|| || "TurboTasks::event_primary_done".to_string()),
-            event_primary_start: Event::new(|| || "TurboTasks::event_primary_start".to_string()),
-            event_secondary_done: Event::new(|| || "TurboTasks::event_secondary_done".to_string()),
+            event_foreground_done: Event::new(|| {
+                || "TurboTasks::event_foreground_done".to_string()
+            }),
+            event_foreground_start: Event::new(|| {
+                || "TurboTasks::event_foreground_start".to_string()
+            }),
+            event_background_done: Event::new(|| {
+                || "TurboTasks::event_background_done".to_string()
+            }),
             program_start: Instant::now(),
             compilation_events: CompilationEventQueue::default(),
         });
@@ -691,7 +697,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
 
     #[track_caller]
     pub(crate) fn schedule(&self, task_id: TaskId) {
-        self.begin_primary_job();
+        self.begin_foreground_job();
         self.scheduled_tasks.fetch_add(1, Ordering::AcqRel);
 
         let this = self.pin();
@@ -760,7 +766,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
                     .scope(current_task_state, single_execution_future)
                     .await;
             }
-            this.finish_primary_job();
+            this.finish_foreground_job();
             anyhow::Ok(())
         };
 
@@ -869,21 +875,21 @@ impl<B: Backend + 'static> TurboTasks<B> {
         RawVc::LocalOutput(execution_id, local_task_id, persistence)
     }
 
-    fn begin_primary_job(&self) {
+    fn begin_foreground_job(&self) {
         if self
-            .currently_scheduled_primary_tasks
+            .currently_scheduled_foreground_tasks
             .fetch_add(1, Ordering::AcqRel)
             == 0
         {
             *self.start.lock().unwrap() = Some(Instant::now());
-            self.event_primary_start.notify(usize::MAX);
+            self.event_foreground_start.notify(usize::MAX);
             self.backend.idle_end(self);
         }
     }
 
-    fn finish_primary_job(&self) {
+    fn finish_foreground_job(&self) {
         if self
-            .currently_scheduled_primary_tasks
+            .currently_scheduled_foreground_tasks
             .fetch_sub(1, Ordering::AcqRel)
             == 1
         {
@@ -901,27 +907,27 @@ impl<B: Backend + 'static> TurboTasks<B> {
                     *update = Some((start.elapsed(), total));
                 }
             }
-            self.event_primary_done.notify(usize::MAX);
+            self.event_foreground_done.notify(usize::MAX);
         }
     }
 
-    fn begin_secondary_task(&self) {
-        self.currently_scheduled_secondary_jobs
+    fn begin_background_task(&self) {
+        self.currently_scheduled_background_jobs
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    fn finish_secondary_task(&self) {
+    fn finish_background_task(&self) {
         if self
-            .currently_scheduled_secondary_jobs
+            .currently_scheduled_background_jobs
             .fetch_sub(1, Ordering::Relaxed)
             == 1
         {
-            self.event_secondary_done.notify(usize::MAX);
+            self.event_background_done.notify(usize::MAX);
         }
     }
 
     pub fn get_in_progress_count(&self) -> usize {
-        self.currently_scheduled_primary_tasks
+        self.currently_scheduled_foreground_tasks
             .load(Ordering::Acquire)
     }
 
@@ -963,7 +969,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
         timeout: Duration,
     ) -> Option<UpdateInfo> {
         let listener = self
-            .event_primary_done
+            .event_foreground_done
             .listen_with_note(|| || "wait for update info".to_string());
         let wait_for_finish = {
             let (update, reason_set) = &mut *self.aggregated_update.lock().unwrap();
@@ -989,10 +995,10 @@ impl<B: Backend + 'static> TurboTasks<B> {
             } else {
                 // wait for start, then wait for finish or timeout
                 let start_listener = self
-                    .event_primary_start
+                    .event_foreground_start
                     .listen_with_note(|| || "wait for update info".to_string());
                 if self
-                    .currently_scheduled_primary_tasks
+                    .currently_scheduled_foreground_tasks
                     .load(Ordering::Acquire)
                     == 0
                 {
@@ -1012,7 +1018,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
                     () = tokio::time::sleep(aggregation) => {
                         break;
                     }
-                    () = self.event_primary_done.listen_with_note(|| || "wait for update info".to_string()) => {
+                    () = self.event_foreground_done.listen_with_note(|| || "wait for update info".to_string()) => {
                         // Resets the sleep
                     }
                 }
@@ -1031,10 +1037,10 @@ impl<B: Backend + 'static> TurboTasks<B> {
         }
     }
 
-    pub async fn wait_secondary_done(&self) {
-        let listener = self.event_secondary_done.listen();
+    pub async fn wait_background_done(&self) {
+        let listener = self.event_background_done.listen();
         if self
-            .currently_scheduled_secondary_jobs
+            .currently_scheduled_background_jobs
             .load(Ordering::Acquire)
             != 0
         {
@@ -1048,10 +1054,10 @@ impl<B: Backend + 'static> TurboTasks<B> {
             self.stopped.store(true, Ordering::Release);
             {
                 let listener = self
-                    .event_primary_done
+                    .event_foreground_done
                     .listen_with_note(|| || "wait for stop".to_string());
                 if self
-                    .currently_scheduled_primary_tasks
+                    .currently_scheduled_foreground_tasks
                     .load(Ordering::Acquire)
                     != 0
                 {
@@ -1059,9 +1065,9 @@ impl<B: Backend + 'static> TurboTasks<B> {
                 }
             }
             {
-                let listener = self.event_secondary_done.listen();
+                let listener = self.event_background_done.listen();
                 if self
-                    .currently_scheduled_secondary_jobs
+                    .currently_scheduled_background_jobs
                     .load(Ordering::Acquire)
                     != 0
                 {
@@ -1074,40 +1080,40 @@ impl<B: Backend + 'static> TurboTasks<B> {
     }
 
     #[track_caller]
-    pub(crate) fn schedule_primary_job<T>(&self, func: T)
+    pub(crate) fn schedule_foreground_job<T>(&self, func: T)
     where
         T: AsyncFnOnce(Arc<TurboTasks<B>>) -> Arc<TurboTasks<B>> + Send + 'static,
         T::CallOnceFuture: Send,
     {
         let mut this = self.pin();
-        this.begin_primary_job();
+        this.begin_foreground_job();
         tokio::spawn(
             TURBO_TASKS
                 .scope(this.clone(), async move {
                     if !this.stopped.load(Ordering::Acquire) {
                         this = func(this.clone()).await;
                     }
-                    this.finish_primary_job();
+                    this.finish_foreground_job();
                 })
                 .in_current_span(),
         );
     }
 
     #[track_caller]
-    pub(crate) fn schedule_secondary_job<T>(&self, func: T)
+    pub(crate) fn schedule_background_job<T>(&self, func: T)
     where
         T: AsyncFnOnce(Arc<TurboTasks<B>>) -> Arc<TurboTasks<B>> + Send + 'static,
         T::CallOnceFuture: Send,
     {
         let mut this = self.pin();
-        self.begin_secondary_task();
+        self.begin_background_task();
         tokio::spawn(
             TURBO_TASKS
                 .scope(this.clone(), async move {
                     if !this.stopped.load(Ordering::Acquire) {
                         this = func(this).await;
                     }
-                    this.finish_secondary_task();
+                    this.finish_background_task();
                 })
                 .in_current_span(),
         );
@@ -1209,9 +1215,9 @@ impl<B: Backend + 'static> TurboTasksCallApi for TurboTasks<B> {
     ) -> TaskId {
         let this = self.pin();
         self.spawn_once_task(async move {
-            this.finish_primary_job();
+            this.finish_foreground_job();
             future.await?;
-            this.begin_primary_job();
+            this.begin_foreground_job();
             Ok(Completion::new())
         })
     }
@@ -1447,16 +1453,16 @@ impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
     }
 
     #[track_caller]
-    fn schedule_backend_secondary_job(&self, job: B::BackendJob) {
-        self.schedule_secondary_job(async move |this| {
+    fn schedule_backend_background_job(&self, job: B::BackendJob) {
+        self.schedule_background_job(async move |this| {
             this.backend.run_backend_job(job, &*this).await;
             this
         })
     }
 
     #[track_caller]
-    fn schedule_backend_primary_job(&self, job: B::BackendJob) {
-        self.schedule_primary_job(async move |this| {
+    fn schedule_backend_foreground_job(&self, job: B::BackendJob) {
+        self.schedule_foreground_job(async move |this| {
             this.backend.run_backend_job(job, &*this).await;
             this
         })
@@ -1530,7 +1536,7 @@ impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
     }
 
     fn is_idle(&self) -> bool {
-        self.currently_scheduled_primary_tasks
+        self.currently_scheduled_foreground_tasks
             .load(Ordering::Acquire)
             == 0
     }

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -372,17 +372,17 @@ pub struct TurboTasks<B: Backend + 'static> {
     transient_task_id_factory: IdFactoryWithReuse<TaskId>,
     execution_id_factory: IdFactory<ExecutionId>,
     stopped: AtomicBool,
-    currently_scheduled_foreground_tasks: AtomicUsize,
+    currently_scheduled_foreground_jobs: AtomicUsize,
     currently_scheduled_background_jobs: AtomicUsize,
     scheduled_tasks: AtomicUsize,
     start: Mutex<Option<Instant>>,
     aggregated_update: Mutex<(Option<(Duration, usize)>, InvalidationReasonSet)>,
-    /// Event that is triggered when currently_scheduled_foreground_tasks becomes non-zero
+    /// Event that is triggered when currently_scheduled_foreground_jobs becomes non-zero
     event_foreground_start: Event,
-    /// Event that is triggered when all foreground tasks are done
-    /// (currently_scheduled_foreground_tasks becomes zero)
+    /// Event that is triggered when all foreground jobs are done
+    /// (currently_scheduled_foreground_jobs becomes zero)
     event_foreground_done: Event,
-    /// Event that is triggered when all background tasks are done
+    /// Event that is triggered when all background jobs are done
     event_background_done: Event,
     program_start: Instant,
     compilation_events: CompilationEventQueue,
@@ -504,7 +504,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
             transient_task_id_factory,
             execution_id_factory,
             stopped: AtomicBool::new(false),
-            currently_scheduled_foreground_tasks: AtomicUsize::new(0),
+            currently_scheduled_foreground_jobs: AtomicUsize::new(0),
             currently_scheduled_background_jobs: AtomicUsize::new(0),
             scheduled_tasks: AtomicUsize::new(0),
             start: Default::default(),
@@ -877,7 +877,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
 
     fn begin_foreground_job(&self) {
         if self
-            .currently_scheduled_foreground_tasks
+            .currently_scheduled_foreground_jobs
             .fetch_add(1, Ordering::AcqRel)
             == 0
         {
@@ -889,7 +889,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
 
     fn finish_foreground_job(&self) {
         if self
-            .currently_scheduled_foreground_tasks
+            .currently_scheduled_foreground_jobs
             .fetch_sub(1, Ordering::AcqRel)
             == 1
         {
@@ -911,12 +911,12 @@ impl<B: Backend + 'static> TurboTasks<B> {
         }
     }
 
-    fn begin_background_task(&self) {
+    fn begin_background_job(&self) {
         self.currently_scheduled_background_jobs
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    fn finish_background_task(&self) {
+    fn finish_background_job(&self) {
         if self
             .currently_scheduled_background_jobs
             .fetch_sub(1, Ordering::Relaxed)
@@ -927,7 +927,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
     }
 
     pub fn get_in_progress_count(&self) -> usize {
-        self.currently_scheduled_foreground_tasks
+        self.currently_scheduled_foreground_jobs
             .load(Ordering::Acquire)
     }
 
@@ -998,7 +998,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
                     .event_foreground_start
                     .listen_with_note(|| || "wait for update info".to_string());
                 if self
-                    .currently_scheduled_foreground_tasks
+                    .currently_scheduled_foreground_jobs
                     .load(Ordering::Acquire)
                     == 0
                 {
@@ -1057,7 +1057,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
                     .event_foreground_done
                     .listen_with_note(|| || "wait for stop".to_string());
                 if self
-                    .currently_scheduled_foreground_tasks
+                    .currently_scheduled_foreground_jobs
                     .load(Ordering::Acquire)
                     != 0
                 {
@@ -1106,14 +1106,14 @@ impl<B: Backend + 'static> TurboTasks<B> {
         T::CallOnceFuture: Send,
     {
         let mut this = self.pin();
-        self.begin_background_task();
+        self.begin_background_job();
         tokio::spawn(
             TURBO_TASKS
                 .scope(this.clone(), async move {
                     if !this.stopped.load(Ordering::Acquire) {
                         this = func(this).await;
                     }
-                    this.finish_background_task();
+                    this.finish_background_job();
                 })
                 .in_current_span(),
         );
@@ -1536,7 +1536,7 @@ impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
     }
 
     fn is_idle(&self) -> bool {
-        self.currently_scheduled_foreground_tasks
+        self.currently_scheduled_foreground_jobs
             .load(Ordering::Acquire)
             == 0
     }

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -524,7 +524,7 @@ fn node_file_trace<B: Backend + 'static>(
 
             let tt = create_turbo_tasks(directory_path.as_path());
             let output = timeout(Duration::from_secs(timeout_len), tt.run_once(task)).await;
-            let _ = timeout(Duration::from_secs(2), tt.wait_background_done()).await;
+            let _ = timeout(Duration::from_secs(2), tt.wait_secondary_done()).await;
             let stop = timeout(Duration::from_secs(60), tt.stop_and_wait()).await;
             match (output, stop) {
                 (Ok(result), Ok(_)) => handle_result(result),

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -524,7 +524,7 @@ fn node_file_trace<B: Backend + 'static>(
 
             let tt = create_turbo_tasks(directory_path.as_path());
             let output = timeout(Duration::from_secs(timeout_len), tt.run_once(task)).await;
-            let _ = timeout(Duration::from_secs(2), tt.wait_secondary_done()).await;
+            let _ = timeout(Duration::from_secs(2), tt.wait_background_done()).await;
             let stop = timeout(Duration::from_secs(60), tt.stop_and_wait()).await;
             match (output, stop) {
                 (Ok(result), Ok(_)) => handle_result(result),


### PR DESCRIPTION
### What?

We don't need background jobs that run when idle. We already have a `idle_start` event for that.
Instead we need "background jobs" that do not count towards activeness of the system (do not contribute to the compile duration and these effects).

Also remove a bunch of unused stuff from the manager.

Closes PACK-5380