### PR TITLE
BREAKING CHANGE!: next/image only allow quality 75 by default

### DIFF
--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -684,15 +684,33 @@ module.exports = {
 
 `qualities` allows you to specify a list of image quality values.
 
+If not configuration is provided, the default below is used:
+
 ```js filename="next.config.js"
 module.exports = {
   images: {
-    qualities: [25, 50, 75],
+    qualities: [75],
   },
 }
 ```
 
-In the example above, only three qualities are allowed: 25, 50, and 75. If the [`quality`](#quality) prop does not match a value in this array, the image will fail with a `400` Bad Request.
+> **Good to know**: This field is required starting with Next.js 16 because unrestricted access could allow malicious actors to optimize more qualities than you intended.
+
+You can add more image qualities to the allowlist, such as the following:
+
+```js filename="next.config.js"
+module.exports = {
+  images: {
+    qualities: [25, 50, 75, 100],
+  },
+}
+```
+
+In the example above, only four qualities are allowed: 25, 50, 75, and 100.
+
+If the [`quality`](#quality) prop does not match a value in this array, the closest allowed value will be used.
+
+If the REST API is visited directly with a quality that does not match a value in this array, the server will return a 400 Bad Request response.
 
 #### `formats`
 
@@ -1251,6 +1269,7 @@ export default function Home() {
 
 | Version    | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `v16.0.0`  | `qualities` default configuration changed to `[75]`.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `v15.3.0`  | `remotePatterns` added support for array of `URL` objects.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `v15.0.0`  | `contentDispositionType` configuration default changed to `attachment`.                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `v14.2.23` | `qualities` configuration added.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |

--- a/packages/next/src/client/legacy/image.tsx
+++ b/packages/next/src/client/legacy/image.tsx
@@ -23,13 +23,13 @@ import { useIntersection } from '../use-intersection'
 import { ImageConfigContext } from '../../shared/lib/image-config-context.shared-runtime'
 import { warnOnce } from '../../shared/lib/utils/warn-once'
 import { normalizePathTrailingSlash } from '../normalize-trailing-slash'
+import { findClosestQuality } from '../../shared/lib/find-closest-quality'
 
 function normalizeSrc(src: string): string {
   return src[0] === '/' ? src.slice(1) : src
 }
 
 const supportsFloat = typeof ReactDOM.preload === 'function'
-const DEFAULT_Q = 75
 const configEnv = process.env.__NEXT_IMAGE_OPTS as any as ImageConfigComplete
 const loadedImageURLs = new Set<string>()
 const allImgs = new Map<
@@ -190,14 +190,7 @@ function defaultLoader({
     }
   }
 
-  // find the closest matching `quality` in the list of `config.qualities`
-  const q =
-    config.qualities?.reduce((prev, cur) =>
-      Math.abs(cur - (quality || DEFAULT_Q)) <
-      Math.abs(prev - (quality || DEFAULT_Q))
-        ? cur
-        : prev
-    ) || DEFAULT_Q
+  const q = findClosestQuality(quality, config)
 
   if (!config.dangerouslyAllowSVG && src.split('?', 1)[0].endsWith('.svg')) {
     // Special case to make svg serve as-is to avoid proxying

--- a/packages/next/src/client/legacy/image.tsx
+++ b/packages/next/src/client/legacy/image.tsx
@@ -860,7 +860,7 @@ export default function Image({
         !config.qualities.includes(qualityInt)
       ) {
         warnOnce(
-          `Image with src "${src}" is using quality "${qualityInt}" which is not configured in images.qualities [${config.qualities.join(', ')}]. Please update your config to [${[...config.qualities, qualityInt].sort().join(',')}].` +
+          `Image with src "${src}" is using quality "${qualityInt}" which is not configured in images.qualities [${config.qualities.join(', ')}]. Please update your config to [${[...config.qualities, qualityInt].sort().join(', ')}].` +
             `\nRead more: https://nextjs.org/docs/messages/next-image-unconfigured-qualities`
         )
       }

--- a/packages/next/src/client/legacy/image.tsx
+++ b/packages/next/src/client/legacy/image.tsx
@@ -188,21 +188,16 @@ function defaultLoader({
         }
       }
     }
-
-    if (quality && config.qualities && !config.qualities.includes(quality)) {
-      throw new Error(
-        `Invalid quality prop (${quality}) on \`next/image\` does not match \`images.qualities\` configured in your \`next.config.js\`\n` +
-          `See more info: https://nextjs.org/docs/messages/next-image-unconfigured-qualities`
-      )
-    }
   }
 
+  // find the closest matching `quality` in the list of `config.qualities`
   const q =
-    quality ||
     config.qualities?.reduce((prev, cur) =>
-      Math.abs(cur - DEFAULT_Q) < Math.abs(prev - DEFAULT_Q) ? cur : prev
-    ) ||
-    DEFAULT_Q
+      Math.abs(cur - (quality || DEFAULT_Q)) <
+      Math.abs(prev - (quality || DEFAULT_Q))
+        ? cur
+        : prev
+    ) || DEFAULT_Q
 
   if (!config.dangerouslyAllowSVG && src.split('?', 1)[0].endsWith('.svg')) {
     // Special case to make svg serve as-is to avoid proxying

--- a/packages/next/src/client/legacy/image.tsx
+++ b/packages/next/src/client/legacy/image.tsx
@@ -854,9 +854,13 @@ export default function Image({
         )
       }
 
-      if (qualityInt && qualityInt !== 75 && !config.qualities) {
+      if (
+        qualityInt &&
+        config.qualities &&
+        !config.qualities.includes(qualityInt)
+      ) {
         warnOnce(
-          `Image with src "${src}" is using quality "${qualityInt}" which is not configured in images.qualities. This config will be required starting in Next.js 16.` +
+          `Image with src "${src}" is using quality "${qualityInt}" which is not configured in images.qualities [${config.qualities.join(', ')}]. Please update your config to [${[...config.qualities, qualityInt].sort().join(',')}].` +
             `\nRead more: https://nextjs.org/docs/messages/next-image-unconfigured-qualities`
         )
       }

--- a/packages/next/src/shared/lib/find-closest-quality.ts
+++ b/packages/next/src/shared/lib/find-closest-quality.ts
@@ -1,0 +1,21 @@
+import type { NextConfig } from '../../server/config-shared'
+
+/**
+ * Find the closest matching `quality` in the list of `config.qualities`
+ * @param quality the quality prop passed to the image component
+ * @param config the "images" configuration from next.config.js
+ * @returns the closest matching quality value
+ */
+export function findClosestQuality(
+  quality: number | undefined,
+  config: NextConfig['images'] | undefined
+): number {
+  const q = quality || 75
+  if (!config?.qualities?.length) {
+    return q
+  }
+  return config.qualities.reduce(
+    (prev, cur) => (Math.abs(cur - q) < Math.abs(prev - q) ? cur : prev),
+    0
+  )
+}

--- a/packages/next/src/shared/lib/get-img-props.ts
+++ b/packages/next/src/shared/lib/get-img-props.ts
@@ -532,9 +532,13 @@ export function getImgProps(
         )
       }
     }
-    if (qualityInt && qualityInt !== 75 && !config.qualities) {
+    if (
+      qualityInt &&
+      config.qualities &&
+      !config.qualities.includes(qualityInt)
+    ) {
       warnOnce(
-        `Image with src "${src}" is using quality "${qualityInt}" which is not configured in images.qualities. This config will be required starting in Next.js 16.` +
+        `Image with src "${src}" is using quality "${qualityInt}" which is not configured in images.qualities [${config.qualities.join(', ')}]. Please update your config to [${[...config.qualities, qualityInt].sort().join(', ')}].` +
           `\nRead more: https://nextjs.org/docs/messages/next-image-unconfigured-qualities`
       )
     }

--- a/packages/next/src/shared/lib/image-config.ts
+++ b/packages/next/src/shared/lib/image-config.ts
@@ -142,6 +142,6 @@ export const imageConfigDefault: ImageConfigComplete = {
   contentDispositionType: 'attachment',
   localPatterns: undefined, // default: allow all local images
   remotePatterns: [], // default: allow no remote images
-  qualities: undefined, // default: allow all qualities
+  qualities: [75],
   unoptimized: false,
 }

--- a/packages/next/src/shared/lib/image-loader.ts
+++ b/packages/next/src/shared/lib/image-loader.ts
@@ -78,21 +78,15 @@ function defaultLoader({
         }
       }
     }
-
-    if (quality && config.qualities && !config.qualities.includes(quality)) {
-      throw new Error(
-        `Invalid quality prop (${quality}) on \`next/image\` does not match \`images.qualities\` configured in your \`next.config.js\`\n` +
-          `See more info: https://nextjs.org/docs/messages/next-image-unconfigured-qualities`
-      )
-    }
   }
-
+  // find the closest matching `quality` in the list of `config.qualities`
   const q =
-    quality ||
     config.qualities?.reduce((prev, cur) =>
-      Math.abs(cur - DEFAULT_Q) < Math.abs(prev - DEFAULT_Q) ? cur : prev
-    ) ||
-    DEFAULT_Q
+      Math.abs(cur - (quality || DEFAULT_Q)) <
+      Math.abs(prev - (quality || DEFAULT_Q))
+        ? cur
+        : prev
+    ) || DEFAULT_Q
 
   return `${config.path}?url=${encodeURIComponent(src)}&w=${width}&q=${q}${
     src.startsWith('/_next/static/media/') && process.env.NEXT_DEPLOYMENT_ID

--- a/packages/next/src/shared/lib/image-loader.ts
+++ b/packages/next/src/shared/lib/image-loader.ts
@@ -1,6 +1,5 @@
 import type { ImageLoaderPropsWithConfig } from './image-config'
-
-const DEFAULT_Q = 75
+import { findClosestQuality } from './find-closest-quality'
 
 function defaultLoader({
   config,
@@ -79,14 +78,8 @@ function defaultLoader({
       }
     }
   }
-  // find the closest matching `quality` in the list of `config.qualities`
-  const q =
-    config.qualities?.reduce((prev, cur) =>
-      Math.abs(cur - (quality || DEFAULT_Q)) <
-      Math.abs(prev - (quality || DEFAULT_Q))
-        ? cur
-        : prev
-    ) || DEFAULT_Q
+
+  const q = findClosestQuality(quality, config)
 
   return `${config.path}?url=${encodeURIComponent(src)}&w=${width}&q=${q}${
     src.startsWith('/_next/static/media/') && process.env.NEXT_DEPLOYMENT_ID

--- a/test/e2e/app-dir/next-image/next.config.ts
+++ b/test/e2e/app-dir/next-image/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [new URL('https://image-optimization-test.vercel.app/**')],
+    qualities: [50, 55, 60, 65, 70, 75, 80, 85, 90],
   },
 }
 

--- a/test/integration/image-optimizer/test/util.ts
+++ b/test/integration/image-optimizer/test/util.ts
@@ -28,6 +28,7 @@ type SetupTestsCtx = {
 
 type RunTestsCtx = SetupTestsCtx & {
   w: number
+  q: number
   app?: import('child_process').ChildProcess
   appDir?: string
   appPort?: number
@@ -174,7 +175,7 @@ export function runTests(ctx: RunTestsCtx) {
   if (domains.length > 0) {
     it('should normalize invalid status codes', async () => {
       const url = `http://localhost:${slowImageServer.port}/slow.png?delay=${1}&status=308`
-      const query = { url, w: ctx.w, q: 39 }
+      const query = { url, w: ctx.w, q: ctx.q }
       const opts: RequestInit = {
         headers: { accept: 'image/webp' },
         redirect: 'manual',
@@ -186,7 +187,7 @@ export function runTests(ctx: RunTestsCtx) {
 
     it('should timeout for upstream image exceeding 7 seconds', async () => {
       const url = `http://localhost:${slowImageServer.port}/slow.png?delay=${8000}`
-      const query = { url, w: ctx.w, q: 100 }
+      const query = { url, w: ctx.w, q: ctx.q }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
       expect(res.status).toBe(504)
     })
@@ -198,13 +199,13 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should handle non-ascii characters in image url', async () => {
-    const query = { w: ctx.w, q: 90, url: '/äöüščří.png' }
+    const query = { w: ctx.w, q: ctx.q, url: '/äöüščří.png' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
   })
 
   it('should maintain icns', async () => {
-    const query = { w: ctx.w, q: 90, url: '/test.icns' }
+    const query = { w: ctx.w, q: ctx.q, url: '/test.icns' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toContain('image/x-icns')
@@ -220,7 +221,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should maintain jxl', async () => {
-    const query = { w: ctx.w, q: 90, url: '/test.jxl' }
+    const query = { w: ctx.w, q: ctx.q, url: '/test.jxl' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toContain('image/jxl')
@@ -236,7 +237,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should maintain heic', async () => {
-    const query = { w: ctx.w, q: 90, url: '/test.heic' }
+    const query = { w: ctx.w, q: ctx.q, url: '/test.heic' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toContain('image/heic')
@@ -252,7 +253,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should maintain jp2', async () => {
-    const query = { w: ctx.w, q: 90, url: '/test.jp2' }
+    const query = { w: ctx.w, q: ctx.q, url: '/test.jp2' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toContain('image/jp2')
@@ -268,7 +269,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should maintain animated gif', async () => {
-    const query = { w: ctx.w, q: 90, url: '/animated.gif' }
+    const query = { w: ctx.w, q: ctx.q, url: '/animated.gif' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toContain('image/gif')
@@ -285,7 +286,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should maintain animated png', async () => {
-    const query = { w: ctx.w, q: 90, url: '/animated.png' }
+    const query = { w: ctx.w, q: ctx.q, url: '/animated.png' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toContain('image/png')
@@ -302,7 +303,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should maintain animated png 2', async () => {
-    const query = { w: ctx.w, q: 90, url: '/animated2.png' }
+    const query = { w: ctx.w, q: ctx.q, url: '/animated2.png' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toContain('image/png')
@@ -319,7 +320,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should maintain animated webp', async () => {
-    const query = { w: ctx.w, q: 90, url: '/animated.webp' }
+    const query = { w: ctx.w, q: ctx.q, url: '/animated.webp' }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toContain('image/webp')
@@ -336,7 +337,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should not forward cookie header', async () => {
-    const query = { w: ctx.w, q: 30, url: '/api/conditional-cookie' }
+    const query = { w: ctx.w, q: ctx.q, url: '/api/conditional-cookie' }
     const opts = { headers: { accept: 'image/webp', cookie: '1' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(400)
@@ -344,7 +345,7 @@ export function runTests(ctx: RunTestsCtx) {
 
   if (ctx.nextConfigImages?.dangerouslyAllowSVG) {
     it('should maintain vector svg', async () => {
-      const query = { w: ctx.w, q: 90, url: '/test.svg' }
+      const query = { w: ctx.w, q: ctx.q, url: '/test.svg' }
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
@@ -369,7 +370,7 @@ export function runTests(ctx: RunTestsCtx) {
     })
   } else {
     it('should not allow vector svg', async () => {
-      const query = { w: ctx.w, q: 35, url: '/test.svg' }
+      const query = { w: ctx.w, q: ctx.q, url: '/test.svg' }
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(400)
@@ -377,7 +378,7 @@ export function runTests(ctx: RunTestsCtx) {
     })
 
     it('should not allow svg with application header', async () => {
-      const query = { w: ctx.w, q: 45, url: '/api/application.svg' }
+      const query = { w: ctx.w, q: ctx.q, url: '/api/application.svg' }
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(400)
@@ -387,7 +388,7 @@ export function runTests(ctx: RunTestsCtx) {
     })
 
     it('should not allow svg with comma header', async () => {
-      const query = { w: ctx.w, q: 55, url: '/api/comma.svg' }
+      const query = { w: ctx.w, q: ctx.q, url: '/api/comma.svg' }
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(400)
@@ -397,7 +398,7 @@ export function runTests(ctx: RunTestsCtx) {
     })
 
     it('should not allow svg with uppercase header', async () => {
-      const query = { w: ctx.w, q: 65, url: '/api/uppercase.svg' }
+      const query = { w: ctx.w, q: ctx.q, url: '/api/uppercase.svg' }
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(400)
@@ -407,7 +408,7 @@ export function runTests(ctx: RunTestsCtx) {
     })
 
     it('should not allow svg with wrong header', async () => {
-      const query = { w: ctx.w, q: 65, url: '/api/wrong-header.svg' }
+      const query = { w: ctx.w, q: ctx.q, url: '/api/wrong-header.svg' }
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(400)
@@ -418,7 +419,7 @@ export function runTests(ctx: RunTestsCtx) {
   }
 
   it('should not allow pdf format', async () => {
-    const query = { w: ctx.w, q: 90, url: '/test.pdf' }
+    const query = { w: ctx.w, q: ctx.q, url: '/test.pdf' }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(400)
@@ -428,7 +429,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should maintain ico format', async () => {
-    const query = { w: ctx.w, q: 90, url: `/test.ico` }
+    const query = { w: ctx.w, q: ctx.q, url: `/test.ico` }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -452,7 +453,7 @@ export function runTests(ctx: RunTestsCtx) {
   it('should maintain jpg format for old Safari', async () => {
     const accept =
       'image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5'
-    const query = { w: ctx.w, q: 90, url: '/test.jpg' }
+    const query = { w: ctx.w, q: ctx.q, url: '/test.jpg' }
     const opts = { headers: { accept } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -470,7 +471,7 @@ export function runTests(ctx: RunTestsCtx) {
   it('should maintain png format for old Safari', async () => {
     const accept =
       'image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5'
-    const query = { w: ctx.w, q: 75, url: '/test.png' }
+    const query = { w: ctx.w, q: ctx.q, url: '/test.png' }
     const opts = { headers: { accept } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -488,7 +489,7 @@ export function runTests(ctx: RunTestsCtx) {
   it('should downlevel webp format to jpeg for old Safari', async () => {
     const accept =
       'image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5'
-    const query = { w: ctx.w, q: 74, url: '/test.webp' }
+    const query = { w: ctx.w, q: ctx.q, url: '/test.webp' }
     const opts = { headers: { accept } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -507,7 +508,7 @@ export function runTests(ctx: RunTestsCtx) {
   it('should downlevel avif format to jpeg for old Safari', async () => {
     const accept =
       'image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5'
-    const query = { w: ctx.w, q: 74, url: '/test.avif' }
+    const query = { w: ctx.w, q: ctx.q, url: '/test.avif' }
     const opts = { headers: { accept } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -524,14 +525,14 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should fail when url is missing', async () => {
-    const query = { w: ctx.w, q: 100 }
+    const query = { w: ctx.w, q: ctx.q }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(400)
     expect(await res.text()).toBe(`"url" parameter is required`)
   })
 
   it('should fail when w is missing', async () => {
-    const query = { url: '/test.png', q: 100 }
+    const query = { url: '/test.png', q: ctx.q }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(400)
     expect(await res.text()).toBe(`"w" parameter (width) is required`)
@@ -562,8 +563,19 @@ export function runTests(ctx: RunTestsCtx) {
     )
   })
 
+  if (ctx?.nextConfigImages?.qualities) {
+    it('should fail when q is not in config', async () => {
+      const query = { url: '/test.png', w: ctx.w, q: 13 }
+      const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
+      expect(res.status).toBe(400)
+      expect(await res.text()).toBe(
+        `"q" parameter (quality) of 13 is not allowed`
+      )
+    })
+  }
+
   it('should fail when w is 0', async () => {
-    const query = { url: '/test.png', w: 0, q: 100 }
+    const query = { url: '/test.png', w: 0, q: ctx.q }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(400)
     expect(await res.text()).toBe(
@@ -572,7 +584,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should fail when w is less than 0', async () => {
-    const query = { url: '/test.png', w: -100, q: 100 }
+    const query = { url: '/test.png', w: -100, q: ctx.q }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(400)
     expect(await res.text()).toBe(
@@ -581,7 +593,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should fail when w is not a number', async () => {
-    const query = { url: '/test.png', w: 'foo', q: 100 }
+    const query = { url: '/test.png', w: 'foo', q: ctx.q }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(400)
     expect(await res.text()).toBe(
@@ -590,7 +602,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should fail when w is not an integer', async () => {
-    const query = { url: '/test.png', w: 99.9, q: 100 }
+    const query = { url: '/test.png', w: 99.9, q: ctx.q }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(400)
     expect(await res.text()).toBe(
@@ -618,7 +630,7 @@ export function runTests(ctx: RunTestsCtx) {
 
   it('should fail when domain is not defined in next.config.js', async () => {
     const url = `http://vercel.com/button`
-    const query = { url, w: ctx.w, q: 100 }
+    const query = { url, w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(400)
@@ -626,7 +638,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should fail when width is not in next.config.js', async () => {
-    const query = { url: '/test.png', w: 1000, q: 100 }
+    const query = { url: '/test.png', w: 1000, q: ctx.q }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(400)
@@ -668,7 +680,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should resize relative url and webp Firefox accept header', async () => {
-    const query = { url: '/test.png', w: ctx.w, q: 80 }
+    const query = { url: '/test.png', w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/webp,*/*' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -685,7 +697,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should resize relative url and png accept header', async () => {
-    const query = { url: '/test.png', w: ctx.w, q: 80 }
+    const query = { url: '/test.png', w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/png' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -702,7 +714,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should resize relative url with invalid accept header as png', async () => {
-    const query = { url: '/test.png', w: ctx.w, q: 80 }
+    const query = { url: '/test.png', w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/invalid' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -719,7 +731,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should resize relative url with invalid accept header as gif', async () => {
-    const query = { url: '/test.gif', w: ctx.w, q: 80 }
+    const query = { url: '/test.gif', w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/invalid' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -736,7 +748,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should resize relative url with invalid accept header as tiff', async () => {
-    const query = { url: '/test.tiff', w: ctx.w, q: 80 }
+    const query = { url: '/test.tiff', w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/invalid' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -753,7 +765,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should resize gif (not animated)', async () => {
-    const query = { url: '/test.gif', w: ctx.w, q: 75 }
+    const query = { url: '/test.gif', w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -770,7 +782,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should resize tiff', async () => {
-    const query = { url: '/test.tiff', w: ctx.w, q: 75 }
+    const query = { url: '/test.tiff', w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -787,7 +799,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should resize avif', async () => {
-    const query = { url: '/test.avif', w: ctx.w, q: 75 }
+    const query = { url: '/test.avif', w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -804,7 +816,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should resize relative url and old Chrome accept header as webp', async () => {
-    const query = { url: '/test.png', w: ctx.w, q: 80 }
+    const query = { url: '/test.png', w: ctx.w, q: ctx.q }
     const opts = {
       headers: { accept: 'image/webp,image/apng,image/*,*/*;q=0.8' },
     }
@@ -824,7 +836,7 @@ export function runTests(ctx: RunTestsCtx) {
 
   if (avifEnabled) {
     it('should resize relative url and new Chrome accept header as avif', async () => {
-      const query = { url: '/test.png', w: ctx.w, q: 80 }
+      const query = { url: '/test.png', w: ctx.w, q: ctx.q }
       const opts = {
         headers: {
           accept: 'image/avif,image/webp,image/apng,image/*,*/*;q=0.8',
@@ -845,7 +857,7 @@ export function runTests(ctx: RunTestsCtx) {
     })
 
     it('should resize avif and maintain format', async () => {
-      const query = { url: '/test.avif', w: ctx.w, q: 75 }
+      const query = { url: '/test.avif', w: ctx.w, q: ctx.q }
       const opts = { headers: { accept: 'image/avif' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
@@ -877,7 +889,7 @@ export function runTests(ctx: RunTestsCtx) {
   if (domains.length > 0) {
     it('should resize absolute url from localhost', async () => {
       const url = `http://localhost:${ctx.appPort}/test.png`
-      const query = { url, w: ctx.w, q: 80 }
+      const query = { url, w: ctx.w, q: ctx.q }
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
@@ -900,7 +912,7 @@ export function runTests(ctx: RunTestsCtx) {
       expect(resOrig.headers.get('Content-Type')).toBe(
         'application/octet-stream'
       )
-      const query = { url, w: ctx.w, q: 80 }
+      const query = { url, w: ctx.w, q: ctx.q }
       const opts = { headers: { accept: 'image/webp' } }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
@@ -923,14 +935,8 @@ export function runTests(ctx: RunTestsCtx) {
       await cleanImagesDir(ctx)
       const delay = 500
 
-      if (globalThis.isrImgQuality) {
-        globalThis.isrImgQuality++
-      } else {
-        globalThis.isrImgQuality = 40
-      }
-
       const url = `http://localhost:${slowImageServer.port}/slow.png?delay=${delay}`
-      const query = { url, w: ctx.w, q: globalThis.isrImgQuality }
+      const query = { url, w: ctx.w, q: ctx.q }
       const opts = { headers: { accept: 'image/webp' } }
 
       const one = await fetchWithDuration(
@@ -1037,7 +1043,7 @@ export function runTests(ctx: RunTestsCtx) {
 
   it('should fail when url has file protocol', async () => {
     const url = `file://localhost:${ctx.appPort}/test.png`
-    const query = { url, w: ctx.w, q: 80 }
+    const query = { url, w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(400)
@@ -1046,7 +1052,7 @@ export function runTests(ctx: RunTestsCtx) {
 
   it('should fail when url has ftp protocol', async () => {
     const url = `ftp://localhost:${ctx.appPort}/test.png`
-    const query = { url, w: ctx.w, q: 80 }
+    const query = { url, w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(400)
@@ -1054,14 +1060,14 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should fail when url is too long', async () => {
-    const query = { url: `/${'a'.repeat(4000)}`, w: ctx.w, q: 1 }
+    const query = { url: `/${'a'.repeat(4000)}`, w: ctx.w, q: ctx.q }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(400)
     expect(await res.text()).toBe(`"url" parameter is too long`)
   })
 
   it('should fail when url is protocol relative', async () => {
-    const query = { url: `//example.com`, w: ctx.w, q: 1 }
+    const query = { url: `//example.com`, w: ctx.w, q: ctx.q }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
     expect(res.status).toBe(400)
     expect(await res.text()).toBe(
@@ -1071,7 +1077,11 @@ export function runTests(ctx: RunTestsCtx) {
 
   describe('recursive url is not allowed', () => {
     it('should fail with relative next image url', async () => {
-      const query = { url: `/_next/image?url=test.pngw=1&q=1`, w: ctx.w, q: 1 }
+      const query = {
+        url: `/_next/image?url=test.pngw=1&q=75`,
+        w: ctx.w,
+        q: ctx.q,
+      }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
       expect(res.status).toBe(400)
       expect(await res.text()).toBe(`"url" parameter cannot be recursive`)
@@ -1081,7 +1091,7 @@ export function runTests(ctx: RunTestsCtx) {
       const query = {
         url: '%2F_next%2Fimage%3Furl%3Dtest.pngw%3D1%26q%3D1',
         w: ctx.w,
-        q: 1,
+        q: ctx.q,
       }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
       expect(res.status).toBe(400)
@@ -1092,7 +1102,7 @@ export function runTests(ctx: RunTestsCtx) {
       it('should pass with absolute next image url', async () => {
         const fullUrl =
           'https://image-optimization-test.vercel.app/_next/image?url=%2Ffrog.jpg&w=1024&q=75'
-        const query = { url: fullUrl, w: ctx.w, q: 1 }
+        const query = { url: fullUrl, w: ctx.w, q: ctx.q }
         const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
         expect(res.status).toBe(200)
         await expectWidth(res, ctx.w)
@@ -1101,7 +1111,7 @@ export function runTests(ctx: RunTestsCtx) {
       it('should fail with absolute next image url', async () => {
         const fullUrl =
           'https://image-optimization-test.vercel.app/_next/image?url=%2Ffrog.jpg&w=1024&q=75'
-        const query = { url: fullUrl, w: ctx.w, q: 1 }
+        const query = { url: fullUrl, w: ctx.w, q: ctx.q }
         const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
         expect(res.status).toBe(400)
         expect(await res.text()).toBe(`"url" parameter is not allowed`)
@@ -1110,7 +1120,7 @@ export function runTests(ctx: RunTestsCtx) {
 
     it('should fail with relative image url with assetPrefix', async () => {
       const fullUrl = '/assets/_next/image?url=%2Ftest.png&w=128&q=75'
-      const query = { url: fullUrl, w: ctx.w, q: 1 }
+      const query = { url: fullUrl, w: ctx.w, q: ctx.q }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
       expect(res.status).toBe(400)
       expect(await res.text()).toBe(`"url" parameter cannot be recursive`)
@@ -1119,7 +1129,7 @@ export function runTests(ctx: RunTestsCtx) {
 
   it('should fail when internal url is not an image', async () => {
     const url = `/api/no-header`
-    const query = { url, w: ctx.w, q: 39 }
+    const query = { url, w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(400)
@@ -1131,7 +1141,7 @@ export function runTests(ctx: RunTestsCtx) {
   if (domains.length > 0) {
     it('should fail when url fails to load an image', async () => {
       const url = `http://localhost:${ctx.appPort}/not-an-image`
-      const query = { w: ctx.w, url, q: 100 }
+      const query = { w: ctx.w, url, q: ctx.q }
       const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, {})
       expect(res.status).toBe(404)
       expect(await res.text()).toBe(
@@ -1146,16 +1156,10 @@ export function runTests(ctx: RunTestsCtx) {
     }
     await cleanImagesDir(ctx)
 
-    if (globalThis.isrImgQuality) {
-      globalThis.isrImgQuality++
-    } else {
-      globalThis.isrImgQuality = 80
-    }
-
     const query = {
       url: '/api/stateful/test.png',
       w: ctx.w,
-      q: globalThis.isrImgQuality,
+      q: ctx.q,
     }
     const opts = { headers: { accept: 'image/webp' } }
 
@@ -1259,7 +1263,7 @@ export function runTests(ctx: RunTestsCtx) {
     it('should use cached image file when parameters are the same for svg', async () => {
       await cleanImagesDir(ctx)
 
-      const query = { url: '/test.svg', w: ctx.w, q: 80 }
+      const query = { url: '/test.svg', w: ctx.w, q: ctx.q }
       const opts = { headers: { accept: 'image/webp' } }
 
       const res1 = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
@@ -1299,7 +1303,7 @@ export function runTests(ctx: RunTestsCtx) {
     }
     await cleanImagesDir(ctx)
 
-    const query = { url: '/animated.gif', w: ctx.w, q: 80 }
+    const query = { url: '/animated.gif', w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/webp' } }
 
     const res1 = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
@@ -1328,7 +1332,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should set 304 status without body when etag matches if-none-match', async () => {
-    const query = { url: '/test.jpg', w: ctx.w, q: 80 }
+    const query = { url: '/test.jpg', w: ctx.w, q: ctx.q }
     const opts1 = { headers: { accept: 'image/webp' } }
 
     const res1 = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts1)
@@ -1357,27 +1361,35 @@ export function runTests(ctx: RunTestsCtx) {
     expect(res2.headers.get('Content-Disposition')).toBeFalsy()
     expect((await res2.buffer()).length).toBe(0)
 
-    const query3 = { url: '/test.jpg', w: ctx.w, q: 25 }
-    const res3 = await fetchViaHTTP(ctx.appPort, '/_next/image', query3, opts2)
-    expect(res3.status).toBe(200)
-    expect(res3.headers.get('Content-Type')).toBe('image/webp')
-    expect(res3.headers.get('Cache-Control')).toBe(
-      `public, max-age=${isDev ? 0 : minimumCacheTTL}, must-revalidate`
-    )
-    expect(res3.headers.get('Vary')).toBe('Accept')
-    expect(res3.headers.get('Etag')).toBeTruthy()
-    expect(res3.headers.get('Etag')).not.toBe(etag)
-    expect(res3.headers.get('Content-Disposition')).toBe(
-      `${contentDispositionType}; filename="test.webp"`
-    )
-    await expectWidth(res3, ctx.w)
+    if (ctx?.nextConfigImages?.qualities) {
+      const q = ctx.nextConfigImages.qualities[0]
+      const query3 = { url: '/test.jpg', w: ctx.w, q }
+      const res3 = await fetchViaHTTP(
+        ctx.appPort,
+        '/_next/image',
+        query3,
+        opts2
+      )
+      expect(res3.status).toBe(200)
+      expect(res3.headers.get('Content-Type')).toBe('image/webp')
+      expect(res3.headers.get('Cache-Control')).toBe(
+        `public, max-age=${isDev ? 0 : minimumCacheTTL}, must-revalidate`
+      )
+      expect(res3.headers.get('Vary')).toBe('Accept')
+      expect(res3.headers.get('Etag')).toBeTruthy()
+      expect(res3.headers.get('Etag')).not.toBe(etag)
+      expect(res3.headers.get('Content-Disposition')).toBe(
+        `${contentDispositionType}; filename="test.webp"`
+      )
+      await expectWidth(res3, ctx.w)
+    }
   })
 
   it('should maintain bmp', async () => {
     const json1 = await fsToJson(ctx.imagesDir)
     expect(json1).toBeTruthy()
 
-    const query = { url: '/test.bmp', w: ctx.w, q: 80 }
+    const query = { url: '/test.bmp', w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/invalid' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -1409,7 +1421,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should not resize if requested width is larger than original source image', async () => {
-    const query = { url: '/test.jpg', w: largeSize, q: 80 }
+    const query = { url: '/test.jpg', w: largeSize, q: ctx.q }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(200)
@@ -1431,7 +1443,7 @@ export function runTests(ctx: RunTestsCtx) {
       const query = {
         url: `/_next/static/media/${filename}.fab2915d.jpg`,
         w: ctx.w,
-        q: 100,
+        q: ctx.q,
       }
       const opts = { headers: { accept: 'image/webp' } }
 
@@ -1461,7 +1473,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it("should error if the resource isn't a valid image", async () => {
-    const query = { url: '/test.txt', w: ctx.w, q: 80 }
+    const query = { url: '/test.txt', w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(400)
@@ -1469,7 +1481,7 @@ export function runTests(ctx: RunTestsCtx) {
   })
 
   it('should error if the image file does not exist', async () => {
-    const query = { url: '/does_not_exist.jpg', w: ctx.w, q: 80 }
+    const query = { url: '/does_not_exist.jpg', w: ctx.w, q: ctx.q }
     const opts = { headers: { accept: 'image/webp' } }
     const res = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res.status).toBe(400)
@@ -1483,7 +1495,7 @@ export function runTests(ctx: RunTestsCtx) {
       const query = {
         url: `http://localhost:${slowImageServer.port}/slow.png?delay=${delay}`,
         w: ctx.w,
-        q: 80,
+        q: ctx.q,
       }
       const opts = { headers: { accept: 'image/webp,*/*' } }
       const [res1, res2, res3] = await Promise.all([
@@ -1549,6 +1561,7 @@ export const setupTests = (ctx: SetupTestsCtx) => {
     const curCtx: RunTestsCtx = {
       ...ctx,
       w: size,
+      q: 75,
       isDev: true,
     }
 
@@ -1582,6 +1595,7 @@ export const setupTests = (ctx: SetupTestsCtx) => {
     const curCtx: RunTestsCtx = {
       ...ctx,
       w: size,
+      q: 100,
       isDev: true,
       nextConfigImages: {
         domains: [
@@ -1594,6 +1608,7 @@ export const setupTests = (ctx: SetupTestsCtx) => {
         formats: ['image/avif', 'image/webp'] as any,
         deviceSizes: [largeSize],
         imageSizes: [size],
+        qualities: [50, 75, 100],
         ...ctx.nextConfigImages,
       },
     }
@@ -1633,6 +1648,7 @@ export const setupTests = (ctx: SetupTestsCtx) => {
     const curCtx: RunTestsCtx = {
       ...ctx,
       w: size,
+      q: 75,
       isDev: false,
     }
     beforeAll(async () => {
@@ -1667,6 +1683,7 @@ export const setupTests = (ctx: SetupTestsCtx) => {
     const curCtx: RunTestsCtx = {
       ...ctx,
       w: size,
+      q: 100,
       isDev: false,
       nextConfigImages: {
         domains: [
@@ -1678,6 +1695,7 @@ export const setupTests = (ctx: SetupTestsCtx) => {
         ],
         formats: ['image/avif', 'image/webp'] as any,
         deviceSizes: [size, largeSize],
+        qualities: [50, 75, 100],
         ...ctx.nextConfigImages,
       },
     }

--- a/test/integration/next-image-legacy/default/test/index.test.ts
+++ b/test/integration/next-image-legacy/default/test/index.test.ts
@@ -923,7 +923,7 @@ function runTests(mode) {
         .join('\n')
       await assertNoRedbox(browser)
       expect(warnings).toMatch(
-        /Image with src (.*)jpg(.*) is using quality "50" which is not configured in images.qualities. This config will be required starting in Next.js 16./gm
+        /Image with src (.*)jpg(.*) is using quality "50" which is not configured in images.qualities \[75\]. Please update your config to \[50, 75\]./gm
       )
     })
 

--- a/test/integration/next-image-new/app-dir-localpatterns/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir-localpatterns/test/index.test.ts
@@ -98,7 +98,7 @@ function runTests(mode: 'dev' | 'server') {
           ],
           minimumCacheTTL: 60,
           path: '/_next/image',
-          qualities: undefined,
+          qualities: [75],
           sizes: [
             640, 750, 828, 1080, 1200, 1920, 2048, 3840, 16, 32, 48, 64, 96,
             128, 256, 384,

--- a/test/integration/next-image-new/app-dir-qualities/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir-qualities/test/index.test.ts
@@ -1,12 +1,10 @@
 /* eslint-env jest */
 
 import {
-  assertHasRedbox,
   assertNoRedbox,
   fetchViaHTTP,
   findPort,
   getImagesManifest,
-  getRedboxHeader,
   killApp,
   launchApp,
   nextBuild,
@@ -73,19 +71,16 @@ function runTests(mode: 'dev' | 'server') {
     expect(res.status).toStrictEqual(200)
   })
 
-  it('should fail to load img when quality is 100', async () => {
+  it('should coerce quality 100 to closest matching of 88', async () => {
     const page = '/invalid-quality'
     const browser = await webdriver(appPort, page)
     if (mode === 'dev') {
-      await assertHasRedbox(browser)
-      expect(await getRedboxHeader(browser)).toMatch(
-        /Invalid quality prop (.+) on `next\/image` does not match `images.qualities` configured/g
-      )
-    } else {
-      const url = await getSrc(browser, 'q-100')
-      const res = await fetchViaHTTP(appPort, url)
-      expect(res.status).toBe(400)
+      await assertNoRedbox(browser)
     }
+    const url = await getSrc(browser, 'q-100')
+    expect(url).toContain('&q=88') // coerced to closest matching of 88
+    const res = await fetchViaHTTP(appPort, url)
+    expect(res.status).toBe(200)
   })
 
   if (mode === 'server') {

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -792,10 +792,10 @@ function runTests(mode: 'dev' | 'server') {
     expect(await img.getAttribute('data-nimg')).toBe('fill')
     expect(await img.getAttribute('sizes')).toBe('200px')
     expect(await img.getAttribute('src')).toBe(
-      '/_next/image?url=%2Ftest.jpg&w=3840&q=50'
+      '/_next/image?url=%2Ftest.jpg&w=3840&q=75'
     )
     expect(await img.getAttribute('srcset')).toContain(
-      '/_next/image?url=%2Ftest.jpg&w=640&q=50 640w,'
+      '/_next/image?url=%2Ftest.jpg&w=640&q=75 640w,'
     )
     expect(await img.getAttribute('style')).toBe(
       'position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;object-fit:cover;object-position:10% 10%;color:transparent'

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -1060,7 +1060,7 @@ function runTests(mode: 'dev' | 'server') {
         .join('\n')
       await assertNoRedbox(browser)
       expect(warnings).toMatch(
-        /Image with src (.*)jpg(.*) is using quality "50" which is not configured in images.qualities. This config will be required starting in Next.js 16./gm
+        /Image with src (.*)jpg(.*) is using quality "50" which is not configured in images.qualities \[75\]. Please update your config to \[50, 75\]./gm
       )
     })
 
@@ -1636,7 +1636,7 @@ function runTests(mode: 'dev' | 'server') {
           localPatterns: undefined,
           minimumCacheTTL: 60,
           path: '/_next/image',
-          qualities: undefined,
+          qualities: [75],
           sizes: [
             640, 750, 828, 1080, 1200, 1920, 2048, 3840, 16, 32, 48, 64, 96,
             128, 256, 384,

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -794,10 +794,10 @@ function runTests(mode) {
     expect(await img.getAttribute('data-nimg')).toBe('fill')
     expect(await img.getAttribute('sizes')).toBe('200px')
     expect(await img.getAttribute('src')).toBe(
-      '/_next/image?url=%2Ftest.jpg&w=3840&q=50'
+      '/_next/image?url=%2Ftest.jpg&w=3840&q=75'
     )
     expect(await img.getAttribute('srcset')).toContain(
-      '/_next/image?url=%2Ftest.jpg&w=640&q=50 640w,'
+      '/_next/image?url=%2Ftest.jpg&w=640&q=75 640w,'
     )
     expect(await img.getAttribute('style')).toBe(
       'position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;object-fit:cover;object-position:10% 10%;color:transparent'

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -1062,7 +1062,7 @@ function runTests(mode) {
         .join('\n')
       await assertNoRedbox(browser)
       expect(warnings).toMatch(
-        /Image with src (.*)jpg(.*) is using quality "50" which is not configured in images.qualities. This config will be required starting in Next.js 16./gm
+        /Image with src (.*)jpg(.*) is using quality "50" which is not configured in images.qualities \[75\]. Please update your config to \[50, 75\]/gm
       )
     })
 

--- a/test/integration/next-image-new/loader-config-default-loader-with-file/next.config.js
+++ b/test/integration/next-image-new/loader-config-default-loader-with-file/next.config.js
@@ -2,5 +2,6 @@ module.exports = {
   images: {
     loader: 'default',
     loaderFile: './dummy-loader.js',
+    qualities: [50, 75],
   },
 }

--- a/test/integration/next-image-new/unicode/test/index.test.ts
+++ b/test/integration/next-image-new/unicode/test/index.test.ts
@@ -96,6 +96,7 @@ function runTests(mode: 'server' | 'dev') {
           ],
           minimumCacheTTL: 60,
           path: '/_next/image',
+          qualities: [75],
           sizes: [
             640, 750, 828, 1080, 1200, 1920, 2048, 3840, 16, 32, 48, 64, 96,
             128, 256, 384,

--- a/test/integration/next-image-new/unoptimized/test/index.test.ts
+++ b/test/integration/next-image-new/unoptimized/test/index.test.ts
@@ -112,7 +112,7 @@ function runTests(url: string, mode: 'dev' | 'server') {
           localPatterns: undefined,
           minimumCacheTTL: 60,
           path: '/_next/image',
-          qualities: undefined,
+          qualities: [75],
           sizes: [
             640, 750, 828, 1080, 1200, 1920, 2048, 3840, 16, 32, 48, 64, 96,
             128, 256, 384,

--- a/test/unit/image-optimizer/find-closest-quality.test.ts
+++ b/test/unit/image-optimizer/find-closest-quality.test.ts
@@ -1,0 +1,77 @@
+/* eslint-env jest */
+import { findClosestQuality } from 'next/dist/shared/lib/find-closest-quality'
+
+describe('findClosestQuality', () => {
+  it.each<{ input: Parameters<typeof findClosestQuality>; output: number }>([
+    {
+      input: [undefined, undefined],
+      output: 75,
+    },
+    {
+      input: [50, undefined],
+      output: 50,
+    },
+    {
+      input: [50, { qualities: undefined }],
+      output: 50,
+    },
+    {
+      input: [35, { qualities: [10, 30, 50] }],
+      output: 30,
+    },
+    {
+      input: [30, { qualities: [10, 30, 50] }],
+      output: 30,
+    },
+    {
+      input: [31, { qualities: [10, 30, 50] }],
+      output: 30,
+    },
+    {
+      input: [29, { qualities: [10, 30, 50] }],
+      output: 30,
+    },
+    {
+      input: [39, { qualities: [10, 30, 50] }],
+      output: 30,
+    },
+    {
+      input: [40, { qualities: [10, 30, 50] }],
+      output: 30, // favor the lower number when halfway
+    },
+    {
+      input: [41, { qualities: [10, 30, 50] }],
+      output: 50,
+    },
+    {
+      input: [75, { qualities: [50, 75, 100] }],
+      output: 75,
+    },
+    {
+      input: [undefined, { qualities: [50, 75, 100] }],
+      output: 75,
+    },
+    {
+      input: [undefined, { qualities: [25, 60, 100] }],
+      output: 60, // use closest to 75 when 75 is not in the config
+    },
+    {
+      input: [undefined, { qualities: [25, 50, 75] }],
+      output: 75, // use 75 when 75 is in the config
+    },
+    {
+      input: [undefined, { qualities: [100, 10, 75, 15] }],
+      output: 75, // use 75 when 75 is in the config, even out of order
+    },
+    {
+      input: [10, { qualities: [100, 10, 75, 15] }],
+      output: 10, // use input even when config is out of order
+    },
+    {
+      input: [14, { qualities: [100, 10, 75, 15] }],
+      output: 15, // use closet input even when config is out of order
+    },
+  ])('for quality $input expected $output', ({ input, output }) => {
+    expect(findClosestQuality(...input)).toEqual(output)
+  })
+})

--- a/test/unit/next-image-get-img-props.test.ts
+++ b/test/unit/next-image-get-img-props.test.ts
@@ -111,7 +111,7 @@ describe('getImageProps()', () => {
       ['src', '/_next/image?url=%2Ftest.png&w=256&q=75'],
     ])
   })
-  it('should handle quality', async () => {
+  it('should handle quality coercion from 50 to 75', async () => {
     const { props } = getImageProps({
       alt: 'a nice desc',
       id: 'my-image',
@@ -121,7 +121,7 @@ describe('getImageProps()', () => {
       quality: 50,
     })
     expect(warningMessages).toStrictEqual([
-      'Image with src "/test.png" is using quality "50" which is not configured in images.qualities. This config will be required starting in Next.js 16.\nRead more: https://nextjs.org/docs/messages/next-image-unconfigured-qualities',
+      'Image with src "/test.png" is using quality "50" which is not configured in images.qualities [75]. Please update your config to [50, 75].\nRead more: https://nextjs.org/docs/messages/next-image-unconfigured-qualities',
     ])
     expect(Object.entries(props)).toStrictEqual([
       ['alt', 'a nice desc'],
@@ -133,9 +133,34 @@ describe('getImageProps()', () => {
       ['style', { color: 'transparent' }],
       [
         'srcSet',
-        '/_next/image?url=%2Ftest.png&w=128&q=50 1x, /_next/image?url=%2Ftest.png&w=256&q=50 2x',
+        '/_next/image?url=%2Ftest.png&w=128&q=75 1x, /_next/image?url=%2Ftest.png&w=256&q=75 2x',
       ],
-      ['src', '/_next/image?url=%2Ftest.png&w=256&q=50'],
+      ['src', '/_next/image?url=%2Ftest.png&w=256&q=75'],
+    ])
+  })
+  it('should handle quality exact match config and not warn', async () => {
+    const { props } = getImageProps({
+      alt: 'a nice desc',
+      id: 'my-image',
+      src: '/test.png',
+      width: 100,
+      height: 200,
+      quality: 75,
+    })
+    expect(warningMessages).toStrictEqual([])
+    expect(Object.entries(props)).toStrictEqual([
+      ['alt', 'a nice desc'],
+      ['id', 'my-image'],
+      ['loading', 'lazy'],
+      ['width', 100],
+      ['height', 200],
+      ['decoding', 'async'],
+      ['style', { color: 'transparent' }],
+      [
+        'srcSet',
+        '/_next/image?url=%2Ftest.png&w=128&q=75 1x, /_next/image?url=%2Ftest.png&w=256&q=75 2x',
+      ],
+      ['src', '/_next/image?url=%2Ftest.png&w=256&q=75'],
     ])
   })
   it('should handle quality as a string and not warn', async () => {


### PR DESCRIPTION
## Background
We have default allowlists for the `url` (localPatterns/remotePatterns config) and `w` (imageSizes/deviceSizes config) but we don't have a default allowlist for `q` (currently opt-in with via qualities config).

## What's changing?
BREAKING CHANGE: This PR is a breaking change that sets the default allowlist to `qualities: [75]`, meaning that anything other than 75 is invalid. Since most images don't set the quality prop and therefore default to 75, most apps will be unaffected.

However, we can be even more gracious when users upgrade because we can coerce the value automatically to 75 (or rather any value in `qualities` allowlist). In dev, this will print a warning explaining why the prop was not observed. This also works if you had `qualities` configured but removed 75, since the closest matching value in the array will be used instead.