### PR TITLE
[turbopack] Change execution and snapshot tests to check for the existence of files rather than directories

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -102,8 +102,12 @@ fn register() {
 //
 // "Skip" directories named `__skipped__`, which include test directories to
 // skip.
-#[testing::fixture("tests/execution/*/*/*", exclude("node_modules|__skipped__"))]
+#[testing::fixture(
+    "tests/execution/*/*/*/input/index.js",
+    exclude("node_modules|__skipped__")
+)]
 fn test(resource: PathBuf) {
+    let resource = resource.parent().unwrap().parent().unwrap().to_path_buf();
     let messages = get_messages(run(resource, IssueSnapshotMode::Snapshots).unwrap());
     if !messages.is_empty() {
         panic!(
@@ -113,10 +117,10 @@ fn test(resource: PathBuf) {
     }
 }
 
-#[testing::fixture("tests/execution/*/*/__skipped__/*/input")]
+#[testing::fixture("tests/execution/*/*/__skipped__/*/input/index.js")]
 #[should_panic]
 fn test_skipped_fails(resource: PathBuf) {
-    let resource = resource.parent().unwrap().to_path_buf();
+    let resource = resource.parent().unwrap().parent().unwrap().to_path_buf();
 
     let JsResult {
         // Ignore uncaught exceptions for skipped tests.

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -168,8 +168,9 @@ fn is_empty_dir_tree(dir_entries: impl IntoIterator<Item = io::Result<fs::DirEnt
     true
 }
 
-#[testing::fixture("tests/snapshot/*/*/", exclude("node_modules"))]
+#[testing::fixture("tests/snapshot/*/*/input/index.js", exclude("node_modules"))]
 fn test(resource: PathBuf) {
+    let resource = resource.parent().unwrap().parent().unwrap().to_path_buf();
     let resource = canonicalize(resource).unwrap();
 
     let mut has_output_dir = false;


### PR DESCRIPTION
This fixes an annoying devex issue when switching branches

Closes PACK-5368