### PR TITLE
[backport] fix: relative paths in dev in validator.ts (#83073)

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -576,10 +576,7 @@ async function startWatcher(
                   ''
                 )
               ),
-              filePath: path.relative(
-                path.dirname(validatorFilePath),
-                fileName
-              ),
+              filePath: fileName,
             })
           }
 
@@ -606,18 +603,12 @@ async function startWatcher(
           if (validFileMatcher.isAppRouterRoute(fileName)) {
             appRouteHandlers.push({
               route: normalizePathSep(pageName),
-              filePath: path.relative(
-                path.dirname(validatorFilePath),
-                fileName
-              ),
+              filePath: fileName,
             })
           } else {
             appRoutes.push({
               route: normalizePathSep(pageName),
-              filePath: path.relative(
-                path.dirname(validatorFilePath),
-                fileName
-              ),
+              filePath: fileName,
             })
           }
 
@@ -635,18 +626,12 @@ async function startWatcher(
           if (pageName.startsWith('/api/')) {
             pageApiRoutes.push({
               route: normalizePathSep(pageName),
-              filePath: path.relative(
-                path.dirname(validatorFilePath),
-                fileName
-              ),
+              filePath: fileName,
             })
           } else {
             pageRoutes.push({
               route: normalizePathSep(pageName),
-              filePath: path.relative(
-                path.dirname(validatorFilePath),
-                fileName
-              ),
+              filePath: fileName,
             })
           }
         }
@@ -1062,6 +1047,9 @@ async function startWatcher(
             slots,
             redirects: opts.nextConfig.redirects,
             rewrites: opts.nextConfig.rewrites,
+            // Ensure relative paths in validator.ts are computed from validatorFilePath,
+            // matching behavior of build and CLI typegen.
+            validatorFilePath,
             appRouteHandlers,
             pageApiRoutes,
           })


### PR DESCRIPTION
Fixed #83063 

- **Problem**: `next dev` produced overly deep relative imports in `validator.ts` that differed from `next typegen`/`next build`.
- **Cause**: Dev pre-relativized page file paths and didn’t pass `validatorFilePath`, causing incorrect relative path computation.
- **Solution**:
  - Pass `validatorFilePath` to `createRouteTypesManifest` in dev.
- Stop pre-relativizing file paths; provide absolute `fileName` so the manifest computes paths relative to the validator directory.
- **Result**: `validator.ts` now uses correct, shallow relative imports, matching `next typegen` and `next build`.
- **Verification**: Reproduced with `test/e2e/app-dir/typed-routes-validator`; outputs from `pnpm next dev` and `pnpm next typegen` now match.

### Example
Before (next dev):
```typescript
// Validate ../../../../../../app/page.tsx
{
  const handler = {} as typeof import("../../../../../../app/page.js")
  handler satisfies AppPageConfig<"/">
}
```

After (next dev/typegen/build):
```typescript
// Validate ../../app/page.tsx
{
  const handler = {} as typeof import("../../app/page.js")
  handler satisfies AppPageConfig<"/">
}
```

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
