### PR TITLE
[backport] fix: validation return types of pages API routes (#83069)

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -563,7 +563,7 @@ export function generateValidatorFile(
 
   if (pagesApiRouteValidations) {
     typeDefinitions += `type ApiRouteConfig = {
-  default: (req: any, res: any) => Promise<Response | void> | Response | void
+  default: (req: any, res: any) => ReturnType<NextApiHandler>
   config?: {
     api?: {
       bodyParser?: boolean | { sizeLimit?: string }
@@ -609,10 +609,17 @@ export function generateValidatorFile(
     ? "import type { NextRequest } from 'next/server.js'\n"
     : ''
 
-  // Only import metadata types if there are App Router pages or layouts that might use them
-  const metadataImport =
-    appPageValidations || layoutValidations
-      ? 'import type { ResolvingMetadata, ResolvingViewport } from "next/dist/lib/metadata/types/metadata-interface.js"\n'
+  // Conditionally import types from next/types, merged into a single statement
+  const nextTypes: string[] = []
+  if (pagesApiRouteValidations) {
+    nextTypes.push('NextApiHandler')
+  }
+  if (appPageValidations || layoutValidations) {
+    nextTypes.push('ResolvingMetadata', 'ResolvingViewport')
+  }
+  const nextTypesImport =
+    nextTypes.length > 0
+      ? `import type { ${nextTypes.join(', ')} } from "next/types.js"\n`
       : ''
 
   return `// This file is generated automatically by Next.js
@@ -620,7 +627,7 @@ export function generateValidatorFile(
 // This file validates that all pages and layouts export the correct types
 
 ${routeImportStatement}
-${metadataImport}${nextRequestImport}
+${nextTypesImport}${nextRequestImport}
 ${typeDefinitions}
 ${appPageValidations}
 

--- a/test/e2e/app-dir/typed-routes-validator/pages/api/test-route-2.ts
+++ b/test/e2e/app-dir/typed-routes-validator/pages/api/test-route-2.ts
@@ -1,0 +1,11 @@
+import type { NextApiHandler } from 'next/types'
+
+type ResponseData = {
+  message: string
+}
+
+const handler: NextApiHandler<ResponseData> = (req, res) => {
+  res.status(200).json({ message: 'Hello from Next.js!' })
+}
+
+export default handler

--- a/test/e2e/app-dir/typed-routes-validator/pages/api/test-route.ts
+++ b/test/e2e/app-dir/typed-routes-validator/pages/api/test-route.ts
@@ -1,11 +1,5 @@
-import type { NextApiHandler } from 'next/types'
+import type { NextApiRequest, NextApiResponse } from 'next/types'
 
-type ResponseData = {
-  message: string
-}
-
-const handler: NextApiHandler<ResponseData> = (req, res) => {
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
   res.status(200).json({ message: 'Hello from Next.js!' })
 }
-
-export default handler

--- a/test/e2e/app-dir/typed-routes-validator/pages/api/test-route.ts
+++ b/test/e2e/app-dir/typed-routes-validator/pages/api/test-route.ts
@@ -1,5 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next/types'
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+type ResponseData = {
+  message: string
+}
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+) {
   res.status(200).json({ message: 'Hello from Next.js!' })
 }

--- a/test/e2e/app-dir/typed-routes-validator/pages/api/test-route.ts
+++ b/test/e2e/app-dir/typed-routes-validator/pages/api/test-route.ts
@@ -1,12 +1,11 @@
-import type { NextApiRequest, NextApiResponse } from 'next/types'
+import type { NextApiHandler } from 'next/types'
 
 type ResponseData = {
   message: string
 }
 
-export default function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<ResponseData>
-) {
+const handler: NextApiHandler<ResponseData> = (req, res) => {
   res.status(200).json({ message: 'Hello from Next.js!' })
 }
+
+export default handler


### PR DESCRIPTION
- Updates the (previously incorrect) API route handler type definition in the validator
- Changes the return type from `Promise<Response | void> | Response | void` to `unknown | Promise<unknown>`
- Updates the test route example to use the `NextApiHandler` type (making sure it works)

Fixed #83067