### PR TITLE
[backport] fix: use ESM import instead of triple-slash reference for routes.d.ts (#82867)

### DIFF
--- a/packages/create-next-app/templates/app-api/ts/next-env.d.ts
+++ b/packages/create-next-app/templates/app-api/ts/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/create-next-app/templates/app-empty/ts/next-env.d.ts
+++ b/packages/create-next-app/templates/app-empty/ts/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/create-next-app/templates/app-tw-empty/ts/next-env.d.ts
+++ b/packages/create-next-app/templates/app-tw-empty/ts/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/create-next-app/templates/app-tw/ts/next-env.d.ts
+++ b/packages/create-next-app/templates/app-tw/ts/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/create-next-app/templates/app/ts/next-env.d.ts
+++ b/packages/create-next-app/templates/app/ts/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/create-next-app/templates/default-empty/ts/next-env.d.ts
+++ b/packages/create-next-app/templates/default-empty/ts/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/create-next-app/templates/default-tw-empty/ts/next-env.d.ts
+++ b/packages/create-next-app/templates/default-tw-empty/ts/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/create-next-app/templates/default-tw/ts/next-env.d.ts
+++ b/packages/create-next-app/templates/default-tw/ts/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/create-next-app/templates/default/ts/next-env.d.ts
+++ b/packages/create-next-app/templates/default/ts/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
+++ b/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
@@ -62,7 +62,13 @@ export async function writeAppTypeDeclarations({
     'types/routes.d.ts'
   )
 
-  directives.push(`/// <reference path="./${routeTypesPath}" />`)
+  // Ensure the path is POSIX-compliant for imports.
+  const routeTypesPathPosix = routeTypesPath
+    .split(path.sep)
+    .join(path.posix.sep)
+
+  // Use ESM import instead of triple-slash reference for better ESLint compatibility
+  directives.push(`import "./${routeTypesPathPosix}";`)
 
   // Push the notice in.
   directives.push(

--- a/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
+++ b/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
@@ -62,13 +62,8 @@ export async function writeAppTypeDeclarations({
     'types/routes.d.ts'
   )
 
-  // Ensure the path is POSIX-compliant for imports.
-  const routeTypesPathPosix = routeTypesPath
-    .split(path.sep)
-    .join(path.posix.sep)
-
   // Use ESM import instead of triple-slash reference for better ESLint compatibility
-  directives.push(`import "./${routeTypesPathPosix}";`)
+  directives.push(`import "./${routeTypesPath}";`)
 
   // Push the notice in.
   directives.push(

--- a/test/integration/typescript-app-type-declarations/next-env.d.ts
+++ b/test/integration/typescript-app-type-declarations/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/test/unit/write-app-declarations.test.ts
+++ b/test/unit/write-app-declarations.test.ts
@@ -22,7 +22,7 @@ describe('find config', () => {
       (imageImportsEnabled
         ? '/// <reference types="next/image-types/global" />' + eol
         : '') +
-      '/// <reference path="./.next/types/routes.d.ts" />' +
+      `import "./.next/types/routes.d.ts";` +
       eol +
       eol +
       '// NOTE: This file should not be edited' +
@@ -50,7 +50,7 @@ describe('find config', () => {
       (imageImportsEnabled
         ? '/// <reference types="next/image-types/global" />' + eol
         : '') +
-      '/// <reference path="./.next/types/routes.d.ts" />' +
+      `import "./.next/types/routes.d.ts";` +
       eol +
       eol +
       '// NOTE: This file should not be edited' +
@@ -78,7 +78,7 @@ describe('find config', () => {
       (imageImportsEnabled
         ? '/// <reference types="next/image-types/global" />' + eol
         : '') +
-      '/// <reference path="./.next/types/routes.d.ts" />' +
+      `import "./.next/types/routes.d.ts";` +
       eol +
       eol +
       '// NOTE: This file should not be edited' +


### PR DESCRIPTION
## What?

Replace `/// <reference path="./.next/types/routes.d.ts" />` with `import type {} from './.next/types/routes.d.ts'` in generated `next-env.d.ts` files.

## Why?

The current implementation uses triple-slash reference directives which trigger ESLint errors when using the
`@typescript-eslint/triple-slash-reference` rule. This rule is commonly enabled in TypeScript projects to encourage modern ES module imports over legacy triple-slash references.

## How?

- Modified `writeAppTypeDeclarations.ts` to generate ESM import statements instead of triple-slash references
- Updated all create-next-app templates to use the new format
- Updated corresponding unit tests to reflect the new expected output

The change maintains identical TypeScript functionality while improving ESLint compatibility. The `import type {}` syntax ensures type-only imports that are properly elided during compilation.

**Testing:**
- Existing unit tests pass with updated expectations
- Verified ESLint `@typescript-eslint/triple-slash-reference` rule no longer triggers errors
- TypeScript functionality remains unchanged

Fixed #82828