### PR TITLE
[turbopack] RFC: Serialize turbopack objects as u16s instead of fully qualified symbol names

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -36,7 +36,7 @@ use turbo_tasks::{
     },
     event::{Event, EventListener},
     message_queue::TimingEvent,
-    registry::get_value_type_global_name,
+    registry::get_value_type,
     task_statistics::TaskStatisticsApi,
     trace::TraceRawVcs,
     turbo_tasks,
@@ -867,7 +867,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         let _span = tracing::trace_span!(
             "recomputation",
-            cell_type = get_value_type_global_name(cell.type_id),
+            cell_type = get_value_type(cell.type_id).global_name,
             cell_index = cell.index
         )
         .entered();
@@ -3133,7 +3133,7 @@ impl DebugTraceTransientTask {
             cell_type_id: Option<ValueTypeId>,
         ) -> fmt::Result {
             if let Some(ty) = cell_type_id {
-                write!(f, " (read cell of type {})", get_value_type_global_name(ty))
+                write!(f, " (read cell of type {})", get_value_type(ty).global_name)
             } else {
                 Ok(())
             }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -36,7 +36,7 @@ use turbo_tasks::{
     },
     event::{Event, EventListener},
     message_queue::TimingEvent,
-    registry::{self, get_value_type_global_name},
+    registry::get_value_type_global_name,
     task_statistics::TaskStatisticsApi,
     trace::TraceRawVcs,
     turbo_tasks,
@@ -867,7 +867,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         let _span = tracing::trace_span!(
             "recomputation",
-            cell_type = registry::get_value_type_global_name(cell.type_id),
+            cell_type = get_value_type_global_name(cell.type_id),
             cell_index = cell.index
         )
         .entered();

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -210,7 +210,7 @@ mod ser {
                 unreachable!();
             };
             let mut state = serializer.serialize_seq(Some(2))?;
-            state.serialize_element(native_fn.global_name)?;
+            state.serialize_element(&registry::get_function_id(native_fn))?;
             let arg = *arg;
             let arg = native_fn.arg_meta.as_serialize(arg);
             state.serialize_element(arg)?;
@@ -232,10 +232,10 @@ mod ser {
                 where
                     A: serde::de::SeqAccess<'de>,
                 {
-                    let fn_name = seq
+                    let fn_id = seq
                         .next_element()?
                         .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
-                    let native_fn = registry::get_function_by_global_name(fn_name);
+                    let native_fn = registry::get_native_function(fn_id);
                     let seed = native_fn.arg_meta.deserialization_seed();
                     let arg = seq
                         .next_element_seed(seed)?

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -127,7 +127,7 @@ mod ser {
                 None
             };
             let mut state = serializer.serialize_tuple(3)?;
-            state.serialize_element(registry::get_value_type_global_name(self.0))?;
+            state.serialize_element(&self.0)?;
             if let Some(serializable) = serializable {
                 state.serialize_element(&true)?;
                 state.serialize_element(serializable)?;
@@ -157,11 +157,9 @@ mod ser {
                 where
                     A: de::SeqAccess<'de>,
                 {
-                    let value_type = seq
+                    let value_type: ValueTypeId = seq
                         .next_element()?
                         .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                    let value_type = registry::get_value_type_id_by_global_name(value_type)
-                        .ok_or_else(|| de::Error::custom("Unknown value type"))?;
                     let has_value: bool = seq
                         .next_element()?
                         .ok_or_else(|| de::Error::invalid_length(1, &self))?;

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -120,6 +120,7 @@ macro_rules! define_id {
 }
 
 define_id!(TaskId: u32, derive(Serialize, Deserialize), serde(transparent));
+define_id!(FunctionId: u32);
 define_id!(ValueTypeId: u32);
 define_id!(TraitTypeId: u32);
 define_id!(SessionId: u32, derive(Debug, Serialize, Deserialize), serde(transparent));
@@ -210,3 +211,8 @@ macro_rules! make_serializable {
 
 make_serializable!(ValueTypeId, registry::get_value_type, ValueTypeVisitor);
 make_serializable!(TraitTypeId, registry::get_trait, TraitTypeVisitor);
+make_serializable!(
+    FunctionId,
+    registry::get_native_function,
+    FunctionTypeVisitor
+);

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -119,9 +119,9 @@ macro_rules! define_id {
 }
 
 define_id!(TaskId: u32, derive(Serialize, Deserialize), serde(transparent));
-define_id!(FunctionId: u32);
-define_id!(ValueTypeId: u32);
-define_id!(TraitTypeId: u32);
+define_id!(FunctionId: u16);
+define_id!(ValueTypeId: u16);
+define_id!(TraitTypeId: u16);
 define_id!(SessionId: u32, derive(Debug, Serialize, Deserialize), serde(transparent));
 define_id!(
     LocalTaskId: u32,
@@ -166,7 +166,7 @@ macro_rules! make_serializable {
             where
                 S: serde::Serializer,
             {
-                serializer.serialize_u32(self.id.into())
+                serializer.serialize_u16(self.id.into())
             }
         }
 
@@ -175,7 +175,7 @@ macro_rules! make_serializable {
             where
                 D: serde::Deserializer<'de>,
             {
-                deserializer.deserialize_u32($visitor_name)
+                deserializer.deserialize_u16($visitor_name)
             }
         }
 
@@ -188,7 +188,7 @@ macro_rules! make_serializable {
                 formatter.write_str(concat!("an id of a registered ", stringify!($ty)))
             }
 
-            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
@@ -200,7 +200,7 @@ macro_rules! make_serializable {
                             Ok(value)
                         }
                     }
-                    None => Err(E::unknown_variant(&format!("{v}"), &["a non zero u32"])),
+                    None => Err(E::unknown_variant(&format!("{v}"), &["a non zero u16"])),
                 }
             }
         }

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -41,9 +41,8 @@ macro_rules! define_id {
             }
             /// Constructs a wrapper type from the numeric identifier.
             ///
-            /// # Safety
-            ///
-            /// The passed `id` must not be zero.
+            /// Returns `None` if the provided `id` is zero, otherwise returns
+            /// `Some(Self)` containing the wrapped non-zero identifier.
             pub fn new(id: $primitive) -> Option<Self> {
                 NonZero::<$primitive>::new(id).map(|id| Self{id})
             }
@@ -161,7 +160,7 @@ impl TaskId {
 }
 
 macro_rules! make_serializable {
-    ($ty:ty, $get_object:path, $visitor_name:ident) => {
+    ($ty:ty, $get_object:path, $validate_type_id:path, $visitor_name:ident) => {
         impl Serialize for $ty {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -193,8 +192,16 @@ macro_rules! make_serializable {
             where
                 E: serde::de::Error,
             {
-                Self::Value::new(v)
-                    .ok_or_else(|| E::unknown_variant(&format!("{v}"), &["a non zero u32"]))
+                match Self::Value::new(v) {
+                    Some(value) => {
+                        if let Some(error) = $validate_type_id(value) {
+                            Err(E::custom(error))
+                        } else {
+                            Ok(value)
+                        }
+                    }
+                    None => Err(E::unknown_variant(&format!("{v}"), &["a non zero u32"])),
+                }
             }
         }
 
@@ -209,10 +216,21 @@ macro_rules! make_serializable {
     };
 }
 
-make_serializable!(ValueTypeId, registry::get_value_type, ValueTypeVisitor);
-make_serializable!(TraitTypeId, registry::get_trait, TraitTypeVisitor);
+make_serializable!(
+    ValueTypeId,
+    registry::get_value_type,
+    registry::validate_value_type_id,
+    ValueTypeVisitor
+);
+make_serializable!(
+    TraitTypeId,
+    registry::get_trait,
+    registry::validate_trait_type_id,
+    TraitTypeVisitor
+);
 make_serializable!(
     FunctionId,
     registry::get_native_function,
+    registry::validate_function_id,
     FunctionTypeVisitor
 );

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -39,7 +39,14 @@ macro_rules! define_id {
             pub const unsafe fn new_unchecked(id: $primitive) -> Self {
                 Self { id: unsafe { NonZero::<$primitive>::new_unchecked(id) } }
             }
-
+            /// Constructs a wrapper type from the numeric identifier.
+            ///
+            /// # Safety
+            ///
+            /// The passed `id` must not be zero.
+            pub fn new(id: $primitive) -> Option<Self> {
+                NonZero::<$primitive>::new(id).map(|id| Self{id})
+            }
             /// Allows `const` conversion to a [`NonZeroU64`], useful with
             /// [`crate::id_factory::IdFactory::new_const`].
             pub const fn to_non_zero_u64(self) -> NonZeroU64 {
@@ -153,13 +160,13 @@ impl TaskId {
 }
 
 macro_rules! make_serializable {
-    ($ty:ty, $get_global_name:path, $get_id:path, $visitor_name:ident) => {
+    ($ty:ty, $get_global_name:path, $visitor_name:ident) => {
         impl Serialize for $ty {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: serde::Serializer,
             {
-                serializer.serialize_str($get_global_name(*self))
+                serializer.serialize_u32(self.id.into())
             }
         }
 
@@ -168,7 +175,7 @@ macro_rules! make_serializable {
             where
                 D: serde::Deserializer<'de>,
             {
-                deserializer.deserialize_str($visitor_name)
+                deserializer.deserialize_u32($visitor_name)
             }
         }
 
@@ -178,14 +185,15 @@ macro_rules! make_serializable {
             type Value = $ty;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str(concat!("a name of a registered ", stringify!($ty)))
+                formatter.write_str(concat!("an id of a registered ", stringify!($ty)))
             }
 
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                $get_id(v).ok_or_else(|| E::unknown_variant(v, &[]))
+                Self::Value::new(v)
+                    .ok_or_else(|| E::unknown_variant(&format!("{v}"), &["a non zero u32"]))
             }
         }
 
@@ -203,12 +211,10 @@ macro_rules! make_serializable {
 make_serializable!(
     ValueTypeId,
     registry::get_value_type_global_name,
-    registry::get_value_type_id_by_global_name,
     ValueTypeVisitor
 );
 make_serializable!(
     TraitTypeId,
     registry::get_trait_type_global_name,
-    registry::get_trait_type_id_by_global_name,
     TraitTypeVisitor
 );

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -160,7 +160,7 @@ impl TaskId {
 }
 
 macro_rules! make_serializable {
-    ($ty:ty, $get_global_name:path, $visitor_name:ident) => {
+    ($ty:ty, $get_object:path, $visitor_name:ident) => {
         impl Serialize for $ty {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -201,20 +201,12 @@ macro_rules! make_serializable {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 f.debug_struct(stringify!($ty))
                     .field("id", &self.id)
-                    .field("name", &$get_global_name(*self))
+                    .field("name", &$get_object(*self))
                     .finish()
             }
         }
     };
 }
 
-make_serializable!(
-    ValueTypeId,
-    registry::get_value_type_global_name,
-    ValueTypeVisitor
-);
-make_serializable!(
-    TraitTypeId,
-    registry::get_trait_type_global_name,
-    TraitTypeVisitor
-);
+make_serializable!(ValueTypeId, registry::get_value_type, ValueTypeVisitor);
+make_serializable!(TraitTypeId, registry::get_trait, TraitTypeVisitor);

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -273,18 +273,16 @@ impl NativeFunction {
         tracing::trace_span!("turbo_tasks::resolve_call", name = self.name, flags = flags)
     }
 }
-
-impl PartialEq for &'static NativeFunction {
+impl PartialEq for NativeFunction {
     fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(*self, *other)
+        std::ptr::eq(self, other)
     }
 }
 
-impl Eq for &'static NativeFunction {}
-
-impl Hash for &'static NativeFunction {
+impl Eq for NativeFunction {}
+impl Hash for NativeFunction {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        Hash::hash(&(*self as *const NativeFunction), state);
+        (self as *const NativeFunction).hash(state);
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU32;
+use std::num::NonZeroU16;
 
 use anyhow::Error;
 use once_cell::sync::Lazy;
@@ -25,7 +25,7 @@ static FUNCTIONS: Lazy<Functions> = Lazy::new(|| {
     let mut value_to_id = FxHashMap::with_capacity_and_hasher(functions.len(), Default::default());
     let mut names = FxHashSet::with_capacity_and_hasher(functions.len(), Default::default());
 
-    let mut id = NonZeroU32::MIN;
+    let mut id = NonZeroU16::MIN;
     for &native_function in functions.iter() {
         value_to_id.insert(native_function, id.into());
         let global_name = native_function.global_name;
@@ -84,7 +84,7 @@ static VALUES: Lazy<Values> = Lazy::new(|| {
     // Our sort above is non-sensical if names are not unique
     let mut names = FxHashSet::with_capacity_and_hasher(all_values.len(), Default::default());
 
-    let mut id = NonZeroU32::MIN;
+    let mut id = NonZeroU16::MIN;
     for &value_type in all_values.iter() {
         value_to_id.insert(value_type, id.into());
         let global_name = value_type.global_name;
@@ -140,7 +140,7 @@ static TRAITS: Lazy<Traits> = Lazy::new(|| {
     let mut trait_to_id = FxHashMap::with_capacity_and_hasher(all_traits.len(), Default::default());
     // Our sort above is non-sensical if names are not unique
     let mut names = FxHashSet::with_capacity_and_hasher(all_traits.len(), Default::default());
-    let mut id = NonZeroU32::MIN;
+    let mut id = NonZeroU16::MIN;
     for &trait_type in all_traits.iter() {
         trait_to_id.insert(trait_type, id.into());
 

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -1,37 +1,56 @@
 use std::num::NonZeroU32;
 
 use once_cell::sync::Lazy;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     TraitType, ValueType,
-    id::{TraitTypeId, ValueTypeId},
+    id::{FunctionId, TraitTypeId, ValueTypeId},
     macro_helpers::CollectableFunction,
     native_function::NativeFunction,
     value_type::{CollectableTrait, CollectableValueType},
 };
 
-pub fn get_function_by_global_name(global_name: &str) -> &'static NativeFunction {
-    static NAME_TO_FUNCTION: Lazy<FxHashMap<&'static str, &'static NativeFunction>> =
-        Lazy::new(|| {
-            let mut map = FxHashMap::default();
-            for collected in inventory::iter::<CollectableFunction> {
-                let native_function = &**collected.0;
-                let global_name = native_function.global_name;
-                let prev = map.insert(global_name, native_function);
-                assert!(
-                    prev.is_none(),
-                    "multiple functions registered with the name {global_name}!"
-                );
-            }
-            map.shrink_to_fit();
-            map
-        });
+struct Functions {
+    id_to_value: Box<[&'static NativeFunction]>,
+    value_to_id: FxHashMap<&'static NativeFunction, FunctionId>,
+}
+static FUNCTIONS: Lazy<Functions> = Lazy::new(|| {
+    let mut functions = inventory::iter::<CollectableFunction>
+        .into_iter()
+        .map(|c| &**c.0)
+        .collect::<Vec<_>>();
+    functions.sort_unstable_by_key(|f| f.global_name);
+    let mut value_to_id = FxHashMap::with_capacity_and_hasher(functions.len(), Default::default());
+    let mut names = FxHashSet::with_capacity_and_hasher(functions.len(), Default::default());
 
-    match NAME_TO_FUNCTION.get(global_name) {
-        Some(f) => f,
-        None => panic!("unable to find function: {global_name}"),
+    let mut id = NonZeroU32::MIN;
+    for &native_function in functions.iter() {
+        value_to_id.insert(native_function, id.into());
+        let global_name = native_function.global_name;
+        let new = names.insert(global_name);
+        assert!(
+            !new,
+            "multiple functions registered with name: {global_name}!"
+        );
+        id = id.checked_add(1).expect("overflowing function ids");
     }
+
+    Functions {
+        id_to_value: functions.into_boxed_slice(),
+        value_to_id,
+    }
+});
+
+pub fn get_native_function(id: FunctionId) -> &'static NativeFunction {
+    FUNCTIONS.id_to_value[*id as usize - 1]
+}
+
+pub fn get_function_id(func: &'static NativeFunction) -> FunctionId {
+    *FUNCTIONS
+        .value_to_id
+        .get(&func)
+        .expect("function isn't registered")
 }
 
 struct Values {
@@ -51,22 +70,20 @@ static VALUES: Lazy<Values> = Lazy::new(|| {
     all_values.sort_unstable_by_key(|t| t.global_name);
 
     let mut value_to_id = FxHashMap::with_capacity_and_hasher(all_values.len(), Default::default());
-    let mut global_name_to_value =
-        FxHashMap::with_capacity_and_hasher(all_values.len(), Default::default());
+    // Our sort above is non-sensical if names are not unique
+    let mut names = FxHashSet::with_capacity_and_hasher(all_values.len(), Default::default());
 
     let mut id = NonZeroU32::MIN;
     for &value_type in all_values.iter() {
         value_to_id.insert(value_type, id.into());
-        let prev = global_name_to_value.insert(value_type.global_name, (id.into(), value_type));
+        let global_name = value_type.global_name;
         assert!(
-            prev.is_none(),
-            "two value types registered with the same name: {}",
-            value_type.global_name
+            names.insert(global_name),
+            "two values registered with the same name: {global_name}"
         );
         id = id.checked_add(1).expect("overflowing value type ids");
     }
 
-    value_to_id.shrink_to_fit();
     Values {
         value_to_id,
         id_to_value: all_values.into_boxed_slice(),
@@ -103,22 +120,19 @@ static TRAITS: Lazy<Traits> = Lazy::new(|| {
     all_traits.sort_unstable_by_key(|t| t.global_name);
 
     let mut trait_to_id = FxHashMap::with_capacity_and_hasher(all_traits.len(), Default::default());
-    let mut global_name_to_trait =
-        FxHashMap::with_capacity_and_hasher(all_traits.len(), Default::default());
-
+    // Our sort above is non-sensical if names are not unique
+    let mut names = FxHashSet::with_capacity_and_hasher(all_traits.len(), Default::default());
     let mut id = NonZeroU32::MIN;
     for &trait_type in all_traits.iter() {
         trait_to_id.insert(trait_type, id.into());
 
-        let prev = global_name_to_trait.insert(trait_type.global_name, (id.into(), trait_type));
+        let global_name = trait_type.global_name;
         assert!(
-            prev.is_none(),
-            "two traits registered with the same name: {}",
-            trait_type.global_name
+            names.insert(global_name),
+            "two traits registered with the same name: {global_name}"
         );
         id = id.checked_add(1).expect("overflowing trait type ids");
     }
-    trait_to_id.shrink_to_fit();
     Traits {
         trait_to_id,
         id_to_trait: all_traits.into_boxed_slice(),

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -141,9 +141,7 @@ pub fn validate_function_id(id: FunctionId) -> Option<Error> {
 
 static VALUES: Lazy<Registry<ValueType>> = Lazy::new(|| {
     // Inventory does not guarantee an order. So we sort by the global name to get a stable order
-    // This ensures that assigned ids are also stable.
-    // We don't currently take advantage of this but we could in the future.  The remaining issue is
-    // ensuring the set of values is the same across runs.
+    // This ensures that assigned ids are also stable which is important since they are serialized.
     let all_values = inventory::iter::<CollectableValueType>
         .into_iter()
         .map(|t| &**t.0)

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -145,13 +145,6 @@ pub fn get_trait_type_id(trait_type: &'static TraitType) -> TraitTypeId {
     }
 }
 
-pub fn get_trait_type_id_by_global_name(global_name: &str) -> Option<TraitTypeId> {
-    TRAITS
-        .global_name_to_trait
-        .get(global_name)
-        .map(|(id, _)| *id)
-}
-
 pub fn get_trait(id: TraitTypeId) -> &'static TraitType {
     TRAITS.id_to_trait[*id as usize - 1]
 }

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroU32;
 
+use anyhow::Error;
 use once_cell::sync::Lazy;
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -52,6 +53,17 @@ pub fn get_function_id(func: &'static NativeFunction) -> FunctionId {
         .expect("function isn't registered")
 }
 
+pub fn validate_function_id(id: FunctionId) -> Option<Error> {
+    let len = FUNCTIONS.id_to_value.len();
+    if *id as usize <= len {
+        None
+    } else {
+        Some(anyhow::anyhow!(
+            "Invalid function type id, {id} expected a value <= {len}"
+        ))
+    }
+}
+
 struct Values {
     id_to_value: Box<[&'static ValueType]>,
     value_to_id: FxHashMap<&'static ValueType, ValueTypeId>,
@@ -100,6 +112,17 @@ pub fn get_value_type(id: ValueTypeId) -> &'static ValueType {
     VALUES.id_to_value[*id as usize - 1]
 }
 
+pub fn validate_value_type_id(id: ValueTypeId) -> Option<Error> {
+    let len = VALUES.id_to_value.len();
+    if *id as usize <= len {
+        None
+    } else {
+        Some(anyhow::anyhow!(
+            "Invalid value type id, {id} expected a value <= {len}"
+        ))
+    }
+}
+
 struct Traits {
     id_to_trait: Box<[&'static TraitType]>,
     trait_to_id: FxHashMap<&'static TraitType, TraitTypeId>,
@@ -143,4 +166,14 @@ pub fn get_trait_type_id(trait_type: &'static TraitType) -> TraitTypeId {
 
 pub fn get_trait(id: TraitTypeId) -> &'static TraitType {
     TRAITS.id_to_trait[*id as usize - 1]
+}
+pub fn validate_trait_type_id(id: TraitTypeId) -> Option<Error> {
+    let len = TRAITS.id_to_trait.len();
+    if *id as usize <= len {
+        None
+    } else {
+        Some(anyhow::anyhow!(
+            "Invalid trait type id, {id} expected a value <= {len}"
+        ))
+    }
 }

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -12,168 +12,175 @@ use crate::{
     value_type::{CollectableTrait, CollectableValueType},
 };
 
-struct Functions {
-    id_to_value: Box<[&'static NativeFunction]>,
-    value_to_id: FxHashMap<&'static NativeFunction, FunctionId>,
+/// A trait for types that can be registered in a registry.
+///
+/// This allows the generic registry to work with different types
+/// while maintaining their specific requirements.
+trait RegistryItem: 'static + Eq + std::hash::Hash {
+    /// The ID type used for this registry item
+    type Id: Copy + From<NonZeroU16> + std::ops::Deref<Target = u16> + std::fmt::Display;
+    const TYPE_NAME: &'static str;
+
+    /// Get the global name used for sorting and uniqueness validation
+    fn global_name(&self) -> &'static str;
 }
-static FUNCTIONS: Lazy<Functions> = Lazy::new(|| {
-    let mut functions = inventory::iter::<CollectableFunction>
+
+impl RegistryItem for NativeFunction {
+    type Id = FunctionId;
+    const TYPE_NAME: &'static str = "Function";
+
+    fn global_name(&self) -> &'static str {
+        self.global_name
+    }
+}
+
+impl RegistryItem for ValueType {
+    type Id = ValueTypeId;
+    const TYPE_NAME: &'static str = "Value";
+
+    fn global_name(&self) -> &'static str {
+        self.global_name
+    }
+}
+
+impl RegistryItem for TraitType {
+    type Id = TraitTypeId;
+    const TYPE_NAME: &'static str = "Trait";
+    fn global_name(&self) -> &'static str {
+        self.global_name
+    }
+}
+
+/// A generic registry that maps between IDs and static references to items.
+///
+/// This eliminates the code duplication between Functions, Values, and Traits registries.
+struct Registry<T: RegistryItem> {
+    id_to_item: Box<[&'static T]>,
+    item_to_id: FxHashMap<&'static T, T::Id>,
+}
+
+impl<T: RegistryItem> Registry<T> {
+    /// Create a new registry from a collection of items.
+    ///
+    /// Items are sorted by global_name to ensure stable ID assignment.
+    fn new_from_items(mut items: Vec<&'static T>) -> Self {
+        // Sort by global name to get stable order
+        items.sort_unstable_by_key(|item| item.global_name());
+
+        let mut item_to_id = FxHashMap::with_capacity_and_hasher(items.len(), Default::default());
+        let mut names = FxHashSet::with_capacity_and_hasher(items.len(), Default::default());
+
+        let mut id = NonZeroU16::MIN;
+        for &item in items.iter() {
+            item_to_id.insert(item, id.into());
+            let global_name = item.global_name();
+            assert!(
+                names.insert(global_name),
+                "multiple {ty} items registered with name: {global_name}!",
+                ty = T::TYPE_NAME
+            );
+            id = id.checked_add(1).expect("overflowing item ids");
+        }
+
+        Self {
+            id_to_item: items.into_boxed_slice(),
+            item_to_id,
+        }
+    }
+
+    /// Get an item by its ID
+    fn get_item(&self, id: T::Id) -> &'static T {
+        self.id_to_item[*id as usize - 1]
+    }
+
+    /// Get the ID for an item
+    fn get_id(&self, item: &'static T) -> T::Id {
+        match self.item_to_id.get(&item) {
+            Some(id) => *id,
+            None => panic!(
+                "{ty} isn't registered: {item}",
+                ty = T::TYPE_NAME,
+                item = item.global_name()
+            ),
+        }
+    }
+
+    /// Validate that an ID is within the valid range
+    fn validate_id(&self, id: T::Id) -> Option<Error> {
+        let len = self.id_to_item.len();
+        if *id as usize <= len {
+            None
+        } else {
+            Some(anyhow::anyhow!(
+                "Invalid {ty} id, {id} expected a value <= {len}",
+                ty = T::TYPE_NAME
+            ))
+        }
+    }
+}
+
+static FUNCTIONS: Lazy<Registry<NativeFunction>> = Lazy::new(|| {
+    let functions = inventory::iter::<CollectableFunction>
         .into_iter()
         .map(|c| &**c.0)
         .collect::<Vec<_>>();
-    functions.sort_unstable_by_key(|f| f.global_name);
-    let mut value_to_id = FxHashMap::with_capacity_and_hasher(functions.len(), Default::default());
-    let mut names = FxHashSet::with_capacity_and_hasher(functions.len(), Default::default());
-
-    let mut id = NonZeroU16::MIN;
-    for &native_function in functions.iter() {
-        value_to_id.insert(native_function, id.into());
-        let global_name = native_function.global_name;
-        assert!(
-            names.insert(global_name),
-            "multiple functions registered with name: {global_name}!"
-        );
-        id = id.checked_add(1).expect("overflowing function ids");
-    }
-
-    Functions {
-        id_to_value: functions.into_boxed_slice(),
-        value_to_id,
-    }
+    Registry::new_from_items(functions)
 });
 
 pub fn get_native_function(id: FunctionId) -> &'static NativeFunction {
-    FUNCTIONS.id_to_value[*id as usize - 1]
+    FUNCTIONS.get_item(id)
 }
 
 pub fn get_function_id(func: &'static NativeFunction) -> FunctionId {
-    *FUNCTIONS
-        .value_to_id
-        .get(&func)
-        .expect("function isn't registered")
+    FUNCTIONS.get_id(func)
 }
 
 pub fn validate_function_id(id: FunctionId) -> Option<Error> {
-    let len = FUNCTIONS.id_to_value.len();
-    if *id as usize <= len {
-        None
-    } else {
-        Some(anyhow::anyhow!(
-            "Invalid function type id, {id} expected a value <= {len}"
-        ))
-    }
+    FUNCTIONS.validate_id(id)
 }
 
-struct Values {
-    id_to_value: Box<[&'static ValueType]>,
-    value_to_id: FxHashMap<&'static ValueType, ValueTypeId>,
-}
-
-static VALUES: Lazy<Values> = Lazy::new(|| {
+static VALUES: Lazy<Registry<ValueType>> = Lazy::new(|| {
     // Inventory does not guarantee an order. So we sort by the global name to get a stable order
     // This ensures that assigned ids are also stable.
     // We don't currently take advantage of this but we could in the future.  The remaining issue is
     // ensuring the set of values is the same across runs.
-    let mut all_values = inventory::iter::<CollectableValueType>
+    let all_values = inventory::iter::<CollectableValueType>
         .into_iter()
         .map(|t| &**t.0)
         .collect::<Vec<_>>();
-    all_values.sort_unstable_by_key(|t| t.global_name);
-
-    let mut value_to_id = FxHashMap::with_capacity_and_hasher(all_values.len(), Default::default());
-    // Our sort above is non-sensical if names are not unique
-    let mut names = FxHashSet::with_capacity_and_hasher(all_values.len(), Default::default());
-
-    let mut id = NonZeroU16::MIN;
-    for &value_type in all_values.iter() {
-        value_to_id.insert(value_type, id.into());
-        let global_name = value_type.global_name;
-        assert!(
-            names.insert(global_name),
-            "two values registered with the same name: {global_name}"
-        );
-        id = id.checked_add(1).expect("overflowing value type ids");
-    }
-
-    Values {
-        value_to_id,
-        id_to_value: all_values.into_boxed_slice(),
-    }
+    Registry::new_from_items(all_values)
 });
 
 pub fn get_value_type_id(value: &'static ValueType) -> ValueTypeId {
-    match VALUES.value_to_id.get(value) {
-        Some(id) => *id,
-        None => panic!("Use of unregistered trait {value:?}"),
-    }
+    VALUES.get_id(value)
 }
 
 pub fn get_value_type(id: ValueTypeId) -> &'static ValueType {
-    VALUES.id_to_value[*id as usize - 1]
+    VALUES.get_item(id)
 }
 
 pub fn validate_value_type_id(id: ValueTypeId) -> Option<Error> {
-    let len = VALUES.id_to_value.len();
-    if *id as usize <= len {
-        None
-    } else {
-        Some(anyhow::anyhow!(
-            "Invalid value type id, {id} expected a value <= {len}"
-        ))
-    }
+    VALUES.validate_id(id)
 }
 
-struct Traits {
-    id_to_trait: Box<[&'static TraitType]>,
-    trait_to_id: FxHashMap<&'static TraitType, TraitTypeId>,
-}
-
-static TRAITS: Lazy<Traits> = Lazy::new(|| {
+static TRAITS: Lazy<Registry<TraitType>> = Lazy::new(|| {
     // Inventory does not guarantee an order. So we sort by the global name to get a stable order
     // This ensures that assigned ids are also stable.
-    let mut all_traits = inventory::iter::<CollectableTrait>
+    let all_traits = inventory::iter::<CollectableTrait>
         .into_iter()
         .map(|t| &**t.0)
         .collect::<Vec<_>>();
-    all_traits.sort_unstable_by_key(|t| t.global_name);
-
-    let mut trait_to_id = FxHashMap::with_capacity_and_hasher(all_traits.len(), Default::default());
-    // Our sort above is non-sensical if names are not unique
-    let mut names = FxHashSet::with_capacity_and_hasher(all_traits.len(), Default::default());
-    let mut id = NonZeroU16::MIN;
-    for &trait_type in all_traits.iter() {
-        trait_to_id.insert(trait_type, id.into());
-
-        let global_name = trait_type.global_name;
-        assert!(
-            names.insert(global_name),
-            "two traits registered with the same name: {global_name}"
-        );
-        id = id.checked_add(1).expect("overflowing trait type ids");
-    }
-    Traits {
-        trait_to_id,
-        id_to_trait: all_traits.into_boxed_slice(),
-    }
+    Registry::new_from_items(all_traits)
 });
 
 pub fn get_trait_type_id(trait_type: &'static TraitType) -> TraitTypeId {
-    match TRAITS.trait_to_id.get(trait_type) {
-        Some(id) => *id,
-        None => panic!("Use of unregistered trait {trait_type:?}"),
-    }
+    TRAITS.get_id(trait_type)
 }
 
 pub fn get_trait(id: TraitTypeId) -> &'static TraitType {
-    TRAITS.id_to_trait[*id as usize - 1]
+    TRAITS.get_item(id)
 }
+
 pub fn validate_trait_type_id(id: TraitTypeId) -> Option<Error> {
-    let len = TRAITS.id_to_trait.len();
-    if *id as usize <= len {
-        None
-    } else {
-        Some(anyhow::anyhow!(
-            "Invalid trait type id, {id} expected a value <= {len}"
-        ))
-    }
+    TRAITS.validate_id(id)
 }

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -37,7 +37,6 @@ pub fn get_function_by_global_name(global_name: &str) -> &'static NativeFunction
 struct Values {
     id_to_value: Box<[&'static ValueType]>,
     value_to_id: FxHashMap<&'static ValueType, ValueTypeId>,
-    global_name_to_value: FxHashMap<&'static str, (ValueTypeId, &'static ValueType)>,
 }
 
 static VALUES: Lazy<Values> = Lazy::new(|| {
@@ -68,11 +67,9 @@ static VALUES: Lazy<Values> = Lazy::new(|| {
     }
 
     value_to_id.shrink_to_fit();
-    global_name_to_value.shrink_to_fit();
     Values {
         value_to_id,
         id_to_value: all_values.into_boxed_slice(),
-        global_name_to_value,
     }
 });
 
@@ -81,13 +78,6 @@ pub fn get_value_type_id(value: &'static ValueType) -> ValueTypeId {
         Some(id) => *id,
         None => panic!("Use of unregistered trait {value:?}"),
     }
-}
-
-pub fn get_value_type_id_by_global_name(global_name: &str) -> Option<ValueTypeId> {
-    VALUES
-        .global_name_to_value
-        .get(global_name)
-        .map(|(id, _)| *id)
 }
 
 pub fn get_value_type(id: ValueTypeId) -> &'static ValueType {
@@ -101,7 +91,6 @@ pub fn get_value_type_global_name(id: ValueTypeId) -> &'static str {
 struct Traits {
     id_to_trait: Box<[&'static TraitType]>,
     trait_to_id: FxHashMap<&'static TraitType, TraitTypeId>,
-    global_name_to_trait: FxHashMap<&'static str, (TraitTypeId, &'static TraitType)>,
 }
 
 static TRAITS: Lazy<Traits> = Lazy::new(|| {
@@ -130,11 +119,9 @@ static TRAITS: Lazy<Traits> = Lazy::new(|| {
         id = id.checked_add(1).expect("overflowing trait type ids");
     }
     trait_to_id.shrink_to_fit();
-    global_name_to_trait.shrink_to_fit();
     Traits {
         trait_to_id,
         id_to_trait: all_traits.into_boxed_slice(),
-        global_name_to_trait,
     }
 });
 

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -28,9 +28,8 @@ static FUNCTIONS: Lazy<Functions> = Lazy::new(|| {
     for &native_function in functions.iter() {
         value_to_id.insert(native_function, id.into());
         let global_name = native_function.global_name;
-        let new = names.insert(global_name);
         assert!(
-            !new,
+            names.insert(global_name),
             "multiple functions registered with name: {global_name}!"
         );
         id = id.checked_add(1).expect("overflowing function ids");
@@ -101,10 +100,6 @@ pub fn get_value_type(id: ValueTypeId) -> &'static ValueType {
     VALUES.id_to_value[*id as usize - 1]
 }
 
-pub fn get_value_type_global_name(id: ValueTypeId) -> &'static str {
-    get_value_type(id).global_name
-}
-
 struct Traits {
     id_to_trait: Box<[&'static TraitType]>,
     trait_to_id: FxHashMap<&'static TraitType, TraitTypeId>,
@@ -148,8 +143,4 @@ pub fn get_trait_type_id(trait_type: &'static TraitType) -> TraitTypeId {
 
 pub fn get_trait(id: TraitTypeId) -> &'static TraitType {
     TRAITS.id_to_trait[*id as usize - 1]
-}
-
-pub fn get_trait_type_global_name(id: TraitTypeId) -> &'static str {
-    get_trait(id).global_name
 }

--- a/turbopack/crates/turbo-tasks/src/task/shared_reference.rs
+++ b/turbopack/crates/turbo-tasks/src/task/shared_reference.rs
@@ -116,7 +116,7 @@ impl Serialize for TypedSharedReference {
         } else {
             Err(serde::ser::Error::custom(format!(
                 "{:?} is not serializable",
-                registry::get_value_type_global_name(*ty)
+                registry::get_value_type(*ty).global_name
             )))
         }
     }

--- a/turbopack/crates/turbo-tasks/src/task/shared_reference.rs
+++ b/turbopack/crates/turbo-tasks/src/task/shared_reference.rs
@@ -110,7 +110,7 @@ impl Serialize for TypedSharedReference {
         let value_type = registry::get_value_type(*ty);
         if let Some(serializable) = value_type.any_as_serializable(arc) {
             let mut t = serializer.serialize_tuple(2)?;
-            t.serialize_element(registry::get_value_type_global_name(*ty))?;
+            t.serialize_element(ty)?;
             t.serialize_element(serializable)?;
             t.end()
         } else {
@@ -156,29 +156,25 @@ impl<'de> Deserialize<'de> for TypedSharedReference {
             where
                 A: serde::de::SeqAccess<'de>,
             {
-                if let Some(global_name) = seq.next_element()? {
-                    if let Some(ty) = registry::get_value_type_id_by_global_name(global_name) {
-                        if let Some(seed) = registry::get_value_type(ty).get_any_deserialize_seed()
-                        {
-                            if let Some(value) = seq.next_element_seed(seed)? {
-                                let arc = triomphe::Arc::<dyn Any + Send + Sync>::from(value);
-                                Ok(TypedSharedReference {
-                                    type_id: ty,
-                                    reference: SharedReference(arc),
-                                })
-                            } else {
-                                Err(serde::de::Error::invalid_length(
-                                    1,
-                                    &"tuple with type and value",
-                                ))
-                            }
+                if let Some(type_id) = seq.next_element()? {
+                    let value_type = registry::get_value_type(type_id);
+                    if let Some(seed) = value_type.get_any_deserialize_seed() {
+                        if let Some(value) = seq.next_element_seed(seed)? {
+                            let arc = triomphe::Arc::<dyn Any + Send + Sync>::from(value);
+                            Ok(TypedSharedReference {
+                                type_id,
+                                reference: SharedReference(arc),
+                            })
                         } else {
-                            Err(serde::de::Error::custom(format!(
-                                "{ty} is not deserializable"
-                            )))
+                            Err(serde::de::Error::invalid_length(
+                                1,
+                                &"tuple with type and value",
+                            ))
                         }
                     } else {
-                        Err(serde::de::Error::unknown_variant(global_name, &[]))
+                        Err(serde::de::Error::custom(format!(
+                            "{value_type} is not deserializable"
+                        )))
                     }
                 } else {
                     Err(serde::de::Error::invalid_length(


### PR DESCRIPTION
Change the serialization strategy for `ValueTypeId`, `TraitTypeId` and `NativeFunction` to use `u16` values instead of the `global_name` (a fully qualified name of the object).

For all these objects the value is the index+1 of the corresponding object in the set of all objects sorted by name.   This is a deterministic ordering which should ensure we can deserialize them with the same version of turbopack.

Potential concerns with this approach:

* debuggability in the Persistent Cache (is this even a thing?)
* stability of ids across architectures
    * if different architectures enable/disable turbotasks then ids will change and make the PC database non-portable. 

Still this should speed up serialization/deserialization by making everything smaller and faster to encode/decode

On an optimized build with a fresh `.next` directory, i measured the size of the `.cache/turbopack/vxxxx` directory

`benches/module-cost`:  
    change: 2.38Gb (-22%), wrote in 9.5s, compacted in 5.4s
    head:  3.06Gb bytes, wrote in 10.3s, compacted in 7.6s

`vercel-site`
    change: 4.8Gb(-12%), wrote in 46ss, compacted in 6.2s
    head:  5.5Gb, wrote in 48s, compacted in 7.6s

So a non-trivial size reduction as expected.  This should also speed up encoding/decoding but i didnt attempt to directly measure that.


Closes PACK-5411