### PR TITLE
fix: web manifest should always be emitted in head

### DIFF
--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -382,8 +382,13 @@ async function renderViewport(
     workStore
   )
 
-  const elements: Array<React.ReactNode> =
-    createViewportElements(resolvedViewport)
+  // Get manifest from static metadata
+  const manifestUrl = tree[2].metadata?.manifest
+
+  const elements: Array<React.ReactNode> = createViewportElements(
+    resolvedViewport,
+    manifestUrl
+  )
   return (
     <>
       {elements.map((el, index) => {
@@ -410,6 +415,6 @@ function createMetadataElements(metadata: ResolvedMetadata) {
   ])
 }
 
-function createViewportElements(viewport: ResolvedViewport) {
-  return MetaFilter([ViewportMeta({ viewport: viewport })])
+function createViewportElements(viewport: ResolvedViewport, manifest?: string) {
+  return MetaFilter([ViewportMeta({ viewport: viewport, manifest })])
 }

--- a/test/e2e/app-dir/hello-world/app/manifest.ts
+++ b/test/e2e/app-dir/hello-world/app/manifest.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from 'next'
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Next.js App',
+    short_name: 'Next.js App',
+    description: 'Next.js App',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#fff',
+    theme_color: '#fff',
+    icons: [
+      {
+        src: '/favicon.ico',
+        sizes: 'any',
+        type: 'image/x-icon',
+      },
+    ],
+  }
+}

--- a/test/e2e/app-dir/metadata/app/async-metadata-streaming/page.tsx
+++ b/test/e2e/app-dir/metadata/app/async-metadata-streaming/page.tsx
@@ -1,0 +1,23 @@
+import { connection } from 'next/server'
+
+export async function generateMetadata() {
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  return {
+    title: 'Async Metadata Page',
+    description: 'This page has async metadata that should stream',
+  }
+}
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Async Metadata Streaming Test</h1>
+      <p id="async-metadata-page">
+        This page tests that manifest links remain in the head even when
+        metadata is streamed
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
When a page has streaming metadata and a manifest, the manifest will be emitted in the body even though it can be eagerly emitted in the `head`. Additionally, the `manifest` needs to be emitted in the head, otherwise it isn't detected.

`ViewportMetadata` was created to solve a similar problem: certain viewport properties _need_ to be in the `head` to be recognized. This PR renames "ViewportMetadata" to be "StaticMetadata" since these are the values that can always be eagerly emitted in the `head`. I then moved the manifest handling to be rendered inside.

x-ref: https://github.com/vercel/next.js/issues/79313#issuecomment-3154326044