### PR TITLE
docs(opentelemetry): update manual configuration to use resourceFromAttributes

### DIFF
--- a/docs/01-app/02-guides/open-telemetry.mdx
+++ b/docs/01-app/02-guides/open-telemetry.mdx
@@ -117,13 +117,13 @@ export async function register() {
 
 ```ts filename="instrumentation.node.ts" switcher
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
-import { Resource } from '@opentelemetry/resources'
+import { resourceFromAttributes } from '@opentelemetry/resources'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node'
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
 
 const sdk = new NodeSDK({
-  resource: new Resource({
+  resource: resourceFromAttributes({
     [ATTR_SERVICE_NAME]: 'next-app',
   }),
   spanProcessor: new SimpleSpanProcessor(new OTLPTraceExporter()),
@@ -133,13 +133,13 @@ sdk.start()
 
 ```js filename="instrumentation.node.js" switcher
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
-import { Resource } from '@opentelemetry/resources'
+import { resourceFromAttributes } from '@opentelemetry/resources'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node'
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
 
 const sdk = new NodeSDK({
-  resource: new Resource({
+  resource: resourceFromAttributes({
     [ATTR_SERVICE_NAME]: 'next-app',
   }),
   spanProcessor: new SimpleSpanProcessor(new OTLPTraceExporter()),


### PR DESCRIPTION
## Documentation Update

This PR updates the OpenTelemetry guide to use `resourceFromAttributes` instead of `detectResources` in the manual configuration example.  

- Updated code snippet in `docs/01-app/02-guides/open-telemetry.mdx`  
- Keeps documentation aligned with the latest OpenTelemetry API  
- Resolves issue #77451  

---

### Checklist
- [x] Updated relevant documentation
- [x] Verified code snippet reflects current API usage
