### PR TITLE
[metadata] update metadata routes cache headers

### DIFF
--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -112,7 +112,6 @@ pub async fn get_app_metadata_route_entry(
 }
 
 const CACHE_HEADER_NONE: &str = "no-cache, no-store";
-const CACHE_HEADER_LONG_CACHE: &str = "public, immutable, no-transform, max-age=31536000";
 const CACHE_HEADER_REVALIDATE: &str = "public, max-age=0, must-revalidate";
 
 async fn get_base64_file_content(path: FileSystemPath) -> Result<String> {
@@ -137,10 +136,8 @@ async fn static_route_source(mode: NextMode, path: FileSystemPath) -> Result<Vc<
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
 
-    let cache_control = if stem == "favicon" {
+    let cache_control = if mode.is_production() {
         CACHE_HEADER_REVALIDATE
-    } else if mode.is_production() {
-        CACHE_HEADER_LONG_CACHE
     } else {
         CACHE_HEADER_NONE
     };

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -43,11 +43,7 @@ async function nextMetadataImageLoader(
 
   const opts = { context, content }
 
-  // No hash query for favicon.ico
-  const contentHash =
-    type === 'favicon'
-      ? ''
-      : loaderUtils.interpolateName(this, '[contenthash]', opts)
+  const contentHash = loaderUtils.interpolateName(this, '[contenthash]', opts)
 
   const interpolatedName = loaderUtils.interpolateName(
     this,
@@ -179,7 +175,7 @@ async function nextMetadataImageLoader(
 
     return [{
       ...imageData,
-      url: imageUrl + ${JSON.stringify(type === 'favicon' ? '' : hashQuery)},
+      url: imageUrl + ${JSON.stringify(hashQuery)},
     }]
   }`
 }

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -35,10 +35,9 @@ async function createReExportsCode(
     : ''
 }
 
-const cacheHeader = {
-  none: 'no-cache, no-store',
-  longCache: 'public, immutable, no-transform, max-age=31536000',
-  revalidate: 'public, max-age=0, must-revalidate',
+const CACHE_HEADERS = {
+  NO_CACHE: 'no-cache, no-store',
+  REVALIDATE: 'public, max-age=0, must-revalidate',
 }
 
 export type MetadataRouteLoaderOptions = {
@@ -77,11 +76,9 @@ async function getStaticAssetRouteCode(
   fileBaseName: string
 ) {
   const cache =
-    fileBaseName === 'favicon'
-      ? 'public, max-age=0, must-revalidate'
-      : process.env.NODE_ENV !== 'production'
-        ? cacheHeader.none
-        : cacheHeader.longCache
+    process.env.NODE_ENV !== 'production'
+      ? CACHE_HEADERS.NO_CACHE
+      : CACHE_HEADERS.REVALIDATE
 
   const isTwitter = fileBaseName === 'twitter-image'
   const isOpenGraph = fileBaseName === 'opengraph-image'
@@ -149,7 +146,7 @@ export async function GET() {
   return new NextResponse(content, {
     headers: {
       'Content-Type': contentType,
-      'Cache-Control': ${JSON.stringify(cacheHeader.revalidate)},
+      'Cache-Control': ${JSON.stringify(CACHE_HEADERS.REVALIDATE)},
     },
   })
 }
@@ -271,7 +268,7 @@ export async function GET(_, ctx) {
   return new NextResponse(content, {
     headers: {
       'Content-Type': contentType,
-      'Cache-Control': ${JSON.stringify(cacheHeader.revalidate)},
+      'Cache-Control': ${JSON.stringify(CACHE_HEADERS.REVALIDATE)},
     },
   })
 }

--- a/packages/next/src/server/og/image-response.ts
+++ b/packages/next/src/server/og/image-response.ts
@@ -49,7 +49,7 @@ export class ImageResponse extends Response {
       'cache-control':
         process.env.NODE_ENV === 'development'
           ? 'no-cache, no-store'
-          : 'public, immutable, no-transform, max-age=31536000',
+          : 'public, max-age=0, must-revalidate',
     })
     if (options.headers) {
       const newHeaders = new Headers(options.headers)

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -4,7 +4,6 @@ import { check } from 'next-test-utils'
 
 const CACHE_HEADERS = {
   NONE: 'no-cache, no-store',
-  LONG: 'public, immutable, no-transform, max-age=31536000',
   REVALIDATE: 'public, max-age=0, must-revalidate',
 }
 
@@ -209,7 +208,7 @@ describe('app dir - metadata dynamic routes', () => {
 
       expect(res.headers.get('content-type')).toBe('image/png')
       expect(res.headers.get('cache-control')).toBe(
-        isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.LONG
+        isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.REVALIDATE
       )
     })
 
@@ -219,7 +218,7 @@ describe('app dir - metadata dynamic routes', () => {
 
       expect(res.headers.get('content-type')).toBe('image/png')
       expect(res.headers.get('cache-control')).toBe(
-        isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.LONG
+        isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.REVALIDATE
       )
 
       if (isNextDev) {
@@ -241,7 +240,7 @@ describe('app dir - metadata dynamic routes', () => {
       res = await next.fetch('/twitter-image2')
       expect(res.headers.get('content-type')).toBe('image/png')
       expect(res.headers.get('cache-control')).toBe(
-        isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.LONG
+        isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.REVALIDATE
       )
     })
 
@@ -338,7 +337,7 @@ describe('app dir - metadata dynamic routes', () => {
 
       expect(res.headers.get('content-type')).toBe('image/png')
       expect(res.headers.get('cache-control')).toBe(
-        isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.LONG
+        isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.REVALIDATE
       )
     })
 
@@ -347,7 +346,7 @@ describe('app dir - metadata dynamic routes', () => {
 
       expect(res.headers.get('content-type')).toBe('image/png')
       expect(res.headers.get('cache-control')).toBe(
-        isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.LONG
+        isNextDev ? CACHE_HEADERS.NONE : CACHE_HEADERS.REVALIDATE
       )
     })
   })

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -12,6 +12,10 @@ import {
 import fs from 'fs/promises'
 import path from 'path'
 
+// Webpack: /favicon.ico?<hash>
+// Turbopack: /favicon.ico?favicon.<hash>.ico
+const FAVICON_REGEX = /\/favicon.ico\?\w+/
+
 describe('app dir - metadata', () => {
   const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
@@ -428,7 +432,7 @@ describe('app dir - metadata', () => {
       })
 
       // favicon shouldn't be overridden
-      expect($('link[rel="icon"]').attr('href')).toMatch('/favicon.ico')
+      expect($('link[rel="icon"]').attr('href')).toMatch(FAVICON_REGEX)
     })
 
     it('should override file based images when opengraph-image and twitter-image specify images property', async () => {
@@ -450,7 +454,7 @@ describe('app dir - metadata', () => {
         .toArray()
         .map((i) => $(i).attr('href'))
 
-      expect(favicon).toMatch('/favicon.ico')
+      expect(favicon).toMatch(FAVICON_REGEX)
       expect(icons).toEqual(['https://custom-icon-1.png'])
     })
 
@@ -485,7 +489,7 @@ describe('app dir - metadata', () => {
 
       await checkLink(browser, 'shortcut icon', '/shortcut-icon.png')
       await checkLink(browser, 'icon', [
-        expect.stringMatching(/favicon\.ico/),
+        expect.stringMatching(FAVICON_REGEX),
         '/icon.png',
         'https://example.com/icon.png',
       ])
@@ -524,7 +528,7 @@ describe('app dir - metadata', () => {
     it('should support root level of favicon.ico', async () => {
       let $ = await next.render$('/')
       const favIcon = $('link[rel="icon"]')
-      expect(favIcon.attr('href')).toMatch('/favicon.ico')
+      expect(favIcon.attr('href')).toMatch(FAVICON_REGEX)
       expect(favIcon.attr('type')).toBe('image/x-icon')
       // Turbopack renders / emits image differently
       expect(['16x16', '48x48']).toContain(favIcon.attr('sizes'))
@@ -536,7 +540,7 @@ describe('app dir - metadata', () => {
 
       $ = await next.render$('/basic')
       const icon = $('link[rel="icon"]')
-      expect(icon.attr('href')).toMatch('/favicon.ico')
+      expect(icon.attr('href')).toMatch(FAVICON_REGEX)
       expect(['16x16', '48x48']).toContain(favIcon.attr('sizes'))
 
       if (!isNextDeploy) {
@@ -689,20 +693,12 @@ describe('app dir - metadata', () => {
       expect(resAppleIcon.status).toBe(200)
       expect(resAppleIcon.headers.get('content-type')).toBe('image/png')
       expect(resAppleIcon.headers.get('cache-control')).toBe(
-        isNextDev
-          ? 'no-cache, no-store'
-          : isNextDeploy
-            ? 'public, max-age=0, must-revalidate'
-            : 'public, immutable, no-transform, max-age=31536000'
+        isNextDev ? 'no-cache, no-store' : 'public, max-age=0, must-revalidate'
       )
       expect(resIcon.status).toBe(200)
       expect(resIcon.headers.get('content-type')).toBe('image/png')
       expect(resIcon.headers.get('cache-control')).toBe(
-        isNextDev
-          ? 'no-cache, no-store'
-          : isNextDeploy
-            ? 'public, max-age=0, must-revalidate'
-            : 'public, immutable, no-transform, max-age=31536000'
+        isNextDev ? 'no-cache, no-store' : 'public, max-age=0, must-revalidate'
       )
     })
 

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -680,7 +680,7 @@ describe('app dir - metadata', () => {
       expect(res.status).toBe(200)
       expect(res.headers.get('content-type')).toBe('image/x-icon')
       expect(res.headers.get('cache-control')).toBe(
-        'public, max-age=0, must-revalidate'
+        isNextDev ? 'no-cache, no-store' : 'public, max-age=0, must-revalidate'
       )
     })
 


### PR DESCRIPTION
We changed static metadata files serving in Vercel CLI in https://github.com/vercel/vercel/pull/13816, where they can be served as static files directly. This will have a different header between local next build and deployment. Since they're already handled on CDN, changing them to use the must-revalidate cache is safer and easier than the previous immutable 1-year cache header.

Previously we're using revalidate cache header for `/favicon.ico` and the rest static files will have immutable cache. Since they can be cached on CND as files now we can just align the cache header to must-revalidate, and CDN will decide to serve a new one and serve 304.

This will change the `/favico.ico` to `/favicon.ico?<hash>` in the page but turbopack already has the hash as well.
This will change the metadata routes handlers to respond must-revalidate cache header instead of immutable 1-year one.