### PR TITLE
[test] update the metadata deployment cache header tests

### DIFF
--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -691,14 +691,18 @@ describe('app dir - metadata', () => {
       expect(resAppleIcon.headers.get('cache-control')).toBe(
         isNextDev
           ? 'no-cache, no-store'
-          : 'public, immutable, no-transform, max-age=31536000'
+          : isNextDeploy
+            ? 'public, max-age=0, must-revalidate'
+            : 'public, immutable, no-transform, max-age=31536000'
       )
       expect(resIcon.status).toBe(200)
       expect(resIcon.headers.get('content-type')).toBe('image/png')
       expect(resIcon.headers.get('cache-control')).toBe(
         isNextDev
           ? 'no-cache, no-store'
-          : 'public, immutable, no-transform, max-age=31536000'
+          : isNextDeploy
+            ? 'public, max-age=0, must-revalidate'
+            : 'public, immutable, no-transform, max-age=31536000'
       )
     })
 


### PR DESCRIPTION
Update metadata deployment tests assertion due to https://github.com/vercel/vercel/pull/13816 is rolled out, they're served as static file on vercel with `must-revalidate` header.

This is for unblocking the deployment tests failure. Will follow up to align and simplify the general cache approach in #83215