### PR TITLE
Turbopack: add test case for react lazy in cache components

### DIFF
--- a/test/e2e/app-dir/cache-components/app/lazy/client.tsx
+++ b/test/e2e/app-dir/cache-components/app/lazy/client.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function ClientComponent() {
+  return <p>Client Component</p>
+}

--- a/test/e2e/app-dir/cache-components/app/lazy/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/lazy/page.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+
+import UnrelatedComponent from './unrelated'
+
+const LazyClientComponent = React.lazy(() => import('./client'))
+
+async function CachedComponent() {
+  'use cache'
+
+  return (
+    <>
+      <LazyClientComponent />
+      <UnrelatedComponent />
+    </>
+  )
+}
+
+export default function Page() {
+  return <CachedComponent />
+}

--- a/test/e2e/app-dir/cache-components/app/lazy/unrelated.tsx
+++ b/test/e2e/app-dir/cache-components/app/lazy/unrelated.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function UnrelatedComponent() {
+  return <section>Unrelated Component</section>
+}

--- a/test/e2e/app-dir/cache-components/cache-components.lazy.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.lazy.test.ts
@@ -1,0 +1,65 @@
+import { nextTestSetup } from 'e2e-utils'
+import { assertNoRedbox, retry } from 'next-test-utils'
+
+describe('cache-components', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should load correctly', async () => {
+    const browser = await next.browser('/lazy')
+    expect(await browser.elementByCss('p').text()).toBe('Client Component')
+  })
+
+  if (isNextDev) {
+    it('should still work after changes', async () => {
+      {
+        const browser = await next.browser('/lazy')
+        expect(await browser.elementByCss('p').text()).toBe('Client Component')
+        expect(await browser.elementByCss('section').text()).toBe(
+          'Unrelated Component'
+        )
+
+        await next.patchFile(
+          'app/lazy/unrelated.tsx',
+          (content) =>
+            content.replace(
+              'Unrelated Component',
+              'Unrelated Changed Component'
+            ),
+          async () => {
+            await retry(async () => {
+              expect(await browser.elementByCss('section').text()).toBe(
+                'Unrelated Changed Component'
+              )
+              expect(await browser.elementByCss('p').text()).toBe(
+                'Client Component'
+              )
+              assertNoRedbox(browser)
+            })
+
+            {
+              const browser = await next.browser('/lazy')
+              expect(await browser.elementByCss('p').text()).toBe(
+                'Client Component'
+              )
+              expect(await browser.elementByCss('section').text()).toBe(
+                'Unrelated Changed Component'
+              )
+              assertNoRedbox(browser)
+            }
+          }
+        )
+      }
+
+      {
+        const browser = await next.browser('/lazy')
+        expect(await browser.elementByCss('p').text()).toBe('Client Component')
+        expect(await browser.elementByCss('section').text()).toBe(
+          'Unrelated Component'
+        )
+        assertNoRedbox(browser)
+      }
+    })
+  }
+})


### PR DESCRIPTION
### What?

Adds a test cases for using a React.lazy inside of "use cache".