### PR TITLE
Turbopack: Remove undocumented `turbopack.conditions` configuration

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -14,7 +14,7 @@ use turbo_tasks_fetch::FetchClient;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{
     ConditionItem, ConditionPath, LoaderRuleItem, WebpackRules,
-    module_options_context::{MdxTransformOptions, OptionWebpackConditions},
+    module_options_context::MdxTransformOptions,
 };
 use turbopack_core::{
     issue::{Issue, IssueExt, IssueStage, OptionStyledString, StyledString},
@@ -558,8 +558,6 @@ pub struct TurbopackConfig {
     /// This option has been replaced by `rules`.
     pub loaders: Option<JsonValue>,
     pub rules: Option<FxIndexMap<RcStr, RuleConfigCollection>>,
-    #[turbo_tasks(trace_ignore)]
-    pub conditions: Option<FxIndexMap<RcStr, ConfigConditionItem>>,
     pub resolve_alias: Option<FxIndexMap<RcStr, JsonValue>>,
     pub resolve_extensions: Option<Vec<RcStr>>,
     pub module_ids: Option<ModuleIds>,
@@ -1482,24 +1480,6 @@ impl NextConfig {
             }
         }
         Ok(Vc::cell(rules))
-    }
-
-    #[turbo_tasks::function]
-    pub fn webpack_conditions(&self) -> Result<Vc<OptionWebpackConditions>> {
-        let Some(config_conditions) = self.turbopack.as_ref().and_then(|t| t.conditions.as_ref())
-        else {
-            return Ok(Vc::cell(None));
-        };
-
-        let conditions = config_conditions
-            .iter()
-            .map(|(k, v)| {
-                let item: Result<ConditionItem> = TryInto::<ConditionItem>::try_into((*v).clone());
-                item.map(|item| (k.clone(), item))
-            })
-            .collect::<Result<FxIndexMap<RcStr, ConditionItem>>>()?;
-
-        Ok(Vc::cell(Some(ResolvedVc::cell(conditions))))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -26,8 +26,6 @@ pub(crate) mod sass;
 
 /// Built-in conditions provided by the Next.js Turbopack integration for configuring webpack
 /// loaders. These can be used in the `next.config.js` `turbopack.rules` section.
-///
-/// These are different from than the user-configurable "conditions" field.
 //
 // Note: If you add a field here, make sure to also add it in:
 // - The typescript definition in `packages/next/src/server/config-shared.ts`
@@ -210,11 +208,9 @@ pub async fn webpack_loader_options(
         return Ok(Vc::cell(None));
     }
 
-    let conditions = next_config.webpack_conditions().to_resolved().await?;
     Ok(Vc::cell(Some(
         WebpackLoadersOptions {
             rules: ResolvedVc::cell(rules),
-            conditions,
             loader_runner_package: Some(loader_runner_package_mapping().to_resolved().await?),
             builtin_conditions: NextWebpackLoaderBuiltinConditionSet::new(builtin_conditions)
                 .to_resolved()

--- a/packages/next-mdx/index.js
+++ b/packages/next-mdx/index.js
@@ -26,7 +26,8 @@ module.exports =
     /**
      * @type {import('next').NextConfig}
      */
-    let nextConfig = Object.assign({}, inputConfig, {
+    const nextConfig = {
+      ...inputConfig,
       webpack(config, options) {
         config.resolve.alias['next-mdx-import-source-file'] = [
           'private-next-root-dir/src/mdx-components',
@@ -45,26 +46,41 @@ module.exports =
 
         return config
       },
-    })
+    }
 
     if (process.env.TURBOPACK) {
-      nextConfig.turbopack = Object.assign({}, nextConfig?.turbopack, {
-        rules: Object.assign({}, nextConfig?.turbopack?.rules, {
-          '#next-mdx': {
-            loaders: [loader],
-            as: '*.tsx',
-          },
-        }),
-        conditions: {
-          '#next-mdx': {
-            path: extension,
-          },
+      const mdxRule = {
+        loaders: [loader],
+        as: '*.tsx',
+        condition: {
+          path: extension,
         },
-        resolveAlias: Object.assign({}, nextConfig?.turbopack?.resolveAlias, {
+      }
+
+      // Use a unique glob string for two reasons:
+      // - This makes it clear where the rule was defined if someone needs to debug.
+      // - Reduces the chance of a collision (can still happen if `next-mdx` is applied twice with
+      //   different options). Rule evaluation is ordering-sensitive, and a unique glob means we're
+      //   less likely to break the ordering of existing rules.
+      let wildcardGlob = '{*,next-mdx-rule}'
+      let wildcardRule = inputConfig.turbopack?.rules?.[wildcardGlob] ?? []
+      wildcardRule = [
+        ...(Array.isArray(wildcardRule) ? wildcardRule : [wildcardRule]),
+        mdxRule,
+      ]
+
+      nextConfig.turbopack = {
+        ...inputConfig?.turbopack,
+        rules: {
+          ...inputConfig?.turbopack?.rules,
+          [wildcardGlob]: wildcardRule,
+        },
+        resolveAlias: {
+          ...inputConfig?.turbopack?.resolveAlias,
           'next-mdx-import-source-file':
             '@vercel/turbopack-next/mdx-import-source',
-        }),
-      })
+        },
+      }
     }
 
     return nextConfig

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -149,7 +149,6 @@ const zTurbopackRuleConfigCollection: zod.ZodType<TurbopackRuleConfigCollection>
 
 const zTurbopackConfig: zod.ZodType<TurbopackOptions> = z.strictObject({
   rules: z.record(z.string(), zTurbopackRuleConfigCollection).optional(),
-  conditions: z.record(z.string(), zTurbopackCondition).optional(),
   resolveAlias: z
     .record(
       z.string(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -301,7 +301,7 @@ export interface TurbopackOptions {
   /**
    * (`next --turbopack` only) A mapping of aliased imports to modules to load in their place.
    *
-   * @see [Resolve Alias](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#resolve-alias)
+   * @see [Resolve Alias](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#resolving-aliases)
    */
   resolveAlias?: Record<
     string,
@@ -311,23 +311,16 @@ export interface TurbopackOptions {
   /**
    * (`next --turbopack` only) A list of extensions to resolve when importing files.
    *
-   * @see [Resolve Extensions](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#resolve-extensions)
+   * @see [Resolve Extensions](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#resolving-custom-extensions)
    */
   resolveExtensions?: string[]
 
   /**
    * (`next --turbopack` only) A list of webpack loaders to apply when running with Turbopack.
    *
-   * @see [Turbopack Loaders](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders)
+   * @see [Turbopack Loaders](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#configuring-webpack-loaders)
    */
   rules?: Record<string, TurbopackRuleConfigCollection>
-
-  /**
-   * (`next --turbopack` only) A list of conditions to apply when running webpack loaders with Turbopack.
-   *
-   * @see [Turbopack Loaders](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders)
-   */
-  conditions?: Record<`#${string}`, TurbopackRuleCondition>
 
   /**
    * The module ID strategy to use for Turbopack.
@@ -348,7 +341,7 @@ export interface DeprecatedExperimentalTurboOptions extends TurbopackOptions {
    * (`next --turbopack` only) A list of webpack loaders to apply when running with Turbopack.
    *
    * @deprecated Use `rules` instead.
-   * @see [Turbopack Loaders](https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders)
+   * @see [Turbopack Loaders](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#configuring-webpack-loaders)
    */
   loaders?: Record<string, TurbopackLoaderItem[]>
 

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -577,37 +577,11 @@ impl ModuleOptions {
             for (key, rule) in webpack_loaders_options.rules.await?.iter() {
                 let mut rule_conditions = Vec::new();
 
-                if key.starts_with("#") {
-                    // Legacy (undocumented) condition reference syntax:
-                    // https://www.notion.so/vercel/Turbopack-loader-rule-syntax-254e06b059c4809096d1e7c9afad278c
-                    //
-                    // This is a custom marker requiring a corresponding condition entry
-                    let conditions = (*webpack_loaders_options.conditions.await?)
-                        .context(
-                            "Expected a condition entry for the webpack loader rule matching \
-                             {key}. Create a `conditions` mapping in your next.config.js",
-                        )?
-                        .await?;
-
-                    let condition = conditions.get(key).context(
-                        "Expected a condition entry for the webpack loader rule matching {key}.",
-                    )?;
-
-                    rule_conditions.push(
-                        rule_condition_from_webpack_condition(
-                            execution_context,
-                            &*builtin_conditions,
-                            condition,
-                        )
-                        .await?,
-                    )
-                } else {
-                    // prefer to add this condition ahead of the user-defined `condition` field,
-                    // because we know it's cheap to check
-                    rule_conditions.push(
-                        rule_condition_from_webpack_condition_glob(execution_context, key).await?,
-                    )
-                };
+                // prefer to add the glob condition ahead of the user-defined `condition` field,
+                // because we know it's cheap to check
+                rule_conditions.push(
+                    rule_condition_from_webpack_condition_glob(execution_context, key).await?,
+                );
 
                 if let Some(condition) = &rule.condition {
                     rule_conditions.push(

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 use turbo_esregex::EsRegex;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, NonLocalValue, ResolvedVc, ValueDefault, Vc, trace::TraceRawVcs};
+use turbo_tasks::{NonLocalValue, ResolvedVc, ValueDefault, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::SourceMapsType, compile_time_info::CompileTimeInfo, condition::ContextCondition,
@@ -35,14 +35,6 @@ pub struct LoaderRuleItem {
 #[turbo_tasks::value(transparent)]
 pub struct WebpackRules(Vec<(RcStr, LoaderRuleItem)>);
 
-#[derive(Default)]
-#[turbo_tasks::value(transparent)]
-pub struct WebpackConditions(pub FxIndexMap<RcStr, ConditionItem>);
-
-#[derive(Default)]
-#[turbo_tasks::value(transparent)]
-pub struct OptionWebpackConditions(Option<ResolvedVc<WebpackConditions>>);
-
 #[derive(Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
 pub enum ConditionPath {
     Glob(RcStr),
@@ -66,7 +58,6 @@ pub enum ConditionItem {
 #[derive(Clone, Debug)]
 pub struct WebpackLoadersOptions {
     pub rules: ResolvedVc<WebpackRules>,
-    pub conditions: ResolvedVc<OptionWebpackConditions>,
     pub builtin_conditions: ResolvedVc<Box<dyn WebpackLoaderBuiltinConditionSet>>,
     pub loader_runner_package: Option<ResolvedVc<ImportMapping>>,
 }


### PR DESCRIPTION
This syntax was undocumented, and as far as I can tell, there are no OSS external users of this API: https://sourcegraph.com/search?q=context:global+/turbopack:%28.%7C%5Cn%29*conditions:/&patternType=keyword&sm=0

https://github.com/vercel/next.js/pull/82857 provides a better syntax for defining these conditions that we intend to document.

Closes PACK-5399