### PR TITLE
[next-config-ts] verify typescript on only init

### DIFF
--- a/packages/next/src/build/next-config-ts/transpile-config.ts
+++ b/packages/next/src/build/next-config-ts/transpile-config.ts
@@ -32,7 +32,7 @@ function resolveSWCOptions(
     env: {
       targets: {
         // Setting the Node.js version can reduce unnecessary code generation.
-        node: process?.versions?.node ?? '20.19.0',
+        node: process.versions.node,
       },
     },
   } satisfies SWCOptions
@@ -103,6 +103,9 @@ async function getTsConfig(cwd: string): Promise<CompilerOptions> {
   return parsedCommandLine.options
 }
 
+let compilerOptions: CompilerOptions | null = null
+let verifiedTsSetup = false
+
 export async function transpileConfig({
   nextConfigPath,
   configFileName,
@@ -113,9 +116,14 @@ export async function transpileConfig({
   cwd: string
 }) {
   try {
-    // Ensure TypeScript is installed to use the API.
-    await verifyTypeScriptSetup(cwd, configFileName)
-    const compilerOptions = await getTsConfig(cwd)
+    if (compilerOptions === null) {
+      if (process.env.NODE_ENV === 'development' && !verifiedTsSetup) {
+        // Ensure TypeScript is installed to use the API.
+        await verifyTypeScriptSetup(cwd, configFileName)
+        verifiedTsSetup = true
+      }
+      compilerOptions = await getTsConfig(cwd)
+    }
 
     return handleCJS({ cwd, nextConfigPath, compilerOptions })
   } catch (cause) {
@@ -128,13 +136,13 @@ export async function transpileConfig({
 async function handleCJS({
   cwd,
   nextConfigPath,
-  compilerOptions,
+  compilerOptions: compilerOptsParam,
 }: {
   cwd: string
   nextConfigPath: string
   compilerOptions: CompilerOptions
 }) {
-  const swcOptions = resolveSWCOptions(cwd, compilerOptions)
+  const swcOptions = resolveSWCOptions(cwd, compilerOptsParam)
   let hasRequire = false
   try {
     const nextConfigString = await readFile(nextConfigPath, 'utf8')

--- a/packages/next/src/build/next-config-ts/transpile-config.ts
+++ b/packages/next/src/build/next-config-ts/transpile-config.ts
@@ -115,6 +115,7 @@ export async function transpileConfig({
   cwd: string
 }) {
   try {
+    // Verify only in dev as we expect the deps are already installed in prod.
     if (process.env.NODE_ENV === 'development' && !verifiedTsSetup) {
       // Ensure TypeScript is installed to use the API.
       await verifyTypeScriptSetup(cwd, configFileName)

--- a/packages/next/src/build/next-config-ts/transpile-config.ts
+++ b/packages/next/src/build/next-config-ts/transpile-config.ts
@@ -73,7 +73,7 @@ async function verifyTypeScriptSetup(cwd: string, configFileName: string) {
   }
 }
 
-async function getTsConfig(cwd: string): Promise<CompilerOptions> {
+async function getCompilerOptions(cwd: string): Promise<CompilerOptions> {
   const ts: typeof import('typescript') = require(
     require.resolve('typescript', { paths: [cwd] })
   )
@@ -103,7 +103,6 @@ async function getTsConfig(cwd: string): Promise<CompilerOptions> {
   return parsedCommandLine.options
 }
 
-let compilerOptions: CompilerOptions | null = null
 let verifiedTsSetup = false
 
 export async function transpileConfig({
@@ -116,16 +115,17 @@ export async function transpileConfig({
   cwd: string
 }) {
   try {
-    if (compilerOptions === null) {
-      if (process.env.NODE_ENV === 'development' && !verifiedTsSetup) {
-        // Ensure TypeScript is installed to use the API.
-        await verifyTypeScriptSetup(cwd, configFileName)
-        verifiedTsSetup = true
-      }
-      compilerOptions = await getTsConfig(cwd)
+    if (process.env.NODE_ENV === 'development' && !verifiedTsSetup) {
+      // Ensure TypeScript is installed to use the API.
+      await verifyTypeScriptSetup(cwd, configFileName)
+      verifiedTsSetup = true
     }
 
-    return handleCJS({ cwd, nextConfigPath, compilerOptions })
+    return handleCJS({
+      cwd,
+      nextConfigPath,
+      compilerOptions: await getCompilerOptions(cwd),
+    })
   } catch (cause) {
     throw new Error(`Failed to transpile "${configFileName}".`, {
       cause,
@@ -136,13 +136,13 @@ export async function transpileConfig({
 async function handleCJS({
   cwd,
   nextConfigPath,
-  compilerOptions: compilerOptsParam,
+  compilerOptions,
 }: {
   cwd: string
   nextConfigPath: string
   compilerOptions: CompilerOptions
 }) {
-  const swcOptions = resolveSWCOptions(cwd, compilerOptsParam)
+  const swcOptions = resolveSWCOptions(cwd, compilerOptions)
   let hasRequire = false
   try {
     const nextConfigString = await readFile(nextConfigPath, 'utf8')


### PR DESCRIPTION
Skip unnecessary `verifyTsSetup()` when running `transpileConfig()` after once.