### PR TITLE
[turbopack] Remove the `should_track_children` parameter of the turbo tasks backend

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -733,7 +733,6 @@ impl AggregationUpdateQueue {
     /// Runs the job and all dependent jobs until it's done. It can persist the operation, so
     /// following code might not be executed when persisted.
     pub fn run(job: AggregationUpdateJob, ctx: &mut impl ExecuteContext) {
-        debug_assert!(ctx.should_track_children());
         let mut queue = Self::new();
         queue.push(job);
         queue.execute(ctx);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -24,19 +24,6 @@ pub enum ConnectChildOperation {
 
 impl ConnectChildOperation {
     pub fn run(parent_task_id: TaskId, child_task_id: TaskId, mut ctx: impl ExecuteContext) {
-        if !ctx.should_track_children() {
-            let mut child_task = ctx.task(child_task_id, TaskDataCategory::All);
-            if !child_task.has_key(&CachedDataItemKey::Output {})
-                && child_task.add(CachedDataItem::new_scheduled(
-                    TaskExecutionReason::Connect,
-                    || ctx.get_task_desc_fn(child_task_id),
-                ))
-            {
-                ctx.schedule_task(child_task);
-            }
-            return;
-        }
-
         let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::All);
         let Some(InProgressState::InProgress(box InProgressStateInner { new_children, .. })) =
             get_mut!(parent_task, InProgress)

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -280,7 +280,7 @@ pub fn make_task_dirty_internal(
     )
     .entered();
 
-    let should_schedule = if ctx.should_track_children() {
+    let should_schedule = {
         let aggregated_update = dirty_container.update_with_dirty_state(&DirtyState {
             clean_in_session: None,
         });
@@ -291,8 +291,6 @@ pub fn make_task_dirty_internal(
             ));
         }
         !ctx.should_track_activeness() || task.has_key(&CachedDataItemKey::Activeness {})
-    } else {
-        true
     };
 
     if should_schedule {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -65,7 +65,6 @@ pub trait ExecuteContext<'e>: Sized {
     fn suspending_requested(&self) -> bool;
     fn get_task_desc_fn(&self, task_id: TaskId) -> impl Fn() -> String + Send + Sync + 'static;
     fn get_task_description(&self, task_id: TaskId) -> String;
-    fn should_track_children(&self) -> bool;
     fn should_track_dependencies(&self) -> bool;
     fn should_track_activeness(&self) -> bool;
 }
@@ -287,10 +286,6 @@ where
 
     fn get_task_description(&self, task_id: TaskId) -> String {
         self.backend.get_task_description(task_id)
-    }
-
-    fn should_track_children(&self) -> bool {
-        self.backend.should_track_children()
     }
 
     fn should_track_dependencies(&self) -> bool {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
@@ -24,10 +24,6 @@ impl UpdateCollectibleOperation {
         mut count: i32,
         mut ctx: impl ExecuteContext,
     ) {
-        if !ctx.should_track_children() {
-            // Collectibles are not supported without children tracking
-            return;
-        }
         let mut task = ctx.task(task_id, TaskDataCategory::All);
         if count < 0 {
             // Ensure it's an root node

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_output.rs
@@ -46,7 +46,7 @@ impl UpdateOutputOperation {
     pub fn run(
         task_id: TaskId,
         output: Result<RawVc, TurboTasksExecutionError>,
-        mut ctx: impl ExecuteContext,
+        mut ctx: impl ExecuteContext<'_>,
     ) {
         let mut dependent_tasks = Default::default();
         let mut children = Default::default();
@@ -66,9 +66,7 @@ impl UpdateOutputOperation {
                 // Skip updating the output when the task is stale
                 break 'output;
             }
-            if ctx.should_track_children() {
-                children = new_children.iter().copied().collect();
-            }
+            children = new_children.iter().copied().collect();
 
             let current_output = get!(task, Output);
             let output_value = match output {


### PR DESCRIPTION
This appears to be dead, is there a reason to keep it?



Closes PACK-5453