### PR TITLE
[turbopack] Drop turbo_tasks::function from EcmascriptAnalyzable::module_content

### DIFF
--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -243,7 +243,7 @@ where
     /// Returns `None` if the underlying value type does not implement `K`.
     ///
     /// **Note:** if the trait `T` is required to implement `K`, use [`ResolvedVc::upcast`] instead.
-    /// This provides stronger guarantees, removing the need for a [`Option`] return type.
+    /// That method provides stronger guarantees, removing the need for a [`Option`] return type.
     ///
     /// See also: [`Vc::try_resolve_sidecast`].
     pub fn try_sidecast<K>(this: Self) -> Option<ResolvedVc<K>>

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
@@ -8,7 +8,7 @@ use turbopack_core::{
 
 use super::module::EcmascriptModuleFacadeModule;
 use crate::{
-    EcmascriptAnalyzable,
+    EcmascriptAnalyzableExt,
     chunk::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType,

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -8,7 +8,7 @@ use turbopack_core::{
 
 use super::module::EcmascriptModuleLocalsModule;
 use crate::{
-    EcmascriptAnalyzable,
+    EcmascriptAnalyzableExt,
     chunk::{EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkType},
 };
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -10,7 +10,7 @@ use turbopack_core::{
 
 use super::asset::EcmascriptModulePartAsset;
 use crate::{
-    EcmascriptAnalyzable,
+    EcmascriptAnalyzableExt,
     chunk::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemOptions,
         EcmascriptChunkPlaceable, EcmascriptChunkType,


### PR DESCRIPTION
This function simply plugs two other VCs together, and it never gets a cache hit because it is "dominated" by other tasks.

The only reason it is a turbotask is because it is defined as a trait item, however, we recently (#79217) allowed for value_trait items to not be turbo tasks.  This PR builds on that to additionally allow for non-turbo_task trait items to accept `Vc<Self>`.  This only really works if there is also a default implementation which works for this case.

A tiny speed up progression in production

![image.png](https://app.graphite.dev/user-attachments/assets/c6d82929-5fb2-4921-b566-d648751a00ee.png)



Closes PACK-5466