### PR TITLE
Turbopack: skip next-server.js.nft.json for Vercel

### DIFF
--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -38,18 +38,26 @@ enum ServerNftType {
 
 #[turbo_tasks::function]
 pub async fn next_server_nft_assets(project: Vc<Project>) -> Result<Vc<OutputAssets>> {
-    Ok(Vc::cell(vec![
-        ResolvedVc::upcast(
-            ServerNftJsonAsset::new(project, ServerNftType::Full)
-                .to_resolved()
-                .await?,
-        ),
-        ResolvedVc::upcast(
-            ServerNftJsonAsset::new(project, ServerNftType::Minimal)
-                .to_resolved()
-                .await?,
-        ),
-    ]))
+    let has_next_support = *project.next_config().ci_has_next_support().await?;
+
+    let minimal = ResolvedVc::upcast(
+        ServerNftJsonAsset::new(project, ServerNftType::Minimal)
+            .to_resolved()
+            .await?,
+    );
+
+    if has_next_support {
+        Ok(Vc::cell(vec![minimal]))
+    } else {
+        Ok(Vc::cell(vec![
+            minimal,
+            ResolvedVc::upcast(
+                ServerNftJsonAsset::new(project, ServerNftType::Full)
+                    .to_resolved()
+                    .await?,
+            ),
+        ]))
+    }
 }
 
 #[turbo_tasks::value]

--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -39,6 +39,7 @@ enum ServerNftType {
 #[turbo_tasks::function]
 pub async fn next_server_nft_assets(project: Vc<Project>) -> Result<Vc<OutputAssets>> {
     let has_next_support = *project.ci_has_next_support().await?;
+    let is_standalone = *project.next_config().is_standalone().await?;
 
     let minimal = ResolvedVc::upcast(
         ServerNftJsonAsset::new(project, ServerNftType::Minimal)
@@ -46,7 +47,8 @@ pub async fn next_server_nft_assets(project: Vc<Project>) -> Result<Vc<OutputAss
             .await?,
     );
 
-    if has_next_support {
+    if has_next_support && !is_standalone {
+        // When deploying to Vercel, we only need next-minimal-server.js.nft.json
         Ok(Vc::cell(vec![minimal]))
     } else {
         Ok(Vc::cell(vec![

--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -38,7 +38,7 @@ enum ServerNftType {
 
 #[turbo_tasks::function]
 pub async fn next_server_nft_assets(project: Vc<Project>) -> Result<Vc<OutputAssets>> {
-    let has_next_support = *project.next_config().ci_has_next_support().await?;
+    let has_next_support = *project.ci_has_next_support().await?;
 
     let minimal = ResolvedVc::upcast(
         ServerNftJsonAsset::new(project, ServerNftType::Minimal)
@@ -256,7 +256,7 @@ impl ServerNftJsonAsset {
     #[turbo_tasks::function]
     async fn ignores(&self) -> Result<Vc<Glob>> {
         let is_standalone = *self.project.next_config().is_standalone().await?;
-        let has_next_support = *self.project.next_config().ci_has_next_support().await?;
+        let has_next_support = *self.project.ci_has_next_support().await?;
         let project_path = self.project.project_path().owned().await?;
 
         let output_file_tracing_excludes = self

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -765,6 +765,13 @@ impl Project {
     }
 
     #[turbo_tasks::function]
+    pub async fn ci_has_next_support(&self) -> Result<Vc<bool>> {
+        Ok(Vc::cell(
+            self.env.read(rcstr!("NOW_BUILDER")).await?.is_some(),
+        ))
+    }
+
+    #[turbo_tasks::function]
     pub(super) fn current_node_js_version(&self) -> Vc<NodeJsVersion> {
         NodeJsVersion::Static(ResolvedVc::cell(self.current_node_js_version.clone())).cell()
     }

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1329,11 +1329,6 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub fn ci_has_next_support(&self) -> Vc<bool> {
-        Vc::cell(self.env.contains_key("NOW_BUILDER"))
-    }
-
-    #[turbo_tasks::function]
     pub fn cache_handler(&self, project_path: FileSystemPath) -> Result<Vc<OptionFileSystemPath>> {
         if let Some(handler) = &self.cache_handler {
             Ok(Vc::cell(Some(project_path.join(handler)?)))

--- a/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
@@ -99,6 +99,7 @@ describe('required server files app router', () => {
     await setupNext({ nextEnv: true, minimalMode: true })
   })
   afterAll(async () => {
+    delete process.env.NOW_BUILDER
     delete process.env.NEXT_PRIVATE_TEST_HEADERS
     await next.destroy()
     if (server) await killApp(server)

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -112,6 +112,7 @@ describe('required server files app router', () => {
   })
 
   afterAll(async () => {
+    delete process.env.NOW_BUILDER
     delete process.env.NEXT_PRIVATE_TEST_HEADERS
     await next.destroy()
     if (server) await killApp(server)

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -161,6 +161,7 @@ describe('required server files', () => {
   })
 
   afterAll(async () => {
+    delete process.env.NOW_BUILDER
     delete process.env.NEXT_PRIVATE_TEST_HEADERS
     await next.destroy()
   })

--- a/test/production/standalone-mode/response-cache/index.test.ts
+++ b/test/production/standalone-mode/response-cache/index.test.ts
@@ -85,6 +85,7 @@ describe('minimal-mode-response-cache', () => {
     appPort = `http://127.0.0.1:${port}`
   })
   afterAll(async () => {
+    delete process.env.NOW_BUILDER
     delete process.env.NEXT_PRIVATE_TEST_HEADERS
     await next.destroy()
     if (server) await killApp(server)


### PR DESCRIPTION
On Vercel, we only need `next-minimal-server.js.nft.json`

Also, `ci_has_next_support` was implemented correctly, it previously read from `nextConfig.env`, instead of the real (full) environment variables from the system.

Closes PACK-5404