### PR TITLE
FIX: check for s-maxage before setting cache control

### DIFF
--- a/packages/next/src/server/send-payload.ts
+++ b/packages/next/src/server/send-payload.ts
@@ -57,8 +57,13 @@ export async function sendRenderResult({
 
   // If cache control is already set on the response we don't
   // override it to allow users to customize it via next.config
-  if (cacheControl && !res.getHeader('Cache-Control')) {
-    res.setHeader('Cache-Control', getCacheControlHeader(cacheControl))
+
+  if (cacheControl) {
+    const current = res.getHeader('Cache-Control')
+    const next = getCacheControlHeader(cacheControl)
+    if (next.includes('s-maxage') || !current) {
+      res.setHeader('Cache-Control', next)
+    }
   }
 
   const payload = result.isDynamic ? null : result.toUnchunkedString()


### PR DESCRIPTION
prevents _app from setting headers after ISR response is sent.

What: Fix header setting after ISR responses.
Why: In production _app tried to set headers after response was finished, which caused errors.
How: Only set Cache-Control if it includes s-maxage or no headers are present.