### PR TITLE
[test] Resolve `elementByCSS` and `waitForElementByCSS` once visible

### DIFF
--- a/test/development/acceptance-app/editor-links.test.ts
+++ b/test/development/acceptance-app/editor-links.test.ts
@@ -1,10 +1,11 @@
 import { check, retry } from 'next-test-utils'
+import type { Playwright } from 'next-webdriver'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { createSandbox } from 'development-sandbox'
 import { outdent } from 'outdent'
 
-async function clickSourceFile(browser: any) {
+async function clickSourceFile(browser: Playwright) {
   await browser.waitForElementByCss(
     '[data-with-open-in-editor-link-source-file]'
   )
@@ -13,7 +14,7 @@ async function clickSourceFile(browser: any) {
     .click()
 }
 
-async function clickImportTraceFiles(browser: any) {
+async function clickImportTraceFiles(browser: Playwright) {
   await browser.waitForElementByCss(
     '[data-with-open-in-editor-link-import-trace]'
   )

--- a/test/development/app-dir/react-performance-track/react-performance-track.test.ts
+++ b/test/development/app-dir/react-performance-track/react-performance-track.test.ts
@@ -10,7 +10,9 @@ describe('react-performance-track', () => {
 
   it('should show setTimeout', async () => {
     const browser = await next.browser('/set-timeout')
-    await browser.elementByCss('[data-react-server-requests-done]')
+    await browser.elementByCss('[data-react-server-requests-done]', {
+      state: 'attached',
+    })
 
     const track = await browser.eval('window.reactServerRequests.getSnapshot()')
     expect(track).toEqual(
@@ -23,7 +25,9 @@ describe('react-performance-track', () => {
 
   it('should show fetch', async () => {
     const browser = await next.browser('/fetch')
-    await browser.elementByCss('[data-react-server-requests-done]')
+    await browser.elementByCss('[data-react-server-requests-done]', {
+      state: 'attached',
+    })
 
     const track = await browser.eval('window.reactServerRequests.getSnapshot()')
     expect(track).toEqual(

--- a/test/development/app-dir/segment-explorer/segment-explorer.test.ts
+++ b/test/development/app-dir/segment-explorer/segment-explorer.test.ts
@@ -92,7 +92,7 @@ describe('segment-explorer', () => {
       `"app/ [global-error.js]"`
     )
     // FIXME: handle preserve the url when hitting global-error
-    expect(await getSegmentExplorerRoute(browser)).toBe('')
+    expect(await getSegmentExplorerRoute(browser)).toBe('<empty>')
   })
 
   it('should show navigation boundaries of the segment', async () => {

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -123,7 +123,9 @@ describe(`app-dir-hmr`, () => {
       await browser
         .elementByCss('a')
         .click()
-        .waitForElementByCss('[data-testid="new-runtime-functionality-page"]')
+        .waitForElementByCss('[data-testid="new-runtime-functionality-page"]', {
+          state: 'attached',
+        })
 
       const logs = await browser.log()
       // TODO: Should assert on all logs but these are cluttered with logs from our test utils (e.g. playwright tracing or webdriver)

--- a/test/development/basic/define-class-fields/define-class-fields.test.ts
+++ b/test/development/basic/define-class-fields/define-class-fields.test.ts
@@ -1,5 +1,4 @@
 import { join } from 'path'
-import webdriver from 'next-webdriver'
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
@@ -16,32 +15,18 @@ describe('useDefineForClassFields SWC option', () => {
   })
 
   it('tsx should compile with useDefineForClassFields enabled', async () => {
-    let browser
-    try {
-      browser = await webdriver(next.url, '/')
-      await browser.elementByCss('#action').click()
-      await check(
-        () => browser.elementByCss('#name').text(),
-        /this is my name: next/
-      )
-    } finally {
-      if (browser) {
-        await browser.close()
-      }
-    }
+    const browser = await next.browser('/')
+    await browser.elementByCss('#action').click()
+    await check(
+      () => browser.elementByCss('#name').text(),
+      /this is my name: next/
+    )
   })
 
   it("Initializes resident to undefined after the call to 'super()' when with useDefineForClassFields enabled", async () => {
-    let browser
-    try {
-      browser = await webdriver(next.url, '/animal')
-      expect(await browser.elementByCss('#dog').text()).toBe('')
-      expect(await browser.elementByCss('#dogDecl').text()).toBe('dog')
-    } finally {
-      if (browser) {
-        await browser.close()
-      }
-    }
+    const browser = await next.browser('/animal')
+    expect(await browser.elementByCss('#dog').text()).toBe('undefined')
+    expect(await browser.elementByCss('#dogDecl').text()).toBe('dog')
   })
 
   async function matchLogs$(browser) {
@@ -62,17 +47,10 @@ describe('useDefineForClassFields SWC option', () => {
   }
 
   it('set accessors from base classes won’t get triggered with useDefineForClassFields enabled', async () => {
-    let browser
-    try {
-      browser = await webdriver(next.url, '/derived')
-      await matchLogs$(browser).then(([data_foundLog, name_foundLog]) => {
-        expect(data_foundLog).toBe(true)
-        expect(name_foundLog).toBe(false)
-      })
-    } finally {
-      if (browser) {
-        await browser.close()
-      }
-    }
+    const browser = await next.browser('/derived')
+    await matchLogs$(browser).then(([data_foundLog, name_foundLog]) => {
+      expect(data_foundLog).toBe(true)
+      expect(name_foundLog).toBe(false)
+    })
   })
 })

--- a/test/development/basic/define-class-fields/fixture/pages/animal.tsx
+++ b/test/development/basic/define-class-fields/fixture/pages/animal.tsx
@@ -46,7 +46,7 @@ export default function AnimalView() {
   })
   return (
     <>
-      <div id={'dog'}>{dog.resident}</div>
+      <div id={'dog'}>{String(dog.resident)}</div>
       <div id={'dogDecl'}>{dogDeclare.resident?.dogStuff}</div>
     </>
   )

--- a/test/development/basic/define-class-fields/fixture/tsconfig.json
+++ b/test/development/basic/define-class-fields/fixture/tsconfig.json
@@ -17,5 +17,5 @@
     "isolatedModules": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/test/e2e/404-page-router/app/components/debug.js
+++ b/test/e2e/404-page-router/app/components/debug.js
@@ -2,7 +2,7 @@ export default function Debug({ name, value }) {
   return (
     <>
       <dt>{name}</dt>
-      <dd id={name}>{value}</dd>
+      <dd id={name}>{value || '<empty>'}</dd>
     </>
   )
 }

--- a/test/e2e/404-page-router/index.test.ts
+++ b/test/e2e/404-page-router/index.test.ts
@@ -1,6 +1,5 @@
 import path from 'path'
 import fs from 'fs-extra'
-import webdriver from 'next-webdriver'
 import { createNext, FileRef, type NextInstance } from 'e2e-utils'
 import { check, retry } from 'next-test-utils'
 
@@ -122,29 +121,23 @@ describe('404-page-router', () => {
 
       describe.each(urls)('for $url', ({ url, pathname, asPath }) => {
         it('should have the correct router parameters after it is ready', async () => {
-          const query = url.split('?', 2)[1] ?? ''
-          const browser = await webdriver(next.url, url)
+          const query = url.split('?', 2)[1] ?? '<empty>'
+          const browser = await next.browser(url)
 
-          try {
-            await check(
-              () => browser.eval('next.router.isReady ? "yes" : "no"'),
-              'yes'
-            )
-            expect(await browser.elementById('pathname').text()).toEqual(
-              pathname
-            )
-            expect(await browser.elementById('asPath').text()).toEqual(asPath)
-            expect(await browser.elementById('query').text()).toEqual(query)
-          } finally {
-            await browser.close()
-          }
+          await check(
+            () => browser.eval('next.router.isReady ? "yes" : "no"'),
+            'yes'
+          )
+          expect(await browser.elementById('pathname').text()).toEqual(pathname)
+          expect(await browser.elementById('asPath').text()).toEqual(asPath)
+          expect(await browser.elementById('query').text()).toEqual(query)
         })
       })
 
       // It should not throw any errors when re-fetching the route info:
       // https://github.com/vercel/next.js/issues/44293
       it('should not throw any errors when re-fetching the route info', async () => {
-        const browser = await webdriver(next.url, '/?test=1')
+        const browser = await next.browser('/?test=1')
         await check(
           () => browser.eval('next.router.isReady ? "yes" : "no"'),
           'yes'

--- a/test/e2e/app-dir/actions/app-action-progressive-enhancement.test.ts
+++ b/test/e2e/app-dir/actions/app-action-progressive-enhancement.test.ts
@@ -71,7 +71,7 @@ describe('app-dir action progressive enhancement', () => {
       await browser.elementById('set-cookie').click()
 
       await retry(async () => {
-        expect(await browser.elementById('referer').text()).toBe('')
+        expect(await browser.elementById('referer').text()).toBe('<null>')
       })
 
       await browser.elementById('get-cookie').click()

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -198,7 +198,7 @@ describe('app-dir action handling', () => {
 
     await browser.elementByCss('#cookie').click()
     await retry(async () => {
-      const res = (await browser.elementByCss('h1').text()) || ''
+      const res = await browser.elementByCss('h1', { state: 'attached' }).text()
       const id = res.split(':', 2)
       expect(id[0]).toBeDefined()
       expect(id[0]).toBe(id[1])
@@ -206,14 +206,14 @@ describe('app-dir action handling', () => {
 
     await browser.elementByCss('#header').click()
     await retry(async () => {
-      const res = (await browser.elementByCss('h1').text()) || ''
+      const res = await browser.elementByCss('h1').text()
       expect(res).toContain('Mozilla')
     })
 
     // Set cookies
     await browser.elementByCss('#setCookie').click()
     await retry(async () => {
-      const res = (await browser.elementByCss('h1').text()) || ''
+      const res = await browser.elementByCss('h1').text()
       const id = res.split(':', 3)
 
       expect(id[0]).toBeDefined()
@@ -231,7 +231,7 @@ describe('app-dir action handling', () => {
       const browser = await next.browser('/mutate-cookie-with-redirect', {
         disableJavaScript,
       })
-      expect(await browser.elementByCss('#value').text()).toBe('')
+      expect(await browser.elementByCss('#value').text()).toBe('<null>')
 
       await browser.elementByCss('#update-cookie').click()
       await browser.elementByCss('#redirect-target')
@@ -864,7 +864,9 @@ describe('app-dir action handling', () => {
       const browser = await next.browser(`/delayed-action/${runtime}`)
 
       // confirm there's no data yet
-      expect(await browser.elementById('delayed-action-result').text()).toBe('')
+      expect(await browser.elementById('delayed-action-result').text()).toBe(
+        '<null>'
+      )
 
       // Trigger the delayed action. This will sleep for a few seconds before dispatching the server action handler
       await browser.elementById('run-action').click()
@@ -1395,7 +1397,9 @@ describe('app-dir action handling', () => {
 
     it('should revalidate when cookies.set is called', async () => {
       const browser = await next.browser('/revalidate')
-      const randomNumber = await browser.elementByCss('#random-cookie').text()
+      const randomNumber = await browser
+        .elementByCss('#random-cookie', { state: 'attached' })
+        .text()
 
       await browser.elementByCss('#set-cookie').click()
 
@@ -1446,11 +1450,8 @@ describe('app-dir action handling', () => {
       await retry(async () => {
         randomCookie = JSON.parse(
           await browser.elementByCss('#random-cookie').text()
-        ).value
-        expect(randomCookie).toBeDefined()
+        ).cookie.value
       })
-
-      console.log(123, await browser.elementByCss('body').text())
 
       await browser.elementByCss('#another').click()
       await retry(async () => {
@@ -1461,7 +1462,7 @@ describe('app-dir action handling', () => {
 
       const newRandomCookie = JSON.parse(
         await browser.elementByCss('#random-cookie').text()
-      ).value
+      ).cookie.value
 
       console.log(456, await browser.elementByCss('body').text())
 
@@ -1478,7 +1479,7 @@ describe('app-dir action handling', () => {
       await retry(async () => {
         revalidatedRandomCookie = JSON.parse(
           await browser.elementByCss('#random-cookie').text()
-        ).value
+        ).cookie.value
         expect(revalidatedRandomCookie).not.toBe(randomCookie)
       })
 
@@ -1488,7 +1489,7 @@ describe('app-dir action handling', () => {
       await retry(async () => {
         const newRandomCookie = await JSON.parse(
           await browser.elementByCss('#random-cookie').text()
-        ).value
+        ).cookie.value
         expect(revalidatedRandomCookie).toBe(newRandomCookie)
       })
     })

--- a/test/e2e/app-dir/actions/app/delayed-action/layout-edge.tsx
+++ b/test/e2e/app-dir/actions/app/delayed-action/layout-edge.tsx
@@ -11,7 +11,7 @@ export default function Layout({ children }) {
   return (
     <DataContext.Provider value={{ data, setData }}>
       <div>{children}</div>
-      <div id="delayed-action-result">{data}</div>
+      <div id="delayed-action-result">{data ?? '<null>'}</div>
     </DataContext.Provider>
   )
 }

--- a/test/e2e/app-dir/actions/app/delayed-action/layout-node.tsx
+++ b/test/e2e/app-dir/actions/app/delayed-action/layout-node.tsx
@@ -9,7 +9,7 @@ export default function Layout({ children }) {
   return (
     <DataContext.Provider value={{ data, setData }}>
       <div>{children}</div>
-      <div id="delayed-action-result">{data}</div>
+      <div id="delayed-action-result">{data ?? '<null>'}</div>
     </DataContext.Provider>
   )
 }

--- a/test/e2e/app-dir/actions/app/header/node/form/page.tsx
+++ b/test/e2e/app-dir/actions/app/header/node/form/page.tsx
@@ -17,7 +17,7 @@ export default function Page() {
   return (
     <>
       <form action={getReferrerAction}>
-        <p id="referer">{referer}</p>
+        <p id="referer">{referer ?? '<null>'}</p>
         <button id="get-referer">Get Referer</button>
       </form>
       <form action={getTestCookieAction}>

--- a/test/e2e/app-dir/actions/app/mutate-cookie-with-redirect/page.js
+++ b/test/e2e/app-dir/actions/app/mutate-cookie-with-redirect/page.js
@@ -10,7 +10,7 @@ async function updateCookieAndRedirect() {
 export default async function Page() {
   return (
     <>
-      <p id="value">{(await cookies()).get('testCookie')?.value ?? null}</p>
+      <p id="value">{(await cookies()).get('testCookie')?.value ?? '<null>'}</p>
       <form action={updateCookieAndRedirect}>
         <button id="update-cookie" type="submit">
           Update Cookie

--- a/test/e2e/app-dir/actions/app/revalidate-2/page.js
+++ b/test/e2e/app-dir/actions/app/revalidate-2/page.js
@@ -34,7 +34,9 @@ export default async function Page() {
       </form>
       <p>
         random cookie:{' '}
-        <span id="random-cookie">{JSON.stringify(randomCookie)}</span>
+        <span id="random-cookie">
+          {JSON.stringify({ cookie: randomCookie })}
+        </span>
       </p>
     </>
   )

--- a/test/e2e/app-dir/actions/app/revalidate/page.js
+++ b/test/e2e/app-dir/actions/app/revalidate/page.js
@@ -40,7 +40,8 @@ export default async function Page() {
         <span id="justputit">{data2}</span>
       </p>
       <p>
-        random cookie: <span id="random-cookie">{JSON.stringify(cookie)}</span>
+        random cookie:{' '}
+        <span id="random-cookie">{JSON.stringify({ cookie })}</span>
       </p>
       <form>
         <button

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -287,7 +287,9 @@ describe('app dir - external dependency', () => {
   describe('server actions', () => {
     it('should prefer to resolve esm over cjs for bundling optout packages', async () => {
       const browser = await next.browser('/optout/action')
-      expect(await browser.elementByCss('#dual-pkg-outout p').text()).toBe('')
+      expect(await browser.elementByCss('#dual-pkg-outout p').text()).toBe(
+        'initial'
+      )
 
       browser.elementByCss('#dual-pkg-outout button').click()
       await check(async () => {

--- a/test/e2e/app-dir/app-external/app/optout/action/page.js
+++ b/test/e2e/app-dir/app-external/app/optout/action/page.js
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { getDualOptoutValue } from './actions'
 
 export default function Page() {
-  const [optoutDisplayValue, setOptoutDisplayValue] = useState('')
+  const [optoutDisplayValue, setOptoutDisplayValue] = useState('initial')
   return (
     <div id="dual-pkg-outout">
       <p>{optoutDisplayValue}</p>

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -4244,7 +4244,11 @@ describe('app-dir static/dynamic handling', () => {
         expect(await browser.elementByCss('#params-second').text()).toBe(
           'other'
         )
-        expect(await browser.elementByCss('#params-third').text()).toBe('')
+        expect(
+          await browser
+            .elementByCss('#params-third', { state: 'attached' })
+            .text()
+        ).toBe('')
         expect(await browser.elementByCss('#params-not-real').text()).toBe(
           'N/A'
         )

--- a/test/e2e/app-dir/global-not-found/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/global-not-found/metadata/metadata.test.ts
@@ -24,7 +24,9 @@ describe('global-not-found - metadata', () => {
       'global-not-found description'
     )
     // pick up static icon svg
-    const icon = await browser.elementByCss('link[rel="icon"]')
+    const icon = await browser.elementByCss('link[rel="icon"]', {
+      state: 'attached',
+    })
     expect(await icon.getAttribute('type')).toBe('image/svg+xml')
   })
 })

--- a/test/e2e/app-dir/hooks/components/router-hooks-fixtures.js
+++ b/test/e2e/app-dir/hooks/components/router-hooks-fixtures.js
@@ -27,7 +27,7 @@ export const RouterHooksFixtures = () => {
 
   return (
     <div id={pagesRouter.isReady ? 'router-ready' : 'router-not-ready'}>
-      <div id="key-value">{value}</div>
+      <div id="key-value">Value:{value}</div>
       <div id="pathname">{pathname}</div>
       <button type="button" onClick={onClick}>
         Push

--- a/test/e2e/app-dir/hooks/hooks.test.ts
+++ b/test/e2e/app-dir/hooks/hooks.test.ts
@@ -22,16 +22,14 @@ describe('app dir - hooks', () => {
           pathname + (keyValue ? `?key=${keyValue}` : '')
         )
 
-        try {
-          await browser.waitForElementByCss('#router-ready')
-          expect(await browser.elementById('key-value').text()).toBe(keyValue)
-          expect(await browser.elementById('pathname').text()).toBe(pathname)
+        await browser.waitForElementByCss('#router-ready')
+        expect(await browser.elementById('key-value').text()).toBe(
+          `Value:${keyValue}`
+        )
+        expect(await browser.elementById('pathname').text()).toBe(pathname)
 
-          await browser.elementByCss('button').click()
-          await browser.waitForElementByCss('#pushed')
-        } finally {
-          await browser.close()
-        }
+        await browser.elementByCss('button').click()
+        await browser.waitForElementByCss('#pushed', { state: 'attached' })
       }
     )
   })
@@ -108,20 +106,16 @@ describe('app dir - hooks', () => {
     it('should allow access to the router', async () => {
       const browser = await next.browser('/hooks/use-router')
 
-      try {
-        // Wait for the page to load, click the button (which uses a method
-        // on the router) and then wait for the correct page to load.
-        await browser.waitForElementByCss('#router')
-        await browser.elementById('button-push').click()
-        await browser.waitForElementByCss('#router-sub-page')
+      // Wait for the page to load, click the button (which uses a method
+      // on the router) and then wait for the correct page to load.
+      await browser.waitForElementByCss('#router')
+      await browser.elementById('button-push').click()
+      await browser.waitForElementByCss('#router-sub-page')
 
-        // Go back (confirming we did do a hard push), and wait for the
-        // correct previous page.
-        await browser.back()
-        await browser.waitForElementByCss('#router')
-      } finally {
-        await browser.close()
-      }
+      // Go back (confirming we did do a hard push), and wait for the
+      // correct previous page.
+      await browser.back()
+      await browser.waitForElementByCss('#router')
     })
   })
 

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/app/[locale]/@modal/default.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/app/[locale]/@modal/default.tsx
@@ -1,1 +1,1 @@
-export default () => null
+export default () => 'default'

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/interception-dynamic-segment-middleware.test.ts
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/interception-dynamic-segment-middleware.test.ts
@@ -12,7 +12,7 @@ describe('interception-dynamic-segment-middleware', () => {
     await browser.elementByCss('[href="/foo/p/1"]').click()
     await check(() => browser.elementById('modal').text(), /intercepted/)
     await browser.refresh()
-    await check(() => browser.elementById('modal').text(), '')
+    await check(() => browser.elementById('modal').text(), 'default')
     await check(() => browser.elementById('children').text(), /not intercepted/)
   })
 })

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/[...catchAll]/page.tsx
@@ -1,3 +1,3 @@
 export default function CatchAll() {
-  return null
+  return 'catch-all'
 }

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/default.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/default.tsx
@@ -1,1 +1,1 @@
-export default () => null
+export default () => 'default'

--- a/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+++ b/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('interception-dynamic-segment', () => {
   const { next, isNextStart } = nextTestSetup({
@@ -10,10 +10,18 @@ describe('interception-dynamic-segment', () => {
     const browser = await next.browser('/')
 
     await browser.elementByCss('[href="/foo/1"]').click()
-    await check(() => browser.elementById('modal').text(), /intercepted/)
+    await retry(async () => {
+      expect(await browser.elementById('modal').text()).toEqual('intercepted')
+    })
     await browser.refresh()
-    await check(() => browser.elementById('modal').text(), '')
-    await check(() => browser.elementById('children').text(), /not intercepted/)
+    await retry(async () => {
+      expect(await browser.elementById('modal').text()).toEqual('catch-all')
+    })
+    await retry(async () => {
+      expect(await browser.elementById('children').text()).toEqual(
+        'not intercepted'
+      )
+    })
   })
 
   if (isNextStart) {

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/@modal/default.tsx
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/@modal/default.tsx
@@ -1,1 +1,1 @@
-export default () => null
+export default () => 'default'

--- a/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
+++ b/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
@@ -15,24 +15,24 @@ describe('interception-middleware-rewrite', () => {
   it('should support intercepting routes with a middleware rewrite', async () => {
     const browser = await next.browser('/')
 
-    await check(() => browser.waitForElementByCss('#children').text(), 'root')
+    await check(() => browser.elementByCss('#children').text(), 'root')
 
     await check(
       () =>
         browser
           .elementByCss('[href="/feed"]')
           .click()
-          .waitForElementByCss('#modal')
+          .elementByCss('#modal')
           .text(),
       'intercepted'
     )
 
     await check(
-      () => browser.refresh().waitForElementByCss('#children').text(),
+      () => browser.refresh().elementByCss('#children').text(),
       'not intercepted'
     )
 
-    await check(() => browser.waitForElementByCss('#modal').text(), '')
+    await check(() => browser.elementByCss('#modal').text(), 'default')
   })
 
   it('should continue to work after using browser back button and following another intercepting route', async () => {
@@ -73,7 +73,7 @@ describe('interception-middleware-rewrite', () => {
     )
 
     // modal should no longer be showing
-    await check(() => browser.elementById('modal').text(), '')
+    await check(() => browser.elementById('modal').text(), 'default')
 
     await browser.back()
 

--- a/test/e2e/app-dir/interception-middleware-rewrite/tsconfig.json
+++ b/test/e2e/app-dir/interception-middleware-rewrite/tsconfig.json
@@ -1,25 +1,24 @@
 {
   "compilerOptions": {
+    "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
-    "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "incremental": true,
-    "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"
       }
-    ],
-    "target": "ES2017"
+    ]
   },
   "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts
+++ b/test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts
@@ -89,14 +89,14 @@ describe('app dir - metadata navigation', () => {
 
     it('should show the index title', async () => {
       const browser = await next.browser('/parallel-route')
-      expect(await browser.elementByCss('title').text()).toBe('Home Layout')
+      expect(await getTitle(browser)).toBe('Home Layout')
     })
 
     it('should show target page metadata after navigation', async () => {
       const browser = await next.browser('/parallel-route')
       await browser.elementByCss('#product-link').click()
       await browser.waitForElementByCss('#product-title')
-      expect(await browser.elementByCss('title').text()).toBe('Product Layout')
+      expect(await getTitle(browser)).toBe('Product Layout')
     })
 
     it('should show target page metadata after navigation with back', async () => {
@@ -105,7 +105,7 @@ describe('app dir - metadata navigation', () => {
       await browser.waitForElementByCss('#product-title')
       await browser.elementByCss('#home-link').click()
       await browser.waitForElementByCss('#home-title')
-      expect(await browser.elementByCss('title').text()).toBe('Home Layout')
+      expect(await getTitle(browser)).toBe('Home Layout')
     })
   })
 

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -98,9 +98,9 @@ describe('app-dir - metadata-streaming', () => {
     it('should load the metadata in browser', async () => {
       const browser = await next.browser('/dynamic-api')
       await retry(async () => {
-        expect(await browser.elementByCss('body title').text()).toMatch(
-          /Dynamic api \d+/
-        )
+        expect(
+          await browser.elementByCss('body title', { state: 'attached' }).text()
+        ).toMatch(/Dynamic api \d+/)
       })
     })
   })

--- a/test/e2e/app-dir/navigation/app/page.js
+++ b/test/e2e/app-dir/navigation/app/page.js
@@ -10,7 +10,7 @@ export default function Page() {
       <Link id="set-query" href="/?a=b&c=d">
         set Query
       </Link>
-      <div id="query">{params.toString()}</div>
+      <div id="query">{params.toString() || '<empty-query>'}</div>
     </>
   )
 }

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry, waitFor } from 'next-test-utils'
+import { getTitle, retry, waitFor } from 'next-test-utils'
 
 describe('app dir - navigation', () => {
   const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
@@ -10,7 +10,7 @@ describe('app dir - navigation', () => {
     it('should set query correctly', async () => {
       const browser = await next.browser('/')
       expect(await browser.elementById('query').text()).toMatchInlineSnapshot(
-        `""`
+        `"<empty-query>"`
       )
 
       await browser.elementById('set-query').click()
@@ -895,7 +895,7 @@ describe('app dir - navigation', () => {
       await waitFor(resolveMetadataDuration + 500)
 
       expect(await browser.elementById('page-content').text()).toBe('Content')
-      expect(await browser.elementByCss('title').text()).toBe('Async Title')
+      expect(await getTitle(browser)).toBe('Async Title')
     })
 
     it('shows a fallback when prefetch completed', async () => {

--- a/test/e2e/app-dir/parallel-routes-use-selected-layout-segment/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-use-selected-layout-segment/app/layout.tsx
@@ -34,17 +34,11 @@ export default function RootLayout({
               Reset with Mobile (/app/@auth/reset/withMobile)
             </Link>
           </nav>
-          <div>
-            navSegment (parallel route): <div id="navSegment">{navSegment}</div>
+          <div id="navSegment">navSegment (parallel route): {navSegment}</div>
+          <div id="authSegment">
+            authSegment (parallel route): {authSegment}
           </div>
-          <div>
-            authSegment (parallel route):{' '}
-            <div id="authSegment">{authSegment}</div>
-          </div>
-          <div>
-            routeSegment (app route):{' '}
-            <div id="routeSegment">{routeSegment}</div>
-          </div>
+          <div id="routeSegment">routeSegment (app route): {routeSegment}</div>
 
           <section id="navSlot">{nav}</section>
           <section id="authSlot">{auth}</section>

--- a/test/e2e/app-dir/parallel-routes-use-selected-layout-segment/parallel-routes-use-selected-layout-segment.test.ts
+++ b/test/e2e/app-dir/parallel-routes-use-selected-layout-segment/parallel-routes-use-selected-layout-segment.test.ts
@@ -8,66 +8,156 @@ describe('parallel-routes-use-selected-layout-segment', () => {
 
   it('hard nav to router page and soft nav around other router pages', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /^$/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await check(
+      () => browser.elementById('navSegment').text(),
+      'navSegment (parallel route):'
+    )
+    await check(
+      () => browser.elementById('authSegment').text(),
+      'authSegment (parallel route):'
+    )
+    await check(
+      () => browser.elementById('routeSegment').text(),
+      'routeSegment (app route):'
+    )
 
     await browser.elementByCss('[href="/foo"]').click()
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /^$/)
-    await check(() => browser.elementById('routeSegment').text(), /foo/)
+    await check(
+      () => browser.elementById('navSegment').text(),
+      'navSegment (parallel route):'
+    )
+    await check(
+      () => browser.elementById('authSegment').text(),
+      'authSegment (parallel route):'
+    )
+    await check(
+      () => browser.elementById('routeSegment').text(),
+      'routeSegment (app route): foo'
+    )
   })
 
   it('hard nav to router page and soft nav to parallel routes', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /^$/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await check(
+      () => browser.elementById('navSegment').text(),
+      'navSegment (parallel route):'
+    )
+    await check(
+      () => browser.elementById('authSegment').text(),
+      'authSegment (parallel route):'
+    )
+    await check(
+      () => browser.elementById('routeSegment').text(),
+      'routeSegment (app route):'
+    )
 
     // soft nav to /login, since both @nav and @auth has /login defined, we expect both navSegment and authSegment to be 'login'
     await browser.elementByCss('[href="/login"]').click()
-    await check(() => browser.elementById('navSegment').text(), /login/)
-    await check(() => browser.elementById('authSegment').text(), /login/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await check(
+      () => browser.elementById('navSegment').text(),
+      'navSegment (parallel route): login'
+    )
+    await check(
+      () => browser.elementById('authSegment').text(),
+      'authSegment (parallel route): login'
+    )
+    await check(
+      () => browser.elementById('routeSegment').text(),
+      'routeSegment (app route):'
+    )
 
     // when navigating to /reset, the @auth slot will render the /reset page ('reset') while maintaining the currently active page for the @nav slot ('login') since /reset is only defined in @auth
     await browser.elementByCss('[href="/reset"]').click()
-    await check(() => browser.elementById('navSegment').text(), /login/)
-    await check(() => browser.elementById('authSegment').text(), /reset/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await check(
+      () => browser.elementById('navSegment').text(),
+      'navSegment (parallel route): login'
+    )
+    await check(
+      () => browser.elementById('authSegment').text(),
+      'authSegment (parallel route): reset'
+    )
+    await check(
+      () => browser.elementById('routeSegment').text(),
+      'routeSegment (app route):'
+    )
 
     // when navigating to nested path /reset/withEmail, the @auth slot will render the nested /reset/withEmail page ('reset') while maintaining the currently active page for the @nav slot ('login') since /reset/withEmail is only defined in @auth
     await browser.elementByCss('[href="/reset/withEmail"]').click()
-    await check(() => browser.elementById('navSegment').text(), /login/)
-    await check(() => browser.elementById('authSegment').text(), /withEmail/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await check(
+      () => browser.elementById('navSegment').text(),
+      'navSegment (parallel route): login'
+    )
+    await check(
+      () => browser.elementById('authSegment').text(),
+      'authSegment (parallel route): withEmail'
+    )
+    await check(
+      () => browser.elementById('routeSegment').text(),
+      'routeSegment (app route):'
+    )
   })
 
   it('hard nav to router page and soft nav to parallel route and soft nav back to another router page', async () => {
     const browser = await next.browser('/')
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /^$/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await check(
+      () => browser.elementById('navSegment').text(),
+      'navSegment (parallel route):'
+    )
+    await check(
+      () => browser.elementById('authSegment').text(),
+      'authSegment (parallel route):'
+    )
+    await check(
+      () => browser.elementById('routeSegment').text(),
+      'routeSegment (app route):'
+    )
 
     // when navigating to /reset, the @auth slot will render the /reset page ('reset') while maintaining the currently active page for the @nav slot ('null') since /reset is only defined in @auth
     await browser.elementByCss('[href="/reset"]').click()
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /reset/)
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await check(
+      () => browser.elementById('navSegment').text(),
+      'navSegment (parallel route):'
+    )
+    await check(
+      () => browser.elementById('authSegment').text(),
+      'authSegment (parallel route): reset'
+    )
+    await check(
+      () => browser.elementById('routeSegment').text(),
+      'routeSegment (app route):'
+    )
 
     // when soft navigate to /foo, the @auth and @nav slot will maintain their the currently active states since they do not have /foo defined
     await browser.elementByCss('[href="/foo"]').click()
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /reset/)
-    await check(() => browser.elementById('routeSegment').text(), /foo/)
+    await check(
+      () => browser.elementById('navSegment').text(),
+      'navSegment (parallel route):'
+    )
+    await check(
+      () => browser.elementById('authSegment').text(),
+      'authSegment (parallel route): reset'
+    )
+    await check(
+      () => browser.elementById('routeSegment').text(),
+      'routeSegment (app route): foo'
+    )
   })
 
   it('hard nav to parallel route', async () => {
     const browser = await next.browser('/reset/withMobile')
-    await check(() => browser.elementById('navSegment').text(), /^$/)
-    await check(() => browser.elementById('authSegment').text(), /withMobile/)
+    await check(
+      () => browser.elementById('navSegment').text(),
+      'navSegment (parallel route):'
+    )
+    await check(
+      () => browser.elementById('authSegment').text(),
+      'authSegment (parallel route): withMobile'
+    )
 
     // the /app/default.tsx is rendered since /reset/withMobile is only defined in @auth
-    await check(() => browser.elementById('routeSegment').text(), /^$/)
+    await check(
+      () => browser.elementById('routeSegment').text(),
+      'routeSegment (app route):'
+    )
   })
 })

--- a/test/e2e/app-dir/ppr-metadata-streaming/ppr-metadata-streaming.test.ts
+++ b/test/e2e/app-dir/ppr-metadata-streaming/ppr-metadata-streaming.test.ts
@@ -23,7 +23,9 @@ describe('ppr-metadata-streaming', () => {
         pushErrorAsConsoleLog: true,
       })
       expect(
-        await browser.waitForElementByCss(`${rootSelector} title`).text()
+        await browser
+          .waitForElementByCss(`${rootSelector} title`, { state: 'attached' })
+          .text()
       ).toBe('fully static')
       await assertNoConsoleErrors(browser)
     })
@@ -36,9 +38,11 @@ describe('ppr-metadata-streaming', () => {
       const browser = await next.browser('/dynamic-page', {
         pushErrorAsConsoleLog: true,
       })
-      expect(await browser.waitForElementByCss('body title').text()).toBe(
-        'dynamic page'
-      )
+      expect(
+        await browser
+          .waitForElementByCss('body title', { state: 'attached' })
+          .text()
+      ).toBe('dynamic page')
       await assertNoConsoleErrors(browser)
     })
   })
@@ -53,9 +57,11 @@ describe('ppr-metadata-streaming', () => {
       const browser = await next.browser('/fully-dynamic', {
         pushErrorAsConsoleLog: true,
       })
-      expect(await browser.waitForElementByCss('body title').text()).toBe(
-        'fully dynamic'
-      )
+      expect(
+        await browser
+          .waitForElementByCss('body title', { state: 'attached' })
+          .text()
+      ).toBe('fully dynamic')
       await assertNoConsoleErrors(browser)
     })
 
@@ -65,9 +71,11 @@ describe('ppr-metadata-streaming', () => {
       expect(countSubstring($.html(), '<title>')).toBe(1)
 
       const browser = await next.browser('/dynamic-metadata')
-      expect(await browser.waitForElementByCss('body title').text()).toBe(
-        'dynamic metadata'
-      )
+      expect(
+        await browser
+          .waitForElementByCss('body title', { state: 'attached' })
+          .text()
+      ).toBe('dynamic metadata')
       await assertNoConsoleErrors(browser)
     })
   })
@@ -81,9 +89,11 @@ describe('ppr-metadata-streaming', () => {
       const browser = await next.browser('/dynamic-metadata/partial', {
         pushErrorAsConsoleLog: true,
       })
-      expect(await browser.waitForElementByCss('body title').text()).toBe(
-        'dynamic-metadata - partial'
-      )
+      expect(
+        await browser
+          .waitForElementByCss('body title', { state: 'attached' })
+          .text()
+      ).toBe('dynamic-metadata - partial')
       await assertNoConsoleErrors(browser)
     })
 
@@ -97,7 +107,9 @@ describe('ppr-metadata-streaming', () => {
         pushErrorAsConsoleLog: true,
       })
       expect(
-        await browser.waitForElementByCss(`${rootSelector} title`).text()
+        await browser
+          .waitForElementByCss(`${rootSelector} title`, { state: 'attached' })
+          .text()
       ).toBe('dynamic-page - partial')
       await assertNoConsoleErrors(browser)
     })

--- a/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
+++ b/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
@@ -4,8 +4,8 @@
 // no shell + no metadata
 // no shell + streaming metadata
 
-import { nextTestSetup } from '../../../lib/e2e-utils'
-import { retry } from '../../../lib/next-test-utils'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 describe('PPR - partial hydration', () => {
   const { next, isNextDev } = nextTestSetup({ files: __dirname })
@@ -51,16 +51,13 @@ describe('PPR - partial hydration', () => {
           // without waiting for the dynamic content
           expect(
             await browser
-              .elementByCssInstant('#shell-hydrated', { state: 'visible' })
+              .elementByCssInstant('#shell-hydrated')
               .getAttribute('data-is-hydrated')
           ).toBe('true')
 
           // The dynamic content hasn't streamed in yet, we should only see the fallback
-          expect(await browser.elementsByCss('main #dynamic')).toHaveLength(0)
           expect(
-            await browser
-              .elementByCssInstant('#dynamic-fallback', { state: 'visible' })
-              .text()
+            await browser.elementByCssInstant('#dynamic-fallback').text()
           ).toContain('Loading...')
         },
         1000,
@@ -72,19 +69,17 @@ describe('PPR - partial hydration', () => {
         // The shell is already hydrated, this shouldn't change
         expect(
           await browser
-            .elementByCssInstant('#shell-hydrated', { state: 'visible' })
+            .elementByCssInstant('#shell-hydrated')
             .getAttribute('data-is-hydrated')
         ).toBe('true')
 
         // The dynamic content should be visible and hydrated
+        expect(await browser.elementByCssInstant('#dynamic').text()).toMatch(
+          /Random value: \d+/
+        )
         expect(
           await browser
-            .elementByCssInstant('#dynamic', { state: 'visible' })
-            .text()
-        ).toMatch(/Random value: \d+/)
-        expect(
-          await browser
-            .elementByCssInstant('#dynamic-hydrated', { state: 'visible' })
+            .elementByCssInstant('#dynamic-hydrated')
             .getAttribute('data-is-hydrated')
         ).toBe('true')
       })
@@ -122,18 +117,15 @@ describe('PPR - partial hydration', () => {
       )
       expect(
         await browser
-          .elementByCss('#shell-hydrated', { state: 'visible' })
+          .elementByCss('#shell-hydrated')
           .getAttribute('data-is-hydrated')
       ).toBe('false')
 
       // The dynamic content can't be inserted into the document because we disabled JS,
       // so we should only see the fallback
-      expect(await browser.elementsByCss('main #dynamic')).toHaveLength(0)
-      expect(
-        await browser
-          .elementByCss('#dynamic-fallback', { state: 'visible' })
-          .text()
-      ).toContain('Loading...')
+      expect(await browser.elementByCss('#dynamic-fallback').text()).toContain(
+        'Loading...'
+      )
     })
   })
 })

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -75,37 +75,55 @@ describe('app dir - rsc basics', () => {
 
   it('should correctly render page returning null', async () => {
     const browser = await next.browser('/return-null/page')
-    expect(await browser.elementByCss('#return-null-layout').text()).toBeEmpty()
+    expect(
+      await browser
+        .elementByCss('#return-null-layout', { state: 'attached' })
+        .text()
+    ).toBeEmpty()
   })
 
   it('should correctly render component returning null', async () => {
     const browser = await next.browser('/return-null/component')
-    expect(await browser.elementByCss('#return-null-layout').text()).toBeEmpty()
+    expect(
+      await browser
+        .elementByCss('#return-null-layout', { state: 'attached' })
+        .text()
+    ).toBeEmpty()
   })
 
   it('should correctly render layout returning null', async () => {
     const browser = await next.browser('/return-null/layout')
-    expect(await browser.elementByCss('#return-null-layout').text()).toBeEmpty()
+    expect(
+      await browser
+        .elementByCss('#return-null-layout', { state: 'attached' })
+        .text()
+    ).toBeEmpty()
   })
 
   it('should correctly render page returning undefined', async () => {
     const browser = await next.browser('/return-undefined/page')
     expect(
-      await browser.elementByCss('#return-undefined-layout').text()
+      await browser
+        .elementByCss('#return-undefined-layout', { state: 'attached' })
+        .text()
     ).toBeEmpty()
   })
 
   it('should correctly render component returning undefined', async () => {
     const browser = await next.browser('/return-undefined/component')
     expect(
-      await browser.elementByCss('#return-undefined-layout').text()
+      await browser
+        .elementByCss('#return-undefined-layout', { state: 'attached' })
+        .text()
     ).toBeEmpty()
   })
 
   it('should correctly render layout returning undefined', async () => {
     const browser = await next.browser('/return-undefined/layout')
     expect(
-      await browser.elementByCss('#return-undefined-layout').text()
+      await browser
+        .elementByCss('#return-undefined-layout', { state: 'attached' })
+        .text()
     ).toBeEmpty()
   })
 

--- a/test/e2e/app-dir/script-before-interactive/script-before-interactive.test.ts
+++ b/test/e2e/app-dir/script-before-interactive/script-before-interactive.test.ts
@@ -9,7 +9,7 @@ describe('Script component with beforeInteractive strategy CSS class rendering',
     const browser = await next.browser('/')
 
     // Wait for the page to fully load
-    await browser.waitForElementByCss('#example-script')
+    await browser.waitForElementByCss('script#example-script')
 
     // Get the HTML content to check the actual rendered attributes
     const html = await browser.eval(() => document.documentElement.innerHTML)
@@ -19,7 +19,7 @@ describe('Script component with beforeInteractive strategy CSS class rendering',
     expect(html).not.toContain('classname="example-class"')
 
     // Also verify the script element directly
-    const scriptElement = await browser.elementByCss('#example-script')
+    const scriptElement = await browser.elementByCss('script#example-script')
     const className = await scriptElement.getAttribute('class')
 
     expect(className).toBe('example-class')

--- a/test/e2e/app-dir/shallow-routing/shallow-routing.test.ts
+++ b/test/e2e/app-dir/shallow-routing/shallow-routing.test.ts
@@ -19,7 +19,7 @@ describe('shallow-routing', () => {
       await browser
         .elementByCss('#push-state')
         .click()
-        .waitForElementByCss('#state-updated')
+        .waitForElementByCss('#state-updated', { state: 'attached' })
         .elementByCss('#get-latest')
         .click()
       await check(
@@ -192,7 +192,7 @@ describe('shallow-routing', () => {
       await browser
         .elementByCss('#replace-state')
         .click()
-        .waitForElementByCss('#state-updated')
+        .waitForElementByCss('#state-updated', { state: 'attached' })
         .elementByCss('#get-latest')
         .click()
       await check(
@@ -408,7 +408,7 @@ describe('shallow-routing', () => {
         await browser
           .elementByCss('#push-state')
           .click()
-          .waitForElementByCss('#state-updated')
+          .waitForElementByCss('#state-updated', { state: 'attached' })
           .elementByCss('#get-latest')
           .click()
 

--- a/test/e2e/app-dir/third-parties/basic.test.ts
+++ b/test/e2e/app-dir/third-parties/basic.test.ts
@@ -1,5 +1,4 @@
 import { nextTestSetup } from 'e2e-utils'
-import { waitFor } from 'next-test-utils'
 
 describe('@next/third-parties basic usage', () => {
   const { next } = nextTestSetup({
@@ -33,17 +32,11 @@ describe('@next/third-parties basic usage', () => {
   it('renders GTM', async () => {
     const browser = await next.browser('/gtm')
 
-    await browser.waitForElementByCss('#_next-gtm')
-    await waitFor(1000)
-
-    const gtmInlineScript = await browser.elementsByCss('#_next-gtm-init')
-    expect(gtmInlineScript.length).toBe(1)
-
-    const gtmScript = await browser.elementsByCss(
-      '[src^="https://www.googletagmanager.com/gtm.js?id=GTM-XYZ"]'
+    await browser.waitForElementByCss('script#_next-gtm')
+    await browser.elementByCss('script#_next-gtm-init')
+    await browser.elementByCssInstant(
+      'script[src^="https://www.googletagmanager.com/gtm.js?id=GTM-XYZ"]'
     )
-
-    expect(gtmScript.length).toBe(1)
 
     const dataLayer = await browser.eval('window.dataLayer')
     expect(dataLayer.length).toBe(1)
@@ -57,17 +50,12 @@ describe('@next/third-parties basic usage', () => {
   it('renders GA', async () => {
     const browser = await next.browser('/ga')
 
-    await browser.waitForElementByCss('#_next-ga')
-    await waitFor(1000)
-
-    const gaInlineScript = await browser.elementsByCss('#_next-ga-init')
-    expect(gaInlineScript.length).toBe(1)
-
-    const gaScript = await browser.elementsByCss(
-      '[src^="https://www.googletagmanager.com/gtag/js?id=GA-XYZ"]'
+    await browser.waitForElementByCss('script#_next-ga')
+    await browser.elementByCss('script#_next-ga-init')
+    await browser.elementByCssInstant(
+      'script[src^="https://www.googletagmanager.com/gtag/js?id=GA-XYZ"]'
     )
 
-    expect(gaScript.length).toBe(1)
     const dataLayer = await browser.eval('window.dataLayer')
     expect(dataLayer.length).toBe(4)
 

--- a/test/e2e/app-dir/use-cache-private/app/cookies/page.tsx
+++ b/test/e2e/app-dir/use-cache-private/app/cookies/page.tsx
@@ -25,7 +25,7 @@ async function Private() {
 
   return (
     <pre>
-      test-cookie: <span id="test-cookie">{cookieHeader}</span>
+      test-cookie: <span id="test-cookie">{cookieHeader || '<empty>'}</span>
     </pre>
   )
 }

--- a/test/e2e/app-dir/use-cache-private/use-cache-private.test.ts
+++ b/test/e2e/app-dir/use-cache-private/use-cache-private.test.ts
@@ -22,7 +22,7 @@ describe('use-cache-private', () => {
   it('allows reading cookies in private caches', async () => {
     const browser = await next.browser('/cookies')
 
-    expect(await browser.elementById('test-cookie').text()).toBe('')
+    expect(await browser.elementById('test-cookie').text()).toBe('<empty>')
 
     await browser.addCookie({ name: 'test-cookie', value: 'foo' })
     await browser.refresh()

--- a/test/e2e/basepath/basepath.test.ts
+++ b/test/e2e/basepath/basepath.test.ts
@@ -67,7 +67,7 @@ describe('basePath', () => {
     await browser
       .elementByCss('a')
       .click()
-      .waitForElementByCss('input')
+      .waitForElementByCss('input', { state: 'attached' })
       .back()
       .waitForElementByCss('p')
 

--- a/test/e2e/third-parties/index.test.ts
+++ b/test/e2e/third-parties/index.test.ts
@@ -32,7 +32,7 @@ describe('@next/third-parties basic usage', () => {
   it('renders GTM', async () => {
     const browser = await next.browser('/gtm')
 
-    await browser.waitForElementByCss('#_next-gtm')
+    await browser.waitForElementByCss('script#_next-gtm')
     await waitFor(1000)
 
     const gtmInlineScript = await browser.elementsByCss('#_next-gtm-init')
@@ -56,7 +56,7 @@ describe('@next/third-parties basic usage', () => {
   it('renders GA', async () => {
     const browser = await next.browser('/ga')
 
-    await browser.waitForElementByCss('#_next-ga')
+    await browser.waitForElementByCss('script#_next-ga')
     await waitFor(1000)
 
     const gaInlineScript = await browser.elementsByCss('#_next-ga-init')

--- a/test/e2e/trailing-slashes/shared-tests.util.ts
+++ b/test/e2e/trailing-slashes/shared-tests.util.ts
@@ -45,7 +45,9 @@ export function testShouldResolve(
       try {
         browser = await next.browser(route)
 
-        await browser.waitForElementByCss('#hydration-marker')
+        await browser.waitForElementByCss('#hydration-marker', {
+          state: 'attached',
+        })
         const text = await browser.elementByCss('#page-marker').text()
         expect(text).toBe(expectedPage)
         const routerPathname = await browser
@@ -92,7 +94,9 @@ export function testLinkShouldRewriteTo(
         browser = await next.browser(linkPage)
         await browser.elementByCss('#link').click()
 
-        await browser.waitForElementByCss('#hydration-marker')
+        await browser.waitForElementByCss('#hydration-marker', {
+          state: 'attached',
+        })
         const url = new URL(await browser.eval('window.location.href'))
         const pathname = url.href.slice(url.origin.length)
         expect(pathname).toBe(expectedHref)
@@ -110,7 +114,9 @@ export function testLinkShouldRewriteTo(
         browser = await next.browser(linkPage)
         await browser.elementByCss('#route-pusher').click()
 
-        await browser.waitForElementByCss('#hydration-marker')
+        await browser.waitForElementByCss('#hydration-marker', {
+          state: 'attached',
+        })
         const url = new URL(await browser.eval('window.location.href'))
         const pathname = url.href.slice(url.origin.length)
         expect(pathname).toBe(expectedHref)

--- a/test/integration/config-mjs/pages/next-config.js
+++ b/test/integration/config-mjs/pages/next-config.js
@@ -3,7 +3,7 @@ const { serverRuntimeConfig, publicRuntimeConfig } = getConfig()
 
 export default () => (
   <div>
-    <p id="server-only">{serverRuntimeConfig.mySecret}</p>
+    <p id="server-only">server-only: {serverRuntimeConfig.mySecret || '***'}</p>
     <p id="server-and-client">{publicRuntimeConfig.staticFolder}</p>
     <p id="env">{process.env.customVar}</p>
   </div>

--- a/test/integration/config-mjs/test/index.test.ts
+++ b/test/integration/config-mjs/test/index.test.ts
@@ -6,7 +6,7 @@ import webdriver from 'next-webdriver'
 import fetch from 'node-fetch'
 import { join } from 'path'
 
-const context = {}
+const context = { output: '', appPort: -1, server: undefined }
 
 describe('Configuration', () => {
   beforeAll(async () => {
@@ -33,7 +33,7 @@ describe('Configuration', () => {
     await killApp(context.server)
   })
 
-  async function get$(path, query) {
+  async function get$(path: string, query?: any) {
     const html = await renderViaHTTP(context.appPort, path, query)
     return cheerio.load(html)
   }
@@ -46,7 +46,7 @@ describe('Configuration', () => {
 
   test('renders server config on the server only', async () => {
     const $ = await get$('/next-config')
-    expect($('#server-only').text()).toBe('secret')
+    expect($('#server-only').text()).toBe('server-only: secret')
   })
 
   test('renders public config on the server only', async () => {
@@ -68,7 +68,7 @@ describe('Configuration', () => {
       .text()
     const envValue = await browser.elementByCss('#env').text()
 
-    expect(serverText).toBe('')
+    expect(serverText).toBe('server-only: ***')
     expect(serverClientText).toBe('/static')
     expect(envValue).toBe('hello')
     await browser.close()

--- a/test/integration/config/pages/next-config.js
+++ b/test/integration/config/pages/next-config.js
@@ -3,7 +3,7 @@ const { serverRuntimeConfig, publicRuntimeConfig } = getConfig()
 
 export default () => (
   <div>
-    <p id="server-only">{serverRuntimeConfig.mySecret}</p>
+    <p id="server-only">server-only: {serverRuntimeConfig.mySecret || '***'}</p>
     <p id="server-and-client">{publicRuntimeConfig.staticFolder}</p>
     <p id="env">{process.env.customVar}</p>
   </div>

--- a/test/integration/config/test/index.test.js
+++ b/test/integration/config/test/index.test.js
@@ -46,7 +46,7 @@ describe('Configuration', () => {
 
   test('renders server config on the server only', async () => {
     const $ = await get$('/next-config')
-    expect($('#server-only').text()).toBe('secret')
+    expect($('#server-only').text()).toBe('server-only: secret')
   })
 
   test('renders public config on the server only', async () => {
@@ -68,7 +68,7 @@ describe('Configuration', () => {
       .text()
     const envValue = await browser.elementByCss('#env').text()
 
-    expect(serverText).toBe('')
+    expect(serverText).toBe('server-only: ***')
     expect(serverClientText).toBe('/static')
     expect(envValue).toBe('hello')
     await browser.close()

--- a/test/integration/env-config/app/pages/index.js
+++ b/test/integration/env-config/app/pages/index.js
@@ -55,7 +55,7 @@ export default function Page({ env }) {
         {process.env.NEXT_PUBLIC_NEW_NEXT_CONFIG_VALUE}
       </div>
       <div id="nextPublicEmptyEnvVar">
-        {`${process.env.NEXT_PUBLIC_EMPTY_ENV_VAR}`}
+        content: {`${process.env.NEXT_PUBLIC_EMPTY_ENV_VAR}`}
       </div>
     </>
   )

--- a/test/integration/env-config/test/index.test.js
+++ b/test/integration/env-config/test/index.test.js
@@ -134,7 +134,7 @@ const runTests = (mode = 'dev', didReload = false) => {
     // Verify that after hydration, the empty env var is not replaced by undefined
     expect(
       await browser.waitForElementByCss('#nextPublicEmptyEnvVar').text()
-    ).toBe('')
+    ).toBe('content:')
   })
 }
 

--- a/test/integration/hydrate-then-render/test/index.test.ts
+++ b/test/integration/hydrate-then-render/test/index.test.ts
@@ -5,8 +5,8 @@ import webdriver from 'next-webdriver'
 import { join } from 'path'
 
 const appDir = join(__dirname, '../')
-let appPort
-let server
+let appPort: number
+let server: Awaited<ReturnType<typeof nextStart>>
 
 describe('hydrate/render ordering', () => {
   ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
@@ -23,7 +23,7 @@ describe('hydrate/render ordering', () => {
         const browser = await webdriver(appPort, '/')
         await browser.waitForElementByCss('#to-other')
         await browser.elementByCss('#to-other').click()
-        await browser.waitForElementByCss('#on-other')
+        await browser.waitForElementByCss('#on-other', { state: 'attached' })
 
         const beacons = (await browser.eval('window.__BEACONS'))
           .map(([, value]) => Object.fromEntries(new URLSearchParams(value)))

--- a/test/integration/index-index/test/index.test.ts
+++ b/test/integration/index-index/test/index.test.ts
@@ -16,11 +16,14 @@ import {
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 
-let app
-let appPort
+let app: Awaited<ReturnType<typeof launchApp>>
+let appPort: number
 const appDir = join(__dirname, '../')
 
-function runTests() {
+function runTests(testMode: 'start' | 'dev') {
+  const testNotWebpackDev =
+    testMode !== 'dev' || process.env.IS_TURBOPACK_TEST ? it : it.failing
+
   it('should ssr page /', async () => {
     const html = await renderViaHTTP(appPort, '/')
     const $ = cheerio.load(html)
@@ -54,7 +57,8 @@ function runTests() {
     expect($('#page').text()).toBe('index > index')
   })
 
-  it('should client render page /index', async () => {
+  // FIXME: pages named "index" are never hydrated in Webpack during development
+  testNotWebpackDev('should client render page /index', async () => {
     const browser = await webdriver(appPort, '/index')
     try {
       const text = await browser.elementByCss('#page').text()
@@ -81,7 +85,8 @@ function runTests() {
     expect($('#page').text()).toBe('index > user')
   })
 
-  it('should client render page /index/user', async () => {
+  // FIXME: pages named "index" are never hydrated in Webpack during development
+  testNotWebpackDev('should client render page /index/user', async () => {
     const browser = await webdriver(appPort, '/index/user')
     try {
       const text = await browser.elementByCss('#page').text()
@@ -108,7 +113,8 @@ function runTests() {
     expect($('#page').text()).toBe('index > project')
   })
 
-  it('should client render page /index/project', async () => {
+  // FIXME: pages named "index" are never hydrated in Webpack during development
+  testNotWebpackDev('should client render page /index/project', async () => {
     const browser = await webdriver(appPort, '/index/project')
     try {
       const text = await browser.elementByCss('#page').text()
@@ -138,7 +144,8 @@ function runTests() {
     expect($('#page').text()).toBe('index > index > index')
   })
 
-  it('should client render page /index/index', async () => {
+  // FIXME: pages named "index" are never hydrated in Webpack during development
+  testNotWebpackDev('should client render page /index/index', async () => {
     const browser = await webdriver(appPort, '/index/index')
     try {
       const text = await browser.elementByCss('#page').text()
@@ -191,7 +198,7 @@ describe('nested index.js', () => {
       })
       afterAll(() => killApp(app))
 
-      runTests()
+      runTests('dev')
     }
   )
   ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
@@ -210,7 +217,7 @@ describe('nested index.js', () => {
       })
       afterAll(() => killApp(app))
 
-      runTests()
+      runTests('start')
     }
   )
 })

--- a/test/integration/middleware-dev-update/pages/index.js
+++ b/test/integration/middleware-dev-update/pages/index.js
@@ -1,4 +1,6 @@
-export default (props) => <div id="from-middleware">{props.fromMiddleware}</div>
+export default (props) => (
+  <div id="from-middleware">{String(props.fromMiddleware)}</div>
+)
 
 export async function getServerSideProps({ req, res }) {
   return {

--- a/test/integration/middleware-dev-update/test/index.test.js
+++ b/test/integration/middleware-dev-update/test/index.test.js
@@ -53,7 +53,7 @@ describe('Middleware development errors', () => {
   async function assertMiddlewareRender(hasMiddleware, path = '/') {
     const browser = await webdriver(context.appPort, path)
     const fromMiddleware = await browser.elementById('from-middleware').text()
-    expect(fromMiddleware).toBe(hasMiddleware ? 'true' : '')
+    expect(fromMiddleware).toBe(hasMiddleware ? 'true' : 'null')
   }
 
   describe('when middleware is removed', () => {

--- a/test/integration/script-loader/base/pages/page4.js
+++ b/test/integration/script-loader/base/pages/page4.js
@@ -8,7 +8,7 @@ const url =
 const Page = () => {
   return (
     <div class="container">
-      <div id="onload-div-1" />
+      <div id="onload-div-1">initial</div>
       <Link href="/page9">Page 9</Link>
       <Script
         src={url}

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -968,6 +968,7 @@ export async function getSegmentExplorerRoute(browser: Playwright) {
   return await browser
     .elementByCss('.segment-explorer-page-route-bar-path')
     .text()
+    .catch(() => '<empty>')
 }
 
 export async function getSegmentExplorerContent(browser: Playwright) {
@@ -1581,7 +1582,7 @@ export function getUrlFromBackgroundImage(backgroundImage: string) {
 }
 
 export const getTitle = (browser: Playwright) =>
-  browser.elementByCss('title').text()
+  browser.elementByCss('title', { state: 'attached' }).text()
 
 async function checkMeta(
   browser: Playwright,

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -783,7 +783,8 @@ describe('Production Usage', () => {
     await browser
       .elementByCss('a')
       .click()
-      .waitForElementByCss('input')
+      // Just wait for google.com to be revealed. We can't control which input we get.
+      .waitForElementByCss('input', { state: 'attached' })
       .back()
       .waitForElementByCss('p')
 
@@ -800,7 +801,7 @@ describe('Production Usage', () => {
     await browser
       .elementByCss('a')
       .click()
-      .waitForElementByCss('input')
+      .waitForElementByCss('input', { state: 'attached' })
       .back()
       .waitForElementByCss('p')
 
@@ -820,7 +821,7 @@ describe('Production Usage', () => {
     await browser
       .elementByCss('a')
       .click()
-      .waitForElementByCss('input')
+      .waitForElementByCss('input', { state: 'attached' })
       .back()
       .waitForElementByCss('p')
 


### PR DESCRIPTION
Selected elements may be in a completed boundary that React has not revealed yet. That could lead to continuing the test with click or scroll actions/assertions even though React hadn't finished the commit. But even without React you probably almost always want `waitForElementByCSS` to wait for display not DOM attachment.

We're now defaulting to `state: 'visible'` just like [Playwright's default](https://playwright.dev/docs/api/class-locator#locator-wait-for). Visible elements need to be in the accessibility tree (no `visibility:hidden`, `display:none`, `aria-hidden`) and have a non-zero bounding box.

This means that elements without text content (e.g. in `expect(await browser.elementByCSS(selector).text()).toBe('')` will now fail. I don't find that particularly useful in framework tests. However, we rarely did that and can work around it by  rendering a non-empty placeholder instead e.g. `<div>{value || '<empty>'}</div>`. Elements that will never display text e.g. `<style>`, `<script>`, `<meta>`, `<link>` will just be checked for being `attached`. This only works for selectors that start with such a metadata element (e.g. `meta[name="viewport"]` works but `body title` doesn't). Ideally https://github.com/microsoft/playwright/pull/37265 gets accepted to make that heuristic more robust). I haven't found a single assertion on these elements where we want to check if they're visible. 


Moved JS tests that I encountered to TS (not striving for full coverage). The `try { browser = await webdriver() } finally { await browser.close() }` I encountered in e2e tests I unwrapped in favor of `next.browser` which is automatically closed when appropriate.