### PR TITLE
docs: use `resourceFromAttributes` to replace `new Resource()` to obtain `Resource`

### DIFF
--- a/docs/01-app/02-guides/open-telemetry.mdx
+++ b/docs/01-app/02-guides/open-telemetry.mdx
@@ -117,13 +117,13 @@ export async function register() {
 
 ```ts filename="instrumentation.node.ts" switcher
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
-import { Resource } from '@opentelemetry/resources'
+import { resourceFromAttributes } from '@opentelemetry/resources'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node'
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
 
 const sdk = new NodeSDK({
-  resource: new Resource({
+  resource: resourceFromAttributes({
     [ATTR_SERVICE_NAME]: 'next-app',
   }),
   spanProcessor: new SimpleSpanProcessor(new OTLPTraceExporter()),
@@ -133,13 +133,13 @@ sdk.start()
 
 ```js filename="instrumentation.node.js" switcher
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
-import { Resource } from '@opentelemetry/resources'
+import { resourceFromAttributes } from '@opentelemetry/resources'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node'
 import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
 
 const sdk = new NodeSDK({
-  resource: new Resource({
+  resource: resourceFromAttributes({
     [ATTR_SERVICE_NAME]: 'next-app',
   }),
   spanProcessor: new SimpleSpanProcessor(new OTLPTraceExporter()),


### PR DESCRIPTION
### What?

By following the default method to integrate OpenTelemetry in Next.js applications... this error occurs:

```
'Resource' only refers to a type, but is being used as a value here.
```

### Why?

`Resource` presented here as a `interface` or type only definition, as specified in OpenTelemetry's repo, https://github.com/open-telemetry/opentelemetry-js/blob/2d544088ac9a4bcb07986be7d9cdc2d0688e7b44/packages/opentelemetry-resources/src/Resource.ts#L20-L30:

> This interface is NOT user-implementable. Valid ways to obtain a {@link Resource} are by using either of these functions
> - [`resourceFromAttributes`](https://github.com/open-telemetry/opentelemetry-js/blob/2d544088ac9a4bcb07986be7d9cdc2d0688e7b44/packages/opentelemetry-resources/src/ResourceImpl.ts#L149)
> - [`emptyResource`](https://github.com/open-telemetry/opentelemetry-js/blob/2d544088ac9a4bcb07986be7d9cdc2d0688e7b44/packages/opentelemetry-resources/src/ResourceImpl.ts#L163)
> - [`defaultResource`](https://github.com/open-telemetry/opentelemetry-js/blob/2d544088ac9a4bcb07986be7d9cdc2d0688e7b44/packages/opentelemetry-resources/src/ResourceImpl.ts#L167)
> - [`detectResources`](https://github.com/open-telemetry/opentelemetry-js/blob/2d544088ac9a4bcb07986be7d9cdc2d0688e7b44/packages/opentelemetry-resources/src/detect-resources.ts#L27)

### How?

By default, we use `resourceFromAttributes` for OTEL resources with attributes.


Fixes: https://github.com/vercel/next.js/issues/77451