### PR TITLE
Turbopack: Remove passing jsConfig

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -146,9 +146,6 @@ pub struct NapiProjectOptions {
     /// The contents of next.config.js, serialized to JSON.
     pub next_config: RcStr,
 
-    /// The contents of ts/config read by load-jsconfig, serialized to JSON.
-    pub js_config: RcStr,
-
     /// A map of environment variables to use when compiling code.
     pub env: Vec<NapiEnvVar>,
 
@@ -203,9 +200,6 @@ pub struct NapiPartialProjectOptions {
 
     /// The contents of next.config.js, serialized to JSON.
     pub next_config: Option<RcStr>,
-
-    /// The contents of ts/config read by load-jsconfig, serialized to JSON.
-    pub js_config: Option<RcStr>,
 
     /// A map of environment variables to use when compiling code.
     pub env: Option<Vec<NapiEnvVar>>,
@@ -276,7 +270,6 @@ impl From<NapiProjectOptions> for ProjectOptions {
             project_path: val.project_path,
             watch: val.watch.into(),
             next_config: val.next_config,
-            js_config: val.js_config,
             env: val
                 .env
                 .into_iter()
@@ -301,7 +294,6 @@ impl From<NapiPartialProjectOptions> for PartialProjectOptions {
             project_path: val.project_path,
             watch: val.watch.map(From::from),
             next_config: val.next_config,
-            js_config: val.js_config,
             env: val
                 .env
                 .map(|env| env.into_iter().map(|var| (var.name, var.value)).collect()),

--- a/crates/next-api/benches/hmr.rs
+++ b/crates/next-api/benches/hmr.rs
@@ -192,7 +192,6 @@ impl HmrBenchmark {
                 root_path: RcStr::from(root_path),
                 project_path: RcStr::from(project_path.clone()),
                 next_config: load_next_config(),
-                js_config: rcstr!("{}"),
                 env: vec![],
                 define_env: DefineEnv {
                     client: vec![],

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -13,7 +13,7 @@ use next_core::{
     next_client::{
         ClientChunkingContextOptions, get_client_chunking_context, get_client_compile_time_info,
     },
-    next_config::{JsConfig, ModuleIds as ModuleIdStrategyConfig, NextConfig},
+    next_config::{ModuleIds as ModuleIdStrategyConfig, NextConfig},
     next_edge::context::EdgeChunkingContextOptions,
     next_server::{
         ServerChunkingContextOptions, ServerContextType, get_server_chunking_context,
@@ -160,9 +160,6 @@ pub struct ProjectOptions {
     /// The contents of next.config.js, serialized to JSON.
     pub next_config: RcStr,
 
-    /// The contents of ts/config read by load-jsconfig, serialized to JSON.
-    pub js_config: RcStr,
-
     /// A map of environment variables to use when compiling code.
     pub env: Vec<(RcStr, RcStr)>,
 
@@ -211,9 +208,6 @@ pub struct PartialProjectOptions {
 
     /// The contents of next.config.js, serialized to JSON.
     pub next_config: Option<RcStr>,
-
-    /// The contents of ts/config read by load-jsconfig, serialized to JSON.
-    pub js_config: Option<RcStr>,
 
     /// A map of environment variables to use when compiling code.
     pub env: Option<Vec<(RcStr, RcStr)>>,
@@ -341,7 +335,6 @@ impl ProjectContainer {
             root_path,
             project_path,
             next_config,
-            js_config,
             env,
             define_env,
             watch,
@@ -367,9 +360,6 @@ impl ProjectContainer {
         }
         if let Some(next_config) = next_config {
             new_options.next_config = next_config;
-        }
-        if let Some(js_config) = js_config {
-            new_options.js_config = js_config;
         }
         if let Some(env) = env {
             new_options.env = env;
@@ -443,7 +433,6 @@ impl ProjectContainer {
         let env_map: Vc<EnvMap>;
         let next_config;
         let define_env;
-        let js_config;
         let root_path;
         let project_path;
         let watch;
@@ -467,7 +456,6 @@ impl ProjectContainer {
             }
             .cell();
             next_config = NextConfig::from_string(Vc::cell(options.next_config.clone()));
-            js_config = JsConfig::from_string(Vc::cell(options.js_config.clone()));
             root_path = options.root_path.clone();
             project_path = options.project_path.clone();
             watch = options.watch;
@@ -491,7 +479,6 @@ impl ProjectContainer {
             project_path,
             watch,
             next_config: next_config.to_resolved().await?,
-            js_config: js_config.to_resolved().await?,
             dist_dir,
             env: ResolvedVc::upcast(env_map.to_resolved().await?),
             define_env: define_env.to_resolved().await?,
@@ -561,9 +548,6 @@ pub struct Project {
 
     /// Next config.
     next_config: ResolvedVc<NextConfig>,
-
-    /// Js/Tsconfig read by load-jsconfig
-    js_config: ResolvedVc<JsConfig>,
 
     /// A map of environment variables to use when compiling code.
     env: ResolvedVc<Box<dyn ProcessEnv>>,
@@ -787,11 +771,6 @@ impl Project {
     #[turbo_tasks::function]
     pub(super) async fn per_page_module_graph(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(*self.mode.await? == NextMode::Development))
-    }
-
-    #[turbo_tasks::function]
-    pub(super) fn js_config(&self) -> Vc<JsConfig> {
-        *self.js_config
     }
 
     #[turbo_tasks::function]
@@ -1130,21 +1109,6 @@ impl Project {
         // This is different to webpack-config; when this is being called,
         // it is always using SWC so we don't check swc here.
         emit_event(env!("VERGEN_CARGO_TARGET_TRIPLE"), true);
-
-        // Go over jsconfig and report enabled features.
-        let compiler_options = self.js_config().compiler_options().await?;
-        let compiler_options = compiler_options.as_object();
-        let experimental_decorators_enabled = compiler_options
-            .as_ref()
-            .and_then(|compiler_options| compiler_options.get("experimentalDecorators"))
-            .is_some();
-        let jsx_import_source_enabled = compiler_options
-            .as_ref()
-            .and_then(|compiler_options| compiler_options.get("jsxImportSource"))
-            .is_some();
-
-        emit_event("swcExperimentalDecorators", experimental_decorators_enabled);
-        emit_event("swcImportSource", jsx_import_source_enabled);
 
         // Go over config and report enabled features.
         // [TODO]: useSwcLoader is not being reported as it is not directly corresponds (it checks babel config existence)

--- a/crates/next-build-test/src/main.rs
+++ b/crates/next-build-test/src/main.rs
@@ -169,7 +169,6 @@ fn main() {
                 dev: true,
                 encryption_key: rcstr!("deadbeef"),
                 env: vec![],
-                js_config: include_str!("../jsConfig.json").into(),
                 next_config: include_str!("../nextConfig.json").into(),
                 preview_props: next_api::project::DraftModeOptions {
                     preview_mode_encryption_key: rcstr!("deadbeef"),

--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -78,10 +78,6 @@ pub async fn get_decorators_transform_options(
         false
     };
 
-    NextFeatureTelemetry::new("swcExperimentalDecorators".into(), experimental_decorators)
-        .resolved_cell()
-        .emit();
-
     let decorators_kind = if experimental_decorators {
         Some(DecoratorsKind::Legacy)
     } else {
@@ -180,10 +176,6 @@ pub async fn get_jsx_transform_options(
             let jsx_import_source = json["compilerOptions"]["jsxImportSource"]
                 .as_str()
                 .map(|s| s.into());
-
-            NextFeatureTelemetry::new("swcImportSource".into(), jsx_import_source.is_some())
-                .resolved_cell()
-                .emit();
 
             Some(JsxTransformOptions {
                 import_source: if jsx_import_source.is_some() {

--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -20,18 +20,31 @@ use crate::{mode::NextMode, next_config::NextConfig};
 
 async fn get_typescript_options(
     project_path: FileSystemPath,
+    tsconfig_path: Option<FileSystemPath>,
 ) -> Result<Option<Vec<(Vc<FileJsonContent>, ResolvedVc<Box<dyn Source>>)>>> {
-    let tsconfig = find_context_file(project_path, tsconfig());
-    Ok(match tsconfig.await.ok().as_deref() {
-        Some(FindContextFileResult::Found(path, _)) => read_tsconfigs(
-            path.read(),
-            ResolvedVc::upcast(FileSource::new(path.clone()).to_resolved().await?),
-            node_cjs_resolve_options(path.root().owned().await?),
+    if let Some(tsconfig_path) = tsconfig_path {
+        let tsconfigs = read_tsconfigs(
+            tsconfig_path.read(),
+            ResolvedVc::upcast(FileSource::new(tsconfig_path.clone()).to_resolved().await?),
+            node_cjs_resolve_options(tsconfig_path.root().owned().await?),
         )
         .await
-        .ok(),
-        Some(FindContextFileResult::NotFound(_)) | None => None,
-    })
+        .ok();
+
+        Ok(tsconfigs)
+    } else {
+        let tsconfig = find_context_file(project_path, tsconfig());
+        Ok(match tsconfig.await.ok().as_deref() {
+            Some(FindContextFileResult::Found(path, _)) => read_tsconfigs(
+                path.read(),
+                ResolvedVc::upcast(FileSource::new(path.clone()).to_resolved().await?),
+                node_cjs_resolve_options(path.root().owned().await?),
+            )
+            .await
+            .ok(),
+            Some(FindContextFileResult::NotFound(_)) | None => None,
+        })
+    }
 }
 
 /// Build the transform options for specifically for the typescript's runtime
@@ -39,11 +52,14 @@ async fn get_typescript_options(
 #[turbo_tasks::function]
 pub async fn get_typescript_transform_options(
     project_path: FileSystemPath,
+    tsconfig_path: Option<FileSystemPath>,
 ) -> Result<Vc<TypescriptTransformOptions>> {
-    let tsconfig = get_typescript_options(project_path).await?;
+    let tsconfig = get_typescript_options(project_path, tsconfig_path).await?;
 
     let use_define_for_class_fields = if let Some(tsconfig) = tsconfig {
         read_from_tsconfigs(&tsconfig, |json, _| {
+            println!("json: {:?}", json);
+
             json["compilerOptions"]["useDefineForClassFields"].as_bool()
         })
         .await?
@@ -64,8 +80,9 @@ pub async fn get_typescript_transform_options(
 #[turbo_tasks::function]
 pub async fn get_decorators_transform_options(
     project_path: FileSystemPath,
+    tsconfig_path: Option<FileSystemPath>,
 ) -> Result<Vc<DecoratorsOptions>> {
-    let tsconfig = get_typescript_options(project_path).await?;
+    let tsconfig = get_typescript_options(project_path, tsconfig_path).await?;
 
     let experimental_decorators = if let Some(ref tsconfig) = tsconfig {
         read_from_tsconfigs(tsconfig, |json, _| {
@@ -135,8 +152,9 @@ pub async fn get_jsx_transform_options(
     resolve_options_context: Option<Vc<ResolveOptionsContext>>,
     is_rsc_context: bool,
     next_config: Vc<NextConfig>,
+    tsconfig_path: Option<FileSystemPath>,
 ) -> Result<Vc<JsxTransformOptions>> {
-    let tsconfig = get_typescript_options(project_path.clone()).await?;
+    let tsconfig = get_typescript_options(project_path.clone(), tsconfig_path).await?;
 
     let is_react_development = mode.await?.is_react_development();
     let enable_react_refresh = if is_react_development {

--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -10,14 +10,13 @@ use turbopack::{
 };
 use turbopack_browser::react_refresh::assert_can_resolve_react_refresh;
 use turbopack_core::{
-    diagnostics::DiagnosticExt,
     file_source::FileSource,
     resolve::{FindContextFileResult, find_context_file, node::node_cjs_resolve_options},
     source::Source,
 };
 use turbopack_ecmascript::typescript::resolve::{read_from_tsconfigs, read_tsconfigs, tsconfig};
 
-use crate::{mode::NextMode, next_config::NextConfig, next_telemetry::NextFeatureTelemetry};
+use crate::{mode::NextMode, next_config::NextConfig};
 
 async fn get_typescript_options(
     project_path: FileSystemPath,

--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -53,13 +53,6 @@ pub async fn get_typescript_transform_options(
         false
     };
 
-    NextFeatureTelemetry::new(
-        "swcExperimentalDecorators".into(),
-        use_define_for_class_fields,
-    )
-    .resolved_cell()
-    .emit();
-
     let ts_transform_options = TypescriptTransformOptions {
         use_define_for_class_fields,
     };
@@ -84,6 +77,10 @@ pub async fn get_decorators_transform_options(
     } else {
         false
     };
+
+    NextFeatureTelemetry::new("swcExperimentalDecorators".into(), experimental_decorators)
+        .resolved_cell()
+        .emit();
 
     let decorators_kind = if experimental_decorators {
         Some(DecoratorsKind::Legacy)

--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -58,8 +58,6 @@ pub async fn get_typescript_transform_options(
 
     let use_define_for_class_fields = if let Some(tsconfig) = tsconfig {
         read_from_tsconfigs(&tsconfig, |json, _| {
-            println!("json: {:?}", json);
-
             json["compilerOptions"]["useDefineForClassFields"].as_bool()
         })
         .await?

--- a/packages/next/src/build/load-jsconfig.ts
+++ b/packages/next/src/build/load-jsconfig.ts
@@ -65,19 +65,17 @@ export default async function loadJsConfig(
     ])
     typeScriptPath = deps.resolved.get('typescript')
   } catch {}
-  const tsConfigPath = path.join(dir, config.typescript.tsconfigPath)
+  const tsConfigFileName = config.typescript.tsconfigPath || 'tsconfig.json'
+  const tsConfigPath = path.join(dir, tsConfigFileName)
   const useTypeScript = Boolean(typeScriptPath && fs.existsSync(tsConfigPath))
 
   let implicitBaseurl
   let jsConfig: { compilerOptions: Record<string, any> } | undefined
   // jsconfig is a subset of tsconfig
   if (useTypeScript) {
-    if (
-      config.typescript.tsconfigPath !== 'tsconfig.json' &&
-      TSCONFIG_WARNED === false
-    ) {
+    if (tsConfigFileName !== 'tsconfig.json' && TSCONFIG_WARNED === false) {
       TSCONFIG_WARNED = true
-      Log.info(`Using tsconfig file: ${config.typescript.tsconfigPath}`)
+      Log.info(`Using tsconfig file: ${tsConfigFileName}`)
     }
 
     const ts = (await Promise.resolve(

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -34,6 +34,12 @@ export declare class ExternalObject<T> {
     [K: symbol]: T
   }
 }
+export interface TransformOutput {
+  code: string
+  map?: string
+  output?: string
+  diagnostics: Array<string>
+}
 export declare function mdxCompile(
   value: string,
   option: Buffer,

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -34,12 +34,6 @@ export declare class ExternalObject<T> {
     [K: symbol]: T
   }
 }
-export interface TransformOutput {
-  code: string
-  map?: string
-  output?: string
-  diagnostics: Array<string>
-}
 export declare function mdxCompile(
   value: string,
   option: Buffer,
@@ -120,8 +114,6 @@ export interface NapiProjectOptions {
   watch: NapiWatchOptions
   /** The contents of next.config.js, serialized to JSON. */
   nextConfig: RcStr
-  /** The contents of ts/config read by load-jsconfig, serialized to JSON. */
-  jsConfig: RcStr
   /** A map of environment variables to use when compiling code. */
   env: Array<NapiEnvVar>
   /**
@@ -172,8 +164,6 @@ export interface NapiPartialProjectOptions {
   watch?: NapiWatchOptions
   /** The contents of next.config.js, serialized to JSON. */
   nextConfig?: RcStr
-  /** The contents of ts/config read by load-jsconfig, serialized to JSON. */
-  jsConfig?: RcStr
   /** A map of environment variables to use when compiling code. */
   env?: Array<NapiEnvVar>
   /**

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -625,7 +625,6 @@ function bindingToApi(
         options.nextConfig,
         path.join(options.rootPath, options.projectPath)
       ),
-      jsConfig: JSON.stringify(options.jsConfig),
       env: rustifyEnv(options.env),
     }
   }
@@ -641,7 +640,6 @@ function bindingToApi(
           options.nextConfig,
           path.join(options.rootPath!, options.projectPath!)
         )),
-      jsConfig: options.jsConfig && JSON.stringify(options.jsConfig),
       env: options.env && rustifyEnv(options.env),
     }
   }

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -379,17 +379,6 @@ export interface ProjectOptions {
   nextConfig: NextConfigComplete
 
   /**
-   * Jsconfig, or tsconfig contents.
-   *
-   * Next.js implicitly requires to read it to support few options
-   * https://nextjs.org/docs/architecture/nextjs-compiler#legacy-decorators
-   * https://nextjs.org/docs/architecture/nextjs-compiler#importsource
-   */
-  jsConfig: {
-    compilerOptions: object
-  }
-
-  /**
    * A map of environment variables to use when compiling code.
    */
   env: Record<string, string>

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -2,7 +2,6 @@ import path from 'path'
 import { validateTurboNextConfig } from '../../lib/turbopack-warning'
 import {
   formatIssue,
-  getTurbopackJsConfig,
   isPersistentCachingEnabled,
   isRelevantWarning,
 } from '../../shared/lib/turbopack/utils'
@@ -60,7 +59,6 @@ export async function turbopackBuild(): Promise<{
       projectPath: normalizePath(path.relative(rootPath, dir) || '.'),
       distDir,
       nextConfig: config,
-      jsConfig: await getTurbopackJsConfig(dir, config),
       watch: {
         enable: false,
       },

--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -23,7 +23,7 @@ function verifyTypeScriptSetup(
   distDir: string,
   intentDirs: string[],
   typeCheckPreflight: boolean,
-  tsconfigPath: string,
+  tsconfigPath: string | undefined,
   disableStaticImages: boolean,
   cacheDir: string | undefined,
   enableWorkerThreads: boolean | undefined,

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -835,7 +835,7 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
       const [createdRootLayout, rootLayoutPath] = await verifyRootLayout({
         appDir: appDir,
         dir: rootDir!,
-        tsconfigPath: tsconfigPath!,
+        tsconfigPath: tsconfigPath,
         pagePath,
         pageExtensions,
       })

--- a/packages/next/src/lib/verify-root-layout.ts
+++ b/packages/next/src/lib/verify-root-layout.ts
@@ -63,7 +63,7 @@ export async function verifyRootLayout({
 }: {
   dir: string
   appDir: string
-  tsconfigPath: string
+  tsconfigPath: string | undefined
   pagePath: string
   pageExtensions: PageExtensions
 }): Promise<[boolean, string | undefined]> {
@@ -112,7 +112,8 @@ export async function verifyRootLayout({
     }
 
     if (typeof availableDir === 'string') {
-      const resolvedTsConfigPath = path.join(dir, tsconfigPath)
+      const tsConfigFileName = tsconfigPath || 'tsconfig.json'
+      const resolvedTsConfigPath = path.join(dir, tsConfigFileName)
       const hasTsConfig = await fs.access(resolvedTsConfigPath).then(
         () => true,
         () => false

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -47,18 +47,19 @@ export async function verifyTypeScriptSetup({
   dir: string
   distDir: string
   cacheDir?: string
-  tsconfigPath: string
+  tsconfigPath: string | undefined
   intentDirs: string[]
   typeCheckPreflight: boolean
   disableStaticImages: boolean
   hasAppDir: boolean
   hasPagesDir: boolean
 }): Promise<{ result?: TypeCheckResult; version: string | null }> {
-  const resolvedTsConfigPath = path.join(dir, tsconfigPath)
+  const tsConfigFileName = tsconfigPath || 'tsconfig.json'
+  const resolvedTsConfigPath = path.join(dir, tsConfigFileName)
 
   try {
     // Check if the project uses TypeScript:
-    const intent = await getTypeScriptIntent(dir, intentDirs, tsconfigPath)
+    const intent = await getTypeScriptIntent(dir, intentDirs, tsConfigFileName)
     if (!intent) {
       return { version: null }
     }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -33,7 +33,7 @@ import type { FallbackRouteParam } from '../build/static-paths/types'
 
 export type NextConfigComplete = Required<NextConfig> & {
   images: Required<ImageConfigComplete>
-  typescript: Required<TypeScriptConfig>
+  typescript: TypeScriptConfig
   configOrigin?: string
   configFile?: string
   configFileName: string
@@ -1456,7 +1456,7 @@ export const defaultConfig = Object.freeze({
   },
   typescript: {
     ignoreBuildErrors: false,
-    tsconfigPath: 'tsconfig.json',
+    tsconfigPath: undefined,
   },
   typedRoutes: false,
   distDir: '.next',

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -84,7 +84,6 @@ import { setBundlerFindSourceMapImplementation } from '../patch-error-inspect'
 import { getNextErrorFeedbackMiddleware } from '../../next-devtools/server/get-next-error-feedback-middleware'
 import {
   formatIssue,
-  getTurbopackJsConfig,
   isPersistentCachingEnabled,
   isWellKnownError,
   processIssues,
@@ -224,7 +223,6 @@ export async function createHotReloaderTurbopack(
       projectPath: normalizePath(relative(rootPath, projectPath) || '.'),
       distDir,
       nextConfig: opts.nextConfig,
-      jsConfig: await getTurbopackJsConfig(projectPath, nextConfig),
       watch: {
         enable: dev,
         pollIntervalMs: nextConfig.watchOptions?.pollIntervalMs,

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -14,7 +14,6 @@ import {
 import type { EntryKey } from './entry-key'
 import * as Log from '../../../build/output/log'
 import type { NextConfigComplete } from '../../../server/config-shared'
-import loadJsConfig from '../../../build/load-jsconfig'
 
 type IssueKey = `${Issue['severity']}-${Issue['filePath']}-${string}-${string}`
 export type IssuesMap = Map<IssueKey, Issue>
@@ -51,14 +50,6 @@ export function getIssueKey(issue: Issue): IssueKey {
   return `${issue.severity}-${issue.filePath}-${JSON.stringify(
     issue.title
   )}-${JSON.stringify(issue.description)}`
-}
-
-export async function getTurbopackJsConfig(
-  dir: string,
-  nextConfig: NextConfigComplete
-) {
-  const { jsConfig } = await loadJsConfig(dir, nextConfig)
-  return jsConfig ?? { compilerOptions: {} }
 }
 
 export function processIssues(

--- a/test/development/basic/__snapshots__/next-rs-api.test.ts.snap
+++ b/test/development/basic/__snapshots__/next-rs-api.test.ts.snap
@@ -104,20 +104,6 @@ exports[`next.rs api should detect the correct routes: diagnostics 1`] = `
     "category": "NextFeatureTelemetry_category_tbd",
     "name": "EVENT_BUILD_FEATURE_USAGE",
     "payload": {
-      "swcExperimentalDecorators": "false",
-    },
-  },
-  {
-    "category": "NextFeatureTelemetry_category_tbd",
-    "name": "EVENT_BUILD_FEATURE_USAGE",
-    "payload": {
-      "swcImportSource": "false",
-    },
-  },
-  {
-    "category": "NextFeatureTelemetry_category_tbd",
-    "name": "EVENT_BUILD_FEATURE_USAGE",
-    "payload": {
       "swcReactRemoveProperties": "false",
     },
   },

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -195,9 +195,6 @@ describe('next.rs api', () => {
     const distDir = '.next'
     project = await bindings.turbo.createProject({
       env: {},
-      jsConfig: {
-        compilerOptions: {},
-      },
       nextConfig: nextConfig,
       rootPath,
       projectPath: path.relative(rootPath, next.testDir) || '.',

--- a/test/integration/jsconfig/test/index.test.js
+++ b/test/integration/jsconfig/test/index.test.js
@@ -25,8 +25,16 @@ describe('jsconfig.json', () => {
         })
         try {
           const res = await nextBuild(appDir, [], { stderr: true })
-          expect(res.stderr).toMatch(/Error: Failed to parse "/)
-          expect(res.stderr).toMatch(/JSON5: invalid end of input at 1:2/)
+          if (process.env.IS_TURBOPACK_TEST) {
+            expect(res.stderr).toMatch(/An issue occurred while parsing/)
+            expect(res.stderr).toMatch(/jsconfig.json:1:1/)
+            expect(res.stderr).toMatch(
+              /tsconfig is not parseable: invalid JSON: Unterminated object/
+            )
+          } else {
+            expect(res.stderr).toMatch(/Error: Failed to parse "/)
+            expect(res.stderr).toMatch(/JSON5: invalid end of input at 1:2/)
+          }
         } finally {
           await fs.writeFile(jsconfigPath, originalJsconfig, {
             encoding: 'utf-8',

--- a/test/integration/typescript-custom-tsconfig/test/index.test.js
+++ b/test/integration/typescript-custom-tsconfig/test/index.test.js
@@ -7,17 +7,20 @@ const appDir = join(__dirname, '..')
 
 const warnMessage = /Using tsconfig file:/
 
-describe('Custom TypeScript Config', () => {
-  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
-    'production mode',
-    () => {
-      it('should warn when using custom typescript path', async () => {
-        const { stdout } = await nextBuild(appDir, [], {
-          stdout: true,
-        })
+;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
+  'Custom TypeScript Config',
+  () => {
+    ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+      'production mode',
+      () => {
+        it('should warn when using custom typescript path', async () => {
+          const { stdout } = await nextBuild(appDir, [], {
+            stdout: true,
+          })
 
-        expect(stdout).toMatch(warnMessage)
-      })
-    }
-  )
-})
+          expect(stdout).toMatch(warnMessage)
+        })
+      }
+    )
+  }
+)


### PR DESCRIPTION
## What?

These values were only provided to emit events and not for the actual handling of jsconfig/tsconfig `paths` and such, those are handled separately by Turbopack itself. This removes the events as they're no longer relevant and it's not worth slowing down dev/build for them.

Closes PACK-5405