### PR TITLE
fix(turbopack): Pass correct browserslist to `styled-jsx`

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -997,6 +997,7 @@ impl Project {
             format!("/ROOT/{}", self.project_path().await?.path).into(),
             this.define_env.nodejs(),
             self.current_node_js_version(),
+            this.browserslist_query.clone(),
         ))
     }
 
@@ -1007,6 +1008,7 @@ impl Project {
             self.project_path().owned().await?,
             this.define_env.edge(),
             self.current_node_js_version(),
+            this.browserslist_query.clone(),
         ))
     }
 

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -107,11 +107,9 @@ pub async fn get_client_compile_time_info(
     .resolved_cell();
 
     CompileTimeInfo::builder(
-        Environment::new(ExecutionEnvironment::Browser(
-            environment,
-        ),*environment)
-        .to_resolved()
-        .await?,
+        Environment::new(ExecutionEnvironment::Browser(environment), *environment)
+            .to_resolved()
+            .await?,
     )
     .defines(next_client_defines(define_env).to_resolved().await?)
     .free_var_references(next_client_free_vars(define_env).to_resolved().await?)

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -261,6 +261,7 @@ pub async fn get_client_module_options_context(
         .tree_shaking_mode_for_foreign_code(next_mode.is_development())
         .await?;
     let target_browsers = env.runtime_versions();
+    let css_target_browsers = env.css_runtime_versions();
 
     let mut next_client_rules =
         get_next_client_transforms_rules(next_config, ty.clone(), mode, false, encryption_key)
@@ -273,7 +274,7 @@ pub async fn get_client_module_options_context(
         get_relay_transform_rule(next_config, project_path.clone()).await?,
         get_emotion_transform_rule(next_config).await?,
         get_styled_components_transform_rule(next_config).await?,
-        get_styled_jsx_transform_rule(next_config, target_browsers).await?,
+        get_styled_jsx_transform_rule(next_config, css_target_browsers).await?,
         get_react_remove_properties_transform_rule(next_config).await?,
         get_remove_console_transform_rule(next_config).await?,
     ]

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -98,16 +98,18 @@ pub async fn get_client_compile_time_info(
     browserslist_query: RcStr,
     define_env: Vc<OptionEnvMap>,
 ) -> Result<Vc<CompileTimeInfo>> {
+    let environment = BrowserEnvironment {
+        dom: true,
+        web_worker: false,
+        service_worker: false,
+        browserslist_query: browserslist_query.to_owned(),
+    }
+    .resolved_cell();
+
     CompileTimeInfo::builder(
         Environment::new(ExecutionEnvironment::Browser(
-            BrowserEnvironment {
-                dom: true,
-                web_worker: false,
-                service_worker: false,
-                browserslist_query: browserslist_query.to_owned(),
-            }
-            .resolved_cell(),
-        ))
+            environment,
+        ),*environment)
         .to_resolved()
         .await?,
     )
@@ -260,7 +262,6 @@ pub async fn get_client_module_options_context(
     let tree_shaking_mode_for_foreign_code = *next_config
         .tree_shaking_mode_for_foreign_code(next_mode.is_development())
         .await?;
-    let target_browsers = env.runtime_versions();
     let css_target_browsers = env.css_runtime_versions();
 
     let mut next_client_rules =

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -7,10 +7,13 @@ use turbopack::{css::chunk::CssChunkType, resolve_options_context::ResolveOption
 use turbopack_browser::BrowserChunkingContext;
 use turbopack_core::{
     chunk::{
-        module_id_strategies::ModuleIdStrategy, ChunkingConfig, ChunkingContext, MangleType, MinifyType, SourceMapsType
+        ChunkingConfig, ChunkingContext, MangleType, MinifyType, SourceMapsType,
+        module_id_strategies::ModuleIdStrategy,
     },
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReference, FreeVarReferences},
-    environment::{BrowserEnvironment, EdgeWorkerEnvironment, Environment, ExecutionEnvironment, NodeJsVersion},
+    environment::{
+        BrowserEnvironment, EdgeWorkerEnvironment, Environment, ExecutionEnvironment, NodeJsVersion,
+    },
     free_var_references,
     module_graph::export_usage::OptionExportUsageInfo,
 };
@@ -59,11 +62,23 @@ pub async fn get_edge_compile_time_info(
     project_path: FileSystemPath,
     define_env: Vc<OptionEnvMap>,
     node_version: ResolvedVc<NodeJsVersion>,
+    css_browserslist_query: RcStr,
 ) -> Result<Vc<CompileTimeInfo>> {
+    let css_environment = BrowserEnvironment {
+        dom: false,
+        web_worker: false,
+        service_worker: false,
+        browserslist_query: css_browserslist_query,
+    }
+    .resolved_cell();
+
     CompileTimeInfo::builder(
-        Environment::new(ExecutionEnvironment::EdgeWorker(
-            EdgeWorkerEnvironment { node_version }.resolved_cell(),
-        ),BrowserEnvironment::default().cell())
+        Environment::new(
+            ExecutionEnvironment::EdgeWorker(
+                EdgeWorkerEnvironment { node_version }.resolved_cell(),
+            ),
+            *css_environment,
+        )
         .to_resolved()
         .await?,
     )

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -7,11 +7,10 @@ use turbopack::{css::chunk::CssChunkType, resolve_options_context::ResolveOption
 use turbopack_browser::BrowserChunkingContext;
 use turbopack_core::{
     chunk::{
-        ChunkingConfig, ChunkingContext, MangleType, MinifyType, SourceMapsType,
-        module_id_strategies::ModuleIdStrategy,
+        module_id_strategies::ModuleIdStrategy, ChunkingConfig, ChunkingContext, MangleType, MinifyType, SourceMapsType
     },
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReference, FreeVarReferences},
-    environment::{EdgeWorkerEnvironment, Environment, ExecutionEnvironment, NodeJsVersion},
+    environment::{BrowserEnvironment, EdgeWorkerEnvironment, Environment, ExecutionEnvironment, NodeJsVersion},
     free_var_references,
     module_graph::export_usage::OptionExportUsageInfo,
 };
@@ -64,7 +63,7 @@ pub async fn get_edge_compile_time_info(
     CompileTimeInfo::builder(
         Environment::new(ExecutionEnvironment::EdgeWorker(
             EdgeWorkerEnvironment { node_version }.resolved_cell(),
-        ))
+        ),BrowserEnvironment::default().cell())
         .to_resolved()
         .await?,
     )

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -16,12 +16,13 @@ use turbopack::{
 };
 use turbopack_core::{
     chunk::{
-        module_id_strategies::ModuleIdStrategy, ChunkingConfig, MangleType, MinifyType, SourceMapsType
+        ChunkingConfig, MangleType, MinifyType, SourceMapsType,
+        module_id_strategies::ModuleIdStrategy,
     },
     compile_time_defines,
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReferences},
     environment::{
-        BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion
+        BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion,
     },
     free_var_references,
     module_graph::export_usage::OptionExportUsageInfo,
@@ -363,16 +364,28 @@ pub async fn get_server_compile_time_info(
     cwd: RcStr,
     define_env: Vc<OptionEnvMap>,
     node_version: ResolvedVc<NodeJsVersion>,
+    css_browserslist_query: RcStr,
 ) -> Result<Vc<CompileTimeInfo>> {
+    let css_environment = BrowserEnvironment {
+        dom: false,
+        web_worker: false,
+        service_worker: false,
+        browserslist_query: css_browserslist_query,
+    }
+    .resolved_cell();
+
     CompileTimeInfo::builder(
-        Environment::new(ExecutionEnvironment::NodeJsLambda(
-            NodeJsEnvironment {
-                compile_target: CompileTarget::current().to_resolved().await?,
-                node_version,
-                cwd: ResolvedVc::cell(Some(cwd)),
-            }
-            .resolved_cell(),
-        ),BrowserEnvironment::default().cell())
+        Environment::new(
+            ExecutionEnvironment::NodeJsLambda(
+                NodeJsEnvironment {
+                    compile_target: CompileTarget::current().to_resolved().await?,
+                    node_version,
+                    cwd: ResolvedVc::cell(Some(cwd)),
+                }
+                .resolved_cell(),
+            ),
+            *css_environment,
+        )
         .to_resolved()
         .await?,
     )
@@ -385,9 +398,10 @@ pub async fn get_server_compile_time_info(
 #[turbo_tasks::function]
 pub async fn get_tracing_compile_time_info() -> Result<Vc<CompileTimeInfo>> {
     CompileTimeInfo::builder(
-        Environment::new(ExecutionEnvironment::NodeJsLambda(
-            NodeJsEnvironment::default().resolved_cell(),
-        ),BrowserEnvironment::default().cell())
+        Environment::new(
+            ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().resolved_cell()),
+            BrowserEnvironment::default().cell(),
+        )
         .to_resolved()
         .await?,
     )
@@ -545,7 +559,8 @@ pub async fn get_server_module_options_context(
     // context type.
     let styled_components_transform_rule =
         get_styled_components_transform_rule(next_config).await?;
-    let styled_jsx_transform_rule = get_styled_jsx_transform_rule(next_config, css_versions).await?;
+    let styled_jsx_transform_rule =
+        get_styled_jsx_transform_rule(next_config, css_versions).await?;
 
     let source_maps = if *next_config.server_source_maps().await? {
         SourceMapsType::Full

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -506,6 +506,7 @@ pub async fn get_server_module_options_context(
         .tree_shaking_mode_for_foreign_code(next_mode.is_development())
         .await?;
     let versions = RuntimeVersions(Default::default()).cell();
+    let css_versions = environment.css_runtime_versions();
 
     // ModuleOptionsContext related options
     let tsconfig = get_typescript_transform_options(project_path.clone())
@@ -546,7 +547,7 @@ pub async fn get_server_module_options_context(
     // context type.
     let styled_components_transform_rule =
         get_styled_components_transform_rule(next_config).await?;
-    let styled_jsx_transform_rule = get_styled_jsx_transform_rule(next_config, versions).await?;
+    let styled_jsx_transform_rule = get_styled_jsx_transform_rule(next_config, css_versions).await?;
 
     let source_maps = if *next_config.server_source_maps().await? {
         SourceMapsType::Full

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -16,13 +16,12 @@ use turbopack::{
 };
 use turbopack_core::{
     chunk::{
-        ChunkingConfig, MangleType, MinifyType, SourceMapsType,
-        module_id_strategies::ModuleIdStrategy,
+        module_id_strategies::ModuleIdStrategy, ChunkingConfig, MangleType, MinifyType, SourceMapsType
     },
     compile_time_defines,
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReferences},
     environment::{
-        Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion, RuntimeVersions,
+        BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion
     },
     free_var_references,
     module_graph::export_usage::OptionExportUsageInfo,
@@ -373,7 +372,7 @@ pub async fn get_server_compile_time_info(
                 cwd: ResolvedVc::cell(Some(cwd)),
             }
             .resolved_cell(),
-        ))
+        ),BrowserEnvironment::default().cell())
         .to_resolved()
         .await?,
     )
@@ -388,7 +387,7 @@ pub async fn get_tracing_compile_time_info() -> Result<Vc<CompileTimeInfo>> {
     CompileTimeInfo::builder(
         Environment::new(ExecutionEnvironment::NodeJsLambda(
             NodeJsEnvironment::default().resolved_cell(),
-        ))
+        ),BrowserEnvironment::default().cell())
         .to_resolved()
         .await?,
     )
@@ -505,7 +504,6 @@ pub async fn get_server_module_options_context(
     let tree_shaking_mode_for_foreign_code = *next_config
         .tree_shaking_mode_for_foreign_code(next_mode.is_development())
         .await?;
-    let versions = RuntimeVersions(Default::default()).cell();
     let css_versions = environment.css_runtime_versions();
 
     // ModuleOptionsContext related options

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -237,9 +237,12 @@ async fn build_internal(
                 build_output_root.clone(),
                 build_output_root.clone(),
                 build_output_root.clone(),
-                Environment::new(ExecutionEnvironment::NodeJsLambda(
-                    NodeJsEnvironment::default().resolved_cell(),
-                ),compile_time_info.css_environment())
+                Environment::new(
+                    ExecutionEnvironment::NodeJsLambda(
+                        NodeJsEnvironment::default().resolved_cell(),
+                    ),
+                    compile_time_info.css_environment(),
+                )
                 .to_resolved()
                 .await?,
                 runtime_type,
@@ -336,9 +339,10 @@ async fn build_internal(
                 build_output_root.clone(),
                 build_output_root.clone(),
                 build_output_root.clone(),
-                Environment::new(ExecutionEnvironment::Browser(
-                    browser_environment,
-                ),*browser_environment)
+                Environment::new(
+                    ExecutionEnvironment::Browser(browser_environment),
+                    *browser_environment,
+                )
                 .to_resolved()
                 .await?,
                 runtime_type,
@@ -384,9 +388,12 @@ async fn build_internal(
                 build_output_root.clone(),
                 build_output_root.clone(),
                 build_output_root.clone(),
-                Environment::new(ExecutionEnvironment::NodeJsLambda(
-                    NodeJsEnvironment::default().resolved_cell(),
-                ),BrowserEnvironment::default().cell())
+                Environment::new(
+                    ExecutionEnvironment::NodeJsLambda(
+                        NodeJsEnvironment::default().resolved_cell(),
+                    ),
+                    BrowserEnvironment::default().cell(),
+                )
                 .to_resolved()
                 .await?,
                 runtime_type,

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -239,7 +239,7 @@ async fn build_internal(
                 build_output_root.clone(),
                 Environment::new(ExecutionEnvironment::NodeJsLambda(
                     NodeJsEnvironment::default().resolved_cell(),
-                ))
+                ),compile_time_info.css_environment())
                 .to_resolved()
                 .await?,
                 runtime_type,
@@ -321,6 +321,14 @@ async fn build_internal(
 
     let chunking_context: Vc<Box<dyn ChunkingContext>> = match target {
         Target::Browser => {
+            let browser_environment = BrowserEnvironment {
+                dom: true,
+                web_worker: false,
+                service_worker: false,
+                browserslist_query: browserslist_query.clone(),
+            }
+            .resolved_cell();
+
             let mut builder = BrowserChunkingContext::builder(
                 project_path,
                 build_output_root.clone(),
@@ -329,14 +337,8 @@ async fn build_internal(
                 build_output_root.clone(),
                 build_output_root.clone(),
                 Environment::new(ExecutionEnvironment::Browser(
-                    BrowserEnvironment {
-                        dom: true,
-                        web_worker: false,
-                        service_worker: false,
-                        browserslist_query: browserslist_query.clone(),
-                    }
-                    .resolved_cell(),
-                ))
+                    browser_environment,
+                ),*browser_environment)
                 .to_resolved()
                 .await?,
                 runtime_type,
@@ -384,7 +386,7 @@ async fn build_internal(
                 build_output_root.clone(),
                 Environment::new(ExecutionEnvironment::NodeJsLambda(
                     NodeJsEnvironment::default().resolved_cell(),
-                ))
+                ),BrowserEnvironment::default().cell())
                 .to_resolved()
                 .await?,
                 runtime_type,

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -199,16 +199,19 @@ pub async fn get_client_compile_time_info(
     node_env: Vc<NodeEnv>,
 ) -> Result<Vc<CompileTimeInfo>> {
     let node_env = node_env.await?;
+
+    let environment = BrowserEnvironment {
+        dom: true,
+        web_worker: false,
+        service_worker: false,
+        browserslist_query,
+    }
+    .resolved_cell();
+
     CompileTimeInfo::builder(
         Environment::new(ExecutionEnvironment::Browser(
-            BrowserEnvironment {
-                dom: true,
-                web_worker: false,
-                service_worker: false,
-                browserslist_query,
-            }
-            .resolved_cell(),
-        ))
+            environment,
+        ),*environment)
         .to_resolved()
         .await?,
     )

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -209,11 +209,9 @@ pub async fn get_client_compile_time_info(
     .resolved_cell();
 
     CompileTimeInfo::builder(
-        Environment::new(ExecutionEnvironment::Browser(
-            environment,
-        ),*environment)
-        .to_resolved()
-        .await?,
+        Environment::new(ExecutionEnvironment::Browser(environment), *environment)
+            .to_resolved()
+            .await?,
     )
     .defines(client_defines(&node_env).resolved_cell())
     .free_var_references(

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -271,7 +271,7 @@ async fn source(
 
     let env = load_env(root_path.clone());
     let build_output_root = output_fs.root().await?.join(".turbopack/build")?;
-
+    
     let build_output_root_to_root_path = project_path
         .join(".turbopack/build")?
         .get_relative_path_to(&root_path)

--- a/turbopack/crates/turbopack-cli/src/dev/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/mod.rs
@@ -271,7 +271,7 @@ async fn source(
 
     let env = load_env(root_path.clone());
     let build_output_root = output_fs.root().await?.join(".turbopack/build")?;
-    
+
     let build_output_root_to_root_path = project_path
         .join(".turbopack/build")?
         .get_relative_path_to(&root_path)

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -4,7 +4,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 
-use crate::environment::Environment;
+use crate::environment::{BrowserEnvironment, Environment};
 
 #[macro_export]
 macro_rules! definable_name_map_pattern_internal {
@@ -348,6 +348,11 @@ impl CompileTimeInfo {
     #[turbo_tasks::function]
     pub fn environment(&self) -> Vc<Environment> {
         *self.environment
+    }
+
+    #[turbo_tasks::function]
+    pub async fn css_environment(&self) -> Result<Vc<BrowserEnvironment>> {
+        Ok(self.environment.css_environment())
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -42,14 +42,20 @@ pub enum ChunkLoading {
 pub struct Environment {
     // members must be private to avoid leaking non-custom types
     execution: ExecutionEnvironment,
-    css_runtime_versions: ResolvedVc<RuntimeVersions>,
+    css_environment: ResolvedVc<BrowserEnvironment>,
 }
 
 #[turbo_tasks::value_impl]
 impl Environment {
     #[turbo_tasks::function]
-    pub fn new(execution: ExecutionEnvironment, css_runtime_versions: ResolvedVc<RuntimeVersions>) -> Vc<Self> {
-        Self::cell(Environment { execution, css_runtime_versions })
+    pub async fn new(
+        execution: ExecutionEnvironment,
+        css_environment: ResolvedVc<BrowserEnvironment>,
+    ) -> Vc<Self> {
+        Self::cell(Environment {
+            execution,
+            css_environment,
+        })
     }
 }
 
@@ -103,7 +109,8 @@ impl Environment {
 
     #[turbo_tasks::function]
     pub async fn css_runtime_versions(&self) -> Result<Vc<RuntimeVersions>> {
-        Ok(*self.css_runtime_versions)
+        let distribs = resolve_browserslist(self.css_environment).await?;
+        Ok(Vc::cell(Versions::parse_versions(distribs)?))
     }
 
     #[turbo_tasks::function]
@@ -323,6 +330,7 @@ impl Default for NodeJsVersion {
 }
 
 #[turbo_tasks::value(shared)]
+#[derive(Default)]
 pub struct BrowserEnvironment {
     pub dom: bool,
     pub web_worker: bool,

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -42,13 +42,14 @@ pub enum ChunkLoading {
 pub struct Environment {
     // members must be private to avoid leaking non-custom types
     execution: ExecutionEnvironment,
+    css_runtime_versions: ResolvedVc<RuntimeVersions>,
 }
 
 #[turbo_tasks::value_impl]
 impl Environment {
     #[turbo_tasks::function]
-    pub fn new(execution: ExecutionEnvironment) -> Vc<Self> {
-        Self::cell(Environment { execution })
+    pub fn new(execution: ExecutionEnvironment, css_runtime_versions: ResolvedVc<RuntimeVersions>) -> Vc<Self> {
+        Self::cell(Environment { execution, css_runtime_versions })
     }
 }
 
@@ -98,6 +99,11 @@ impl Environment {
             ExecutionEnvironment::EdgeWorker(edge_env) => edge_env.runtime_versions(),
             ExecutionEnvironment::Custom(_) => todo!(),
         })
+    }
+
+    #[turbo_tasks::function]
+    pub async fn css_runtime_versions(&self) -> Result<Vc<RuntimeVersions>> {
+        Ok(*self.css_runtime_versions)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -108,6 +108,11 @@ impl Environment {
     }
 
     #[turbo_tasks::function]
+    pub fn css_environment(&self) -> Vc<BrowserEnvironment> {
+        *self.css_environment
+    }
+
+    #[turbo_tasks::function]
     pub async fn css_runtime_versions(&self) -> Result<Vc<RuntimeVersions>> {
         let distribs = resolve_browserslist(self.css_environment).await?;
         Ok(Vc::cell(Versions::parse_versions(distribs)?))

--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -14,7 +14,7 @@ use turbo_tasks::ResolvedVc;
 use turbo_tasks_testing::VcStorage;
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
-    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
+    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
     target::CompileTarget,
 };
 use turbopack_ecmascript::analyzer::{
@@ -102,6 +102,8 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
         let var_cache = Default::default();
         for val in input.var_graph.values.values() {
             VcStorage::with(async {
+                let css_environment = BrowserEnvironment::default().cell();
+
                 let compile_time_info = CompileTimeInfo::builder(
                     Environment::new(ExecutionEnvironment::NodeJsLambda(
                         NodeJsEnvironment {
@@ -110,7 +112,8 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
                             cwd: ResolvedVc::cell(None),
                         }
                         .resolved_cell(),
-                    ))
+                     
+                    ),   css_environment,)
                     .to_resolved()
                     .await?,
                 )

--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -14,7 +14,9 @@ use turbo_tasks::ResolvedVc;
 use turbo_tasks_testing::VcStorage;
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
-    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
+    environment::{
+        BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion,
+    },
     target::CompileTarget,
 };
 use turbopack_ecmascript::analyzer::{
@@ -105,15 +107,17 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
                 let css_environment = BrowserEnvironment::default().cell();
 
                 let compile_time_info = CompileTimeInfo::builder(
-                    Environment::new(ExecutionEnvironment::NodeJsLambda(
-                        NodeJsEnvironment {
-                            compile_target: CompileTarget::unknown().to_resolved().await?,
-                            node_version: NodeJsVersion::default().resolved_cell(),
-                            cwd: ResolvedVc::cell(None),
-                        }
-                        .resolved_cell(),
-                     
-                    ),   css_environment,)
+                    Environment::new(
+                        ExecutionEnvironment::NodeJsLambda(
+                            NodeJsEnvironment {
+                                compile_target: CompileTarget::unknown().to_resolved().await?,
+                                node_version: NodeJsVersion::default().resolved_cell(),
+                                cwd: ResolvedVc::cell(None),
+                            }
+                            .resolved_cell(),
+                        ),
+                        css_environment,
+                    )
                     .to_resolved()
                     .await?,
                 )

--- a/turbopack/crates/turbopack-ecmascript/benches/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/references.rs
@@ -41,9 +41,10 @@ pub fn benchmark(c: &mut Criterion) {
             let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/benches/");
             let fs = DiskFileSystem::new(rcstr!("project"), root_dir.to_str().unwrap().into());
 
-            let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
-                NodeJsEnvironment::default().resolved_cell(),
-            ),BrowserEnvironment::default().cell());
+            let environment = Environment::new(
+                ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().resolved_cell()),
+                BrowserEnvironment::default().cell(),
+            );
             let compile_time_info = CompileTimeInfo::new(environment).to_resolved().await?;
             let layer = Layer::new(rcstr!("test"));
             let module_asset_context = NoopAssetContext {

--- a/turbopack/crates/turbopack-ecmascript/benches/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/references.rs
@@ -9,7 +9,7 @@ use turbo_tasks_backend::{
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
-    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
 };
@@ -43,7 +43,7 @@ pub fn benchmark(c: &mut Criterion) {
 
             let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
                 NodeJsEnvironment::default().resolved_cell(),
-            ));
+            ),BrowserEnvironment::default().cell());
             let compile_time_info = CompileTimeInfo::new(environment).to_resolved().await?;
             let layer = Layer::new(rcstr!("test"));
             let module_asset_context = NoopAssetContext {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3777,7 +3777,9 @@ mod tests {
     use turbo_tasks::{ResolvedVc, util::FormatDuration};
     use turbopack_core::{
         compile_time_info::CompileTimeInfo,
-        environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
+        environment::{
+            BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion,
+        },
         target::{Arch, CompileTarget, Endianness, Libc, Platform},
     };
 
@@ -4180,20 +4182,23 @@ mod tests {
             let css_environment = BrowserEnvironment::default().resolved_cell();
 
             let compile_time_info = CompileTimeInfo::builder(
-                Environment::new(ExecutionEnvironment::NodeJsLambda(
-                    NodeJsEnvironment {
-                        compile_target: CompileTarget {
-                            arch: Arch::X64,
-                            platform: Platform::Linux,
-                            endianness: Endianness::Little,
-                            libc: Libc::Glibc,
+                Environment::new(
+                    ExecutionEnvironment::NodeJsLambda(
+                        NodeJsEnvironment {
+                            compile_target: CompileTarget {
+                                arch: Arch::X64,
+                                platform: Platform::Linux,
+                                endianness: Endianness::Little,
+                                libc: Libc::Glibc,
+                            }
+                            .resolved_cell(),
+                            node_version: NodeJsVersion::default().resolved_cell(),
+                            cwd: ResolvedVc::cell(None),
                         }
                         .resolved_cell(),
-                        node_version: NodeJsVersion::default().resolved_cell(),
-                        cwd: ResolvedVc::cell(None),
-                    }
-                    .resolved_cell(),
-                ),*css_environment)
+                    ),
+                    *css_environment,
+                )
                 .to_resolved()
                 .await?,
             )

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3777,7 +3777,7 @@ mod tests {
     use turbo_tasks::{ResolvedVc, util::FormatDuration};
     use turbopack_core::{
         compile_time_info::CompileTimeInfo,
-        environment::{Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
+        environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
         target::{Arch, CompileTarget, Endianness, Libc, Platform},
     };
 
@@ -4177,6 +4177,8 @@ mod tests {
         var_cache: &Mutex<FxHashMap<Id, JsValue>>,
     ) -> (JsValue, u32) {
         turbo_tasks_testing::VcStorage::with(async {
+            let css_environment = BrowserEnvironment::default().resolved_cell();
+
             let compile_time_info = CompileTimeInfo::builder(
                 Environment::new(ExecutionEnvironment::NodeJsLambda(
                     NodeJsEnvironment {
@@ -4191,7 +4193,7 @@ mod tests {
                         cwd: ResolvedVc::cell(None),
                     }
                     .resolved_cell(),
-                ))
+                ),*css_environment)
                 .to_resolved()
                 .await?,
             )

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -15,7 +15,7 @@ use turbopack_core::{
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
-    issue::{handle_issues, IssueReporter, IssueSeverity},
+    issue::{IssueReporter, IssueSeverity, handle_issues},
     output::OutputAsset,
     reference::all_assets_from_entries,
     reference_type::ReferenceType,
@@ -69,9 +69,10 @@ async fn node_file_trace_operation(
     let input = input_dir.join(&format!("{input}"))?;
 
     let source = FileSource::new(input);
-    let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
-        NodeJsEnvironment::default().resolved_cell(),
-    ),BrowserEnvironment::default().cell());
+    let environment = Environment::new(
+        ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().resolved_cell()),
+        BrowserEnvironment::default().cell(),
+    );
     let module_asset_context = ModuleAssetContext::new(
         Default::default(),
         // This config should be kept in sync with

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -12,10 +12,10 @@ use turbopack_cli_utils::issue::{ConsoleUi, LogOptions};
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
-    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
-    issue::{IssueReporter, IssueSeverity, handle_issues},
+    issue::{handle_issues, IssueReporter, IssueSeverity},
     output::OutputAsset,
     reference::all_assets_from_entries,
     reference_type::ReferenceType,
@@ -71,7 +71,7 @@ async fn node_file_trace_operation(
     let source = FileSource::new(input);
     let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
         NodeJsEnvironment::default().resolved_cell(),
-    ));
+    ),BrowserEnvironment::default().cell());
     let module_asset_context = ModuleAssetContext::new(
         Default::default(),
         // This config should be kept in sync with

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -41,11 +41,12 @@ use turbopack_core::{
     ident::Layer,
     issue::IssueDescriptionExt,
     module_graph::{
-        chunk_group_info::ChunkGroupEntry, export_usage::compute_export_usage_info, ModuleGraph
+        ModuleGraph, chunk_group_info::ChunkGroupEntry, export_usage::compute_export_usage_info,
     },
     reference_type::{InnerAssets, ReferenceType},
     resolve::{
-        options::{ImportMap, ImportMapping}, ExternalTraced, ExternalType
+        ExternalTraced, ExternalType,
+        options::{ImportMap, ImportMapping},
     },
 };
 use turbopack_ecmascript_runtime::RuntimeType;
@@ -351,9 +352,10 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         .get_relative_path_to(project_root)
         .context("Project path is in root path")?;
 
-    let env = Environment::new(ExecutionEnvironment::NodeJsBuildTime(
-        NodeJsEnvironment::default().resolved_cell(),
-    ),BrowserEnvironment::default().cell())
+    let env = Environment::new(
+        ExecutionEnvironment::NodeJsBuildTime(NodeJsEnvironment::default().resolved_cell()),
+        BrowserEnvironment::default().cell(),
+    )
     .to_resolved()
     .await?;
 

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -36,17 +36,16 @@ use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     condition::ContextCondition,
     context::AssetContext,
-    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
     issue::IssueDescriptionExt,
     module_graph::{
-        ModuleGraph, chunk_group_info::ChunkGroupEntry, export_usage::compute_export_usage_info,
+        chunk_group_info::ChunkGroupEntry, export_usage::compute_export_usage_info, ModuleGraph
     },
     reference_type::{InnerAssets, ReferenceType},
     resolve::{
-        ExternalTraced, ExternalType,
-        options::{ImportMap, ImportMapping},
+        options::{ImportMap, ImportMapping}, ExternalTraced, ExternalType
     },
 };
 use turbopack_ecmascript_runtime::RuntimeType;
@@ -354,7 +353,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
 
     let env = Environment::new(ExecutionEnvironment::NodeJsBuildTime(
         NodeJsEnvironment::default().resolved_cell(),
-    ))
+    ),BrowserEnvironment::default().cell())
     .to_resolved()
     .await?;
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -285,17 +285,18 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             }
             .resolved_cell();
 
-            Environment::new(ExecutionEnvironment::Browser(
-                environment,
-            ),*environment)
-    .to_resolved()
-    .await?
+            Environment::new(ExecutionEnvironment::Browser(environment), *environment)
+                .to_resolved()
+                .await?
         }
         SnapshotEnvironment::NodeJs => {
-            Environment::new( ExecutionEnvironment::NodeJsBuildTime(
-                // TODO: load more from options.json
-                NodeJsEnvironment::default().resolved_cell(),
-            ),BrowserEnvironment::default().cell())
+            Environment::new(
+                ExecutionEnvironment::NodeJsBuildTime(
+                    // TODO: load more from options.json
+                    NodeJsEnvironment::default().resolved_cell(),
+                ),
+                BrowserEnvironment::default().cell(),
+            )
             .to_resolved()
             .await?
         }

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -274,28 +274,32 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
 
     let entry_asset = project_path.join(&options.entry)?;
 
-    let env = Environment::new(match options.environment {
+    let env = match options.environment {
         SnapshotEnvironment::Browser => {
-            ExecutionEnvironment::Browser(
-                // TODO: load more from options.json
-                BrowserEnvironment {
-                    dom: true,
-                    web_worker: false,
-                    service_worker: false,
-                    browserslist_query: options.browserslist.into(),
-                }
-                .resolved_cell(),
-            )
+            let environment=// TODO: load more from options.json
+            BrowserEnvironment {
+                dom: true,
+                web_worker: false,
+                service_worker: false,
+                browserslist_query: options.browserslist.into(),
+            }
+            .resolved_cell();
+
+            Environment::new(ExecutionEnvironment::Browser(
+                environment,
+            ),*environment)
+    .to_resolved()
+    .await?
         }
         SnapshotEnvironment::NodeJs => {
-            ExecutionEnvironment::NodeJsBuildTime(
+            Environment::new( ExecutionEnvironment::NodeJsBuildTime(
                 // TODO: load more from options.json
                 NodeJsEnvironment::default().resolved_cell(),
-            )
+            ),BrowserEnvironment::default().cell())
+            .to_resolved()
+            .await?
         }
-    })
-    .to_resolved()
-    .await?;
+    };
 
     let mut defines = compile_time_defines!(
         process.turbopack = true,

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -14,7 +14,7 @@ use turbopack::{
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
-    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
     rebase::RebasedAsset,
@@ -90,7 +90,7 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                 let compile_time_info = CompileTimeInfo::builder(
                     Environment::new(ExecutionEnvironment::NodeJsLambda(
                         NodeJsEnvironment::default().resolved_cell(),
-                    ))
+                    ),BrowserEnvironment::default().cell())
                     .to_resolved()
                     .await?,
                 )

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -88,9 +88,12 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
 
                 let source = FileSource::new(input);
                 let compile_time_info = CompileTimeInfo::builder(
-                    Environment::new(ExecutionEnvironment::NodeJsLambda(
-                        NodeJsEnvironment::default().resolved_cell(),
-                    ),BrowserEnvironment::default().cell())
+                    Environment::new(
+                        ExecutionEnvironment::NodeJsLambda(
+                            NodeJsEnvironment::default().resolved_cell(),
+                        ),
+                        BrowserEnvironment::default().cell(),
+                    )
                     .to_resolved()
                     .await?,
                 )

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -14,7 +14,13 @@ use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storag
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 use turbopack::{emit_with_completion, register};
 use turbopack_core::{
-    compile_time_info::CompileTimeInfo, context::AssetContext, environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment}, file_source::FileSource, ident::Layer, rebase::RebasedAsset, PROJECT_FILESYSTEM_NAME
+    PROJECT_FILESYSTEM_NAME,
+    compile_time_info::CompileTimeInfo,
+    context::AssetContext,
+    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
+    file_source::FileSource,
+    ident::Layer,
+    rebase::RebasedAsset,
 };
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 
@@ -43,9 +49,12 @@ async fn main() -> Result<()> {
             let source = FileSource::new(entry);
             let module_asset_context = turbopack::ModuleAssetContext::new(
                 Default::default(),
-                CompileTimeInfo::new(Environment::new(ExecutionEnvironment::NodeJsLambda(
-                    NodeJsEnvironment::default().resolved_cell(),
-                ),BrowserEnvironment::default().cell()) ),
+                CompileTimeInfo::new(Environment::new(
+                    ExecutionEnvironment::NodeJsLambda(
+                        NodeJsEnvironment::default().resolved_cell(),
+                    ),
+                    BrowserEnvironment::default().cell(),
+                )),
                 Default::default(),
                 ResolveOptionsContext {
                     enable_typescript: true,

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -14,13 +14,7 @@ use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storag
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 use turbopack::{emit_with_completion, register};
 use turbopack_core::{
-    PROJECT_FILESYSTEM_NAME,
-    compile_time_info::CompileTimeInfo,
-    context::AssetContext,
-    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
-    file_source::FileSource,
-    ident::Layer,
-    rebase::RebasedAsset,
+    compile_time_info::CompileTimeInfo, context::AssetContext, environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment}, file_source::FileSource, ident::Layer, rebase::RebasedAsset, PROJECT_FILESYSTEM_NAME
 };
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 
@@ -51,7 +45,7 @@ async fn main() -> Result<()> {
                 Default::default(),
                 CompileTimeInfo::new(Environment::new(ExecutionEnvironment::NodeJsLambda(
                     NodeJsEnvironment::default().resolved_cell(),
-                ))),
+                ),BrowserEnvironment::default().cell()) ),
                 Default::default(),
                 ResolveOptionsContext {
                     enable_typescript: true,

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -24,9 +24,10 @@ use crate::{
 
 #[turbo_tasks::function]
 pub fn node_build_environment() -> Vc<Environment> {
-    Environment::new(ExecutionEnvironment::NodeJsBuildTime(
-        NodeJsEnvironment::default().resolved_cell(),
-    ), BrowserEnvironment::default().cell())
+    Environment::new(
+        ExecutionEnvironment::NodeJsBuildTime(NodeJsEnvironment::default().resolved_cell()),
+        BrowserEnvironment::default().cell(),
+    )
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -8,7 +8,7 @@ use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     condition::ContextCondition,
     context::AssetContext,
-    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
     ident::Layer,
     resolve::options::{ImportMap, ImportMapping},
 };
@@ -26,7 +26,7 @@ use crate::{
 pub fn node_build_environment() -> Vc<Environment> {
     Environment::new(ExecutionEnvironment::NodeJsBuildTime(
         NodeJsEnvironment::default().resolved_cell(),
-    ))
+    ), BrowserEnvironment::default().cell())
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -40,7 +40,7 @@ use turbopack::{
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
-    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
     output::OutputAsset,
@@ -348,7 +348,8 @@ async fn node_file_trace_operation(
     let source = FileSource::new(input);
     let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
         NodeJsEnvironment::default().resolved_cell(),
-    ));
+       
+    ), BrowserEnvironment::default().cell(),);
     let module_asset_context = ModuleAssetContext::new(
         Default::default(),
         // TODO These test cases should move into the `node-file-trace` crate and use the same

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -346,10 +346,10 @@ async fn node_file_trace_operation(
     let output_dir = output_fs.root().owned().await?;
 
     let source = FileSource::new(input);
-    let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
-        NodeJsEnvironment::default().resolved_cell(),
-       
-    ), BrowserEnvironment::default().cell(),);
+    let environment = Environment::new(
+        ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().resolved_cell()),
+        BrowserEnvironment::default().cell(),
+    );
     let module_asset_context = ModuleAssetContext::new(
         Default::default(),
         // TODO These test cases should move into the `node-file-trace` crate and use the same


### PR DESCRIPTION
### What?

Pass the correct browserslist query to `lightningcss` in `styled-jsx`.

### Why?

To fix an issue with `styled-jsx`.

#### Testing instruction:

1. `git clone https://github.com/kdy1/repro-next-styled-jsx-526 ~/projects/repro-next-styled-jsx-526`
2. `pnpm pack-next -p ~/projects/repro-next-styled-jsx-526 && (cd repro-next-styled-jsx-526 && pnpm i && pnpm build && pnpm start`


### How?

Closes https://github.com/swc-project/plugins/issues/526



Closes PACK-5391