### PR TITLE
refactor: Consistently call HMR messages `message`

### DIFF
--- a/packages/next/src/client/dev/amp-dev.ts
+++ b/packages/next/src/client/dev/amp-dev.ts
@@ -2,7 +2,7 @@
 import { displayContent } from './fouc'
 import initOnDemandEntries from './on-demand-entries-client'
 import { addMessageListener, connectHMR } from './hot-reloader/pages/websocket'
-import { HMR_ACTIONS_SENT_TO_BROWSER } from '../../server/dev/hot-reloader-types'
+import { HMR_MESSAGE_SENT_TO_BROWSER } from '../../server/dev/hot-reloader-types'
 import { reportInvalidHmrMessage } from './hot-reloader/shared'
 
 /// <reference types="webpack/module.d.ts" />
@@ -78,23 +78,23 @@ async function tryApplyUpdates() {
 
 addMessageListener((message) => {
   try {
-    // actions which are not related to amp-dev
+    // messages which are not related to amp-dev
     if (
-      message.action === HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ERROR ||
-      message.action === HMR_ACTIONS_SENT_TO_BROWSER.DEV_PAGES_MANIFEST_UPDATE
+      message.type === HMR_MESSAGE_SENT_TO_BROWSER.SERVER_ERROR ||
+      message.type === HMR_MESSAGE_SENT_TO_BROWSER.DEV_PAGES_MANIFEST_UPDATE
     ) {
       return
     }
     if (
-      message.action === HMR_ACTIONS_SENT_TO_BROWSER.SYNC ||
-      message.action === HMR_ACTIONS_SENT_TO_BROWSER.BUILT
+      message.type === HMR_MESSAGE_SENT_TO_BROWSER.SYNC ||
+      message.type === HMR_MESSAGE_SENT_TO_BROWSER.BUILT
     ) {
       if (!message.hash) {
         return
       }
       mostRecentHash = message.hash
       tryApplyUpdates()
-    } else if (message.action === HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE) {
+    } else if (message.type === HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE) {
       window.location.reload()
     }
   } catch (err: unknown) {

--- a/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
+++ b/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
@@ -1,7 +1,7 @@
 import { useContext, useEffect } from 'react'
 import { GlobalLayoutRouterContext } from '../../../../shared/lib/app-router-context.shared-runtime'
 import { getSocketUrl } from '../get-socket-url'
-import type { TurbopackMsgToBrowser } from '../../../../server/dev/hot-reloader-types'
+import type { TurbopackMessageSentToBrowser } from '../../../../server/dev/hot-reloader-types'
 import { reportInvalidHmrMessage } from '../shared'
 import {
   performFullReload,
@@ -37,9 +37,9 @@ export function createWebSocket(
 
   webSocket.addEventListener('message', (event) => {
     try {
-      const obj = JSON.parse(event.data)
+      const message = JSON.parse(event.data)
       processMessage(
-        obj,
+        message,
         sendMessage,
         processTurbopackMessage,
         staticIndicatorState
@@ -54,15 +54,15 @@ export function createWebSocket(
 
 export function createProcessTurbopackMessage(
   sendMessage: (data: string) => void
-): (msg: TurbopackMsgToBrowser) => void {
+): (msg: TurbopackMessageSentToBrowser) => void {
   if (!process.env.TURBOPACK) {
     return () => {}
   }
 
-  let queue: TurbopackMsgToBrowser[] = []
-  let callback: ((msg: TurbopackMsgToBrowser) => void) | undefined
+  let queue: TurbopackMessageSentToBrowser[] = []
+  let callback: ((msg: TurbopackMessageSentToBrowser) => void) | undefined
 
-  const processTurbopackMessage = (msg: TurbopackMsgToBrowser) => {
+  const processTurbopackMessage = (msg: TurbopackMessageSentToBrowser) => {
     if (callback) {
       callback(msg)
     } else {
@@ -75,7 +75,7 @@ export function createProcessTurbopackMessage(
     '@vercel/turbopack-ecmascript-runtime/browser/dev/hmr-client/hmr-client.ts'
   ).then(({ connect }) => {
     connect({
-      addMessageListener(cb: (msg: TurbopackMsgToBrowser) => void) {
+      addMessageListener(cb: (msg: TurbopackMessageSentToBrowser) => void) {
         callback = cb
 
         // Replay all Turbopack messages before we were able to establish the HMR client.

--- a/packages/next/src/client/dev/hot-reloader/pages/websocket.ts
+++ b/packages/next/src/client/dev/hot-reloader/pages/websocket.ts
@@ -3,19 +3,19 @@ import {
   logQueue,
 } from '../../../../next-devtools/userspace/app/forward-logs'
 import {
-  HMR_ACTIONS_SENT_TO_BROWSER,
-  type HMR_ACTION_TYPES,
+  HMR_MESSAGE_SENT_TO_BROWSER,
+  type HmrMessageSentToBrowser,
 } from '../../../../server/dev/hot-reloader-types'
 import { getSocketUrl } from '../get-socket-url'
 
 let source: WebSocket
 
-type ActionCallback = (action: HMR_ACTION_TYPES) => void
+type MessageCallback = (message: HmrMessageSentToBrowser) => void
 
-const eventCallbacks: Array<ActionCallback> = []
+const messageCallbacks: Array<MessageCallback> = []
 
-export function addMessageListener(callback: ActionCallback) {
-  eventCallbacks.push(callback)
+export function addMessageListener(callback: MessageCallback) {
+  messageCallbacks.push(callback)
 }
 
 export function sendMessage(data: string) {
@@ -46,13 +46,12 @@ export function connectHMR(options: { path: string; assetPrefix: string }) {
         return
       }
 
-      // Coerce into HMR_ACTION_TYPES as that is the format.
-      const msg: HMR_ACTION_TYPES = JSON.parse(event.data)
+      const message: HmrMessageSentToBrowser = JSON.parse(event.data)
 
-      if (msg.action === HMR_ACTIONS_SENT_TO_BROWSER.TURBOPACK_CONNECTED) {
+      if (message.type === HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_CONNECTED) {
         if (
           serverSessionId !== null &&
-          serverSessionId !== msg.data.sessionId
+          serverSessionId !== message.data.sessionId
         ) {
           // Either the server's session id has changed and it's a new server, or
           // it's been too long since we disconnected and we should reload the page.
@@ -64,11 +63,11 @@ export function connectHMR(options: { path: string; assetPrefix: string }) {
           return
         }
 
-        serverSessionId = msg.data.sessionId
+        serverSessionId = message.data.sessionId
       }
 
-      for (const eventCallback of eventCallbacks) {
-        eventCallback(msg)
+      for (const messageCallback of messageCallbacks) {
+        messageCallback(message)
       }
     }
 

--- a/packages/next/src/client/dev/hot-reloader/shared.ts
+++ b/packages/next/src/client/dev/hot-reloader/shared.ts
@@ -1,4 +1,4 @@
-import type { HMR_ACTION_TYPES } from '../../../server/dev/hot-reloader-types'
+import type { HmrMessageSentToBrowser } from '../../../server/dev/hot-reloader-types'
 
 export const REACT_REFRESH_FULL_RELOAD =
   '[Fast Refresh] performing full reload\n\n' +
@@ -12,7 +12,7 @@ export const REACT_REFRESH_FULL_RELOAD_FROM_ERROR =
   '[Fast Refresh] performing full reload because your application had an unrecoverable error'
 
 export function reportInvalidHmrMessage(
-  message: HMR_ACTION_TYPES | MessageEvent<unknown>,
+  message: HmrMessageSentToBrowser | MessageEvent<unknown>,
   err: unknown
 ) {
   console.warn(

--- a/packages/next/src/client/dev/hot-reloader/turbopack-hot-reloader-common.ts
+++ b/packages/next/src/client/dev/hot-reloader/turbopack-hot-reloader-common.ts
@@ -1,4 +1,4 @@
-import type { TurbopackMessageAction } from '../../../server/dev/hot-reloader-types'
+import type { TurbopackMessage } from '../../../server/dev/hot-reloader-types'
 import type { Update as TurbopackUpdate } from '../../../build/swc/types'
 
 declare global {
@@ -72,7 +72,7 @@ export class TurbopackHmr {
     this.#lastUpdateMsSinceEpoch = Date.now()
   }
 
-  onTurbopackMessage(msg: TurbopackMessageAction) {
+  onTurbopackMessage(msg: TurbopackMessage) {
     this.#onUpdate()
     const updatedModules = extractModulesFromTurbopackMessage(msg.data)
     for (const module of updatedModules) {
@@ -98,7 +98,7 @@ export class TurbopackHmr {
    *   the HMR in the browser console, but the HMR was a no-op.
    */
   onBuilt(): HmrUpdate | null {
-    // Check that we got *any* `TurbopackMessageAction`, even if
+    // Check that we got *any* `TurbopackMessage`, even if
     // `updatedModules` is empty (not everything gets recorded there).
     //
     // There's also a case where `onBuilt` gets called before `onBuilding`,

--- a/packages/next/src/client/next-dev-turbopack.ts
+++ b/packages/next/src/client/next-dev-turbopack.ts
@@ -5,7 +5,7 @@ import initHMR from './dev/hot-middleware-client'
 import { pageBootstrap } from './page-bootstrap'
 //@ts-expect-error requires "moduleResolution": "node16" in tsconfig.json and not .ts extension
 import { connect } from '@vercel/turbopack-ecmascript-runtime/browser/dev/hmr-client/hmr-client.ts'
-import type { TurbopackMsgToBrowser } from '../server/dev/hot-reloader-types'
+import type { TurbopackMessageSentToBrowser } from '../server/dev/hot-reloader-types'
 
 window.next = {
   version,
@@ -42,7 +42,7 @@ initialize({
     }
 
     connect({
-      addMessageListener(cb: (msg: TurbopackMsgToBrowser) => void) {
+      addMessageListener(cb: (message: TurbopackMessageSentToBrowser) => void) {
         devClient.addTurbopackMessageListener(cb)
       },
       sendMessage: devClient.sendTurbopackMessage,

--- a/packages/next/src/server/dev/hot-middleware.ts
+++ b/packages/next/src/server/dev/hot-middleware.ts
@@ -26,8 +26,8 @@ import type ws from 'next/dist/compiled/ws'
 import type { DevToolsConfig } from '../../next-devtools/dev-overlay/shared'
 import { isMiddlewareFilename } from '../../build/utils'
 import type { VersionInfo } from './parse-version-info'
-import type { HMR_ACTION_TYPES } from './hot-reloader-types'
-import { HMR_ACTIONS_SENT_TO_BROWSER } from './hot-reloader-types'
+import type { HmrMessageSentToBrowser } from './hot-reloader-types'
+import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
 import { devIndicatorServerState } from './dev-indicator-server-state'
 
 function isMiddlewareStats(stats: webpack.Stats) {
@@ -89,9 +89,9 @@ class EventStream {
     })
   }
 
-  publish(payload: any) {
+  publish(message: any) {
     for (const wsClient of this.clients) {
-      wsClient.send(JSON.stringify(payload))
+      wsClient.send(JSON.stringify(message))
     }
   }
 }
@@ -141,7 +141,7 @@ export class WebpackHotMiddleware {
   onClientInvalid = () => {
     if (this.closed || this.serverLatestStats?.stats.hasErrors()) return
     this.publish({
-      action: HMR_ACTIONS_SENT_TO_BROWSER.BUILDING,
+      type: HMR_MESSAGE_SENT_TO_BROWSER.BUILDING,
     })
   }
 
@@ -216,7 +216,7 @@ export class WebpackHotMiddleware {
       }
 
       this.publish({
-        action: HMR_ACTIONS_SENT_TO_BROWSER.SYNC,
+        type: HMR_MESSAGE_SENT_TO_BROWSER.SYNC,
         hash: stats.hash!,
         errors: [...(stats.errors || []), ...(middlewareStats.errors || [])],
         warnings: [
@@ -243,16 +243,16 @@ export class WebpackHotMiddleware {
     })
 
     this.publish({
-      action: HMR_ACTIONS_SENT_TO_BROWSER.BUILT,
+      type: HMR_MESSAGE_SENT_TO_BROWSER.BUILT,
       hash: stats.hash!,
       warnings: stats.warnings || [],
       errors: stats.errors || [],
     })
   }
 
-  publish = (payload: HMR_ACTION_TYPES) => {
+  publish = (message: HmrMessageSentToBrowser) => {
     if (this.closed) return
-    this.eventStream.publish(payload)
+    this.eventStream.publish(message)
   }
   close = () => {
     if (this.closed) return

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -9,13 +9,13 @@ import type { OutputState } from '../../build/output/store'
 import { store as consoleStore } from '../../build/output/store'
 import type {
   CompilationError,
-  HMR_ACTION_TYPES,
+  HmrMessageSentToBrowser,
   NextJsHotReloaderInterface,
-  ReloadPageAction,
-  SyncAction,
-  TurbopackConnectedAction,
+  ReloadPageMessage,
+  SyncMessage,
+  TurbopackConnectedMessage,
 } from './hot-reloader-types'
-import { HMR_ACTIONS_SENT_TO_BROWSER } from './hot-reloader-types'
+import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
 import type {
   Update as TurbopackUpdate,
   Endpoint,
@@ -415,8 +415,8 @@ export async function createHotReloaderTurbopack(
   const clients = new Set<ws>()
   const clientStates = new WeakMap<ws, ClientState>()
 
-  function sendToClient(client: ws, payload: HMR_ACTION_TYPES) {
-    client.send(JSON.stringify(payload))
+  function sendToClient(client: ws, message: HmrMessageSentToBrowser) {
+    client.send(JSON.stringify(message))
   }
 
   function sendEnqueuedMessages() {
@@ -446,14 +446,14 @@ export async function createHotReloaderTurbopack(
         }
       }
 
-      for (const payload of state.hmrPayloads.values()) {
-        sendToClient(client, payload)
+      for (const message of state.messages.values()) {
+        sendToClient(client, message)
       }
-      state.hmrPayloads.clear()
+      state.messages.clear()
 
       if (state.turbopackUpdates.length > 0) {
         sendToClient(client, {
-          action: HMR_ACTIONS_SENT_TO_BROWSER.TURBOPACK_MESSAGE,
+          type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_MESSAGE,
           data: state.turbopackUpdates,
         })
         state.turbopackUpdates.length = 0
@@ -462,9 +462,9 @@ export async function createHotReloaderTurbopack(
   }
   const sendEnqueuedMessagesDebounce = debounce(sendEnqueuedMessages, 2)
 
-  const sendHmr: SendHmr = (id: string, payload: HMR_ACTION_TYPES) => {
+  const sendHmr: SendHmr = (id: string, message: HmrMessageSentToBrowser) => {
     for (const client of clients) {
-      clientStates.get(client)?.hmrPayloads.set(id, payload)
+      clientStates.get(client)?.messages.set(id, message)
     }
 
     hmrEventHappened = true
@@ -490,13 +490,13 @@ export async function createHotReloaderTurbopack(
     key: EntryKey,
     includeIssues: boolean,
     endpoint: Endpoint,
-    makePayload: (
+    createMessage: (
       change: TurbopackResult,
       hash: string
-    ) => Promise<HMR_ACTION_TYPES> | HMR_ACTION_TYPES | void,
+    ) => Promise<HmrMessageSentToBrowser> | HmrMessageSentToBrowser | void,
     onError?: (
       error: Error
-    ) => Promise<HMR_ACTION_TYPES> | HMR_ACTION_TYPES | void
+    ) => Promise<HmrMessageSentToBrowser> | HmrMessageSentToBrowser | void
   ) {
     if (changeSubscriptions.has(key)) {
       return
@@ -512,9 +512,9 @@ export async function createHotReloaderTurbopack(
       for await (const change of changed) {
         processIssues(currentEntryIssues, key, change, false, true)
         // TODO: Get an actual content hash from Turbopack.
-        const payload = await makePayload(change, String(++hmrHash))
-        if (payload) {
-          sendHmr(key, payload)
+        const message = await createMessage(change, String(++hmrHash))
+        if (message) {
+          sendHmr(key, message)
         }
       }
     } catch (e) {
@@ -568,11 +568,11 @@ export async function createHotReloaderTurbopack(
       // to fully reload the page to resolve the issue. We can't use
       // `hotReloader.send` since that would force every connected client to
       // reload, only this client is out of date.
-      const reloadAction: ReloadPageAction = {
-        action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE,
+      const reloadMessage: ReloadPageMessage = {
+        type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
         data: `error in HMR event subscription for ${id}: ${e}`,
       }
-      sendToClient(client, reloadAction)
+      sendToClient(client, reloadMessage)
       client.close()
       return
     }
@@ -671,7 +671,7 @@ export async function createHotReloaderTurbopack(
       distDir,
       sendUpdateSignal: (data) => {
         hotReloader.send({
-          action: HMR_ACTIONS_SENT_TO_BROWSER.DEVTOOLS_CONFIG,
+          type: HMR_MESSAGE_SENT_TO_BROWSER.DEVTOOLS_CONFIG,
           data,
         })
       },
@@ -751,7 +751,7 @@ export async function createHotReloaderTurbopack(
         clients.add(client)
         clientStates.set(client, {
           clientIssues,
-          hmrPayloads: new Map(),
+          messages: new Map(),
           turbopackUpdates: [],
           subscriptions,
         })
@@ -859,11 +859,11 @@ export async function createHotReloaderTurbopack(
           }
         })
 
-        const turbopackConnected: TurbopackConnectedAction = {
-          action: HMR_ACTIONS_SENT_TO_BROWSER.TURBOPACK_CONNECTED,
+        const turbopackConnectedMessage: TurbopackConnectedMessage = {
+          type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_CONNECTED,
           data: { sessionId },
         }
-        sendToClient(client, turbopackConnected)
+        sendToClient(client, turbopackConnectedMessage)
 
         const errors: CompilationError[] = []
 
@@ -887,8 +887,8 @@ export async function createHotReloaderTurbopack(
           const versionInfo = await versionInfoPromise
           const devToolsConfig = await getDevToolsConfig(distDir)
 
-          const sync: SyncAction = {
-            action: HMR_ACTIONS_SENT_TO_BROWSER.SYNC,
+          const syncMessage: SyncMessage = {
+            type: HMR_MESSAGE_SENT_TO_BROWSER.SYNC,
             errors,
             warnings: [],
             hash: '',
@@ -900,7 +900,7 @@ export async function createHotReloaderTurbopack(
             devToolsConfig,
           }
 
-          sendToClient(client, sync)
+          sendToClient(client, syncMessage)
         })()
       })
     },
@@ -976,7 +976,7 @@ export async function createHotReloaderTurbopack(
 
         await clearAllModuleContexts()
         this.send({
-          action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+          type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
           hash: String(++hmrHash),
         })
       }
@@ -1167,7 +1167,7 @@ export async function createHotReloaderTurbopack(
     for await (const updateMessage of project.updateInfoSubscribe(30)) {
       switch (updateMessage.updateType) {
         case 'start': {
-          hotReloader.send({ action: HMR_ACTIONS_SENT_TO_BROWSER.BUILDING })
+          hotReloader.send({ type: HMR_MESSAGE_SENT_TO_BROWSER.BUILDING })
           break
         }
         case 'end': {
@@ -1207,7 +1207,7 @@ export async function createHotReloaderTurbopack(
             addErrors(clientErrors, state.clientIssues)
 
             sendToClient(client, {
-              action: HMR_ACTIONS_SENT_TO_BROWSER.BUILT,
+              type: HMR_MESSAGE_SENT_TO_BROWSER.BUILT,
               hash: String(++hmrHash),
               errors: [...clientErrors.values()],
               warnings: [],

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -10,7 +10,7 @@ import type { DebugInfo } from '../../next-devtools/shared/types'
 import type { DevIndicatorServerState } from './dev-indicator-server-state'
 import type { DevToolsConfig } from '../../next-devtools/dev-overlay/shared'
 
-export const enum HMR_ACTIONS_SENT_TO_BROWSER {
+export const enum HMR_MESSAGE_SENT_TO_BROWSER {
   ADDED_PAGE = 'addedPage',
   REMOVED_PAGE = 'removedPage',
   RELOAD_PAGE = 'reloadPage',
@@ -30,18 +30,18 @@ export const enum HMR_ACTIONS_SENT_TO_BROWSER {
   DEVTOOLS_CONFIG = 'devtoolsConfig',
 }
 
-interface ServerErrorAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ERROR
+export interface ServerErrorMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_ERROR
   errorJSON: string
 }
 
-export interface TurbopackMessageAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.TURBOPACK_MESSAGE
+export interface TurbopackMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_MESSAGE
   data: TurbopackUpdate | TurbopackUpdate[]
 }
 
-interface BuildingAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.BUILDING
+export interface BuildingMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.BUILDING
 }
 
 export interface CompilationError {
@@ -51,8 +51,9 @@ export interface CompilationError {
   moduleTrace?: Array<{ moduleName?: string }>
   stack?: string
 }
-export interface SyncAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.SYNC
+
+export interface SyncMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.SYNC
   hash: string
   errors: ReadonlyArray<CompilationError>
   warnings: ReadonlyArray<CompilationError>
@@ -62,49 +63,50 @@ export interface SyncAction {
   devIndicator: DevIndicatorServerState
   devToolsConfig?: DevToolsConfig
 }
-interface BuiltAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.BUILT
+
+export interface BuiltMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.BUILT
   hash: string
   errors: ReadonlyArray<CompilationError>
   warnings: ReadonlyArray<CompilationError>
   updatedModules?: ReadonlyArray<string>
 }
 
-interface AddedPageAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.ADDED_PAGE
+export interface AddedPageMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.ADDED_PAGE
   data: [page: string | null]
 }
 
-interface RemovedPageAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.REMOVED_PAGE
+export interface RemovedPageMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.REMOVED_PAGE
   data: [page: string | null]
 }
 
-export interface ReloadPageAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE
+export interface ReloadPageMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE
   data: string
 }
 
-interface ServerComponentChangesAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES
+export interface ServerComponentChangesMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES
   hash: string
 }
 
-interface MiddlewareChangesAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.MIDDLEWARE_CHANGES
+export interface MiddlewareChangesMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.MIDDLEWARE_CHANGES
 }
 
-interface ClientChangesAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.CLIENT_CHANGES
+export interface ClientChangesMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.CLIENT_CHANGES
 }
 
-interface ServerOnlyChangesAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ONLY_CHANGES
+export interface ServerOnlyChangesMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_ONLY_CHANGES
   pages: ReadonlyArray<string>
 }
 
-interface DevPagesManifestUpdateAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.DEV_PAGES_MANIFEST_UPDATE
+export interface DevPagesManifestUpdateMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.DEV_PAGES_MANIFEST_UPDATE
   data: [
     {
       devPagesManifest: true
@@ -112,43 +114,46 @@ interface DevPagesManifestUpdateAction {
   ]
 }
 
-export interface TurbopackConnectedAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.TURBOPACK_CONNECTED
+export interface TurbopackConnectedMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_CONNECTED
   data: { sessionId: number }
 }
 
-export interface AppIsrManifestAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.ISR_MANIFEST
+export interface AppIsrManifestMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.ISR_MANIFEST
   data: Record<string, true>
 }
 
-export interface DevToolsConfigAction {
-  action: HMR_ACTIONS_SENT_TO_BROWSER.DEVTOOLS_CONFIG
+export interface DevToolsConfigMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.DEVTOOLS_CONFIG
   data: DevToolsConfig
 }
 
-export type HMR_ACTION_TYPES =
-  | TurbopackMessageAction
-  | TurbopackConnectedAction
-  | BuildingAction
-  | SyncAction
-  | BuiltAction
-  | AddedPageAction
-  | RemovedPageAction
-  | ReloadPageAction
-  | ServerComponentChangesAction
-  | ClientChangesAction
-  | MiddlewareChangesAction
-  | ServerOnlyChangesAction
-  | DevPagesManifestUpdateAction
-  | ServerErrorAction
-  | AppIsrManifestAction
-  | DevToolsConfigAction
+export type HmrMessageSentToBrowser =
+  | TurbopackMessage
+  | TurbopackConnectedMessage
+  | BuildingMessage
+  | SyncMessage
+  | BuiltMessage
+  | AddedPageMessage
+  | RemovedPageMessage
+  | ReloadPageMessage
+  | ServerComponentChangesMessage
+  | ClientChangesMessage
+  | MiddlewareChangesMessage
+  | ServerOnlyChangesMessage
+  | DevPagesManifestUpdateMessage
+  | ServerErrorMessage
+  | AppIsrManifestMessage
+  | DevToolsConfigMessage
 
-export type TurbopackMsgToBrowser =
-  | { type: HMR_ACTIONS_SENT_TO_BROWSER.TURBOPACK_MESSAGE; data: any }
+export type TurbopackMessageSentToBrowser =
   | {
-      type: HMR_ACTIONS_SENT_TO_BROWSER.TURBOPACK_CONNECTED
+      type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_MESSAGE
+      data: any
+    }
+  | {
+      type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_CONNECTED
       data: { sessionId: number }
     }
 
@@ -166,7 +171,7 @@ export interface NextJsHotReloaderInterface {
   setHmrServerError(error: Error | null): void
   clearHmrServerError(): void
   start(): Promise<void>
-  send(action: HMR_ACTION_TYPES): void
+  send(message: HmrMessageSentToBrowser): void
   getCompilationErrors(page: string): Promise<any[]>
   onHMR(
     req: IncomingMessage,

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -76,10 +76,10 @@ import {
 } from '../../lib/is-internal-component'
 import { RouteKind } from '../route-kind'
 import {
-  HMR_ACTIONS_SENT_TO_BROWSER,
+  HMR_MESSAGE_SENT_TO_BROWSER,
   type NextJsHotReloaderInterface,
 } from './hot-reloader-types'
-import type { HMR_ACTION_TYPES } from './hot-reloader-types'
+import type { HmrMessageSentToBrowser } from './hot-reloader-types'
 import type { WebpackError } from 'webpack'
 import { PAGE_TYPES } from '../../lib/page-types'
 import { FAST_REFRESH_RUNTIME_RELOAD } from './messages'
@@ -416,7 +416,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     if (this.hmrServerError) {
       this.setHmrServerError(null)
       this.send({
-        action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE,
+        type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
         data: 'clear hmr server error',
       })
     }
@@ -424,7 +424,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
 
   protected async refreshServerComponents(hash: string): Promise<void> {
     this.send({
-      action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+      type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
       hash,
       // TODO: granular reloading of changes
       // entrypoints: serverComponentChanges,
@@ -1435,7 +1435,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
 
         // Notify reload to reload the page, as _document.js was changed (different hash)
         this.send({
-          action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE,
+          type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
           data: '_document has changed',
         })
       }
@@ -1466,13 +1466,13 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
 
       if (middlewareChanges.length > 0) {
         this.send({
-          action: HMR_ACTIONS_SENT_TO_BROWSER.MIDDLEWARE_CHANGES,
+          type: HMR_MESSAGE_SENT_TO_BROWSER.MIDDLEWARE_CHANGES,
         })
       }
 
       if (pageChanges.length > 0) {
         this.send({
-          action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ONLY_CHANGES,
+          type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_ONLY_CHANGES,
           pages: serverOnlyChanges.map((pg) =>
             denormalizePagePath(pg.slice('pages'.length))
           ),
@@ -1525,7 +1525,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
             for (const addedPage of addedPages) {
               const page = getRouteFromEntrypoint(addedPage)
               this.send({
-                action: HMR_ACTIONS_SENT_TO_BROWSER.ADDED_PAGE,
+                type: HMR_MESSAGE_SENT_TO_BROWSER.ADDED_PAGE,
                 data: [page],
               })
             }
@@ -1535,7 +1535,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
             for (const removedPage of removedPages) {
               const page = getRouteFromEntrypoint(removedPage)
               this.send({
-                action: HMR_ACTIONS_SENT_TO_BROWSER.REMOVED_PAGE,
+                type: HMR_MESSAGE_SENT_TO_BROWSER.REMOVED_PAGE,
                 data: [page],
               })
             }
@@ -1613,7 +1613,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
           this.webpackHotMiddleware?.updateDevToolsConfig(data)
 
           this.send({
-            action: HMR_ACTIONS_SENT_TO_BROWSER.DEVTOOLS_CONFIG,
+            type: HMR_MESSAGE_SENT_TO_BROWSER.DEVTOOLS_CONFIG,
             data,
           })
         },
@@ -1659,8 +1659,8 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     }
   }
 
-  public send(action: HMR_ACTION_TYPES): void {
-    this.webpackHotMiddleware!.publish(action)
+  public send(message: HmrMessageSentToBrowser): void {
+    this.webpackHotMiddleware!.publish(message)
   }
 
   public async ensurePage({

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -38,7 +38,7 @@ import {
   UNDERSCORE_NOT_FOUND_ROUTE_ENTRY,
 } from '../../shared/lib/constants'
 import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
-import { HMR_ACTIONS_SENT_TO_BROWSER } from './hot-reloader-types'
+import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
 import { isAppPageRouteDefinition } from '../route-definitions/app-page-route-definition'
 import { scheduleOnNextTick } from '../../lib/scheduler'
 import { Batcher } from '../../lib/batcher'
@@ -984,7 +984,7 @@ export function onDemandEntryHandler({
           // New error occurred: buffered error is flushed and new error occurred
           if (!bufferedHmrServerError && error) {
             hotReloader.send({
-              action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ERROR,
+              type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_ERROR,
               errorJSON: stringifyError(error),
             })
             bufferedHmrServerError = null

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -11,8 +11,8 @@ import type {
   WrittenEndpoint,
 } from '../../build/swc/types'
 import {
-  type HMR_ACTION_TYPES,
-  HMR_ACTIONS_SENT_TO_BROWSER,
+  type HmrMessageSentToBrowser,
+  HMR_MESSAGE_SENT_TO_BROWSER,
 } from './hot-reloader-types'
 import * as Log from '../../build/output/log'
 import type { PropagateToWorkersField } from '../lib/router-utils/types'
@@ -106,16 +106,18 @@ export type StartChangeSubscription = (
   key: EntryKey,
   includeIssues: boolean,
   endpoint: Endpoint,
-  makePayload: (
+  createMessage: (
     change: TurbopackResult,
     hash: string
-  ) => Promise<HMR_ACTION_TYPES> | HMR_ACTION_TYPES | void,
-  onError?: (e: Error) => Promise<HMR_ACTION_TYPES> | HMR_ACTION_TYPES | void
+  ) => Promise<HmrMessageSentToBrowser> | HmrMessageSentToBrowser | void,
+  onError?: (
+    e: Error
+  ) => Promise<HmrMessageSentToBrowser> | HmrMessageSentToBrowser | void
 ) => Promise<void>
 
 export type StopChangeSubscription = (key: EntryKey) => Promise<void>
 
-export type SendHmr = (id: string, payload: HMR_ACTION_TYPES) => void
+export type SendHmr = (id: string, message: HmrMessageSentToBrowser) => void
 
 export type StartBuilding = (
   id: string,
@@ -127,7 +129,7 @@ export type ReadyIds = Set<string>
 
 export type ClientState = {
   clientIssues: EntryIssuesMap
-  hmrPayloads: Map<string, HMR_ACTION_TYPES>
+  messages: Map<string, HmrMessageSentToBrowser>
   turbopackUpdates: TurbopackUpdate[]
   subscriptions: Map<string, AsyncIterator<any>>
 }
@@ -266,13 +268,13 @@ export async function handleRouteType({
               // Report the next compilation again
               readyIds?.delete(pathname)
               return {
-                action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_ONLY_CHANGES,
+                type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_ONLY_CHANGES,
                 pages: [page],
               }
             },
             (e) => {
               return {
-                action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE,
+                type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
                 data: `error in ${page} data subscription: ${e}`,
               }
             }
@@ -283,12 +285,12 @@ export async function handleRouteType({
             route.htmlEndpoint,
             () => {
               return {
-                action: HMR_ACTIONS_SENT_TO_BROWSER.CLIENT_CHANGES,
+                type: HMR_MESSAGE_SENT_TO_BROWSER.CLIENT_CHANGES,
               }
             },
             (e) => {
               return {
-                action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE,
+                type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
                 data: `error in ${page} html subscription: ${e}`,
               }
             }
@@ -300,13 +302,13 @@ export async function handleRouteType({
               entrypoints.global.document,
               () => {
                 return {
-                  action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE,
+                  type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
                   data: '_document has changed (page route)',
                 }
               },
               (e) => {
                 return {
-                  action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE,
+                  type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
                   data: `error in _document subscription (page route): ${e}`,
                 }
               }
@@ -364,13 +366,13 @@ export async function handleRouteType({
             // Report the next compilation again
             readyIds?.delete(pathname)
             return {
-              action: HMR_ACTIONS_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+              type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
               hash,
             }
           },
           (e) => {
             return {
-              action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE,
+              type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
               data: `error in ${page} app-page subscription: ${e}`,
             }
           }
@@ -650,12 +652,12 @@ export async function handleEntrypoints({
     await dev?.hooks.unsubscribeFromChanges(key)
     currentEntryIssues.delete(key)
     dev.hooks.sendHmr('middleware', {
-      action: HMR_ACTIONS_SENT_TO_BROWSER.MIDDLEWARE_CHANGES,
+      type: HMR_MESSAGE_SENT_TO_BROWSER.MIDDLEWARE_CHANGES,
     })
   } else if (!currentEntrypoints.global.middleware && middleware) {
     // Went from no middleware to middleware
     dev.hooks.sendHmr('middleware', {
-      action: HMR_ACTIONS_SENT_TO_BROWSER.MIDDLEWARE_CHANGES,
+      type: HMR_MESSAGE_SENT_TO_BROWSER.MIDDLEWARE_CHANGES,
     })
   }
 
@@ -764,12 +766,12 @@ export async function handleEntrypoints({
 
           finishBuilding?.()
           return {
-            action: HMR_ACTIONS_SENT_TO_BROWSER.MIDDLEWARE_CHANGES,
+            type: HMR_MESSAGE_SENT_TO_BROWSER.MIDDLEWARE_CHANGES,
           }
         },
         () => {
           return {
-            action: HMR_ACTIONS_SENT_TO_BROWSER.MIDDLEWARE_CHANGES,
+            type: HMR_MESSAGE_SENT_TO_BROWSER.MIDDLEWARE_CHANGES,
           }
         }
       )
@@ -882,12 +884,12 @@ export async function handlePagesErrorRoute({
         // There's a special case for this in `../client/page-bootstrap.ts`.
         // https://github.com/vercel/next.js/blob/08d7a7e5189a835f5dcb82af026174e587575c0e/packages/next/src/client/page-bootstrap.ts#L69-L71
         return {
-          action: HMR_ACTIONS_SENT_TO_BROWSER.CLIENT_CHANGES,
+          type: HMR_MESSAGE_SENT_TO_BROWSER.CLIENT_CHANGES,
         }
       },
       () => {
         return {
-          action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE,
+          type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
           data: '_app has changed (error route)',
         }
       }
@@ -909,13 +911,13 @@ export async function handlePagesErrorRoute({
       entrypoints.global.document,
       () => {
         return {
-          action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE,
+          type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
           data: '_document has changed (error route)',
         }
       },
       (e) => {
         return {
-          action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE,
+          type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
           data: `error in _document subscription (error route): ${e}`,
         }
       }
@@ -937,12 +939,12 @@ export async function handlePagesErrorRoute({
         // There's a special case for this in `../client/page-bootstrap.ts`.
         // https://github.com/vercel/next.js/blob/08d7a7e5189a835f5dcb82af026174e587575c0e/packages/next/src/client/page-bootstrap.ts#L69-L71
         return {
-          action: HMR_ACTIONS_SENT_TO_BROWSER.CLIENT_CHANGES,
+          type: HMR_MESSAGE_SENT_TO_BROWSER.CLIENT_CHANGES,
         }
       },
       (e) => {
         return {
-          action: HMR_ACTIONS_SENT_TO_BROWSER.RELOAD_PAGE,
+          type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
           data: `error in _error subscription: ${e}`,
         }
       }

--- a/packages/next/src/server/lib/dev-bundler-service.ts
+++ b/packages/next/src/server/lib/dev-bundler-service.ts
@@ -4,7 +4,7 @@ import type { WorkerRequestHandler } from './types'
 
 import { LRUCache } from './lru-cache'
 import { createRequestResponseMocks } from './mock-request'
-import { HMR_ACTIONS_SENT_TO_BROWSER } from '../dev/hot-reloader-types'
+import { HMR_MESSAGE_SENT_TO_BROWSER } from '../dev/hot-reloader-types'
 
 /**
  * The DevBundlerService provides an interface to perform tasks with the
@@ -101,7 +101,7 @@ export class DevBundlerService {
       this.appIsrManifestInner.set(key, value)
     }
     this.bundler?.hotReloader?.send({
-      action: HMR_ACTIONS_SENT_TO_BROWSER.ISR_MANIFEST,
+      type: HMR_MESSAGE_SENT_TO_BROWSER.ISR_MANIFEST,
       data: this.appIsrManifest,
     })
   }

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -41,8 +41,8 @@ import { getHostname } from '../../shared/lib/get-hostname'
 import { detectDomainLocale } from '../../shared/lib/i18n/detect-domain-locale'
 import { MockedResponse } from './mock-request'
 import {
-  HMR_ACTIONS_SENT_TO_BROWSER,
-  type AppIsrManifestAction,
+  HMR_MESSAGE_SENT_TO_BROWSER,
+  type AppIsrManifestMessage,
 } from '../dev/hot-reloader-types'
 import { normalizedAssetPrefix } from '../../shared/lib/normalized-asset-prefix'
 import { NEXT_PATCH_SYMBOL } from './patch-fetch'
@@ -801,9 +801,9 @@ export async function initialize(opts: {
             (client) => {
               client.send(
                 JSON.stringify({
-                  action: HMR_ACTIONS_SENT_TO_BROWSER.ISR_MANIFEST,
+                  type: HMR_MESSAGE_SENT_TO_BROWSER.ISR_MANIFEST,
                   data: devBundlerService?.appIsrManifest || {},
-                } satisfies AppIsrManifestAction)
+                } satisfies AppIsrManifestMessage)
               )
             }
           )

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -67,7 +67,7 @@ import {
 } from '../../../build/utils'
 import { devPageFiles } from '../../../build/webpack/plugins/next-types-plugin/shared'
 import type { LazyRenderServerInstance } from '../router-server'
-import { HMR_ACTIONS_SENT_TO_BROWSER } from '../../dev/hot-reloader-types'
+import { HMR_MESSAGE_SENT_TO_BROWSER } from '../../dev/hot-reloader-types'
 import { PAGE_TYPES } from '../../../lib/page-types'
 import { createHotReloaderTurbopack } from '../../dev/hot-reloader-turbopack'
 import { generateEncryptionKeyBase64 } from '../../app-render/encryption-utils-server'
@@ -1014,7 +1014,7 @@ async function startWatcher(
 
           // emit the change so clients fetch the update
           hotReloader.send({
-            action: HMR_ACTIONS_SENT_TO_BROWSER.DEV_PAGES_MANIFEST_UPDATE,
+            type: HMR_MESSAGE_SENT_TO_BROWSER.DEV_PAGES_MANIFEST_UPDATE,
             data: [
               {
                 devPagesManifest: true,
@@ -1024,14 +1024,14 @@ async function startWatcher(
 
           addedRoutes.forEach((route) => {
             hotReloader.send({
-              action: HMR_ACTIONS_SENT_TO_BROWSER.ADDED_PAGE,
+              type: HMR_MESSAGE_SENT_TO_BROWSER.ADDED_PAGE,
               data: [route],
             })
           })
 
           removedRoutes.forEach((route) => {
             hotReloader.send({
-              action: HMR_ACTIONS_SENT_TO_BROWSER.REMOVED_PAGE,
+              type: HMR_MESSAGE_SENT_TO_BROWSER.REMOVED_PAGE,
               data: [route],
             })
           })

--- a/turbopack/crates/turbopack-cli/js/src/entry/websocket.ts
+++ b/turbopack/crates/turbopack-cli/js/src/entry/websocket.ts
@@ -3,7 +3,7 @@
 import type { WebSocketMessage } from '@vercel/turbopack-ecmascript-runtime/browser/dev/hmr-client/hmr-client'
 
 let source: WebSocket
-const eventCallbacks: ((msg: WebSocketMessage) => void)[] = []
+const messageCallbacks: ((message: WebSocketMessage) => void)[] = []
 
 // TODO: add timeout again
 // let lastActivity = Date.now()
@@ -19,8 +19,8 @@ function getSocketProtocol(assetPrefix: string): string {
   return protocol === 'http:' ? 'ws' : 'wss'
 }
 
-export function addMessageListener(cb: (msg: WebSocketMessage) => void) {
-  eventCallbacks.push(cb)
+export function addMessageListener(cb: (message: WebSocketMessage) => void) {
+  messageCallbacks.push(cb)
 }
 
 export function sendMessage(data: any) {
@@ -46,7 +46,7 @@ export function connectHMR(options: HMROptions) {
 
     function handleOnline() {
       const connected = { type: 'turbopack-connected' as const }
-      eventCallbacks.forEach((cb) => {
+      messageCallbacks.forEach((cb) => {
         cb(connected)
       })
 
@@ -61,7 +61,7 @@ export function connectHMR(options: HMROptions) {
         type: 'turbopack-message' as const,
         data: JSON.parse(event.data),
       }
-      eventCallbacks.forEach((cb) => {
+      messageCallbacks.forEach((cb) => {
         cb(message)
       })
     }

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-1/input.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-1/input.js
@@ -1,5 +1,5 @@
 let source;
-const eventCallbacks = [];
+const messageCallbacks = [];
 function getSocketProtocol(assetPrefix) {
     let protocol = location.protocol;
     try {
@@ -8,7 +8,7 @@ function getSocketProtocol(assetPrefix) {
     return protocol === "http:" ? "ws" : "wss";
 }
 export function addMessageListener(cb) {
-    eventCallbacks.push(cb);
+    messageCallbacks.push(cb);
 }
 export function sendMessage(data) {
     if (!source || source.readyState !== source.OPEN) return;
@@ -23,7 +23,7 @@ export function connectHMR(options) {
             const connected = {
                 type: "turbopack-connected"
             };
-            eventCallbacks.forEach((cb)=>{
+            messageCallbacks.forEach((cb)=>{
                 cb(connected);
             });
             if (options.log) console.log("[HMR] connected");
@@ -33,7 +33,7 @@ export function connectHMR(options) {
                 type: "turbopack-message",
                 data: JSON.parse(event.data)
             };
-            eventCallbacks.forEach((cb)=>{
+            messageCallbacks.forEach((cb)=>{
                 cb(message);
             });
         }

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-1/output.md
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/failed-1/output.md
@@ -15,12 +15,12 @@ let source;
 ## Item 2: Stmt 1, `VarDeclarator(0)`
 
 ```js
-const eventCallbacks = [];
+const messageCallbacks = [];
 
 ```
 
-- Declares: `eventCallbacks`
-- Write: `eventCallbacks`
+- Declares: `messageCallbacks`
+- Write: `messageCallbacks`
 
 ## Item 3: Stmt 2, `Normal`
 
@@ -43,16 +43,16 @@ function getSocketProtocol(assetPrefix) {
 
 ```js
 export function addMessageListener(cb) {
-    eventCallbacks.push(cb);
+    messageCallbacks.push(cb);
 }
 
 ```
 
 - Hoisted
 - Declares: `addMessageListener`
-- Reads (eventual): `eventCallbacks`
+- Reads (eventual): `messageCallbacks`
 - Write: `addMessageListener`
-- Write (eventual): `eventCallbacks`
+- Write (eventual): `messageCallbacks`
 
 ## Item 5: Stmt 4, `Normal`
 
@@ -82,7 +82,7 @@ export function connectHMR(options) {
             const connected = {
                 type: "turbopack-connected"
             };
-            eventCallbacks.forEach((cb)=>{
+            messageCallbacks.forEach((cb)=>{
                 cb(connected);
             });
             if (options.log) console.log("[HMR] connected");
@@ -92,7 +92,7 @@ export function connectHMR(options) {
                 type: "turbopack-message",
                 data: JSON.parse(event.data)
             };
-            eventCallbacks.forEach((cb)=>{
+            messageCallbacks.forEach((cb)=>{
                 cb(message);
             });
         }
@@ -119,9 +119,9 @@ export function connectHMR(options) {
 
 - Hoisted
 - Declares: `connectHMR`
-- Reads (eventual): `source`, `eventCallbacks`, `getSocketProtocol`
+- Reads (eventual): `source`, `messageCallbacks`, `getSocketProtocol`
 - Write: `connectHMR`
-- Write (eventual): `source`, `eventCallbacks`
+- Write (eventual): `source`, `messageCallbacks`
 
 # Phase 1
 ```mermaid
@@ -249,15 +249,15 @@ export { source as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 1
 ```js
-const eventCallbacks = [];
-export { eventCallbacks as b } from "__TURBOPACK_VAR__" assert {
+const messageCallbacks = [];
+export { messageCallbacks as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
 ## Part 2
 ```js
-import { b as eventCallbacks } from "__TURBOPACK_PART__" assert {
+import { b as messageCallbacks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -1
 };
 import { a as source } from "__TURBOPACK_PART__" assert {
@@ -279,7 +279,7 @@ function connectHMR(options) {
             const connected = {
                 type: "turbopack-connected"
             };
-            eventCallbacks.forEach((cb)=>{
+            messageCallbacks.forEach((cb)=>{
                 cb(connected);
             });
             if (options.log) console.log("[HMR] connected");
@@ -289,7 +289,7 @@ function connectHMR(options) {
                 type: "turbopack-message",
                 data: JSON.parse(event.data)
             };
-            eventCallbacks.forEach((cb)=>{
+            messageCallbacks.forEach((cb)=>{
                 cb(message);
             });
         }
@@ -322,11 +322,11 @@ export { connectHMR as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 3
 ```js
-import { b as eventCallbacks } from "__TURBOPACK_PART__" assert {
+import { b as messageCallbacks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -1
 };
 function addMessageListener(cb) {
-    eventCallbacks.push(cb);
+    messageCallbacks.push(cb);
 }
 export { addMessageListener };
 export { addMessageListener as e } from "__TURBOPACK_VAR__" assert {
@@ -402,15 +402,15 @@ export { source as a } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 1
 ```js
-const eventCallbacks = [];
-export { eventCallbacks as b } from "__TURBOPACK_VAR__" assert {
+const messageCallbacks = [];
+export { messageCallbacks as b } from "__TURBOPACK_VAR__" assert {
     __turbopack_var__: true
 };
 
 ```
 ## Part 2
 ```js
-import { b as eventCallbacks } from "__TURBOPACK_PART__" assert {
+import { b as messageCallbacks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -1
 };
 import { a as source } from "__TURBOPACK_PART__" assert {
@@ -432,7 +432,7 @@ function connectHMR(options) {
             const connected = {
                 type: "turbopack-connected"
             };
-            eventCallbacks.forEach((cb)=>{
+            messageCallbacks.forEach((cb)=>{
                 cb(connected);
             });
             if (options.log) console.log("[HMR] connected");
@@ -442,7 +442,7 @@ function connectHMR(options) {
                 type: "turbopack-message",
                 data: JSON.parse(event.data)
             };
-            eventCallbacks.forEach((cb)=>{
+            messageCallbacks.forEach((cb)=>{
                 cb(message);
             });
         }
@@ -475,11 +475,11 @@ export { connectHMR as d } from "__TURBOPACK_VAR__" assert {
 ```
 ## Part 3
 ```js
-import { b as eventCallbacks } from "__TURBOPACK_PART__" assert {
+import { b as messageCallbacks } from "__TURBOPACK_PART__" assert {
     __turbopack_part__: -1
 };
 function addMessageListener(cb) {
-    eventCallbacks.push(cb);
+    messageCallbacks.push(cb);
 }
 export { addMessageListener };
 export { addMessageListener as e } from "__TURBOPACK_VAR__" assert {


### PR DESCRIPTION
The HMR messages we send through the WebSocket to the browser were inconsistently called `message`, `msg`, `obj`, `payload`, or `action`.

With this PR, we're streamlining the naming to consistently use `message` throughout the codebase. In addition, the discriminating property `action` is renamed to `type`, aligning it with Turbopack's own HMR messages.

As an alternative, I considered naming them `action` instead, but this did not yield the desired consistency across the codebase. Ultimately, I decided to stick with `message` to avoid confusion and maintain alignment with Turbopack's terminology (see `@vercel/turbopack-ecmascript-runtime/browser/dev/hmr-client/hmr-client`).