### PR TITLE
[turbopack] Improve handling of symlink resolution errors in track_glob and read_glob

### DIFF
--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -106,11 +106,11 @@ pub async fn find_pages_structure(
     page_extensions: Vc<Vec<RcStr>>,
     next_mode: Vc<crate::mode::NextMode>,
 ) -> Result<Vc<PagesStructure>> {
-    let pages_root = project_root.join("pages")?.realpath().owned().await?;
+    let pages_root = project_root.join("pages")?.realpath().await?;
     let pages_root = if *pages_root.get_type().await? == FileSystemEntryType::Directory {
         Some(pages_root)
     } else {
-        let src_pages_root = project_root.join("src/pages")?.realpath().owned().await?;
+        let src_pages_root = project_root.join("src/pages")?.realpath().await?;
         if *src_pages_root.get_type().await? == FileSystemEntryType::Directory {
             Some(src_pages_root)
         } else {

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1383,8 +1383,23 @@ impl FileSystemPath {
         self.fs().metadata(self.clone())
     }
 
-    pub fn realpath(&self) -> Vc<FileSystemPath> {
-        self.realpath_with_links().path()
+    // Returns the realpath to the file, resolving all symlinks and reporting an error if the path
+    // is invalid.
+    pub async fn realpath(&self) -> Result<FileSystemPath> {
+        let result = &(*self.realpath_with_links().await?);
+        match &result.path_or_error {
+            Ok(path) => Ok(path.clone()),
+            Err(error) => match error {
+                RealPathResultError::TooManySymlinks => Err(anyhow::anyhow!(
+                    "Symlink {self} leads to too many other symlinks ({} links)",
+                    result.symlinks.len()
+                )),
+                RealPathResultError::CycleDetected => Err(anyhow::anyhow!(
+                    "Symlink {self} is in a symlink loop: {:?}",
+                    result.symlinks
+                )),
+            },
+        }
     }
 
     pub fn rebase(
@@ -1443,16 +1458,14 @@ impl ValueToString for FileSystemPath {
 #[derive(Clone, Debug)]
 #[turbo_tasks::value(shared)]
 pub struct RealPathResult {
-    pub path: FileSystemPath,
+    pub path_or_error: Result<FileSystemPath, RealPathResultError>,
     pub symlinks: Vec<FileSystemPath>,
 }
 
-#[turbo_tasks::value_impl]
-impl RealPathResult {
-    #[turbo_tasks::function]
-    pub fn path(&self) -> Vc<FileSystemPath> {
-        self.path.clone().cell()
-    }
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, NonLocalValue, TraceRawVcs)]
+pub enum RealPathResultError {
+    TooManySymlinks,
+    CycleDetected,
 }
 
 #[derive(Clone, Copy, Debug, DeterministicHash, PartialOrd, Ord)]
@@ -2071,8 +2084,8 @@ pub enum RawDirectoryEntry {
     File,
     Directory,
     Symlink,
+    // Other just means 'not a file, directory, or symlink'
     Other,
-    Error,
 }
 
 #[derive(Hash, Clone, Debug, PartialEq, Eq, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
@@ -2081,7 +2094,7 @@ pub enum DirectoryEntry {
     Directory(FileSystemPath),
     Symlink(FileSystemPath),
     Other(FileSystemPath),
-    Error,
+    Error(RcStr),
 }
 
 impl DirectoryEntry {
@@ -2090,12 +2103,38 @@ impl DirectoryEntry {
     /// `DirectoryEntry::Directory`.
     pub async fn resolve_symlink(self) -> Result<Self> {
         if let DirectoryEntry::Symlink(symlink) = &self {
-            let real_path = symlink.realpath().owned().await?;
-            match *real_path.get_type().await? {
-                FileSystemEntryType::Directory => Ok(DirectoryEntry::Directory(real_path)),
-                FileSystemEntryType::File => Ok(DirectoryEntry::File(real_path)),
-                _ => Ok(self),
-            }
+            let RealPathResult {
+                path_or_error,
+                symlinks,
+            } = &*symlink.realpath_with_links().await?;
+            let real_path = match path_or_error {
+                Ok(path) => path,
+                Err(error) => {
+                    return Ok(DirectoryEntry::Error(match error {
+                        RealPathResultError::TooManySymlinks => format!(
+                            "Symlink {symlink} leads to too many other symlinks ({} links)",
+                            symlinks.len()
+                        )
+                        .into(),
+                        RealPathResultError::CycleDetected => {
+                            format!("Symlink {symlink} is in a symlink loop").into()
+                        }
+                    }));
+                }
+            };
+            Ok(match *real_path.get_type().await? {
+                FileSystemEntryType::Directory => DirectoryEntry::Directory(real_path.clone()),
+                FileSystemEntryType::File => DirectoryEntry::File(real_path.clone()),
+                // Happens if the link is to a non-existent file
+                FileSystemEntryType::NotFound => DirectoryEntry::Error(
+                    format!("Symlink {symlink} points at {real_path} which does not exist").into(),
+                ),
+                FileSystemEntryType::Symlink => bail!(
+                    "Symlink {symlink} points at a symlink but realpath_with_links returned a \
+                     path, this is caused by eventual consistency."
+                ),
+                _ => self,
+            })
         } else {
             Ok(self)
         }
@@ -2107,7 +2146,7 @@ impl DirectoryEntry {
             | DirectoryEntry::Directory(path)
             | DirectoryEntry::Symlink(path)
             | DirectoryEntry::Other(path) => Some(path),
-            DirectoryEntry::Error => None,
+            DirectoryEntry::Error(_) => None,
         }
     }
 }
@@ -2119,6 +2158,7 @@ pub enum FileSystemEntryType {
     File,
     Directory,
     Symlink,
+    /// These would be things like named pipes, sockets, etc.
     Other,
     Error,
 }
@@ -2147,7 +2187,7 @@ impl From<&DirectoryEntry> for FileSystemEntryType {
             DirectoryEntry::Directory(_) => FileSystemEntryType::Directory,
             DirectoryEntry::Symlink(_) => FileSystemEntryType::Symlink,
             DirectoryEntry::Other(_) => FileSystemEntryType::Other,
-            DirectoryEntry::Error => FileSystemEntryType::Error,
+            DirectoryEntry::Error(_) => FileSystemEntryType::Error,
         }
     }
 }
@@ -2165,7 +2205,6 @@ impl From<&RawDirectoryEntry> for FileSystemEntryType {
             RawDirectoryEntry::Directory => FileSystemEntryType::Directory,
             RawDirectoryEntry::Symlink => FileSystemEntryType::Symlink,
             RawDirectoryEntry::Other => FileSystemEntryType::Other,
-            RawDirectoryEntry::Error => FileSystemEntryType::Error,
         }
     }
 }
@@ -2290,7 +2329,6 @@ async fn read_dir(path: FileSystemPath) -> Result<Vc<DirectoryContent>> {
                     RawDirectoryEntry::Directory => DirectoryEntry::Directory(entry_path),
                     RawDirectoryEntry::Symlink => DirectoryEntry::Symlink(entry_path),
                     RawDirectoryEntry::Other => DirectoryEntry::Other(entry_path),
-                    RawDirectoryEntry::Error => DirectoryEntry::Error,
                 };
                 normalized_entries.insert(name.clone(), entry);
             }
@@ -2321,61 +2359,74 @@ async fn get_type(path: FileSystemPath) -> Result<Vc<FileSystemEntryType>> {
 
 #[turbo_tasks::function]
 async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>> {
-    let mut current_vc = path.clone();
+    let mut current_path = path.clone();
     let mut symlinks: IndexSet<FileSystemPath> = IndexSet::new();
     let mut visited: AutoSet<RcStr> = AutoSet::new();
+    let mut error = RealPathResultError::TooManySymlinks;
     // Pick some arbitrary symlink depth limit... similar to the ELOOP logic for realpath(3).
     // SYMLOOP_MAX is 40 for Linux: https://unix.stackexchange.com/q/721724
     for _i in 0..40 {
-        let current = current_vc.clone();
-        if current.is_root() {
+        if current_path.is_root() {
             // fast path
             return Ok(RealPathResult {
-                path: current_vc,
+                path_or_error: Ok(current_path),
                 symlinks: symlinks.into_iter().collect(),
             }
             .cell());
         }
 
-        if !visited.insert(current.path.clone()) {
+        if !visited.insert(current_path.path.clone()) {
+            error = RealPathResultError::CycleDetected;
             break; // we detected a cycle
         }
 
         // see if a parent segment of the path is a symlink and resolve that first
-        let parent = current_vc.parent();
+        let parent = current_path.parent();
         let parent_result = parent.realpath_with_links().owned().await?;
-        let basename = current
+        let basename = current_path
             .path
             .rsplit_once('/')
-            .map_or(current.path.as_str(), |(_, name)| name);
-        if parent_result.path != parent {
-            current_vc = parent_result.path.join(basename)?;
-        }
+            .map_or(current_path.path.as_str(), |(_, name)| name);
         symlinks.extend(parent_result.symlinks);
+        let parent_path = match parent_result.path_or_error {
+            Ok(path) => {
+                if path != parent {
+                    current_path = path.join(basename)?;
+                }
+                path
+            }
+            Err(parent_error) => {
+                error = parent_error;
+                break;
+            }
+        };
 
         // use `get_type` before trying `read_link`, as there's a good chance of a cache hit on
         // `get_type`, and `read_link` isn't the common codepath.
-        if !matches!(*current_vc.get_type().await?, FileSystemEntryType::Symlink) {
+        if !matches!(
+            *current_path.get_type().await?,
+            FileSystemEntryType::Symlink
+        ) {
             return Ok(RealPathResult {
-                path: current_vc,
+                path_or_error: Ok(current_path),
                 symlinks: symlinks.into_iter().collect(), // convert set to vec
             }
             .cell());
         }
 
-        if let LinkContent::Link { target, link_type } = &*current_vc.read_link().await? {
-            symlinks.insert(current_vc.clone());
-            current_vc = if link_type.contains(LinkType::ABSOLUTE) {
-                current_vc.root().owned().await?
+        if let LinkContent::Link { target, link_type } = &*current_path.read_link().await? {
+            symlinks.insert(current_path.clone());
+            current_path = if link_type.contains(LinkType::ABSOLUTE) {
+                current_path.root().owned().await?
             } else {
-                parent_result.path
+                parent_path
             }
             .join(target)?;
         } else {
             // get_type() and read_link() might disagree temporarily due to turbo-tasks
             // eventual consistency or if the file gets invalidated before the directory does
             return Ok(RealPathResult {
-                path: current_vc,
+                path_or_error: Ok(current_path),
                 symlinks: symlinks.into_iter().collect(), // convert set to vec
             }
             .cell());
@@ -2390,7 +2441,7 @@ async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>>
     // Returning the followed symlinks is still important, even if there is an error! Otherwise
     // we may never notice if the symlink loop is fixed.
     Ok(RealPathResult {
-        path,
+        path_or_error: Err(error),
         symlinks: symlinks.into_iter().collect(),
     }
     .cell())

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1389,16 +1389,7 @@ impl FileSystemPath {
         let result = &(*self.realpath_with_links().await?);
         match &result.path_or_error {
             Ok(path) => Ok(path.clone()),
-            Err(error) => match error {
-                RealPathResultError::TooManySymlinks => Err(anyhow::anyhow!(
-                    "Symlink {self} leads to too many other symlinks ({} links)",
-                    result.symlinks.len()
-                )),
-                RealPathResultError::CycleDetected => Err(anyhow::anyhow!(
-                    "Symlink {self} is in a symlink loop: {:?}",
-                    result.symlinks
-                )),
-            },
+            Err(error) => Err(anyhow::anyhow!(error.as_error_message(self, result))),
         }
     }
 
@@ -1462,10 +1453,34 @@ pub struct RealPathResult {
     pub symlinks: Vec<FileSystemPath>,
 }
 
+/// Errors that can occur when resolving a path with symlinks.
+/// Many of these can be transient conditions that might happen when package managers are running.
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, NonLocalValue, TraceRawVcs)]
 pub enum RealPathResultError {
     TooManySymlinks,
     CycleDetected,
+    Invalid,
+    NotFound,
+}
+impl RealPathResultError {
+    /// Formats the error message
+    pub fn as_error_message(&self, orig: &FileSystemPath, result: &RealPathResult) -> String {
+        match self {
+            RealPathResultError::TooManySymlinks => format!(
+                "Symlink {orig} leads to too many other symlinks ({len} links)",
+                len = result.symlinks.len()
+            ),
+            RealPathResultError::CycleDetected => {
+                format!("Symlink {orig} is in a symlink loop: {:?}", result.symlinks)
+            }
+            RealPathResultError::Invalid => {
+                format!("Symlink {orig} is invalid, it points out of the filesystem root")
+            }
+            RealPathResultError::NotFound => {
+                format!("Symlink {orig} is invalid, it points at a file that doesn't exist")
+            }
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, DeterministicHash, PartialOrd, Ord)]
@@ -1631,7 +1646,9 @@ pub enum LinkContent {
     // link because there is only **dist** path in `fn write_link`, and we need the raw path if
     // we want to restore the link value in `fn write_link`
     Link { target: RcStr, link_type: LinkType },
+    // Invalid means the link is invalid it points out of the filesystem root
     Invalid,
+    // The target was not found
     NotFound,
 }
 
@@ -2103,23 +2120,13 @@ impl DirectoryEntry {
     /// `DirectoryEntry::Directory`.
     pub async fn resolve_symlink(self) -> Result<Self> {
         if let DirectoryEntry::Symlink(symlink) = &self {
-            let RealPathResult {
-                path_or_error,
-                symlinks,
-            } = &*symlink.realpath_with_links().await?;
-            let real_path = match path_or_error {
+            let result = &*symlink.realpath_with_links().await?;
+            let real_path = match &result.path_or_error {
                 Ok(path) => path,
                 Err(error) => {
-                    return Ok(DirectoryEntry::Error(match error {
-                        RealPathResultError::TooManySymlinks => format!(
-                            "Symlink {symlink} leads to too many other symlinks ({} links)",
-                            symlinks.len()
-                        )
-                        .into(),
-                        RealPathResultError::CycleDetected => {
-                            format!("Symlink {symlink} is in a symlink loop").into()
-                        }
-                    }));
+                    return Ok(DirectoryEntry::Error(
+                        error.as_error_message(symlink, result).into(),
+                    ));
                 }
             };
             Ok(match *real_path.get_type().await? {
@@ -2359,7 +2366,7 @@ async fn get_type(path: FileSystemPath) -> Result<Vc<FileSystemEntryType>> {
 
 #[turbo_tasks::function]
 async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>> {
-    let mut current_path = path.clone();
+    let mut current_path = path;
     let mut symlinks: IndexSet<FileSystemPath> = IndexSet::new();
     let mut visited: AutoSet<RcStr> = AutoSet::new();
     let mut error = RealPathResultError::TooManySymlinks;
@@ -2414,22 +2421,24 @@ async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>>
             .cell());
         }
 
-        if let LinkContent::Link { target, link_type } = &*current_path.read_link().await? {
-            symlinks.insert(current_path.clone());
-            current_path = if link_type.contains(LinkType::ABSOLUTE) {
-                current_path.root().owned().await?
-            } else {
-                parent_path
+        match &*current_path.read_link().await? {
+            LinkContent::Link { target, link_type } => {
+                symlinks.insert(current_path.clone());
+                current_path = if link_type.contains(LinkType::ABSOLUTE) {
+                    current_path.root().owned().await?
+                } else {
+                    parent_path
+                }
+                .join(target)?;
             }
-            .join(target)?;
-        } else {
-            // get_type() and read_link() might disagree temporarily due to turbo-tasks
-            // eventual consistency or if the file gets invalidated before the directory does
-            return Ok(RealPathResult {
-                path_or_error: Ok(current_path),
-                symlinks: symlinks.into_iter().collect(), // convert set to vec
+            LinkContent::NotFound => {
+                error = RealPathResultError::NotFound;
+                break;
             }
-            .cell());
+            LinkContent::Invalid => {
+                error = RealPathResultError::Invalid;
+                break;
+            }
         }
     }
 

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -209,6 +209,10 @@ async fn track_glob_internal(
                             types.push(path.get_type())
                         }
                     }
+                    // The most likely case of this is actually a sylink resolution error, it is
+                    // fine to ignore since the mere act of attempting to resolve it has triggered
+                    // the ncecessary dependencies.  If this file is actually a dependency we should
+                    // get an error in the actual webpack loader when it reads it.
                     DirectoryEntry::Error(_) => {}
                 }
             }

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -564,7 +564,6 @@ pub mod tests {
     #[cfg(unix)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn dead_symlinks() {
-        crate::register();
         let scratch = tempfile::tempdir().unwrap();
         {
             use std::os::unix::fs::symlink;
@@ -619,6 +618,39 @@ pub mod tests {
             );
 
             anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
+    // Reproduces an issue where a dead symlink would cause a panic when tracking/reading a glob
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn symlink_escapes_fs_root() {
+        let scratch = tempfile::tempdir().unwrap();
+        {
+            use std::os::unix::fs::symlink;
+
+            // Create a simple directory with 1 file and a symlink pointing at a non-existent file
+            let path = scratch.path();
+            let sub = &path.join("sub");
+            create_dir(sub).unwrap();
+            let foo = scratch.path().join("foo.js");
+            File::create_new(&foo).unwrap().write_all(b"foo").unwrap();
+            // put a link in sub that points to a parent file
+            symlink(foo, sub.join("escape.js")).unwrap();
+        }
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        let root: RcStr = scratch.path().join("sub").to_str().unwrap().into();
+        tt.run_once(async {
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(rcstr!("temp"), root));
+            fs.root()
+                .await?
+                .track_glob(Glob::new(rcstr!("*.js"), GlobOptions::default()), false)
+                .await
         })
         .await
         .unwrap();

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -601,10 +601,17 @@ pub mod tests {
             assert_eq!(inner_sub.inner.len(), 0);
             assert_eq!(
                 inner_sub.results,
-                HashMap::from_iter([(
-                    "foo.js".into(),
-                    DirectoryEntry::File(root.join("sub/foo.js")?),
-                )])
+                HashMap::from_iter([
+                    (
+                        "foo.js".into(),
+                        DirectoryEntry::File(root.join("sub/foo.js")?),
+                    ),
+                    // read_glob doesn't resolve symlinks and thus doesn't detect that it is dead
+                    (
+                        "dead_link.js".into(),
+                        DirectoryEntry::Symlink(root.join("sub/dead_link.js")?),
+                    )
+                ])
             );
 
             anyhow::Ok(())

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -99,7 +99,7 @@ async fn read_glob_internal(
                             }
                         }
                     }
-                    DirectoryEntry::Other(_) | DirectoryEntry::Error => continue,
+                    DirectoryEntry::Other(_) | DirectoryEntry::Error(_) => continue,
                 }
             }
         }
@@ -198,9 +198,9 @@ async fn track_glob_internal(
                         }
                     }
                     DirectoryEntry::Symlink(symlink_path) => bail!(
-                        "resolve_symlink_safely() should have resolved all symlinks, but found \
-                         unresolved symlink at path: '{}'. Found path: '{}'. Please report this \
-                         as a bug.",
+                        "resolve_symlink_safely() should have resolved all symlinks or returned \
+                         an error, but found unresolved symlink at path: '{}'. Found path: '{}'. \
+                         Please report this as a bug.",
                         entry_path,
                         symlink_path
                     ),
@@ -209,7 +209,7 @@ async fn track_glob_internal(
                             types.push(path.get_type())
                         }
                     }
-                    DirectoryEntry::Error => {}
+                    DirectoryEntry::Error(_) => {}
                 }
             }
         }
@@ -524,8 +524,6 @@ pub mod tests {
         ));
         let path: RcStr = scratch.path().to_str().unwrap().into();
         tt.run_once(async {
-            use turbo_rcstr::rcstr;
-
             let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(rcstr!("temp"), path));
             let err = fs
                 .root()
@@ -550,6 +548,63 @@ pub mod tests {
             assert_eq!(
                 "'sub/link' is a symlink causes that causes an infinite loop!",
                 format!("{}", err.root_cause())
+            );
+
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
+    // Reproduces an issue where a dead symlink would cause a panic when tracking/reading a glob
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dead_symlinks() {
+        crate::register();
+        let scratch = tempfile::tempdir().unwrap();
+        {
+            use std::os::unix::fs::symlink;
+
+            // Create a simple directory with 1 file and a symlink pointing at a non-existent file
+            let path = scratch.path();
+            let sub = &path.join("sub");
+            create_dir(sub).unwrap();
+            let foo = sub.join("foo.js");
+            File::create_new(&foo).unwrap().write_all(b"foo").unwrap();
+            // put a link in sub that points to a sibling file that doesn't exist
+            symlink(sub.join("doesntexist.js"), sub.join("dead_link.js")).unwrap();
+        }
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        let path: RcStr = scratch.path().to_str().unwrap().into();
+        tt.run_once(async {
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(rcstr!("temp"), path));
+            fs.root()
+                .await?
+                .track_glob(Glob::new(rcstr!("sub/*.js"), GlobOptions::default()), false)
+                .await
+        })
+        .await
+        .unwrap();
+        let path: RcStr = scratch.path().to_str().unwrap().into();
+        tt.run_once(async {
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(DiskFileSystem::new(rcstr!("temp"), path));
+            let root = fs.root().owned().await?;
+            let read_dir = root
+                .read_glob(Glob::new(rcstr!("sub/*.js"), GlobOptions::default()))
+                .await?;
+            assert_eq!(read_dir.results.len(), 0);
+            assert_eq!(read_dir.inner.len(), 1);
+            let inner_sub = &*read_dir.inner.get("sub").unwrap().await?;
+            assert_eq!(inner_sub.inner.len(), 0);
+            assert_eq!(
+                inner_sub.results,
+                HashMap::from_iter([(
+                    "foo.js".into(),
+                    DirectoryEntry::File(root.join("sub/foo.js")?),
+                )])
             );
 
             anyhow::Ok(())

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -125,7 +125,7 @@ async fn dir_references(package_dir: FileSystemPath) -> Result<Vc<ModuleReferenc
                     Ok(path) => {
                         results.insert(path.clone());
                     }
-                    Err(e) => bail!(e.as_error_message(file, &*realpath)),
+                    Err(e) => bail!(e.as_error_message(file, &realpath)),
                 }
             }
             PatternMatch::Directory(..) => {}

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -125,7 +125,7 @@ async fn dir_references(package_dir: FileSystemPath) -> Result<Vc<ModuleReferenc
                     Ok(path) => {
                         results.insert(path.clone());
                     }
-                    Err(e) => bail!("error resolving symlink {file}: {e:?}"),
+                    Err(e) => bail!(e.as_error_message(file, &*realpath)),
                 }
             }
             PatternMatch::Directory(..) => {}

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -1,6 +1,6 @@
 use std::sync::LazyLock;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use regex::Regex;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{FxIndexSet, ResolvedVc, TryJoinIterExt, Vc};
@@ -121,7 +121,12 @@ async fn dir_references(package_dir: FileSystemPath) -> Result<Vc<ModuleReferenc
             PatternMatch::File(_, file) => {
                 let realpath = file.realpath_with_links().await?;
                 results.extend(realpath.symlinks.iter().cloned());
-                results.insert(realpath.path.clone());
+                match &realpath.path_or_error {
+                    Ok(path) => {
+                        results.insert(path.clone());
+                    }
+                    Err(e) => bail!("error resolving symlink {file}: {e:?}"),
+                }
             }
             PatternMatch::Directory(..) => {}
         }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -15,7 +15,7 @@ use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, SliceMap, TaskInput,
     TryJoinIterExt, ValueToString, Vc, trace::TraceRawVcs,
 };
-use turbo_tasks_fs::{FileSystemEntryType, FileSystemPath, RealPathResult};
+use turbo_tasks_fs::{FileSystemEntryType, FileSystemPath};
 use turbo_unix_path::normalize_request;
 
 use self::{
@@ -1172,22 +1172,22 @@ async fn realpath(
     fs_path: &FileSystemPath,
     refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
 ) -> Result<FileSystemPath> {
-    let result = fs_path.realpath_with_links().owned().await?;
+    let result = fs_path.realpath_with_links().await?;
     refs.extend(
         result
             .symlinks
-            .into_iter()
+            .iter()
             .map(|path| async move {
                 Ok(ResolvedVc::upcast(
-                    FileSource::new(path).to_resolved().await?,
+                    FileSource::new(path.clone()).to_resolved().await?,
                 ))
             })
             .try_join()
             .await?,
     );
-    match result.path_or_error {
-        Ok(path) => Ok(path),
-        Err(e) => bail!("error resolving symlink {fs_path}: {e:?}"),
+    match &result.path_or_error {
+        Ok(path) => Ok(path.clone()),
+        Err(e) => bail!(e.as_error_message(fs_path, &result)),
     }
 }
 
@@ -1519,18 +1519,16 @@ pub async fn resolve_raw(
     force_in_lookup_dir: bool,
 ) -> Result<Vc<ResolveResult>> {
     async fn to_result(request: RcStr, path: FileSystemPath) -> Result<Vc<ResolveResult>> {
-        let RealPathResult {
-            path_or_error,
-            symlinks,
-        } = &*path.realpath_with_links().await?;
-        let path = match path_or_error {
+        let result = &*path.realpath_with_links().await?;
+        let path = match &result.path_or_error {
             Ok(path) => path,
-            Err(e) => bail!("error resolving symlink {path}: {e:?}"),
+            Err(e) => bail!(e.as_error_message(&path, result)),
         };
         Ok(*ResolveResult::source_with_affecting_sources(
             RequestKey::new(request),
             ResolvedVc::upcast(FileSource::new(path.clone()).to_resolved().await?),
-            symlinks
+            result
+                .symlinks
                 .iter()
                 .map(|symlink| async move {
                     anyhow::Ok(ResolvedVc::upcast(
@@ -2874,13 +2872,10 @@ async fn resolved(
     query: RcStr,
     fragment: RcStr,
 ) -> Result<Vc<ResolveResult>> {
-    let RealPathResult {
-        path_or_error,
-        symlinks,
-    } = &*fs_path.realpath_with_links().await?;
-    let path = match path_or_error {
+    let result = &*fs_path.realpath_with_links().await?;
+    let path = match &result.path_or_error {
         Ok(path) => path,
-        Err(e) => bail!("error resolving symlink {fs_path}: {e:?}"),
+        Err(e) => bail!(e.as_error_message(&fs_path, result)),
     };
 
     let path_ref = path.clone();
@@ -2925,7 +2920,8 @@ async fn resolved(
                 .to_resolved()
                 .await?,
         ),
-        symlinks
+        result
+            .symlinks
             .iter()
             .map(|symlink| async move {
                 anyhow::Ok(ResolvedVc::upcast(

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1185,7 +1185,10 @@ async fn realpath(
             .try_join()
             .await?,
     );
-    Ok(result.path)
+    match result.path_or_error {
+        Ok(path) => Ok(path),
+        Err(e) => bail!("error resolving symlink {fs_path}: {e:?}"),
+    }
 }
 
 #[turbo_tasks::value(shared)]
@@ -1516,7 +1519,14 @@ pub async fn resolve_raw(
     force_in_lookup_dir: bool,
 ) -> Result<Vc<ResolveResult>> {
     async fn to_result(request: RcStr, path: FileSystemPath) -> Result<Vc<ResolveResult>> {
-        let RealPathResult { path, symlinks } = &*path.realpath_with_links().await?;
+        let RealPathResult {
+            path_or_error,
+            symlinks,
+        } = &*path.realpath_with_links().await?;
+        let path = match path_or_error {
+            Ok(path) => path,
+            Err(e) => bail!("error resolving symlink {path}: {e:?}"),
+        };
         Ok(*ResolveResult::source_with_affecting_sources(
             RequestKey::new(request),
             ResolvedVc::upcast(FileSource::new(path.clone()).to_resolved().await?),
@@ -2864,7 +2874,14 @@ async fn resolved(
     query: RcStr,
     fragment: RcStr,
 ) -> Result<Vc<ResolveResult>> {
-    let RealPathResult { path, symlinks } = &*fs_path.realpath_with_links().await?;
+    let RealPathResult {
+        path_or_error,
+        symlinks,
+    } = &*fs_path.realpath_with_links().await?;
+    let path = match path_or_error {
+        Ok(path) => path,
+        Err(e) => bail!("error resolving symlink {fs_path}: {e:?}"),
+    };
 
     let path_ref = path.clone();
     // Check alias field for path aliases first

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -1847,7 +1847,6 @@ pub async fn read_matches(
                                 prefix.truncate(len)
                             }
                             RawDirectoryEntry::Other => {}
-                            RawDirectoryEntry::Error => {}
                         }
                     }
                 }

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -142,7 +142,7 @@ impl Introspectable for StaticAssetsContentSource {
                             .to_resolved()
                             .await?,
                         ),
-                        DirectoryEntry::Other(_) | DirectoryEntry::Error => {
+                        DirectoryEntry::Other(_) | DirectoryEntry::Error(_) => {
                             todo!("unsupported DirectoryContent variant: {entry:?}")
                         }
                     };

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -126,7 +126,7 @@ async fn resolve_reference_from_dir(
                 }
                 let path: FileSystemPath = match &realpath.path_or_error {
                     Ok(path) => path.clone(),
-                    Err(e) => bail!(e.as_error_message(&file, &*realpath)),
+                    Err(e) => bail!(e.as_error_message(file, &realpath)),
                 };
                 results.push((
                     RequestKey::new(matched_path.clone()),

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -126,7 +126,7 @@ async fn resolve_reference_from_dir(
                 }
                 let path: FileSystemPath = match &realpath.path_or_error {
                     Ok(path) => path.clone(),
-                    Err(e) => bail!("error resolving symlink {file}: {e:?}"),
+                    Err(e) => bail!(e.as_error_message(&file, &*realpath)),
                 };
                 results.push((
                     RequestKey::new(matched_path.clone()),

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
@@ -124,10 +124,14 @@ async fn resolve_reference_from_dir(
                         FileSource::new(symlink.clone()).to_resolved().await?,
                     ));
                 }
+                let path: FileSystemPath = match &realpath.path_or_error {
+                    Ok(path) => path.clone(),
+                    Err(e) => bail!("error resolving symlink {file}: {e:?}"),
+                };
                 results.push((
                     RequestKey::new(matched_path.clone()),
                     ResolvedVc::upcast(
-                        RawModule::new(Vc::upcast(FileSource::new(realpath.path.clone())))
+                        RawModule::new(Vc::upcast(FileSource::new(path)))
                             .to_resolved()
                             .await?,
                     ),

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -187,7 +187,7 @@ pub async fn resolve_node_pre_gyp_files(
                             format!("deps/lib/{key}").into(),
                             Vc::upcast(FileSource::new(match &realpath_with_links.path_or_error {
                                 Ok(path) => path.clone(),
-                                Err(e) => bail!(e.as_error_message(&dylib, &*realpath_with_links)),
+                                Err(e) => bail!(e.as_error_message(dylib, &realpath_with_links)),
                             })),
                         );
                     }

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -1,6 +1,6 @@
 use std::sync::LazyLock;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
@@ -185,7 +185,10 @@ pub async fn resolve_node_pre_gyp_files(
                         }
                         sources.insert(
                             format!("deps/lib/{key}").into(),
-                            Vc::upcast(FileSource::new(realpath_with_links.path.clone())),
+                            Vc::upcast(FileSource::new(match &realpath_with_links.path_or_error {
+                                Ok(path) => path.clone(),
+                                Err(e) => bail!("error resolving symlink {dylib}: {e:?}"),
+                            })),
                         );
                     }
                     _ => {}

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -187,7 +187,7 @@ pub async fn resolve_node_pre_gyp_files(
                             format!("deps/lib/{key}").into(),
                             Vc::upcast(FileSource::new(match &realpath_with_links.path_or_error {
                                 Ok(path) => path.clone(),
-                                Err(e) => bail!("error resolving symlink {dylib}: {e:?}"),
+                                Err(e) => bail!(e.as_error_message(&dylib, &*realpath_with_links)),
                             })),
                         );
                     }


### PR DESCRIPTION
# Improve symlink handling in turbo-tasks-fs

This PR enhances symlink handling in the filesystem layer to better handle error cases and provide more detailed error messages. The key changes include:

- Refactored `realpath_with_links` to return a more structured error instead of silently returning the input path when hitting a resolution error
    - propagate this through the callers
- Improved `DirectoryEntry::Error` to include error messages instead of just signaling an error occurred
- Enhanced `resolve_symlink()` to handle more edge cases like dead symlinks

These changes make the system more robust when dealing with complex symlink scenarios, including symlink loops, dead links, and excessive symlink chains.

A few customers have hit errors where broad tailwind globs cause turbopack to navigate through symlinks that trigger crashes, this is due a a few reasons:
* a symlink pointing at a non-existent file.
* a symlink pointing outside the filesystem root

This can happen with certain package managers and we need to be defensive.  For `track_glob` we just want to track matching files and directories, but we don't want to navigate out of the filesystem so just ignore links that trigger these conditions.

Closes PACK-5383

One interesting thing is that `read_glob` does not resolve symlinks, and therefore doesn't trigger the errors, that behavior is unchanged.