### PR TITLE
fix(ppr): fix prerender info matching for rewritten paths

### DIFF
--- a/test/e2e/app-dir/sub-shell-generation-middleware/app/[first]/[second]/[third]/layout.tsx
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/app/[first]/[second]/[third]/layout.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import SharedComponent from '../../../shared'
+
+export default async function ThirdLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<Record<string, string>>
+}) {
+  const current = await params
+
+  return (
+    <>
+      <pre>{JSON.stringify(current)}</pre>
+      <SharedComponent layout={`/[first]/[second]/[third]`} />
+      <Suspense>{children}</Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/sub-shell-generation-middleware/app/[first]/[second]/[third]/page.tsx
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/app/[first]/[second]/[third]/page.tsx
@@ -1,0 +1,16 @@
+export default async function NotRewritePage({
+  params,
+}: {
+  params: Promise<{ first: string; second: string; third: string }>
+}) {
+  const { first, second, third } = await params
+  return (
+    <div data-slug={`${first}/${second}/${third}`}>
+      Page /{first}/{second}/{third}
+    </div>
+  )
+}
+
+export async function generateStaticParams() {
+  return [{ first: 'first', second: 'second', third: 'third' }]
+}

--- a/test/e2e/app-dir/sub-shell-generation-middleware/app/[first]/[second]/layout.tsx
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/app/[first]/[second]/layout.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import SharedComponent from '../../shared'
+
+export default async function SecondLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<Record<string, string>>
+}) {
+  const current = await params
+
+  return (
+    <>
+      <pre>{JSON.stringify(current)}</pre>
+      <SharedComponent layout={`/[first]/[second]`} />
+      <Suspense>{children}</Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/sub-shell-generation-middleware/app/[first]/layout.tsx
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/app/[first]/layout.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import SharedComponent from '../shared'
+
+export default async function FirstLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<Record<string, string>>
+}) {
+  const current = await params
+
+  return (
+    <>
+      <pre>{JSON.stringify(current)}</pre>
+      <SharedComponent layout={`/[first]`} />
+      <Suspense>{children}</Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/sub-shell-generation-middleware/app/layout.tsx
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/app/layout.tsx
@@ -1,0 +1,13 @@
+import { type ReactNode, Suspense } from 'react'
+import SharedComponent from './shared'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <SharedComponent layout="/" />
+        <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/sub-shell-generation-middleware/app/page.tsx
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/sub-shell-generation-middleware/app/rewrite/[slug]/layout.tsx
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/app/rewrite/[slug]/layout.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import SharedComponent from '../../shared'
+
+export default async function RewriteSlugLayout({
+  children,
+  params,
+}: {
+  params: Promise<Record<string, string>>
+  children: React.ReactNode
+}) {
+  const current = await params
+
+  return (
+    <>
+      <pre>{JSON.stringify(current)}</pre>
+      <SharedComponent layout={`/rewrite/[slug]`} />
+      <Suspense>{children}</Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/sub-shell-generation-middleware/app/rewrite/[slug]/page.tsx
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/app/rewrite/[slug]/page.tsx
@@ -1,0 +1,12 @@
+export default async function RewritePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <div data-rewrite-slug={slug}>Page /rewrite/{slug}</div>
+}
+
+export async function generateStaticParams() {
+  return []
+}

--- a/test/e2e/app-dir/sub-shell-generation-middleware/app/rewrite/layout.tsx
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/app/rewrite/layout.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import SharedComponent from '../shared'
+
+export default async function RewriteLayout({
+  children,
+  params,
+}: {
+  params: Promise<Record<string, string>>
+  children: React.ReactNode
+}) {
+  const current = await params
+
+  return (
+    <div>
+      <pre>{JSON.stringify(current)}</pre>
+      <SharedComponent layout={`/rewrite`} />
+      <Suspense>{children}</Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/sub-shell-generation-middleware/app/shared.tsx
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/app/shared.tsx
@@ -1,0 +1,19 @@
+const { PHASE_PRODUCTION_BUILD } = require('next/constants')
+
+function getSentinelValue() {
+  return process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
+    ? 'buildtime'
+    : 'runtime'
+}
+
+type Props = {
+  layout: string
+}
+
+export default function SharedComponent({ layout }: Props) {
+  return (
+    <div data-layout={layout} data-sentinel={getSentinelValue()}>
+      SharedComponent {layout} → {getSentinelValue()}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/sub-shell-generation-middleware/middleware.ts
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/middleware.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+export const middleware = (request: NextRequest) => {
+  if (request.nextUrl.pathname.includes('/not-broken')) {
+    const destination = new URL(
+      '/rewrite' + request.nextUrl.pathname + request.nextUrl.search,
+      request.url
+    )
+
+    return NextResponse.rewrite(destination)
+  }
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/not-broken'],
+}

--- a/test/e2e/app-dir/sub-shell-generation-middleware/next.config.js
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/sub-shell-generation-middleware/sub-shell-generation-middleware.test.ts
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/sub-shell-generation-middleware.test.ts
@@ -1,0 +1,167 @@
+import { nextTestSetup } from 'e2e-utils'
+import * as cheerio from 'cheerio'
+import { retry } from 'next-test-utils'
+
+describe('middleware-static-rewrite', () => {
+  const { next, isNextDeploy, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    it.skip('skipping dev test', () => {})
+    return
+  }
+
+  if (
+    process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true' ||
+    process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+  ) {
+    // Here we're validating that the correct fallback shell was used for
+    // rendering.
+    it('should use the correct fallback route', async () => {
+      // First try to load a page that'll use the base fallback route with the
+      // `/[first]/[second]/[third]` fallback.
+      let $ = await next.render$('/first/second/third')
+
+      expect($('[data-slug]').data('slug')).toBe('first/second/third')
+
+      // Get the sentinel value that was generated at build time or runtime.
+      expect($('[data-layout="/"]').data('sentinel')).toBe('buildtime')
+      expect($('[data-layout="/[first]"]').data('sentinel')).toBe('buildtime')
+      expect($('[data-layout="/[first]/[second]"]').data('sentinel')).toBe(
+        'buildtime'
+      )
+      expect(
+        $('[data-layout="/[first]/[second]/[third]"]').data('sentinel')
+      ).toBe('buildtime')
+
+      // Then we try to load a page that'll use the `/first/second/[third]`
+      // fallback.
+      $ = await next.render$('/first/second/not-third')
+
+      expect($('[data-slug]').data('slug')).toBe('first/second/not-third')
+
+      expect($('[data-layout="/"]').data('sentinel')).toBe('buildtime')
+      expect($('[data-layout="/[first]"]').data('sentinel')).toBe('buildtime')
+      expect($('[data-layout="/[first]/[second]"]').data('sentinel')).toBe(
+        'buildtime'
+      )
+      expect(
+        $('[data-layout="/[first]/[second]/[third]"]').data('sentinel')
+      ).toBe('runtime')
+
+      // Then we try to load a page that'll use the `/first/[second]/[third]`
+      $ = await next.render$('/first/not-second/not-third')
+
+      expect($('[data-slug]').data('slug')).toBe('first/not-second/not-third')
+
+      expect($('[data-layout="/"]').data('sentinel')).toBe('buildtime')
+      expect($('[data-layout="/[first]"]').data('sentinel')).toBe('buildtime')
+      expect($('[data-layout="/[first]/[second]"]').data('sentinel')).toBe(
+        'runtime'
+      )
+      expect(
+        $('[data-layout="/[first]/[second]/[third]"]').data('sentinel')
+      ).toBe('runtime')
+
+      // Then we try to load a page that'll use the `/[first]/[second]/[third]`
+      $ = await next.render$('/not-first/not-second/not-third')
+
+      expect($('[data-slug]').data('slug')).toBe(
+        'not-first/not-second/not-third'
+      )
+
+      expect($('[data-layout="/"]').data('sentinel')).toBe('buildtime')
+      expect($('[data-layout="/[first]"]').data('sentinel')).toBe('runtime')
+      expect($('[data-layout="/[first]/[second]"]').data('sentinel')).toBe(
+        'runtime'
+      )
+      expect(
+        $('[data-layout="/[first]/[second]/[third]"]').data('sentinel')
+      ).toBe('runtime')
+    })
+
+    it('should handle middleware rewrites as well', async () => {
+      let res = await next.fetch('/not-broken')
+
+      expect(res.status).toBe(200)
+
+      if (isNextDeploy) {
+        expect(res.headers.get('x-vercel-cache')).toMatch(/MISS|HIT|PRERENDER/)
+      } else {
+        expect(res.headers.get('x-nextjs-cache')).toBe(null)
+      }
+
+      let html = await res.text()
+      let $ = cheerio.load(html)
+
+      expect($('[data-layout="/"]').data('sentinel')).toBe('buildtime')
+      expect($('[data-layout="/rewrite"]').data('sentinel')).toBe('buildtime')
+      expect($('[data-layout="/rewrite/[slug]"]').data('sentinel')).toBe(
+        'runtime'
+      )
+
+      await retry(async () => {
+        res = await next.fetch('/not-broken')
+
+        expect(res.status).toBe(200)
+        if (isNextDeploy) {
+          expect(res.headers.get('x-vercel-cache')).toBe('HIT')
+        } else {
+          expect(res.headers.get('x-nextjs-cache')).toBe(null)
+        }
+      })
+
+      html = await res.text()
+      $ = cheerio.load(html)
+
+      expect($('[data-rewrite-slug]').data('rewrite-slug')).toBe('not-broken')
+
+      expect($('[data-layout="/"]').data('sentinel')).toBe('buildtime')
+      expect($('[data-layout="/rewrite"]').data('sentinel')).toBe('buildtime')
+      expect($('[data-layout="/rewrite/[slug]"]').data('sentinel')).toBe(
+        'runtime'
+      )
+    })
+  } else {
+    // Here we're validating that there is a static page generated for the
+    // rewritten path.
+    it('should eventually result in a cache hit', async () => {
+      let res = await next.fetch('/not-broken')
+
+      expect(res.status).toBe(200)
+      expect(
+        res.headers.get(isNextDeploy ? 'x-vercel-cache' : 'x-nextjs-cache')
+      ).toMatch(/MISS|HIT|PRERENDER/)
+
+      let html = await res.text()
+      let $ = cheerio.load(html)
+
+      expect($('[data-layout="/"]').data('sentinel')).toBe('runtime')
+      expect($('[data-layout="/rewrite"]').data('sentinel')).toBe('runtime')
+      expect($('[data-layout="/rewrite/[slug]"]').data('sentinel')).toBe(
+        'runtime'
+      )
+
+      await retry(async () => {
+        res = await next.fetch('/not-broken')
+
+        expect(res.status).toBe(200)
+        expect(
+          res.headers.get(isNextDeploy ? 'x-vercel-cache' : 'x-nextjs-cache')
+        ).toBe('HIT')
+      })
+
+      html = await res.text()
+      $ = cheerio.load(html)
+
+      expect($('[data-rewrite-slug]').data('rewrite-slug')).toBe('not-broken')
+
+      expect($('[data-layout="/"]').data('sentinel')).toBe('runtime')
+      expect($('[data-layout="/rewrite"]').data('sentinel')).toBe('runtime')
+      expect($('[data-layout="/rewrite/[slug]"]').data('sentinel')).toBe(
+        'runtime'
+      )
+    })
+  }
+})

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -120,6 +120,10 @@ export class NextDeployInstance extends NextInstance {
         cwd: this.testDir,
         env: vercelEnv,
         reject: false,
+        // This will print deployment information earlier to the console so we
+        // don't have to wait until the deployment is complete to get the
+        // inspect URL.
+        stderr: 'inherit',
       }
     )
 


### PR DESCRIPTION
## What?

Fixed prerender info matching for rewritten paths in App Router by using `resolvedPathname` instead of `parsedUrl.pathname` in the app-page template.

## Why?

Previously, the app-page template used `parsedUrl.pathname` to match against `prerenderManifest` routes. However, when middleware rewrites paths, `parsedUrl.pathname` contains the original (unrewritten) path, while `resolvedPathname` contains the actual path that should be used for prerender lookup.

This mismatch caused incorrect prerender behavior for routes that were rewritten by middleware, as the handler would look up prerender info using the wrong path.

This handling is special cased for when not handling an interception route when cache components is not enabled. This work is being tracked in NAR-335.

## How?

- **Modified `packages/next/src/build/templates/app-page.ts`**: 
  - Removed unused `parsedUrl` parameter from handler function
  - Updated prerender info matching to use `resolvedPathname` instead of `parsedUrl.pathname`
  - Added explanatory comment about why `resolvedPathname` is the correct choice

- **Added comprehensive test suite** in `test/e2e/app-dir/sub-shell-generation-middleware/`:
  - Tests various middleware rewrite scenarios
  - Validates sub-shell generation behavior with nested dynamic routes
  - Tests both static and dynamic prerender scenarios
  - Includes middleware that rewrites paths to different route structures

- **Enhanced deploy testing** in `test/lib/next-modes/next-deploy.ts`:
  - Added `stderr: 'inherit'` to provide earlier deployment feedback
  - Improves debugging experience for deployment-related tests

The fix ensures that prerender info lookup works correctly for all paths, whether they're rewritten by middleware or not, providing consistent behavior across different routing scenarios.

Fixes #83354