### PR TITLE
[turbopack] add an experimental feature to enable a whole app module graph

### DIFF
--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -502,9 +502,6 @@ impl PagesProject {
     async fn ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_server_resolve_options_context(
             self.project().project_path().owned().await?,
-            // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
-            // matter (for now at least) because `get_server_resolve_options_context` doesn't
-            // differentiate between the two.
             ServerContextType::Pages {
                 pages_dir: self.pages_dir().owned().await?,
             },
@@ -519,9 +516,6 @@ impl PagesProject {
     async fn edge_ssr_resolve_options_context(self: Vc<Self>) -> Result<Vc<ResolveOptionsContext>> {
         Ok(get_edge_resolve_options_context(
             self.project().project_path().owned().await?,
-            // NOTE(alexkirsz) This could be `PagesData` for the data endpoint, but it doesn't
-            // matter (for now at least) because `get_server_resolve_options_context` doesn't
-            // differentiate between the two.
             ServerContextType::Pages {
                 pages_dir: self.pages_dir().owned().await?,
             },

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1236,7 +1236,12 @@ impl Project {
 
     #[turbo_tasks::function]
     pub(super) async fn per_page_module_graph(&self) -> Result<Vc<bool>> {
-        Ok(Vc::cell(*self.mode.await? == NextMode::Development))
+        Ok(Vc::cell(
+            !*self
+                .next_config
+                .turbo_use_whole_app_module_graph(*self.mode)
+                .await?,
+        ))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -61,8 +61,7 @@ use turbopack_core::{
     file_source::FileSource,
     ident::Layer,
     issue::{
-        CollectibleIssuesExt, Issue, IssueExt, IssueFilter, IssueSeverity, IssueStage,
-        OptionStyledString, StyledString,
+        CollectibleIssuesExt, Issue, IssueExt, IssueFilter, IssueSeverity, IssueStage, StyledString,
     },
     module::Module,
     module_graph::{

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -61,7 +61,8 @@ use turbopack_core::{
     file_source::FileSource,
     ident::Layer,
     issue::{
-        CollectibleIssuesExt, Issue, IssueExt, IssueFilter, IssueSeverity, IssueStage, StyledString,
+        CollectibleIssuesExt, Issue, IssueExt, IssueFilter, IssueSeverity, IssueStage,
+        OptionStyledString, StyledString,
     },
     module::Module,
     module_graph::{
@@ -1530,15 +1531,14 @@ impl Project {
         // In development watch mode, keep issues so individual routes can report them.
         // In non-watch dev mode (e.g. next build --debug-prerender) or production, drop issues
         // so every route doesn't redundantly re-report all shared graph issues.
-        let module_graphs_vc = if !self.next_mode().await?.is_production()
-            && *self.is_watch_enabled().await?
-        {
-            module_graphs_op.connect()
-        } else {
-            let vc = module_graphs_op.resolve().strongly_consistent().await?;
-            module_graphs_op.drop_issues();
-            *vc
-        };
+        let module_graphs_vc =
+            if !self.next_mode().await?.is_production() && *self.is_watch_enabled().await? {
+                module_graphs_op.connect()
+            } else {
+                let vc = module_graphs_op.resolve().strongly_consistent().await?;
+                module_graphs_op.drop_issues();
+                *vc
+            };
         scale_down_node_pool(self).await?;
         Ok(module_graphs_vc)
     }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1527,7 +1527,12 @@ impl Project {
         self: ResolvedVc<Self>,
     ) -> Result<Vc<BaseAndFullModuleGraph>> {
         let module_graphs_op = whole_app_module_graph_operation(self);
-        let module_graphs_vc = if self.next_mode().await?.is_production() {
+        // In development watch mode, keep issues so individual routes can report them.
+        // In non-watch dev mode (e.g. next build --debug-prerender) or production, drop issues
+        // so every route doesn't redundantly re-report all shared graph issues.
+        let module_graphs_vc = if !self.next_mode().await?.is_production()
+            && *self.is_watch_enabled().await?
+        {
             module_graphs_op.connect()
         } else {
             let vc = module_graphs_op.resolve().strongly_consistent().await?;

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2209,7 +2209,7 @@ impl NextConfig {
             NextMode::Development => self
                 .experimental
                 .turbopack_use_whole_app_module_graph_in_dev
-                .unwrap_or(true),
+                .unwrap_or(false),
             NextMode::Build => true,
         }))
     }

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1157,6 +1157,8 @@ pub struct ExperimentalConfig {
     turbopack_server_side_nested_async_chunking: Option<bool>,
     turbopack_import_type_bytes: Option<bool>,
     turbopack_import_type_text: Option<bool>,
+    turbopack_use_system_tls_certs: Option<bool>,
+    turbopack_use_whole_app_module_graph_in_dev: Option<bool>,
     /// Disable automatic configuration of the sass loader.
     #[serde(default)]
     turbopack_use_builtin_sass: Option<bool>,
@@ -2200,6 +2202,25 @@ impl NextConfig {
                 .turbopack_import_type_text
                 .unwrap_or(false),
         )
+    }
+    #[turbo_tasks::function]
+    pub async fn turbo_use_whole_app_module_graph(&self, mode: Vc<NextMode>) -> Result<Vc<bool>> {
+        Ok(Vc::cell(match *mode.await? {
+            NextMode::Development => self
+                .experimental
+                .turbopack_use_whole_app_module_graph_in_dev
+                .unwrap_or(true),
+            NextMode::Build => true,
+        }))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn client_source_maps(&self, mode: Vc<NextMode>) -> Result<Vc<bool>> {
+        let source_maps = self.experimental.turbopack_source_maps;
+        Ok(Vc::cell(source_maps.unwrap_or(match &*mode.await? {
+            NextMode::Development => true,
+            NextMode::Build => self.production_browser_source_maps,
+        })))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2215,15 +2215,6 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn client_source_maps(&self, mode: Vc<NextMode>) -> Result<Vc<bool>> {
-        let source_maps = self.experimental.turbopack_source_maps;
-        Ok(Vc::cell(source_maps.unwrap_or(match &*mode.await? {
-            NextMode::Development => true,
-            NextMode::Build => self.production_browser_source_maps,
-        })))
-    }
-
-    #[turbo_tasks::function]
     pub fn lightningcss_feature_flags(
         &self,
     ) -> Result<Vc<turbopack_css::LightningCssFeatureFlags>> {

--- a/examples/with-turbopack/app/page.tsx
+++ b/examples/with-turbopack/app/page.tsx
@@ -1,6 +1,3 @@
-import { foo } from "./foo";
 export default function Page() {
-  /** @ts-ignore */
-  foo();
   return <h1>Hello, Next.js!</h1>;
 }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -373,6 +373,7 @@ export const experimentalSchema = {
   turbopackModuleIds: z.enum(['named', 'deterministic']).optional(),
   turbopackInferModuleSideEffects: z.boolean().optional(),
   turbopackServerFastRefresh: z.boolean().optional(),
+  turbopackUseWholeAppModuleGraphInDev: z.boolean().optional(),
   optimizePackageImports: z.array(z.string()).optional(),
   optimizeServerReact: z.boolean().optional(),
   strictRouteTypes: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -782,6 +782,12 @@ export interface ExperimentalConfig {
   turbopackServerFastRefresh?: boolean
 
   /**
+   * Whether to compute the whole app module graph in development mode. This may reduce memory usage
+   * by enabling more sharing of chunking decisions across routes.
+   */
+  turbopackUseWholeAppModuleGraphInDev?: boolean
+
+  /**
    * For use with `@next/mdx`. Compile MDX files using the new Rust compiler.
    * @see https://nextjs.org/docs/app/api-reference/next-config-js/mdxRs
    */

--- a/test/development/basic/hmr/whole-app-graph-basic.test.ts
+++ b/test/development/basic/hmr/whole-app-graph-basic.test.ts
@@ -1,0 +1,17 @@
+import { runBasicHmrTest } from './run-basic-hmr-test.util'
+
+const nextConfig = {
+  basePath: '',
+  assetPrefix: '',
+  experimental: {
+    turbopackUseWholeAppModuleGraphInDev: true,
+  },
+}
+
+// Only run for Turbopack since this is a Turbopack-specific feature
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  `HMR - basic with whole app graph, nextConfig: ${JSON.stringify(nextConfig)}`,
+  () => {
+    runBasicHmrTest(nextConfig)
+  }
+)

--- a/test/development/basic/hmr/whole-app-graph-error-recovery.test.ts
+++ b/test/development/basic/hmr/whole-app-graph-error-recovery.test.ts
@@ -1,0 +1,17 @@
+import { runErrorRecoveryHmrTest } from './run-error-recovery-hmr-test.util'
+
+const nextConfig = {
+  basePath: '',
+  assetPrefix: '',
+  experimental: {
+    turbopackUseWholeAppModuleGraphInDev: true,
+  },
+}
+
+// Only run for Turbopack since this is a Turbopack-specific feature
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  `HMR - error recovery with whole app graph, nextConfig: ${JSON.stringify(nextConfig)}`,
+  () => {
+    runErrorRecoveryHmrTest(nextConfig)
+  }
+)

--- a/test/development/basic/hmr/whole-app-graph-full-reload.test.ts
+++ b/test/development/basic/hmr/whole-app-graph-full-reload.test.ts
@@ -1,0 +1,17 @@
+import { runFullReloadHmrTest } from './run-full-reload-hmr-test.util'
+
+const nextConfig = {
+  basePath: '',
+  assetPrefix: '',
+  experimental: {
+    turbopackUseWholeAppModuleGraphInDev: true,
+  },
+}
+
+// Only run for Turbopack since this is a Turbopack-specific feature
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  `HMR - full reload with whole app graph, nextConfig: ${JSON.stringify(nextConfig)}`,
+  () => {
+    runFullReloadHmrTest(nextConfig)
+  }
+)

--- a/test/development/basic/hmr/whole-app-graph-hot-module-reload.test.ts
+++ b/test/development/basic/hmr/whole-app-graph-hot-module-reload.test.ts
@@ -1,0 +1,17 @@
+import { runHotModuleReloadHmrTest } from './run-hot-module-reload-hmr-test.util'
+
+const nextConfig = {
+  basePath: '',
+  assetPrefix: '',
+  experimental: {
+    turbopackUseWholeAppModuleGraphInDev: true,
+  },
+}
+
+// Only run for Turbopack since this is a Turbopack-specific feature
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  `HMR - hot module reload with whole app graph, nextConfig: ${JSON.stringify(nextConfig)}`,
+  () => {
+    runHotModuleReloadHmrTest(nextConfig)
+  }
+)

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -298,6 +298,7 @@ pub struct UnusedReferences(FxHashSet<ResolvedVc<Box<dyn ModuleReference>>>);
 pub trait ChunkingContext {
     #[turbo_tasks::function]
     fn name(self: Vc<Self>) -> Vc<RcStr>;
+    /// Whether to use file URIs in source maps.
     #[turbo_tasks::function]
     fn source_map_source_type(self: Vc<Self>) -> Vc<SourceMapSourceType>;
     /// The root path of the project

--- a/turbopack/crates/turbopack-core/src/issue/module.rs
+++ b/turbopack/crates/turbopack-core/src/issue/module.rs
@@ -62,10 +62,10 @@ impl Issue for ModuleIssue {
 pub async fn emit_unknown_module_type_error(source: Vc<Box<dyn Source>>) -> Result<()> {
     ModuleIssue {ident: source.ident().to_resolved().await?,
         title: StyledString::Text(rcstr!("Unknown module type")).resolved_cell(),
-        description: StyledString::Text(
+        description: StyledString::Text(rcstr!(
             r"This module doesn't have an associated type. Use a known file extension, or register a loader for it.
 
-Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders".into(),
+Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders"),
         )
         .resolved_cell(),
         source: Some(IssueSource::from_source_only(source.to_resolved().await?)),}


### PR DESCRIPTION
In theory this is a memory optimization and development 'load performance' optimization but it comes at the cost of a slower time to first route and impacted HMR times

This exposed a few issues related to development mode differences:
  * PagesData enpoints need to be collected. Done in #84194
  * `/_error` endpoints need to be collected to support fallback errors #85415 

This does not adopt production chunking behavior.  That will be attempted as future work.


On vercel-site i tried this out to see the impact on HMR



....
