### PR TITLE
fix: shrink bottom stack container height

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-bottom-stack/index.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-bottom-stack/index.tsx
@@ -66,7 +66,8 @@ export const styles = `
     place-items: center center;
     width: 100%;
     position: fixed;
-    overflow: hidden;
+    height: 0;
+    overflow: visible;
     z-index: -1;
     max-width: var(--next-dialog-max-width);
 


### PR DESCRIPTION
The bottom stack container was taking extra size even when there's no stacks. This led to unable to close the tab when you click the bottom stack area. Unless you move to a bit more bottom then you can close it.

<img width="600"  alt="image" src="https://github.com/user-attachments/assets/db27892f-9fab-4f21-9b52-6f851de9e5fe" />

Tweak CSS to make sure that area is available to click and close the overlay.

| After | Before |
|:------|:-------|
| <video src="https://github.com/user-attachments/assets/2b193a6f-e57b-44e9-a738-f7e32588f6e8"> | <video src="https://github.com/user-attachments/assets/c662fd1d-9372-4a23-8e22-3ef1ed7be04c"> |

Closes NEXT-4707