### PR TITLE
tests: migrate on-reuqest-error tests to new model

### DIFF
--- a/test/e2e/on-request-error/basic/app/app-route/edge/route.js
+++ b/test/e2e/on-request-error/basic/app/app-route/edge/route.js
@@ -1,6 +1,8 @@
-export function GET() {
+import { connection } from 'next/server'
+
+export async function GET() {
+  await connection()
   throw new Error('route-edge-error')
 }
 
-export const dynamic = 'force-dynamic'
 export const runtime = 'edge'

--- a/test/e2e/on-request-error/basic/app/app-route/route.js
+++ b/test/e2e/on-request-error/basic/app/app-route/route.js
@@ -1,5 +1,6 @@
-export function GET() {
+import { connection } from 'next/server'
+
+export async function GET() {
+  await connection()
   throw new Error('route-node-error')
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/basic/app/client-page/edge/page.js
+++ b/test/e2e/on-request-error/basic/app/client-page/edge/page.js
@@ -1,9 +1,6 @@
 'use client'
 
-import { connection } from 'next/server'
-
 export default async function Page() {
-  await connection()
   if (typeof window === 'undefined') {
     throw new Error('client-page-edge-error')
   }

--- a/test/e2e/on-request-error/basic/app/client-page/edge/page.js
+++ b/test/e2e/on-request-error/basic/app/client-page/edge/page.js
@@ -1,11 +1,13 @@
 'use client'
 
-export default function Page() {
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
   if (typeof window === 'undefined') {
     throw new Error('client-page-edge-error')
   }
   return <div>client-page</div>
 }
 
-export const dynamic = 'force-dynamic'
 export const runtime = 'edge'

--- a/test/e2e/on-request-error/basic/app/client-page/page.js
+++ b/test/e2e/on-request-error/basic/app/client-page/page.js
@@ -1,9 +1,6 @@
 'use client'
 
-import { connection } from 'next/server'
-
 export default async function Page() {
-  await connection()
   if (typeof window === 'undefined') {
     throw new Error('client-page-node-error')
   }

--- a/test/e2e/on-request-error/basic/app/client-page/page.js
+++ b/test/e2e/on-request-error/basic/app/client-page/page.js
@@ -1,10 +1,11 @@
 'use client'
 
-export default function Page() {
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
   if (typeof window === 'undefined') {
     throw new Error('client-page-node-error')
   }
   return <div>client-page</div>
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/basic/app/layout.js
+++ b/test/e2e/on-request-error/basic/app/layout.js
@@ -1,9 +1,10 @@
-export default function Layout({ children }) {
+import { connection } from 'next/server'
+
+export default async function Layout({ children }) {
+  await connection()
   return (
     <html>
       <body>{children}</body>
     </html>
   )
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/basic/app/server-page/edge/page.js
+++ b/test/e2e/on-request-error/basic/app/server-page/edge/page.js
@@ -1,6 +1,8 @@
-export default function Page() {
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
   throw new Error('server-page-edge-error')
 }
 
-export const dynamic = 'force-dynamic'
 export const runtime = 'edge'

--- a/test/e2e/on-request-error/basic/app/server-page/page.js
+++ b/test/e2e/on-request-error/basic/app/server-page/page.js
@@ -1,5 +1,6 @@
-export default function Page() {
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
   throw new Error('server-page-node-error')
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/dynamic-routes/app/app-page/dynamic/[id]/page.js
+++ b/test/e2e/on-request-error/dynamic-routes/app/app-page/dynamic/[id]/page.js
@@ -1,5 +1,6 @@
-export default function Page() {
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
   throw new Error('server-dynamic-page-node-error')
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/dynamic-routes/app/app-page/suspense/page.js
+++ b/test/e2e/on-request-error/dynamic-routes/app/app-page/suspense/page.js
@@ -1,6 +1,8 @@
+import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export default function Page() {
+export default async function Page() {
+  await connection()
   return (
     <Suspense>
       <Inner />
@@ -14,5 +16,3 @@ function Inner() {
   }
   return 'inner'
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/dynamic-routes/app/app-route/dynamic/[id]/route.js
+++ b/test/e2e/on-request-error/dynamic-routes/app/app-route/dynamic/[id]/route.js
@@ -1,5 +1,6 @@
-export function GET() {
+import { connection } from 'next/server'
+
+export async function GET() {
+  await connection()
   throw new Error('server-dynamic-route-node-error')
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/server-action-error/app/client/callback/edge/page.js
+++ b/test/e2e/on-request-error/server-action-error/app/client/callback/edge/page.js
@@ -1,10 +1,8 @@
 'use client'
 
-import { connection } from 'next/server'
 import { serverLog } from '../../actions'
 
-export default async function Page() {
-  await connection()
+export default function Page() {
   return (
     <div>
       <button onClick={() => serverLog('callback:edge')}>Log to server</button>

--- a/test/e2e/on-request-error/server-action-error/app/client/callback/edge/page.js
+++ b/test/e2e/on-request-error/server-action-error/app/client/callback/edge/page.js
@@ -1,8 +1,10 @@
 'use client'
 
+import { connection } from 'next/server'
 import { serverLog } from '../../actions'
 
-export default function Page() {
+export default async function Page() {
+  await connection()
   return (
     <div>
       <button onClick={() => serverLog('callback:edge')}>Log to server</button>
@@ -11,4 +13,3 @@ export default function Page() {
 }
 
 export const runtime = 'edge'
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/server-action-error/app/client/callback/page.js
+++ b/test/e2e/on-request-error/server-action-error/app/client/callback/page.js
@@ -1,10 +1,8 @@
 'use client'
 
-import { connection } from 'next/server'
 import { serverLog } from '../actions'
 
-export default async function Page() {
-  await connection()
+export default function Page() {
   return (
     <div>
       <button onClick={() => serverLog('callback')}>Log to server</button>

--- a/test/e2e/on-request-error/server-action-error/app/client/callback/page.js
+++ b/test/e2e/on-request-error/server-action-error/app/client/callback/page.js
@@ -1,13 +1,13 @@
 'use client'
 
+import { connection } from 'next/server'
 import { serverLog } from '../actions'
 
-export default function Page() {
+export default async function Page() {
+  await connection()
   return (
     <div>
       <button onClick={() => serverLog('callback')}>Log to server</button>
     </div>
   )
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/server-action-error/app/form-error/edge/page.js
+++ b/test/e2e/on-request-error/server-action-error/app/form-error/edge/page.js
@@ -1,4 +1,7 @@
-export default function Page() {
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
   async function action(formData) {
     'use server'
 
@@ -14,4 +17,3 @@ export default function Page() {
 }
 
 export const runtime = 'edge'
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/server-action-error/app/form-error/page.js
+++ b/test/e2e/on-request-error/server-action-error/app/form-error/page.js
@@ -1,4 +1,7 @@
-export default function Page() {
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
   async function action(formData) {
     'use server'
 
@@ -12,5 +15,3 @@ export default function Page() {
     </form>
   )
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/server-action-error/app/layout.js
+++ b/test/e2e/on-request-error/server-action-error/app/layout.js
@@ -1,9 +1,10 @@
-export default function Layout({ children }) {
+import { connection } from 'next/server'
+
+export default async function Layout({ children }) {
+  await connection()
   return (
     <html>
       <body>{children}</body>
     </html>
   )
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/app-route/not-found/route.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/app-route/not-found/route.js
@@ -1,7 +1,7 @@
+import { connection } from 'next/server'
 import { notFound } from 'next/navigation'
 
-export function GET() {
+export async function GET() {
+  await connection()
   notFound()
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/app-route/redirect/route.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/app-route/redirect/route.js
@@ -1,7 +1,7 @@
+import { connection } from 'next/server'
 import { redirect } from 'next/navigation'
 
-export function GET() {
+export async function GET() {
+  await connection()
   redirect('/another')
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/client/no-ssr/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/client/no-ssr/page.js
@@ -1,11 +1,11 @@
 'use client'
 
+import { connection } from 'next/server'
 import nextDynamic from 'next/dynamic'
 
 const Component = nextDynamic(() => import('./component'))
 
-export default function Page() {
+export default async function Page() {
+  await connection()
   return <Component />
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/client/not-found/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/client/not-found/page.js
@@ -1,9 +1,9 @@
 'use client'
 
+import { connection } from 'next/server'
 import { notFound } from 'next/navigation'
 
-export default function Page() {
+export default async function Page() {
+  await connection()
   notFound()
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/client/redirect/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/client/redirect/page.js
@@ -1,9 +1,9 @@
 'use client'
 
+import { connection } from 'next/server'
 import { redirect } from 'next/navigation'
 
-export default function Page() {
+export default async function Page() {
+  await connection()
   redirect('/another')
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/form/not-found/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/form/not-found/page.js
@@ -1,6 +1,8 @@
+import { connection } from 'next/server'
 import { notFoundAction } from '../action'
 
-export default function Page() {
+export default async function Page() {
+  await connection()
   return (
     <form action={notFoundAction}>
       <input type="hidden" name="payload" value={'payload-value'} />
@@ -8,5 +10,3 @@ export default function Page() {
     </form>
   )
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/form/redirect/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/form/redirect/page.js
@@ -1,6 +1,8 @@
+import { connection } from 'next/server'
 import { redirectAction } from '../action'
 
-export default function Page() {
+export default async function Page() {
+  await connection()
   return (
     <form action={redirectAction}>
       <input type="hidden" name="payload" value={'payload-value'} />
@@ -8,5 +10,3 @@ export default function Page() {
     </form>
   )
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/layout.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/layout.js
@@ -1,9 +1,10 @@
-export default function Layout({ children }) {
+import { connection } from 'next/server'
+
+export default async function Layout({ children }) {
+  await connection()
   return (
     <html>
       <body>{children}</body>
     </html>
   )
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/server/not-found/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/server/not-found/page.js
@@ -1,7 +1,7 @@
+import { connection } from 'next/server'
 import { notFound } from 'next/navigation'
 
-export default function Page() {
+export default async function Page() {
+  await connection()
   notFound()
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/on-request-error/skip-next-internal-error/app/server/redirect/page.js
+++ b/test/e2e/on-request-error/skip-next-internal-error/app/server/redirect/page.js
@@ -1,7 +1,7 @@
+import { connection } from 'next/server'
 import { redirect } from 'next/navigation'
 
-export default function Page() {
+export default async function Page() {
+  await connection()
   redirect('/another')
 }
-
-export const dynamic = 'force-dynamic'


### PR DESCRIPTION
migrate the existing on-request-error tests to cache components model compatible, this is for unblocking the experimental test suite failure on #83343