### PR TITLE
Remove the experimental.devtoolSegmentExplorer flag

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -312,8 +312,6 @@ export function getDefineEnv({
           ),
         }
       : {}),
-    'process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER':
-      !!config.experimental.devtoolSegmentExplorer,
 
     'process.env.__NEXT_BROWSER_DEBUG_INFO_IN_TERMINAL': JSON.stringify(
       config.experimental.browserDebugInfoInTerminal || false

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -550,8 +550,6 @@ export async function handler(
           deploymentId: nextConfig.deploymentId,
           enableTainting: nextConfig.experimental.taint,
           htmlLimitedBots: nextConfig.htmlLimitedBots,
-          devtoolSegmentExplorer:
-            nextConfig.experimental.devtoolSegmentExplorer,
           reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
 
           multiZoneDraftMode,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -149,7 +149,6 @@ async function requestHandler(
       deploymentId: nextConfig.deploymentId,
       enableTainting: nextConfig.experimental.taint,
       htmlLimitedBots: nextConfig.htmlLimitedBots,
-      devtoolSegmentExplorer: nextConfig.experimental.devtoolSegmentExplorer,
       reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
 
       multiZoneDraftMode: false,

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -608,10 +608,7 @@ export default function OuterLayoutRouter({
 
     let segmentBoundaryTriggerNode: React.ReactNode = null
     let segmentViewStateNode: React.ReactNode = null
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER
-    ) {
+    if (process.env.NODE_ENV !== 'production') {
       const { SegmentBoundaryTriggerNode, SegmentViewStateNode } =
         require('../../next-devtools/userspace/app/segment-explorer-node') as typeof import('../../next-devtools/userspace/app/segment-explorer-node')
 

--- a/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/menu/panel-router.tsx
@@ -84,15 +84,14 @@ const MenuPanel = () => {
               value: <ChevronRight />,
               onClick: () => setPanel('turbo-info'),
             },
-        !!process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER &&
-          isAppRouter && {
-            label: 'Route Info',
-            value: <ChevronRight />,
-            onClick: () => setPanel('segment-explorer'),
-            attributes: {
-              'data-segment-explorer': true,
-            },
+        isAppRouter && {
+          label: 'Route Info',
+          value: <ChevronRight />,
+          onClick: () => setPanel('segment-explorer'),
+          attributes: {
+            'data-segment-explorer': true,
           },
+        },
         {
           label: 'Preferences',
           value: <GearIcon />,
@@ -201,7 +200,7 @@ export const PanelRouter = () => {
         </DynamicPanel>
       </PanelRoute>
 
-      {process.env.__NEXT_DEVTOOL_SEGMENT_EXPLORER && isAppRouter && (
+      {isAppRouter && (
         <PanelRoute name="segment-explorer">
           <DynamicPanel
             sharePanelSizeGlobally={false}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4612,7 +4612,7 @@ const getGlobalErrorStyles = async (
       dir,
       globalErrorModule?.[1]
     )
-    if (ctx.renderOpts.devtoolSegmentExplorer && globalErrorModulePath) {
+    if (globalErrorModulePath) {
       const SegmentViewNode = ctx.componentMod.SegmentViewNode
       globalErrorStyles = (
         // This will be rendered next to GlobalError component under ErrorBoundary,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -422,9 +422,7 @@ async function createComponentTreeInternal(
 
   // Resolve the segment param
   const actualSegment = segmentParam ? segmentParam.treeSegment : segment
-  const isSegmentViewEnabled =
-    process.env.NODE_ENV === 'development' &&
-    ctx.renderOpts.devtoolSegmentExplorer
+  const isSegmentViewEnabled = !!ctx.renderOpts.dev
   const dir =
     (process.env.NEXT_RUNTIME === 'edge'
       ? process.env.__NEXT_EDGE_PROJECT_DIR
@@ -1145,9 +1143,7 @@ async function createBoundaryConventionElement({
   styles: React.ReactNode | undefined
   tree: LoaderTree
 }) {
-  const isSegmentViewEnabled =
-    process.env.NODE_ENV === 'development' &&
-    ctx.renderOpts.devtoolSegmentExplorer
+  const isSegmentViewEnabled = !!ctx.renderOpts.dev
   const dir =
     (process.env.NEXT_RUNTIME === 'edge'
       ? process.env.__NEXT_EDGE_PROJECT_DIR

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -183,11 +183,6 @@ export interface RenderOptsPartial {
    * Prerendering those routes would catch any invalid dynamic accesses.
    */
   allowEmptyStaticShell?: boolean
-
-  /**
-   * next config experimental.devtoolSegmentExplorer
-   */
-  devtoolSegmentExplorer?: boolean
 }
 
 export type RenderOpts = LoadComponentsReturnType<AppPageModule> &

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -581,8 +581,6 @@ export default abstract class Server<
       onInstrumentationRequestError:
         this.instrumentationOnRequestError.bind(this),
       reactMaxHeadersLength: this.nextConfig.reactMaxHeadersLength,
-      devtoolSegmentExplorer:
-        this.nextConfig.experimental.devtoolSegmentExplorer,
     }
 
     // Initialize next/config with the environment configuration

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -513,7 +513,6 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
           })
           .optional(),
         globalNotFound: z.boolean().optional(),
-        devtoolSegmentExplorer: z.boolean().optional(),
         browserDebugInfoInTerminal: z
           .union([
             z.boolean(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -925,11 +925,6 @@ export interface ExperimentalConfig {
   globalNotFound?: boolean
 
   /**
-   * Enable segment viewer for the app directory in Next.js DevTools.
-   */
-  devtoolSegmentExplorer?: boolean
-
-  /**
    * Enable debug information to be forwarded from browser to dev server stdout/stderr
    */
   browserDebugInfoInTerminal?:
@@ -1647,7 +1642,6 @@ export const defaultConfig = Object.freeze({
     useCache: undefined,
     slowModuleDetection: undefined,
     globalNotFound: false,
-    devtoolSegmentExplorer: true,
     browserDebugInfoInTerminal: false,
     optimizeRouterScrolling: false,
   },

--- a/test/development/app-dir/segment-explorer-globals/next.config.js
+++ b/test/development/app-dir/segment-explorer-globals/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    devtoolSegmentExplorer: true,
     authInterrupts: true,
     globalNotFound: true,
   },

--- a/test/development/app-dir/segment-explorer/next.config.js
+++ b/test/development/app-dir/segment-explorer/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    devtoolSegmentExplorer: true,
     authInterrupts: true,
   },
 }

--- a/test/e2e/app-dir/detachable-panels/next.config.js
+++ b/test/e2e/app-dir/detachable-panels/next.config.js
@@ -1,10 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  experimental: {
-    devtoolSegmentExplorer: true,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/turbopack/crates/turbopack-ecmascript/tests/benches/app-page-turbo.runtime.prod.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/benches/app-page-turbo.runtime.prod.js
@@ -28191,7 +28191,7 @@ ${e}`),
       }
       if (t.renderOpts.dev) {
         let e = rT(t.renderOpts.dir || '', null == n ? void 0 : n[1])
-        if (t.renderOpts.devtoolSegmentExplorer && e) {
+        if (e) {
           let n = t.componentMod.SegmentViewNode
           r = (0, u.jsx)(
             n,


### PR DESCRIPTION
Since `experimental.devtoolSegmentExplorer` was already the default in 15.5, and we're going to keep it as the default devtool feature in v16. Hence removing the `experimental.devtoolSegmentExplorer` flag