### PR TITLE
test: Refactor edge-runtime-dynamic-code test

### DIFF
--- a/test/integration/edge-runtime-dynamic-code/lib/utils.js
+++ b/test/integration/edge-runtime-dynamic-code/lib/utils.js
@@ -1,11 +1,3 @@
-export const useCases = {
-  eval: 'using-eval',
-  noEval: 'not-using-eval',
-  wasmCompile: 'using-webassembly-compile',
-  wasmInstanciate: 'using-webassembly-instantiate',
-  wasmBufferInstanciate: 'using-webassembly-instantiate-with-buffer',
-}
-
 export async function usingEval() {
   // eslint-disable-next-line no-eval
   return { value: eval('100') }

--- a/test/integration/edge-runtime-dynamic-code/middleware.js
+++ b/test/integration/edge-runtime-dynamic-code/middleware.js
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { useCases, notUsingEval, usingEval } from './lib/utils'
+import { notUsingEval, usingEval } from './lib/utils'
 import {
   usingWebAssemblyCompile,
   usingWebAssemblyInstantiate,
@@ -7,31 +7,33 @@ import {
 } from './lib/wasm'
 
 export async function middleware(request) {
-  if (request.nextUrl.pathname === `/${useCases.eval}`) {
+  if (request.nextUrl.pathname === '/using-eval') {
     return new Response(null, {
       headers: { data: JSON.stringify(await usingEval()) },
     })
   }
 
-  if (request.nextUrl.pathname === `/${useCases.noEval}`) {
+  if (request.nextUrl.pathname === '/not-using-eval') {
     return new Response(null, {
       headers: { data: JSON.stringify(await notUsingEval()) },
     })
   }
 
-  if (request.nextUrl.pathname === `/${useCases.wasmCompile}`) {
+  if (request.nextUrl.pathname === '/using-webassembly-compile') {
     return new Response(null, {
       headers: { data: JSON.stringify(await usingWebAssemblyCompile(9)) },
     })
   }
 
-  if (request.nextUrl.pathname === `/${useCases.wasmInstanciate}`) {
+  if (request.nextUrl.pathname === '/using-webassembly-instantiate') {
     return new Response(null, {
       headers: { data: JSON.stringify(await usingWebAssemblyInstantiate(9)) },
     })
   }
 
-  if (request.nextUrl.pathname === `/${useCases.wasmBufferInstanciate}`) {
+  if (
+    request.nextUrl.pathname === '/using-webassembly-instantiate-with-buffer'
+  ) {
     return new Response(null, {
       headers: {
         data: JSON.stringify(await usingWebAssemblyInstantiateWithBuffer(9)),
@@ -43,5 +45,11 @@ export async function middleware(request) {
 }
 
 export const config = {
-  matcher: Object.values(useCases).map((route) => `/${route}`),
+  matcher: [
+    '/using-eval',
+    '/not-using-eval',
+    '/using-webassembly-compile',
+    '/using-webassembly-instantiate',
+    '/using-webassembly-instantiate-with-buffer',
+  ],
 }

--- a/test/integration/edge-runtime-dynamic-code/pages/api/route.js
+++ b/test/integration/edge-runtime-dynamic-code/pages/api/route.js
@@ -1,4 +1,4 @@
-import { useCases, notUsingEval, usingEval } from '../../lib/utils'
+import { notUsingEval, usingEval } from '../../lib/utils'
 import {
   usingWebAssemblyCompile,
   usingWebAssemblyInstantiate,
@@ -8,19 +8,27 @@ import {
 export default async function handler(request) {
   const useCase = request.nextUrl.searchParams.get('case')
 
-  return Response.json(
-    useCase === useCases.eval
-      ? await usingEval()
-      : useCase === useCases.noEval
-        ? await notUsingEval()
-        : useCase === useCases.wasmCompile
-          ? await usingWebAssemblyCompile(9)
-          : useCase === useCases.wasmInstanciate
-            ? await usingWebAssemblyInstantiate(9)
-            : useCase === useCases.wasmBufferInstanciate
-              ? await usingWebAssemblyInstantiateWithBuffer(9)
-              : { ok: true }
-  )
+  if (useCase === 'using-eval') {
+    return Response.json(await usingEval())
+  }
+
+  if (useCase === 'not-using-eval') {
+    return Response.json(await notUsingEval())
+  }
+
+  if (useCase === 'using-webassembly-compile') {
+    return Response.json(await usingWebAssemblyCompile(9))
+  }
+
+  if (useCase === 'using-webassembly-instantiate') {
+    return Response.json(await usingWebAssemblyInstantiate(9))
+  }
+
+  if (useCase === 'using-webassembly-instantiate-with-buffer') {
+    return Response.json(await usingWebAssemblyInstantiateWithBuffer(9))
+  }
+
+  return Response.json({ ok: true })
 }
 
 export const config = { runtime: 'edge' }

--- a/test/integration/edge-runtime-dynamic-code/test/index.test.js
+++ b/test/integration/edge-runtime-dynamic-code/test/index.test.js
@@ -42,7 +42,7 @@ describe('Page using eval in development mode', () => {
   beforeEach(() => (output = ''))
   afterAll(() => killApp(context.app))
 
-  it('does issue dynamic code evaluation warnings', async () => {
+  it('does not issue dynamic code evaluation warnings', async () => {
     const html = await renderViaHTTP(context.appPort, '/')
     expect(html).toMatch(/>.*?100.*?and.*?100.*?<\//)
     await waitFor(500)
@@ -108,10 +108,10 @@ describe.each([
               isTurbopack
                 ? '' +
                     // TODO(veil): Turbopack duplicates project path
-                    '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/lib/utils.js:11:17)' +
+                    '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/lib/utils.js:3:17)' +
                     '\n    at middleware (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/middleware.js:12:54)' +
-                    '\n   9 | export async function usingEval() {'
-                : '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/lib/utils.js:11:19)' +
+                    '\n  1 | export async function usingEval() {'
+                : '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/lib/utils.js:3:19)' +
                     '\n    at middleware (../../test/integration/edge-runtime-dynamic-code/middleware.js:12:54)' +
                     // Next.js internal frame. Feel free to adjust.
                     // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
@@ -122,12 +122,12 @@ describe.each([
               isTurbopack
                 ? '' +
                     // TODO(veil): Turbopack duplicates project path
-                    '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/lib/utils.js:11:17)' +
-                    '\n    at handler (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/pages/api/route.js:13:24)' +
-                    '\n   9 | export async function usingEval() {'
-                : '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/lib/utils.js:11:19)' +
-                    '\n    at handler (../../test/integration/edge-runtime-dynamic-code/pages/api/route.js:13:24)' +
-                    '\n   9 | export async function usingEval() {'
+                    '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/lib/utils.js:3:17)' +
+                    '\n    at handler (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/pages/api/route.js:12:41)' +
+                    '\n  1 | export async function usingEval() {'
+                : '\n    at usingEval (../../test/integration/edge-runtime-dynamic-code/lib/utils.js:3:19)' +
+                    '\n    at handler (../../test/integration/edge-runtime-dynamic-code/pages/api/route.js:12:41)' +
+                    '\n  1 | export async function usingEval() {'
             )
           }
 
@@ -135,14 +135,14 @@ describe.each([
           if (isTurbopack) {
             expect(output).toContain(
               '' +
-                "\n> 11 |   return { value: eval('100') }" +
-                '\n     |                 ^'
+                "\n> 3 |   return { value: eval('100') }" +
+                '\n    |                 ^'
             )
           } else {
             expect(output).toContain(
               '' +
-                "\n> 11 |   return { value: eval('100') }" +
-                '\n     |                   ^'
+                "\n> 3 |   return { value: eval('100') }" +
+                '\n    |                   ^'
             )
           }
         })
@@ -189,14 +189,12 @@ describe.each([
                 ? '' +
                     // TODO(veil): Turbopack duplicates project path
                     '\n    at usingWebAssemblyCompile (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/lib/wasm.js:22:18)' +
-                    '\n    at handler (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/pages/api/route.js:17:42)' +
+                    '\n    at handler (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/pages/api/route.js:20:55)' +
                     '\n  20 |'
                 : '' +
                     '\n    at usingWebAssemblyCompile (../../test/integration/edge-runtime-dynamic-code/lib/wasm.js:22:24)' +
-                    '\n    at handler (../../test/integration/edge-runtime-dynamic-code/pages/api/route.js:17:42)' +
-                    // Next.js internal frame. Feel free to adjust.
-                    // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-                    '\n    at'
+                    '\n    at handler (../../test/integration/edge-runtime-dynamic-code/pages/api/route.js:20:55)' +
+                    '\n  20 |'
             )
 
             // Turbopack produces incorrect mappings in the sourcemap.
@@ -230,11 +228,11 @@ describe.each([
               isTurbopack
                 ? '' +
                     '\n    at async usingWebAssemblyInstantiateWithBuffer (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/lib/wasm.js:28:24)' +
-                    '\n    at async middleware (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/middleware.js:37:30)' +
+                    '\n    at async middleware (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/middleware.js:39:30)' +
                     '\n  26 |\n'
                 : '' +
                     '\n    at async usingWebAssemblyInstantiateWithBuffer (../../test/integration/edge-runtime-dynamic-code/lib/wasm.js:28:24)' +
-                    '\n    at async middleware (../../test/integration/edge-runtime-dynamic-code/middleware.js:37:30)' +
+                    '\n    at async middleware (../../test/integration/edge-runtime-dynamic-code/middleware.js:39:30)' +
                     // Next.js internal frame. Feel free to adjust.
                     // TODO(veil): https://linear.app/vercel/issue/NDX-464
                     '\n    at '
@@ -250,14 +248,12 @@ describe.each([
                 ? '' +
                     // TODO(veil): Turbopack duplicates project path
                     '\n    at async usingWebAssemblyInstantiateWithBuffer (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/lib/wasm.js:28:24)' +
-                    '\n    at async handler (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/pages/api/route.js:21:17)' +
+                    '\n    at async handler (../../test/integration/edge-runtime-dynamic-code/test/integration/edge-runtime-dynamic-code/pages/api/route.js:28:26)' +
                     '\n  26 |'
                 : '' +
                     '\n    at async usingWebAssemblyInstantiateWithBuffer (../../test/integration/edge-runtime-dynamic-code/lib/wasm.js:28:24)' +
-                    '\n    at async handler (../../test/integration/edge-runtime-dynamic-code/pages/api/route.js:21:17)' +
-                    // Next.js internal frame. Feel free to adjust.
-                    // Not ignore-listed because we're not in an isolated app and Next.js is symlinked so it's not in node_modules
-                    '\n    at'
+                    '\n    at async handler (../../test/integration/edge-runtime-dynamic-code/pages/api/route.js:28:26)' +
+                    '\n  26 |'
             )
             // TODO(veil): Inconsistent cursor position
             expect(stripAnsi(output)).toContain(


### PR DESCRIPTION
This test is about `eval`
But it also used a non-static middleware `matchers` config, which is going to break once we are more strict about this and throw a build error.

Closes PACK-5400