### PR TITLE
Tests: Mirror arguments and environment between `next.build()` and `next.start()`

### DIFF
--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -43,18 +43,7 @@ export class NextStartInstance extends NextInstance {
     }
 
     this._cliOutput = ''
-    const spawnOpts: import('child_process').SpawnOptions = {
-      cwd: this.testDir,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      shell: false,
-      env: {
-        ...process.env,
-        ...this.env,
-        NODE_ENV: this.env.NODE_ENV || ('' as any),
-        PORT: this.forcedPort ?? '0',
-        __NEXT_TEST_MODE: 'e2e',
-      },
-    }
+    const spawnOpts = this.getSpawnOpts()
 
     let startArgs = ['pnpm', 'next', 'start']
 
@@ -183,6 +172,24 @@ export class NextStartInstance extends NextInstance {
     return buildArgs
   }
 
+  private getSpawnOpts(
+    env?: Record<string, string>
+  ): import('child_process').SpawnOptions {
+    return {
+      cwd: this.testDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: false,
+      env: {
+        ...process.env,
+        ...this.env,
+        ...env,
+        NODE_ENV: this.env.NODE_ENV || ('' as any),
+        PORT: this.forcedPort ?? '0',
+        __NEXT_TEST_MODE: 'e2e',
+      },
+    }
+  }
+
   public async build(
     options: { env?: Record<string, string>; args?: string[] } = {}
   ) {
@@ -192,24 +199,12 @@ export class NextStartInstance extends NextInstance {
       )
     }
 
-    const spawnOpts: import('child_process').SpawnOptions = {
-      cwd: this.testDir,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      shell: false,
-      env: {
-        ...process.env,
-        ...this.env,
-        ...options.env,
-        NODE_ENV: this.env.NODE_ENV || ('' as any),
-        PORT: this.forcedPort ?? '0',
-        __NEXT_TEST_MODE: 'e2e',
-      },
-    }
     return new Promise<{
       exitCode: NodeJS.Signals | number | null
       cliOutput: string
     }>((resolve) => {
       const curOutput = this._cliOutput.length
+      const spawnOpts = this.getSpawnOpts(options.env)
       const buildArgs = this.getBuildArgs(options.args)
 
       console.log('running', buildArgs.join(' '))

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -8,7 +8,6 @@ import stripAnsi from 'strip-ansi'
 export class NextStartInstance extends NextInstance {
   private _buildId: string
   private _cliOutput: string = ''
-  private spawnOpts: import('child_process').SpawnOptions
 
   public get buildId() {
     return this._buildId
@@ -44,7 +43,7 @@ export class NextStartInstance extends NextInstance {
     }
 
     this._cliOutput = ''
-    this.spawnOpts = {
+    const spawnOpts: import('child_process').SpawnOptions = {
       cwd: this.testDir,
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: false,
@@ -63,60 +62,30 @@ export class NextStartInstance extends NextInstance {
       },
     }
 
-    let buildArgs = ['pnpm', 'next', 'build']
     let startArgs = ['pnpm', 'next', 'start']
-
-    if (this.buildCommand) {
-      buildArgs = this.buildCommand.split(' ')
-    }
-
-    if (this.buildArgs) {
-      buildArgs.push(...this.buildArgs)
-    }
-
     if (this.startCommand) {
       startArgs = this.startCommand.split(' ')
     }
-
     if (this.startArgs) {
       startArgs.push(...this.startArgs)
     }
-
     if (process.env.NEXT_SKIP_ISOLATE) {
       // without isolation yarn can't be used and pnpm must be used instead
-      if (buildArgs[0] === 'yarn') {
-        buildArgs[0] = 'pnpm'
-      }
       if (startArgs[0] === 'yarn') {
         startArgs[0] = 'pnpm'
       }
     }
 
     if (!options.skipBuild) {
-      console.log('running', buildArgs.join(' '))
-      await new Promise<void>((resolve, reject) => {
-        try {
-          this.childProcess = spawn(
-            buildArgs[0],
-            buildArgs.slice(1),
-            this.spawnOpts
-          )
-          this.handleStdio(this.childProcess)
-          this.childProcess.on('exit', (code, signal) => {
-            this.childProcess = undefined
-            if (code || signal)
-              reject(
-                new Error(
-                  `next build failed with code/signal ${code || signal}`
-                )
-              )
-            else resolve()
-          })
-        } catch (err) {
-          require('console').error(`Failed to run ${buildArgs.join(' ')}`, err)
-          setTimeout(() => process.exit(1), 0)
+      try {
+        const { exitCode } = await this.build()
+        if (exitCode !== 0) {
+          throw new Error(`next build failed with code/signal ${exitCode}`)
         }
-      })
+      } catch (err) {
+        require('console').error(`Failed to run build command`, err)
+        setTimeout(() => process.exit(1), 0)
+      }
 
       this._buildId = (
         await fs
@@ -135,11 +104,7 @@ export class NextStartInstance extends NextInstance {
     console.log('running', startArgs.join(' '))
     await new Promise<void>((resolve, reject) => {
       try {
-        this.childProcess = spawn(
-          startArgs[0],
-          startArgs.slice(1),
-          this.spawnOpts
-        )
+        this.childProcess = spawn(startArgs[0], startArgs.slice(1), spawnOpts)
         this.handleStdio(this.childProcess)
 
         this.childProcess.on('close', (code, signal) => {
@@ -187,7 +152,7 @@ export class NextStartInstance extends NextInstance {
   public async build(
     options: { env?: Record<string, string>; args?: string[] } = {}
   ) {
-    this.spawnOpts = {
+    const spawnOpts: import('child_process').SpawnOptions = {
       cwd: this.testDir,
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: false,
@@ -215,23 +180,25 @@ export class NextStartInstance extends NextInstance {
         buildArgs.push(...options.args)
       }
 
+      if (process.env.NEXT_SKIP_ISOLATE) {
+        // without isolation yarn can't be used and pnpm must be used instead
+        if (buildArgs[0] === 'yarn') {
+          buildArgs[0] = 'pnpm'
+        }
+      }
+
       if (this.childProcess) {
         throw new Error(
-          `can not run export while server is running, use next.stop() first`
+          `can not run build while server is running, use next.stop() first`
         )
       }
 
       console.log('running', buildArgs.join(' '))
 
-      this.childProcess = spawn(
-        buildArgs[0],
-        buildArgs.slice(1),
-        this.spawnOpts
-      )
-      this.handleStdio(this.childProcess)
+      const buildProcess = spawn(buildArgs[0], buildArgs.slice(1), spawnOpts)
+      this.handleStdio(buildProcess)
 
-      this.childProcess.on('exit', (code, signal) => {
-        this.childProcess = undefined
+      buildProcess.on('exit', (code, signal) => {
         resolve({
           exitCode: signal || code,
           cliOutput: this.cliOutput.slice(curOutput),

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -62,22 +62,7 @@ export class NextStartInstance extends NextInstance {
       },
     }
 
-    let buildArgs = ['pnpm', 'next', 'build']
-
-    if (this.buildCommand) {
-      buildArgs = this.buildCommand.split(' ')
-    }
-
-    if (this.buildArgs) {
-      buildArgs.push(...this.buildArgs)
-    }
-
-    if (process.env.NEXT_SKIP_ISOLATE) {
-      // without isolation yarn can't be used and pnpm must be used instead
-      if (buildArgs[0] === 'yarn') {
-        buildArgs[0] = 'pnpm'
-      }
-    }
+    const buildArgs = this.getBuildArgs()
 
     let startArgs = ['pnpm', 'next', 'start']
 
@@ -180,6 +165,31 @@ export class NextStartInstance extends NextInstance {
     })
   }
 
+  private getBuildArgs(args?: string[]) {
+    let buildArgs = ['pnpm', 'next', 'build']
+
+    if (this.buildCommand) {
+      buildArgs = this.buildCommand.split(' ')
+    }
+
+    if (this.buildArgs) {
+      buildArgs.push(...this.buildArgs)
+    }
+
+    if (args) {
+      buildArgs.push(...args)
+    }
+
+    if (process.env.NEXT_SKIP_ISOLATE) {
+      // without isolation yarn can't be used and pnpm must be used instead
+      if (buildArgs[0] === 'yarn') {
+        buildArgs[0] = 'pnpm'
+      }
+    }
+
+    return buildArgs
+  }
+
   public async build(
     options: { env?: Record<string, string>; args?: string[] } = {}
   ) {
@@ -207,22 +217,7 @@ export class NextStartInstance extends NextInstance {
       cliOutput: string
     }>((resolve) => {
       const curOutput = this._cliOutput.length
-      const buildArgs = ['pnpm', 'next', 'build']
-
-      if (this.buildArgs) {
-        buildArgs.push(...this.buildArgs)
-      }
-
-      if (options.args) {
-        buildArgs.push(...options.args)
-      }
-
-      if (process.env.NEXT_SKIP_ISOLATE) {
-        // without isolation yarn can't be used and pnpm must be used instead
-        if (buildArgs[0] === 'yarn') {
-          buildArgs[0] = 'pnpm'
-        }
-      }
+      const buildArgs = this.getBuildArgs(options.args)
 
       console.log('running', buildArgs.join(' '))
 

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -211,6 +211,13 @@ export class NextStartInstance extends NextInstance {
         buildArgs.push(...options.args)
       }
 
+      if (process.env.NEXT_SKIP_ISOLATE) {
+        // without isolation yarn can't be used and pnpm must be used instead
+        if (buildArgs[0] === 'yarn') {
+          buildArgs[0] = 'pnpm'
+        }
+      }
+
       if (this.childProcess) {
         throw new Error(
           `can not run export while server is running, use next.stop() first`

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -183,6 +183,12 @@ export class NextStartInstance extends NextInstance {
   public async build(
     options: { env?: Record<string, string>; args?: string[] } = {}
   ) {
+    if (this.childProcess) {
+      throw new Error(
+        `can not run export while server is running, use next.stop() first`
+      )
+    }
+
     const spawnOpts: import('child_process').SpawnOptions = {
       cwd: this.testDir,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -216,12 +222,6 @@ export class NextStartInstance extends NextInstance {
         if (buildArgs[0] === 'yarn') {
           buildArgs[0] = 'pnpm'
         }
-      }
-
-      if (this.childProcess) {
-        throw new Error(
-          `can not run export while server is running, use next.stop() first`
-        )
       }
 
       console.log('running', buildArgs.join(' '))

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -62,8 +62,6 @@ export class NextStartInstance extends NextInstance {
       },
     }
 
-    const buildArgs = this.getBuildArgs()
-
     let startArgs = ['pnpm', 'next', 'start']
 
     if (this.startCommand) {
@@ -82,6 +80,7 @@ export class NextStartInstance extends NextInstance {
     }
 
     if (!options.skipBuild) {
+      const buildArgs = this.getBuildArgs()
       console.log('running', buildArgs.join(' '))
       await new Promise<void>((resolve, reject) => {
         try {

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -51,13 +51,7 @@ export class NextStartInstance extends NextInstance {
         ...process.env,
         ...this.env,
         NODE_ENV: this.env.NODE_ENV || ('' as any),
-        ...(this.forcedPort
-          ? {
-              PORT: this.forcedPort,
-            }
-          : {
-              PORT: '0',
-            }),
+        PORT: this.forcedPort ?? '0',
         __NEXT_TEST_MODE: 'e2e',
       },
     }
@@ -207,7 +201,7 @@ export class NextStartInstance extends NextInstance {
         ...this.env,
         ...options.env,
         NODE_ENV: '' as any,
-        PORT: this.forcedPort || '0',
+        PORT: this.forcedPort ?? '0',
         __NEXT_TEST_MODE: 'e2e',
       },
     }

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -62,30 +62,56 @@ export class NextStartInstance extends NextInstance {
       },
     }
 
+    let buildArgs = ['pnpm', 'next', 'build']
     let startArgs = ['pnpm', 'next', 'start']
+
+    if (this.buildCommand) {
+      buildArgs = this.buildCommand.split(' ')
+    }
+
+    if (this.buildArgs) {
+      buildArgs.push(...this.buildArgs)
+    }
+
     if (this.startCommand) {
       startArgs = this.startCommand.split(' ')
     }
+
     if (this.startArgs) {
       startArgs.push(...this.startArgs)
     }
+
     if (process.env.NEXT_SKIP_ISOLATE) {
       // without isolation yarn can't be used and pnpm must be used instead
+      if (buildArgs[0] === 'yarn') {
+        buildArgs[0] = 'pnpm'
+      }
       if (startArgs[0] === 'yarn') {
         startArgs[0] = 'pnpm'
       }
     }
 
     if (!options.skipBuild) {
-      try {
-        const { exitCode } = await this.build()
-        if (exitCode !== 0) {
-          throw new Error(`next build failed with code/signal ${exitCode}`)
+      console.log('running', buildArgs.join(' '))
+      await new Promise<void>((resolve, reject) => {
+        try {
+          this.childProcess = spawn(buildArgs[0], buildArgs.slice(1), spawnOpts)
+          this.handleStdio(this.childProcess)
+          this.childProcess.on('exit', (code, signal) => {
+            this.childProcess = undefined
+            if (code || signal)
+              reject(
+                new Error(
+                  `next build failed with code/signal ${code || signal}`
+                )
+              )
+            else resolve()
+          })
+        } catch (err) {
+          require('console').error(`Failed to run ${buildArgs.join(' ')}`, err)
+          setTimeout(() => process.exit(1), 0)
         }
-      } catch (err) {
-        require('console').error(`Failed to run build command`, err)
-        setTimeout(() => process.exit(1), 0)
-      }
+      })
 
       this._buildId = (
         await fs
@@ -180,25 +206,19 @@ export class NextStartInstance extends NextInstance {
         buildArgs.push(...options.args)
       }
 
-      if (process.env.NEXT_SKIP_ISOLATE) {
-        // without isolation yarn can't be used and pnpm must be used instead
-        if (buildArgs[0] === 'yarn') {
-          buildArgs[0] = 'pnpm'
-        }
-      }
-
       if (this.childProcess) {
         throw new Error(
-          `can not run build while server is running, use next.stop() first`
+          `can not run export while server is running, use next.stop() first`
         )
       }
 
       console.log('running', buildArgs.join(' '))
 
-      const buildProcess = spawn(buildArgs[0], buildArgs.slice(1), spawnOpts)
-      this.handleStdio(buildProcess)
+      this.childProcess = spawn(buildArgs[0], buildArgs.slice(1), spawnOpts)
+      this.handleStdio(this.childProcess)
 
-      buildProcess.on('exit', (code, signal) => {
+      this.childProcess.on('exit', (code, signal) => {
+        this.childProcess = undefined
         resolve({
           exitCode: signal || code,
           cliOutput: this.cliOutput.slice(curOutput),

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -63,7 +63,6 @@ export class NextStartInstance extends NextInstance {
     }
 
     let buildArgs = ['pnpm', 'next', 'build']
-    let startArgs = ['pnpm', 'next', 'start']
 
     if (this.buildCommand) {
       buildArgs = this.buildCommand.split(' ')
@@ -72,6 +71,15 @@ export class NextStartInstance extends NextInstance {
     if (this.buildArgs) {
       buildArgs.push(...this.buildArgs)
     }
+
+    if (process.env.NEXT_SKIP_ISOLATE) {
+      // without isolation yarn can't be used and pnpm must be used instead
+      if (buildArgs[0] === 'yarn') {
+        buildArgs[0] = 'pnpm'
+      }
+    }
+
+    let startArgs = ['pnpm', 'next', 'start']
 
     if (this.startCommand) {
       startArgs = this.startCommand.split(' ')
@@ -83,9 +91,6 @@ export class NextStartInstance extends NextInstance {
 
     if (process.env.NEXT_SKIP_ISOLATE) {
       // without isolation yarn can't be used and pnpm must be used instead
-      if (buildArgs[0] === 'yarn') {
-        buildArgs[0] = 'pnpm'
-      }
       if (startArgs[0] === 'yarn') {
         startArgs[0] = 'pnpm'
       }

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -200,7 +200,7 @@ export class NextStartInstance extends NextInstance {
         ...process.env,
         ...this.env,
         ...options.env,
-        NODE_ENV: '' as any,
+        NODE_ENV: this.env.NODE_ENV || ('' as any),
         PORT: this.forcedPort ?? '0',
         __NEXT_TEST_MODE: 'e2e',
       },


### PR DESCRIPTION
## What?

Preparation for swapping the special logic in `start()` to using `build()` directly.

The build() method now respects buildCommand and `NEXT_SKIP_ISOLATE` settings that it previously ignored.

Closes PACK-5403