### PR TITLE
[test] Do not use sandboxes for hydration error tests

### DIFF
--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/bad-nesting/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/bad-nesting/page.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+export default function Page() {
+  return (
+    <p>
+      <span>
+        <span>
+          <span>
+            <span>
+              <p>hello world</p>
+            </span>
+          </span>
+        </span>
+      </span>
+    </p>
+  )
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/div-under-p/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/div-under-p/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+export default function Page() {
+  return (
+    <div>
+      <div>
+        <p>
+          <div>Nested div under p tag</div>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-element-client/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-element-client/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+const isClient = typeof window !== 'undefined'
+
+export default function Mismatch() {
+  return <div className="parent">{isClient && <main className="only" />}</div>
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-element-server/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-element-server/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+const isServer = typeof window === 'undefined'
+
+export default function Mismatch() {
+  return <div className="parent">{isServer && <main className="only" />}</div>
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-node-suspense/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-node-suspense/page.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import React from 'react'
+
+const isClient = typeof window !== 'undefined'
+
+export default function Mismatch() {
+  return (
+    <div className="parent">
+      <React.Suspense fallback={<p>Loading...</p>}>
+        <header className="1" />
+        {isClient && <main className="second" />}
+        <footer className="3" />
+      </React.Suspense>
+    </div>
+  )
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-text-node-client/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-text-node-client/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+const isClient = typeof window !== 'undefined'
+
+export default function Mismatch() {
+  return (
+    <div className="parent">
+      <header className="1" />
+      {isClient && 'second'}
+      <footer className="3" />
+    </div>
+  )
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-text-node-invalid-place/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-text-node-invalid-place/page.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+export default function Page() {
+  return (
+    <table>
+      <tbody>
+        <tr>test</tr>
+      </tbody>
+    </table>
+  )
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-text-node-server/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-text-node-server/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+const isServer = typeof window === 'undefined'
+
+export default function Mismatch() {
+  return <div className="parent">{isServer && 'only'}</div>
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-whitespace-invalid-place/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/extra-whitespace-invalid-place/page.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+export default function Page() {
+  return (
+    <table>
+      {' '}
+      <tbody></tbody>
+    </table>
+  )
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/layout.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/p-under-p/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/p-under-p/page.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export default function Page() {
+  return (
+    <p>
+      <p>Nested p tags</p>
+    </p>
+  )
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/text-mismatch/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/text-mismatch/page.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+const isClient = typeof window !== 'undefined'
+
+export default function Mismatch() {
+  return (
+    <div className="parent">
+      <main className="child">{isClient ? 'client' : 'server'}</main>
+    </div>
+  )
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/tr-under-div/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/tr-under-div/page.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export default function Page() {
+  return (
+    <div>
+      <tr></tr>
+    </div>
+  )
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/use-id/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/use-id/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { useId } from 'react'
+
+export default function Page() {
+  let id = useId()
+
+  return (
+    <div className="parent" data-id={id}>
+      Hello World
+    </div>
+  )
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(extra-attributes)/extra-attributes/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(extra-attributes)/extra-attributes/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'page'
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(extra-attributes)/layout.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(extra-attributes)/layout.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { ReactNode } from 'react'
+
+const isServer = typeof window === 'undefined'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html {...(isServer ? { className: 'server-html' } : undefined)}>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(script-under-html)/layout.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(script-under-html)/layout.tsx
@@ -1,0 +1,14 @@
+import Script from 'next/script'
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+      <Script
+        src="https://example.com/script.js"
+        strategy="beforeInteractive"
+      />
+    </html>
+  )
+}

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(script-under-html)/script-under-html/page.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(script-under-html)/script-under-html/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Hello World</div>
+}

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -1,39 +1,24 @@
 /* eslint-env jest */
-import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { outdent } from 'outdent'
-import { getToastErrorCount, retry } from 'next-test-utils'
+import {
+  assertNoRedbox,
+  getRedboxErrorLink,
+  getToastErrorCount,
+  retry,
+} from 'next-test-utils'
 
 describe('Error overlay for hydration errors in App router', () => {
   const { next, isTurbopack } = nextTestSetup({
-    files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
-    skipStart: true,
+    files: new FileRef(path.join(__dirname, 'fixtures', 'hydration-errors')),
   })
 
   it('includes a React docs link when hydration error does occur', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-            const isClient = typeof window !== 'undefined'
-            export default function Mismatch() {
-              return (
-                <div className="parent">
-                  <main className="child">{isClient ? "client" : "server"}</main>
-                </div>
-              );
-            }
-          `,
-        ],
-      ]),
-      '/',
-      { pushErrorAsConsoleLog: true }
-    )
-    const { browser } = sandbox
+    const browser = await next.browser('/text-mismatch', {
+      pushErrorAsConsoleLog: true,
+    })
+
     const logs = await browser.log()
     expect(logs).toEqual(
       expect.arrayContaining([
@@ -49,40 +34,21 @@ describe('Error overlay for hydration errors in App router', () => {
   })
 
   it('should show correct hydration error when client and server render different text', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-            const isClient = typeof window !== 'undefined'
-            export default function Mismatch() {
-              return (
-                <div className="parent">
-                  <main className="child">{isClient ? "client" : "server"}</main>
-                </div>
-              );
-            }
-          `,
-        ],
-      ])
-    )
-    const { session, browser } = sandbox
+    const browser = await next.browser('/text-mismatch')
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "componentStack": "...
-         <ScrollAndFocusHandler segmentPath={[...]}>
-           <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-             <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-               <LoadingBoundary loading={null}>
-                 <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                   <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<SegmentViewNode>} forbidden={undefined} ...>
+         <RenderFromTemplateContext>
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                           <SegmentViewNode type="page" pagePath="page.js">
+                         <InnerLayoutRouter url="/text-mism..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                           <SegmentViewNode type="page" pagePath="(default)/...">
                              <SegmentTrieNode>
                              <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
                                <Mismatch params={Promise} searchParams={Promise}>
@@ -92,25 +58,26 @@ describe('Error overlay for hydration errors in App router', () => {
      -                               server
                            ...
                          ...
-             ...",
+               ...",
        "description": "Hydration failed because the server rendered text didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
        "environmentLabel": null,
        "label": "Recoverable Error",
-       "source": "app/page.js (6:7) @ Mismatch
-     > 6 |       <main className="child">{isClient ? "client" : "server"}</main>
-         |       ^",
+       "source": "app/(default)/text-mismatch/page.tsx (8:7) @ Mismatch
+     >  8 |       <main className="child">{isClient ? 'client' : 'server'}</main>
+          |       ^",
        "stack": [
          "main <anonymous>",
-         "Mismatch app/page.js (6:7)",
+         "Mismatch app/(default)/text-mismatch/page.tsx (8:7)",
        ],
      }
     `)
-    expect(await session.getRedboxErrorLink()).toMatchInlineSnapshot(
+
+    expect(await getRedboxErrorLink(browser)).toMatchInlineSnapshot(
       `"See more info here: https://nextjs.org/docs/messages/react-hydration-error"`
     )
 
-    await session.patch(
-      'app/page.js',
+    await next.patchFile(
+      'app/(default)/text-mismatch/page.tsx',
       outdent`
       'use client'
       export default function Mismatch() {
@@ -120,49 +87,30 @@ describe('Error overlay for hydration errors in App router', () => {
           </div>
         );
       }
-    `
+    `,
+      async () => {
+        await assertNoRedbox(browser)
+        expect(await browser.elementByCss('.child').text()).toBe('Value')
+      }
     )
-
-    await session.assertNoRedbox()
-
-    expect(await browser.elementByCss('.child').text()).toBe('Value')
   })
 
   it('should show correct hydration error when client renders an extra element', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-            const isClient = typeof window !== 'undefined'
-            export default function Mismatch() {
-              return (
-                <div className="parent">
-                  {isClient && <main className="only" />}
-                </div>
-              );
-            }
-          `,
-        ],
-      ])
-    )
-    const { browser } = sandbox
+    const browser = await next.browser('/extra-element-client')
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "componentStack": "...
-         <ScrollAndFocusHandler segmentPath={[...]}>
-           <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-             <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-               <LoadingBoundary loading={null}>
-                 <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                   <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<SegmentViewNode>} forbidden={undefined} ...>
+         <RenderFromTemplateContext>
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                           <SegmentViewNode type="page" pagePath="page.js">
+                         <InnerLayoutRouter url="/extra-ele..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                           <SegmentViewNode type="page" pagePath="(default)/...">
                              <SegmentTrieNode>
                              <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
                                <Mismatch params={Promise} searchParams={Promise}>
@@ -170,79 +118,58 @@ describe('Error overlay for hydration errors in App router', () => {
      +                             <main className="only">
                            ...
                          ...
-             ...",
+               ...",
        "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
        "environmentLabel": null,
        "label": "Recoverable Error",
-       "source": "app/page.js (6:20) @ Mismatch
-     > 6 |       {isClient && <main className="only" />}
-         |                    ^",
+       "source": "app/(default)/extra-element-client/page.tsx (6:47) @ Mismatch
+     > 6 |   return <div className="parent">{isClient && <main className="only" />}</div>
+         |                                               ^",
        "stack": [
          "main <anonymous>",
-         "Mismatch app/page.js (6:20)",
+         "Mismatch app/(default)/extra-element-client/page.tsx (6:47)",
        ],
      }
     `)
   })
 
   it('should show correct hydration error when extra attributes set on server', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/layout.js',
-          outdent`
-          'use client'
-          const isServer = typeof window === 'undefined'
-          export default function Root({ children }) {
-            return (
-              <html 
-                {...(isServer ? ({ className: 'server-html'}) : undefined)}
-              >
-                <body>{children}</body>
-              </html>
-            )
-          }
-          `,
-        ],
-        ['app/page.js', `export default function Page() { return 'page' }`],
-      ])
-    )
-    const { browser } = sandbox
+    const browser = await next.browser('/extra-attributes')
 
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
          "componentStack": "...
-           <HotReload globalError={[...]} webSocket={WebSocket} staticIndicatorState={{pathname:null, ...}}>
-             <AppDevOverlayErrorBoundary globalError={[...]}>
-               <ReplaySsrOnlyErrors>
-               <DevRootHTTPAccessFallbackBoundary>
-                 <HTTPAccessFallbackBoundary notFound={<NotAllowedRootHTTPFallbackError>}>
-                   <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<NotAllowedRootHTTPFallbackError>} ...>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <Head>
-                         <__next_root_layout_boundary__>
-                           <SegmentViewNode type="layout" pagePath="layout.js">
-                             <SegmentTrieNode>
-                             <script>
-                             <script>
-                             <ClientSegmentRoot Component={function Root} slots={{...}} params={{}}>
-                               <Root params={Promise}>
-                                 <html
-       -                           className="server-html"
-                                 >
-                         ...",
+           <RenderFromTemplateContext>
+             <ScrollAndFocusHandler segmentPath={[...]}>
+               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                   <LoadingBoundary loading={null}>
+                     <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
+                       <HTTPAccessFallbackErrorBoundary pathname="/extra-att..." notFound={<SegmentViewNode>} ...>
+                         <RedirectBoundary>
+                           <RedirectErrorBoundary router={{...}}>
+                             <InnerLayoutRouter url="/extra-att..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                               <SegmentViewNode type="layout" pagePath="(extra-att...">
+                                 <SegmentTrieNode>
+                                 <script>
+                                 <script>
+                                 <ClientSegmentRoot Component={function Root} slots={{...}} params={{}}>
+                                   <Root params={Promise}>
+                                     <html
+       -                               className="server-html"
+                                     >
+                             ...
+                 ...",
          "description": "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Console Error",
-         "source": "app/layout.js (5:5) @ Root
-       > 5 |     <html
-           |     ^",
+         "source": "app/(extra-attributes)/layout.tsx (9:5) @ Root
+       >  9 |     <html {...(isServer ? { className: 'server-html' } : undefined)}>
+            |     ^",
          "stack": [
            "html <anonymous>",
-           "Root app/layout.js (5:5)",
+           "Root app/(extra-attributes)/layout.tsx (9:5)",
          ],
        }
       `)
@@ -250,33 +177,34 @@ describe('Error overlay for hydration errors in App router', () => {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
          "componentStack": "...
-           <HotReload globalError={[...]} webSocket={WebSocket} staticIndicatorState={{pathname:null, ...}}>
-             <AppDevOverlayErrorBoundary globalError={[...]}>
-               <ReplaySsrOnlyErrors>
-               <DevRootHTTPAccessFallbackBoundary>
-                 <HTTPAccessFallbackBoundary notFound={<NotAllowedRootHTTPFallbackError>}>
-                   <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<NotAllowedRootHTTPFallbackError>} ...>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <Head>
-                         <__next_root_layout_boundary__>
-                           <SegmentViewNode type="layout" pagePath="layout.js">
-                             <SegmentTrieNode>
-                             <ClientSegmentRoot Component={function Root} slots={{...}} params={{}}>
-                               <Root params={Promise}>
-                                 <html
-       -                           className="server-html"
-                                 >
-                         ...",
+           <RenderFromTemplateContext>
+             <ScrollAndFocusHandler segmentPath={[...]}>
+               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                   <LoadingBoundary loading={null}>
+                     <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
+                       <HTTPAccessFallbackErrorBoundary pathname="/extra-att..." notFound={<SegmentViewNode>} ...>
+                         <RedirectBoundary>
+                           <RedirectErrorBoundary router={{...}}>
+                             <InnerLayoutRouter url="/extra-att..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                               <SegmentViewNode type="layout" pagePath="(extra-att...">
+                                 <SegmentTrieNode>
+                                 <ClientSegmentRoot Component={function Root} slots={{...}} params={{}}>
+                                   <Root params={Promise}>
+                                     <html
+       -                               className="server-html"
+                                     >
+                             ...
+                 ...",
          "description": "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Console Error",
-         "source": "app/layout.js (5:5) @ Root
-       > 5 |     <html
-           |     ^",
+         "source": "app/(extra-attributes)/layout.tsx (9:5) @ Root
+       >  9 |     <html {...(isServer ? { className: 'server-html' } : undefined)}>
+            |     ^",
          "stack": [
            "html <anonymous>",
-           "Root app/layout.js (5:5)",
+           "Root app/(extra-attributes)/layout.tsx (9:5)",
          ],
        }
       `)
@@ -284,42 +212,21 @@ describe('Error overlay for hydration errors in App router', () => {
   })
 
   it('should show correct hydration error when client renders an extra text node', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-            const isClient = typeof window !== 'undefined'
-            export default function Mismatch() {
-              return (
-                <div className="parent">
-                  <header className="1" />
-                  {isClient && "second"}
-                  <footer className="3" />
-                </div>
-              );
-            }
-          `,
-        ],
-      ])
-    )
-    const { browser } = sandbox
+    const browser = await next.browser('/extra-text-node-client')
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "componentStack": "...
-         <ScrollAndFocusHandler segmentPath={[...]}>
-           <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-             <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-               <LoadingBoundary loading={null}>
-                 <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                   <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<SegmentViewNode>} forbidden={undefined} ...>
+         <RenderFromTemplateContext>
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                           <SegmentViewNode type="page" pagePath="page.js">
+                         <InnerLayoutRouter url="/extra-tex..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                           <SegmentViewNode type="page" pagePath="(default)/...">
                              <SegmentTrieNode>
                              <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
                                <Mismatch params={Promise} searchParams={Promise}>
@@ -330,42 +237,23 @@ describe('Error overlay for hydration errors in App router', () => {
                                    ...
                            ...
                          ...
-             ...",
+               ...",
        "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
        "environmentLabel": null,
        "label": "Recoverable Error",
-       "source": "app/page.js (5:5) @ Mismatch
-     > 5 |     <div className="parent">
-         |     ^",
+       "source": "app/(default)/extra-text-node-client/page.tsx (7:5) @ Mismatch
+     >  7 |     <div className="parent">
+          |     ^",
        "stack": [
          "div <anonymous>",
-         "Mismatch app/page.js (5:5)",
+         "Mismatch app/(default)/extra-text-node-client/page.tsx (7:5)",
        ],
      }
     `)
   })
 
   it('should show correct hydration error when server renders an extra element', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-            const isClient = typeof window !== 'undefined'
-            export default function Mismatch() {
-              return (
-                <div className="parent">
-                  {!isClient && <main className="only" />}
-                </div>
-              );
-            }
-          `,
-        ],
-      ])
-    )
-    const { browser } = sandbox
+    const browser = await next.browser('/extra-element-server')
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
@@ -375,51 +263,35 @@ describe('Error overlay for hydration errors in App router', () => {
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
                  <LoadingBoundary loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<SegmentViewNode>} forbidden={undefined} ...>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                             <SegmentViewNode type="page" pagePath="page.js">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
-                                 <Mismatch params={Promise} searchParams={Promise}>
-                                   <div className="parent">
-     -                               <main className="only">
-                             ...
+                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+                     <RedirectBoundary>
+                       <RedirectErrorBoundary router={{...}}>
+                         <InnerLayoutRouter url="/extra-ele..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                           <SegmentViewNode type="page" pagePath="(default)/...">
+                             <SegmentTrieNode>
+                             <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
+                               <Mismatch params={Promise} searchParams={Promise}>
+                                 <div className="parent">
+     -                             <main className="only">
                            ...
+                         ...
                ...",
        "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
        "environmentLabel": null,
        "label": "Recoverable Error",
-       "source": "app/page.js (5:5) @ Mismatch
-     > 5 |     <div className="parent">
-         |     ^",
+       "source": "app/(default)/extra-element-server/page.tsx (6:10) @ Mismatch
+     > 6 |   return <div className="parent">{isServer && <main className="only" />}</div>
+         |          ^",
        "stack": [
          "div <anonymous>",
-         "Mismatch app/page.js (5:5)",
+         "Mismatch app/(default)/extra-element-server/page.tsx (6:10)",
        ],
      }
     `)
   })
 
   it('should show correct hydration error when server renders an extra text node', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-            const isClient = typeof window !== 'undefined'
-            export default function Mismatch() {
-              return <div className="parent">{!isClient && "only"}</div>;
-            }
-          `,
-        ],
-      ])
-    )
-    const { browser } = sandbox
+    const browser = await next.browser('/extra-text-node-server')
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
@@ -429,56 +301,35 @@ describe('Error overlay for hydration errors in App router', () => {
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
                  <LoadingBoundary loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<SegmentViewNode>} forbidden={undefined} ...>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                             <SegmentViewNode type="page" pagePath="page.js">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
-                                 <Mismatch params={Promise} searchParams={Promise}>
-                                   <div className="parent">
-     -                               only
-                             ...
+                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+                     <RedirectBoundary>
+                       <RedirectErrorBoundary router={{...}}>
+                         <InnerLayoutRouter url="/extra-tex..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                           <SegmentViewNode type="page" pagePath="(default)/...">
+                             <SegmentTrieNode>
+                             <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
+                               <Mismatch params={Promise} searchParams={Promise}>
+                                 <div className="parent">
+     -                             only
                            ...
+                         ...
                ...",
        "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
        "environmentLabel": null,
        "label": "Recoverable Error",
-       "source": "app/page.js (4:10) @ Mismatch
-     > 4 |   return <div className="parent">{!isClient && "only"}</div>;
+       "source": "app/(default)/extra-text-node-server/page.tsx (6:10) @ Mismatch
+     > 6 |   return <div className="parent">{isServer && 'only'}</div>
          |          ^",
        "stack": [
          "div <anonymous>",
-         "Mismatch app/page.js (4:10)",
+         "Mismatch app/(default)/extra-text-node-server/page.tsx (6:10)",
        ],
      }
     `)
   })
 
   it('should show correct hydration error when server renders an extra text node in an invalid place', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-            export default function Page() {
-              return (
-                <table>
-                  <tbody>
-                    <tr>test</tr>
-                  </tbody>
-                </table>
-              )
-            }
-          `,
-        ],
-      ])
-    )
-    const { browser } = sandbox
+    const browser = await next.browser('/extra-text-node-invalid-place')
 
     await retry(async () => {
       expect(await getToastErrorCount(browser)).toBe(2)
@@ -488,15 +339,15 @@ describe('Error overlay for hydration errors in App router', () => {
      [
        {
          "componentStack": "...
-         <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-           <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-             <LoadingBoundary loading={null}>
-               <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                 <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<SegmentViewNode>} forbidden={undefined} ...>
+         <ScrollAndFocusHandler segmentPath={[...]}>
+           <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+             <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+               <LoadingBoundary loading={null}>
+                 <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                    <RedirectBoundary>
                      <RedirectErrorBoundary router={{...}}>
-                       <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                         <SegmentViewNode type="page" pagePath="page.js">
+                       <InnerLayoutRouter url="/extra-tex..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                         <SegmentViewNode type="page" pagePath="(default)/...">
                            <SegmentTrieNode>
                            <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
                              <Page params={Promise} searchParams={Promise}>
@@ -506,17 +357,17 @@ describe('Error overlay for hydration errors in App router', () => {
      >                               test
                          ...
                        ...
-           ...",
+             ...",
          "description": "In HTML, text nodes cannot be a child of <tr>.
      This will cause a hydration error.",
          "environmentLabel": null,
          "label": "Console Error",
-         "source": "app/page.js (6:9) @ Page
-     > 6 |         <tr>test</tr>
-         |         ^",
+         "source": "app/(default)/extra-text-node-invalid-place/page.tsx (7:9) @ Page
+     >  7 |         <tr>test</tr>
+          |         ^",
          "stack": [
            "tr <anonymous>",
-           "Page app/page.js (6:9)",
+           "Page app/(default)/extra-text-node-invalid-place/page.tsx (7:9)",
          ],
        },
        {
@@ -526,29 +377,28 @@ describe('Error overlay for hydration errors in App router', () => {
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
                  <LoadingBoundary loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<SegmentViewNode>} forbidden={undefined} ...>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                             <SegmentViewNode type="page" pagePath="page.js">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                                 <Page params={Promise} searchParams={Promise}>
-     +                             <table>
-     -                             test
-                             ...
+                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+                     <RedirectBoundary>
+                       <RedirectErrorBoundary router={{...}}>
+                         <InnerLayoutRouter url="/extra-tex..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                           <SegmentViewNode type="page" pagePath="(default)/...">
+                             <SegmentTrieNode>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     +                           <table>
+     -                           test
                            ...
+                         ...
                ...",
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Recoverable Error",
-         "source": "app/page.js (4:5) @ Page
-     > 4 |     <table>
+         "source": "app/(default)/extra-text-node-invalid-place/page.tsx (5:5) @ Page
+     > 5 |     <table>
          |     ^",
          "stack": [
            "table <anonymous>",
-           "Page app/page.js (4:5)",
+           "Page app/(default)/extra-text-node-invalid-place/page.tsx (5:5)",
          ],
        },
      ]
@@ -556,26 +406,7 @@ describe('Error overlay for hydration errors in App router', () => {
   })
 
   it('should show correct hydration error when server renders an extra whitespace in an invalid place', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-            export default function Page() {
-              return (
-                <table>
-                  {' '}
-                  <tbody></tbody>
-                </table>
-              )
-            }
-          `,
-        ],
-      ])
-    )
-    const { browser } = sandbox
+    const browser = await next.browser('/extra-whitespace-invalid-place')
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
@@ -585,74 +416,49 @@ describe('Error overlay for hydration errors in App router', () => {
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
                  <LoadingBoundary loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<SegmentViewNode>} forbidden={undefined} ...>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                             <SegmentViewNode type="page" pagePath="page.js">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                                 <Page params={Promise} searchParams={Promise}>
-     >                             <table>
-     >                               {" "}
-                                     ...
-                             ...
+                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+                     <RedirectBoundary>
+                       <RedirectErrorBoundary router={{...}}>
+                         <InnerLayoutRouter url="/extra-whi..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                           <SegmentViewNode type="page" pagePath="(default)/...">
+                             <SegmentTrieNode>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     >                           <table>
+     >                             {" "}
+                                   ...
                            ...
+                         ...
                ...",
        "description": "In HTML, whitespace text nodes cannot be a child of <table>. Make sure you don't have any extra whitespace between tags on each line of your source code.
      This will cause a hydration error.",
        "environmentLabel": null,
        "label": "Console Error",
-       "source": "app/page.js (4:5) @ Page
-     > 4 |     <table>
+       "source": "app/(default)/extra-whitespace-invalid-place/page.tsx (5:5) @ Page
+     > 5 |     <table>
          |     ^",
        "stack": [
          "table <anonymous>",
-         "Page app/page.js (4:5)",
+         "Page app/(default)/extra-whitespace-invalid-place/page.tsx (5:5)",
        ],
      }
     `)
   })
 
   it('should show correct hydration error when client renders an extra node inside Suspense content', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-            import React from "react"
-            const isClient = typeof window !== 'undefined'
-            export default function Mismatch() {
-              return (
-                <div className="parent">
-                  <React.Suspense fallback={<p>Loading...</p>}>
-                    <header className="1" />
-                    {isClient && <main className="second" />}
-                    <footer className="3" />
-                  </React.Suspense>
-                </div>
-              );
-            }
-          `,
-        ],
-      ])
-    )
-    const { browser } = sandbox
+    const browser = await next.browser('/extra-node-suspense')
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "componentStack": "...
-         <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-           <LoadingBoundary loading={null}>
-             <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-               <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<SegmentViewNode>} forbidden={undefined} ...>
+         <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+           <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+             <LoadingBoundary loading={null}>
+               <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                  <RedirectBoundary>
                    <RedirectErrorBoundary router={{...}}>
-                     <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                       <SegmentViewNode type="page" pagePath="page.js">
+                     <InnerLayoutRouter url="/extra-nod..." tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                       <SegmentViewNode type="page" pagePath="(default)/...">
                          <SegmentTrieNode>
                          <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
                            <Mismatch params={Promise} searchParams={Promise}>
@@ -663,73 +469,34 @@ describe('Error overlay for hydration errors in App router', () => {
      -                           <footer className="3">
                                  ...
                        ...
-                     ...",
+                     ...
+           ...",
        "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
        "environmentLabel": null,
        "label": "Recoverable Error",
-       "source": "app/page.js (9:22) @ Mismatch
-     >  9 |         {isClient && <main className="second" />}
+       "source": "app/(default)/extra-node-suspense/page.tsx (12:22) @ Mismatch
+     > 12 |         {isClient && <main className="second" />}
           |                      ^",
        "stack": [
          "main <anonymous>",
-         "Mismatch app/page.js (9:22)",
+         "Mismatch app/(default)/extra-node-suspense/page.tsx (12:22)",
        ],
      }
     `)
   })
 
   it('should not show a hydration error when using `useId` in a client component', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
+    const browser = await next.browser('/use-id', {
+      pushErrorAsConsoleLog: true,
+    })
 
-            import { useId } from "react"
-
-            export default function Page() {
-              let id = useId();
-              return (
-                <div className="parent" data-id={id}>
-                  Hello World
-                </div>
-              );
-            }
-          `,
-        ],
-      ])
-    )
-
-    const { browser } = sandbox
     const logs = await browser.log()
     const errors = logs.filter((x) => x.source === 'error')
     expect(errors).toEqual([])
   })
 
   it('should only show one hydration error when bad nesting happened - p under p', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-
-            export default function Page() {
-              return (
-                <p>
-                  <p>Nested p tags</p>
-                </p>
-              )
-            }
-          `,
-        ],
-      ])
-    )
-
-    const { browser } = sandbox
+    const browser = await next.browser('/p-under-p')
 
     await retry(async () => {
       expect(await getToastErrorCount(browser)).toBe(2)
@@ -744,42 +511,41 @@ describe('Error overlay for hydration errors in App router', () => {
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
                  <LoadingBoundary loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<SegmentViewNode>} forbidden={undefined} ...>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                             <SegmentViewNode type="page" pagePath="page.js">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                                 <Page params={Promise} searchParams={Promise}>
+                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+                     <RedirectBoundary>
+                       <RedirectErrorBoundary router={{...}}>
+                         <InnerLayoutRouter url="/p-under-p" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                           <SegmentViewNode type="page" pagePath="(default)/...">
+                             <SegmentTrieNode>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     >                           <p>
      >                             <p>
-     >                               <p>
-                             ...
                            ...
+                         ...
                ...",
          "description": "In HTML, <p> cannot be a descendant of <p>.
      This will cause a hydration error.",
          "environmentLabel": null,
          "label": "Console Error",
-         "source": "app/page.js (6:7) @ Page
+         "source": "app/(default)/p-under-p/page.tsx (6:7) @ Page
      > 6 |       <p>Nested p tags</p>
          |       ^",
          "stack": [
            "p <anonymous>",
-           "Page app/page.js (6:7)",
+           "Page app/(default)/p-under-p/page.tsx (6:7)",
          ],
        },
        {
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Recoverable Error",
-         "source": "app/page.js (6:7) @ Page
+         "source": "app/(default)/p-under-p/page.tsx (6:7) @ Page
      > 6 |       <p>Nested p tags</p>
          |       ^",
          "stack": [
            "p <anonymous>",
-           "Page app/page.js (6:7)",
+           "Page app/(default)/p-under-p/page.tsx (6:7)",
          ],
        },
      ]
@@ -787,31 +553,7 @@ describe('Error overlay for hydration errors in App router', () => {
   })
 
   it('should only show one hydration error when bad nesting happened - div under p', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-
-            export default function Page() {
-              return (
-                <div>
-                  <div>
-                    <p>
-                      <div>Nested div under p tag</div>
-                    </p>
-                  </div>
-                </div>
-              )
-            }
-          `,
-        ],
-      ])
-    )
-
-    const { browser } = sandbox
+    const browser = await next.browser('/div-under-p')
 
     await retry(async () => {
       expect(await getToastErrorCount(browser)).toBe(2)
@@ -821,15 +563,15 @@ describe('Error overlay for hydration errors in App router', () => {
      [
        {
          "componentStack": "...
-         <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-           <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-             <LoadingBoundary loading={null}>
-               <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                 <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<SegmentViewNode>} forbidden={undefined} ...>
+         <ScrollAndFocusHandler segmentPath={[...]}>
+           <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+             <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+               <LoadingBoundary loading={null}>
+                 <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                    <RedirectBoundary>
                      <RedirectErrorBoundary router={{...}}>
-                       <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                         <SegmentViewNode type="page" pagePath="page.js">
+                       <InnerLayoutRouter url="/div-under-p" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                         <SegmentViewNode type="page" pagePath="(default)/...">
                            <SegmentTrieNode>
                            <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
                              <Page params={Promise} searchParams={Promise}>
@@ -839,29 +581,29 @@ describe('Error overlay for hydration errors in App router', () => {
      >                               <div>
                          ...
                        ...
-           ...",
+             ...",
          "description": "In HTML, <div> cannot be a descendant of <p>.
      This will cause a hydration error.",
          "environmentLabel": null,
          "label": "Console Error",
-         "source": "app/page.js (8:11) @ Page
+         "source": "app/(default)/div-under-p/page.tsx (8:11) @ Page
      >  8 |           <div>Nested div under p tag</div>
           |           ^",
          "stack": [
            "div <anonymous>",
-           "Page app/page.js (8:11)",
+           "Page app/(default)/div-under-p/page.tsx (8:11)",
          ],
        },
        {
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Recoverable Error",
-         "source": "app/page.js (8:11) @ Page
+         "source": "app/(default)/div-under-p/page.tsx (8:11) @ Page
      >  8 |           <div>Nested div under p tag</div>
           |           ^",
          "stack": [
            "div <anonymous>",
-           "Page app/page.js (8:11)",
+           "Page app/(default)/div-under-p/page.tsx (8:11)",
          ],
        },
      ]
@@ -869,22 +611,7 @@ describe('Error overlay for hydration errors in App router', () => {
   })
 
   it('should only show one hydration error when bad nesting happened - div > tr', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-            export default function Page() {
-              return <div><tr></tr></div>
-            }
-          `,
-        ],
-      ])
-    )
-
-    const { browser } = sandbox
+    const browser = await next.browser('/tr-under-div')
 
     await retry(async () => {
       expect(await getToastErrorCount(browser)).toBe(2)
@@ -899,42 +626,41 @@ describe('Error overlay for hydration errors in App router', () => {
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
                  <LoadingBoundary loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<SegmentViewNode>} forbidden={undefined} ...>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                             <SegmentViewNode type="page" pagePath="page.js">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                                 <Page params={Promise} searchParams={Promise}>
-     >                             <div>
-     >                               <tr>
-                             ...
+                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+                     <RedirectBoundary>
+                       <RedirectErrorBoundary router={{...}}>
+                         <InnerLayoutRouter url="/tr-under-div" tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                           <SegmentViewNode type="page" pagePath="(default)/...">
+                             <SegmentTrieNode>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     >                           <div>
+     >                             <tr>
                            ...
+                         ...
                ...",
          "description": "In HTML, <tr> cannot be a child of <div>.
      This will cause a hydration error.",
          "environmentLabel": null,
          "label": "Console Error",
-         "source": "app/page.js (3:15) @ Page
-     > 3 |   return <div><tr></tr></div>
-         |               ^",
+         "source": "app/(default)/tr-under-div/page.tsx (6:7) @ Page
+     > 6 |       <tr></tr>
+         |       ^",
          "stack": [
            "tr <anonymous>",
-           "Page app/page.js (3:15)",
+           "Page app/(default)/tr-under-div/page.tsx (6:7)",
          ],
        },
        {
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Recoverable Error",
-         "source": "app/page.js (3:15) @ Page
-     > 3 |   return <div><tr></tr></div>
-         |               ^",
+         "source": "app/(default)/tr-under-div/page.tsx (6:7) @ Page
+     > 6 |       <tr></tr>
+         |       ^",
          "stack": [
            "tr <anonymous>",
-           "Page app/page.js (3:15)",
+           "Page app/(default)/tr-under-div/page.tsx (6:7)",
          ],
        },
      ]
@@ -942,25 +668,7 @@ describe('Error overlay for hydration errors in App router', () => {
   })
 
   it('should show the highlighted bad nesting html snippet when bad nesting happened', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/page.js',
-          outdent`
-            'use client'
-
-            export default function Page() {
-              return (
-                <p><span><span><span><span><p>hello world</p></span></span></span></span></p>
-              )
-            }
-          `,
-        ],
-      ])
-    )
-
-    const { browser } = sandbox
+    const browser = await next.browser('/bad-nesting')
 
     await retry(async () => {
       expect(await getToastErrorCount(browser)).toBe(3)
@@ -975,34 +683,33 @@ describe('Error overlay for hydration errors in App router', () => {
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
                  <LoadingBoundary loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                     <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<SegmentViewNode>} forbidden={undefined} ...>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
-                             <SegmentViewNode type="page" pagePath="page.js">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
-                                 <Page params={Promise} searchParams={Promise}>
-     >                             <p>
+                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
+                     <RedirectBoundary>
+                       <RedirectErrorBoundary router={{...}}>
+                         <InnerLayoutRouter url="/bad-nesting" tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                           <SegmentViewNode type="page" pagePath="(default)/...">
+                             <SegmentTrieNode>
+                             <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
+                               <Page params={Promise} searchParams={Promise}>
+     >                           <p>
+                                   <span>
                                      <span>
                                        <span>
                                          <span>
-                                           <span>
-     >                                       <p>
-                             ...
+     >                                     <p>
                            ...
+                         ...
                ...",
          "description": "In HTML, <p> cannot be a descendant of <p>.
      This will cause a hydration error.",
          "environmentLabel": null,
          "label": "Console Error",
-         "source": "app/page.js (5:32) @ Page
-     > 5 |     <p><span><span><span><span><p>hello world</p></span></span></span></span></p>
-         |                                ^",
+         "source": "app/(default)/bad-nesting/page.tsx (10:15) @ Page
+     > 10 |               <p>hello world</p>
+          |               ^",
          "stack": [
            "p <anonymous>",
-           "Page app/page.js (5:32)",
+           "Page app/(default)/bad-nesting/page.tsx (10:15)",
          ],
        },
        {
@@ -1010,24 +717,24 @@ describe('Error overlay for hydration errors in App router', () => {
      See this log for the ancestor stack trace.",
          "environmentLabel": null,
          "label": "Console Error",
-         "source": "app/page.js (5:5) @ Page
-     > 5 |     <p><span><span><span><span><p>hello world</p></span></span></span></span></p>
+         "source": "app/(default)/bad-nesting/page.tsx (5:5) @ Page
+     > 5 |     <p>
          |     ^",
          "stack": [
            "p <anonymous>",
-           "Page app/page.js (5:5)",
+           "Page app/(default)/bad-nesting/page.tsx (5:5)",
          ],
        },
        {
          "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Recoverable Error",
-         "source": "app/page.js (5:32) @ Page
-     > 5 |     <p><span><span><span><span><p>hello world</p></span></span></span></span></p>
-         |                                ^",
+         "source": "app/(default)/bad-nesting/page.tsx (10:15) @ Page
+     > 10 |               <p>hello world</p>
+          |               ^",
          "stack": [
            "p <anonymous>",
-           "Page app/page.js (5:32)",
+           "Page app/(default)/bad-nesting/page.tsx (10:15)",
          ],
        },
      ]
@@ -1035,38 +742,7 @@ describe('Error overlay for hydration errors in App router', () => {
   })
 
   it('should show error if script is directly placed under html instead of body', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/layout.js',
-          outdent`
-            import Script from 'next/script'
-
-            export default function Layout({ children }) {
-              return (
-                <html>
-                  <body>{children}</body>
-                  <Script
-                    src="https://example.com/script.js"
-                    strategy="beforeInteractive"
-                  />
-                </html>
-              )
-            }
-          `,
-        ],
-        [
-          'app/page.js',
-          outdent`
-            export default function Page() {
-              return <div>Hello World</div>
-            }
-          `,
-        ],
-      ])
-    )
-    const { browser } = sandbox
+    const browser = await next.browser('/script-under-html')
 
     await retry(async () => {
       expect(await getToastErrorCount(browser)).toBe(
@@ -1082,47 +758,60 @@ describe('Error overlay for hydration errors in App router', () => {
            "description": "Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.",
            "environmentLabel": null,
            "label": "Console Error",
-           "source": "app/layout.js (7:7) @ Layout
-       >  7 |       <Script
+           "source": "app/(script-under-html)/layout.tsx (8:7) @ Root
+       >  8 |       <Script
             |       ^",
            "stack": [
-             "Layout app/layout.js (7:7)",
+             "Root app/(script-under-html)/layout.tsx (8:7)",
            ],
          },
          {
            "componentStack": "...
-           <HotReload globalError={[...]} webSocket={WebSocket} staticIndicatorState={{pathname:null, ...}}>
-             <AppDevOverlayErrorBoundary globalError={[...]}>
-               <ReplaySsrOnlyErrors>
-               <DevRootHTTPAccessFallbackBoundary>
-                 <HTTPAccessFallbackBoundary notFound={<NotAllowedRootHTTPFallbackError>}>
-                   <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<NotAllowedRootHTTPFallbackError>} ...>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <Head>
-                         <__next_root_layout_boundary__>
-                           <SegmentViewNode type="layout" pagePath="layout.js">
-                             <SegmentTrieNode>
-                             <script>
-                             <script>
-                             <Layout>
-                               <NotFound>
-                                 <HTTPAccessErrorFallback>
-       >                           <html>
-                                     <body>
-                                     <Script src="https://ex..." strategy="beforeInte...">
-       >                               <script nonce={undefined} dangerouslySetInnerHTML={{__html:"(self.__ne..."}}>
-                         ...",
+           <RenderFromTemplateContext>
+             <ScrollAndFocusHandler segmentPath={[...]}>
+               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                   <LoadingBoundary loading={null}>
+                     <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
+                       <HTTPAccessFallbackErrorBoundary pathname="/script-un..." notFound={<SegmentViewNode>} ...>
+                         <RedirectBoundary>
+                           <RedirectErrorBoundary router={{...}}>
+                             <InnerLayoutRouter url="/script-un..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                               <SegmentViewNode type="layout" pagePath="(script-un...">
+                                 <SegmentTrieNode>
+                                 <script>
+                                 <script>
+                                 <Root>
+                                   <NotFound>
+                                     <HTTPAccessErrorFallback>
+                                       <NotFound>
+                                         <HTTPAccessErrorFallback>
+                                           <NotFound>
+                                             <HTTPAccessErrorFallback>
+                                               <NotFound>
+                                                 <HTTPAccessErrorFallback>
+                                                   <NotFound>
+                                                     <HTTPAccessErrorFallback>
+       >                                               <html>
+                                                         <body>
+                                                         <Script src="https://ex..." strategy="beforeInte...">
+       >                                                   <script
+       >                                                     nonce={undefined}
+       >                                                     dangerouslySetInnerHTML={{__html:"(self.__ne..."}}
+       >                                                   >
+                             ...
+                 ...
+           ...",
            "description": "In HTML, <script> cannot be a child of <html>.
        This will cause a hydration error.",
            "environmentLabel": null,
            "label": "Console Error",
-           "source": "app/layout.js (7:7) @ Layout
-       >  7 |       <Script
+           "source": "app/(script-under-html)/layout.tsx (8:7) @ Root
+       >  8 |       <Script
             |       ^",
            "stack": [
              "script <anonymous>",
-             "Layout app/layout.js (7:7)",
+             "Root app/(script-under-html)/layout.tsx (8:7)",
            ],
          },
          {
@@ -1130,12 +819,12 @@ describe('Error overlay for hydration errors in App router', () => {
        See this log for the ancestor stack trace.",
            "environmentLabel": null,
            "label": "Console Error",
-           "source": "app/layout.js (5:5) @ Layout
-       > 5 |     <html>
+           "source": "app/(script-under-html)/layout.tsx (6:5) @ Root
+       > 6 |     <html>
            |     ^",
            "stack": [
              "html <anonymous>",
-             "Layout app/layout.js (5:5)",
+             "Root app/(script-under-html)/layout.tsx (6:5)",
            ],
          },
        ]
@@ -1147,45 +836,58 @@ describe('Error overlay for hydration errors in App router', () => {
            "description": "Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.",
            "environmentLabel": null,
            "label": "Console Error",
-           "source": "app/layout.js (7:7) @ Layout
-       >  7 |       <Script
+           "source": "app/(script-under-html)/layout.tsx (8:7) @ Root
+       >  8 |       <Script
             |       ^",
            "stack": [
-             "Layout app/layout.js (7:7)",
+             "Root app/(script-under-html)/layout.tsx (8:7)",
            ],
          },
          {
            "componentStack": "...
-           <HotReload globalError={[...]} webSocket={WebSocket} staticIndicatorState={{pathname:null, ...}}>
-             <AppDevOverlayErrorBoundary globalError={[...]}>
-               <ReplaySsrOnlyErrors>
-               <DevRootHTTPAccessFallbackBoundary>
-                 <HTTPAccessFallbackBoundary notFound={<NotAllowedRootHTTPFallbackError>}>
-                   <HTTPAccessFallbackErrorBoundary pathname="/" notFound={<NotAllowedRootHTTPFallbackError>} ...>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <Head>
-                         <__next_root_layout_boundary__>
-                           <SegmentViewNode type="layout" pagePath="layout.js">
-                             <SegmentTrieNode>
-                             <Layout>
-                               <NotFound>
-                                 <HTTPAccessErrorFallback>
-       >                           <html>
-                                     <body>
-                                     <Script src="https://ex..." strategy="beforeInte...">
-       >                               <script nonce={undefined} dangerouslySetInnerHTML={{__html:"(self.__ne..."}}>
-                         ...",
+           <RenderFromTemplateContext>
+             <ScrollAndFocusHandler segmentPath={[...]}>
+               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                   <LoadingBoundary loading={null}>
+                     <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
+                       <HTTPAccessFallbackErrorBoundary pathname="/script-un..." notFound={<SegmentViewNode>} ...>
+                         <RedirectBoundary>
+                           <RedirectErrorBoundary router={{...}}>
+                             <InnerLayoutRouter url="/script-un..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                               <SegmentViewNode type="layout" pagePath="(script-un...">
+                                 <SegmentTrieNode>
+                                 <Root>
+                                   <NotFound>
+                                     <HTTPAccessErrorFallback>
+                                       <NotFound>
+                                         <HTTPAccessErrorFallback>
+                                           <NotFound>
+                                             <HTTPAccessErrorFallback>
+                                               <NotFound>
+                                                 <HTTPAccessErrorFallback>
+                                                   <NotFound>
+                                                     <HTTPAccessErrorFallback>
+       >                                               <html>
+                                                         <body>
+                                                         <Script src="https://ex..." strategy="beforeInte...">
+       >                                                   <script
+       >                                                     nonce={undefined}
+       >                                                     dangerouslySetInnerHTML={{__html:"(self.__ne..."}}
+       >                                                   >
+                             ...
+                 ...
+           ...",
            "description": "In HTML, <script> cannot be a child of <html>.
        This will cause a hydration error.",
            "environmentLabel": null,
            "label": "Console Error",
-           "source": "app/layout.js (7:7) @ Layout
-       >  7 |       <Script
+           "source": "app/(script-under-html)/layout.tsx (8:7) @ Root
+       >  8 |       <Script
             |       ^",
            "stack": [
              "script <anonymous>",
-             "Layout app/layout.js (7:7)",
+             "Root app/(script-under-html)/layout.tsx (8:7)",
            ],
          },
          {
@@ -1193,12 +895,12 @@ describe('Error overlay for hydration errors in App router', () => {
        See this log for the ancestor stack trace.",
            "environmentLabel": null,
            "label": "Console Error",
-           "source": "app/layout.js (5:5) @ Layout
-       > 5 |     <html>
+           "source": "app/(script-under-html)/layout.tsx (6:5) @ Root
+       > 6 |     <html>
            |     ^",
            "stack": [
              "html <anonymous>",
-             "Layout app/layout.js (5:5)",
+             "Root app/(script-under-html)/layout.tsx (6:5)",
            ],
          },
        ]


### PR DESCRIPTION
The sandboxes used in the `Error overlay for hydration errors in App router` test suite frequently lead to timeout errors in CI ([DD](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.type%3A%22nextjs%22%20%40test.status%3A%22fail%22%20%40git.branch%3Acanary%20%40test.suite%3A%22Error%20overlay%20for%20hydration%20errors%20in%20App%20router%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1755633071704&end=1756929071704&paused=false)) and also make it unnecessarily complicated to run the scenarios locally with `pnpm next dev`. I also have a suspicion that the sandboxes are not properly cleaning up after themselves, leading to test interference.

By saving the inlined layouts and pages to actual files, we can avoid the issues caused by sandboxes and make the tests faster, more reliable, and easier to debug.