### PR TITLE
Bump Rust to nightly-2025-09-21

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -34,7 +34,7 @@ rustflags = [
   "target-feature=+crt-static"
 ]
 
-[target.'cfg(all(target_os = "linux", target_env = "gnu"))']
+[target.aarch64-unknown-linux-gnu]
 rustflags = [
   "--cfg",
   "tokio_unstable",
@@ -42,7 +42,18 @@ rustflags = [
   "-Zthreads=8",
   "-Zunstable-options",
   "-Csymbol-mangling-version=v0",
-  "-Clinker-flavor=gnu-lld-cc",
+  "-Clinker-features=+lld",
+  "-Clink-self-contained=+linker",
+]
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = [
+  "--cfg",
+  "tokio_unstable",
+  "-Zshare-generics=y",
+  "-Zthreads=8",
+  "-Zunstable-options",
+  "-Csymbol-mangling-version=v0",
   "-Clink-self-contained=+linker",
 ]
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -34,7 +34,7 @@ rustflags = [
   "target-feature=+crt-static"
 ]
 
-[target.aarch64-unknown-linux-gnu]
+[target.'cfg(all(target_os = "linux", target_env = "gnu"))']
 rustflags = [
   "--cfg",
   "tokio_unstable",
@@ -42,18 +42,7 @@ rustflags = [
   "-Zthreads=8",
   "-Zunstable-options",
   "-Csymbol-mangling-version=v0",
-  "-Clinker-features=+lld",
-  "-Clink-self-contained=+linker",
-]
-
-[target.x86_64-unknown-linux-gnu]
-rustflags = [
-  "--cfg",
-  "tokio_unstable",
-  "-Zshare-generics=y",
-  "-Zthreads=8",
-  "-Zunstable-options",
-  "-Csymbol-mangling-version=v0",
+  "-Clinker-flavor=gnu-lld-cc",
   "-Clink-self-contained=+linker",
 ]
 

--- a/.devcontainer/rust/devcontainer-feature.json
+++ b/.devcontainer/rust/devcontainer-feature.json
@@ -5,7 +5,7 @@
   "dependsOn": {
     "ghcr.io/devcontainers/features/rust:1": {
       // this should match the `rust-toolchain.toml`
-      "version": "nightly-2025-06-04",
+      "version": "nightly-2025-09-02",
       "profile": "minimal",
       "components": "rustfmt,clippy,rust-analyzer"
     }

--- a/.devcontainer/rust/devcontainer-feature.json
+++ b/.devcontainer/rust/devcontainer-feature.json
@@ -5,7 +5,7 @@
   "dependsOn": {
     "ghcr.io/devcontainers/features/rust:1": {
       // this should match the `rust-toolchain.toml`
-      "version": "nightly-2025-09-02",
+      "version": "nightly-2025-09-21",
       "profile": "minimal",
       "components": "rustfmt,clippy,rust-analyzer"
     }

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -734,33 +734,23 @@ pub enum MdxRsOptions {
 }
 
 #[turbo_tasks::value(shared, operation)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub enum ReactCompilerCompilationMode {
+    #[default]
     Infer,
     Annotation,
     All,
 }
 
-impl Default for ReactCompilerCompilationMode {
-    fn default() -> Self {
-        Self::Infer
-    }
-}
-
 #[turbo_tasks::value(shared, operation)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ReactCompilerPanicThreshold {
+    #[default]
     None,
     CriticalErrors,
     AllErrors,
-}
-
-impl Default for ReactCompilerPanicThreshold {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 /// Subset of react compiler options

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -6,5 +6,5 @@ module.exports = {
   '*.{json,md,css,html,yml,yaml,scss}': [
     'prettier --with-node-modules --ignore-path .prettierignore --write',
   ],
-  '*.rs': ['cargo fmt --'],
+  '*.rs': ['rustfmt --edition 2024 --'],
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # if you update this, also update `.devcontainer/rust/devcontainer-feature.json`
 [toolchain]
-channel = "nightly-2025-06-04"
+channel = "nightly-2025-09-02"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # if you update this, also update `.devcontainer/rust/devcontainer-feature.json`
 [toolchain]
-channel = "nightly-2025-09-02"
+channel = "nightly-2025-09-21"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(min_specialization)]
 #![feature(iter_advance_by)]
 #![feature(io_error_more)]
-#![feature(round_char_boundary)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 #![allow(clippy::mutable_key_type)]

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1494,18 +1494,13 @@ impl RealPathResultError {
     }
 }
 
-#[derive(Clone, Copy, Debug, DeterministicHash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Default, DeterministicHash, PartialOrd, Ord)]
 #[turbo_tasks::value(shared)]
 pub enum Permissions {
     Readable,
+    #[default]
     Writable,
     Executable,
-}
-
-impl Default for Permissions {
-    fn default() -> Self {
-        Self::Writable
-    }
 }
 
 // Only handle the permissions on unix platform for now

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/derive_non_local_value/fail_simple_enum.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/derive_non_local_value/fail_simple_enum.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `UnresolvedValue: NonLocalValue` is not satisfied
   --> tests/derive_non_local_value/fail_simple_enum.rs:10:13
    |
 10 |     Unnamed(UnresolvedValue),
-   |             ^^^^^^^^^^^^^^^ the trait `NonLocalValue` is not implemented for `UnresolvedValue`
+   |             ^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `NonLocalValue` is not implemented for `UnresolvedValue`
+  --> tests/derive_non_local_value/fail_simple_enum.rs:5:1
+   |
+ 5 | struct UnresolvedValue;
+   | ^^^^^^^^^^^^^^^^^^^^^^
    = help: the following other types implement trait `NonLocalValue`:
              &T
              &mut T
@@ -17,7 +22,7 @@ error[E0277]: the trait bound `UnresolvedValue: NonLocalValue` is not satisfied
 note: required by a bound in `DeriveNonLocalValueAssertion::assert_impl_NonLocalValue`
   --> tests/derive_non_local_value/fail_simple_enum.rs:7:10
    |
-7  | #[derive(NonLocalValue)]
+ 7 | #[derive(NonLocalValue)]
    |          ^^^^^^^^^^^^^ required by this bound in `DeriveNonLocalValueAssertion::assert_impl_NonLocalValue`
    = note: this error originates in the derive macro `NonLocalValue` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -25,8 +30,13 @@ error[E0277]: the trait bound `UnresolvedValue: NonLocalValue` is not satisfied
   --> tests/derive_non_local_value/fail_simple_enum.rs:11:16
    |
 11 |     Named { a: UnresolvedValue },
-   |                ^^^^^^^^^^^^^^^ the trait `NonLocalValue` is not implemented for `UnresolvedValue`
+   |                ^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
+help: the trait `NonLocalValue` is not implemented for `UnresolvedValue`
+  --> tests/derive_non_local_value/fail_simple_enum.rs:5:1
+   |
+ 5 | struct UnresolvedValue;
+   | ^^^^^^^^^^^^^^^^^^^^^^
    = help: the following other types implement trait `NonLocalValue`:
              &T
              &mut T
@@ -40,6 +50,6 @@ error[E0277]: the trait bound `UnresolvedValue: NonLocalValue` is not satisfied
 note: required by a bound in `DeriveNonLocalValueAssertion::assert_impl_NonLocalValue`
   --> tests/derive_non_local_value/fail_simple_enum.rs:7:10
    |
-7  | #[derive(NonLocalValue)]
+ 7 | #[derive(NonLocalValue)]
    |          ^^^^^^^^^^^^^ required by this bound in `DeriveNonLocalValueAssertion::assert_impl_NonLocalValue`
    = note: this error originates in the derive macro `NonLocalValue` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/derive_non_local_value/fail_simple_named_struct.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/derive_non_local_value/fail_simple_named_struct.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `UnresolvedValue: NonLocalValue` is not satisfied
  --> tests/derive_non_local_value/fail_simple_named_struct.rs:9:8
   |
 9 |     a: UnresolvedValue,
-  |        ^^^^^^^^^^^^^^^ the trait `NonLocalValue` is not implemented for `UnresolvedValue`
+  |        ^^^^^^^^^^^^^^^ unsatisfied trait bound
   |
+help: the trait `NonLocalValue` is not implemented for `UnresolvedValue`
+ --> tests/derive_non_local_value/fail_simple_named_struct.rs:5:1
+  |
+5 | struct UnresolvedValue;
+  | ^^^^^^^^^^^^^^^^^^^^^^
   = help: the following other types implement trait `NonLocalValue`:
             &T
             &mut T

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/derive_non_local_value/fail_simple_unnamed_struct.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/derive_non_local_value/fail_simple_unnamed_struct.stderr
@@ -2,8 +2,13 @@ error[E0277]: the trait bound `UnresolvedValue: NonLocalValue` is not satisfied
  --> tests/derive_non_local_value/fail_simple_unnamed_struct.rs:8:39
   |
 8 | struct ContainsUnresolvedValueUnnamed(UnresolvedValue);
-  |                                       ^^^^^^^^^^^^^^^ the trait `NonLocalValue` is not implemented for `UnresolvedValue`
+  |                                       ^^^^^^^^^^^^^^^ unsatisfied trait bound
   |
+help: the trait `NonLocalValue` is not implemented for `UnresolvedValue`
+ --> tests/derive_non_local_value/fail_simple_unnamed_struct.rs:5:1
+  |
+5 | struct UnresolvedValue;
+  | ^^^^^^^^^^^^^^^^^^^^^^
   = help: the following other types implement trait `NonLocalValue`:
             &T
             &mut T

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
@@ -14,19 +14,19 @@ error[E0307]: invalid `self` parameter type: `OperationVc<Foobar>`
    = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
 
 error[E0277]: the trait bound `fn(OperationVc<Foobar>) -> Vc<()> {Foobar::arbitrary_self_type_turbo_tasks_function_inline}: turbo_tasks::task::function::IntoTaskFnWithThis<_, _, _>` is not satisfied
-  --> tests/function/fail_operation_method_self_type.rs:11:1
-   |
-11 | #[turbo_tasks::value_impl]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
-   |
-   = help: the trait `turbo_tasks::task::function::TaskFnInputFunctionWithThis<_, _, _>` is not implemented for fn item `fn(OperationVc<Foobar>) -> Vc<()> {Foobar::arbitrary_self_type_turbo_tasks_function_inline}`
-   = note: required for `fn(OperationVc<Foobar>) -> Vc<()> {Foobar::arbitrary_self_type_turbo_tasks_function_inline}` to implement `turbo_tasks::task::function::IntoTaskFnWithThis<_, _, _>`
+ --> tests/function/fail_operation_method_self_type.rs:11:1
+  |
+ 11 | #[turbo_tasks::value_impl]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |
+    = help: the trait `turbo_tasks::task::function::TaskFnInputFunctionWithThis<_, _, _>` is not implemented for fn item `fn(OperationVc<Foobar>) -> Vc<()> {Foobar::arbitrary_self_type_turbo_tasks_function_inline}`
+    = note: required for `fn(OperationVc<Foobar>) -> Vc<()> {Foobar::arbitrary_self_type_turbo_tasks_function_inline}` to implement `turbo_tasks::task::function::IntoTaskFnWithThis<_, _, _>`
 note: required by a bound in `NativeFunction::new_method`
-  --> $WORKSPACE/turbopack/crates/turbo-tasks/src/native_function.rs
-   |
-   |     pub fn new_method<Mode, This, Inputs, I>(
-   |            ---------- required by a bound in this associated function
+   --> $WORKSPACE/turbopack/crates/turbo-tasks/src/native_function.rs
+    |
+    |     pub fn new_method<Mode, This, Inputs, I>(
+    |            ---------- required by a bound in this associated function
 ...
-   |         I: IntoTaskFnWithThis<Mode, This, Inputs>,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `NativeFunction::new_method`
-   = note: this error originates in the attribute macro `turbo_tasks::value_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+    |         I: IntoTaskFnWithThis<Mode, This, Inputs>,
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `NativeFunction::new_method`
+    = note: this error originates in the attribute macro `turbo_tasks::value_impl` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_vc_arg.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_vc_arg.stderr
@@ -1,21 +1,21 @@
 error[E0277]: the trait bound `Vc<i32>: NonLocalValue` is not satisfied
  --> tests/function/fail_operation_vc_arg.rs:8:26
   |
-8 | async fn multiply(value: Vc<i32>, coefficient: ResolvedVc<i32>) -> Result<Vc<i32>> {
-  |                          ^^^^^^^ the trait `NonLocalValue` is not implemented for `Vc<i32>`
-  |
-  = help: the following other types implement trait `NonLocalValue`:
-            &T
-            &mut T
-            ()
-            (A, Z, Y, X, W, V, U, T)
-            (B, A, Z, Y, X, W, V, U, T)
-            (C, B, A, Z, Y, X, W, V, U, T)
-            (D, C, B, A, Z, Y, X, W, V, U, T)
-            (E, D, C, B, A, Z, Y, X, W, V, U, T)
-          and $N others
+ 8 | async fn multiply(value: Vc<i32>, coefficient: ResolvedVc<i32>) -> Result<Vc<i32>> {
+   |                          ^^^^^^^ the trait `NonLocalValue` is not implemented for `Vc<i32>`
+   |
+   = help: the following other types implement trait `NonLocalValue`:
+             &T
+             &mut T
+             ()
+             (A, Z, Y, X, W, V, U, T)
+             (B, A, Z, Y, X, W, V, U, T)
+             (C, B, A, Z, Y, X, W, V, U, T)
+             (D, C, B, A, Z, Y, X, W, V, U, T)
+             (E, D, C, B, A, Z, Y, X, W, V, U, T)
+           and $N others
 note: required by a bound in `assert_argument_is_non_local_value`
- --> $WORKSPACE/turbopack/crates/turbo-tasks/src/macro_helpers.rs
-  |
-  | pub fn assert_argument_is_non_local_value<Argument: NonLocalValue>() {}
-  |                                                     ^^^^^^^^^^^^^ required by this bound in `assert_argument_is_non_local_value`
+  --> $WORKSPACE/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+   |
+   | pub fn assert_argument_is_non_local_value<Argument: NonLocalValue>() {}
+   |                                                     ^^^^^^^^^^^^^ required by this bound in `assert_argument_is_non_local_value`

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -133,9 +133,7 @@ impl TurboTasksCallApi for VcStorage {
         &self,
         _future: std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
     ) -> Pin<
-        Box<
-            (dyn futures::Future<Output = Result<(), anyhow::Error>> + std::marker::Send + 'static),
-        >,
+        Box<dyn futures::Future<Output = Result<(), anyhow::Error>> + std::marker::Send + 'static>,
     > {
         unreachable!()
     }
@@ -145,9 +143,7 @@ impl TurboTasksCallApi for VcStorage {
         _reason: StaticOrArc<dyn InvalidationReason>,
         _future: std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
     ) -> Pin<
-        Box<
-            (dyn futures::Future<Output = Result<(), anyhow::Error>> + std::marker::Send + 'static),
-        >,
+        Box<dyn futures::Future<Output = Result<(), anyhow::Error>> + std::marker::Send + 'static>,
     > {
         unreachable!()
     }

--- a/turbopack/crates/turbopack-cli-utils/src/lib.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(min_specialization)]
-#![feature(round_char_boundary)]
 #![feature(thread_id_value)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]

--- a/turbopack/crates/turbopack-dev-server/src/lib.rs
+++ b/turbopack/crates/turbopack-dev-server/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(min_specialization)]
 #![feature(trait_alias)]
-#![feature(array_chunks)]
 #![feature(iter_intersperse)]
 #![feature(str_split_remainder)]
 #![feature(arbitrary_self_types)]

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -657,7 +657,7 @@ impl Visit for Analyzer<'_> {
                             SyntaxContext::empty(),
                         )
                     },
-                    |ident| (ident.to_id()),
+                    |ident| ident.to_id(),
                 ),
                 DefaultDecl::TsInterfaceDecl(_) => {
                     // not matching, might happen due to eventual consistency

--- a/turbopack/crates/turbopack-trace-server/src/server.rs
+++ b/turbopack/crates/turbopack-trace-server/src/server.rs
@@ -73,15 +73,6 @@ pub enum ClientToServerMessage {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct SpanViewEvent {
-    pub start: Timestamp,
-    pub duration: Timestamp,
-    pub name: String,
-    pub id: Option<SpanId>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
 pub struct Filter {
     pub op: Op,
     pub value: u64,

--- a/turbopack/crates/turbopack-trace-utils/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(min_specialization)]
-#![feature(round_char_boundary)]
 #![feature(thread_id_value)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]

--- a/turbopack/crates/turbopack/src/global_module_ids.rs
+++ b/turbopack/crates/turbopack/src/global_module_ids.rs
@@ -106,7 +106,7 @@ fn finalize_module_ids(
     // Filter conflicts
     let mut conflicting_hashes = used_ids
         .iter()
-        .filter(|(_, list)| (list.len() > 1))
+        .filter(|(_, list)| list.len() > 1)
         .map(|(hash, _)| *hash)
         .collect::<Vec<_>>();
     conflicting_hashes.sort();


### PR DESCRIPTION
It compiles fine, but we have another problem: `cargo fmt` really doesn't like it

```
cargo fmt -- turbopack/crates/turbo-tasks-fs/src/lib.rs
error: let chains are only allowed in Rust 2024 or later
   --> /Users/niklas/code/next.js/turbopack/crates/turbo-tasks-fs/src/lib.rs:749:44
    |
749 |                     if create_directory && let Some(parent) = full_path.parent() {
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: let chains are only allowed in Rust 2024 or later
   --> /Users/niklas/code/next.js/turbopack/crates/turbo-tasks-fs/src/lib.rs:893:44
    |
893 |                     if create_directory && let Some(parent) = full_path.parent() {
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: let chains are only allowed in Rust 2024 or later
    --> /Users/niklas/code/next.js/turbopack/crates/turbo-tasks-fs/src/lib.rs:1233:12
     |
1233 |         if let Some(path) = join_path(&self.path, path)
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```

The precommit hook that selectively runs on files is simply not a supported usecase.

So I changed that to `rustfmt --edition 2024 -- `​ now :shrug: 

Previous discussion: https://vercel.slack.com/archives/C03EWR7LGEN/p1748898285716779

Closes PACK-5550