### PR TITLE
build: error on different root folder

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -798,5 +798,6 @@
   "797": "Failed to transpile \"%s\".",
   "798": "expected a result to be returned",
   "799": "expected a page response, got %s",
-  "800": "`experimental.rdcForNavigations` is enabled, but `experimental.ppr` is not."
+  "800": "`experimental.rdcForNavigations` is enabled, but `experimental.ppr` is not.",
+  "801": "> `pages` and `app` directories should be under the same folder"
 }

--- a/packages/next/src/lib/find-pages-dir.ts
+++ b/packages/next/src/lib/find-pages-dir.ts
@@ -25,6 +25,16 @@ export function findPagesDir(dir: string): {
     )
   }
 
+  if (pagesDir && appDir) {
+    const pagesParent = path.dirname(pagesDir)
+    const appParent = path.dirname(appDir)
+    if (pagesParent !== appParent) {
+      throw new Error(
+        '> `pages` and `app` directories should be under the same folder'
+      )
+    }
+  }
+
   return {
     pagesDir,
     appDir,

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -102,43 +102,6 @@ describe('Telemetry CLI', () => {
   ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
     'production mode',
     () => {
-      it('detects isSrcDir dir correctly for `next build`', async () => {
-        // must clear cache for GSSP imports to be detected correctly
-        await fs.remove(path.join(appDir, '.next'))
-        const { stderr } = await runNextCommand(['build', appDir], {
-          stderr: true,
-          env: {
-            NEXT_TELEMETRY_DEBUG: 1,
-          },
-        })
-
-        expect(stderr).toMatch(/isSrcDir.*?false/)
-
-        // Turbopack intentionally does not support these events
-        if (!process.env.IS_TURBOPACK_TEST) {
-          expect(stderr).toMatch(/package.*?"fs"/)
-          expect(stderr).toMatch(/package.*?"path"/)
-          expect(stderr).toMatch(/package.*?"http"/)
-          expect(stderr).toMatch(/NEXT_PACKAGE_USED_IN_GET_SERVER_SIDE_PROPS/)
-        }
-        await fs.move(
-          path.join(appDir, 'pages'),
-          path.join(appDir, 'src/pages')
-        )
-        const { stderr: stderr2 } = await runNextCommand(['build', appDir], {
-          stderr: true,
-          env: {
-            NEXT_TELEMETRY_DEBUG: 1,
-          },
-        })
-        await fs.move(
-          path.join(appDir, 'src/pages'),
-          path.join(appDir, 'pages')
-        )
-
-        expect(stderr2).toMatch(/isSrcDir.*?true/)
-      })
-
       it('emits event when swc fails to load', async () => {
         await fs.remove(path.join(appDir, '.next'))
         const { stderr } = await runNextCommand(['build', appDir], {

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -4,10 +4,6 @@ import path from 'path'
 import fs from 'fs-extra'
 import {
   runNextCommand,
-  launchApp,
-  findPort,
-  killApp,
-  waitFor,
   nextBuild,
   findAllTelemetryEvents,
 } from 'next-test-utils'
@@ -372,38 +368,4 @@ describe('Telemetry CLI', () => {
       })
     }
   )
-
-  it('detects isSrcDir dir correctly for `next dev`', async () => {
-    let port = await findPort()
-    let stderr = ''
-
-    const handleStderr = (msg) => {
-      stderr += msg
-    }
-    let app = await launchApp(appDir, port, {
-      onStderr: handleStderr,
-      env: {
-        NEXT_TELEMETRY_DEBUG: 1,
-      },
-    })
-    await waitFor(1000)
-    await killApp(app)
-    expect(stderr).toMatch(/isSrcDir.*?false/)
-
-    await fs.move(path.join(appDir, 'pages'), path.join(appDir, 'src/pages'))
-    stderr = ''
-
-    port = await findPort()
-    app = await launchApp(appDir, port, {
-      onStderr: handleStderr,
-      env: {
-        NEXT_TELEMETRY_DEBUG: 1,
-      },
-    })
-    await waitFor(1000)
-    await killApp(app)
-    await fs.move(path.join(appDir, 'src/pages'), path.join(appDir, 'pages'))
-
-    expect(stderr).toMatch(/isSrcDir.*?true/)
-  })
 })

--- a/test/production/app-dir/bad-file-structure/bad-file-structure.test.ts
+++ b/test/production/app-dir/bad-file-structure/bad-file-structure.test.ts
@@ -1,0 +1,18 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('bad-file-structure', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  it('should error for bad file structure', async () => {
+    await next.build()
+
+    const output = next.cliOutput
+    expect(output).toContain(
+      '`pages` and `app` directories should be under the same folder'
+    )
+  })
+})

--- a/test/production/app-dir/bad-file-structure/next.config.js
+++ b/test/production/app-dir/bad-file-structure/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/app-dir/bad-file-structure/pages/foo.tsx
+++ b/test/production/app-dir/bad-file-structure/pages/foo.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>foo</p>
+}

--- a/test/production/app-dir/bad-file-structure/src/app/layout.tsx
+++ b/test/production/app-dir/bad-file-structure/src/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/bad-file-structure/src/app/page.tsx
+++ b/test/production/app-dir/bad-file-structure/src/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>index</p>
+}


### PR DESCRIPTION
When the root folder is different for `pages/` and `app/`, like one is under the project root folder but the other one is under the `<project root>/src/`. It will cause the issue that Next.js can get confused and could lead to inconsistent behavior

The `detects isSrcDir dir correctly`  test case is not long valid, the earlier error can throw and ask users to move the `pages/` and `app/` into same root.

[slack-ref](https://vercel.slack.com/archives/C03S8ED1DKM/p1756975195834279)