### PR TITLE
auto-enable errors.json merge driver

### DIFF
--- a/scripts/git-configure.mjs
+++ b/scripts/git-configure.mjs
@@ -1,12 +1,19 @@
+// @ts-check
 import execa from 'execa'
 
 // See https://github.com/vercel/next.js/pull/47375
-const { stdout, stderr } = await execa(
-  'git',
-  ['config', 'index.skipHash', 'false'],
-  {
-    reject: false,
-  }
-)
+await execa('git', ['config', 'index.skipHash', 'false'], {
+  stdio: 'inherit',
+  reject: false,
+})
 
-console.log(stderr + stdout)
+// Enable the errors.json git merge driver.
+// It can be disabled by running:
+//
+//   scripts/merge-errors-json/uninstall
+//
+// or by manually removing the `[merge "errors-json"]` section from your .git/config.
+await execa('scripts/merge-errors-json/install', [], {
+  stdio: 'inherit',
+  reject: false,
+})

--- a/scripts/merge-errors-json/merge.mjs
+++ b/scripts/merge-errors-json/merge.mjs
@@ -50,6 +50,16 @@ function main() {
     process.exit(0)
   } catch (error) {
     console.error('merge-errors-json: merge failed:', error.message)
+    console.error()
+    console.error(
+      [
+        'if this error persists, you can disable the merge driver by running',
+        '',
+        '  scripts/merge-errors-json/uninstall',
+        '',
+        'or by manually removing the `[merge "errors-json"]` section from your .git/config.',
+      ].join('\n')
+    )
     process.exit(1)
   }
 }

--- a/scripts/merge-errors-json/uninstall
+++ b/scripts/merge-errors-json/uninstall
@@ -1,0 +1,3 @@
+#!/bin/sh
+driver_name='errors-json'
+git config --remove-section merge."$driver_name"


### PR DESCRIPTION
The merge driver for `errors.json` has been around for a while, and seems to work without issues. This PR enables it by default by installing it in `postinstall`(via the existing `git-configure.mjs` script which is invoked from there already)

It also adds `scripts/merge-errors-json/uninstall` to temporarily disable it in case of issues. If the driver crashes, we'll also print instructions on how to disable it.
