### PR TITLE
[test] Improve debug logs for Playwright tests

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -463,7 +463,6 @@ ${ENDGROUP}`)
         '--runInBand',
         '--forceExit',
         '--verbose',
-        '--silent',
         ...(isTestJob
           ? ['--json', `--outputFile=${test.file}${RESULTS_EXT}`]
           : []),

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra'
+import { debugPrint } from 'next-test-utils'
 import {
   chromium,
   webkit,
@@ -269,7 +270,7 @@ export class Playwright<TCurrent = undefined> {
     websocketFrames = []
 
     page.on('console', (msg) => {
-      console.log('browser log:', msg)
+      debugPrint('Browser Log:', msg)
 
       pageLogs.push(
         Promise.all(

--- a/test/lib/next-webdriver.ts
+++ b/test/lib/next-webdriver.ts
@@ -1,4 +1,4 @@
-import { getFullUrl, waitFor } from 'next-test-utils'
+import { debugPrint, getFullUrl, waitFor } from 'next-test-utils'
 import os from 'os'
 import {
   Playwright,
@@ -146,7 +146,7 @@ export default async function webdriver(
     isBrowserStack ? deviceIP : 'localhost'
   )
 
-  console.log(`\n> Loading browser with ${fullUrl}\n`)
+  debugPrint(`Loading browser with ${fullUrl}`)
 
   await browser.loadPage(fullUrl, {
     disableCache,
@@ -155,13 +155,13 @@ export default async function webdriver(
     pushErrorAsConsoleLog,
     waitUntil,
   })
-  console.log(`\n> Loaded browser with ${fullUrl}\n`)
+  debugPrint(`Loaded browser with ${fullUrl}`)
 
   browserTeardown.push(browser.close.bind(browser))
 
   // Wait for application to hydrate
   if (!disableJavaScript && waitHydration) {
-    console.log(`\n> Waiting hydration for ${fullUrl}\n`)
+    debugPrint(`Waiting hydration for ${fullUrl}`)
 
     const checkHydrated = async () => {
       await browser.eval(() => {
@@ -207,7 +207,7 @@ export default async function webdriver(
       }
     }
 
-    console.log(`\n> Hydration complete for ${fullUrl}\n`)
+    debugPrint(`Hydration complete for ${fullUrl}`)
   }
 
   // This is a temporary workaround for turbopack starting watching too late.
@@ -215,7 +215,7 @@ export default async function webdriver(
   // to connect the WebSocket and start watching.
   // TODO: Is this still needed? Can we wait in a more useful way, like a socket connection event?
   if (process.env.IS_TURBOPACK_TEST && process.env.TURBOPACK_DEV) {
-    console.log(`\n> Waiting for for turbopack watcher to start`)
+    debugPrint(`Waiting for for turbopack watcher to start`)
     await waitFor(1000)
   }
   return browser


### PR DESCRIPTION
This PR enhances the debug logging for Playwright tests by prefixing the messages with a timestamp, which helps debugging timing related issues. It also sends debug messages directly to Node's stdout, bypassing Jest's verbose logging, yielding a more compact output.

In addition, we're not running the tests in silent mode anymore in CI. This is a relic from the past, and we do already set `TRACE_PLAYWRIGHT=true`, which indicates that we want to see all the debug output.

**Before:**

<img width="1487" height="856" alt="playwright logs before" src="https://github.com/user-attachments/assets/dee7455e-25df-46d6-b873-685b0a03be11" />

**After:**

<img width="1487" height="631" alt="playwright logs after" src="https://github.com/user-attachments/assets/5d8eba72-c385-421c-8139-44f48ee3060c" />


