### PR TITLE
test: add prerender snapshot for metadata-dynamic-routes test

### DIFF
--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -50,21 +50,21 @@ describe('app dir - metadata dynamic routes', () => {
       expect(res.headers.get('cache-control')).toBe(CACHE_HEADERS.REVALIDATE)
 
       expect(text).toMatchInlineSnapshot(`
-      "<?xml version="1.0" encoding="UTF-8"?>
-      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-      <url>
-      <loc>https://example.com</loc>
-      <lastmod>2021-01-01</lastmod>
-      <changefreq>weekly</changefreq>
-      <priority>0.5</priority>
-      </url>
-      <url>
-      <loc>https://example.com/about</loc>
-      <lastmod>2021-01-01</lastmod>
-      </url>
-      </urlset>
-      "
-    `)
+             "<?xml version="1.0" encoding="UTF-8"?>
+             <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+             <url>
+             <loc>https://example.com</loc>
+             <lastmod>2021-01-01</lastmod>
+             <changefreq>weekly</changefreq>
+             <priority>0.5</priority>
+             </url>
+             <url>
+             <loc>https://example.com/about</loc>
+             <lastmod>2021-01-01</lastmod>
+             </url>
+             </urlset>
+             "
+          `)
     })
 
     it('should support generate multi sitemaps with generateSitemaps', async () => {
@@ -502,14 +502,46 @@ describe('app dir - metadata dynamic routes', () => {
       expect(isTraced).toBe(true)
     })
 
-    it('should statically optimized single image route', async () => {
+    it('should contain generated routes in prerender manifest', async () => {
       const prerenderManifest = JSON.parse(
         await next.readFile('.next/prerender-manifest.json')
       )
-      const dynamicRoutes = Object.keys(prerenderManifest.routes)
-      expect(dynamicRoutes).toContain('/opengraph-image')
-      expect(dynamicRoutes).toContain('/opengraph-image-1ow20b')
-      expect(dynamicRoutes).toContain('/apple-icon')
+      const routes = Object.keys(prerenderManifest.routes).sort()
+
+      // contains the dynamic metadata routes
+      // - /gsp/sitemap/child0.xml
+      // - /gsp/sitemap/child1.xml
+      // - /gsp/sitemap/child2.xml
+      // - /gsp/sitemap/child3.xml
+      expect(routes).toMatchInlineSnapshot(`
+       [
+         "/",
+         "/_global-error",
+         "/_not-found",
+         "/apple-icon",
+         "/blog",
+         "/client-ref-dependency/sitemap.xml",
+         "/gsp",
+         "/gsp/sitemap/child0.xml",
+         "/gsp/sitemap/child1.xml",
+         "/gsp/sitemap/child2.xml",
+         "/gsp/sitemap/child3.xml",
+         "/icon",
+         "/lang/sitemap.xml",
+         "/manifest.webmanifest",
+         "/metadata-base/unset",
+         "/metadata-base/unset/twitter-image.png",
+         "/opengraph-image",
+         "/opengraph-image-1ow20b",
+         "/robots.txt",
+         "/sitemap-image/sitemap.xml",
+         "/sitemap-video/sitemap.xml",
+         "/sitemap.xml",
+         "/static",
+         "/static/opengraph-image-hwkw89.png",
+         "/twitter-image",
+       ]
+      `)
     })
   }
 })


### PR DESCRIPTION
add snapshot test for prerender manifest to capture all the generated routes in `test/e2e/app-dir/metadata-dynamic-routes/index.test.ts`