### PR TITLE
[metadata] refactor metadata sitemap loader code

### DIFF
--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -274,6 +274,9 @@ fn get_sitemap_generate_static_params_code() -> &'static str {
                 const params = []
 
                 for (const item of sitemaps) {
+                    if (item?.id == null) {
+                        throw new Error('id property is required for every item returned from generateSitemaps')
+                    }
                     params.push({ __metadata_id__: item.id.toString() + '.xml' })
                 }
                 return params
@@ -457,6 +460,9 @@ async fn dynamic_image_route_with_metadata_source(
                 const staticParams = []
 
                 for (const item of imageMetadata) {
+                    if (item?.id == null) {
+                        throw new Error('id property is required for every item returned from generateImageMetadata')
+                    }
                     staticParams.push({ __metadata_id__: item.id.toString() })
                 }
                 return staticParams

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -290,21 +290,27 @@ async fn dynamic_sitemap_route_with_generate_source(
     let ext = path.extension();
     let content_type = get_content_type(path.clone()).await?;
 
-    let static_generation_code = if mode.is_production() {
-        get_sitemap_generate_static_params_code()
-    } else {
-        ""
-    };
+    let static_generation_code = get_sitemap_generate_static_params_code();
 
     let validation_code = if !mode.is_production() {
         indoc! {
             r#"
                 if (process.env.NODE_ENV !== 'production') {
                     const sitemaps = await generateSitemaps()
+                    let foundId
                     for (const item of sitemaps) {
                         if (item?.id == null) {
                             throw new Error('id property is required for every item returned from generateSitemaps')
                         }
+                        const baseId = id && hasXmlExtension ? id.slice(0, -4) : undefined
+                        if (item.id.toString() === baseId) {
+                            foundId = item.id
+                        }
+                    }
+                    if (!foundId) {
+                        return new NextResponse('Not Found', {
+                            status: 404,
+                        })
                     }
                 }
             "#,
@@ -320,8 +326,10 @@ async fn dynamic_sitemap_route_with_generate_source(
             import {{ resolveRouteData }} from 'next/dist/build/webpack/loaders/metadata/resolve-route-data'
 
             const contentType = {content_type}
-            const cacheControl = {cache_control}
+            const cache_control = {cache_control}
             const fileType = {file_type}
+
+            export const dynamicParams = false
 
             if (typeof handler !== 'function') {{
                 throw new Error('Default export is missing in {resource_path}')
@@ -345,7 +353,7 @@ async fn dynamic_sitemap_route_with_generate_source(
                 return new NextResponse(content, {{
                     headers: {{
                         'Content-Type': contentType,
-                        'Cache-Control': cacheControl,
+                        'Cache-Control': cache_control,
                     }},
                 }})
             }}
@@ -359,7 +367,6 @@ async fn dynamic_sitemap_route_with_generate_source(
         file_type = StringifyJs(&stem),
         cache_control = StringifyJs(CACHE_HEADER_REVALIDATE),
         validation_code = validation_code,
-        static_generation_code = static_generation_code,
     };
 
     let file = File::from(code);
@@ -443,33 +450,49 @@ async fn dynamic_image_route_with_metadata_source(
     let stem = stem.unwrap_or_default();
     let ext = path.extension();
 
-    let mut static_generation_code = "";
+    let static_generation_code = indoc! {
+        r#"
+            export async function generateStaticParams({ params }) {
+                const imageMetadata = await generateImageMetadata({ params })
+                const staticParams = []
 
-    if mode.is_production() {
-        static_generation_code = indoc! {
+                for (const item of imageMetadata) {
+                    staticParams.push({ __metadata_id__: item.id.toString() })
+                }
+                return staticParams
+            }
+        "#,
+    };
+
+    let validation_code = if !mode.is_production() {
+        indoc! {
             r#"
-                export async function generateStaticParams({ params }) {
-                    const imageMetadata = await generateImageMetadata({ params })
-                    const staticParams = []
+                if (process.env.NODE_ENV !== 'production') {
+                    const imageMetadata = await generateImageMetadata({ params: restParams })
+                    const id = imageMetadata.find((item) => {
+                        if (item?.id == null) {
+                            throw new Error('id property is required for every item returned from generateImageMetadata')
+                        }
 
-                    for (const item of imageMetadata) {
-                        staticParams.push({ __metadata_id__: item.id.toString() })
+                        return item.id.toString() === __metadata_id__
+                    })?.id
+
+                    if (id == null) {
+                        return new NextResponse('Not Found', {
+                            status: 404,
+                        })
                     }
-                    return staticParams
                 }
             "#,
-        };
-    }
+        }
+    } else {
+        ""
+    };
 
     let code = formatdoc! {
         r#"
             import {{ NextResponse }} from 'next/server'
-            import * as _imageModule from {resource_path}
-
-            const imageModule = {{ ..._imageModule }}
-
-            const handler = imageModule.default
-            const generateImageMetadata = imageModule.generateImageMetadata
+            import {{ default as handler, generateImageMetadata }} from {resource_path}
 
             if (typeof handler !== 'function') {{
                 throw new Error('Default export is missing in {resource_path}')
@@ -479,25 +502,10 @@ async fn dynamic_image_route_with_metadata_source(
                 const params = await ctx.params
                 const {{ __metadata_id__, ...rest }} = params || {{}}
                 const restParams = params ? rest : undefined
-                const targetId = __metadata_id__
+                
+                {validation_code}
 
-                const imageMetadata = await generateImageMetadata({{ params: restParams }})
-                const id = imageMetadata.find((item) => {{
-                    if (process.env.NODE_ENV !== 'production') {{
-                        if (item?.id == null) {{
-                            throw new Error('id property is required for every item returned from generateImageMetadata')
-                        }}
-                    }}
-                    return item.id.toString() === targetId
-                }})?.id
-
-                if (id == null) {{
-                    return new NextResponse('Not Found', {{
-                        status: 404,
-                    }})
-                }}
-
-                return handler({{ params: restParams, id }})
+                return handler({{ params: restParams, id: __metadata_id__ }})
             }}
 
             export * from {resource_path}
@@ -505,6 +513,7 @@ async fn dynamic_image_route_with_metadata_source(
             {static_generation_code}
         "#,
         resource_path = StringifyJs(&format!("./{stem}.{ext}")),
+        validation_code = validation_code,
         static_generation_code = static_generation_code,
     };
 

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -265,59 +265,60 @@ async fn dynamic_text_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn So
     Ok(Vc::upcast(source))
 }
 
-#[turbo_tasks::function]
-async fn dynamic_site_map_route_source(
+fn get_sitemap_generate_static_params_code() -> &'static str {
+    indoc! {
+        r#"
+            export async function generateStaticParams() {
+                const sitemaps = await generateSitemaps()
+                const params = []
+
+                for (const item of sitemaps) {
+                    params.push({ __metadata_id__: item.id.toString() + '.xml' })
+                }
+                return params
+            }
+        "#,
+    }
+}
+
+async fn dynamic_sitemap_route_with_generate_source(
     mode: NextMode,
     path: FileSystemPath,
-    is_multi_dynamic: bool,
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
     let stem = stem.unwrap_or_default();
     let ext = path.extension();
     let content_type = get_content_type(path.clone()).await?;
-    let mut static_generation_code = "";
-    let mut validation_code = "";
 
-    if is_multi_dynamic {
-        if mode.is_production() {
-            static_generation_code = indoc! {
-                r#"
-                    export async function generateStaticParams() {
-                        const sitemaps = await generateSitemaps()
-                        const params = []
+    let static_generation_code = if mode.is_production() {
+        get_sitemap_generate_static_params_code()
+    } else {
+        ""
+    };
 
-                        for (const item of sitemaps) {{
-                            params.push({ __metadata_id__: item.id.toString() + '.xml' })
-                        }}
-                        return params
-                    }
-                "#,
-            };
-        } else {
-            validation_code = indoc! {
-                r#"
-                    if (process.env.NODE_ENV !== 'production' && sitemapModule.generateSitemaps) {
-                        const sitemaps = await sitemapModule.generateSitemaps()
-                        for (const item of sitemaps) {
-                            if (item?.id == null) {
-                                throw new Error('id property is required for every item returned from generateSitemaps')
-                            }
+    let validation_code = if !mode.is_production() {
+        indoc! {
+            r#"
+                if (process.env.NODE_ENV !== 'production') {
+                    const sitemaps = await generateSitemaps()
+                    for (const item of sitemaps) {
+                        if (item?.id == null) {
+                            throw new Error('id property is required for every item returned from generateSitemaps')
                         }
                     }
-                "#,
-            };
+                }
+            "#,
         }
-    }
+    } else {
+        ""
+    };
 
     let code = formatdoc! {
         r#"
             import {{ NextResponse }} from 'next/server'
-            import * as _sitemapModule from {resource_path}
+            import {{ default as handler, generateSitemaps }} from {resource_path}
             import {{ resolveRouteData }} from 'next/dist/build/webpack/loaders/metadata/resolve-route-data'
 
-            const sitemapModule = {{ ..._sitemapModule }}
-            const handler = sitemapModule.default
-            const generateSitemaps = sitemapModule.generateSitemaps
             const contentType = {content_type}
             const cacheControl = {cache_control}
             const fileType = {file_type}
@@ -368,6 +369,70 @@ async fn dynamic_site_map_route_source(
     );
 
     Ok(Vc::upcast(source))
+}
+
+async fn dynamic_sitemap_route_without_generate_source(
+    path: FileSystemPath,
+) -> Result<Vc<Box<dyn Source>>> {
+    let stem = path.file_stem();
+    let stem = stem.unwrap_or_default();
+    let ext = path.extension();
+    let content_type = get_content_type(path.clone()).await?;
+
+    let code = formatdoc! {
+        r#"
+            import {{ NextResponse }} from 'next/server'
+            import {{ default as handler }} from {resource_path}
+            import {{ resolveRouteData }} from 'next/dist/build/webpack/loaders/metadata/resolve-route-data'
+
+            const contentType = {content_type}
+            const cacheControl = {cache_control}
+            const fileType = {file_type}
+
+            if (typeof handler !== 'function') {{
+                throw new Error('Default export is missing in {resource_path}')
+            }}
+
+            export async function GET() {{
+                const data = await handler()
+                const content = resolveRouteData(data, fileType)
+
+                return new NextResponse(content, {{
+                    headers: {{
+                        'Content-Type': contentType,
+                        'Cache-Control': cacheControl,
+                    }},
+                }})
+            }}
+
+            export * from {resource_path}
+        "#,
+        resource_path = StringifyJs(&format!("./{stem}.{ext}")),
+        content_type = StringifyJs(&content_type),
+        file_type = StringifyJs(&stem),
+        cache_control = StringifyJs(CACHE_HEADER_REVALIDATE),
+    };
+
+    let file = File::from(code);
+    let source = VirtualSource::new(
+        path.parent().join(&format!("{stem}--route-entry.js"))?,
+        AssetContent::file(file.into()),
+    );
+
+    Ok(Vc::upcast(source))
+}
+
+#[turbo_tasks::function]
+async fn dynamic_site_map_route_source(
+    mode: NextMode,
+    path: FileSystemPath,
+    is_multi_dynamic: bool,
+) -> Result<Vc<Box<dyn Source>>> {
+    if is_multi_dynamic {
+        dynamic_sitemap_route_with_generate_source(mode, path).await
+    } else {
+        dynamic_sitemap_route_without_generate_source(path).await
+    }
 }
 
 async fn dynamic_image_route_with_metadata_source(

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{Ok, Result, bail};
 use base64::{display::Base64Display, engine::general_purpose::STANDARD};
-use indoc::{formatdoc, indoc};
+use indoc::formatdoc;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::Vc;
 use turbo_tasks_fs::{self, File, FileContent, FileSystemPath};
@@ -274,34 +274,6 @@ async fn dynamic_sitemap_route_with_generate_source(
     let ext = path.extension();
     let content_type = get_content_type(path.clone()).await?;
 
-    let validation_code = if !mode.is_production() {
-        indoc! {
-            r#"
-                if (process.env.NODE_ENV !== 'production') {
-                    const sitemaps = await generateSitemaps()
-                    let foundId
-                    for (const item of sitemaps) {
-                        if (item?.id == null) {
-                            throw new Error('id property is required for every item returned from generateSitemaps')
-                        }
-                        const hasXmlExtension = id ? id.endsWith('.xml') : false
-                        const baseId = id && hasXmlExtension ? id.slice(0, -4) : undefined
-                        if (item.id.toString() === baseId) {
-                            foundId = item.id
-                        }
-                    }
-                    if (!foundId) {
-                        return new NextResponse('Not Found', {
-                            status: 404,
-                        })
-                    }
-                }
-            "#,
-        }
-    } else {
-        ""
-    };
-
     let code = formatdoc! {
         r#"
             import {{ NextResponse }} from 'next/server'
@@ -319,13 +291,30 @@ async fn dynamic_sitemap_route_with_generate_source(
             export async function GET(_, ctx) {{
                 const {{ __metadata_id__: id, ...params }} = await ctx.params || {{}}
                 const hasXmlExtension = id ? id.endsWith('.xml') : false
-                if (id && !hasXmlExtension) {{
+                if (id && !hasXmlExtension) {{{
                     return new NextResponse('Not Found', {{
                         status: 404,
                     }})
                 }}
 
-                {validation_code}
+                if (process.env.NODE_ENV !== 'production') {
+                    const sitemaps = await generateSitemaps()
+                    let foundId
+                    for (const item of sitemaps) {
+                        if (item?.id == null) {
+                            throw new Error('id property is required for every item returned from generateSitemaps')
+                        }
+                        const baseId = id && hasXmlExtension ? id.slice(0, -4) : id
+                        if (item.id.toString() === baseId) {
+                            foundId = item.id
+                        }
+                    }
+                    if (foundId == null) {{
+                        return new NextResponse('Not Found', {{
+                            status: 404,
+                        }})
+                    }}
+                }
                 
                 const targetId = id && hasXmlExtension ? id.slice(0, -4) : undefined
                 const data = await handler({{ id: targetId }})
@@ -359,7 +348,6 @@ async fn dynamic_sitemap_route_with_generate_source(
         content_type = StringifyJs(&content_type),
         file_type = StringifyJs(&stem),
         cache_control = StringifyJs(CACHE_HEADER_REVALIDATE),
-        validation_code = validation_code,
     };
 
     let file = File::from(code);
@@ -443,31 +431,6 @@ async fn dynamic_image_route_with_metadata_source(
     let stem = stem.unwrap_or_default();
     let ext = path.extension();
 
-    let validation_code = if !mode.is_production() {
-        indoc! {
-            r#"
-                if (process.env.NODE_ENV !== 'production') {
-                    const imageMetadata = await generateImageMetadata({ params: restParams })
-                    const id = imageMetadata.find((item) => {
-                        if (item?.id == null) {
-                            throw new Error('id property is required for every item returned from generateImageMetadata')
-                        }
-
-                        return item.id.toString() === __metadata_id__
-                    })?.id
-
-                    if (id == null) {
-                        return new NextResponse('Not Found', {
-                            status: 404,
-                        })
-                    }
-                }
-            "#,
-        }
-    } else {
-        ""
-    };
-
     let code = formatdoc! {
         r#"
             import {{ NextResponse }} from 'next/server'
@@ -482,7 +445,22 @@ async fn dynamic_image_route_with_metadata_source(
                 const {{ __metadata_id__, ...rest }} = params || {{}}
                 const restParams = params ? rest : undefined
                 
-                {validation_code}
+                if (process.env.NODE_ENV !== 'production') {
+                    const imageMetadata = await generateImageMetadata({{ params: restParams }})
+                    const id = imageMetadata.find((item) => {
+                        if (item?.id == null) {
+                            throw new Error('id property is required for every item returned from generateImageMetadata')
+                        }
+
+                        return item.id.toString() === __metadata_id__
+                    })?.id
+
+                    if (id == null) {
+                        return new NextResponse('Not Found', {
+                            status: 404,
+                        })
+                    }
+                }
 
                 return handler({{ params: restParams, id: __metadata_id__ }})
             }}
@@ -504,7 +482,6 @@ async fn dynamic_image_route_with_metadata_source(
             }}
         "#,
         resource_path = StringifyJs(&format!("./{stem}.{ext}")),
-        validation_code = validation_code,
     };
 
     let file = File::from(code);

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -46,9 +46,9 @@ pub async fn get_app_metadata_route_source(
             if stem == "robots" || stem == "manifest" {
                 dynamic_text_route_source(path)
             } else if stem == "sitemap" {
-                dynamic_site_map_route_source(mode, path, is_multi_dynamic)
+                dynamic_site_map_route_source(path, is_multi_dynamic)
             } else {
-                dynamic_image_route_source(mode, path, is_multi_dynamic)
+                dynamic_image_route_source(path, is_multi_dynamic)
             }
         }
     })
@@ -266,7 +266,6 @@ async fn dynamic_text_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn So
 }
 
 async fn dynamic_sitemap_route_with_generate_source(
-    mode: NextMode,
     path: FileSystemPath,
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
@@ -291,30 +290,30 @@ async fn dynamic_sitemap_route_with_generate_source(
             export async function GET(_, ctx) {{
                 const {{ __metadata_id__: id, ...params }} = await ctx.params || {{}}
                 const hasXmlExtension = id ? id.endsWith('.xml') : false
-                if (id && !hasXmlExtension) {{{
+                if (id && !hasXmlExtension) {{
                     return new NextResponse('Not Found', {{
                         status: 404,
                     }})
                 }}
 
-                if (process.env.NODE_ENV !== 'production') {
+                if (process.env.NODE_ENV !== 'production') {{
                     const sitemaps = await generateSitemaps()
                     let foundId
-                    for (const item of sitemaps) {
-                        if (item?.id == null) {
+                    for (const item of sitemaps) {{
+                        if (item?.id == null) {{
                             throw new Error('id property is required for every item returned from generateSitemaps')
-                        }
+                        }}
                         const baseId = id && hasXmlExtension ? id.slice(0, -4) : id
-                        if (item.id.toString() === baseId) {
+                        if (item.id.toString() === baseId) {{
                             foundId = item.id
-                        }
-                    }
+                        }}
+                    }}
                     if (foundId == null) {{
                         return new NextResponse('Not Found', {{
                             status: 404,
                         }})
                     }}
-                }
+                }}
                 
                 const targetId = id && hasXmlExtension ? id.slice(0, -4) : undefined
                 const data = await handler({{ id: targetId }})
@@ -412,19 +411,17 @@ async fn dynamic_sitemap_route_without_generate_source(
 
 #[turbo_tasks::function]
 async fn dynamic_site_map_route_source(
-    mode: NextMode,
     path: FileSystemPath,
     is_multi_dynamic: bool,
 ) -> Result<Vc<Box<dyn Source>>> {
     if is_multi_dynamic {
-        dynamic_sitemap_route_with_generate_source(mode, path).await
+        dynamic_sitemap_route_with_generate_source(path).await
     } else {
         dynamic_sitemap_route_without_generate_source(path).await
     }
 }
 
 async fn dynamic_image_route_with_metadata_source(
-    mode: NextMode,
     path: FileSystemPath,
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
@@ -445,22 +442,22 @@ async fn dynamic_image_route_with_metadata_source(
                 const {{ __metadata_id__, ...rest }} = params || {{}}
                 const restParams = params ? rest : undefined
                 
-                if (process.env.NODE_ENV !== 'production') {
+                if (process.env.NODE_ENV !== 'production') {{
                     const imageMetadata = await generateImageMetadata({{ params: restParams }})
-                    const id = imageMetadata.find((item) => {
-                        if (item?.id == null) {
+                    const id = imageMetadata.find((item) => {{
+                        if (item?.id == null) {{
                             throw new Error('id property is required for every item returned from generateImageMetadata')
-                        }
+                        }}
 
                         return item.id.toString() === __metadata_id__
-                    })?.id
+                    }})?.id
 
-                    if (id == null) {
-                        return new NextResponse('Not Found', {
+                    if (id == null) {{
+                        return new NextResponse('Not Found', {{
                             status: 404,
-                        })
-                    }
-                }
+                        }})
+                    }}
+                }}
 
                 return handler({{ params: restParams, id: __metadata_id__ }})
             }}
@@ -529,12 +526,11 @@ async fn dynamic_image_route_without_metadata_source(
 
 #[turbo_tasks::function]
 async fn dynamic_image_route_source(
-    mode: NextMode,
     path: FileSystemPath,
     is_multi_dynamic: bool,
 ) -> Result<Vc<Box<dyn Source>>> {
     if is_multi_dynamic {
-        dynamic_image_route_with_metadata_source(mode, path).await
+        dynamic_image_route_with_metadata_source(path).await
     } else {
         dynamic_image_route_without_metadata_source(path).await
     }

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -268,6 +268,7 @@ async fn dynamic_text_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn So
 fn get_sitemap_generate_static_params_code() -> &'static str {
     indoc! {
         r#"
+            export const dynamicParams = false
             export async function generateStaticParams() {
                 const sitemaps = await generateSitemaps()
                 const params = []
@@ -328,8 +329,6 @@ async fn dynamic_sitemap_route_with_generate_source(
             const contentType = {content_type}
             const cache_control = {cache_control}
             const fileType = {file_type}
-
-            export const dynamicParams = false
 
             if (typeof handler !== 'function') {{
                 throw new Error('Default export is missing in {resource_path}')
@@ -452,6 +451,7 @@ async fn dynamic_image_route_with_metadata_source(
 
     let static_generation_code = indoc! {
         r#"
+            export const dynamicParams = false
             export async function generateStaticParams({ params }) {
                 const imageMetadata = await generateImageMetadata({ params })
                 const staticParams = []

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -265,26 +265,6 @@ async fn dynamic_text_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn So
     Ok(Vc::upcast(source))
 }
 
-fn get_sitemap_generate_static_params_code() -> &'static str {
-    indoc! {
-        r#"
-            export const dynamicParams = false
-            export async function generateStaticParams() {
-                const sitemaps = await generateSitemaps()
-                const params = []
-
-                for (const item of sitemaps) {
-                    if (item?.id == null) {
-                        throw new Error('id property is required for every item returned from generateSitemaps')
-                    }
-                    params.push({ __metadata_id__: item.id.toString() + '.xml' })
-                }
-                return params
-            }
-        "#,
-    }
-}
-
 async fn dynamic_sitemap_route_with_generate_source(
     mode: NextMode,
     path: FileSystemPath,
@@ -293,8 +273,6 @@ async fn dynamic_sitemap_route_with_generate_source(
     let stem = stem.unwrap_or_default();
     let ext = path.extension();
     let content_type = get_content_type(path.clone()).await?;
-
-    let static_generation_code = get_sitemap_generate_static_params_code();
 
     let validation_code = if !mode.is_production() {
         indoc! {
@@ -306,6 +284,7 @@ async fn dynamic_sitemap_route_with_generate_source(
                         if (item?.id == null) {
                             throw new Error('id property is required for every item returned from generateSitemaps')
                         }
+                        const hasXmlExtension = id ? id.endsWith('.xml') : false
                         const baseId = id && hasXmlExtension ? id.slice(0, -4) : undefined
                         if (item.id.toString() === baseId) {
                             foundId = item.id
@@ -362,7 +341,19 @@ async fn dynamic_sitemap_route_with_generate_source(
 
             export * from {resource_path}
 
-            {static_generation_code}
+            export const dynamicParams = false
+            export async function generateStaticParams() {{
+                const sitemaps = await generateSitemaps()
+                const params = []
+
+                for (const item of sitemaps) {{
+                    if (item?.id == null) {{
+                        throw new Error('id property is required for every item returned from generateSitemaps')
+                    }}
+                    params.push({{ __metadata_id__: item.id.toString() + '.xml' }})
+                }}
+                return params
+            }}
         "#,
         resource_path = StringifyJs(&format!("./{stem}.{ext}")),
         content_type = StringifyJs(&content_type),
@@ -452,24 +443,6 @@ async fn dynamic_image_route_with_metadata_source(
     let stem = stem.unwrap_or_default();
     let ext = path.extension();
 
-    let static_generation_code = indoc! {
-        r#"
-            export const dynamicParams = false
-            export async function generateStaticParams({ params }) {
-                const imageMetadata = await generateImageMetadata({ params })
-                const staticParams = []
-
-                for (const item of imageMetadata) {
-                    if (item?.id == null) {
-                        throw new Error('id property is required for every item returned from generateImageMetadata')
-                    }
-                    staticParams.push({ __metadata_id__: item.id.toString() })
-                }
-                return staticParams
-            }
-        "#,
-    };
-
     let validation_code = if !mode.is_production() {
         indoc! {
             r#"
@@ -516,11 +489,22 @@ async fn dynamic_image_route_with_metadata_source(
 
             export * from {resource_path}
 
-            {static_generation_code}
+            export const dynamicParams = false
+            export async function generateStaticParams({{ params }}) {{
+                const imageMetadata = await generateImageMetadata({{ params }})
+                const staticParams = []
+
+                for (const item of imageMetadata) {{
+                    if (item?.id == null) {{
+                        throw new Error('id property is required for every item returned from generateImageMetadata')
+                    }}
+                    staticParams.push({{ __metadata_id__: item.id.toString() }})
+                }}
+                return staticParams
+            }}
         "#,
         resource_path = StringifyJs(&format!("./{stem}.{ext}")),
         validation_code = validation_code,
-        static_generation_code = static_generation_code,
     };
 
     let file = File::from(code);

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -161,6 +161,7 @@ async function getDynamicImageRouteCode(
   loaderContext: webpack.LoaderContext<any>
 ) {
   const staticGenerationCode = `\
+export const dynamicParams = false
 export async function generateStaticParams({ params }) {
   const imageMetadata = await generateImageMetadata({ params })
   const staticParams = []
@@ -282,6 +283,7 @@ async function getDynamicSitemapRouteCode(
   loaderContext: webpack.LoaderContext<any>
 ) {
   const staticGenerationCode = `\
+export const dynamicParams = false
 export async function generateStaticParams() {
   const sitemaps = await generateSitemaps()
   const params = []
@@ -301,8 +303,6 @@ import { resolveRouteData } from 'next/dist/build/webpack/loaders/metadata/resol
 
 const contentType = ${JSON.stringify(getContentType(resourcePath))}
 const fileType = ${JSON.stringify(getFilenameAndExtension(resourcePath).name)}
-
-export const dynamicParams = false
 
 ${errorOnBadHandler(resourcePath)}
 ${await createReExportsCode(resourcePath, loaderContext)}

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -160,22 +160,6 @@ async function getDynamicImageRouteCode(
   resourcePath: string,
   loaderContext: webpack.LoaderContext<any>
 ) {
-  const staticGenerationCode = `\
-export const dynamicParams = false
-export async function generateStaticParams({ params }) {
-  const imageMetadata = await generateImageMetadata({ params })
-  const staticParams = []
-
-  for (const item of imageMetadata) {
-    if (item?.id == null) {
-      throw new Error('id property is required for every item returned from generateImageMetadata')
-    }
-    staticParams.push({ __metadata_id__: item.id.toString() })
-  }
-  return staticParams
-}
-`
-
   return `\
 /* dynamic image route with generateImageMetadata */
 import { NextResponse } from 'next/server'
@@ -210,7 +194,19 @@ export async function GET(_, ctx) {
   return handler({ params: restParams, id: __metadata_id__ })
 }
 
-${staticGenerationCode}
+export const dynamicParams = false
+export async function generateStaticParams({ params }) {
+  const imageMetadata = await generateImageMetadata({ params })
+  const staticParams = []
+
+  for (const item of imageMetadata) {
+    if (item?.id == null) {
+      throw new Error('id property is required for every item returned from generateImageMetadata')
+    }
+    staticParams.push({ __metadata_id__: item.id.toString() })
+  }
+  return staticParams
+}
 `
 }
 
@@ -285,22 +281,6 @@ async function getDynamicSitemapRouteCode(
   resourcePath: string,
   loaderContext: webpack.LoaderContext<any>
 ) {
-  const staticGenerationCode = `\
-export const dynamicParams = false
-export async function generateStaticParams() {
-  const sitemaps = await generateSitemaps()
-  const params = []
-
-  for (const item of sitemaps) {
-    if (item?.id == null) {
-      throw new Error('id property is required for every item returned from generateSitemaps')
-    }
-    params.push({ __metadata_id__: item.id.toString() + '.xml' })
-  }
-  return params
-}
-`
-
   const code = `\
 /* dynamic sitemap route with generateSitemaps */
 import { NextResponse } from 'next/server'
@@ -315,13 +295,7 @@ ${await createReExportsCode(resourcePath, loaderContext)}
 
 export async function GET(_, ctx) {
   const { __metadata_id__: id, ...params } = await ctx.params || {}
-  const hasXmlExtension = id ? id.endsWith('.xml') : false
-  if (id && !hasXmlExtension) {
-    return new NextResponse('Not Found', {
-      status: 404,
-    })
-  }
-  
+
   if (process.env.NODE_ENV !== 'production') {
     const sitemaps = await generateSitemaps()
     let foundId
@@ -329,20 +303,20 @@ export async function GET(_, ctx) {
       if (item?.id == null) {
         throw new Error('id property is required for every item returned from generateSitemaps')
       }
+      const hasXmlExtension = id ? id.endsWith('.xml') : false
       const baseId = id && hasXmlExtension ? id.slice(0, -4) : undefined
       if (item.id.toString() === baseId) {
         foundId = item.id
       }
     }
-    if (!foundId) {
+    if (foundId == null) {
       return new NextResponse('Not Found', {
         status: 404,
       })
     }
   }
 
-  const targetId = id && hasXmlExtension ? id.slice(0, -4) : undefined
-  const data = await handler({ id: targetId })
+  const data = await handler({ id })
   const content = resolveRouteData(data, fileType)
 
   return new NextResponse(content, {
@@ -353,7 +327,20 @@ export async function GET(_, ctx) {
   })
 }
 
-${staticGenerationCode}
+export const dynamicParams = false
+export async function generateStaticParams() {
+  const sitemaps = await generateSitemaps()
+  const params = []
+
+  for (const item of sitemaps) {
+    if (item?.id == null) {
+      throw new Error('id property is required for every item returned from generateSitemaps')
+    }
+    params.push({ __metadata_id__: item.id.toString() + '.xml' })
+  }
+  console.log('generateStaticParams:params', params)
+  return params
+}
 `
   return code
 }

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -295,6 +295,7 @@ ${await createReExportsCode(resourcePath, loaderContext)}
 
 export async function GET(_, ctx) {
   const { __metadata_id__: id, ...params } = await ctx.params || {}
+  const hasXmlExtension = id ? id.endsWith('.xml') : false
 
   if (process.env.NODE_ENV !== 'production') {
     const sitemaps = await generateSitemaps()
@@ -303,7 +304,7 @@ export async function GET(_, ctx) {
       if (item?.id == null) {
         throw new Error('id property is required for every item returned from generateSitemaps')
       }
-      const hasXmlExtension = id ? id.endsWith('.xml') : false
+      
       const baseId = id && hasXmlExtension ? id.slice(0, -4) : undefined
       if (item.id.toString() === baseId) {
         foundId = item.id
@@ -316,7 +317,8 @@ export async function GET(_, ctx) {
     }
   }
 
-  const data = await handler({ id })
+  const targetId = id && hasXmlExtension ? id.slice(0, -4) : undefined
+  const data = await handler({ id: targetId })
   const content = resolveRouteData(data, fileType)
 
   return new NextResponse(content, {
@@ -338,7 +340,6 @@ export async function generateStaticParams() {
     }
     params.push({ __metadata_id__: item.id.toString() + '.xml' })
   }
-  console.log('generateStaticParams:params', params)
   return params
 }
 `

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -167,6 +167,9 @@ export async function generateStaticParams({ params }) {
   const staticParams = []
 
   for (const item of imageMetadata) {
+    if (item?.id == null) {
+      throw new Error('id property is required for every item returned from generateImageMetadata')
+    }
     staticParams.push({ __metadata_id__: item.id.toString() })
   }
   return staticParams
@@ -289,6 +292,9 @@ export async function generateStaticParams() {
   const params = []
 
   for (const item of sitemaps) {
+    if (item?.id == null) {
+      throw new Error('id property is required for every item returned from generateSitemaps')
+    }
     params.push({ __metadata_id__: item.id.toString() + '.xml' })
   }
   return params

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -25,7 +25,10 @@ async function createReExportsCode(
   )
   // Re-export configs but avoid conflicted exports
   const reExportNames = exportNames.filter(
-    (name) => name !== 'default' && name !== 'generateSitemaps'
+    (name) =>
+      name !== 'default' &&
+      name !== 'generateSitemaps' &&
+      name !== 'dynamicParams'
   )
 
   return reExportNames.length > 0
@@ -157,10 +160,7 @@ async function getDynamicImageRouteCode(
   resourcePath: string,
   loaderContext: webpack.LoaderContext<any>
 ) {
-  let staticGenerationCode = ''
-
-  if (process.env.NODE_ENV === 'production') {
-    staticGenerationCode = `\
+  const staticGenerationCode = `\
 export async function generateStaticParams({ params }) {
   const imageMetadata = await generateImageMetadata({ params })
   const staticParams = []
@@ -171,7 +171,6 @@ export async function generateStaticParams({ params }) {
   return staticParams
 }
 `
-  }
 
   return `\
 /* dynamic image route with generateImageMetadata */
@@ -185,22 +184,26 @@ export async function GET(_, ctx) {
   const params = await ctx.params
   const { __metadata_id__, ...rest } = params || {}
   const restParams = params ? rest : undefined
-  const imageMetadata = await generateImageMetadata({ params: restParams })
-  const id = imageMetadata.find((item) => {
-    if (process.env.NODE_ENV !== 'production') {
+  
+  ${/* we need a dev assertion for id since dynamicParams=false won't work well in dev */ ''}
+  if (process.env.NODE_ENV !== 'production') {
+    const imageMetadata = await generateImageMetadata({ params: restParams })
+    const id = imageMetadata.find((item) => {
       if (item?.id == null) {
         throw new Error('id property is required for every item returned from generateImageMetadata')
       }
+
+      return item.id.toString() === __metadata_id__
+    })?.id
+
+    if (id == null) {
+      return new NextResponse('Not Found', {
+        status: 404,
+      })
     }
-    return item.id.toString() === __metadata_id__
-  })?.id
-  if (id == null) {
-    return new NextResponse('Not Found', {
-      status: 404,
-    })
   }
 
-  return handler({ params: restParams, id })
+  return handler({ params: restParams, id: __metadata_id__ })
 }
 
 ${staticGenerationCode}
@@ -244,23 +247,6 @@ async function getImageRouteCode(
   }
 }
 
-function getSitemapGenerateStaticParamsCode() {
-  if (process.env.NODE_ENV === 'production') {
-    return `\
-export async function generateStaticParams() {
-  const sitemaps = await generateSitemaps()
-  const params = []
-
-  for (const item of sitemaps) {
-    params.push({ __metadata_id__: item.id.toString() + '.xml' })
-  }
-  return params
-}
-`
-  }
-  return ''
-}
-
 async function getSingleSitemapRouteCode(
   resourcePath: string,
   loaderContext: webpack.LoaderContext<any>
@@ -295,7 +281,17 @@ async function getDynamicSitemapRouteCode(
   resourcePath: string,
   loaderContext: webpack.LoaderContext<any>
 ) {
-  const staticGenerationCode = getSitemapGenerateStaticParamsCode()
+  const staticGenerationCode = `\
+export async function generateStaticParams() {
+  const sitemaps = await generateSitemaps()
+  const params = []
+
+  for (const item of sitemaps) {
+    params.push({ __metadata_id__: item.id.toString() + '.xml' })
+  }
+  return params
+}
+`
 
   const code = `\
 /* dynamic sitemap route with generateSitemaps */
@@ -305,6 +301,8 @@ import { resolveRouteData } from 'next/dist/build/webpack/loaders/metadata/resol
 
 const contentType = ${JSON.stringify(getContentType(resourcePath))}
 const fileType = ${JSON.stringify(getFilenameAndExtension(resourcePath).name)}
+
+export const dynamicParams = false
 
 ${errorOnBadHandler(resourcePath)}
 ${await createReExportsCode(resourcePath, loaderContext)}
@@ -317,13 +315,23 @@ export async function GET(_, ctx) {
       status: 404,
     })
   }
-
+  
   if (process.env.NODE_ENV !== 'production') {
     const sitemaps = await generateSitemaps()
+    let foundId
     for (const item of sitemaps) {
       if (item?.id == null) {
         throw new Error('id property is required for every item returned from generateSitemaps')
       }
+      const baseId = id && hasXmlExtension ? id.slice(0, -4) : undefined
+      if (item.id.toString() === baseId) {
+        foundId = item.id
+      }
+    }
+    if (!foundId) {
+      return new NextResponse('Not Found', {
+        status: 404,
+      })
     }
   }
 

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -244,41 +244,65 @@ async function getImageRouteCode(
   }
 }
 
+function getSitemapGenerateStaticParamsCode() {
+  if (process.env.NODE_ENV === 'production') {
+    return `\
+export async function generateStaticParams() {
+  const sitemaps = await generateSitemaps()
+  const params = []
+
+  for (const item of sitemaps) {
+    params.push({ __metadata_id__: item.id.toString() + '.xml' })
+  }
+  return params
+}
+`
+  }
+  return ''
+}
+
+async function getSingleSitemapRouteCode(
+  resourcePath: string,
+  loaderContext: webpack.LoaderContext<any>
+) {
+  return `\
+/* single sitemap route */
+import { NextResponse } from 'next/server'
+import { default as handler } from ${JSON.stringify(resourcePath)}
+import { resolveRouteData } from 'next/dist/build/webpack/loaders/metadata/resolve-route-data'
+
+const contentType = ${JSON.stringify(getContentType(resourcePath))}
+const fileType = ${JSON.stringify(getFilenameAndExtension(resourcePath).name)}
+
+${errorOnBadHandler(resourcePath)}
+${await createReExportsCode(resourcePath, loaderContext)}
+
+export async function GET() {
+  const data = await handler()
+  const content = resolveRouteData(data, fileType)
+
+  return new NextResponse(content, {
+    headers: {
+      'Content-Type': contentType,
+      'Cache-Control': ${JSON.stringify(CACHE_HEADERS.REVALIDATE)},
+    },
+  })
+}
+`
+}
+
 async function getDynamicSitemapRouteCode(
   resourcePath: string,
   loaderContext: webpack.LoaderContext<any>
 ) {
-  let staticGenerationCode = ''
-
-  const exportNames = await getLoaderModuleNamedExports(
-    resourcePath,
-    loaderContext
-  )
-
-  const hasGenerateSitemaps = exportNames.includes('generateSitemaps')
-
-  if (process.env.NODE_ENV === 'production' && hasGenerateSitemaps) {
-    staticGenerationCode = `\
-    /* dynamic sitemap route */
-    export async function generateStaticParams() {
-      const sitemaps = await sitemapModule.generateSitemaps()
-      const params = []
-
-      for (const item of sitemaps) {
-        params.push({ __metadata_id__: item.id.toString() + '.xml' })
-      }
-      return params
-    }
-    `
-  }
+  const staticGenerationCode = getSitemapGenerateStaticParamsCode()
 
   const code = `\
+/* dynamic sitemap route with generateSitemaps */
 import { NextResponse } from 'next/server'
-import * as userland from ${JSON.stringify(resourcePath)}
+import { default as handler, generateSitemaps } from ${JSON.stringify(resourcePath)}
 import { resolveRouteData } from 'next/dist/build/webpack/loaders/metadata/resolve-route-data'
 
-const sitemapModule = { ...userland }
-const handler = sitemapModule.default
 const contentType = ${JSON.stringify(getContentType(resourcePath))}
 const fileType = ${JSON.stringify(getFilenameAndExtension(resourcePath).name)}
 
@@ -294,8 +318,8 @@ export async function GET(_, ctx) {
     })
   }
 
-  if (process.env.NODE_ENV !== 'production' && sitemapModule.generateSitemaps) {
-    const sitemaps = await sitemapModule.generateSitemaps()
+  if (process.env.NODE_ENV !== 'production') {
+    const sitemaps = await generateSitemaps()
     for (const item of sitemaps) {
       if (item?.id == null) {
         throw new Error('id property is required for every item returned from generateSitemaps')
@@ -320,6 +344,25 @@ ${staticGenerationCode}
   return code
 }
 
+// <metadata-sitemap>/[id]/route.js
+async function getSitemapRouteCode(
+  resourcePath: string,
+  loaderContext: webpack.LoaderContext<any>
+) {
+  const exportNames = await getLoaderModuleNamedExports(
+    resourcePath,
+    loaderContext
+  )
+
+  const hasGenerateSitemaps = exportNames.includes('generateSitemaps')
+
+  if (hasGenerateSitemaps) {
+    return getDynamicSitemapRouteCode(resourcePath, loaderContext)
+  } else {
+    return getSingleSitemapRouteCode(resourcePath, loaderContext)
+  }
+}
+
 // When it's static route, it could be favicon.ico, sitemap.xml, robots.txt etc.
 // TODO-METADATA: improve the cache control strategy
 const nextMetadataRouterLoader: webpack.LoaderDefinitionFunction<MetadataRouteLoaderOptions> =
@@ -333,7 +376,7 @@ const nextMetadataRouterLoader: webpack.LoaderDefinitionFunction<MetadataRouteLo
       if (fileBaseName === 'robots' || fileBaseName === 'manifest') {
         code = await getDynamicTextRouteCode(filePath, this)
       } else if (fileBaseName === 'sitemap') {
-        code = await getDynamicSitemapRouteCode(filePath, this)
+        code = await getSitemapRouteCode(filePath, this)
       } else {
         code = await getImageRouteCode(filePath, this)
       }

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -86,6 +86,11 @@ describe('app dir - metadata dynamic routes', () => {
       }
     })
 
+    it('should 404 for non-existing id from generateImageMetadata', async () => {
+      const res = await next.fetch('/gsp/icon/non-existing-id')
+      expect(res.status).toBe(404)
+    })
+
     it('should not throw if client components are imported but not used in sitemap', async () => {
       const { status } = await next.fetch('/client-ref-dependency/sitemap.xml')
       expect(status).toBe(200)


### PR DESCRIPTION
Separate the metadata route loader generated code for sitemap, similar to #83304

```
if (generateSitemaps defined) {
   output route code for dynamic params
} else {
  output route code for single path
}
```

This PR adds the `export const dynmiacParams = false` for metadata routes with generated params by `generateStaticParams` or `generateImageMetadata`.

Since `dynamicParams = false` won't work out well in dev to respond 404 on the non existing routes, so we'll still generate the params in dev to check if a request is hitting an non-existed param. But in production we can fully rely on gsp + false dynamicParams.