### PR TITLE
[turbopack] Don't execute inventory_submit in rust analyzer

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/fuzz/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/fuzz/Cargo.toml
@@ -32,3 +32,7 @@ path = "afl_targets/graph.rs"
 test = false
 doc = false
 bench = false
+
+
+[lints]
+workspace = true

--- a/turbopack/crates/turbo-tasks-macros-tests/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-macros-tests/Cargo.toml
@@ -14,3 +14,5 @@ turbo-tasks = { workspace = true }
 turbo-tasks-testing = { workspace = true }
 turbo-tasks-backend = { workspace = true }
 
+[lints]
+workspace = true

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.rs
@@ -1,5 +1,6 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
+#![allow(unexpected_cfgs)]
 
 use turbo_tasks::{ResolvedVc, Vc};
 

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.stderr
@@ -1,5 +1,5 @@
 error: unexpected token, expected one of: "fs", "network", "operation", "local"
- --> tests/function/fail_attribute_invalid_args.rs:9:25
-  |
-9 | #[turbo_tasks::function(invalid_argument)]
-  |                         ^^^^^^^^^^^^^^^^
+  --> tests/function/fail_attribute_invalid_args.rs:10:25
+   |
+10 | #[turbo_tasks::function(invalid_argument)]
+   |                         ^^^^^^^^^^^^^^^^

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.rs
@@ -1,5 +1,6 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
+#![allow(unexpected_cfgs)]
 
 use turbo_tasks::{ResolvedVc, Vc};
 

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.stderr
@@ -1,5 +1,5 @@
 error: unexpected token, expected one of: "fs", "network", "operation", "local"
-  --> tests/function/fail_attribute_invalid_args_inherent_impl.rs:14:29
+  --> tests/function/fail_attribute_invalid_args_inherent_impl.rs:15:29
    |
-14 |     #[turbo_tasks::function(invalid_argument)]
+15 |     #[turbo_tasks::function(invalid_argument)]
    |                             ^^^^^^^^^^^^^^^^

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_ref.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_ref.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
+#![allow(unexpected_cfgs)]
 
 use turbo_tasks::Vc;
 

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_ref.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_ref.stderr
@@ -1,5 +1,5 @@
 error: methods taking `self` are not supported with `operation`
-  --> tests/function/fail_operation_method_self_ref.rs:13:17
+  --> tests/function/fail_operation_method_self_ref.rs:14:17
    |
-13 |     fn self_ref(&self) -> Vc<()> {
+14 |     fn self_ref(&self) -> Vc<()> {
    |                 ^^^^^

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
+#![allow(unexpected_cfgs)]
 
 use turbo_tasks::{OperationVc, Vc};
 

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
@@ -1,22 +1,22 @@
 error: methods taking `self` are not supported with `operation`
-  --> tests/function/fail_operation_method_self_type.rs:13:28
+  --> tests/function/fail_operation_method_self_type.rs:14:28
    |
-13 |     fn arbitrary_self_type(self: OperationVc<Self>) -> Vc<()> {
+14 |     fn arbitrary_self_type(self: OperationVc<Self>) -> Vc<()> {
    |                            ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0307]: invalid `self` parameter type: `OperationVc<Foobar>`
-  --> tests/function/fail_operation_method_self_type.rs:13:34
+  --> tests/function/fail_operation_method_self_type.rs:14:34
    |
-13 |     fn arbitrary_self_type(self: OperationVc<Self>) -> Vc<()> {
+14 |     fn arbitrary_self_type(self: OperationVc<Self>) -> Vc<()> {
    |                                  ^^^^^^^^^^^^^^^^^
    |
    = note: type of `self` must be `Self` or some type implementing `Receiver`
    = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
 
 error[E0277]: the trait bound `fn(OperationVc<Foobar>) -> Vc<()> {Foobar::arbitrary_self_type_turbo_tasks_function_inline}: turbo_tasks::task::function::IntoTaskFnWithThis<_, _, _>` is not satisfied
-  --> tests/function/fail_operation_method_self_type.rs:10:1
+  --> tests/function/fail_operation_method_self_type.rs:11:1
    |
-10 | #[turbo_tasks::value_impl]
+11 | #[turbo_tasks::value_impl]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
    = help: the trait `turbo_tasks::task::function::TaskFnInputFunctionWithThis<_, _, _>` is not implemented for fn item `fn(OperationVc<Foobar>) -> Vc<()> {Foobar::arbitrary_self_type_turbo_tasks_function_inline}`

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type_base_vc.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type_base_vc.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
+#![allow(unexpected_cfgs)]
 
 use turbo_tasks::Vc;
 

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type_base_vc.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type_base_vc.stderr
@@ -1,5 +1,5 @@
 error: methods taking `self` are not supported with `operation`
-  --> tests/function/fail_operation_method_self_type_base_vc.rs:13:36
+  --> tests/function/fail_operation_method_self_type_base_vc.rs:14:36
    |
-13 |     fn arbitrary_self_type_base_vc(self: Vc<Self>) -> Vc<()> {
+14 |     fn arbitrary_self_type_base_vc(self: Vc<Self>) -> Vc<()> {
    |                                    ^^^^^^^^^^^^^^

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_vc_arg.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_vc_arg.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![allow(unexpected_cfgs)]
 
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, Vc};

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_vc_arg.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_vc_arg.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `Vc<i32>: NonLocalValue` is not satisfied
- --> tests/function/fail_operation_vc_arg.rs:7:26
+ --> tests/function/fail_operation_vc_arg.rs:8:26
   |
-7 | async fn multiply(value: Vc<i32>, coefficient: ResolvedVc<i32>) -> Result<Vc<i32>> {
+8 | async fn multiply(value: Vc<i32>, coefficient: ResolvedVc<i32>) -> Result<Vc<i32>> {
   |                          ^^^^^^^ the trait `NonLocalValue` is not implemented for `Vc<i32>`
   |
   = help: the following other types implement trait `NonLocalValue`:

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_non_local_vc_input.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_non_local_vc_input.rs
@@ -1,6 +1,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 #![allow(dead_code)]
+#![allow(unexpected_cfgs)]
 
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, Vc};

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_operation_accepts_resolved.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/pass_operation_accepts_resolved.rs
@@ -1,3 +1,4 @@
+#![allow(unexpected_cfgs)]
 use anyhow::Result;
 use turbo_tasks::{OperationVc, ResolvedVc, Vc};
 

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value/fail_non_local.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value/fail_non_local.rs
@@ -1,5 +1,6 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
+#![allow(unexpected_cfgs)]
 
 use turbo_tasks::Vc;
 

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value/fail_non_local.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value/fail_non_local.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `Vc<i32>: NonLocalValue` is not satisfied
- --> tests/value/fail_non_local.rs:8:12
+ --> tests/value/fail_non_local.rs:9:12
   |
-8 |     value: Vc<i32>,
+9 |     value: Vc<i32>,
   |            ^^^^^^^ the trait `NonLocalValue` is not implemented for `Vc<i32>`
   |
   = help: the following other types implement trait `NonLocalValue`:
@@ -15,8 +15,8 @@ error[E0277]: the trait bound `Vc<i32>: NonLocalValue` is not satisfied
             (E, D, C, B, A, Z, Y, X, W, V, U, T)
           and $N others
 note: required by a bound in `DeriveNonLocalValueAssertion::assert_impl_NonLocalValue`
- --> tests/value/fail_non_local.rs:6:1
+ --> tests/value/fail_non_local.rs:7:1
   |
-6 | #[turbo_tasks::value]
+7 | #[turbo_tasks::value]
   | ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeriveNonLocalValueAssertion::assert_impl_NonLocalValue`
   = note: this error originates in the derive macro `turbo_tasks::NonLocalValue` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value/pass_non_local.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value/pass_non_local.rs
@@ -1,5 +1,6 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
+#![allow(unexpected_cfgs)]
 
 #[turbo_tasks::value]
 struct MyValue {

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value_trait/fail_missing_function_annotation.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value_trait/fail_missing_function_annotation.rs
@@ -1,5 +1,6 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
+#![allow(unexpected_cfgs)]
 
 use turbo_tasks::Vc;
 

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value_trait/fail_missing_function_annotation.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value_trait/fail_missing_function_annotation.stderr
@@ -1,5 +1,5 @@
 error: trait items cannot be operations
-  --> tests/value_trait/fail_missing_function_annotation.rs:13:29
+  --> tests/value_trait/fail_missing_function_annotation.rs:14:29
    |
-13 |     #[turbo_tasks::function(operation)]
+14 |     #[turbo_tasks::function(operation)]
    |                             ^^^^^^^^^

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value_trait/pass_non_local.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value_trait/pass_non_local.rs
@@ -1,5 +1,6 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
+#![allow(unexpected_cfgs)]
 
 #[turbo_tasks::value_trait]
 trait MyTrait {}

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value_trait/pass_trait_items.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value_trait/pass_trait_items.rs
@@ -1,5 +1,6 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
+#![allow(unexpected_cfgs)]
 
 use turbo_tasks::Vc;
 

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -183,4 +183,16 @@ pub fn register_trait_methods(value: &mut ValueType) {
     }
 }
 
-pub use inventory::submit as inventory_submit;
+/// Submit an item to the inventory.
+///
+/// This macro is a wrapper around `inventory::submit` that adds a `#[not(cfg(rust_analyzer))]`
+/// attribute to the item. This is to avoid warnings about unused items when using Rust Analyzer.
+#[macro_export]
+macro_rules! inventory_submit {
+    ($($item:tt),*) => {
+        #[cfg(not(rust_analyzer))]
+        {
+            ::inventory::submit! { $($item),* }
+        }
+    }
+}

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -12,6 +12,7 @@ use crate::{
     ValueTypeId, Vc, debug::ValueDebugFormatString, task::TaskOutput,
 };
 pub use crate::{
+    inventory_submit,
     magic_any::MagicAny,
     manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached_for_testing},
     native_function::{
@@ -189,10 +190,12 @@ pub fn register_trait_methods(value: &mut ValueType) {
 /// attribute to the item. This is to avoid warnings about unused items when using Rust Analyzer.
 #[macro_export]
 macro_rules! inventory_submit {
-    ($($item:tt),*) => {
+    ($($item:tt)*) => {
         #[cfg(not(rust_analyzer))]
-        {
-            ::inventory::submit! { $($item),* }
-        }
+        $crate::macro_helpers::inventory_submit_inner! { $($item)* }
     }
 }
+
+/// Exported so the above macro can reference it.
+#[doc(hidden)]
+pub use inventory::submit as inventory_submit_inner;


### PR DESCRIPTION
### What?
In #83074 we changed how turbo task objects were registered to use the `inventory` crate.
This PR adds a new `inventory_submit!` macro that wraps the existing `inventory::submit` function with a `#[cfg(not(rust_analyzer))]` attribute to prevent Rust Analyzer choking on the generated code.

See example error

![image.png](https://app.graphite.dev/user-attachments/assets/2fe87f23-8717-4615-a86d-94c1b19ae099.png)

Because the inventory code does not affect any API surfaces this is safe and if anything should improve rust-analyzer performance

Closes PACK-5408