### PR TITLE
[turbopack] Add an execution test for the behavior when a module throws an error

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/evaluation-errors/basic/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/evaluation-errors/basic/input/index.js
@@ -1,0 +1,16 @@
+it('module evaluation rethrows but does not re-evaluate', async () => {
+  expect(globalThis.evalCounter).toBeUndefined()
+  await assertThrowsThrows()
+  expect(globalThis.evalCounter).toBe(1)
+  await assertThrowsThrows()
+  expect(globalThis.evalCounter).toBe(1)
+})
+
+async function assertThrowsThrows() {
+  try {
+    await import('./throws')
+  } catch (e) {
+    return e
+  }
+  throw new Error('should have thrown')
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/evaluation-errors/basic/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/evaluation-errors/basic/input/index.js
@@ -4,6 +4,13 @@ it('module evaluation rethrows but does not re-evaluate', async () => {
   expect(globalThis.evalCounter).toBe(1)
   await assertThrowsThrows()
   expect(globalThis.evalCounter).toBe(1)
+
+  // We do re-evaluate if the module cache is cleared
+  require.cache[require.resolve('./throws')] = undefined
+  await assertThrowsThrows()
+  expect(globalThis.evalCounter).toBe(2)
+  await assertThrowsThrows()
+  expect(globalThis.evalCounter).toBe(2)
 })
 
 async function assertThrowsThrows() {

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/evaluation-errors/basic/input/throws.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/evaluation-errors/basic/input/throws.js
@@ -1,0 +1,4 @@
+globalThis.evalCounter ??= 0
+globalThis.evalCounter++
+
+throw new Error('uh oh')


### PR DESCRIPTION
Confirms that we don't re-evaluate modules after an error

Clearing the require.cache allows us to re-evaluate

Closes PACK-5407