### PR TITLE
[turbopack] Simplify up and dowcasts

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -525,8 +525,7 @@ async fn benchmark_file_io(
     directory: FileSystemPath,
 ) -> Result<Vc<Completion>> {
     // try to get the real file path on disk so that we can use it with tokio
-    let fs = Vc::try_resolve_downcast_type::<DiskFileSystem>(directory.fs())
-        .await?
+    let fs = ResolvedVc::try_downcast_type::<DiskFileSystem>(directory.fs)
         .context(anyhow!(
             "expected node_root to be a DiskFileSystem, cannot benchmark"
         ))?

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -383,7 +383,7 @@ impl AppProject {
                         )),
                         module_styles_rule_condition(),
                     ]),
-                    ResolvedVc::upcast(self.css_client_reference_transition().to_resolved().await?),
+                    self.css_client_reference_transition().to_resolved().await?,
                 ),
                 // Don't wrap in marker module but change context, this is used to determine
                 // the list of CSS module classes.
@@ -399,7 +399,7 @@ impl AppProject {
                 // Mark as client reference all regular CSS imports
                 TransitionRule::new(
                     styles_rule_condition(),
-                    ResolvedVc::upcast(self.css_client_reference_transition().to_resolved().await?),
+                    self.css_client_reference_transition().to_resolved().await?,
                 ),
             ],
             ..Default::default()
@@ -413,7 +413,7 @@ impl AppProject {
             self.get_rsc_transitions(
                 self.ecmascript_client_reference_transition(),
                 Vc::upcast(self.ssr_transition()),
-                Vc::upcast(self.shared_transition()),
+                self.shared_transition(),
             ),
             self.project().server_compile_time_info(),
             self.rsc_module_options_context(),
@@ -428,7 +428,7 @@ impl AppProject {
             self.get_rsc_transitions(
                 self.edge_ecmascript_client_reference_transition(),
                 Vc::upcast(self.edge_ssr_transition()),
-                Vc::upcast(self.edge_shared_transition()),
+                self.edge_shared_transition(),
             ),
             self.project().edge_compile_time_info(),
             self.edge_rsc_module_options_context(),
@@ -467,7 +467,7 @@ impl AppProject {
             ),
             (
                 rcstr!("next-shared"),
-                ResolvedVc::upcast(self.shared_transition().to_resolved().await?),
+                self.shared_transition().to_resolved().await?,
             ),
             (
                 rcstr!("next-server-utility"),
@@ -518,7 +518,7 @@ impl AppProject {
             ),
             (
                 rcstr!("next-shared"),
-                ResolvedVc::upcast(self.edge_shared_transition().to_resolved().await?),
+                self.edge_shared_transition().to_resolved().await?,
             ),
             (
                 rcstr!("next-server-utility"),
@@ -640,7 +640,7 @@ impl AppProject {
             ),
             (
                 rcstr!("next-shared"),
-                ResolvedVc::upcast(self.shared_transition().to_resolved().await?),
+                self.shared_transition().to_resolved().await?,
             ),
         ]
         .into_iter()
@@ -712,7 +712,7 @@ impl AppProject {
             ),
             (
                 rcstr!("next-shared"),
-                ResolvedVc::upcast(self.edge_shared_transition().to_resolved().await?),
+                self.edge_shared_transition().to_resolved().await?,
             ),
         ]
         .into_iter()
@@ -877,8 +877,7 @@ impl AppProject {
             // Implements layout segment optimization to compute a graph "chain" for each layout
             // segment
             async move {
-                let rsc_entry_chunk_group =
-                    ChunkGroupEntry::Entry(vec![ResolvedVc::upcast(rsc_entry)]);
+                let rsc_entry_chunk_group = ChunkGroupEntry::Entry(vec![rsc_entry]);
 
                 let mut graphs = vec![];
                 let mut visited_modules = if has_layout_segments {
@@ -1389,18 +1388,16 @@ impl AppEndpoint {
                 polyfill_files: vec![polyfill_output_asset],
                 ..Default::default()
             };
-            let build_manifest_output = ResolvedVc::upcast(
-                build_manifest
-                    .build_output(
-                        node_root.join(&format!(
-                            "server/app{manifest_path_prefix}/build-manifest.json",
-                        ))?,
-                        client_relative_path.clone(),
-                    )
-                    .await?
-                    .to_resolved()
-                    .await?,
-            );
+            let build_manifest_output = build_manifest
+                .build_output(
+                    node_root.join(&format!(
+                        "server/app{manifest_path_prefix}/build-manifest.json",
+                    ))?,
+                    client_relative_path.clone(),
+                )
+                .await?
+                .to_resolved()
+                .await?;
             server_assets.insert(build_manifest_output);
         }
 
@@ -1548,7 +1545,7 @@ impl AppEndpoint {
                 if emit_manifests == EmitManifests::Full {
                     let dynamic_import_entries = collect_next_dynamic_chunks(
                         *module_graphs.full,
-                        *ResolvedVc::upcast(client_chunking_context),
+                        *client_chunking_context,
                         next_dynamic_imports,
                         NextDynamicChunkAvailability::ClientReferences(
                             &*(client_references_chunks.await?),
@@ -1663,7 +1660,7 @@ impl AppEndpoint {
                     // create react-loadable-manifest for next/dynamic
                     let dynamic_import_entries = collect_next_dynamic_chunks(
                         *module_graphs.full,
-                        *ResolvedVc::upcast(client_chunking_context),
+                        *client_chunking_context,
                         next_dynamic_imports,
                         NextDynamicChunkAvailability::ClientReferences(
                             &*(client_references_chunks.await?),

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -80,7 +80,7 @@ pub(crate) async fn collect_next_dynamic_chunks(
             let async_chunk_group = async_loader.references().to_resolved().await?;
 
             let module_id = dynamic_entry
-                .chunk_item_id(Vc::upcast(chunking_context))
+                .chunk_item_id(chunking_context)
                 .to_resolved()
                 .await?;
 

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -398,7 +398,7 @@ pub async fn all_assets_from_entries_filtered(
                     .iter()
                     .map(async |asset| {
                         Ok((
-                            ResolvedVc::upcast(*asset),
+                            *asset,
                             if emit_spans {
                                 Some(asset.path().to_string().await?)
                             } else {

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -322,7 +322,7 @@ impl PagesProject {
                 (
                     rcstr!("next-dynamic-client"),
                     ResolvedVc::upcast(
-                        NextDynamicTransition::new_client(Vc::upcast(self.client_transition()))
+                        NextDynamicTransition::new_client(self.client_transition())
                             .to_resolved()
                             .await?,
                     ),
@@ -1073,7 +1073,7 @@ impl PageEndpoint {
             {
                 collect_next_dynamic_chunks(
                     self.client_module_graph(),
-                    Vc::upcast(project.client_chunking_context()),
+                    project.client_chunking_context(),
                     next_dynamic_imports,
                     NextDynamicChunkAvailability::AvailabilityInfo(client_availability_info),
                 )
@@ -1084,7 +1084,7 @@ impl PageEndpoint {
 
             let chunking_context: Vc<Box<dyn ChunkingContext>> = match runtime {
                 NextRuntime::NodeJs => Vc::upcast(node_chunking_context),
-                NextRuntime::Edge => Vc::upcast(edge_chunking_context),
+                NextRuntime::Edge => edge_chunking_context,
             };
 
             let mut current_chunks = OutputAssets::empty();
@@ -1342,16 +1342,14 @@ impl PageEndpoint {
             ..Default::default()
         };
         let manifest_path_prefix = get_asset_prefix_from_pathname(&self.pathname);
-        Ok(Vc::upcast(
-            build_manifest
-                .build_output(
-                    node_root.join(&format!(
-                        "server/pages{manifest_path_prefix}/build-manifest.json",
-                    ))?,
-                    client_relative_path,
-                )
-                .await?,
-        ))
+        build_manifest
+            .build_output(
+                node_root.join(&format!(
+                    "server/pages{manifest_path_prefix}/build-manifest.json",
+                ))?,
+                client_relative_path,
+            )
+            .await
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1380,7 +1380,7 @@ impl Project {
 
         let middleware = self.find_middleware();
         let FindContextFileResult::Found(fs_path, _) = &*middleware.await? else {
-            return Ok(Vc::upcast(edge_module_context));
+            return Ok(edge_module_context);
         };
         let source = Vc::upcast(FileSource::new(fs_path.clone()));
 

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -77,7 +77,7 @@ pub(crate) async fn create_server_actions_manifest(
         .to_resolved()
         .await?;
 
-    let chunk_item = loader.as_chunk_item(module_graph, Vc::upcast(chunking_context));
+    let chunk_item = loader.as_chunk_item(module_graph, chunking_context);
     let manifest = build_manifest(
         node_root,
         page_name,
@@ -275,14 +275,13 @@ pub fn parse_server_actions(
 /// If found, we return the mapping of every action's hashed id to the name of
 /// the exported action function. If not, we return a None.
 #[turbo_tasks::function]
-async fn parse_actions(module: Vc<Box<dyn Module>>) -> Result<Vc<OptionActionMap>> {
-    let Some(ecmascript_asset) =
-        Vc::try_resolve_sidecast::<Box<dyn EcmascriptParsable>>(module).await?
+async fn parse_actions(module: ResolvedVc<Box<dyn Module>>) -> Result<Vc<OptionActionMap>> {
+    let Some(ecmascript_asset) = ResolvedVc::try_sidecast::<Box<dyn EcmascriptParsable>>(module)
     else {
         return Ok(Vc::cell(None));
     };
 
-    if let Some(module) = Vc::try_resolve_downcast_type::<EcmascriptModulePartAsset>(module).await?
+    if let Some(module) = ResolvedVc::try_downcast_type::<EcmascriptModulePartAsset>(module)
         && matches!(
             module.await?.part,
             ModulePart::Evaluation | ModulePart::Facade

--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{ModuleAssetContext, transition::Transition};
@@ -219,10 +219,10 @@ impl AppPageLoaderTreeBuilder {
 
         let identifier = magic_identifier::mangle(&format!("{name} #{i}"));
         let inner_module_id = format!("METADATA_{i}");
-        let helper_import: RcStr = "import { fillMetadataSegment } from \
-                                    'next/dist/lib/metadata/get-metadata-route' with { \
-                                    'turbopack-transition': 'next-server-utility' }"
-            .into();
+        let helper_import = rcstr!(
+            "import { fillMetadataSegment } from 'next/dist/lib/metadata/get-metadata-route' with \
+             { 'turbopack-transition': 'next-server-utility' }"
+        );
 
         if !self.base.imports.contains(&helper_import) {
             self.base.imports.push(helper_import);
@@ -231,11 +231,11 @@ impl AppPageLoaderTreeBuilder {
         self.base
             .imports
             .push(format!("import {identifier} from \"{inner_module_id}\";").into());
-        let module = Vc::upcast(StructuredImageModuleType::create_module(
+        let module = StructuredImageModuleType::create_module(
             Vc::upcast(FileSource::new(path.clone())),
             BlurPlaceholderMode::None,
             *self.base.module_asset_context,
-        ));
+        );
         let module = self.base.process_module(module).to_resolved().await?;
         self.base
             .inner_assets

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -159,7 +159,7 @@ pub async fn all_assets_from_entries(entries: Vc<OutputAssets>) -> Result<Vc<Out
                     .iter()
                     .map(async |asset| {
                         Ok((
-                            ResolvedVc::upcast(*asset),
+                            *asset,
                             if emit_spans {
                                 Some(asset.path().to_string().await?)
                             } else {

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -158,7 +158,7 @@ struct HmrEntryChunkItem {
 impl ChunkItem for HmrEntryChunkItem {
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(*self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -166,7 +166,7 @@ async fn wrap_edge_page(
 
     let wrapped = asset_context
         .process(
-            Vc::upcast(source),
+            source,
             ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
         .module();

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -102,7 +102,7 @@ pub async fn get_app_route_entry(
 
     let mut rsc_entry = module_asset_context
         .process(
-            Vc::upcast(virtual_source),
+            virtual_source,
             ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
         .module();
@@ -153,7 +153,7 @@ async fn wrap_edge_route(
 
     let wrapped = asset_context
         .process(
-            Vc::upcast(source),
+            source,
             ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
         .module();

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -300,7 +300,7 @@ impl ChunkItem for EcmascriptClientReferenceProxyChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(*self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -137,10 +137,7 @@ impl EcmascriptChunkItem for NextDynamicEntryChunkItem {
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
         let inner = self.inner.await?;
 
-        let module_id = inner
-            .module
-            .chunk_item_id(Vc::upcast(*self.chunking_context))
-            .await?;
+        let module_id = inner.module.chunk_item_id(*self.chunking_context).await?;
         Ok(EcmascriptChunkItemContent {
             inner_code: formatdoc!(
                 r#"

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -169,7 +169,7 @@ impl ClientReferenceManifest {
                 let server_path = client_reference_module_ref.server_ident.to_string().await?;
                 let client_module = client_reference_module_ref.client_module;
                 let client_chunk_item_id = client_module
-                    .chunk_item_id(*ResolvedVc::upcast(client_chunking_context))
+                    .chunk_item_id(*client_chunking_context)
                     .await?;
 
                 let (client_chunks_paths, client_is_async) =
@@ -213,12 +213,10 @@ impl ClientReferenceManifest {
 
                 if let Some(ssr_chunking_context) = ssr_chunking_context {
                     let ssr_module = client_reference_module_ref.ssr_module;
-                    let ssr_chunk_item_id = ssr_module
-                        .chunk_item_id(*ResolvedVc::upcast(ssr_chunking_context))
-                        .await?;
+                    let ssr_chunk_item_id = ssr_module.chunk_item_id(*ssr_chunking_context).await?;
 
                     let rsc_chunk_item_id = client_reference_module
-                        .chunk_item_id(*ResolvedVc::upcast(ssr_chunking_context))
+                        .chunk_item_id(*ssr_chunking_context)
                         .await?;
 
                     let (ssr_chunks_paths, ssr_is_async) = if runtime == NextRuntime::Edge {

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -279,7 +279,7 @@ async fn wrap_edge_page(
 
     let wrapped = asset_context
         .process(
-            Vc::upcast(source),
+            source,
             ReferenceType::Internal(ResolvedVc::cell(inner_assets)),
         )
         .module();

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -130,10 +130,7 @@ impl EcmascriptChunkItem for NextServerComponentChunkItem {
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
         let inner = self.inner.await?;
 
-        let module_id = inner
-            .module
-            .chunk_item_id(Vc::upcast(*self.chunking_context))
-            .await?;
+        let module_id = inner.module.chunk_item_id(*self.chunking_context).await?;
         Ok(EcmascriptChunkItemContent {
             inner_code: formatdoc!(
                 r#"

--- a/crates/next-core/src/next_server_utility/server_utility_module.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_module.rs
@@ -130,10 +130,7 @@ impl EcmascriptChunkItem for NextServerComponentChunkItem {
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
         let inner = self.inner.await?;
 
-        let module_id = inner
-            .module
-            .chunk_item_id(Vc::upcast(*self.chunking_context))
-            .await?;
+        let module_id = inner.module.chunk_item_id(*self.chunking_context).await?;
         Ok(EcmascriptChunkItemContent {
             inner_code: formatdoc!(
                 "{TURBOPACK_EXPORT_NAMESPACE}({TURBOPACK_IMPORT}({}));",

--- a/turbopack/crates/turbo-tasks-backend/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/all_in_one.rs
@@ -182,8 +182,8 @@ struct Number(u32);
 #[turbo_tasks::value_impl]
 impl Add for Number {
     #[turbo_tasks::function]
-    async fn add(self: Vc<Self>, other: Vc<Box<dyn Add>>) -> Result<Vc<Self>> {
-        let Some(other) = Vc::try_resolve_downcast_type::<Number>(other).await? else {
+    async fn add(self: Vc<Self>, other: ResolvedVc<Box<dyn Add>>) -> Result<Vc<Self>> {
+        let Some(other) = ResolvedVc::try_downcast_type::<Number>(other) else {
             bail!("Expected Number");
         };
         Ok(Vc::cell(*self.await? + *other.await?))
@@ -196,8 +196,8 @@ struct NumberB(u32);
 #[turbo_tasks::value_impl]
 impl Add for NumberB {
     #[turbo_tasks::function]
-    async fn add(self: Vc<Self>, other: Vc<Box<dyn Add>>) -> Result<Vc<Self>> {
-        let Some(other) = Vc::try_resolve_downcast_type::<NumberB>(other).await? else {
+    async fn add(self: Vc<Self>, other: ResolvedVc<Box<dyn Add>>) -> Result<Vc<Self>> {
+        let Some(other) = ResolvedVc::try_downcast_type::<NumberB>(other) else {
             bail!("Expected NumberB");
         };
         Ok(Vc::cell(*self.await? + *other.await?))

--- a/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell_mode.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell_mode.rs
@@ -125,7 +125,7 @@ where
     // contain the same value
     let mut upcast_vcs = Vec::new();
     for _idx in 0..2 {
-        upcast_vcs.push(Vc::upcast((cell_fn)(input.value)));
+        upcast_vcs.push(Vc::upcast_non_strict((cell_fn)(input.value)));
     }
 
     // pick a different cell idx upon each invalidation/execution

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -2298,12 +2298,12 @@ impl ValueToString for NullFileSystem {
 
 pub async fn to_sys_path(mut path: FileSystemPath) -> Result<Option<PathBuf>> {
     loop {
-        if let Some(fs) = Vc::try_resolve_downcast_type::<AttachedFileSystem>(path.fs()).await? {
+        if let Some(fs) = ResolvedVc::try_downcast_type::<AttachedFileSystem>(path.fs) {
             path = fs.get_inner_fs_path(path).owned().await?;
             continue;
         }
 
-        if let Some(fs) = Vc::try_resolve_downcast_type::<DiskFileSystem>(path.fs()).await? {
+        if let Some(fs) = ResolvedVc::try_downcast_type::<DiskFileSystem>(path.fs) {
             let sys_path = fs.await?.to_sys_path(path)?;
             return Ok(Some(sys_path));
         }

--- a/turbopack/crates/turbo-tasks-fs/src/util.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/util.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow};
-use turbo_tasks::Vc;
+use turbo_tasks::ResolvedVc;
 
 use crate::{DiskFileSystem, FileSystemPath};
 
@@ -23,9 +23,8 @@ pub fn extract_disk_access<T>(value: io::Result<T>, path: &Path) -> Result<Optio
 pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<String> {
     use turbo_unix_path::sys_to_unix;
 
-    let root_fs = root.fs();
-    let root_fs = &*Vc::try_resolve_downcast_type::<DiskFileSystem>(root_fs)
-        .await?
+    let root_fs = root.fs;
+    let root_fs = &*ResolvedVc::try_downcast_type::<DiskFileSystem>(root_fs)
         .context("Expected root to have a DiskFileSystem")?
         .await?;
 
@@ -48,9 +47,8 @@ pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<S
 
 #[cfg(target_os = "windows")]
 pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<String> {
-    let root_fs = root.fs();
-    let root_fs = &*Vc::try_resolve_downcast_type::<DiskFileSystem>(root_fs)
-        .await?
+    let root_fs = root.fs;
+    let root_fs = &*ResolvedVc::try_downcast_type::<DiskFileSystem>(root_fs)
         .context("Expected root to have a DiskFileSystem")?
         .await?;
 

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -329,6 +329,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
             // rustc complains: error[E0210]: type parameter `T` must be covered by another type when it appears before
             // the first local type (`dyn Trait`).
             unsafe impl #impl_generics turbo_tasks::Upcast<::std::boxed::Box<dyn #trait_path>> for #ty #where_clause {}
+            unsafe impl #impl_generics turbo_tasks::UpcastStrict<::std::boxed::Box<dyn #trait_path>> for #ty #where_clause {}
 
             impl #impl_generics #trait_path for #ty #where_clause {
                 #(#trait_items)*

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -250,6 +250,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
         quote! {
             unsafe impl turbo_tasks::Dynamic<Box<dyn turbo_tasks::debug::ValueDebug>> for Box<dyn #trait_ident> {}
             unsafe impl turbo_tasks::Upcast<Box<dyn turbo_tasks::debug::ValueDebug>> for Box<dyn #trait_ident> {}
+            unsafe impl turbo_tasks::UpcastStrict<Box<dyn turbo_tasks::debug::ValueDebug>> for Box<dyn #trait_ident> {}
         }
     } else {
         quote! {}
@@ -314,8 +315,6 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         unsafe impl turbo_tasks::Dynamic<Box<dyn #trait_ident>> for Box<dyn #trait_ident> {}
-        // TODO(alexkirsz) It would be great to have the following identity. However, I run into an ICE when I attempt this,
-        // so tabling it for now.
         unsafe impl turbo_tasks::Upcast<Box<dyn #trait_ident>> for Box<dyn #trait_ident> {}
 
         impl<T> #trait_ident for T
@@ -328,6 +327,8 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
         #(
             unsafe impl turbo_tasks::Dynamic<Box<dyn #supertraits>> for Box<dyn #trait_ident> {}
             unsafe impl turbo_tasks::Upcast<Box<dyn #supertraits>> for Box<dyn #trait_ident> {}
+            unsafe impl turbo_tasks::UpcastStrict<Box<dyn #supertraits>> for Box<dyn #trait_ident> {
+            }
         )*
 
         #value_debug_impl

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -132,8 +132,8 @@ pub use value::{TransientInstance, TransientValue};
 pub use value_type::{TraitMethod, TraitType, ValueType};
 pub use vc::{
     Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, ReadVcFuture, ResolvedVc,
-    Upcast, ValueDefault, Vc, VcCast, VcCellNewMode, VcCellSharedMode, VcDefaultRead, VcRead,
-    VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType, VcValueTypeCast,
+    Upcast, UpcastStrict, ValueDefault, Vc, VcCast, VcCellNewMode, VcCellSharedMode, VcDefaultRead,
+    VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType, VcValueTypeCast,
 };
 
 pub type SliceMap<K, V> = Box<[(K, V)]>;

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -28,7 +28,7 @@ pub use self::{
     operation::{OperationValue, OperationVc},
     read::{ReadOwnedVcFuture, ReadVcFuture, VcDefaultRead, VcRead, VcTransparentRead},
     resolved::ResolvedVc,
-    traits::{Dynamic, Upcast, VcValueTrait, VcValueType},
+    traits::{Dynamic, Upcast, UpcastStrict, VcValueTrait, VcValueType},
 };
 use crate::{
     CellId, RawVc, ResolveTypeError,
@@ -412,6 +412,33 @@ where
     #[inline(always)]
     pub fn upcast<K>(vc: Self) -> Vc<K>
     where
+        T: UpcastStrict<K>,
+        K: VcValueTrait + ?Sized,
+    {
+        Self::upcast_non_strict(vc)
+    }
+
+    /// Upcasts the given `Vc<T>` to a `Vc<Box<dyn K>>`
+    ///
+    /// This has a loose type constraint which would allow upcasting to the same type, prefer using
+    /// [`Vc::upcast`] when possible.  This is useful for extension traits and other more generic
+    /// usecases.
+    ///
+    /// # Example
+    /// ```rust
+    /// // In generic code where T might be the same as K
+    /// fn process_foo(vc: ResolvedVc<impl Upcast<Box<dyn MyTrait>>>) -> Vc<Foo> {
+    ///    let my_trait: ResolvedVc<Box<dyn MyTrait>> = Vc::upcast_non_strict(vc);
+    ///    my_trait.do_something()
+    /// }
+    /// ```
+    /// Using generics you could allow users to pass any compatible type, but if you specified
+    /// `UpcastStrict<...>` instead of `Upcast<...>` you would disallow calling this function if you
+    /// already had a `ResolvedVc<Box<dyn MyTrait>>.  So this function has a looser type constraint
+    /// to make these functions easier to write and use.
+    #[inline(always)]
+    pub fn upcast_non_strict<K>(vc: Self) -> Vc<K>
+    where
         T: Upcast<K>,
         K: VcValueTrait + ?Sized,
     {
@@ -420,7 +447,6 @@ where
             _t: PhantomData,
         }
     }
-
     /// Runs the operation, but ignores the returned Vc. Use that when only interested in running
     /// the task for side effects.
     pub async fn as_side_effect(self) -> Result<()> {
@@ -493,6 +519,12 @@ where
     where
         K: VcValueTrait + ?Sized,
     {
+        debug_assert!(
+            <K as VcValueTrait>::get_trait_type_id() != <T as VcValueTrait>::get_trait_type_id(),
+            "Attempted to cast a type {} to itself, which is pointless. Use the value directly \
+             instead.",
+            crate::registry::get_trait(<T as VcValueTrait>::get_trait_type_id()).global_name
+        );
         let raw_vc: RawVc = vc.node;
         let raw_vc = raw_vc
             .resolve_trait(<K as VcValueTrait>::get_trait_type_id())
@@ -510,16 +542,9 @@ where
     /// Returns `None` if the underlying value type is not a `K`.
     pub async fn try_resolve_downcast<K>(vc: Self) -> Result<Option<Vc<K>>, ResolveTypeError>
     where
-        K: Upcast<T> + VcValueTrait + ?Sized,
+        K: UpcastStrict<T> + VcValueTrait + ?Sized,
     {
-        let raw_vc: RawVc = vc.node;
-        let raw_vc = raw_vc
-            .resolve_trait(<K as VcValueTrait>::get_trait_type_id())
-            .await?;
-        Ok(raw_vc.map(|raw_vc| Vc {
-            node: raw_vc,
-            _t: PhantomData,
-        }))
+        Self::try_resolve_sidecast(vc).await
     }
 
     /// Attempts to downcast the given `Vc<Box<dyn T>>` to a `Vc<K>`, where `K`
@@ -529,7 +554,7 @@ where
     /// Returns `None` if the underlying value type is not a `K`.
     pub async fn try_resolve_downcast_type<K>(vc: Self) -> Result<Option<Vc<K>>, ResolveTypeError>
     where
-        K: Upcast<T> + VcValueType,
+        K: UpcastStrict<T> + VcValueType,
     {
         let raw_vc: RawVc = vc.node;
         let raw_vc = raw_vc
@@ -565,7 +590,7 @@ where
 
 impl<T> ValueDebugFormat for Vc<T>
 where
-    T: Upcast<Box<dyn ValueDebug>> + Send + Sync + ?Sized,
+    T: UpcastStrict<Box<dyn ValueDebug>> + Send + Sync + ?Sized,
 {
     fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         ValueDebugFormatString::Async(Box::pin(async move {

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub use turbo_tasks_macros::OperationValue;
 
 use crate::{
-    CollectiblesSource, RawVc, ReadVcFuture, ResolvedVc, TaskInput, Upcast, Vc, VcValueTrait,
+    CollectiblesSource, RawVc, ReadVcFuture, ResolvedVc, TaskInput, UpcastStrict, Vc, VcValueTrait,
     VcValueType, marker_trait::impl_auto_marker_trait, trace::TraceRawVcs,
 };
 
@@ -94,7 +94,7 @@ impl<T: ?Sized> OperationVc<T> {
     #[inline(always)]
     pub fn upcast<K>(vc: Self) -> OperationVc<K>
     where
-        T: Upcast<K>,
+        T: UpcastStrict<K>,
         K: VcValueTrait + ?Sized,
     {
         OperationVc {

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -12,7 +12,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    RawVc, Upcast, VcRead, VcTransparentRead, VcValueTrait, VcValueType,
+    RawVc, Upcast, UpcastStrict, VcRead, VcTransparentRead, VcValueTrait, VcValueType,
     debug::{ValueDebug, ValueDebugFormat, ValueDebugFormatString},
     trace::{TraceRawVcs, TraceRawVcsContext},
     vc::Vc,
@@ -199,11 +199,25 @@ where
     #[inline(always)]
     pub fn upcast<K>(this: Self) -> ResolvedVc<K>
     where
+        T: UpcastStrict<K>,
+        K: VcValueTrait + ?Sized,
+    {
+        Self::upcast_non_strict(this)
+    }
+
+    /// Upcasts the given `ResolvedVc<T>` to a `ResolvedVc<Box<dyn K>>`.
+    ///
+    /// This has a loose type constraint which would allow upcasting to the same type, prefer using
+    /// [`ResolvedVc::upcast`] when possible. See also: [`Vc::upcast_non_strict`].  This is
+    /// useful for extension traits and other more generic usecases.
+    #[inline(always)]
+    pub fn upcast_non_strict<K>(this: Self) -> ResolvedVc<K>
+    where
         T: Upcast<K>,
         K: VcValueTrait + ?Sized,
     {
         ResolvedVc {
-            node: Vc::upcast(this.node),
+            node: Vc::upcast_non_strict(this.node),
         }
     }
 
@@ -236,6 +250,15 @@ where
     where
         K: VcValueTrait + ?Sized,
     {
+        // Runtime assertion to catch K == T cases with a clear error message
+        // This will be optimized away in release builds but helps during development
+        // We use trait type IDs since T and K might be trait objects (?Sized)
+        debug_assert!(
+            <K as VcValueTrait>::get_trait_type_id() != <T as VcValueTrait>::get_trait_type_id(),
+            "Attempted to cast a type {} to itself, which is pointless. Use the value directly \
+             instead.",
+            crate::registry::get_trait(<T as VcValueTrait>::get_trait_type_id()).global_name
+        );
         // `RawVc::TaskCell` already contains all the type information needed to check this
         // sidecast, so we don't need to read the underlying cell!
         let raw_vc = this.node.node;
@@ -257,7 +280,7 @@ where
     /// See also: [`Vc::try_resolve_downcast`].
     pub fn try_downcast<K>(this: Self) -> Option<ResolvedVc<K>>
     where
-        K: Upcast<T> + VcValueTrait + ?Sized,
+        K: UpcastStrict<T> + VcValueTrait + ?Sized,
     {
         // this is just a more type-safe version of a sidecast
         Self::try_sidecast(this)
@@ -270,7 +293,7 @@ where
     /// See also: [`Vc::try_resolve_downcast_type`].
     pub fn try_downcast_type<K>(this: Self) -> Option<ResolvedVc<K>>
     where
-        K: Upcast<T> + VcValueType,
+        K: UpcastStrict<T> + VcValueType,
     {
         let raw_vc = this.node.node;
         raw_vc
@@ -310,7 +333,7 @@ where
 
 impl<T> ValueDebugFormat for ResolvedVc<T>
 where
-    T: Upcast<Box<dyn ValueDebug>> + Send + Sync + ?Sized,
+    T: UpcastStrict<Box<dyn ValueDebug>> + Send + Sync + ?Sized,
 {
     fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
         self.node.value_debug_format(depth)

--- a/turbopack/crates/turbo-tasks/src/vc/traits.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/traits.rs
@@ -51,6 +51,18 @@ where
 {
 }
 
+/// A speialization of [`Upcast`] that ensures that the upcast is strict meaning that T !== Self
+///
+/// # Safety
+///
+/// The implementor of this trait must ensure that `Self` implements the
+/// trait `T` and that `Self` is not equal to `T`.
+pub unsafe trait UpcastStrict<T>: Upcast<T>
+where
+    T: VcValueTrait + ?Sized,
+{
+}
+
 /// Marker trait that indicates that a [`Vc<Self>`][crate::Vc] can accept all
 /// methods declared on a [`Vc<T>`][crate::Vc].
 ///

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -174,7 +174,7 @@ impl BrowserChunkingContextBuilder {
     {
         self.chunking_context
             .chunking_configs
-            .push((ResolvedVc::upcast(ty), chunking_config));
+            .push((ResolvedVc::upcast_non_strict(ty), chunking_config));
         self
     }
 
@@ -334,17 +334,16 @@ impl BrowserChunkingContext {
     #[turbo_tasks::function]
     async fn generate_chunk(
         self: Vc<Self>,
-        chunk: Vc<Box<dyn Chunk>>,
+        chunk: ResolvedVc<Box<dyn Chunk>>,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
         Ok(
-            if let Some(ecmascript_chunk) =
-                Vc::try_resolve_downcast_type::<EcmascriptChunk>(chunk).await?
+            if let Some(ecmascript_chunk) = ResolvedVc::try_downcast_type::<EcmascriptChunk>(chunk)
             {
-                Vc::upcast(EcmascriptBrowserChunk::new(self, ecmascript_chunk))
+                Vc::upcast(EcmascriptBrowserChunk::new(self, *ecmascript_chunk))
             } else if let Some(output_asset) =
-                Vc::try_resolve_sidecast::<Box<dyn OutputAsset>>(chunk).await?
+                ResolvedVc::try_sidecast::<Box<dyn OutputAsset>>(chunk)
             {
-                output_asset
+                *output_asset
             } else {
                 bail!("Unable to generate output asset for chunk");
             },
@@ -736,7 +735,7 @@ impl ChunkingContext for BrowserChunkingContext {
             ))
         } else {
             let module = AsyncLoaderModule::new(module, Vc::upcast(self), availability_info);
-            Vc::upcast(module.as_chunk_item(module_graph, Vc::upcast(self)))
+            module.as_chunk_item(module_graph, Vc::upcast(self))
         })
     }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
@@ -50,11 +50,11 @@ impl ChunkListUpdate<'_> {
 #[turbo_tasks::function]
 pub(super) async fn update_chunk_list(
     content: Vc<EcmascriptDevChunkListContent>,
-    from_version: Vc<Box<dyn Version>>,
+    from_version: ResolvedVc<Box<dyn Version>>,
 ) -> Result<Vc<Update>> {
     let to_version = content.version();
     let from_version = if let Some(from) =
-        Vc::try_resolve_downcast_type::<EcmascriptDevChunkListVersion>(from_version).await?
+        ResolvedVc::try_downcast_type::<EcmascriptDevChunkListVersion>(from_version)
     {
         from
     } else {

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/content.rs
@@ -49,7 +49,10 @@ impl VersionedContent for EcmascriptBrowserMergedChunkContent {
     }
 
     #[turbo_tasks::function]
-    async fn update(self: Vc<Self>, from_version: Vc<Box<dyn Version>>) -> Result<Vc<Update>> {
+    async fn update(
+        self: Vc<Self>,
+        from_version: ResolvedVc<Box<dyn Version>>,
+    ) -> Result<Vc<Update>> {
         Ok(update_ecmascript_merged_chunk(self, from_version)
             .await?
             .cell())

--- a/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/merged/update.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use serde::Serialize;
-use turbo_tasks::{FxIndexMap, FxIndexSet, IntoTraitRef, ReadRef, TryJoinIterExt, Vc};
+use turbo_tasks::{FxIndexMap, FxIndexSet, IntoTraitRef, ReadRef, ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::rope::Rope;
 use turbopack_core::{
     chunk::{ChunkingContext, ModuleId},
@@ -131,11 +131,11 @@ impl MergedModuleMap {
 
 pub(super) async fn update_ecmascript_merged_chunk(
     content: Vc<EcmascriptBrowserMergedChunkContent>,
-    from_version: Vc<Box<dyn Version>>,
+    from_version: ResolvedVc<Box<dyn Version>>,
 ) -> Result<Update> {
     let to_merged_version = content.version();
     let from_merged_version = if let Some(from) =
-        Vc::try_resolve_downcast_type::<EcmascriptBrowserMergedChunkVersion>(from_version).await?
+        ResolvedVc::try_downcast_type::<EcmascriptBrowserMergedChunkVersion>(from_version)
     {
         from
     } else {

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -479,7 +479,7 @@ async fn build_internal(
                                                     .unwrap(),
                                             )?
                                             .with_extension("entry.js"),
-                                        EvaluatableAssets::one(*ResolvedVc::upcast(ecmascript)),
+                                        EvaluatableAssets::one(*ecmascript),
                                         module_graph,
                                         OutputAssets::empty(),
                                         AvailabilityInfo::Root,

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -385,7 +385,12 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
     ) -> Vc<OutputAssets> {
-        root_chunk_group_assets(Vc::upcast(self), ident, chunk_group, module_graph)
+        root_chunk_group_assets(
+            Vc::upcast_non_strict(self),
+            ident,
+            chunk_group,
+            module_graph,
+        )
     }
 
     fn evaluated_chunk_group_assets(
@@ -396,7 +401,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         availability_info: AvailabilityInfo,
     ) -> Vc<OutputAssets> {
         evaluated_chunk_group_assets(
-            Vc::upcast(self),
+            Vc::upcast_non_strict(self),
             ident,
             chunk_group,
             module_graph,
@@ -413,7 +418,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         availability_info: AvailabilityInfo,
     ) -> Vc<Box<dyn OutputAsset>> {
         entry_chunk_group_asset(
-            Vc::upcast(self),
+            Vc::upcast_non_strict(self),
             path,
             evaluatable_assets,
             module_graph,
@@ -446,7 +451,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         extra_chunks: Vc<OutputAssets>,
     ) -> Vc<Box<dyn OutputAsset>> {
         entry_chunk_group_asset(
-            Vc::upcast(self),
+            Vc::upcast_non_strict(self),
             path,
             evaluatable_assets,
             module_graph,
@@ -463,7 +468,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         availability_info: AvailabilityInfo,
     ) -> Vc<OutputAssets> {
         chunk_group_assets(
-            Vc::upcast(self),
+            Vc::upcast_non_strict(self),
             ident,
             chunk_group,
             module_graph,

--- a/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
@@ -32,7 +32,7 @@ where
         self: Vc<Self>,
         asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Vc<Box<dyn EvaluatableAsset>> {
-        to_evaluatable(Vc::upcast(self), asset_context)
+        to_evaluatable(Vc::upcast_non_strict(self), asset_context)
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -540,7 +540,7 @@ where
 {
     /// Returns the module id of this chunk item.
     fn id(self: Vc<Self>) -> Vc<ModuleId> {
-        let chunk_item = Vc::upcast(self);
+        let chunk_item = Vc::upcast_non_strict(self);
         chunk_item.chunking_context().chunk_item_id(chunk_item)
     }
 }
@@ -560,7 +560,7 @@ where
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Vc<ModuleId> {
-        chunking_context.chunk_item_id_from_module(Vc::upcast(self))
+        chunking_context.chunk_item_id_from_module(Vc::upcast_non_strict(self))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
+++ b/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
@@ -86,7 +86,7 @@ where
     T: Upcast<Box<dyn Diagnostic>>,
 {
     fn emit(self) {
-        let diagnostic = ResolvedVc::upcast::<Box<dyn Diagnostic>>(self);
+        let diagnostic = ResolvedVc::upcast_non_strict::<Box<dyn Diagnostic>>(self);
         emit(diagnostic);
     }
 }

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -129,7 +129,7 @@ pub async fn children_from_output_assets(
     for &reference in &*references {
         children.insert((
             key.clone(),
-            IntrospectableOutputAsset::new(*ResolvedVc::upcast(reference))
+            IntrospectableOutputAsset::new(*reference)
                 .to_resolved()
                 .await?,
         ));

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -353,7 +353,7 @@ where
     T: Upcast<Box<dyn Issue>>,
 {
     fn emit(self) {
-        let issue = ResolvedVc::upcast::<Box<dyn Issue>>(self);
+        let issue = ResolvedVc::upcast_non_strict::<Box<dyn Issue>>(self);
         emit(issue);
         emit(ResolvedVc::upcast::<Box<dyn IssueProcessingPath>>(
             RootIssueProcessingPath::resolved_cell(RootIssueProcessingPath(issue)),

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -335,10 +335,7 @@ pub async fn all_assets_from_entries(entries: Vc<OutputAssets>) -> Result<Vc<Out
     Ok(Vc::cell(
         AdjacencyMap::new()
             .skip_duplicates()
-            .visit(
-                entries.await?.iter().copied().map(ResolvedVc::upcast),
-                get_referenced_assets,
-            )
+            .visit(entries.await?.iter().copied(), get_referenced_assets)
             .await
             .completed()?
             .into_inner()

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -66,7 +66,12 @@ where
         options: Vc<ResolveOptions>,
         reference_type: ReferenceType,
     ) -> impl Future<Output = Result<Vc<ModuleResolveResult>>> + Send {
-        resolve_asset(Vc::upcast(self), request, options, reference_type)
+        resolve_asset(
+            Vc::upcast_non_strict(self),
+            request,
+            options,
+            reference_type,
+        )
     }
 
     async fn resolve_options(
@@ -81,7 +86,7 @@ where
     fn with_transition(self: ResolvedVc<Self>, transition: RcStr) -> Vc<Box<dyn ResolveOrigin>> {
         Vc::upcast(
             ResolveOriginWithTransition {
-                previous: ResolvedVc::upcast(self),
+                previous: ResolvedVc::upcast_non_strict(self),
                 transition,
             }
             .cell(),

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -5,7 +5,7 @@ use const_format::concatcp;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use turbo_tasks::Vc;
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::{
     DiskFileSystem, FileContent, FileSystemPath, rope::Rope, util::uri_from_file,
 };
@@ -174,9 +174,8 @@ pub async fn fileify_source_map(
         return Ok(None);
     };
 
-    let context_fs = context_path.fs();
-    let context_fs = &*Vc::try_resolve_downcast_type::<DiskFileSystem>(context_fs)
-        .await?
+    let context_fs = context_path.fs;
+    let context_fs = &*ResolvedVc::try_downcast_type::<DiskFileSystem>(context_fs)
         .context("Expected the chunking context to have a DiskFileSystem")?
         .await?;
     let prefix = format!("{}///[{}]/", SOURCE_URL_PROTOCOL, context_fs.name());

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -215,7 +215,7 @@ impl ChunkItem for CssModuleChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(*self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -296,7 +296,7 @@ impl ChunkItem for ModuleChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(*self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]
@@ -368,9 +368,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
                         let placeable: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>> =
                             ResolvedVc::upcast(css_module);
 
-                        let module_id = placeable
-                            .chunk_item_id(Vc::upcast(*self.chunking_context))
-                            .await?;
+                        let module_id = placeable.chunk_item_id(*self.chunking_context).await?;
                         let module_id = StringifyJs(&*module_id);
                         let original_name = StringifyJs(&original_name);
                         exported_class_names

--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -106,7 +106,7 @@ impl Visitor<'_> for ModuleReferencesVisitor<'_> {
                     ImportAttributes::new_from_lightningcss(&i.clone().into_owned()).into(),
                     self.import_context.map(|ctx| *ctx),
                     IssueSource::from_line_col(
-                        ResolvedVc::upcast(self.source),
+                        self.source,
                         SourcePos {
                             line: issue_span.line as _,
                             column: issue_span.column as _,
@@ -141,7 +141,7 @@ impl Visitor<'_> for ModuleReferencesVisitor<'_> {
                 *self.origin,
                 Request::parse(RcStr::from(src).into()),
                 IssueSource::from_line_col(
-                    ResolvedVc::upcast(self.source),
+                    self.source,
                     SourcePos {
                         line: issue_span.line as _,
                         column: issue_span.column as _,

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -55,7 +55,7 @@ impl UrlAssetReference {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<ReferencedAsset>> {
         if let Some(module) = *self.resolve_reference().first_module().await?
-            && let Some(embeddable) = Vc::try_resolve_downcast::<Box<dyn CssEmbed>>(*module).await?
+            && let Some(embeddable) = ResolvedVc::try_downcast::<Box<dyn CssEmbed>>(module)
         {
             return Ok(ReferencedAsset::Some(
                 embeddable

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -323,9 +323,7 @@ impl Introspectable for AssetGraphContentSource {
             .map(|&asset| async move {
                 Ok((
                     rcstr!("root"),
-                    IntrospectableOutputAsset::new(*ResolvedVc::upcast(asset))
-                        .to_resolved()
-                        .await?,
+                    IntrospectableOutputAsset::new(*asset).to_resolved().await?,
                 ))
             })
             .try_join()
@@ -338,9 +336,7 @@ impl Introspectable for AssetGraphContentSource {
             .map(|&asset| async move {
                 Ok((
                     rcstr!("inner"),
-                    IntrospectableOutputAsset::new(*ResolvedVc::upcast(asset))
-                        .to_resolved()
-                        .await?,
+                    IntrospectableOutputAsset::new(*asset).to_resolved().await?,
                 ))
             })
             .try_join()

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -450,7 +450,7 @@ where
         Vc::upcast(IssueFilePathContentSource::new_file_path(
             file_path,
             description,
-            Vc::upcast(self),
+            Vc::upcast_non_strict(self),
         ))
     }
 }

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -126,13 +126,9 @@ impl Introspectable for StaticAssetsContentSource {
                 async move {
                     let child = match entry {
                         DirectoryEntry::File(path) | DirectoryEntry::Symlink(path) => {
-                            ResolvedVc::upcast(
-                                IntrospectableSource::new(Vc::upcast(FileSource::new(
-                                    path.clone(),
-                                )))
+                            IntrospectableSource::new(Vc::upcast(FileSource::new(path.clone())))
                                 .to_resolved()
-                                .await?,
-                            )
+                                .await?
                         }
                         DirectoryEntry::Directory(path) => ResolvedVc::upcast(
                             StaticAssetsContentSource::with_prefix(

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -76,13 +76,9 @@ impl EcmascriptChunkItem for AsyncLoaderChunkItem {
         let module = this.module.await?;
 
         let id = if let Some(placeable) =
-            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkPlaceable>>(*module.inner).await?
+            ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(module.inner)
         {
-            Some(
-                placeable
-                    .chunk_item_id(*ResolvedVc::upcast(this.chunking_context))
-                    .await?,
-            )
+            Some(placeable.chunk_item_id(*this.chunking_context).await?)
         } else {
             None
         };
@@ -171,7 +167,7 @@ impl ChunkItem for AsyncLoaderChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *ResolvedVc::upcast(self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -39,12 +39,6 @@ impl ChunkType for EcmascriptChunkType {
         batch_groups: Vec<ResolvedVc<ChunkItemBatchGroup>>,
         referenced_output_assets: Vc<OutputAssets>,
     ) -> Result<Vc<Box<dyn Chunk>>> {
-        let Some(chunking_context) =
-            Vc::try_resolve_downcast::<Box<dyn ChunkingContext>>(chunking_context).await?
-        else {
-            bail!("Ecmascript chunking context not found");
-        };
-
         let content = EcmascriptChunkContent {
             chunk_items: chunk_items
                 .iter()
@@ -69,11 +63,10 @@ impl ChunkType for EcmascriptChunkType {
     async fn chunk_item_size(
         &self,
         _chunking_context: Vc<Box<dyn ChunkingContext>>,
-        chunk_item: Vc<Box<dyn ChunkItem>>,
+        chunk_item: ResolvedVc<Box<dyn ChunkItem>>,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<usize>> {
-        let Some(chunk_item) =
-            Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkItem>>(chunk_item).await?
+        let Some(chunk_item) = ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkItem>>(chunk_item)
         else {
             bail!("Chunk item is not an ecmascript chunk item but reporting chunk type ecmascript");
         };

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -212,7 +212,7 @@ where
 {
     /// Generates the module factory for this chunk item.
     fn code(self: Vc<Self>, async_module_info: Option<Vc<AsyncModuleInfo>>) -> Vc<Code> {
-        module_factory_with_code_generation_issue(Vc::upcast(self), async_module_info)
+        module_factory_with_code_generation_issue(Vc::upcast_non_strict(self), async_module_info)
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -124,7 +124,7 @@ impl Chunk for EcmascriptChunk {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *ResolvedVc::upcast(self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -782,7 +782,7 @@ impl ChunkItem for ModuleChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *ResolvedVc::upcast(self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -88,7 +88,7 @@ impl ChunkItem for ManifestChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *ResolvedVc::upcast(self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -105,7 +105,7 @@ impl ChunkItem for ManifestLoaderChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *ResolvedVc::upcast(self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]
@@ -140,7 +140,7 @@ impl EcmascriptChunkItem for ManifestLoaderChunkItem {
         // exports a promise for all of the necessary chunk loads.
         let item_id = &*this
             .manifest
-            .chunk_item_id(*ResolvedVc::upcast(manifest.chunking_context))
+            .chunk_item_id(*manifest.chunking_context)
             .await?;
 
         // Finally, we need the id of the module that we're actually trying to
@@ -148,9 +148,7 @@ impl EcmascriptChunkItem for ManifestLoaderChunkItem {
         let placeable =
             ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(manifest.inner)
                 .ok_or_else(|| anyhow!("asset is not placeable in ecmascript chunk"))?;
-        let dynamic_id = &*placeable
-            .chunk_item_id(*ResolvedVc::upcast(manifest.chunking_context))
-            .await?;
+        let dynamic_id = &*placeable.chunk_item_id(*manifest.chunking_context).await?;
 
         // This is the code that will be executed when the dynamic import is reached.
         // It will load the manifest chunk, which will load all the chunks needed by

--- a/turbopack/crates/turbopack-ecmascript/src/merged_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/merged_module.rs
@@ -120,7 +120,7 @@ impl ChunkItem for MergedEcmascriptModuleChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *ResolvedVc::upcast(self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]
@@ -153,13 +153,8 @@ impl EcmascriptChunkItem for MergedEcmascriptModuleChunkItem {
         let entry_points = &module.entry_points;
         let options = modules
             .iter()
-            .map(|(m, _)| {
-                let Some(m) = ResolvedVc::try_downcast::<Box<dyn EcmascriptAnalyzable>>(*m) else {
-                    anyhow::bail!("Expected EcmascriptAnalyzable in scope hoisting group");
-                };
-                Ok(m.module_content_options(*self.chunking_context, async_module_info))
-            })
-            .collect::<Result<Vec<_>>>()?;
+            .map(|(m, _)| m.module_content_options(*self.chunking_context, async_module_info))
+            .collect::<Vec<_>>();
 
         let content = EcmascriptModuleContent::new_merged(
             modules.clone(),

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -174,7 +174,7 @@ impl AmdDefineWithDependenciesCodeGen {
                         pattern_mapping: PatternMapping::resolve_request(
                             **request,
                             *self.origin,
-                            Vc::upcast(chunking_context),
+                            chunking_context,
                             cjs_resolve(
                                 *self.origin,
                                 **request,

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -86,9 +86,9 @@ impl OptionAsyncModule {
 struct AsyncModuleIdents(FxIndexSet<(String, AstSyntaxContext)>);
 
 async fn get_inherit_async_referenced_asset(
-    r: Vc<Box<dyn ModuleReference>>,
+    r: ResolvedVc<Box<dyn ModuleReference>>,
 ) -> Result<Option<ReadRef<ReferencedAsset>>> {
-    let Some(r) = Vc::try_resolve_downcast::<Box<dyn ChunkableModuleReference>>(r).await? else {
+    let Some(r) = ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(r) else {
         return Ok(None);
     };
     let Some(ty) = &*r.chunking_type().await? else {
@@ -123,7 +123,7 @@ impl AsyncModule {
             .await?
             .iter()
             .map(|r| async {
-                let Some(referenced_asset) = get_inherit_async_referenced_asset(**r).await? else {
+                let Some(referenced_asset) = get_inherit_async_referenced_asset(*r).await? else {
                     return Ok(None);
                 };
                 Ok(match &*referenced_asset {
@@ -174,8 +174,7 @@ impl AsyncModule {
                     .await?
                     .iter()
                     .map(|r| async {
-                        let Some(referenced_asset) =
-                            get_inherit_async_referenced_asset(**r).await?
+                        let Some(referenced_asset) = get_inherit_async_referenced_asset(*r).await?
                         else {
                             return Ok(false);
                         };

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -166,7 +166,7 @@ impl CjsRequireAssetReferenceCodeGen {
         let pm = PatternMapping::resolve_request(
             *reference.request,
             *reference.origin,
-            Vc::upcast(chunking_context),
+            chunking_context,
             self.reference.resolve_reference(),
             ResolveType::ChunkItem,
         )
@@ -290,7 +290,7 @@ impl CjsRequireResolveAssetReferenceCodeGen {
         let pm = PatternMapping::resolve_request(
             *reference.request,
             *reference.origin,
-            Vc::upcast(chunking_context),
+            chunking_context,
             self.reference.resolve_reference(),
             ResolveType::ChunkItem,
         )

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -171,8 +171,7 @@ impl ReferencedAsset {
     ) -> Result<Option<ReferencedAssetIdent>> {
         Ok(match self {
             ReferencedAsset::Some(asset) => {
-                if let Some(ctxt) =
-                    scope_hoisting_context.get_module_syntax_context(ResolvedVc::upcast(*asset))
+                if let Some(ctxt) = scope_hoisting_context.get_module_syntax_context(*asset)
                     && let Some(export) = &export
                     && let EcmascriptExports::EsmExports(exports) = *asset.get_exports().await?
                 {
@@ -271,7 +270,7 @@ impl ReferencedAsset {
         asset: &Vc<Box<dyn EcmascriptChunkPlaceable>>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<String> {
-        let id = asset.chunk_item_id(Vc::upcast(chunking_context)).await?;
+        let id = asset.chunk_item_id(chunking_context).await?;
         Ok(magic_identifier::mangle(&format!("imported module {id}")))
     }
 }
@@ -604,9 +603,7 @@ impl EsmAssetReference {
                                         unreachable!();
                                     }
                                     ReferencedAsset::Some(asset) => {
-                                        let id = asset
-                                            .chunk_item_id(Vc::upcast(chunking_context))
-                                            .await?;
+                                        let id = asset.chunk_item_id(chunking_context).await?;
                                         let (sym, ctxt) =
                                             ident.into_module_namespace_ident().unwrap();
                                         let name = Ident::new(

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -137,7 +137,7 @@ impl EsmAsyncAssetReferenceCodeGen {
         let pm = PatternMapping::resolve_request(
             *reference.request,
             *reference.origin,
-            Vc::upcast(chunking_context),
+            chunking_context,
             self.reference.resolve_reference(),
             if matches!(
                 *chunking_context.environment().chunk_loading().await?,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -89,7 +89,7 @@ impl EsmModuleIdAssetReferenceCodeGen {
         if let ReferencedAsset::Some(asset) =
             &*self.reference.await?.inner.get_referenced_asset().await?
         {
-            let id = asset.chunk_item_id(Vc::upcast(chunking_context)).await?;
+            let id = asset.chunk_item_id(chunking_context).await?;
             let id = module_id_to_lit(&id);
             visitors.push(create_visitor!(
                 self.path,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -192,7 +192,7 @@ impl UrlAssetReferenceCodeGen {
                     ReferencedAsset::Some(asset) => {
                         // We rewrite the first `new URL()` arguments to be a require() of the chunk
                         // item, which exports the static asset path to the linked file.
-                        let id = asset.chunk_item_id(Vc::upcast(chunking_context)).await?;
+                        let id = asset.chunk_item_id(chunking_context).await?;
 
                         visitors.push(create_visitor!(self.path, visit_mut_expr, |new_expr: &mut Expr| {
                             let should_rewrite_to_relative = if let Expr::New(NewExpr { args: Some(args), .. }) = new_expr {
@@ -257,7 +257,7 @@ impl UrlAssetReferenceCodeGen {
                     ReferencedAsset::Some(asset) => {
                         // We rewrite the first `new URL()` arguments to be a require() of the
                         // chunk item, which returns the asset path as its exports.
-                        let id = asset.chunk_item_id(Vc::upcast(chunking_context)).await?;
+                        let id = asset.chunk_item_id(chunking_context).await?;
 
                         // If there's a rewrite to the base url, then the current rendering
                         // environment should able to resolve the asset path

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -61,8 +61,8 @@ use swc_core::{
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Upcast,
-    ValueToString, Vc, trace::TraceRawVcs,
+    FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt,
+    UpcastStrict, ValueToString, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -255,7 +255,10 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Adds an asset reference to the analysis result.
-    pub fn add_reference(&mut self, reference: ResolvedVc<impl Upcast<Box<dyn ModuleReference>>>) {
+    pub fn add_reference(
+        &mut self,
+        reference: ResolvedVc<impl UpcastStrict<Box<dyn ModuleReference>>>,
+    ) {
         let r = ResolvedVc::upcast(reference);
         self.references.insert(r);
     }
@@ -263,7 +266,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     /// Adds an asset reference with codegen to the analysis result.
     pub fn add_reference_code_gen<R: IntoCodeGenReference>(&mut self, reference: R, path: AstPath) {
         let (reference, code_gen) = reference.into_code_gen_reference(path);
-        self.add_reference(reference);
+        self.references.insert(reference);
         self.add_code_gen(code_gen);
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -331,7 +331,7 @@ impl RequireContextAssetReferenceCodeGen {
             .reference
             .await?
             .inner
-            .chunk_item_id(Vc::upcast(chunking_context))
+            .chunk_item_id(chunking_context)
             .await?;
 
         let mut visitors = Vec::new();
@@ -485,7 +485,7 @@ impl EcmascriptChunkItem for RequireContextChunkItem {
             let pm = PatternMapping::resolve_request(
                 *entry.request,
                 *self.origin,
-                *ResolvedVc::upcast(self.chunking_context),
+                *self.chunking_context,
                 *entry.result,
                 ResolveType::ChunkItem,
             )
@@ -563,7 +563,7 @@ impl ChunkItem for RequireContextChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *ResolvedVc::upcast(self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/chunk_item.rs
@@ -62,7 +62,7 @@ impl ChunkItem for EcmascriptModuleFacadeChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *ResolvedVc::upcast(self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -62,7 +62,7 @@ impl ChunkItem for EcmascriptModuleLocalsChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *ResolvedVc::upcast(self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -204,7 +204,7 @@ impl EcmascriptModulePartReference {
                     let key = sym.as_str().into();
                     let name = Ident::new(sym.into(), DUMMY_SP, ctxt.unwrap_or_default());
 
-                    let id = module.chunk_item_id(Vc::upcast(chunking_context)).await?;
+                    let id = module.chunk_item_id(chunking_context).await?;
 
                     result.push(CodeGenerationHoistedStmt::new(
                         key,

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -216,7 +216,7 @@ impl EcmascriptModulePartAsset {
                     )
                 };
                 if side_effects.is_empty() {
-                    return Ok(*ResolvedVc::upcast(final_module));
+                    return Ok(*final_module);
                 }
                 let side_effects_module = SideEffectsModule::new(
                     module,
@@ -419,13 +419,13 @@ impl EvaluatableAsset for EcmascriptModulePartAsset {}
 
 #[turbo_tasks::function]
 async fn only_effects(
-    module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
+    module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
 ) -> Result<Vc<Box<dyn EcmascriptChunkPlaceable>>> {
-    if let Some(module) = Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(module).await? {
+    if let Some(module) = ResolvedVc::try_downcast_type::<EcmascriptModuleAsset>(module) {
         let module =
-            EcmascriptModulePartAsset::new_with_resolved_part(module, ModulePart::evaluation());
+            EcmascriptModulePartAsset::new_with_resolved_part(*module, ModulePart::evaluation());
         return Ok(Vc::upcast(module));
     }
 
-    Ok(module)
+    Ok(*module)
 }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/chunk_item.rs
@@ -68,7 +68,7 @@ impl ChunkItem for EcmascriptModulePartChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *ResolvedVc::upcast(self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -244,9 +244,7 @@ impl ModuleReference for TsExtendsReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         Ok(*ModuleResolveResult::module(ResolvedVc::upcast(
-            RawModule::new(*ResolvedVc::upcast(self.config))
-                .to_resolved()
-                .await?,
+            RawModule::new(*self.config).to_resolved().await?,
         )))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -99,7 +99,7 @@ impl ChunkItem for WorkerLoaderChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *ResolvedVc::upcast(self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-json/src/lib.rs
+++ b/turbopack/crates/turbopack-json/src/lib.rs
@@ -103,7 +103,7 @@ impl ChunkItem for JsonChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(*self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -261,27 +261,25 @@ pub async fn get_intermediate_asset(
     main_entry: ResolvedVc<Box<dyn EvaluatableAsset>>,
     other_entries: Vc<EvaluatableAssets>,
 ) -> Result<Vc<Box<dyn OutputAsset>>> {
-    Ok(Vc::upcast(
-        chunking_context.root_entry_chunk_group_asset(
-            chunking_context
-                .chunk_path(None, main_entry.ident(), None, rcstr!(".js"))
-                .owned()
-                .await?,
-            other_entries.with_entry(*main_entry),
-            ModuleGraph::from_modules(
-                Vc::cell(vec![ChunkGroupEntry::Entry(
-                    other_entries
-                        .await?
-                        .into_iter()
-                        .copied()
-                        .chain(std::iter::once(main_entry))
-                        .map(ResolvedVc::upcast)
-                        .collect(),
-                )]),
-                false,
-            ),
-            OutputAssets::empty(),
+    Ok(chunking_context.root_entry_chunk_group_asset(
+        chunking_context
+            .chunk_path(None, main_entry.ident(), None, rcstr!(".js"))
+            .owned()
+            .await?,
+        other_entries.with_entry(*main_entry),
+        ModuleGraph::from_modules(
+            Vc::cell(vec![ChunkGroupEntry::Entry(
+                other_entries
+                    .await?
+                    .into_iter()
+                    .copied()
+                    .chain(std::iter::once(main_entry))
+                    .map(ResolvedVc::upcast)
+                    .collect(),
+            )]),
+            false,
         ),
+        OutputAssets::empty(),
     ))
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -108,7 +108,7 @@ impl NodeJsChunkingContextBuilder {
     {
         self.chunking_context
             .chunking_configs
-            .push((ResolvedVc::upcast(ty), chunking_config));
+            .push((ResolvedVc::upcast_non_strict(ty), chunking_config));
         self
     }
 
@@ -205,17 +205,16 @@ impl NodeJsChunkingContext {
     #[turbo_tasks::function]
     async fn generate_chunk(
         self: Vc<Self>,
-        chunk: Vc<Box<dyn Chunk>>,
+        chunk: ResolvedVc<Box<dyn Chunk>>,
     ) -> Result<Vc<Box<dyn OutputAsset>>> {
         Ok(
-            if let Some(ecmascript_chunk) =
-                Vc::try_resolve_downcast_type::<EcmascriptChunk>(chunk).await?
+            if let Some(ecmascript_chunk) = ResolvedVc::try_downcast_type::<EcmascriptChunk>(chunk)
             {
-                Vc::upcast(EcmascriptBuildNodeChunk::new(self, ecmascript_chunk))
+                Vc::upcast(EcmascriptBuildNodeChunk::new(self, *ecmascript_chunk))
             } else if let Some(output_asset) =
-                Vc::try_resolve_sidecast::<Box<dyn OutputAsset>>(chunk).await?
+                ResolvedVc::try_sidecast::<Box<dyn OutputAsset>>(chunk)
             {
-                output_asset
+                *output_asset
             } else {
                 bail!("Unable to generate output asset for chunk");
             },
@@ -509,7 +508,7 @@ impl ChunkingContext for NodeJsChunkingContext {
             ))
         } else {
             let module = AsyncLoaderModule::new(module, Vc::upcast(self), availability_info);
-            Vc::upcast(module.as_chunk_item(module_graph, Vc::upcast(self)))
+            module.as_chunk_item(module_graph, Vc::upcast(self))
         })
     }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -189,9 +189,7 @@ impl OutputAsset for EcmascriptBuildNodeEntryChunk {
         }
 
         let other_chunks = this.other_chunks.await?;
-        for &other_chunk in &*other_chunks {
-            references.push(ResolvedVc::upcast(other_chunk));
-        }
+        references.extend(other_chunks.iter().copied());
 
         Ok(Vc::cell(references))
     }

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -74,7 +74,7 @@ impl ChunkableModule for StaticUrlJsModule {
                 module: self,
                 chunking_context,
                 static_asset: self
-                    .static_output_asset(*ResolvedVc::upcast(chunking_context))
+                    .static_output_asset(*chunking_context)
                     .to_resolved()
                     .await?,
             },
@@ -111,7 +111,7 @@ impl ChunkItem for StaticUrlJsChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *ResolvedVc::upcast(self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -404,7 +404,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
     {
         let evaluatable_assets = runtime_entries
             .unwrap_or_else(EvaluatableAssets::empty)
-            .with_entry(Vc::upcast(ecmascript));
+            .with_entry(ecmascript);
         (
             evaluatable_assets,
             evaluatable_assets

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -221,7 +221,7 @@ impl ChunkItem for ModuleChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(*self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]
@@ -250,8 +250,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
         async_module_info: Option<Vc<AsyncModuleInfo>>,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let loader_asset = self.module.loader();
-        let item =
-            loader_asset.as_chunk_item(*self.module_graph, Vc::upcast(*self.chunking_context));
+        let item = loader_asset.as_chunk_item(*self.module_graph, *self.chunking_context);
 
         let ecmascript_item = Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkItem>>(item)
             .await?

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -117,7 +117,7 @@ impl ChunkItem for RawModuleChunkItem {
 
     #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        Vc::upcast(*self.chunking_context)
+        *self.chunking_context
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack/benches/node_file_trace.rs
@@ -119,7 +119,7 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                 let module = module_asset_context
                     .process(Vc::upcast(source), ReferenceType::Undefined)
                     .module();
-                let rebased = RebasedAsset::new(Vc::upcast(module), input_dir, output_dir.clone())
+                let rebased = RebasedAsset::new(module, input_dir, output_dir.clone())
                     .to_resolved()
                     .await?;
 

--- a/turbopack/crates/turbopack/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack/tests/node-file-trace.rs
@@ -385,7 +385,7 @@ async fn node_file_trace_operation(
         .process(Vc::upcast(source), ReferenceType::Undefined)
         .module();
 
-    let rebased = RebasedAsset::new(Vc::upcast(module), input_dir.clone(), output_dir.clone())
+    let rebased = RebasedAsset::new(module, input_dir.clone(), output_dir.clone())
         .to_resolved()
         .await?;
 


### PR DESCRIPTION
## What 
Casting `ResolvedVc<Box<dyn Module>>` to `ResolvedVc<Box<dyn Module>>` is confusing, so we should reject it.

Ditto for no op `upcast`s.

This PR makes such calls illegal and eliminates them from the codebase.

## How

Introduce a new trait `UpcastStrict` that is only implemented for types that extend or implement different traits.  This way we can say it is only valid to try to downcast if the target type is `UpcastStrict`.  

Then modify the type constraints on our casting utilties to require `UpcastStrict` instead of `Upcast`

In the case of `Vc::upcast` i also introduced a `Vc::upcast_non_strict` to help with writing generic code or extension traits.

## Why?

I got very confused by some `try_downcast` calls that turned out to be no-ops.

Of course this might make some type theorists unhappy, and I don't disagree.  Downcasting X->X is a legitimate operation.   The ideal solution here would be a linter rule, but there doesn't appear to be any way to implement that.

Closes PACK-5419