### PR TITLE
[turbopack] Attempt #2 at making rust-analyzer happy with our macros

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/global_name.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/global_name.rs
@@ -5,7 +5,7 @@ use quote::quote;
 ///
 /// The name is prefixed with the current crate name and module path
 pub(crate) fn global_name(local_name: impl quote::ToTokens) -> TokenStream {
-    let crate_name =
-        std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "unknown_crate".to_string());
-    quote! { concat!(#crate_name, "@", module_path!(), "::", #local_name)}
+    quote! {
+        turbo_tasks::macro_helpers::global_name!(#local_name)
+    }
 }

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -201,19 +201,20 @@ macro_rules! inventory_submit {
 pub use inventory::submit as inventory_submit_inner;
 
 /// Define a global name for a turbo-tasks value.
-#[cfg(not(rust_analyzer))]
+#[cfg(not(rust_analyzer))] // ignore-rust-analyzer due to https://github.com/rust-lang/rust-analyzer/issues/19993
 #[macro_export]
 macro_rules! global_name {
     ($($item:tt)*) => {
 
-        concat!(env!("CARGO_PKG_NAME"), "@", module_path!(), "::", stringify!($($item)*))
+        ::std::concat!(::std::env!("CARGO_PKG_NAME"), "@", ::std::module_path!(), "::", ::std::stringify!($($item)*))
     }
 }
 /// Define a global name for a turbo-tasks value.
+/// This has a dummy implementation for Rust Analyzer to avoid https://github.com/rust-lang/rust-analyzer/issues/19993
 #[cfg(rust_analyzer)]
 #[macro_export]
 macro_rules! global_name {
     ($($item:tt)*) => {
-        stringify!($($item)*)
+        ::std::stringify!($($item)*)
     }
 }

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -206,7 +206,7 @@ pub use inventory::submit as inventory_submit_inner;
 macro_rules! global_name {
     ($($item:tt)*) => {
 
-        ::std::concat!(::std::env!("CARGO_PKG_NAME"), "@", ::std::module_path!(), "::", ::std::stringify!($($item)*))
+        ::std::concat!(::std::env!("CARGO_PKG_NAME"), "@", ::std::module_path!(), "::", $($item)*)
     }
 }
 /// Define a global name for a turbo-tasks value.
@@ -215,6 +215,6 @@ macro_rules! global_name {
 #[macro_export]
 macro_rules! global_name {
     ($($item:tt)*) => {
-        ::std::stringify!($($item)*)
+        $($item)*
     }
 }

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -12,7 +12,7 @@ use crate::{
     ValueTypeId, Vc, debug::ValueDebugFormatString, task::TaskOutput,
 };
 pub use crate::{
-    inventory_submit,
+    global_name, inventory_submit,
     magic_any::MagicAny,
     manager::{find_cell_by_type, notify_scheduled_tasks, spawn_detached_for_testing},
     native_function::{
@@ -199,3 +199,21 @@ macro_rules! inventory_submit {
 /// Exported so the above macro can reference it.
 #[doc(hidden)]
 pub use inventory::submit as inventory_submit_inner;
+
+/// Define a global name for a turbo-tasks value.
+#[cfg(not(rust_analyzer))]
+#[macro_export]
+macro_rules! global_name {
+    ($($item:tt)*) => {
+
+        concat!(env!("CARGO_PKG_NAME"), "@", module_path!(), "::", stringify!($($item)*))
+    }
+}
+/// Define a global name for a turbo-tasks value.
+#[cfg(rust_analyzer)]
+#[macro_export]
+macro_rules! global_name {
+    ($($item:tt)*) => {
+        stringify!($($item)*)
+    }
+}


### PR DESCRIPTION
We are experiencing https://github.com/rust-lang/rust-analyzer/issues/19993 and Rust Analyzer is complaining about our macro gencode.  After some trial and error i determined the issue was our use of the `concat!` and specifically the inclusion of the crate name macro so this works around that.

Apparently Rust Analyzers implementation of concat! or maybe token tree parsing can get confused by string literals with `-` characters in them.  Simply avoiding that for rust analyzer is a reasonable short term workaround


Closes PACK-5410