### PR TITLE
Include prerender interrupted error in unstable_rethrow

### DIFF
--- a/packages/next/src/client/components/unstable-rethrow.server.ts
+++ b/packages/next/src/client/components/unstable-rethrow.server.ts
@@ -2,7 +2,10 @@ import { isHangingPromiseRejectionError } from '../../server/dynamic-rendering-u
 import { isPostpone } from '../../server/lib/router-utils/is-postpone'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { isNextRouterError } from './is-next-router-error'
-import { isDynamicPostpone } from '../../server/app-render/dynamic-rendering'
+import {
+  isDynamicPostpone,
+  isPrerenderInterruptedError,
+} from '../../server/app-render/dynamic-rendering'
 import { isDynamicServerError } from './hooks-server-context'
 
 export function unstable_rethrow(error: unknown): void {
@@ -12,7 +15,8 @@ export function unstable_rethrow(error: unknown): void {
     isDynamicServerError(error) ||
     isDynamicPostpone(error) ||
     isPostpone(error) ||
-    isHangingPromiseRejectionError(error)
+    isHangingPromiseRejectionError(error) ||
+    isPrerenderInterruptedError(error)
   ) {
     throw error
   }


### PR DESCRIPTION
Prerender interrupted errors are part of the control flow for Next.js applications and aren't intended to be caught by user code. Since we can't avoid it we need to include it in the rethrow API.