### PR TITLE
[turbopack]Remove a layer of indirction from cell access

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -75,7 +75,7 @@ enum ModifiedState {
 pub struct Storage {
     snapshot_mode: AtomicBool,
     modified: FxDashMap<TaskId, ModifiedState>,
-    map: FxDashMap<TaskId, Box<TaskStorage>>,
+    map: FxDashMap<TaskId, TaskStorage>,
 }
 
 impl Storage {
@@ -243,7 +243,7 @@ impl Storage {
     pub fn access_mut(&self, key: TaskId) -> StorageWriteGuard<'_> {
         let inner = match self.map.entry(key) {
             dashmap::mapref::entry::Entry::Occupied(e) => e.into_ref(),
-            dashmap::mapref::entry::Entry::Vacant(e) => e.insert(Box::new(TaskStorage::new())),
+            dashmap::mapref::entry::Entry::Vacant(e) => e.insert(TaskStorage::new()),
         };
         StorageWriteGuard {
             storage: self,
@@ -256,7 +256,7 @@ impl Storage {
         key1: TaskId,
         key2: TaskId,
     ) -> (StorageWriteGuard<'_>, StorageWriteGuard<'_>) {
-        let (a, b) = get_multiple_mut(&self.map, key1, key2, || Box::new(TaskStorage::new()));
+        let (a, b) = get_multiple_mut(&self.map, key1, key2, TaskStorage::new);
         (
             StorageWriteGuard {
                 storage: self,
@@ -277,7 +277,7 @@ impl Storage {
 
 pub struct StorageWriteGuard<'a> {
     storage: &'a Storage,
-    inner: RefMut<'a, TaskId, Box<TaskStorage>>,
+    inner: RefMut<'a, TaskId, TaskStorage>,
 }
 
 impl StorageWriteGuard<'_> {


### PR DESCRIPTION
Remove a layer of `Box` wrappers from `TaskStorage`

This should speed up data access by removing a pointer indirection, with the main cost being more expensive dashmap resizes (since the resize needs to move larger TaskStorage structs).  Dashmaps resize individual shards  when their load factor gets too high and we use a very large number of shards (~ `threads^2 * 16`) so this should be somewhat mitigated.

My expectations are that we should see
 * improved performance due to fewer pointer indirections and faster storage allocation
 * lower memory overhead due to tighter packing of the TaskStorage data
      * at 136 bytes we do not match a standard size class, so batching these together in dashmap shards should avoid some wasted space.

The one downside is increase dashmap resize times (more expensive to move 136 bytes instead of an 8 byte pointer).  




