### PR TITLE
[turbopack] enable the signal feature of `nix`

### DIFF
--- a/turbopack/crates/turbopack-bench/Cargo.toml
+++ b/turbopack/crates/turbopack-bench/Cargo.toml
@@ -40,4 +40,4 @@ turbopack-create-test-app = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.30.1"
+nix = { version="0.30.1", features=["signal"] }


### PR DESCRIPTION
This is needed by `prepared_app.rs` to manage subprocesses.  Without this we are seeing build breakages in CI e.g https://github.com/vercel/next.js/runs/49662155436

This was triggered by the nix upgrade in #83414 



Closes PACK-5412