### PR TITLE
Remove `charset` from `text/plain` Content-Type for not-found `/_next/static/` paths

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -612,7 +612,7 @@ export async function initialize(opts: {
       // full HTML 404 pages to save bandwidth.
       if (realRequestPathname.startsWith('/_next/static/')) {
         res.statusCode = 404
-        res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+        res.setHeader('Content-Type', 'text/plain')
         res.end('Not Found')
         return null
       }

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -78,9 +78,7 @@ export function runTests(ctx) {
 
         if (!defaultLocales.includes(locale)) {
           expect(res.status).toBe(404)
-          expect(res.headers.get('content-type')).toBe(
-            'text/plain; charset=utf-8'
-          )
+          expect(res.headers.get('content-type')).toBe('text/plain')
           expect(await res.text()).toBe('Not Found')
         } else {
           // We only 404 for non-default locale

--- a/test/integration/required-server-files-ssr-404/test/index.test.js
+++ b/test/integration/required-server-files-ssr-404/test/index.test.js
@@ -667,9 +667,7 @@ describe('Required Server Files', () => {
             },
           })
           expect(res.status).toBe(404)
-          expect(res.headers.get('content-type')).toBe(
-            'text/plain; charset=utf-8'
-          )
+          expect(res.headers.get('content-type')).toBe('text/plain')
           expect(await res.text()).toBe('Not Found')
         }
       })


### PR DESCRIPTION
PR https://github.com/vercel/next.js/pull/75111 added `Content-Type: text/plain charset=utf-8` for 404 `_next/static` files.

Since the rest of the plain text behavior, e.g., `Internal Server Error`, `robots.txt`, `TEXT_PLAIN_CONTENT_TYPE_HEADER` constant, etc., does not specify the charset, for consistency, remove charset from the Content-Type header of 404 `_next/static` files as well.