### PR TITLE
Turbopack: remove GlobalTypeofs AST pass

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -8,7 +8,7 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack::{
     css::chunk::CssChunkType,
     module_options::{
-        CssOptionsContext, EcmascriptOptionsContext, JsxTransformOptions, ModuleRule, TypeofWindow,
+        CssOptionsContext, EcmascriptOptionsContext, JsxTransformOptions, ModuleRule,
         TypescriptTransformOptions, module_options_context::ModuleOptionsContext,
     },
     resolve_options_context::ResolveOptionsContext,
@@ -28,7 +28,7 @@ use turbopack_core::{
     module_graph::export_usage::OptionExportUsageInfo,
     resolve::{parse::Request, pattern::Pattern},
 };
-use turbopack_ecmascript::chunk::EcmascriptChunkType;
+use turbopack_ecmascript::{TypeofWindow, chunk::EcmascriptChunkType};
 use turbopack_node::{
     execution_context::ExecutionContext,
     transforms::postcss::{PostCssConfigLocation, PostCssTransformOptions},

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -9,7 +9,7 @@ use turbopack::{
     css::chunk::CssChunkType,
     module_options::{
         CssOptionsContext, EcmascriptOptionsContext, ExternalsTracingOptions, JsxTransformOptions,
-        ModuleOptionsContext, ModuleRule, TypeofWindow, TypescriptTransformOptions,
+        ModuleOptionsContext, ModuleRule, TypescriptTransformOptions,
     },
     resolve_options_context::ResolveOptionsContext,
     transition::Transition,
@@ -28,7 +28,9 @@ use turbopack_core::{
     module_graph::export_usage::OptionExportUsageInfo,
     target::CompileTarget,
 };
-use turbopack_ecmascript::{chunk::EcmascriptChunkType, references::esm::UrlRewriteBehavior};
+use turbopack_ecmascript::{
+    TypeofWindow, chunk::EcmascriptChunkType, references::esm::UrlRewriteBehavior,
+};
 use turbopack_ecmascript_plugins::transform::directives::{
     client::ClientDirectiveTransformer, client_disallowed::ClientDisallowedDirectiveTransformer,
 };

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -175,8 +175,27 @@ pub enum TreeShakingMode {
 #[turbo_tasks::value(transparent)]
 pub struct OptionTreeShaking(pub Option<TreeShakingMode>);
 
+/// The constant to replace `typeof window` with.
+#[derive(
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Debug,
+    Hash,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    TaskInput,
+)]
+pub enum TypeofWindow {
+    Object,
+    Undefined,
+}
+
 #[turbo_tasks::value(shared)]
-#[derive(Hash, Debug, Default, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct EcmascriptOptions {
     /// variant of tree shaking to use
     pub tree_shaking_mode: Option<TreeShakingMode>,
@@ -203,6 +222,11 @@ pub struct EcmascriptOptions {
     /// Whether the modules in this context are never chunked/codegen-ed, but only used for
     /// tracing.
     pub is_tracing: bool,
+    // TODO this should just be handled via CompileTimeInfo FreeVarReferences, but then it
+    // (currently) wouldn't be possible to have different replacement values in user code vs
+    // node_modules.
+    /// Whether to replace `typeof window` with some constant value.
+    pub enable_typeof_window_inlining: Option<TypeofWindow>,
 }
 
 #[turbo_tasks::value]

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -2,7 +2,6 @@ use std::{fmt::Debug, hash::Hash, sync::Arc};
 
 use anyhow::Result;
 use async_trait::async_trait;
-use rustc_hash::FxHashMap;
 use swc_core::{
     atoms::{Atom, atom},
     base::SwcComments,
@@ -15,7 +14,6 @@ use swc_core::{
                 assumptions::Assumptions,
                 helpers::{HELPERS, HelperData, Helpers},
             },
-            optimization::inline_globals,
             react::react,
         },
         utils::IsDirective,
@@ -43,9 +41,6 @@ pub enum EcmascriptInputTransform {
         import_source: ResolvedVc<Option<RcStr>>,
         // swc.jsc.transform.react.runtime,
         runtime: ResolvedVc<Option<RcStr>>,
-    },
-    GlobalTypeofs {
-        window_value: RcStr,
     },
     // These options are subset of swc_core::ecma::transforms::typescript::Config, but
     // it doesn't derive `Copy` so repeating values in here
@@ -139,22 +134,6 @@ impl EcmascriptInputTransform {
         } = ctx;
 
         Ok(match self {
-            EcmascriptInputTransform::GlobalTypeofs { window_value } => {
-                let mut typeofs: FxHashMap<Atom, Atom> = Default::default();
-                typeofs.insert(Atom::from("window"), Atom::from(&**window_value));
-
-                apply_transform(
-                    program,
-                    helpers,
-                    inline_globals(
-                        unresolved_mark,
-                        Default::default(),
-                        Default::default(),
-                        Default::default(),
-                        Arc::new(typeofs),
-                    ),
-                )
-            }
             EcmascriptInputTransform::React {
                 development,
                 refresh,

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -207,7 +207,7 @@ impl ModuleOptions {
                     ignore_dynamic_requests,
                     import_externals,
                     esm_url_rewrite_behavior,
-                    ref enable_typeof_window_inlining,
+                    enable_typeof_window_inlining,
                     source_maps: ecmascript_source_maps,
                     ..
                 },
@@ -282,21 +282,13 @@ impl ModuleOptions {
             extract_source_map: matches!(ecmascript_source_maps, SourceMapsType::Full),
             keep_last_successful_parse,
             is_tracing,
+            enable_typeof_window_inlining,
             ..Default::default()
         };
         let ecmascript_options_vc = ecmascript_options.resolved_cell();
 
         if let Some(environment) = environment {
             postprocess.push(EcmascriptInputTransform::PresetEnv(environment));
-        }
-
-        if let Some(enable_typeof_window_inlining) = enable_typeof_window_inlining {
-            postprocess.push(EcmascriptInputTransform::GlobalTypeofs {
-                window_value: match enable_typeof_window_inlining {
-                    TypeofWindow::Object => rcstr!("object"),
-                    TypeofWindow::Undefined => rcstr!("undefined"),
-                },
-            });
         }
 
         let ts_transform = if let Some(options) = enable_typescript_transform {

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     chunk::SourceMapsType, compile_time_info::CompileTimeInfo, condition::ContextCondition,
     environment::Environment, resolve::options::ImportMapping,
 };
-use turbopack_ecmascript::{TreeShakingMode, references::esm::UrlRewriteBehavior};
+use turbopack_ecmascript::{TreeShakingMode, TypeofWindow, references::esm::UrlRewriteBehavior};
 pub use turbopack_mdx::MdxTransformOptions;
 use turbopack_node::{
     execution_context::ExecutionContext,
@@ -106,13 +106,6 @@ impl WebpackLoaderBuiltinConditionSet for EmptyWebpackLoaderBuiltinConditionSet 
 pub enum DecoratorsKind {
     Legacy,
     Ecma,
-}
-
-/// The types when replacing `typeof window` with a constant.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
-pub enum TypeofWindow {
-    Object,
-    Undefined,
 }
 
 /// Configuration options for the decorators transform.
@@ -223,6 +216,9 @@ pub struct ModuleOptionsContext {
 #[derive(Clone, Default)]
 #[serde(default)]
 pub struct EcmascriptOptionsContext {
+    // TODO this should just be handled via CompileTimeInfo FreeVarReferences, but then it
+    // (currently) wouldn't be possible to have different replacement values in user code vs
+    // node_modules.
     pub enable_typeof_window_inlining: Option<TypeofWindow>,
     pub enable_jsx: Option<ResolvedVc<JsxTransformOptions>>,
     /// Follow type references and resolve declaration files in additional to


### PR DESCRIPTION
Port `EcmascriptInputTransform::GlobalTypeofs` from an extra AST pass to using the `CompileTimeInfo` replacement infrastructure.

Ideally, we'd get rid of the `enable_typeof_window_inlining` option entirely. But currently you cannot have different `CompileTimeInfo` per module asset context, so it's not possible to different replacements per directory (which is what we unfortunately want for `typeof window` replacements).

Basically closes PACK-5049