### PR TITLE
Turbopack: Don't resolve tsconfig relative to file

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -188,6 +188,9 @@ pub async fn get_client_resolve_options_context(
         .typescript_tsconfig_path()
         .await?
         .as_ref()
+        // Fall back to tsconfig only for resolving. This is because we don't want Turbopack to
+        // resolve tsconfig.json relative to the file being compiled.
+        .or(Some(&RcStr::from("tsconfig.json")))
         .map(|p| project_path.join(p))
         .transpose()?;
 

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -192,6 +192,9 @@ pub async fn get_edge_resolve_options_context(
             .typescript_tsconfig_path()
             .await?
             .as_ref()
+            // Fall back to tsconfig only for resolving. This is because we don't want Turbopack to
+            // resolve tsconfig.json relative to the file being compiled.
+            .or(Some(&RcStr::from("tsconfig.json")))
             .map(|p| project_path.join(p))
             .transpose()?,
         rules: vec![(

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -333,6 +333,9 @@ pub async fn get_server_resolve_options_context(
         .typescript_tsconfig_path()
         .await?
         .as_ref()
+        // Fall back to tsconfig only for resolving. This is because we don't want Turbopack to
+        // resolve tsconfig.json relative to the file being compiled.
+        .or(Some(&RcStr::from("tsconfig.json")))
         .map(|p| project_path.join(p))
         .transpose()?;
 

--- a/test/production/app-dir/tsconfig-no-relative-resolve/.gitignore
+++ b/test/production/app-dir/tsconfig-no-relative-resolve/.gitignore
@@ -1,0 +1,1 @@
+!tsconfig.json

--- a/test/production/app-dir/tsconfig-no-relative-resolve/app/layout.tsx
+++ b/test/production/app-dir/tsconfig-no-relative-resolve/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/tsconfig-no-relative-resolve/app/page.tsx
+++ b/test/production/app-dir/tsconfig-no-relative-resolve/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/tsconfig-no-relative-resolve/app/tsconfig.json
+++ b/test/production/app-dir/tsconfig-no-relative-resolve/app/tsconfig.json
@@ -1,0 +1,4 @@
+// This file shouldn't be found by Turbopack.
+{
+  "extends": "non-existent-package"
+}

--- a/test/production/app-dir/tsconfig-no-relative-resolve/next.config.js
+++ b/test/production/app-dir/tsconfig-no-relative-resolve/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/app-dir/tsconfig-no-relative-resolve/tsconfig-no-relative-resolve.test.ts
+++ b/test/production/app-dir/tsconfig-no-relative-resolve/tsconfig-no-relative-resolve.test.ts
@@ -1,0 +1,15 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('tsconfig-no-relative-resolve', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  // Next.js should only use the application root tsconfig.json file and not files relative to the file being compiled.
+  it('should fail to build', async () => {
+    const { exitCode, cliOutput } = await next.build()
+    expect(exitCode).toBe(0)
+    expect(cliOutput).not.toContain('non-existent-package')
+  })
+})

--- a/test/production/app-dir/tsconfig-no-relative-resolve/tsconfig.json
+++ b/test/production/app-dir/tsconfig-no-relative-resolve/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
## What?

Changes in #83331 accidentally changed behavior of how `tsconfig.json` is resolved. When using Next.js we don't want it to be resolved relative to the current file being compiled. It should only use the application root.

This PR fixes the behavior to match what it was before and adds a test that fails if it breaks again.

Closes PACK-5416