### PR TITLE
Turbopack: remove `css_environment` from `Environment`

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -218,6 +218,7 @@ impl AppProject {
             NextRuntime::NodeJs,
             self.project().encryption_key(),
             self.project().server_compile_time_info().environment(),
+            self.project().client_compile_time_info().environment(),
         ))
     }
 
@@ -232,6 +233,7 @@ impl AppProject {
             NextRuntime::Edge,
             self.project().encryption_key(),
             self.project().edge_compile_time_info().environment(),
+            self.project().client_compile_time_info().environment(),
         ))
     }
 
@@ -246,6 +248,7 @@ impl AppProject {
             NextRuntime::NodeJs,
             self.project().encryption_key(),
             self.project().server_compile_time_info().environment(),
+            self.project().client_compile_time_info().environment(),
         ))
     }
 
@@ -260,6 +263,7 @@ impl AppProject {
             NextRuntime::Edge,
             self.project().encryption_key(),
             self.project().edge_compile_time_info().environment(),
+            self.project().client_compile_time_info().environment(),
         ))
     }
 
@@ -582,6 +586,7 @@ impl AppProject {
             NextRuntime::NodeJs,
             self.project().encryption_key(),
             self.project().server_compile_time_info().environment(),
+            self.project().client_compile_time_info().environment(),
         ))
     }
 
@@ -596,6 +601,7 @@ impl AppProject {
             NextRuntime::Edge,
             self.project().encryption_key(),
             self.project().edge_compile_time_info().environment(),
+            self.project().client_compile_time_info().environment(),
         ))
     }
 

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -460,6 +460,7 @@ impl PagesProject {
             NextRuntime::NodeJs,
             self.project().encryption_key(),
             self.project().server_compile_time_info().environment(),
+            self.project().client_compile_time_info().environment(),
         ))
     }
 
@@ -476,6 +477,7 @@ impl PagesProject {
             NextRuntime::Edge,
             self.project().encryption_key(),
             self.project().edge_compile_time_info().environment(),
+            self.project().client_compile_time_info().environment(),
         ))
     }
 
@@ -492,6 +494,7 @@ impl PagesProject {
             NextRuntime::NodeJs,
             self.project().encryption_key(),
             self.project().server_compile_time_info().environment(),
+            self.project().client_compile_time_info().environment(),
         ))
     }
 
@@ -508,6 +511,7 @@ impl PagesProject {
             NextRuntime::Edge,
             self.project().encryption_key(),
             self.project().edge_compile_time_info().environment(),
+            self.project().client_compile_time_info().environment(),
         ))
     }
 
@@ -524,6 +528,7 @@ impl PagesProject {
             NextRuntime::NodeJs,
             self.project().encryption_key(),
             self.project().server_compile_time_info().environment(),
+            self.project().client_compile_time_info().environment(),
         ))
     }
 
@@ -542,6 +547,7 @@ impl PagesProject {
             NextRuntime::Edge,
             self.project().encryption_key(),
             self.project().edge_compile_time_info().environment(),
+            self.project().client_compile_time_info().environment(),
         ))
     }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1294,6 +1294,7 @@ impl Project {
                 NextRuntime::Edge,
                 self.encryption_key(),
                 self.edge_compile_time_info().environment(),
+                self.client_compile_time_info().environment(),
             ),
             get_edge_resolve_options_context(
                 self.project_path().owned().await?,
@@ -1356,6 +1357,7 @@ impl Project {
                 NextRuntime::NodeJs,
                 self.encryption_key(),
                 self.server_compile_time_info().environment(),
+                self.client_compile_time_info().environment(),
             ),
             get_server_resolve_options_context(
                 self.project_path().owned().await?,
@@ -1470,6 +1472,7 @@ impl Project {
                 NextRuntime::NodeJs,
                 self.encryption_key(),
                 self.server_compile_time_info().environment(),
+                self.client_compile_time_info().environment(),
             ),
             get_server_resolve_options_context(
                 self.project_path().owned().await?,
@@ -1532,6 +1535,7 @@ impl Project {
                 NextRuntime::Edge,
                 self.encryption_key(),
                 self.edge_compile_time_info().environment(),
+                self.client_compile_time_info().environment(),
             ),
             get_edge_resolve_options_context(
                 self.project_path().owned().await?,

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -984,7 +984,6 @@ impl Project {
             format!("/ROOT/{}", self.project_path().await?.path).into(),
             this.define_env.nodejs(),
             self.current_node_js_version(),
-            this.browserslist_query.clone(),
         ))
     }
 
@@ -995,7 +994,6 @@ impl Project {
             self.project_path().owned().await?,
             this.define_env.edge(),
             self.current_node_js_version(),
-            this.browserslist_query.clone(),
         ))
     }
 

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -98,18 +98,18 @@ pub async fn get_client_compile_time_info(
     browserslist_query: RcStr,
     define_env: Vc<OptionEnvMap>,
 ) -> Result<Vc<CompileTimeInfo>> {
-    let environment = BrowserEnvironment {
-        dom: true,
-        web_worker: false,
-        service_worker: false,
-        browserslist_query: browserslist_query.to_owned(),
-    }
-    .resolved_cell();
-
     CompileTimeInfo::builder(
-        Environment::new(ExecutionEnvironment::Browser(environment), *environment)
-            .to_resolved()
-            .await?,
+        Environment::new(ExecutionEnvironment::Browser(
+            BrowserEnvironment {
+                dom: true,
+                web_worker: false,
+                service_worker: false,
+                browserslist_query: browserslist_query.to_owned(),
+            }
+            .resolved_cell(),
+        ))
+        .to_resolved()
+        .await?,
     )
     .defines(next_client_defines(define_env).to_resolved().await?)
     .free_var_references(next_client_free_vars(define_env).to_resolved().await?)
@@ -274,7 +274,7 @@ pub async fn get_client_module_options_context(
     let tree_shaking_mode_for_foreign_code = *next_config
         .tree_shaking_mode_for_foreign_code(next_mode.is_development())
         .await?;
-    let css_target_browsers = env.css_runtime_versions();
+    let target_browsers = env.runtime_versions();
 
     let mut next_client_rules =
         get_next_client_transforms_rules(next_config, ty.clone(), mode, false, encryption_key)
@@ -287,7 +287,7 @@ pub async fn get_client_module_options_context(
         get_relay_transform_rule(next_config, project_path.clone()).await?,
         get_emotion_transform_rule(next_config).await?,
         get_styled_components_transform_rule(next_config).await?,
-        get_styled_jsx_transform_rule(next_config, css_target_browsers).await?,
+        get_styled_jsx_transform_rule(next_config, target_browsers).await?,
         get_react_remove_properties_transform_rule(next_config).await?,
         get_remove_console_transform_rule(next_config).await?,
     ]

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -11,9 +11,7 @@ use turbopack_core::{
         module_id_strategies::ModuleIdStrategy,
     },
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReference, FreeVarReferences},
-    environment::{
-        BrowserEnvironment, EdgeWorkerEnvironment, Environment, ExecutionEnvironment, NodeJsVersion,
-    },
+    environment::{EdgeWorkerEnvironment, Environment, ExecutionEnvironment, NodeJsVersion},
     free_var_references,
     module_graph::export_usage::OptionExportUsageInfo,
 };
@@ -62,23 +60,11 @@ pub async fn get_edge_compile_time_info(
     project_path: FileSystemPath,
     define_env: Vc<OptionEnvMap>,
     node_version: ResolvedVc<NodeJsVersion>,
-    css_browserslist_query: RcStr,
 ) -> Result<Vc<CompileTimeInfo>> {
-    let css_environment = BrowserEnvironment {
-        dom: false,
-        web_worker: false,
-        service_worker: false,
-        browserslist_query: css_browserslist_query,
-    }
-    .resolved_cell();
-
     CompileTimeInfo::builder(
-        Environment::new(
-            ExecutionEnvironment::EdgeWorker(
-                EdgeWorkerEnvironment { node_version }.resolved_cell(),
-            ),
-            *css_environment,
-        )
+        Environment::new(ExecutionEnvironment::EdgeWorker(
+            EdgeWorkerEnvironment { node_version }.resolved_cell(),
+        ))
         .to_resolved()
         .await?,
     )

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -21,9 +21,7 @@ use turbopack_core::{
     },
     compile_time_defines,
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReferences},
-    environment::{
-        Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion, RuntimeVersions,
-    },
+    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
     free_var_references,
     module_graph::export_usage::OptionExportUsageInfo,
     target::CompileTarget,
@@ -443,6 +441,7 @@ pub async fn get_server_module_options_context(
     next_runtime: NextRuntime,
     encryption_key: ResolvedVc<RcStr>,
     environment: ResolvedVc<Environment>,
+    client_environment: ResolvedVc<Environment>,
 ) -> Result<Vc<ModuleOptionsContext>> {
     let next_mode = mode.await?;
     let mut next_server_rules = get_next_server_transforms_rules(
@@ -512,7 +511,6 @@ pub async fn get_server_module_options_context(
     let tree_shaking_mode_for_foreign_code = *next_config
         .tree_shaking_mode_for_foreign_code(next_mode.is_development())
         .await?;
-    let versions = RuntimeVersions(Default::default()).cell();
 
     let tsconfig_path = next_config
         .typescript_tsconfig_path()
@@ -573,7 +571,10 @@ pub async fn get_server_module_options_context(
     // context type.
     let styled_components_transform_rule =
         get_styled_components_transform_rule(next_config).await?;
-    let styled_jsx_transform_rule = get_styled_jsx_transform_rule(next_config, versions).await?;
+    // It's important the client's browserlist config is used for styled-jsx, otherwise we transpile
+    // the CSS to be compatible with Node.js 20.
+    let styled_jsx_transform_rule =
+        get_styled_jsx_transform_rule(next_config, client_environment.runtime_versions()).await?;
 
     let source_maps = if *next_config.server_source_maps().await? {
         SourceMapsType::Full

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -22,7 +22,7 @@ use turbopack_core::{
     compile_time_defines,
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReferences},
     environment::{
-        BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion,
+        Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion, RuntimeVersions,
     },
     free_var_references,
     module_graph::export_usage::OptionExportUsageInfo,
@@ -371,28 +371,16 @@ pub async fn get_server_compile_time_info(
     cwd: RcStr,
     define_env: Vc<OptionEnvMap>,
     node_version: ResolvedVc<NodeJsVersion>,
-    css_browserslist_query: RcStr,
 ) -> Result<Vc<CompileTimeInfo>> {
-    let css_environment = BrowserEnvironment {
-        dom: false,
-        web_worker: false,
-        service_worker: false,
-        browserslist_query: css_browserslist_query,
-    }
-    .resolved_cell();
-
     CompileTimeInfo::builder(
-        Environment::new(
-            ExecutionEnvironment::NodeJsLambda(
-                NodeJsEnvironment {
-                    compile_target: CompileTarget::current().to_resolved().await?,
-                    node_version,
-                    cwd: ResolvedVc::cell(Some(cwd)),
-                }
-                .resolved_cell(),
-            ),
-            *css_environment,
-        )
+        Environment::new(ExecutionEnvironment::NodeJsLambda(
+            NodeJsEnvironment {
+                compile_target: CompileTarget::current().to_resolved().await?,
+                node_version,
+                cwd: ResolvedVc::cell(Some(cwd)),
+            }
+            .resolved_cell(),
+        ))
         .to_resolved()
         .await?,
     )
@@ -405,10 +393,9 @@ pub async fn get_server_compile_time_info(
 #[turbo_tasks::function]
 pub async fn get_tracing_compile_time_info() -> Result<Vc<CompileTimeInfo>> {
     CompileTimeInfo::builder(
-        Environment::new(
-            ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().resolved_cell()),
-            BrowserEnvironment::default().cell(),
-        )
+        Environment::new(ExecutionEnvironment::NodeJsLambda(
+            NodeJsEnvironment::default().resolved_cell(),
+        ))
         .to_resolved()
         .await?,
     )
@@ -525,7 +512,7 @@ pub async fn get_server_module_options_context(
     let tree_shaking_mode_for_foreign_code = *next_config
         .tree_shaking_mode_for_foreign_code(next_mode.is_development())
         .await?;
-    let css_versions = environment.css_runtime_versions();
+    let versions = RuntimeVersions(Default::default()).cell();
 
     let tsconfig_path = next_config
         .typescript_tsconfig_path()
@@ -586,8 +573,7 @@ pub async fn get_server_module_options_context(
     // context type.
     let styled_components_transform_rule =
         get_styled_components_transform_rule(next_config).await?;
-    let styled_jsx_transform_rule =
-        get_styled_jsx_transform_rule(next_config, css_versions).await?;
+    let styled_jsx_transform_rule = get_styled_jsx_transform_rule(next_config, versions).await?;
 
     let source_maps = if *next_config.server_source_maps().await? {
         SourceMapsType::Full

--- a/test/integration/css-fixtures/compilation-and-prefixing/pages/index.js
+++ b/test/integration/css-fixtures/compilation-and-prefixing/pages/index.js
@@ -1,3 +1,27 @@
 export default function Home() {
-  return <div className="red-text">This text should be red.</div>
+  return (
+    <>
+      <div className="red-text">This text should be red.</div>
+      <StyledJsxTest />
+    </>
+  )
+}
+
+function StyledJsxTest() {
+  return (
+    <>
+      <div className="media-query-test">This text should be blue.</div>
+      <style jsx>{`
+        .media-query-test {
+          color: blue;
+        }
+
+        @media (max-width: 400px) {
+          .media-query-test {
+            color: orange;
+          }
+        }
+      `}</style>
+    </>
+  )
 }

--- a/test/integration/css/test/css-compilation.test.js
+++ b/test/integration/css/test/css-compilation.test.js
@@ -219,6 +219,32 @@ module.exports = {
                   }
                 `)
               }
+
+              const inlineStyle = $('style')
+              expect(inlineStyle.length).toBe(1)
+              const inlineCssContent = inlineStyle
+                .html()
+                .replace(
+                  /media-query-test.jsx-[a-f0-9]{16}/g,
+                  'media-query-test.jsx-HASH'
+                )
+              if (process.env.IS_TURBOPACK_TEST && useLightningcss) {
+                expect(inlineCssContent).toMatchInlineSnapshot(
+                  `".media-query-test.jsx-HASH{color:#00f}@media (width<=400px){.media-query-test.jsx-HASH{color:orange}}"`
+                )
+              } else if (process.env.IS_TURBOPACK_TEST && !useLightningcss) {
+                expect(inlineCssContent).toMatchInlineSnapshot(
+                  `".media-query-test.jsx-HASH{color:#00f}@media (width<=400px){.media-query-test.jsx-HASH{color:orange}}"`
+                )
+              } else if (useLightningcss) {
+                expect(inlineCssContent).toMatchInlineSnapshot(
+                  `".media-query-test.jsx-HASH{color:blue}@media(max-width:400px){.media-query-test.jsx-HASH{color:orange}}"`
+                )
+              } else {
+                expect(inlineCssContent).toMatchInlineSnapshot(
+                  `".media-query-test.jsx-HASH{color:blue}@media(max-width:400px){.media-query-test.jsx-HASH{color:orange}}"`
+                )
+              }
             })
           }
         )

--- a/test/integration/css/test/css-compilation.test.js
+++ b/test/integration/css/test/css-compilation.test.js
@@ -230,11 +230,11 @@ module.exports = {
                 )
               if (process.env.IS_TURBOPACK_TEST && useLightningcss) {
                 expect(inlineCssContent).toMatchInlineSnapshot(
-                  `".media-query-test.jsx-HASH{color:#00f}@media (width<=400px){.media-query-test.jsx-HASH{color:orange}}"`
+                  `".media-query-test.jsx-HASH{color:#00f}@media (max-width:400px){.media-query-test.jsx-HASH{color:orange}}"`
                 )
               } else if (process.env.IS_TURBOPACK_TEST && !useLightningcss) {
                 expect(inlineCssContent).toMatchInlineSnapshot(
-                  `".media-query-test.jsx-HASH{color:#00f}@media (width<=400px){.media-query-test.jsx-HASH{color:orange}}"`
+                  `".media-query-test.jsx-HASH{color:#00f}@media (max-width:400px){.media-query-test.jsx-HASH{color:orange}}"`
                 )
               } else if (useLightningcss) {
                 expect(inlineCssContent).toMatchInlineSnapshot(

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -237,12 +237,9 @@ async fn build_internal(
                 build_output_root.clone(),
                 build_output_root.clone(),
                 build_output_root.clone(),
-                Environment::new(
-                    ExecutionEnvironment::NodeJsLambda(
-                        NodeJsEnvironment::default().resolved_cell(),
-                    ),
-                    compile_time_info.css_environment(),
-                )
+                Environment::new(ExecutionEnvironment::NodeJsLambda(
+                    NodeJsEnvironment::default().resolved_cell(),
+                ))
                 .to_resolved()
                 .await?,
                 runtime_type,
@@ -324,14 +321,6 @@ async fn build_internal(
 
     let chunking_context: Vc<Box<dyn ChunkingContext>> = match target {
         Target::Browser => {
-            let browser_environment = BrowserEnvironment {
-                dom: true,
-                web_worker: false,
-                service_worker: false,
-                browserslist_query: browserslist_query.clone(),
-            }
-            .resolved_cell();
-
             let mut builder = BrowserChunkingContext::builder(
                 project_path,
                 build_output_root.clone(),
@@ -339,10 +328,15 @@ async fn build_internal(
                 build_output_root.clone(),
                 build_output_root.clone(),
                 build_output_root.clone(),
-                Environment::new(
-                    ExecutionEnvironment::Browser(browser_environment),
-                    *browser_environment,
-                )
+                Environment::new(ExecutionEnvironment::Browser(
+                    BrowserEnvironment {
+                        dom: true,
+                        web_worker: false,
+                        service_worker: false,
+                        browserslist_query: browserslist_query.clone(),
+                    }
+                    .resolved_cell(),
+                ))
                 .to_resolved()
                 .await?,
                 runtime_type,
@@ -388,12 +382,9 @@ async fn build_internal(
                 build_output_root.clone(),
                 build_output_root.clone(),
                 build_output_root.clone(),
-                Environment::new(
-                    ExecutionEnvironment::NodeJsLambda(
-                        NodeJsEnvironment::default().resolved_cell(),
-                    ),
-                    BrowserEnvironment::default().cell(),
-                )
+                Environment::new(ExecutionEnvironment::NodeJsLambda(
+                    NodeJsEnvironment::default().resolved_cell(),
+                ))
                 .to_resolved()
                 .await?,
                 runtime_type,

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -199,19 +199,18 @@ pub async fn get_client_compile_time_info(
     node_env: Vc<NodeEnv>,
 ) -> Result<Vc<CompileTimeInfo>> {
     let node_env = node_env.await?;
-
-    let environment = BrowserEnvironment {
-        dom: true,
-        web_worker: false,
-        service_worker: false,
-        browserslist_query,
-    }
-    .resolved_cell();
-
     CompileTimeInfo::builder(
-        Environment::new(ExecutionEnvironment::Browser(environment), *environment)
-            .to_resolved()
-            .await?,
+        Environment::new(ExecutionEnvironment::Browser(
+            BrowserEnvironment {
+                dom: true,
+                web_worker: false,
+                service_worker: false,
+                browserslist_query,
+            }
+            .resolved_cell(),
+        ))
+        .to_resolved()
+        .await?,
     )
     .defines(client_defines(&node_env).resolved_cell())
     .free_var_references(

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -4,7 +4,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 
-use crate::environment::{BrowserEnvironment, Environment};
+use crate::environment::Environment;
 
 #[macro_export]
 macro_rules! definable_name_map_pattern_internal {
@@ -348,11 +348,6 @@ impl CompileTimeInfo {
     #[turbo_tasks::function]
     pub fn environment(&self) -> Vc<Environment> {
         *self.environment
-    }
-
-    #[turbo_tasks::function]
-    pub async fn css_environment(&self) -> Result<Vc<BrowserEnvironment>> {
-        Ok(self.environment.css_environment())
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -42,20 +42,13 @@ pub enum ChunkLoading {
 pub struct Environment {
     // members must be private to avoid leaking non-custom types
     execution: ExecutionEnvironment,
-    css_environment: ResolvedVc<BrowserEnvironment>,
 }
 
 #[turbo_tasks::value_impl]
 impl Environment {
     #[turbo_tasks::function]
-    pub async fn new(
-        execution: ExecutionEnvironment,
-        css_environment: ResolvedVc<BrowserEnvironment>,
-    ) -> Vc<Self> {
-        Self::cell(Environment {
-            execution,
-            css_environment,
-        })
+    pub fn new(execution: ExecutionEnvironment) -> Vc<Self> {
+        Self::cell(Environment { execution })
     }
 }
 
@@ -105,17 +98,6 @@ impl Environment {
             ExecutionEnvironment::EdgeWorker(edge_env) => edge_env.runtime_versions(),
             ExecutionEnvironment::Custom(_) => todo!(),
         })
-    }
-
-    #[turbo_tasks::function]
-    pub fn css_environment(&self) -> Vc<BrowserEnvironment> {
-        *self.css_environment
-    }
-
-    #[turbo_tasks::function]
-    pub async fn css_runtime_versions(&self) -> Result<Vc<RuntimeVersions>> {
-        let distribs = resolve_browserslist(self.css_environment).await?;
-        Ok(Vc::cell(Versions::parse_versions(distribs)?))
     }
 
     #[turbo_tasks::function]
@@ -335,7 +317,6 @@ impl Default for NodeJsVersion {
 }
 
 #[turbo_tasks::value(shared)]
-#[derive(Default)]
 pub struct BrowserEnvironment {
     pub dom: bool,
     pub web_worker: bool,

--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -14,9 +14,7 @@ use turbo_tasks::ResolvedVc;
 use turbo_tasks_testing::VcStorage;
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
-    environment::{
-        BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion,
-    },
+    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
     target::CompileTarget,
 };
 use turbopack_ecmascript::analyzer::{
@@ -102,20 +100,15 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
         let var_cache = Default::default();
         for val in input.var_graph.values.values() {
             VcStorage::with(async {
-                let css_environment = BrowserEnvironment::default().cell();
-
                 let compile_time_info = CompileTimeInfo::builder(
-                    Environment::new(
-                        ExecutionEnvironment::NodeJsLambda(
-                            NodeJsEnvironment {
-                                compile_target: CompileTarget::unknown().to_resolved().await?,
-                                node_version: NodeJsVersion::default().resolved_cell(),
-                                cwd: ResolvedVc::cell(None),
-                            }
-                            .resolved_cell(),
-                        ),
-                        css_environment,
-                    )
+                    Environment::new(ExecutionEnvironment::NodeJsLambda(
+                        NodeJsEnvironment {
+                            compile_target: CompileTarget::unknown().to_resolved().await?,
+                            node_version: NodeJsVersion::default().resolved_cell(),
+                            cwd: ResolvedVc::cell(None),
+                        }
+                        .resolved_cell(),
+                    ))
                     .to_resolved()
                     .await?,
                 )

--- a/turbopack/crates/turbopack-ecmascript/benches/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/references.rs
@@ -9,7 +9,7 @@ use turbo_tasks_backend::{
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
-    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
 };
@@ -38,10 +38,9 @@ pub fn benchmark(c: &mut Criterion) {
             let root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/benches/");
             let fs = DiskFileSystem::new(rcstr!("project"), root_dir.to_str().unwrap().into());
 
-            let environment = Environment::new(
-                ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().resolved_cell()),
-                BrowserEnvironment::default().cell(),
-            );
+            let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
+                NodeJsEnvironment::default().resolved_cell(),
+            ));
             let compile_time_info = CompileTimeInfo::new(environment).to_resolved().await?;
             let layer = Layer::new(rcstr!("test"));
             let module_asset_context = NoopAssetContext {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3777,9 +3777,7 @@ mod tests {
     use turbo_tasks::{ResolvedVc, util::FormatDuration};
     use turbopack_core::{
         compile_time_info::CompileTimeInfo,
-        environment::{
-            BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion,
-        },
+        environment::{Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
         target::{Arch, CompileTarget, Endianness, Libc, Platform},
     };
 
@@ -4178,26 +4176,21 @@ mod tests {
         var_cache: &Mutex<FxHashMap<Id, JsValue>>,
     ) -> (JsValue, u32) {
         turbo_tasks_testing::VcStorage::with(async {
-            let css_environment = BrowserEnvironment::default().resolved_cell();
-
             let compile_time_info = CompileTimeInfo::builder(
-                Environment::new(
-                    ExecutionEnvironment::NodeJsLambda(
-                        NodeJsEnvironment {
-                            compile_target: CompileTarget {
-                                arch: Arch::X64,
-                                platform: Platform::Linux,
-                                endianness: Endianness::Little,
-                                libc: Libc::Glibc,
-                            }
-                            .resolved_cell(),
-                            node_version: NodeJsVersion::default().resolved_cell(),
-                            cwd: ResolvedVc::cell(None),
+                Environment::new(ExecutionEnvironment::NodeJsLambda(
+                    NodeJsEnvironment {
+                        compile_target: CompileTarget {
+                            arch: Arch::X64,
+                            platform: Platform::Linux,
+                            endianness: Endianness::Little,
+                            libc: Libc::Glibc,
                         }
                         .resolved_cell(),
-                    ),
-                    *css_environment,
-                )
+                        node_version: NodeJsVersion::default().resolved_cell(),
+                        cwd: ResolvedVc::cell(None),
+                    }
+                    .resolved_cell(),
+                ))
                 .to_resolved()
                 .await?,
             )

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -12,7 +12,7 @@ use turbopack_cli_utils::issue::{ConsoleUi, LogOptions};
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
-    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
     issue::{IssueReporter, IssueSeverity, handle_issues},
@@ -69,10 +69,9 @@ async fn node_file_trace_operation(
     let input = input_dir.join(&format!("{input}"))?;
 
     let source = FileSource::new(input);
-    let environment = Environment::new(
-        ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().resolved_cell()),
-        BrowserEnvironment::default().cell(),
-    );
+    let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
+        NodeJsEnvironment::default().resolved_cell(),
+    ));
     let module_asset_context = ModuleAssetContext::new(
         Default::default(),
         // This config should be kept in sync with

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -36,7 +36,7 @@ use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     condition::ContextCondition,
     context::AssetContext,
-    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
     issue::IssueDescriptionExt,
@@ -337,10 +337,9 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         .get_relative_path_to(project_root)
         .context("Project path is in root path")?;
 
-    let env = Environment::new(
-        ExecutionEnvironment::NodeJsBuildTime(NodeJsEnvironment::default().resolved_cell()),
-        BrowserEnvironment::default().cell(),
-    )
+    let env = Environment::new(ExecutionEnvironment::NodeJsBuildTime(
+        NodeJsEnvironment::default().resolved_cell(),
+    ))
     .to_resolved()
     .await?;
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -257,33 +257,28 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
 
     let entry_asset = project_path.join(&options.entry)?;
 
-    let env = match options.environment {
+    let env = Environment::new(match options.environment {
         SnapshotEnvironment::Browser => {
-            let environment=// TODO: load more from options.json
-            BrowserEnvironment {
-                dom: true,
-                web_worker: false,
-                service_worker: false,
-                browserslist_query: options.browserslist.into(),
-            }
-            .resolved_cell();
-
-            Environment::new(ExecutionEnvironment::Browser(environment), *environment)
-                .to_resolved()
-                .await?
+            ExecutionEnvironment::Browser(
+                // TODO: load more from options.json
+                BrowserEnvironment {
+                    dom: true,
+                    web_worker: false,
+                    service_worker: false,
+                    browserslist_query: options.browserslist.into(),
+                }
+                .resolved_cell(),
+            )
         }
         SnapshotEnvironment::NodeJs => {
-            Environment::new(
-                ExecutionEnvironment::NodeJsBuildTime(
-                    // TODO: load more from options.json
-                    NodeJsEnvironment::default().resolved_cell(),
-                ),
-                BrowserEnvironment::default().cell(),
+            ExecutionEnvironment::NodeJsBuildTime(
+                // TODO: load more from options.json
+                NodeJsEnvironment::default().resolved_cell(),
             )
-            .to_resolved()
-            .await?
         }
-    };
+    })
+    .to_resolved()
+    .await?;
 
     let mut defines = compile_time_defines!(
         process.turbopack = true,

--- a/turbopack/crates/turbopack-tracing/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack-tracing/benches/node_file_trace.rs
@@ -13,7 +13,7 @@ use turbopack::{
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
-    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
     rebase::RebasedAsset,
@@ -85,12 +85,9 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
 
                 let source = FileSource::new(input);
                 let compile_time_info = CompileTimeInfo::builder(
-                    Environment::new(
-                        ExecutionEnvironment::NodeJsLambda(
-                            NodeJsEnvironment::default().resolved_cell(),
-                        ),
-                        BrowserEnvironment::default().cell(),
-                    )
+                    Environment::new(ExecutionEnvironment::NodeJsLambda(
+                        NodeJsEnvironment::default().resolved_cell(),
+                    ))
                     .to_resolved()
                     .await?,
                 )

--- a/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
@@ -39,7 +39,7 @@ use turbopack::{
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
-    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
     output::OutputAsset,
@@ -345,10 +345,9 @@ async fn node_file_trace_operation(
     let output_dir = output_fs.root().owned().await?;
 
     let source = FileSource::new(input);
-    let environment = Environment::new(
-        ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().resolved_cell()),
-        BrowserEnvironment::default().cell(),
-    );
+    let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
+        NodeJsEnvironment::default().resolved_cell(),
+    ));
     let module_asset_context = ModuleAssetContext::new(
         Default::default(),
         // TODO These test cases should move into the `node-file-trace` crate and use the same

--- a/turbopack/crates/turbopack-tracing/tests/unit.rs
+++ b/turbopack/crates/turbopack-tracing/tests/unit.rs
@@ -21,7 +21,7 @@ use turbopack_core::{
     chunk::ChunkingType,
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
-    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
     module::Module,
@@ -183,10 +183,9 @@ async fn node_file_trace_operation(package_root: RcStr, input: RcStr) -> Result<
     let input = input_dir.join(&input)?;
 
     let source = FileSource::new(input);
-    let environment = Environment::new(
-        ExecutionEnvironment::NodeJsLambda(NodeJsEnvironment::default().resolved_cell()),
-        BrowserEnvironment::default().cell(),
-    );
+    let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
+        NodeJsEnvironment::default().resolved_cell(),
+    ));
     let module_asset_context = ModuleAssetContext::new(
         Default::default(),
         // TODO These test cases should move into the `node-file-trace` crate and use the same

--- a/turbopack/crates/turbopack/examples/turbopack.rs
+++ b/turbopack/crates/turbopack/examples/turbopack.rs
@@ -17,7 +17,7 @@ use turbopack_core::{
     PROJECT_FILESYSTEM_NAME,
     compile_time_info::CompileTimeInfo,
     context::AssetContext,
-    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
     rebase::RebasedAsset,
@@ -47,12 +47,9 @@ async fn main() -> Result<()> {
             let source = FileSource::new(entry);
             let module_asset_context = turbopack::ModuleAssetContext::new(
                 Default::default(),
-                CompileTimeInfo::new(Environment::new(
-                    ExecutionEnvironment::NodeJsLambda(
-                        NodeJsEnvironment::default().resolved_cell(),
-                    ),
-                    BrowserEnvironment::default().cell(),
-                )),
+                CompileTimeInfo::new(Environment::new(ExecutionEnvironment::NodeJsLambda(
+                    NodeJsEnvironment::default().resolved_cell(),
+                ))),
                 Default::default(),
                 ResolveOptionsContext {
                     enable_typescript: true,

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -8,7 +8,7 @@ use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     condition::ContextCondition,
     context::AssetContext,
-    environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
+    environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
     ident::Layer,
     resolve::options::{ImportMap, ImportMapping},
 };
@@ -24,10 +24,9 @@ use crate::{
 
 #[turbo_tasks::function]
 pub fn node_build_environment() -> Vc<Environment> {
-    Environment::new(
-        ExecutionEnvironment::NodeJsBuildTime(NodeJsEnvironment::default().resolved_cell()),
-        BrowserEnvironment::default().cell(),
-    )
+    Environment::new(ExecutionEnvironment::NodeJsBuildTime(
+        NodeJsEnvironment::default().resolved_cell(),
+    ))
 }
 
 #[turbo_tasks::function]


### PR DESCRIPTION
Change the fix from #83334 to not have a "CSS environment" inside of every environment. I don't think that this makes sense, and it also makes the implementation more complicated.
```diff
  pub struct Environment {
    execution: ExecutionEnvironment,
+   css_environment: ResolvedVc<BrowserEnvironment>,
  }
```

Instead, we can just pass the client's `Environment` when we create the server's transform rules, to use the client's browserslist config for styled-jsx.

#83334 was also missing a test case

I recommend the review each commits individually.

Closes PACK-5441