### PR TITLE
docs(eslint): clarify note for no-html-link-for-pages rule

### DIFF
--- a/docs/01-app/03-api-reference/05-config/03-eslint.mdx
+++ b/docs/01-app/03-api-reference/05-config/03-eslint.mdx
@@ -46,6 +46,9 @@ The full set of rules is as follows:
 |      <Check size={18} />      | @next/next/no-typos                                                                                                      | Prevent common typos in [Next.js's data fetching functions](/docs/pages/building-your-application/data-fetching) |
 |      <Check size={18} />      | [@next/next/no-unwanted-polyfillio](/docs/messages/no-unwanted-polyfillio)                                               | Prevent duplicate polyfills from Polyfill.io.                                                                    |
 
+> **Note:** The rule `@next/next/no-html-link-for-pages` does **not currently detect pages** when using custom `pageExtensions` (e.g., `.mdx` or `.page.tsx`).  
+> You may need to disable this rule or configure ESLint manually until support is added. See [issue #53473](https://github.com/vercel/next.js/issues/53473).
+
 We recommend using an appropriate [integration](https://eslint.org/docs/user-guide/integrations#editors) to view warnings and errors directly in your code editor during development.
 
 ## Examples


### PR DESCRIPTION
Add clarification that the rule `@next/next/no-html-link-for-pages` does not currently detect custom `pageExtensions` (e.g., `.mdx`, `.page.tsx`).  
Linked to issue #53473 for reference.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:
-->

## For Contributors

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the [Docs Contribution Guide](https://nextjs.org/docs/community/contribution-guide) to ensure your contribution follows the docs guidelines.

---

### What?
This PR updates the **ESLint rules documentation** by adding a clarification note for the rule `@next/next/no-html-link-for-pages`.  
The note explains that the rule does not currently detect pages when using custom `pageExtensions` (e.g., `.mdx`, `.page.tsx`).

### Why?
Developers using custom `pageExtensions` may be confused when the rule does not apply to their setup.  
This clarification provides better guidance and links directly to the related issue.

### How?
- Updated `eslint.mdx` to include a blockquote note under the `@next/next/no-html-link-for-pages` rule.
- Linked to the open GitHub issue for context and tracking.

---

### Related
Fixes #53473
