### PR TITLE
Turbopack: Merge babel-loader and react-compiler configuration logic to avoid running babel twice

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1314,9 +1314,7 @@ impl AppEndpoint {
 
         // polyfill-nomodule.js is a pre-compiled asset distributed as part of next,
         // load it as a RawModule.
-        let next_package = get_next_package(project.project_path().owned().await?)
-            .owned()
-            .await?;
+        let next_package = get_next_package(project.project_path().owned().await?).await?;
         let polyfill_source =
             FileSource::new(next_package.join("dist/build/polyfills/polyfill-nomodule.js")?);
         let polyfill_output_path = client_chunking_context

--- a/crates/next-core/src/next_build.rs
+++ b/crates/next-core/src/next_build.rs
@@ -16,7 +16,7 @@ pub async fn get_postcss_package_mapping(
             .resolved_cell(),
         ImportMapping::PrimaryAlternative(
             rcstr!("postcss"),
-            Some(get_next_package(project_path.clone()).owned().await?),
+            Some(get_next_package(project_path.clone()).await?),
         )
         .resolved_cell(),
     ])

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -165,25 +165,30 @@ pub async fn get_babel_loader_rules(
             //
             // NOTE: we already bail out at the earlier if `foreign` condition is set or if
             // `browser` is not set.
-            if react_compiler_options.compilation_mode == ReactCompilerCompilationMode::Annotation {
-                loader_conditions.push(ConditionItem::Base {
-                    path: None,
-                    content: Some(
-                        EsRegex::new(r#"['"]use memo['"]"#, "")
-                            .expect("valid const regex")
-                            .resolved_cell(),
-                    ),
-                });
-            } else {
-                loader_conditions.push(ConditionItem::Base {
-                    path: None,
-                    // Matches declaration or useXXX or </ (closing jsx) or /> (self closing jsx)
-                    content: Some(
-                        EsRegex::new(r#"['"]use memo['"]|\Wuse[A-Z]|<\/|\/>"#, "")
-                            .expect("valid const regex")
-                            .resolved_cell(),
-                    ),
-                });
+            match react_compiler_options.compilation_mode {
+                ReactCompilerCompilationMode::Annotation => {
+                    loader_conditions.push(ConditionItem::Base {
+                        path: None,
+                        content: Some(
+                            EsRegex::new(r#"['"]use memo['"]"#, "")
+                                .expect("valid const regex")
+                                .resolved_cell(),
+                        ),
+                    });
+                }
+                ReactCompilerCompilationMode::Infer => {
+                    loader_conditions.push(ConditionItem::Base {
+                        path: None,
+                        // Matches declaration or useXXX or </ (closing jsx) or /> (self closing
+                        // jsx)
+                        content: Some(
+                            EsRegex::new(r#"['"]use memo['"]|\Wuse[A-Z]|<\/|\/>"#, "")
+                                .expect("valid const regex")
+                                .resolved_cell(),
+                        ),
+                    });
+                }
+                ReactCompilerCompilationMode::All => {}
             }
         }
     }

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -1,14 +1,27 @@
-use std::sync::LazyLock;
+use std::{collections::BTreeSet, sync::LazyLock};
 
 use anyhow::{Context, Result};
 use regex::Regex;
+use turbo_esregex::EsRegex;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::ResolvedVc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{self, FileSystemEntryType, FileSystemPath, to_sys_path};
 use turbopack::module_options::{ConditionItem, LoaderRuleItem};
+use turbopack_core::{
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    reference_type::{CommonJsReferenceSubType, ReferenceType},
+    resolve::{node::node_cjs_resolve_options, parse::Request, pattern::Pattern, resolve},
+    source::Source,
+};
 use turbopack_node::transforms::webpack::WebpackLoaderItem;
 
-use crate::next_shared::webpack_rules::WebpackLoaderBuiltinCondition;
+use crate::{
+    next_config::{NextConfig, ReactCompilerCompilationMode},
+    next_import_map::try_get_next_package,
+    next_shared::webpack_rules::{
+        ManuallyConfiguredBuiltinLoaderIssue, WebpackLoaderBuiltinCondition,
+    },
+};
 
 // https://babeljs.io/docs/config-files
 // TODO: Also support a `babel` key in a package.json file
@@ -31,7 +44,12 @@ static BABEL_LOADER_RE: LazyLock<Regex> =
 /// is always available, as it's installed as part of next.js.
 const NEXT_JS_BABEL_LOADER: &str = "next/dist/build/babel/loader";
 
-pub async fn detect_likely_babel_loader(
+const BABEL_PLUGIN_REACT_COMPILER: &str = "babel-plugin-react-compiler";
+const BABEL_PLUGIN_REACT_COMPILER_PACKAGE_JSON: &str = "babel-plugin-react-compiler/package.json";
+
+/// Detect manually-configured babel loaders. This is used to generate a warning, suggesting using
+/// the built-in babel support.
+async fn detect_likely_babel_loader(
     webpack_rules: &[(RcStr, LoaderRuleItem)],
 ) -> Result<Option<RcStr>> {
     for (glob, rule) in webpack_rules {
@@ -51,34 +69,117 @@ pub async fn detect_likely_babel_loader(
 /// configuration, automatically add `babel-loader` as a webpack loader for each eligible file type
 /// if it doesn't already exist.
 pub async fn get_babel_loader_rules(
-    project_root: FileSystemPath,
+    project_path: &FileSystemPath,
+    next_config: Vc<NextConfig>,
+    builtin_conditions: &BTreeSet<WebpackLoaderBuiltinCondition>,
+    user_webpack_rules: &[(RcStr, LoaderRuleItem)],
 ) -> Result<Vec<(RcStr, LoaderRuleItem)>> {
+    if builtin_conditions.contains(&WebpackLoaderBuiltinCondition::Foreign) {
+        return Ok(Vec::new());
+    }
+
+    let use_builtin_babel = next_config
+        .experimental_turbopack_use_builtin_babel()
+        .await?;
+
+    if use_builtin_babel.is_none()
+        && let Some(glob) = detect_likely_babel_loader(user_webpack_rules).await?
+    {
+        ManuallyConfiguredBuiltinLoaderIssue {
+            glob,
+            loader: rcstr!("babel-loader"),
+            config_key: rcstr!("experimental.turbopackUseBuiltinBabel"),
+            config_file_path: next_config
+                .config_file_path(project_path.clone())
+                .owned()
+                .await?,
+        }
+        .resolved_cell()
+        .emit()
+    }
+
     let mut babel_config_path = None;
-    for &filename in BABEL_CONFIG_FILES {
-        let path = project_root.join(filename)?;
-        let filetype = *path.get_type().await?;
-        if matches!(filetype, FileSystemEntryType::File) {
-            babel_config_path = Some(path);
-            break;
+    if use_builtin_babel.unwrap_or(true) {
+        for &filename in BABEL_CONFIG_FILES {
+            let path = project_path.join(filename)?;
+            let filetype = *path.get_type().await?;
+            if matches!(filetype, FileSystemEntryType::File) {
+                babel_config_path = Some(path);
+                break;
+            }
         }
     }
-    let Some(babel_config_path) = babel_config_path else {
+
+    let react_compiler_options = next_config.react_compiler_options().await?;
+
+    if babel_config_path.is_none() && react_compiler_options.is_none() {
         return Ok(Vec::new());
-    };
+    }
 
     // - See `packages/next/src/build/babel/loader/types.d.ts` for all the configuration options.
     // - See `packages/next/src/build/get-babel-loader-config.ts` for how we use this in webpack.
-    let serde_json::Value::Object(loader_options) = serde_json::json!({
+    let serde_json::Value::Object(mut loader_options) = serde_json::json!({
         // `transformMode: default` (what the webpack implementation does) would run all of the
         // Next.js-specific transforms as babel transforms. Because we always have to pay the cost
         // of parsing with SWC after the webpack loader runs, we want to keep running those
         // transforms using SWC, so use `standalone` instead.
         "transformMode": "standalone",
-        "cwd": to_sys_path_str(project_root).await?,
-        "configFile": to_sys_path_str(babel_config_path).await?,
+        "cwd": to_sys_path_str(project_path.clone()).await?,
     }) else {
         unreachable!("is an object")
     };
+
+    if let Some(babel_config_path) = &babel_config_path {
+        loader_options.insert(
+            "configFile".to_owned(),
+            to_sys_path_str(babel_config_path.clone()).await?.into(),
+        );
+    }
+
+    // NOTE: we already bail out at the top of this function is the `foreign` condition is set
+    let mut loader_conditions = Vec::new();
+    if let Some(react_compiler_options) = &*react_compiler_options
+        && let Some(babel_plugin_path) =
+            resolve_babel_plugin_react_compiler(next_config, project_path).await?
+    {
+        let react_compiler_options = react_compiler_options.await?;
+        let react_compiler_plugins =
+            serde_json::Value::Array(vec![serde_json::Value::Array(vec![
+                serde_json::Value::String(babel_plugin_path.into_owned()),
+                serde_json::to_value(&*react_compiler_options)
+                    .expect("react compiler options JSON serialization should never fail"),
+            ])]);
+
+        loader_options.insert("reactCompilerPlugins".to_owned(), react_compiler_plugins);
+
+        if babel_config_path.is_none() {
+            // We're only running react-compiler, so add some extra conditions to limit when babel
+            // runs for performance reasons
+            loader_conditions.push(ConditionItem::Builtin(RcStr::from(
+                WebpackLoaderBuiltinCondition::Browser.as_str(),
+            )));
+            if react_compiler_options.compilation_mode == ReactCompilerCompilationMode::Annotation {
+                loader_conditions.push(ConditionItem::Base {
+                    path: None,
+                    content: Some(
+                        EsRegex::new(r#"['"]use memo['"]"#, "")
+                            .expect("valid const regex")
+                            .resolved_cell(),
+                    ),
+                });
+            } else {
+                loader_conditions.push(ConditionItem::Base {
+                    path: None,
+                    // Matches declaration or useXXX or </ (closing jsx) or /> (self closing jsx)
+                    content: Some(
+                        EsRegex::new(r#"['"]use memo['"]|\Wuse[A-Z]|<\/|\/>"#, "")
+                            .expect("valid const regex")
+                            .resolved_cell(),
+                    ),
+                });
+            }
+        }
+    }
 
     Ok(vec![(
         rcstr!("*.{js,jsx,ts,tsx,cjs,mjs,mts,cts}"),
@@ -88,9 +189,7 @@ pub async fn get_babel_loader_rules(
                 options: loader_options,
             }]),
             rename_as: Some(rcstr!("*")),
-            condition: Some(ConditionItem::Not(Box::new(ConditionItem::Builtin(
-                RcStr::from(WebpackLoaderBuiltinCondition::Foreign.as_str()),
-            )))),
+            condition: Some(ConditionItem::All(loader_conditions.into())),
         },
     )])
 }
@@ -104,4 +203,110 @@ async fn to_sys_path_str(path: FileSystemPath) -> Result<String> {
         .to_str()
         .with_context(|| format!("{sys_path:?} is not valid utf-8"))?
         .to_owned())
+}
+
+/// Resolve `babel-plugin-react-compiler` relative to `next`. This matches the behavior of the
+/// webpack implementation, which resolves the Babel plugin from within `next`. The Babel plugin is
+/// an optional peer dependency of `next`.
+///
+/// The returned path is relative to `project_path`. `project_path` should be the value given to
+/// `babel-loader` using the `cwd` option.
+pub async fn resolve_babel_plugin_react_compiler(
+    next_config: Vc<NextConfig>,
+    project_path: &FileSystemPath,
+) -> Result<Option<RcStr>> {
+    let Some(next_package) = &*try_get_next_package(project_path.clone()).await? else {
+        BabelPluginReactCompilerResolutionIssue {
+            failed_resolution: rcstr!("next"),
+            config_file_path: next_config
+                .config_file_path(project_path.clone())
+                .owned()
+                .await?,
+        }
+        .resolved_cell()
+        .emit();
+        return Ok(None);
+    };
+
+    let babel_plugin_result = resolve(
+        next_package.clone(),
+        ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
+        Request::parse(Pattern::Constant(rcstr!(
+            BABEL_PLUGIN_REACT_COMPILER_PACKAGE_JSON
+        ))),
+        node_cjs_resolve_options(project_path.root().owned().await?),
+    );
+    let Some(source) = &*babel_plugin_result.first_source().await? else {
+        BabelPluginReactCompilerResolutionIssue {
+            failed_resolution: rcstr!(BABEL_PLUGIN_REACT_COMPILER),
+            config_file_path: next_config
+                .config_file_path(project_path.clone())
+                .owned()
+                .await?,
+        }
+        .resolved_cell()
+        .emit();
+        return Ok(None);
+    };
+
+    Ok(Some(
+        // the relative path should only ever fail to resolve when the `fs` is different, which
+        // should only happen due to eventual consistency.
+        project_path
+            .get_relative_path_to(&source.ident().path().await?.parent())
+            .context("failed to resolve relative path for react compiler plugin")?,
+    ))
+}
+
+#[turbo_tasks::value]
+struct BabelPluginReactCompilerResolutionIssue {
+    failed_resolution: RcStr,
+    config_file_path: FileSystemPath,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for BabelPluginReactCompilerResolutionIssue {
+    #[turbo_tasks::function]
+    fn stage(&self) -> Vc<IssueStage> {
+        IssueStage::Transform.into()
+    }
+
+    fn severity(&self) -> IssueSeverity {
+        IssueSeverity::Error
+    }
+
+    #[turbo_tasks::function]
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        self.config_file_path.clone().cell()
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> Vc<StyledString> {
+        StyledString::Line(vec![
+            StyledString::Text(rcstr!("Failed to resolve package ")),
+            StyledString::Code(self.failed_resolution.clone()),
+            StyledString::Text(rcstr!(" while attempting to resolve React Compiler")),
+        ])
+        .cell()
+    }
+
+    #[turbo_tasks::function]
+    fn description(&self) -> Vc<OptionStyledString> {
+        Vc::cell(Some(
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("React compiler is enabled in ")),
+                StyledString::Code(self.config_file_path.path.clone()),
+                StyledString::Text(rcstr!(
+                    ". We attempted to resolve React Compiler relative to the "
+                )),
+                StyledString::Code(rcstr!("next")),
+                StyledString::Text(rcstr!(" package. Is ")),
+                StyledString::Code(rcstr!(BABEL_PLUGIN_REACT_COMPILER)),
+                StyledString::Text(rcstr!(" installed in your ")),
+                StyledString::Code(rcstr!("node_modules")),
+                StyledString::Text(rcstr!(" directory?")),
+            ])
+            .resolved_cell(),
+        ))
+    }
 }

--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -9,16 +9,13 @@ use turbopack::module_options::{
     WebpackLoaderBuiltinConditionSet, WebpackLoaderBuiltinConditionSetMatch, WebpackLoadersOptions,
 };
 use turbopack_core::{
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString},
     resolve::{ExternalTraced, ExternalType, options::ImportMapping},
 };
 
 use crate::{
     next_config::NextConfig,
-    next_shared::webpack_rules::{
-        babel::{detect_likely_babel_loader, get_babel_loader_rules},
-        sass::{detect_likely_sass_loader, get_sass_loader_rules},
-    },
+    next_shared::webpack_rules::{babel::get_babel_loader_rules, sass::get_sass_loader_rules},
 };
 
 pub(crate) mod babel;
@@ -147,63 +144,14 @@ pub async fn webpack_loader_options(
     next_config: Vc<NextConfig>,
     builtin_conditions: BTreeSet<WebpackLoaderBuiltinCondition>,
 ) -> Result<Vc<OptionWebpackLoadersOptions>> {
-    let mut rules = next_config
-        .webpack_rules(project_path.clone())
-        .owned()
-        .await?;
+    let user_rules = next_config.webpack_rules(project_path.clone()).await?;
+    let mut rules = (*user_rules).clone();
 
-    let config_file_path = async || project_path.join(&next_config.await?.config_file_name);
-
-    let use_builtin_sass = next_config
-        .experimental_turbopack_use_builtin_sass()
-        .await?;
-    if use_builtin_sass.unwrap_or(true) {
-        if use_builtin_sass.is_none()
-            && let Some(glob) = detect_likely_sass_loader(&rules).await?
-        {
-            ManuallyConfiguredBuiltinLoaderIssue {
-                glob,
-                loader: rcstr!("sass-loader"),
-                config_key: rcstr!("experimental.turbopackUseBuiltinSass"),
-                config_file_path: config_file_path().await?,
-            }
-            .resolved_cell()
-            .emit()
-        }
-        rules.append(&mut get_sass_loader_rules(next_config.sass_config()).await?);
-    }
-
-    // TODO: Enable this warning after babel configuration is fixed
-    // (https://github.com/vercel/next.js/pull/82676) and the react-compiler logic is moved into
-    // here. React-compiler is currently configured in JS before it gets to us, which could trigger
-    // false-positives.
-    let use_builtin_babel = next_config
-        .experimental_turbopack_use_builtin_babel()
-        .await?;
-    if !builtin_conditions.contains(&WebpackLoaderBuiltinCondition::Foreign)
-        && use_builtin_babel.unwrap_or(true)
-    {
-        if use_builtin_babel.is_none()
-            && let Some(glob) = detect_likely_babel_loader(&rules).await?
-        {
-            let _ = glob;
-            // TODO: Enable this warning after babel configuration is fixed
-            // (https://github.com/vercel/next.js/pull/82676) and the react-compiler logic is moved into
-            // here. React-compiler is currently configured in JS before it gets to us, which could
-            // trigger false-positives.
-            /*
-            ManuallyConfiguredBuiltinLoaderIssue {
-                glob,
-                loader: rcstr!("babel-loader"),
-                disable_builtin_config_key: rcstr!("experimental.turbopackUseBuiltinBabel"),
-                config_file_path: config_file_path().await?,
-            }
-            .resolved_cell()
-            .emit()
-            */
-        }
-        rules.append(&mut get_babel_loader_rules(project_path.clone()).await?);
-    }
+    rules.append(&mut get_sass_loader_rules(&project_path, next_config, &user_rules).await?);
+    rules.append(
+        &mut get_babel_loader_rules(&project_path, next_config, &builtin_conditions, &user_rules)
+            .await?,
+    );
 
     if rules.is_empty() {
         return Ok(Vc::cell(None));
@@ -235,7 +183,7 @@ fn loader_runner_package_mapping() -> Result<Vc<ImportMapping>> {
 }
 
 #[turbo_tasks::value]
-struct ManuallyConfiguredBuiltinLoaderIssue {
+pub struct ManuallyConfiguredBuiltinLoaderIssue {
     glob: RcStr,
     loader: RcStr,
     config_key: RcStr,

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -249,7 +249,7 @@ pub async fn load_next_js_template(
     let content = file_content_rope(template_path.read()).await?;
     let content = content.to_str()?;
 
-    let package_root = &*get_next_package(project_path).await?;
+    let package_root = get_next_package(project_path).await?;
 
     let content = expand_next_js_template(
         &content,

--- a/packages/next/src/build/babel/loader/get-config.ts
+++ b/packages/next/src/build/babel/loader/get-config.ts
@@ -100,6 +100,7 @@ async function getCacheCharacteristics(
   reactCompilerPlugins ??= []
   const hasReactCompiler =
     reactCompilerPlugins.length !== 0 &&
+    !loaderOptions.isServer &&
     !/[/\\]node_modules[/\\]/.test(filename) &&
     !reactCompilerExclude?.(filename) &&
     (await isReactCompilerRequired(filename))

--- a/packages/next/src/build/babel/loader/get-config.ts
+++ b/packages/next/src/build/babel/loader/get-config.ts
@@ -484,7 +484,7 @@ function getCacheKey(cacheCharacteristics: CharacteristicsGermaneToCaching) {
     (hasModuleExports ? 0b010000 : 0) |
     (hasReactCompiler ? 0b100000 : 0)
 
-  // separate strings will null bytes, assuming null bytes are not valid in file
+  // separate strings with null bytes, assuming null bytes are not valid in file
   // paths
   return `${configFilePath || ''}\x00${fileExt}\x00${flags}`
 }

--- a/packages/next/src/build/babel/loader/types.d.ts
+++ b/packages/next/src/build/babel/loader/types.d.ts
@@ -68,6 +68,7 @@ export type NextBabelLoaderOptionDefaultPresets = NextBabelLoaderBaseOptions & {
  */
 export type NextBabelLoaderOptionStandalone = NextBabelLoaderBaseOptions & {
   transformMode: 'standalone'
+  isServer: boolean
 }
 
 export type NextBabelLoaderOptions =

--- a/packages/next/src/build/get-babel-loader-config.ts
+++ b/packages/next/src/build/get-babel-loader-config.ts
@@ -1,8 +1,5 @@
 import path from 'path'
-import type {
-  ReactCompilerOptions,
-  TurbopackLoaderOptions,
-} from '../server/config-shared'
+import type { ReactCompilerOptions } from '../server/config-shared'
 import type { NextBabelLoaderOptions } from './babel/loader/types'
 
 function getReactCompiler() {
@@ -103,7 +100,7 @@ const getReactCompilerLoader = (
     return undefined
   }
 
-  const babelLoaderOptions: NextBabelLoaderOptions & TurbopackLoaderOptions = {
+  const babelLoaderOptions: NextBabelLoaderOptions = {
     transformMode: 'standalone',
     cwd,
     reactCompilerPlugins,

--- a/packages/next/src/build/get-babel-loader-config.ts
+++ b/packages/next/src/build/get-babel-loader-config.ts
@@ -104,6 +104,7 @@ const getReactCompilerLoader = (
     transformMode: 'standalone',
     cwd,
     reactCompilerPlugins,
+    isServer,
   }
   if (reactCompilerExclude) {
     babelLoaderOptions.reactCompilerExclude = reactCompilerExclude

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -10,7 +10,6 @@ import { patchIncorrectLockfile } from '../../lib/patch-incorrect-lockfile'
 import { downloadNativeNextSwc, downloadWasmSwc } from '../../lib/download-swc'
 import type {
   NextConfigComplete,
-  ReactCompilerOptions,
   TurbopackLoaderBuiltinCondition,
   TurbopackLoaderItem,
   TurbopackRuleCondition,
@@ -19,7 +18,6 @@ import type {
 } from '../../server/config-shared'
 import { isDeepStrictEqual } from 'util'
 import { type DefineEnvOptions, getDefineEnv } from '../define-env'
-import { getReactCompilerLoader } from '../get-babel-loader-config'
 import type {
   NapiPartialProjectOptions,
   NapiProjectOptions,

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -795,67 +795,12 @@ function bindingToApi(
     }
   }
 
-  /**
-   * Returns a new copy of next.js config object to avoid mutating the original.
-   *
-   * Also it does some augmentation to the configuration as well, for example set the
-   * turbopack's rules if `experimental.reactCompilerOptions` is set.
-   */
-  function augmentNextConfig(
-    originalNextConfig: NextConfigComplete,
-    projectPath: string
-  ): Record<string, any> {
-    let nextConfig = { ...originalNextConfig }
-
-    // TODO: Merge this with `crates/next-core/src/next_shared/webpack_rules/babel.rs` so that we're
-    // not configuring babel in two different places (potentially causing it to run twice)
-    const reactCompilerOptions = nextConfig.experimental?.reactCompiler
-    const reactCompilerLoader = getReactCompilerLoader(
-      nextConfig.experimental?.reactCompiler,
-      projectPath,
-      /* isServer */ false,
-      /* reactCompilerExclude */ undefined
-    )
-    if (reactCompilerLoader != null) {
-      const options: ReactCompilerOptions =
-        typeof reactCompilerOptions === 'object' ? reactCompilerOptions : {}
-      nextConfig.turbopack = {
-        ...originalNextConfig.turbopack,
-        rules: {
-          ...originalNextConfig.turbopack.rules,
-          // assumption: there is no collision with this glob key
-          '{*.{js,jsx,ts,tsx,cjs,mjs,mts,cts},react-compiler-builtin-rule}': {
-            loaders: [reactCompilerLoader],
-            condition: {
-              all: [
-                'browser',
-                { not: 'foreign' },
-                {
-                  content:
-                    options.compilationMode === 'annotation'
-                      ? /['"]use memo['"]/
-                      : !options.compilationMode ||
-                          options.compilationMode === 'infer'
-                        ? // Matches declaration or useXXX or </ (closing jsx) or /> (self closing jsx)
-                          /['"]use memo['"]|\Wuse[A-Z]|<\/|\/>/
-                        : undefined,
-                },
-              ],
-            },
-          },
-        },
-      }
-    }
-
-    return nextConfig
-  }
-
   async function serializeNextConfig(
     nextConfig: NextConfigComplete,
     projectPath: string
   ): Promise<string> {
-    // Avoid mutating the existing `nextConfig` object. NOTE: This does a shallow clone.
-    let nextConfigSerializable = augmentNextConfig(nextConfig, projectPath)
+    // Avoid mutating the existing `nextConfig` object. NOTE: This is only a shallow clone.
+    let nextConfigSerializable: Record<string, any> = { ...nextConfig }
 
     nextConfigSerializable.generateBuildId =
       await nextConfigSerializable.generateBuildId?.()

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -517,8 +517,13 @@ export interface ExperimentalConfig {
   turbopackUseSystemTlsCerts?: boolean
 
   /**
-   * Set this to `false` to disable the automatic configuration of the babel loader when a babel
-   * configuration file is present. The babel loader configuration is enabled by default.
+   * Set this to `false` to disable the automatic configuration of the babel loader when a Babel
+   * configuration file is present. This option is enabled by default.
+   *
+   * If this is set to `false`, but `experimental.reactCompiler` is `true`, the built-in Babel will
+   * still be configured, but any Babel configuration files on disk will be ignored. If you wish to
+   * use React Compiler with a different manually-configured `babel-loader`, you should disable both
+   * this and `experimental.reactCompiler`.
    */
   turbopackUseBuiltinBabel?: boolean
 


### PR DESCRIPTION
Port the logic for configuring react-compiler from JS to Rust.

This fixes two issues:
- Babel could run twice if you had both react compiler enabled and a babel config file.
- We can now emit a warning if we detect you manually configured babel. Previously, this wasn't safe because we could erroneously warn if react compiler was enabled.

Closes PACK-5532