### PR TITLE
[turbopack] Remove `is_export_missing` as a turbo task

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -454,7 +454,7 @@ impl ModuleReference for EsmAssetReference {
         if let Some(ModulePart::Export(export_name)) = &self.export_name {
             for &module in result.primary_modules().await? {
                 if let Some(module) = ResolvedVc::try_downcast(module)
-                    && *is_export_missing(*module, export_name.clone()).await?
+                    && is_export_missing(module, export_name.as_str()).await?
                 {
                     InvalidExport {
                         export: export_name.clone(),


### PR DESCRIPTION
 Remove `is_export_missing` as a turbo task

In a build of vercel-site we see 70991 executions and 163683 cache hits which implies each execution gets 2.3 cache hits.  By removing turbo tasks we instead have this logic execute in the parent task `EsmAssetReference::resolve_reference`

Based on examining a trace of vercel-site i see that this task takes around 0.2-0.5us  of cpu time, but between 4-6us of 'extent'.   The `overhead.rs` benchmark tells me that the cost of a cache hit is around 220-500ns and the cost of a miss is 4.5-6us.  Because the only caller immediately waits there is no latency opportunity from parallelism so the relevant cost metric is the cpu time of the task.

So, in terms of latency, we can compute _expected_ costs
   * as a turbotask:
        * lower bound: (4.5+0.2 + 2.3*.22)/3.3 = 1.58us
        * upper bound: (6+0.5 + 2.3*.5)/3.3 = 3.5us
   * as an `async fn`
        *  lower bound: .2us
        * upper bound: .5us

Thus we should expect this to be nearly 10x as fast by avoiding the cache.

Additionally by removing the annotation we avoid an `RcStr::clone` and a `Vc::cell` call which lead me to believe we would achieve better times than our estimate.