### PR TITLE
Development: Only load getStaticInfoIncludingLayouts when it's needed

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -12,9 +12,8 @@ import type {
 import type { LoadedEnvFiles } from '@next/env'
 import type { AppLoaderOptions } from './webpack/loaders/next-app-loader'
 
-import { posix, join, dirname, extname, normalize } from 'path'
+import { posix, join, extname, normalize } from 'path'
 import { stringify } from 'querystring'
-import fs from 'fs'
 import {
   PAGES_DIR_ALIAS,
   ROOT_DIR_ALIAS,
@@ -45,13 +44,8 @@ import {
   isMiddlewareFilename,
   isInstrumentationHookFile,
   isInstrumentationHookFilename,
-  reduceAppConfig,
-  isAppBuiltinPage,
 } from './utils'
-import {
-  getAppPageStaticInfo,
-  getPageStaticInfo,
-} from './analysis/get-page-static-info'
+import { getPageStaticInfo } from './analysis/get-page-static-info'
 import { normalizePathSep } from '../shared/lib/page-path/normalize-path-sep'
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
 import type { ServerRuntime } from '../types'
@@ -75,7 +69,6 @@ import { normalizeCatchAllRoutes } from './normalize-catchall-routes'
 import type { PageExtensions } from './page-extensions-type'
 import type { MappedPages } from './build-context'
 import { PAGE_TYPES } from '../lib/page-types'
-import { isAppPageRoute } from '../lib/is-app-page-route'
 import { recursiveReadDir } from '../lib/recursive-readdir'
 import type { createValidFileMatcher } from '../server/lib/find-page-file'
 import { isReservedPage } from './utils'
@@ -86,6 +79,7 @@ import {
   UNDERSCORE_GLOBAL_ERROR_ROUTE,
   UNDERSCORE_GLOBAL_ERROR_ROUTE_ENTRY,
 } from '../shared/lib/entry-constants'
+import { getStaticInfoIncludingLayouts } from './get-static-info-including-layouts'
 
 /**
  * Collect app pages, layouts, and default files from the app directory
@@ -420,88 +414,6 @@ export function sortByPageExts(pageExtensions: PageExtensions) {
     const bExtIndex = pageExtensions.indexOf(bExt.substring(1))
 
     return bExtIndex - aExtIndex
-  }
-}
-
-export async function getStaticInfoIncludingLayouts({
-  isInsideAppDir,
-  pageExtensions,
-  pageFilePath,
-  appDir,
-  config: nextConfig,
-  isDev,
-  page,
-}: {
-  isInsideAppDir: boolean
-  pageExtensions: PageExtensions
-  pageFilePath: string
-  appDir: string | undefined
-  config: NextConfigComplete
-  isDev: boolean | undefined
-  page: string
-}): Promise<PageStaticInfo> {
-  // TODO: sync types for pages: PAGE_TYPES, ROUTER_TYPE, 'app' | 'pages', etc.
-  const pageType = isInsideAppDir ? PAGE_TYPES.APP : PAGE_TYPES.PAGES
-
-  const pageStaticInfo = await getPageStaticInfo({
-    nextConfig,
-    pageFilePath,
-    isDev,
-    page,
-    pageType,
-  })
-
-  if (pageStaticInfo.type === PAGE_TYPES.PAGES || !appDir) {
-    return pageStaticInfo
-  }
-
-  // Skip inheritance for global-error pages - always use default config
-  if (page === UNDERSCORE_GLOBAL_ERROR_ROUTE_ENTRY) {
-    return pageStaticInfo
-  }
-
-  const segments = [pageStaticInfo]
-
-  // inherit from layout files only if it's a page route and not a builtin page
-  if (isAppPageRoute(page) && !isAppBuiltinPage(pageFilePath)) {
-    const layoutFiles = []
-    const potentialLayoutFiles = pageExtensions.map((ext) => 'layout.' + ext)
-    let dir = dirname(pageFilePath)
-
-    // Uses startsWith to not include directories further up.
-    while (dir.startsWith(appDir)) {
-      for (const potentialLayoutFile of potentialLayoutFiles) {
-        const layoutFile = join(dir, potentialLayoutFile)
-        if (!fs.existsSync(layoutFile)) {
-          continue
-        }
-        layoutFiles.push(layoutFile)
-      }
-      // Walk up the directory tree
-      dir = join(dir, '..')
-    }
-
-    for (const layoutFile of layoutFiles) {
-      const layoutStaticInfo = await getAppPageStaticInfo({
-        nextConfig,
-        pageFilePath: layoutFile,
-        isDev,
-        page,
-        pageType: isInsideAppDir ? PAGE_TYPES.APP : PAGE_TYPES.PAGES,
-      })
-
-      segments.unshift(layoutStaticInfo)
-    }
-  }
-
-  const config = reduceAppConfig(segments)
-
-  return {
-    ...pageStaticInfo,
-    config,
-    runtime: config.runtime,
-    preferredRegion: config.preferredRegion,
-    maxDuration: config.maxDuration,
   }
 }
 

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -12,7 +12,7 @@ import type {
 import type { LoadedEnvFiles } from '@next/env'
 import type { AppLoaderOptions } from './webpack/loaders/next-app-loader'
 
-import { posix, join, extname, normalize } from 'path'
+import { posix, join, normalize } from 'path'
 import { stringify } from 'querystring'
 import {
   PAGES_DIR_ALIAS,
@@ -393,28 +393,6 @@ export function processLayoutRoutes(
   }
 
   return layoutRoutes
-}
-
-export function sortByPageExts(pageExtensions: PageExtensions) {
-  return (a: string, b: string) => {
-    // prioritize entries according to pageExtensions order
-    // for consistency as fs order can differ across systems
-    // NOTE: this is reversed so preferred comes last and
-    // overrides prior
-    const aExt = extname(a)
-    const bExt = extname(b)
-
-    const aNoExt = a.substring(0, a.length - aExt.length)
-    const bNoExt = a.substring(0, b.length - bExt.length)
-
-    if (aNoExt !== bNoExt) return 0
-
-    // find extension index (skip '.' as pageExtensions doesn't have it)
-    const aExtIndex = pageExtensions.indexOf(aExt.substring(1))
-    const bExtIndex = pageExtensions.indexOf(bExt.substring(1))
-
-    return bExtIndex - aExtIndex
-  }
 }
 
 type ObjectValue<T> = T extends { [key: string]: infer V } ? V : never

--- a/packages/next/src/build/get-static-info-including-layouts.ts
+++ b/packages/next/src/build/get-static-info-including-layouts.ts
@@ -1,16 +1,19 @@
-import fs from 'fs'
-import { dirname, join } from 'path/posix'
-import { UNDERSCORE_GLOBAL_ERROR_ROUTE_ENTRY } from '../shared/lib/entry-constants'
-import { isAppPageRoute } from '../lib/is-app-page-route'
-import { PAGE_TYPES } from '../lib/page-types'
 import type { NextConfigComplete } from '../server/config-shared'
+import type { PageStaticInfo } from './analysis/get-page-static-info'
+import { join, dirname } from 'path'
+import fs from 'fs'
+import type { __ApiPreviewProps } from '../server/api-utils'
+import { reduceAppConfig, isAppBuiltinPage } from './utils'
 import {
-  type PageStaticInfo,
-  getPageStaticInfo,
   getAppPageStaticInfo,
+  getPageStaticInfo,
 } from './analysis/get-page-static-info'
 import type { PageExtensions } from './page-extensions-type'
-import { isAppBuiltinPage, reduceAppConfig } from './utils'
+
+import { PAGE_TYPES } from '../lib/page-types'
+import { isAppPageRoute } from '../lib/is-app-page-route'
+
+import { UNDERSCORE_GLOBAL_ERROR_ROUTE_ENTRY } from '../shared/lib/entry-constants'
 
 export async function getStaticInfoIncludingLayouts({
   isInsideAppDir,

--- a/packages/next/src/build/get-static-info-including-layouts.ts
+++ b/packages/next/src/build/get-static-info-including-layouts.ts
@@ -1,0 +1,95 @@
+import fs from 'fs'
+import { dirname, join } from 'path/posix'
+import { UNDERSCORE_GLOBAL_ERROR_ROUTE_ENTRY } from '../shared/lib/entry-constants'
+import { isAppPageRoute } from '../lib/is-app-page-route'
+import { PAGE_TYPES } from '../lib/page-types'
+import type { NextConfigComplete } from '../server/config-shared'
+import {
+  type PageStaticInfo,
+  getPageStaticInfo,
+  getAppPageStaticInfo,
+} from './analysis/get-page-static-info'
+import type { PageExtensions } from './page-extensions-type'
+import { isAppBuiltinPage, reduceAppConfig } from './utils'
+
+export async function getStaticInfoIncludingLayouts({
+  isInsideAppDir,
+  pageExtensions,
+  pageFilePath,
+  appDir,
+  config: nextConfig,
+  isDev,
+  page,
+}: {
+  isInsideAppDir: boolean
+  pageExtensions: PageExtensions
+  pageFilePath: string
+  appDir: string | undefined
+  config: NextConfigComplete
+  isDev: boolean | undefined
+  page: string
+}): Promise<PageStaticInfo> {
+  // TODO: sync types for pages: PAGE_TYPES, ROUTER_TYPE, 'app' | 'pages', etc.
+  const pageType = isInsideAppDir ? PAGE_TYPES.APP : PAGE_TYPES.PAGES
+
+  const pageStaticInfo = await getPageStaticInfo({
+    nextConfig,
+    pageFilePath,
+    isDev,
+    page,
+    pageType,
+  })
+
+  if (pageStaticInfo.type === PAGE_TYPES.PAGES || !appDir) {
+    return pageStaticInfo
+  }
+
+  // Skip inheritance for global-error pages - always use default config
+  if (page === UNDERSCORE_GLOBAL_ERROR_ROUTE_ENTRY) {
+    return pageStaticInfo
+  }
+
+  const segments = [pageStaticInfo]
+
+  // inherit from layout files only if it's a page route and not a builtin page
+  if (isAppPageRoute(page) && !isAppBuiltinPage(pageFilePath)) {
+    const layoutFiles = []
+    const potentialLayoutFiles = pageExtensions.map((ext) => 'layout.' + ext)
+    let dir = dirname(pageFilePath)
+
+    // Uses startsWith to not include directories further up.
+    while (dir.startsWith(appDir)) {
+      for (const potentialLayoutFile of potentialLayoutFiles) {
+        const layoutFile = join(dir, potentialLayoutFile)
+        if (!fs.existsSync(layoutFile)) {
+          continue
+        }
+        layoutFiles.push(layoutFile)
+      }
+      // Walk up the directory tree
+      dir = join(dir, '..')
+    }
+
+    for (const layoutFile of layoutFiles) {
+      const layoutStaticInfo = await getAppPageStaticInfo({
+        nextConfig,
+        pageFilePath: layoutFile,
+        isDev,
+        page,
+        pageType: isInsideAppDir ? PAGE_TYPES.APP : PAGE_TYPES.PAGES,
+      })
+
+      segments.unshift(layoutStaticInfo)
+    }
+  }
+
+  const config = reduceAppConfig(segments)
+
+  return {
+    ...pageStaticInfo,
+    config,
+    runtime: config.runtime,
+    preferredRegion: config.preferredRegion,
+    maxDuration: config.maxDuration,
+  }
+}

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -112,7 +112,6 @@ import { Telemetry } from '../telemetry/storage'
 import {
   createPagesMapping,
   collectAppFiles,
-  sortByPageExts,
   processPageRoutes,
   processAppRoutes,
   processLayoutRoutes,
@@ -123,6 +122,7 @@ import {
   type SlotInfo,
   collectPagesFiles,
 } from './entries'
+import { sortByPageExts } from './sort-by-page-exts'
 import { getStaticInfoIncludingLayouts } from './get-static-info-including-layouts'
 import { PAGE_TYPES } from '../lib/page-types'
 import { generateBuildId } from './generate-build-id'

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -112,7 +112,6 @@ import { Telemetry } from '../telemetry/storage'
 import {
   createPagesMapping,
   collectAppFiles,
-  getStaticInfoIncludingLayouts,
   sortByPageExts,
   processPageRoutes,
   processAppRoutes,
@@ -124,6 +123,7 @@ import {
   type SlotInfo,
   collectPagesFiles,
 } from './entries'
+import { getStaticInfoIncludingLayouts } from './get-static-info-including-layouts'
 import { PAGE_TYPES } from '../lib/page-types'
 import { generateBuildId } from './generate-build-id'
 import { isWriteable } from './is-writeable'

--- a/packages/next/src/build/sort-by-page-exts.ts
+++ b/packages/next/src/build/sort-by-page-exts.ts
@@ -1,0 +1,24 @@
+import { extname } from 'path/posix'
+import type { PageExtensions } from './page-extensions-type'
+
+export function sortByPageExts(pageExtensions: PageExtensions) {
+  return (a: string, b: string) => {
+    // prioritize entries according to pageExtensions order
+    // for consistency as fs order can differ across systems
+    // NOTE: this is reversed so preferred comes last and
+    // overrides prior
+    const aExt = extname(a)
+    const bExt = extname(b)
+
+    const aNoExt = a.substring(0, a.length - aExt.length)
+    const bNoExt = a.substring(0, b.length - bExt.length)
+
+    if (aNoExt !== bNoExt) return 0
+
+    // find extension index (skip '.' as pageExtensions doesn't have it)
+    const aExtIndex = pageExtensions.indexOf(aExt.substring(1))
+    const bExtIndex = pageExtensions.indexOf(bExt.substring(1))
+
+    return bExtIndex - aExtIndex
+  }
+}

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -21,9 +21,9 @@ import {
   getEdgeServerEntry,
   getAppEntry,
   runDependingOnPageType,
-  getStaticInfoIncludingLayouts,
   getInstrumentationEntry,
 } from '../../build/entries'
+import { getStaticInfoIncludingLayouts } from '../../build/get-static-info-including-layouts'
 import { watchCompilers } from '../../build/output'
 import * as Log from '../../build/output/log'
 import getBaseWebpackConfig, {

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -13,10 +13,8 @@ import type HotReloaderWebpack from './hot-reloader-webpack'
 import createDebug from 'next/dist/compiled/debug'
 import { EventEmitter } from 'events'
 import { findPageFile } from '../lib/find-page-file'
-import {
-  getStaticInfoIncludingLayouts,
-  runDependingOnPageType,
-} from '../../build/entries'
+import { runDependingOnPageType } from '../../build/entries'
+import { getStaticInfoIncludingLayouts } from '../../build/get-static-info-including-layouts'
 import { join, posix } from 'path'
 import { normalizePathSep } from '../../shared/lib/page-path/normalize-path-sep'
 import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1,10 +1,7 @@
 import type { NextConfigComplete } from '../../config-shared'
 import type { FilesystemDynamicRoute } from './filesystem'
 import type { UnwrapPromise } from '../../../lib/coalesced-function'
-import {
-  getPageStaticInfo,
-  type MiddlewareMatcher,
-} from '../../../build/analysis/get-page-static-info'
+import type { MiddlewareMatcher } from '../../../build/analysis/get-page-static-info'
 import type { RoutesManifest } from '../../../build'
 import type { MiddlewareRouteMatch } from '../../../shared/lib/router/utils/middleware-route-matcher'
 import type { PropagateToWorkersField } from './types'
@@ -31,7 +28,7 @@ import {
   eventCliSession,
 } from '../../../telemetry/events'
 import { getSortedRoutes } from '../../../shared/lib/router/utils'
-import { sortByPageExts } from '../../../build/entries'
+import { sortByPageExts } from '../../../build/sort-by-page-exts'
 import { verifyTypeScriptSetup } from '../../../lib/verify-typescript-setup'
 import { verifyPartytownSetup } from '../../../lib/verify-partytown-setup'
 import { getNamedRouteRegex } from '../../../shared/lib/router/utils/route-regex'
@@ -501,6 +498,9 @@ async function startWatcher(
             true
           )
         ) {
+          const getPageStaticInfo = (
+            require('../../../build/analysis/get-page-static-info') as typeof import('../../../build/analysis/get-page-static-info')
+          ).getPageStaticInfo
           const staticInfo = await getPageStaticInfo({
             pageFilePath: fileName,
             nextConfig: {},

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -31,10 +31,7 @@ import {
   eventCliSession,
 } from '../../../telemetry/events'
 import { getSortedRoutes } from '../../../shared/lib/router/utils'
-import {
-  getStaticInfoIncludingLayouts,
-  sortByPageExts,
-} from '../../../build/entries'
+import { sortByPageExts } from '../../../build/entries'
 import { verifyTypeScriptSetup } from '../../../lib/verify-typescript-setup'
 import { verifyPartytownSetup } from '../../../lib/verify-partytown-setup'
 import { getNamedRouteRegex } from '../../../shared/lib/router/utils/route-regex'
@@ -438,6 +435,9 @@ async function startWatcher(
         })
 
         if (isMiddlewareFile(rootFile)) {
+          const getStaticInfoIncludingLayouts = (
+            require('../../../build/get-static-info-including-layouts') as typeof import('../../../build/get-static-info-including-layouts')
+          ).getStaticInfoIncludingLayouts
           const staticInfo = await getStaticInfoIncludingLayouts({
             pageFilePath: fileName,
             config: nextConfig,


### PR DESCRIPTION
## What?

Makes sure `build/entries` is not loaded in development (has transitive requires that take some time)

Closes PACK-5429