### PR TITLE
[metadata] change the metadata routes params to promises

### DIFF
--- a/test/e2e/app-dir/logging/app/dynamic/[slug]/icon.jsx
+++ b/test/e2e/app-dir/logging/app/dynamic/[slug]/icon.jsx
@@ -1,6 +1,8 @@
 import { ImageResponse } from 'next/og'
 
-export default function icon({ params, id }) {
+export default async function icon({ params, id }) {
+  const { size } = await params
+  const iconId = await id
   return new ImageResponse(
     (
       <div
@@ -15,7 +17,7 @@ export default function icon({ params, id }) {
           color: '#fafafa',
         }}
       >
-        Apple {params.size} {id}
+        Apple {size} {iconId}
       </div>
     )
   )

--- a/test/e2e/app-dir/metadata-dynamic-routes/app/(group)/dynamic/[size]/icon.tsx
+++ b/test/e2e/app-dir/metadata-dynamic-routes/app/(group)/dynamic/[size]/icon.tsx
@@ -15,7 +15,9 @@ export async function generateImageMetadata({ params }) {
   ]
 }
 
-export default function icon({ params, id }) {
+export default async function icon({ params, id }) {
+  const { size } = await params
+  const iconId = await id
   return new ImageResponse(
     (
       <div
@@ -30,7 +32,7 @@ export default function icon({ params, id }) {
           color: '#000',
         }}
       >
-        Icon {params.size} {id}
+        Icon {size} {iconId}
       </div>
     )
   )

--- a/test/e2e/app-dir/metadata-dynamic-routes/app/(group)/dynamic/[size]/opengraph-image.tsx
+++ b/test/e2e/app-dir/metadata-dynamic-routes/app/(group)/dynamic/[size]/opengraph-image.tsx
@@ -2,8 +2,9 @@ import { ImageResponse } from 'next/og'
 
 export const alt = 'Open Graph'
 
-export default function og({ params }) {
-  const big = params.size === 'big'
+export default async function og({ params }) {
+  const { size } = await params
+  const big = size === 'big'
   const background = big ? 'orange' : '#000'
   return new ImageResponse(
     (

--- a/test/e2e/app-dir/metadata-dynamic-routes/app/gsp/icon.tsx
+++ b/test/e2e/app-dir/metadata-dynamic-routes/app/gsp/icon.tsx
@@ -15,7 +15,9 @@ export async function generateImageMetadata({ params }) {
   ]
 }
 
-export default function icon({ params, id }) {
+export default async function icon({ params, id }) {
+  const { size } = await params
+  const iconId = await id
   return new ImageResponse(
     (
       <div
@@ -30,7 +32,7 @@ export default function icon({ params, id }) {
           color: '#000',
         }}
       >
-        Icon {params.size} {id}
+        Icon {size} {iconId}
       </div>
     )
   )

--- a/test/e2e/app-dir/metadata-dynamic-routes/app/gsp/sitemap.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/app/gsp/sitemap.ts
@@ -9,14 +9,15 @@ export async function generateSitemaps() {
   ]
 }
 
-export default function sitemap({ id }): MetadataRoute.Sitemap {
+export default async function sitemap({ id }): Promise<MetadataRoute.Sitemap> {
+  const sitemapId = await id
   return [
     {
-      url: `https://example.com/dynamic/${id}`,
+      url: `https://example.com/dynamic/${sitemapId}`,
       lastModified: '2021-01-01',
     },
     {
-      url: `https://example.com/dynamic/${id}/about`,
+      url: `https://example.com/dynamic/${sitemapId}/about`,
       lastModified: '2021-01-01',
     },
   ]

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/app/products/sitemap.ts
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/app/products/sitemap.ts
@@ -1,6 +1,5 @@
 import type { MetadataRoute } from 'next'
 import { getSentinelValue } from '../sentinel'
-import { setTimeout } from 'timers/promises'
 
 export async function generateSitemaps() {
   return [{ id: 0 }, { id: 1 }]
@@ -9,12 +8,13 @@ export async function generateSitemaps() {
 export default async function sitemap({
   id,
 }: {
-  id: number
+  id: Promise<number>
 }): Promise<MetadataRoute.Sitemap> {
   'use cache'
 
-  // Simulate I/O
-  await setTimeout(100)
+  const resolvedId = await id
 
-  return [{ url: `https://acme.com/${id}?sentinel=${getSentinelValue()}` }]
+  return [
+    { url: `https://acme.com/${resolvedId}?sentinel=${getSentinelValue()}` },
+  ]
 }


### PR DESCRIPTION
**This is a breaking change for metadata API routes.** 
We plan to make the argument `params` in metadata API routes as promises to align with the [App Router async request APIs](https://nextjs.org/docs/app/guides/upgrading/version-15#async-request-apis-breaking-change). This will also change the `id` prop passing to image or sitemap route to be promise as the `id` is basically from the async params that generated from `generateImageMetadata` or `generateSitemaps`.

#### Now
```js
export default async function og({ params, id }) {
  const { slug } = await params
  const imageId = await id
}
```

#### Before (Deprecated)
```js
export default function og({ params, id }) {
  const slug = await params.slug
  const imageId = id
}
```

Once we changed this, the route itself can be statically generated when the route path is static and the `params` is not accessed (no dynamic access).

Note: we don't have to change the `params` in generateImageMetadata to promise cause it's using `generateStaticParams` now where the `params` is not async promise.

Based on:
#83559, #83486, #83443, #83374, #83304.

Closes NAR-242