### PR TITLE
docs: add `next.config.ts` Node.js native resolver

### DIFF
--- a/docs/01-app/03-api-reference/05-config/02-typescript.mdx
+++ b/docs/01-app/03-api-reference/05-config/02-typescript.mdx
@@ -503,7 +503,7 @@ When you need to declare custom types, you might be tempted to modify `next-env.
 
 | Version   | Changes                                                                                                                              |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `v15.0.0` | [`next.config.ts`](#type-checking-nextconfigts) support added for TypeScript projects.                                               |
+| `v15.0.0` | [`next.config.ts`](#type-checking-nextjs-configuration-files) support added for TypeScript projects.                                 |
 | `v13.2.0` | Statically typed links are available in beta.                                                                                        |
 | `v12.0.0` | [SWC](/docs/architecture/nextjs-compiler) is now used by default to compile TypeScript and TSX for faster builds.                    |
 | `v10.2.1` | [Incremental type checking](https://www.typescriptlang.org/tsconfig#incremental) support added when enabled in your `tsconfig.json`. |

--- a/docs/01-app/03-api-reference/05-config/02-typescript.mdx
+++ b/docs/01-app/03-api-reference/05-config/02-typescript.mdx
@@ -135,6 +135,8 @@ const nextConfig: NextConfig = {
   /* config options here */
   typedRoutes: Boolean(flags?.typedRoutes),
 }
+
+export default nextConfig
 ```
 
 ### Statically Typed Links

--- a/docs/01-app/03-api-reference/05-config/02-typescript.mdx
+++ b/docs/01-app/03-api-reference/05-config/02-typescript.mdx
@@ -82,7 +82,7 @@ Next.js generates global helpers for App Router route types. These are available
 
 ## Examples
 
-### Type checking Next.js Configuration files
+### Type Checking Next.js Configuration Files
 
 You can use TypeScript and import types in your Next.js configuration by using `next.config.ts`.
 
@@ -96,7 +96,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-Module resolution in `next.config.ts` is currently limited to CommonJS. However, ECMAScript Modules syntax is available when [using Node.js native TypeScript resolver](#using-nodejs-native-typescript-resolver-for-nextconfigts) for Node.js v22.10.0 and higher.
+Module resolution in `next.config.ts` is currently limited to CommonJS. However, ECMAScript Modules (ESM) syntax is available when [using Node.js native TypeScript resolver](#using-nodejs-native-typescript-resolver-for-nextconfigts) for Node.js v22.10.0 and higher.
 
 When using the `next.config.js` file, you can add some type checking in your IDE using JSDoc as below:
 
@@ -113,17 +113,17 @@ module.exports = nextConfig
 
 ### Using Node.js Native TypeScript Resolver for `next.config.ts`
 
-> **Note**: Resolving `next.config.ts` using Node.js native TypeScript resolver is available for Node.js v22.10.0 and higher, and only when the feature is enabled. Next.js does not enable the feature by default.
+> **Note**: Using Node.js native TypeScript resolver for `next.config.ts` is available for Node.js v22.10.0 and higher, and only when the feature is enabled. Next.js does not enable the feature by default.
 
-Next.js feature detects [Node.js native TypeScript resolver](https://nodejs.org/api/typescript.html) by [`process.features.typescript`](https://nodejs.org/api/process.html#processfeaturestypescript) which was added in Node.js v22.10.0. This allows `next.config.ts` to use native ECMAScript Modules syntax like top-level `await` and dynamic imports in `next.config.ts`. However, it inherits the limitations of the Node.js native TypeScript resolver.
+Next.js feature detects [Node.js native TypeScript resolver](https://nodejs.org/api/typescript.html) by [`process.features.typescript`](https://nodejs.org/api/process.html#processfeaturestypescript) which was added in Node.js v22.10.0. This allows `next.config.ts` to use native ECMAScript Modules (ESM) syntax like top-level `await` and dynamic imports in `next.config.ts`. However, it inherits the limitations of the Node.js native TypeScript resolver.
 
-For Node.js below v23.6.0, you need to run `next dev` with `NODE_OPTIONS=--experimental-transform-types` flag to enable the Node.js native TypeScript resolver:
+Node.js enables the feature by default since [v22.18.0](https://nodejs.org/en/blog/release/v22.18.0). For versions below v22.18.0, you need to run `next dev` with `NODE_OPTIONS=--experimental-transform-types` flag to enable the Node.js native TypeScript resolver:
 
 ```bash
 NODE_OPTIONS=--experimental-transform-types next <command>
 ```
 
-Although `next.config.ts` supports native ECMAScript Modules syntax on CommonJS projects, Node.js will still assume `next.config.ts` is a CommonJS file by default, resulting in Node.js reparsing the file as ECMAScript Modules when module syntax is detected. Therefore, we recommend using the `next.config.mts` file for CommonJS projects.
+Although `next.config.ts` supports native ESM syntax on CommonJS projects, Node.js will still assume `next.config.ts` is a CommonJS file by default, resulting in Node.js reparsing the file as ESM when module syntax is detected. Therefore, we recommend using the `next.config.mts` file for CommonJS projects.
 
 ```ts filename="next.config.mts"
 import type { NextConfig } from 'next'

--- a/docs/01-app/03-api-reference/05-config/02-typescript.mdx
+++ b/docs/01-app/03-api-reference/05-config/02-typescript.mdx
@@ -143,7 +143,7 @@ export default nextConfig
 
 #### For ESM Projects
 
-If your project is configured as an ESM project by adding `"type": "module"` to your `package.json` (see [Node.js documentation](https://nodejs.org/api/packages.html#type)), you can use `next.config.ts` directly with ESM syntax:
+When `"type"` is set to `"module"` in `package.json`, your project uses ESM. Learn more about this setting [in the Node.js docs](https://nodejs.org/api/packages.html#type). In this case, you can write `next.config.ts` directly with ESM syntax.
 
 ```json filename="package.json"
 {

--- a/docs/01-app/03-api-reference/05-config/02-typescript.mdx
+++ b/docs/01-app/03-api-reference/05-config/02-typescript.mdx
@@ -145,13 +145,6 @@ export default nextConfig
 
 When `"type"` is set to `"module"` in `package.json`, your project uses ESM. Learn more about this setting [in the Node.js docs](https://nodejs.org/api/packages.html#type). In this case, you can write `next.config.ts` directly with ESM syntax.
 
-```json filename="package.json"
-{
-  "type": "module"
-  // ... other package.json fields
-}
-```
-
 > **Good to know**: When using `"type": "module"` in your `package.json`, all `.js` and `.ts` files in your project are treated as ESM modules by default. You may need to rename files with CommonJS syntax to `.cjs` or `.cts` extensions if needed.
 
 ### Statically Typed Links

--- a/docs/01-app/03-api-reference/05-config/02-typescript.mdx
+++ b/docs/01-app/03-api-reference/05-config/02-typescript.mdx
@@ -82,7 +82,7 @@ Next.js generates global helpers for App Router route types. These are available
 
 ## Examples
 
-### Type checking `next.config.ts`
+### Type checking Next.js Configuration files
 
 You can use TypeScript and import types in your Next.js configuration by using `next.config.ts`.
 
@@ -96,7 +96,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-> **Good to know**: Module resolution in `next.config.ts` is currently limited to `CommonJS`. This may cause incompatibilities with ESM only packages being loaded in `next.config.ts`.
+Module resolution in `next.config.ts` is currently limited to CommonJS. However, ECMAScript Modules syntax is available when [using Node.js native TypeScript resolver](#using-nodejs-native-typescript-resolver-for-nextconfigts) for Node.js v22.10.0 and higher.
 
 When using the `next.config.js` file, you can add some type checking in your IDE using JSDoc as below:
 
@@ -109,6 +109,30 @@ const nextConfig = {
 }
 
 module.exports = nextConfig
+```
+
+### Using Node.js Native TypeScript Resolver for `next.config.ts`
+
+> **Note**: Resolving `next.config.ts` using Node.js native TypeScript resolver is available for Node.js v22.10.0 and higher, and only when the feature is enabled. Next.js does not enable the feature by default.
+
+Next.js feature detects [Node.js native TypeScript resolver](https://nodejs.org/api/typescript.html) by [`process.features.typescript`](https://nodejs.org/api/process.html#processfeaturestypescript) which was added in Node.js v22.10.0. This allows `next.config.ts` to use native ECMAScript Modules syntax like top-level `await` and dynamic imports in `next.config.ts`. However, it inherits the limitations of the Node.js native TypeScript resolver.
+
+For Node.js below v23.6.0, you need to run `next dev` with `NODE_OPTIONS=--experimental-transform-types` flag to enable the Node.js native TypeScript resolver:
+
+```bash
+NODE_OPTIONS=--experimental-transform-types next <command>
+```
+
+Although `next.config.ts` supports native ECMAScript Modules syntax on CommonJS projects, Node.js will still assume `next.config.ts` is a CommonJS file by default, resulting in Node.js reparsing the file as ECMAScript Modules when module syntax is detected. Therefore, we recommend using the `next.config.mts` file for CommonJS projects.
+
+```ts filename="next.config.mts"
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  /* config options here */
+}
+
+export default nextConfig
 ```
 
 ### Statically Typed Links

--- a/docs/01-app/03-api-reference/05-config/02-typescript.mdx
+++ b/docs/01-app/03-api-reference/05-config/02-typescript.mdx
@@ -113,26 +113,28 @@ module.exports = nextConfig
 
 ### Using Node.js Native TypeScript Resolver for `next.config.ts`
 
-> **Note**: Using Node.js native TypeScript resolver for `next.config.ts` is available for Node.js v22.10.0 and higher, and only when the feature is enabled. Next.js does not enable the feature by default.
+> **Note**: Available on Node.js v22.10.0+ and only when the feature is enabled. Next.js does not enable it.
 
-Next.js feature detects [Node.js native TypeScript resolver](https://nodejs.org/api/typescript.html) by [`process.features.typescript`](https://nodejs.org/api/process.html#processfeaturestypescript) which was added in Node.js v22.10.0. This allows `next.config.ts` to use native ECMAScript Modules (ESM) syntax like top-level `await` and dynamic imports in `next.config.ts`. However, it inherits the limitations of the Node.js native TypeScript resolver.
+Next.js detects the [Node.js native TypeScript resolver](https://nodejs.org/api/typescript.html) via [`process.features.typescript`](https://nodejs.org/api/process.html#processfeaturestypescript), added in **v22.10.0**. When present, `next.config.ts` can use native ESM, including top‑level `await` and dynamic `import()`. This mechanism inherits the capabilities and limitations of Node's resolver.
 
-Node.js enables the feature by default since [v22.18.0](https://nodejs.org/en/blog/release/v22.18.0). For versions below v22.18.0, you need to run `next dev` with `NODE_OPTIONS=--experimental-transform-types` flag to enable the Node.js native TypeScript resolver:
+In Node.js versions **v22.18.0+**, `process.features.typescript` is enabled by default. For versions between **v22.10.0** and **22.17.x**, opt in with `NODE_OPTIONS=--experimental-transform-types`:
 
-```bash
+```bash filename="Terminal"
 NODE_OPTIONS=--experimental-transform-types next <command>
 ```
 
-Although `next.config.ts` supports native ESM syntax on CommonJS projects, Node.js will still assume `next.config.ts` is a CommonJS file by default, resulting in Node.js reparsing the file as ESM when module syntax is detected. Therefore, we recommend using the `next.config.mts` file for CommonJS projects.
+In CommonJS projects, Node treats `.ts` as CommonJS. If `next.config.ts` uses ESM syntax, Node detects that and parses the file again using ESM. This works but will print an error indicating this incurs a performance overhead. Use `next.config.mts` to declare ESM up front and avoid the extra pass.
 
 ```ts filename="next.config.mts"
 import type { NextConfig } from 'next'
 
+// Top-level await and dynamic import are supported
+const flags = await import('./flags.js').then((m) => m.default ?? m)
+
 const nextConfig: NextConfig = {
   /* config options here */
+  typedRoutes: Boolean(flags?.typedRoutes),
 }
-
-export default nextConfig
 ```
 
 ### Statically Typed Links

--- a/docs/01-app/03-api-reference/05-config/02-typescript.mdx
+++ b/docs/01-app/03-api-reference/05-config/02-typescript.mdx
@@ -123,7 +123,9 @@ In Node.js versions **v22.18.0+**, `process.features.typescript` is enabled by d
 NODE_OPTIONS=--experimental-transform-types next <command>
 ```
 
-By default, Node treats `.ts` files as CommonJS. If `next.config.ts` uses ESM syntax, Node re-parses it as ESM, which works but prints a warning about performance overhead. To avoid this extra pass, use `next.config.mts` to declare ESM up front.
+#### For CommonJS Projects (Default)
+
+Although `next.config.ts` supports native ESM syntax on CommonJS projects, Node.js will still assume `next.config.ts` is a CommonJS file by default, resulting in Node.js reparsing the file as ESM when module syntax is detected. Therefore, we recommend using the `next.config.mts` file for CommonJS projects to explicitly indicate it's an ESM module:
 
 ```ts filename="next.config.mts"
 import type { NextConfig } from 'next'
@@ -138,6 +140,19 @@ const nextConfig: NextConfig = {
 
 export default nextConfig
 ```
+
+#### For ESM Projects
+
+If your project is configured as an ESM project by adding `"type": "module"` to your `package.json` (see [Node.js documentation](https://nodejs.org/api/packages.html#type)), you can use `next.config.ts` directly with ESM syntax:
+
+```json filename="package.json"
+{
+  "type": "module"
+  // ... other package.json fields
+}
+```
+
+> **Good to know**: When using `"type": "module"` in your `package.json`, all `.js` and `.ts` files in your project are treated as ESM modules by default. You may need to rename files with CommonJS syntax to `.cjs` or `.cts` extensions if needed.
 
 ### Statically Typed Links
 

--- a/docs/01-app/03-api-reference/05-config/02-typescript.mdx
+++ b/docs/01-app/03-api-reference/05-config/02-typescript.mdx
@@ -123,7 +123,7 @@ In Node.js versions **v22.18.0+**, `process.features.typescript` is enabled by d
 NODE_OPTIONS=--experimental-transform-types next <command>
 ```
 
-In CommonJS projects, Node treats `.ts` as CommonJS. If `next.config.ts` uses ESM syntax, Node detects that and parses the file again using ESM. This works but will print an error indicating this incurs a performance overhead. Use `next.config.mts` to declare ESM up front and avoid the extra pass.
+By default, Node treats `.ts` files as CommonJS. If `next.config.ts` uses ESM syntax, Node re-parses it as ESM, which works but prints a warning about performance overhead. To avoid this extra pass, use `next.config.mts` to declare ESM up front.
 
 ```ts filename="next.config.mts"
 import type { NextConfig } from 'next'


### PR DESCRIPTION
This PR adds docs for using Node.js native TS resolver for `next.config.ts`. It states:

- Supports Node.js native TS resolver
- Why use it
- How to use it
- Restrictions
- Why use `next.config.mts`

I didn't mention how much it's faster compared to the legacy resolver (~68% faster in the hello world app - [link](https://github.com/vercel/next.js/pull/83240)) because the experience may vary for users.