### PR TITLE
Make hasNecessaryDependencies sync

### DIFF
--- a/packages/next/src/build/load-jsconfig.ts
+++ b/packages/next/src/build/load-jsconfig.ts
@@ -56,7 +56,7 @@ export default async function loadJsConfig(
 }> {
   let typeScriptPath: string | undefined
   try {
-    const deps = await hasNecessaryDependencies(dir, [
+    const deps = hasNecessaryDependencies(dir, [
       {
         pkg: 'typescript',
         file: 'typescript/lib/typescript.js',

--- a/packages/next/src/cli/next-test.ts
+++ b/packages/next/src/cli/next-test.ts
@@ -93,7 +93,7 @@ async function checkRequiredDeps(
   baseDir: string,
   testRunner: SupportedTestRunners
 ) {
-  const deps = await hasNecessaryDependencies(
+  const deps = hasNecessaryDependencies(
     baseDir,
     requiredPackagesByTestRunner[testRunner]
   )

--- a/packages/next/src/lib/eslint/runLintCheck.ts
+++ b/packages/next/src/lib/eslint/runLintCheck.ts
@@ -115,7 +115,7 @@ async function lint(
 > {
   try {
     // Load ESLint after we're sure it exists:
-    const deps = await hasNecessaryDependencies(baseDir, requiredPackages)
+    const deps = hasNecessaryDependencies(baseDir, requiredPackages)
     const packageManager = getPkgManager(baseDir)
 
     if (deps.missing.some((dep) => dep.pkg === 'eslint')) {

--- a/packages/next/src/lib/has-necessary-dependencies.ts
+++ b/packages/next/src/lib/has-necessary-dependencies.ts
@@ -1,4 +1,4 @@
-import { existsSync, promises as fs } from 'fs'
+import { existsSync, realpathSync } from 'fs'
 import { resolveFrom } from './resolve-from'
 import { dirname, join, relative } from 'path'
 
@@ -29,41 +29,41 @@ export type NecessaryDependencies = {
   missing: MissingDependency[]
 }
 
-export async function hasNecessaryDependencies(
+export function hasNecessaryDependencies(
   baseDir: string,
   requiredPackages: MissingDependency[]
-): Promise<NecessaryDependencies> {
+): NecessaryDependencies {
   let resolutions = new Map<string, string>()
   const missingPackages: MissingDependency[] = []
 
-  await Promise.all(
-    requiredPackages.map(async (p) => {
-      try {
-        const pkgPath = await fs.realpath(
-          resolveFrom(baseDir, `${p.pkg}/package.json`)
-        )
-        const pkgDir = dirname(pkgPath)
+  for (const p of requiredPackages) {
+    try {
+      const pkgPath = realpathSync(
+        resolveFrom(baseDir, `${p.pkg}/package.json`)
+      )
+      const pkgDir = dirname(pkgPath)
 
-        if (p.exportsRestrict) {
-          const fileNameToVerify = relative(p.pkg, p.file)
-          if (fileNameToVerify) {
-            const fileToVerify = join(pkgDir, fileNameToVerify)
-            if (existsSync(fileToVerify)) {
-              resolutions.set(p.pkg, fileToVerify)
-            } else {
-              return missingPackages.push(p)
-            }
+      if (p.exportsRestrict) {
+        const fileNameToVerify = relative(p.pkg, p.file)
+        if (fileNameToVerify) {
+          const fileToVerify = join(pkgDir, fileNameToVerify)
+          if (existsSync(fileToVerify)) {
+            resolutions.set(p.pkg, fileToVerify)
           } else {
-            resolutions.set(p.pkg, pkgPath)
+            missingPackages.push(p)
+            continue
           }
         } else {
-          resolutions.set(p.pkg, resolveFrom(baseDir, p.file))
+          resolutions.set(p.pkg, pkgPath)
         }
-      } catch (_) {
-        return missingPackages.push(p)
+      } else {
+        resolutions.set(p.pkg, resolveFrom(baseDir, p.file))
       }
-    })
-  )
+    } catch (_) {
+      missingPackages.push(p)
+      continue
+    }
+  }
 
   return {
     resolved: resolutions,

--- a/packages/next/src/lib/verify-partytown-setup.ts
+++ b/packages/next/src/lib/verify-partytown-setup.ts
@@ -66,16 +66,13 @@ export async function verifyPartytownSetup(
   targetDir: string
 ): Promise<void> {
   try {
-    const partytownDeps: NecessaryDependencies = await hasNecessaryDependencies(
-      dir,
-      [
-        {
-          file: '@builder.io/partytown',
-          pkg: '@builder.io/partytown',
-          exportsRestrict: false,
-        },
-      ]
-    )
+    const partytownDeps: NecessaryDependencies = hasNecessaryDependencies(dir, [
+      {
+        file: '@builder.io/partytown',
+        pkg: '@builder.io/partytown',
+        exportsRestrict: false,
+      },
+    ])
 
     if (partytownDeps.missing?.length > 0) {
       await missingDependencyError(dir)

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -65,7 +65,7 @@ export async function verifyTypeScriptSetup({
     }
 
     // Ensure TypeScript and necessary `@types/*` are installed:
-    let deps: NecessaryDependencies = await hasNecessaryDependencies(
+    let deps: NecessaryDependencies = hasNecessaryDependencies(
       dir,
       requiredPackages
     )
@@ -102,7 +102,7 @@ export async function verifyTypeScriptSetup({
         }
         throw err
       })
-      deps = await hasNecessaryDependencies(dir, requiredPackages)
+      deps = hasNecessaryDependencies(dir, requiredPackages)
     }
 
     // Load TypeScript after we're sure it exists:


### PR DESCRIPTION
## What?

It's currently half-sync and half-async. Given this happens in the blocking path when booting in development it's better to use the sync fs version.

Closes PACK-5418