### PR TITLE
fix: transpile-config should await import before return

### DIFF
--- a/packages/next/src/build/next-config-ts/transpile-config.ts
+++ b/packages/next/src/build/next-config-ts/transpile-config.ts
@@ -123,7 +123,8 @@ export async function transpileConfig({
         // Value is 'strip' or 'transform' based on how the feature is enabled.
         // https://nodejs.org/api/process.html#processfeaturestypescript
         if ((process.features as any).typescript) {
-          return import(pathToFileURL(nextConfigPath).href)
+          // Run import() here to catch errors and fallback to legacy resolution.
+          return (await import(pathToFileURL(nextConfigPath).href)).default
         }
 
         if (

--- a/test/e2e/app-dir/next-config-ts/nested-imports/next-config-ts-nested-imports-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts/nested-imports/next-config-ts-nested-imports-esm.test.ts
@@ -8,6 +8,8 @@ describe('next-config-ts-nested-imports-esm', () => {
     },
   })
 
+  console.log('noop')
+
   it('should handle nested imports (ESM)', async () => {
     const $ = await next.render$('/')
     expect($('p').text()).toBe('foobarbaz')

--- a/test/e2e/app-dir/next-config-ts/nested-imports/next-config-ts-nested-imports-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts/nested-imports/next-config-ts-nested-imports-esm.test.ts
@@ -8,8 +8,6 @@ describe('next-config-ts-nested-imports-esm', () => {
     },
   })
 
-  console.log('noop')
-
   it('should handle nested imports (ESM)', async () => {
     const $ = await next.render$('/')
     expect($('p').text()).toBe('foobarbaz')


### PR DESCRIPTION
The fallback didn't work because it didn't await the import when returning.

x-ref: https://github.com/vercel/next.js/actions/runs/17548458762/job/49837846122