### PR TITLE
[backport] fix: validation return types of pages API routes (#83069)

### DIFF
--- a/test/e2e/app-dir/typed-routes-validator/pages/api/test-route.ts
+++ b/test/e2e/app-dir/typed-routes-validator/pages/api/test-route.ts
@@ -1,12 +1,11 @@
-import type { NextApiRequest, NextApiResponse } from 'next/types'
+import type { NextApiHandler } from 'next/types'
 
 type ResponseData = {
   message: string
 }
 
-export default function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<ResponseData>
-) {
+const handler: NextApiHandler<ResponseData> = (req, res) => {
   res.status(200).json({ message: 'Hello from Next.js!' })
 }
+
+export default handler


### PR DESCRIPTION
I don't think this fix ever got backported to Next 15.5!

@huozhi @ijjk @ztanner 