### PR TITLE
Fix build-indicator test flaking

### DIFF
--- a/test/integration/build-indicator/test/index.test.js
+++ b/test/integration/build-indicator/test/index.test.js
@@ -3,7 +3,7 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { findPort, launchApp, killApp, waitFor, check } from 'next-test-utils'
+import { findPort, launchApp, killApp, retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 const appDir = join(__dirname, '..')
@@ -47,12 +47,14 @@ describe('Build Activity Indicator', () => {
     })
     await fs.remove(configPath)
 
-    await check(
-      () => stripAnsi(stderr),
-      new RegExp(
-        `Invalid "devIndicator.position" provided, expected one of top-left, top-right, bottom-left, bottom-right, received ttop-leff`
+    await retry(async () => {
+      const content = stripAnsi(stderr)
+      expect(content).toMatch(
+        new RegExp(
+          `Invalid "devIndicator.position" provided, expected one of top-left, top-right, bottom-left, bottom-right, received ttop-leff`
+        )
       )
-    )
+    })
 
     if (app) {
       await killApp(app)
@@ -76,9 +78,11 @@ describe('Build Activity Indicator', () => {
           )
           await installCheckVisible(browser)
           await browser.elementByCss('#to-a').click()
-          await waitFor(500)
-          const wasVisible = await browser.eval('window.showedBuilder')
-          expect(wasVisible).toBe(true)
+          await retry(async () => {
+            const wasVisible = await browser.eval('window.showedBuilder')
+            expect(wasVisible).toBe(true)
+          })
+
           await browser.close()
         })
       }
@@ -98,10 +102,12 @@ describe('Build Activity Indicator', () => {
       const newContent = origContent.replace('b', 'c')
 
       await fs.writeFile(pagePath, newContent, 'utf8')
-      await waitFor(500)
-      const wasVisible = await browser.eval('window.showedBuilder')
 
-      expect(wasVisible).toBe(true)
+      await retry(async () => {
+        const wasVisible = await browser.eval('window.showedBuilder')
+
+        expect(wasVisible).toBe(true)
+      })
       await fs.writeFile(pagePath, origContent, 'utf8')
       await browser.close()
     })


### PR DESCRIPTION
## What?

Fixes the flaky build-indicator test to use `retry` instead of `waitFor`. `waitFor` assumes something happens within x amount of time but if that's slightly slower than that it fails the test even though the test is not broken.

Closes PACK-5423