### PR TITLE
Use secure token for PPR resume header instead of static value

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4,6 +4,7 @@ import type { ExportPathMap, NextConfigComplete } from '../server/config-shared'
 import type { MiddlewareManifest } from './webpack/plugins/middleware-plugin'
 import type { ActionManifest } from './webpack/plugins/flight-client-entry-plugin'
 import type { CacheControl, Revalidate } from '../server/lib/cache-control'
+import crypto from 'node:crypto'
 
 import '../lib/setup-exception-listeners'
 
@@ -1525,6 +1526,12 @@ export default async function build(
             }
           }
 
+          // Generate a secret token that we can use for the resume header
+          // value. Using this instead of a static value improves the security
+          // of the resume header and prevents arbitrary resumes from wrongly
+          // interacting with the application.
+          const resumeToken = crypto.randomBytes(32).toString('hex')
+
           return {
             version: 3,
             pages404: true,
@@ -1590,7 +1597,7 @@ export default async function build(
               ? {
                   chain: {
                     headers: {
-                      [NEXT_RESUME_HEADER]: '1',
+                      [NEXT_RESUME_HEADER]: resumeToken,
                     },
                   },
                 }


### PR DESCRIPTION
### What?

Replaces the hardcoded `'1'` value used in the PPR resume header with a cryptographically secure token generated during the build process.

### Why?

The previous implementation used a static value (`'1'`) for the `next-resume` header, which could potentially allow unauthorized resume requests. Using a secure, randomly generated token improves the security posture of the PPR (Partial Prerendering) feature by ensuring only legitimate resume requests with the correct token can proceed.

### How?

- Generate a 64-character hex token using `crypto.randomBytes(32)` during the build process
- Store the token in the routes manifest under `ppr.chain.headers`
- Update server validation to compare the request header against the stored token
- Update tests to use the dynamically generated token instead of the hardcoded value

The token is regenerated on every build, ensuring that only the current deployment's resume requests are valid.

NAR-377