### PR TITLE
Enable more tests for Turbopack

### DIFF
--- a/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
+++ b/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
@@ -6,7 +6,7 @@ import { join } from 'path'
 // In order for the global isNextStart to be set
 import 'e2e-utils'
 
-// TODO: Implement warning for Turbopack
+// Importing module CSS in _document is allowed in Turbopack
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'Invalid SCSS in _document',
   () => {

--- a/test/integration/css/test/valid-invalid-css.test.js
+++ b/test/integration/css/test/valid-invalid-css.test.js
@@ -13,7 +13,7 @@ import { join } from 'path'
 
 const fixturesDir = join(__dirname, '../..', 'css-fixtures')
 
-// TODO: Implement warning for Turbopack
+// Importing module CSS in _document is allowed in Turbopack
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'Invalid CSS in _document',
   () => {
@@ -45,38 +45,36 @@ const fixturesDir = join(__dirname, '../..', 'css-fixtures')
     )
   }
 )
-;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-  'Invalid Global CSS',
-  () => {
-    ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
-      'production mode',
-      () => {
-        const appDir = join(fixturesDir, 'invalid-global')
 
-        beforeAll(async () => {
-          await remove(join(appDir, '.next'))
-        })
+describe('Invalid Global CSS', () => {
+  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+    'production mode',
+    () => {
+      const appDir = join(fixturesDir, 'invalid-global')
 
-        // eslint-disable-next-line jest/no-identical-title
-        it('should fail to build', async () => {
-          const { code, stderr } = await nextBuild(appDir, [], {
-            stderr: true,
-          })
-          expect(code).not.toBe(0)
-          expect(stderr).toContain('Failed to compile')
-          expect(stderr).toContain('styles/global.css')
-          expect(stderr).toMatch(
-            /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
-          )
-          // Skip: Rspack loaders cannot access module issuer info for location details
-          if (!process.env.NEXT_RSPACK) {
-            expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
-          }
+      beforeAll(async () => {
+        await remove(join(appDir, '.next'))
+      })
+
+      // eslint-disable-next-line jest/no-identical-title
+      it('should fail to build', async () => {
+        const { code, stderr } = await nextBuild(appDir, [], {
+          stderr: true,
         })
-      }
-    )
-  }
-)
+        expect(code).not.toBe(0)
+        expect(stderr).toContain('Failed to compile')
+        expect(stderr).toContain('styles/global.css')
+        expect(stderr).toMatch(
+          /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
+        )
+        // Skip: Rspack loaders cannot access module issuer info for location details
+        if (!process.env.NEXT_RSPACK) {
+          expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
+        }
+      })
+    }
+  )
+})
 
 describe('Valid Global CSS from npm', () => {
   ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
@@ -114,80 +112,68 @@ describe('Valid Global CSS from npm', () => {
           .replace(/\/\*.*?\*\//g, '')
           .trim()
 
-        if (process.env.IS_TURBOPACK_TEST) {
-          expect(cssContent).toMatchInlineSnapshot(`".red-text{color:"red"}"`)
-        } else {
-          expect(cssContent).toMatchInlineSnapshot(`".red-text{color:"red"}"`)
+        expect(cssContent).toMatchInlineSnapshot(`".red-text{color:"red"}"`)
+      })
+    }
+  )
+})
+
+describe('Invalid Global CSS with Custom App', () => {
+  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+    'production mode',
+    () => {
+      const appDir = join(fixturesDir, 'invalid-global-with-app')
+
+      beforeAll(async () => {
+        await remove(join(appDir, '.next'))
+      })
+
+      // eslint-disable-next-line jest/no-identical-title
+      it('should fail to build', async () => {
+        const { code, stderr } = await nextBuild(appDir, [], {
+          stderr: true,
+        })
+        expect(code).not.toBe(0)
+        expect(stderr).toContain('Failed to compile')
+        expect(stderr).toContain('styles/global.css')
+        expect(stderr).toMatch(
+          /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
+        )
+        // Skip: Rspack loaders cannot access module issuer info for location details
+        if (!process.env.NEXT_RSPACK) {
+          expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
         }
       })
     }
   )
 })
 
-// TODO: Implement warning for Turbopack
-;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-  'Invalid Global CSS with Custom App',
-  () => {
-    ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
-      'production mode',
-      () => {
-        const appDir = join(fixturesDir, 'invalid-global-with-app')
+describe('Valid and Invalid Global CSS with Custom App', () => {
+  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+    'production mode',
+    () => {
+      const appDir = join(fixturesDir, 'valid-and-invalid-global')
 
-        beforeAll(async () => {
-          await remove(join(appDir, '.next'))
+      beforeAll(async () => {
+        await remove(join(appDir, '.next'))
+      })
+
+      // eslint-disable-next-line jest/no-identical-title
+      it('should fail to build', async () => {
+        const { code, stderr } = await nextBuild(appDir, [], {
+          stderr: true,
         })
-
-        // eslint-disable-next-line jest/no-identical-title
-        it('should fail to build', async () => {
-          const { code, stderr } = await nextBuild(appDir, [], {
-            stderr: true,
-          })
-          expect(code).not.toBe(0)
-          expect(stderr).toContain('Failed to compile')
-          expect(stderr).toContain('styles/global.css')
-          expect(stderr).toMatch(
-            /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
-          )
-          // Skip: Rspack loaders cannot access module issuer info for location details
-          if (!process.env.NEXT_RSPACK) {
-            expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
-          }
-        })
-      }
-    )
-  }
-)
-
-// TODO: Implement warning for Turbopack
-;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-  'Valid and Invalid Global CSS with Custom App',
-  () => {
-    ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
-      'production mode',
-      () => {
-        const appDir = join(fixturesDir, 'valid-and-invalid-global')
-
-        beforeAll(async () => {
-          await remove(join(appDir, '.next'))
-        })
-
-        // eslint-disable-next-line jest/no-identical-title
-        it('should fail to build', async () => {
-          const { code, stderr } = await nextBuild(appDir, [], {
-            stderr: true,
-          })
-          expect(code).not.toBe(0)
-          expect(stderr).toContain('Failed to compile')
-          expect(stderr).toContain('styles/global.css')
-          expect(stderr).toContain(
-            'Please move all first-party global CSS imports'
-          )
-          // Skip: Rspack loaders cannot access module issuer info for location details
-          if (!process.env.NEXT_RSPACK) {
-            expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
-          }
-        })
-      }
-    )
-  }
-)
+        expect(code).not.toBe(0)
+        expect(stderr).toContain('Failed to compile')
+        expect(stderr).toContain('styles/global.css')
+        expect(stderr).toContain(
+          'Please move all first-party global CSS imports'
+        )
+        // Skip: Rspack loaders cannot access module issuer info for location details
+        if (!process.env.NEXT_RSPACK) {
+          expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
+        }
+      })
+    }
+  )
+})


### PR DESCRIPTION
These were already passing.

And importing module CSS from app/document is allowed by Turbopack.

Closes PACK-5425