### PR TITLE
Ignore unhandledRejection events for promises that reject after a React render aborts

### DIFF
--- a/packages/next/src/server/node-environment-extensions/unhandled-rejection.tsx
+++ b/packages/next/src/server/node-environment-extensions/unhandled-rejection.tsx
@@ -1,0 +1,388 @@
+/**
+ * Manages unhandled rejection listeners to intelligently filter rejections
+ * from aborted prerenders when cache components are enabled.
+ *
+ * THE PROBLEM:
+ * When we abort prerenders we expect to find numerous unhandled promise rejections due to
+ * things like awaiting Request data like `headers()`. The rejections are fine and should
+ * not be construed as problematic so we need to avoid the appearance of a problem by
+ * omitting them from the logged output.
+ *
+ * THE STRATEGY:
+ * 1. Install a filtering unhandled rejection handler
+ * 2. Intercept process event methods to capture new handlers in our internal queue
+ * 3. For each rejection, check if it comes from an aborted prerender context
+ * 4. If yes, suppress it. If no, delegate to all handlers in our queue
+ * 5. This provides precise filtering without time-based windows
+ *
+ * This ensures we suppress noisy prerender-related rejections while preserving
+ * normal error logging for genuine unhandled rejections.
+ */
+
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+
+type ListenerMetadata = {
+  listener: NodeJS.UnhandledRejectionListener
+  once: boolean
+}
+
+let filterInstalled = false
+
+// We store the proxied listeners for unhandled rejections here.
+let underlyingListeners: Array<NodeJS.UnhandledRejectionListener> = []
+// We store a unique pointer to each event listener registration to track
+// details like whether the listener is a once listener.
+let listenerMetadata: Array<ListenerMetadata> = []
+
+let originalProcessOn: typeof process.on
+let originalProcessAddListener: typeof process.addListener
+let originalProcessOnce: typeof process.once
+let originalProcessRemoveListener: typeof process.removeListener
+let originalProcessRemoveAllListeners: typeof process.removeAllListeners
+let originalProcessListeners: typeof process.listeners
+let originalProcessPrependListener: typeof process.prependListener
+let originalProcessPrependOnceListener: typeof process.prependOnceListener
+let originalProcessOff: typeof process.off
+
+let didWarnPrepend = false
+let didWarnRemoveAll = false
+
+/**
+ * Installs a filtering unhandled rejection handler that intelligently suppresses
+ * rejections from aborted prerender contexts.
+ *
+ * This should be called once during server startup to install the global filter.
+ */
+function installUnhandledRejectionFilter(): void {
+  if (filterInstalled) {
+    return
+  }
+
+  // Capture existing handlers
+  underlyingListeners = Array.from(process.listeners('unhandledRejection'))
+  // We assume all existing handlers are not "once"
+  listenerMetadata = underlyingListeners.map((l) => ({
+    listener: l,
+    once: false,
+  }))
+
+  // Store the original process methods
+  originalProcessOn = process.on
+  originalProcessAddListener = process.addListener
+  originalProcessOnce = process.once
+  originalProcessOff = process.off
+  originalProcessRemoveListener = process.removeListener
+  originalProcessRemoveAllListeners = process.removeAllListeners
+  originalProcessListeners = process.listeners
+  originalProcessPrependListener = process.prependListener
+  originalProcessPrependOnceListener = process.prependOnceListener
+
+  // Helper function to create a patched method that preserves toString behavior
+  function patchMethod<T extends Function>(original: T, patchedImpl: T): T {
+    // Preserve the original toString behavior
+    Object.defineProperty(patchedImpl, 'toString', {
+      value: original.toString.bind(original),
+      writable: true,
+      configurable: true,
+    })
+    return patchedImpl
+  }
+
+  // Intercept process.on to capture new unhandled rejection handlers
+  process.on = patchMethod(originalProcessOn, function (
+    event: string | symbol,
+    listener: (...args: any[]) => void
+  ) {
+    if (event === 'unhandledRejection') {
+      // Add new handlers to our internal queue instead of the process
+      underlyingListeners.push(listener as NodeJS.UnhandledRejectionListener)
+      listenerMetadata.push({ listener, once: false })
+      return process
+    }
+    // For other events, use the original method
+    return originalProcessOn.call(process, event, listener)
+  } as typeof process.on)
+
+  // Intercept process.addListener (alias for process.on)
+  process.addListener = patchMethod(
+    originalProcessAddListener,
+    process.on as typeof originalProcessAddListener
+  )
+
+  // Intercept process.once for one-time handlers
+  process.once = patchMethod(originalProcessOnce, function (
+    event: string | symbol,
+    listener: (...args: any[]) => void
+  ) {
+    if (event === 'unhandledRejection') {
+      underlyingListeners.push(listener)
+      listenerMetadata.push({ listener, once: true })
+      return process
+    }
+    // For other events, use the original method
+    return originalProcessOnce.call(process, event, listener)
+  } as typeof process.once)
+
+  // Intercept process.prependListener for handlers that should go first
+  process.prependListener = patchMethod(
+    originalProcessPrependListener,
+    function (event: string | symbol, listener: (...args: any[]) => void) {
+      if (event === 'unhandledRejection') {
+        if (didWarnPrepend === false) {
+          didWarnPrepend = true
+          console.warn(
+            'Warning: `prependListener("unhandledRejection")` called, but Next.js maintains the first listener ' +
+              'which filters out unnecessary events from aborted prerenders. Your handler will be second.'
+          )
+        }
+        // Add new handlers to the beginning of our internal queue
+        underlyingListeners.unshift(
+          listener as NodeJS.UnhandledRejectionListener
+        )
+        listenerMetadata.unshift({ listener, once: false })
+        return process
+      }
+      // For other events, use the original method
+      return originalProcessPrependListener.call(
+        process,
+        event as any,
+        listener
+      )
+    } as typeof process.prependListener
+  )
+
+  // Intercept process.prependOnceListener for one-time handlers that should go first
+  process.prependOnceListener = patchMethod(
+    originalProcessPrependOnceListener,
+    function (event: string | symbol, listener: (...args: any[]) => void) {
+      if (event === 'unhandledRejection') {
+        if (didWarnPrepend === false) {
+          didWarnPrepend = true
+          console.warn(
+            'Warning: `prependOnceListener("unhandledRejection")` called, but Next.js maintains the first listener ' +
+              'which filters out unnecessary events from aborted prerenders. Your handler will be second.'
+          )
+        }
+        // Add to the beginning of our internal queue
+        underlyingListeners.unshift(listener)
+        listenerMetadata.unshift({ listener, once: true })
+        return process
+      }
+      // For other events, use the original method
+      return originalProcessPrependOnceListener.call(
+        process,
+        event as any,
+        listener
+      )
+    } as typeof process.prependOnceListener
+  )
+
+  // Intercept process.removeListener
+  process.removeListener = patchMethod(originalProcessRemoveListener, function (
+    event: string | symbol,
+    listener: (...args: any[]) => void
+  ) {
+    if (event === 'unhandledRejection') {
+      // Check if they're trying to remove our filtering handler
+      if (listener === filteringUnhandledRejectionHandler) {
+        uninstallUnhandledRejectionFilter()
+        return process
+      }
+
+      const index = underlyingListeners.lastIndexOf(listener)
+      if (index > -1) {
+        underlyingListeners.splice(index, 1)
+        listenerMetadata.splice(index, 1)
+      }
+      return process
+    }
+    // For other events, use the original method
+    return originalProcessRemoveListener.call(process, event, listener)
+  } as typeof process.removeListener)
+
+  // Intercept process.off (alias for process.removeListener)
+  process.off = patchMethod(
+    originalProcessOff,
+    process.removeListener as typeof originalProcessOff
+  )
+
+  // Intercept process.removeAllListeners
+  process.removeAllListeners = patchMethod(
+    originalProcessRemoveAllListeners,
+    function (event?: string | symbol) {
+      if (event === 'unhandledRejection') {
+        if (didWarnRemoveAll === false) {
+          didWarnRemoveAll = true
+          console.warn(
+            'Warning: `removeAllListeners("unhandledRejection")` called. Next.js maintains an `unhandledRejection` listener ' +
+              'to filter out unnecessary rejection warnings caused by aborting prerenders early. It is not recommended that you ' +
+              'uninstall this behavior, but if you want to you must call `process.removeListener("unhandledRejection", listener)`. ' +
+              'You can acquire the listener from `process.listeners("unhandledRejection")[0]`.'
+          )
+        }
+        underlyingListeners.length = 0
+        listenerMetadata.length = 0
+        return process
+      }
+
+      // For other specific events, use the original method
+      if (event !== undefined) {
+        return originalProcessRemoveAllListeners.call(process, event)
+      }
+
+      // If no event specified (removeAllListeners()), uninstall our patch completely
+      console.warn(
+        'Warning: `removeAllListeners()` called - uninstalling Next.js unhandled rejection filter. ' +
+          'You will observe `unhandledRejection` logs from prerendering which are not problematic.'
+      )
+      uninstallUnhandledRejectionFilter()
+      return originalProcessRemoveAllListeners.call(process)
+    } as typeof process.removeAllListeners
+  )
+
+  // Intercept process.listeners to return our internal handlers for unhandled rejection
+  process.listeners = patchMethod(originalProcessListeners, function (
+    event: string | symbol
+  ) {
+    if (event === 'unhandledRejection') {
+      return [filteringUnhandledRejectionHandler, ...underlyingListeners]
+    }
+    return originalProcessListeners.call(process, event as any)
+  } as typeof process.listeners)
+
+  // Remove all existing handlers
+  originalProcessRemoveAllListeners.call(process, 'unhandledRejection')
+
+  // Install our filtering handler
+  originalProcessOn.call(
+    process,
+    'unhandledRejection',
+    filteringUnhandledRejectionHandler
+  )
+
+  originalProcessOn.call(process, 'rejectionHandled', noopRejectionHandled)
+
+  filterInstalled = true
+}
+
+/**
+ * Uninstalls the unhandled rejection filter and restores original process methods.
+ * This is called when someone explicitly removes our filtering handler.
+ * @internal
+ */
+function uninstallUnhandledRejectionFilter(): void {
+  if (!filterInstalled) {
+    return
+  }
+
+  // Restore original process methods
+  process.on = originalProcessOn
+  process.addListener = originalProcessAddListener
+  process.once = originalProcessOnce
+  process.prependListener = originalProcessPrependListener
+  process.prependOnceListener = originalProcessPrependOnceListener
+  process.removeListener = originalProcessRemoveListener
+  process.off = originalProcessOff
+  process.removeAllListeners = originalProcessRemoveAllListeners
+  process.listeners = originalProcessListeners
+
+  // Remove our filtering handler
+  originalProcessRemoveListener.call(
+    process,
+    'unhandledRejection',
+    filteringUnhandledRejectionHandler
+  )
+
+  originalProcessRemoveListener.call(
+    process,
+    'rejectionHandled',
+    noopRejectionHandled
+  )
+
+  // Re-register all the handlers that were in our internal queue
+  for (const meta of listenerMetadata) {
+    if (meta.once) {
+      originalProcessOnce.call(process, 'unhandledRejection', meta.listener)
+    } else {
+      originalProcessOn.call(process, 'unhandledRejection', meta.listener)
+    }
+  }
+
+  // Reset state
+  filterInstalled = false
+  underlyingListeners.length = 0
+  listenerMetadata.length = 0
+}
+
+/**
+ * The filtering handler that decides whether to suppress or delegate unhandled rejections.
+ */
+function filteringUnhandledRejectionHandler(
+  reason: any,
+  promise: Promise<any>
+): void {
+  const capturedListenerMetadata = Array.from(listenerMetadata)
+
+  const workUnitStore = workUnitAsyncStorage.getStore()
+
+  if (workUnitStore) {
+    switch (workUnitStore.type) {
+      case 'prerender':
+      case 'prerender-client':
+      case 'prerender-runtime': {
+        const signal = workUnitStore.renderSignal
+        if (signal.aborted) {
+          // This unhandledRejection is from async work spawned in a now
+          // aborted prerender. We don't need to report this.
+          return
+        }
+        break
+      }
+      case 'prerender-ppr':
+      case 'prerender-legacy':
+      case 'request':
+      case 'cache':
+      case 'private-cache':
+      case 'unstable-cache':
+        break
+      default:
+        workUnitStore satisfies never
+    }
+  }
+
+  // Not from an aborted prerender, delegate to original handlers
+  if (capturedListenerMetadata.length === 0) {
+    // We need to log something because the default behavior when there is
+    // no event handler installed is to trigger an Unhandled Exception.
+    // We don't do that here b/c we don't want to rely on this implicit default
+    // to kill the process since it can be disabled by installing a userland listener
+    // and you may also choose to run Next.js with args such that unhandled rejections
+    // do not automatically terminate the process.
+    console.error('Unhandled Rejection:', reason)
+  } else {
+    try {
+      for (const meta of capturedListenerMetadata) {
+        if (meta.once) {
+          // This is a once listener. we remove it from our set before we call it
+          const index = listenerMetadata.indexOf(meta)
+          if (index !== -1) {
+            underlyingListeners.splice(index, 1)
+            listenerMetadata.splice(index, 1)
+          }
+        }
+        const listener = meta.listener
+        listener(reason, promise)
+      }
+    } catch (error) {
+      // If any handlers error we produce an Uncaught Exception
+      setImmediate(() => {
+        throw error
+      })
+    }
+  }
+}
+
+function noopRejectionHandled() {}
+
+// Install the filter when this module is imported
+installUnhandledRejectionFilter()

--- a/packages/next/src/server/node-environment.ts
+++ b/packages/next/src/server/node-environment.ts
@@ -5,6 +5,7 @@ import './node-environment-baseline'
 // Import as early as possible so that unexpected errors in other extensions are properly formatted.
 // Has to come after baseline since error-inspect requires AsyncLocalStorage that baseline provides.
 import './node-environment-extensions/error-inspect'
+import './node-environment-extensions/unhandled-rejection'
 import './node-environment-extensions/random'
 import './node-environment-extensions/date'
 import './node-environment-extensions/web-crypto'

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -5074,5 +5074,90 @@ describe('Cache Components Errors', () => {
         })
       }
     })
+
+    describe('Unhandled Rejection Suppression', () => {
+      const pathname = '/unhandled-rejection'
+
+      if (isNextDev) {
+        it('should suppress unhandled rejections during prerender validation in dev', async () => {
+          const browser = await next.browser(pathname)
+
+          await expect(browser).toDisplayCollapsedRedbox(`
+           [
+             {
+               "description": "BOOM",
+               "environmentLabel": "Prerender",
+               "label": "Console Error",
+               "source": null,
+               "stack": [
+                 "Page <anonymous>",
+               ],
+             },
+             {
+               "description": " ⨯ "unhandledRejection:" "BOOM"",
+               "environmentLabel": "Prerender",
+               "label": "Console Error",
+               "source": null,
+               "stack": [
+                 "Page <anonymous>",
+               ],
+             },
+             {
+               "description": " ⨯ "unhandledRejection: " "BOOM"",
+               "environmentLabel": "Prerender",
+               "label": "Console Error",
+               "source": null,
+               "stack": [
+                 "Page <anonymous>",
+               ],
+             },
+             {
+               "description": "BAM",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": null,
+               "stack": [
+                 "Page <anonymous>",
+               ],
+             },
+             {
+               "description": " ⨯ "unhandledRejection:" "BAM"",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": null,
+               "stack": [
+                 "Page <anonymous>",
+               ],
+             },
+             {
+               "description": " ⨯ "unhandledRejection: " "BAM"",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": null,
+               "stack": [
+                 "Page <anonymous>",
+               ],
+             },
+           ]
+          `)
+        })
+      } else {
+        it('should suppress unhandled rejections after prerender abort', async () => {
+          try {
+            await prerender(pathname)
+          } catch {}
+
+          const output = getPrerenderOutput(
+            next.cliOutput.slice(cliOutputLength),
+            { isMinified: !isDebugPrerender }
+          )
+
+          expect(output).toMatchInlineSnapshot(`
+             "BOOM
+             BOOM"
+            `)
+        })
+      }
+    })
   })
 })

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/unhandled-rejection/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/unhandled-rejection/layout.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>
+          <Suspense>{children}</Suspense>
+        </main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/unhandled-rejection/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/unhandled-rejection/page.tsx
@@ -1,0 +1,22 @@
+export default async function Page() {
+  // This promise will reject before we abort during prerendering
+  Promise.reject('BOOM')
+
+  // This promise will reject after we abort during prerendering
+  setTimeout(() => {
+    Promise.reject('BAM')
+  }, 0)
+
+  return (
+    <>
+      <p>
+        This page tests unhandled rejection suppression after prerender abort.
+      </p>
+      <p>
+        With cache components enabled, this page produces a partial static shell
+        and it has one early rejection "BOOM" which will show up but two late
+        rejections which should not
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/utils.ts
+++ b/test/e2e/app-dir/cache-components-errors/utils.ts
@@ -1,7 +1,11 @@
 // Used to deterministically stub out minified local names in stack traces.
 const abc = 'abcdefghijklmnopqrstuvwxyz'
 const hostElementsUsedInFixtures = ['html', 'body', 'main', 'div']
-const ignoredLines = ['Generating static pages', 'Inlining static env']
+const ignoredLines = [
+  'Generating static pages',
+  'Inlining static env',
+  'Finalizing page optimization',
+]
 
 /**
  * Converts a module function sequence expression, e.g.:
@@ -47,6 +51,10 @@ export function getPrerenderOutput(
     }
 
     if (line.includes('Next.js build worker exited')) {
+      break
+    }
+
+    if (line.includes('Route (app)')) {
       break
     }
 

--- a/test/e2e/app-dir/cache-components-request-apis/fixtures/reject-hanging-promises-dynamic/app/[slug]/page.tsx
+++ b/test/e2e/app-dir/cache-components-request-apis/fixtures/reject-hanging-promises-dynamic/app/[slug]/page.tsx
@@ -5,16 +5,12 @@ export default async function Page(props: {
   params: Promise<{}>
   searchParams: Promise<{}>
 }) {
-  setTimeout(async () => await props.params)
-  setTimeout(async () => await props.searchParams)
-  let pendingCookies = cookies()
-  setTimeout(async () => await pendingCookies)
-  let pendingHeaders = headers()
-  setTimeout(async () => await pendingHeaders)
-  let pendingDraftMode = draftMode()
-  setTimeout(async () => await pendingDraftMode)
-  let pendingConnection = connection()
-  setTimeout(async () => await pendingConnection)
+  props.params.catch(logReason)
+  props.searchParams.catch(logReason)
+  cookies().catch(logReason)
+  headers().catch(logReason)
+  draftMode().catch(logReason)
+  connection().catch(logReason)
   return (
     <>
       <p>
@@ -29,6 +25,10 @@ export default async function Page(props: {
       </p>
     </>
   )
+}
+
+function logReason(reason: any) {
+  console.log('Reason:', reason)
 }
 
 async function TriggerSyncDynamic() {

--- a/test/e2e/app-dir/cache-components-request-apis/fixtures/reject-hanging-promises-static/app/[slug]/page.tsx
+++ b/test/e2e/app-dir/cache-components-request-apis/fixtures/reject-hanging-promises-static/app/[slug]/page.tsx
@@ -5,16 +5,12 @@ export default async function Page(props: {
   params: Promise<{}>
   searchParams: Promise<{}>
 }) {
-  setTimeout(async () => await props.params)
-  setTimeout(async () => await props.searchParams)
-  let pendingCookies = cookies()
-  setTimeout(async () => await pendingCookies)
-  let pendingHeaders = headers()
-  setTimeout(async () => await pendingHeaders)
-  let pendingDraftMode = draftMode()
-  setTimeout(async () => await pendingDraftMode)
-  let pendingConnection = connection()
-  setTimeout(async () => await pendingConnection)
+  props.params.catch(logReason)
+  props.searchParams.catch(logReason)
+  cookies().catch(logReason)
+  headers().catch(logReason)
+  draftMode().catch(logReason)
+  connection().catch(logReason)
   return (
     <>
       <p>
@@ -25,4 +21,8 @@ export default async function Page(props: {
       </p>
     </>
   )
+}
+
+function logReason(reason: any) {
+  console.log('Reason:', reason)
 }


### PR DESCRIPTION
Currently we only abort React renders that are prerendered so this change in practice only affects prerendering. The intent is to not report unhandledRejections that are downstream of an abort because the signal these errors provide is very limited. If you do have unrelated unhandled rejections they'll usually show up before aborting or in a dynamic page render so even if they are incidentally supressed in the prerender context you should still be able to observe them.

Arguably we should go further and never report unhandled rejections because there are still valid patterns where you initiate work prospectively and then abandon it by choosing a fork or by returning early (i.e. notFound()). This change doesn't attempt to cover every possible case.

The implementation is a bit intense. We need the ability to stop propagating the event which is not natively supported with Node's EventEmitter interface. Instead we patch the listener methods to delegate the filtering to an inner listener queue. If you add/remove or otherwise manipulate the listener list we always ensure our listener is first and can opt to omit propagating the event. If you want to uninstall the this patch you just need to unregister this listener specifically which can be accessing used `process.listeners('unhandledRejection')[0]`

This patch only exists for the node environment because we do not do any prerendering in edge runtimes. In the future if we add aborting to environments like edge runtime we may need an alternative solution to this problem