### PR TITLE
Update PPR cases with adapter config

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -795,7 +795,7 @@ export async function handleBuildComplete({
 
         let filePath = path.join(
           isAppPage ? appDistDir : pagesDistDir,
-          `${route}.${isAppPage && !dataRoute ? 'body' : 'html'}`
+          `${route === '/' ? 'index' : route}.${isAppPage && !dataRoute ? 'body' : 'html'}`
         )
 
         // we use the static 404 for notFound: true if available
@@ -933,7 +933,9 @@ export async function handleBuildComplete({
               ? {
                   filePath: path.join(
                     isAppPage ? appDistDir : pagesDistDir,
-                    fallback
+                    // app router dynamic route fallbacks don't have the
+                    // extension so ensure it's added here
+                    fallback.endsWith('.html') ? fallback : `${fallback}.html`
                   ),
                   initialStatus: fallbackStatus,
                   initialHeaders: {

--- a/test/production/adapter-config/adapter-config-ppr.test.ts
+++ b/test/production/adapter-config/adapter-config-ppr.test.ts
@@ -1,0 +1,2 @@
+process.env.TEST_PPR = '1'
+require('./adapter-config.test')

--- a/test/production/adapter-config/app/page.tsx
+++ b/test/production/adapter-config/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <>
+      <p>/</p>
+      <p>now: {Date.now()}</p>
+    </>
+  )
+}

--- a/test/production/adapter-config/next.config.mjs
+++ b/test/production/adapter-config/next.config.mjs
@@ -5,6 +5,7 @@ const require = Module.createRequire(import.meta.url)
 const nextConfig = {
   experimental: {
     adapterPath: require.resolve('./my-adapter.mjs'),
+    ppr: Boolean(process.env.TEST_PPR),
   },
 }
 


### PR DESCRIPTION
Continues https://github.com/vercel/next.js/pull/82919 from testing fixing `fallback` value missing the extension and `/` app route not being mapping to it's output file correctly. This also adds a test suite with PPR enabled to catch these cases. 