### PR TITLE
Exit `next dev` with a non-zero code when next.config.js is invalid

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -75,6 +75,7 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
   if (signal != null && child?.pid) child.kill(signal)
   if (sessionStopHandled) return
   sessionStopHandled = true
+  const exitCode = child?.exitCode || 0
 
   if (
     signal != null &&
@@ -88,6 +89,8 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
     await once(child, 'exit').catch(() => {})
     clearTimeout(exitTimeout)
   }
+
+  child = undefined
 
   sessionSpan.stop()
   await flushAllTraces({ end: true })
@@ -150,7 +153,7 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
   // the program, or the cursor could remain hidden
   process.stdout.write('\x1B[?25h')
   process.stdout.write('\n')
-  process.exit(0)
+  process.exit(exitCode)
 }
 
 process.on('SIGINT', () => handleSessionStop('SIGINT'))

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -90,6 +90,8 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
     clearTimeout(exitTimeout)
   }
 
+  // Unset the child so that we don't try to send it SIGKILL when the parent
+  // process exits.
   child = undefined
 
   sessionSpan.stop()

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -75,6 +75,9 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
   if (signal != null && child?.pid) child.kill(signal)
   if (sessionStopHandled) return
   sessionStopHandled = true
+
+  // Capture the child's exit code if it has already exited and caused the
+  // session stop (via the 'exit' event), otherwise assume success (0).
   const exitCode = child?.exitCode || 0
 
   if (

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -93,10 +93,6 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
     clearTimeout(exitTimeout)
   }
 
-  // Unset the child so that we don't try to send it SIGKILL when the parent
-  // process exits.
-  child = undefined
-
   sessionSpan.stop()
   await flushAllTraces({ end: true })
 

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -367,22 +367,22 @@ export async function startServer(
       // Only load env and config in dev to for logging purposes
       let envInfo: string[] | undefined
       let experimentalFeatures: ConfiguredExperimentalFeature[] | undefined
-      if (isDev) {
-        const startServerInfo = await getStartServerInfo({ dir, dev: isDev })
-        envInfo = startServerInfo.envInfo
-        experimentalFeatures = startServerInfo.experimentalFeatures
-      }
-      logStartInfo({
-        networkUrl,
-        appUrl,
-        envInfo,
-        experimentalFeatures,
-        logBundler: isDev,
-      })
-
-      Log.event(`Starting...`)
-
       try {
+        if (isDev) {
+          const startServerInfo = await getStartServerInfo({ dir, dev: isDev })
+          envInfo = startServerInfo.envInfo
+          experimentalFeatures = startServerInfo.experimentalFeatures
+        }
+        logStartInfo({
+          networkUrl,
+          appUrl,
+          envInfo,
+          experimentalFeatures,
+          logBundler: isDev,
+        })
+
+        Log.event(`Starting...`)
+
         let cleanupStarted = false
         let closeUpgraded: (() => void) | null = null
         const cleanup = () => {

--- a/test/e2e/build-indicator/test/index.test.ts
+++ b/test/e2e/build-indicator/test/index.test.ts
@@ -23,7 +23,6 @@ describe('Build Activity Indicator', () => {
     const { next } = nextTestSetup({
       files: join(__dirname, '..'),
       skipStart: true,
-      startServerTimeout: 1000,
       nextConfig: {
         devIndicators: {
           // Intentionally invalid position to test error

--- a/test/e2e/build-indicator/test/index.test.ts
+++ b/test/e2e/build-indicator/test/index.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { join } from 'path'
 import { retry } from 'next-test-utils'
-import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
+import { nextTestSetup, isNextDev, isNextDeploy } from 'e2e-utils'
 
 const installCheckVisible = (browser) => {
   return browser.eval(`(function() {
@@ -19,7 +19,7 @@ const installCheckVisible = (browser) => {
 
 describe('Build Activity Indicator', () => {
   // Use describe.skip so that this suite does not fail with "no tests" during deploy tests.
-  ;(isNextStart ? describe : describe.skip)('Invalid position config', () => {
+  ;(isNextDeploy ? describe.skip : describe)('Invalid position config', () => {
     const { next } = nextTestSetup({
       files: join(__dirname, '..'),
       skipStart: true,
@@ -27,16 +27,25 @@ describe('Build Activity Indicator', () => {
       nextConfig: {
         devIndicators: {
           // Intentionally invalid position to test error
-          position: 'ttop-leff' as any,
+          // @ts-expect-error
+          position: 'ttop-leff',
         },
       },
     })
 
     it('should validate position config', async () => {
-      const result = await next.build()
+      if (isNextDev) {
+        try {
+          await next.start()
+        } catch {
+          // We expect `next dev` to fail.
+        }
+      } else {
+        const result = await next.build()
+        expect(result.exitCode).toBe(1)
+      }
 
-      expect(result.exitCode).toBe(1)
-      expect(result.cliOutput).toContain(
+      expect(next.cliOutput).toContain(
         `Invalid "devIndicator.position" provided, expected one of top-left, top-right, bottom-left, bottom-right, received ttop-leff`
       )
     })

--- a/test/e2e/build-indicator/test/index.test.ts
+++ b/test/e2e/build-indicator/test/index.test.ts
@@ -36,8 +36,10 @@ describe('Build Activity Indicator', () => {
       if (isNextDev) {
         try {
           await next.start()
-        } catch {
-          // We expect `next dev` to fail.
+        } catch (err) {
+          expect(err).toEqual(
+            new Error('next dev exited unexpectedly with code/signal 1')
+          )
         }
       } else {
         const result = await next.build()

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -81,6 +81,11 @@ export class NextDevInstance extends NextInstance {
           this.emit('stderr', [msg])
         })
 
+        const serverReadyTimeoutId = this.setServerReadyTimeout(
+          reject,
+          this.startServerTimeout
+        )
+
         this.childProcess.on('close', (code, signal) => {
           if (this.isStopping) return
           if (code || signal) {
@@ -88,15 +93,11 @@ export class NextDevInstance extends NextInstance {
             const error = new Error(
               `next dev exited unexpectedly with code/signal ${code || signal}`
             )
+            clearTimeout(serverReadyTimeoutId)
             require('console').error(error)
             reject(error)
           }
         })
-
-        const serverReadyTimeoutId = this.setServerReadyTimeout(
-          reject,
-          this.startServerTimeout
-        )
 
         const readyCb = (msg) => {
           const resolveServer = () => {

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -84,9 +84,12 @@ export class NextDevInstance extends NextInstance {
         this.childProcess.on('close', (code, signal) => {
           if (this.isStopping) return
           if (code || signal) {
-            require('console').error(
+            this.childProcess = undefined
+            const error = new Error(
               `next dev exited unexpectedly with code/signal ${code || signal}`
             )
+            require('console').error(error)
+            reject(error)
           }
         })
 


### PR DESCRIPTION
In `next dev`, we're currently ignoring the exit code of the spawned child process, and always exiting with `0` instead. We should exit the process with the child's exit code instead. This is relevant when the `next.config.js` is invalid, for example.