### PR TITLE
chore: remove $ from cli cmd

### DIFF
--- a/errors/sync-dynamic-apis.mdx
+++ b/errors/sync-dynamic-apis.mdx
@@ -34,7 +34,7 @@ In future versions, these APIs will be async and direct access will not work as 
 The [`next-async-request-api` codemod](/docs/app/guides/upgrading/codemods#next-async-request-api) can fix many of these cases automatically:
 
 ```bash filename="Terminal"
-$ npx @next/codemod@canary next-async-request-api .
+npx @next/codemod@canary next-async-request-api .
 ```
 
 The codemod cannot cover all cases, so you may need to manually adjust some code.


### PR DESCRIPTION
$ in the command example makes it annoying to copy paste