### PR TITLE
Development: Don't load Babel when it's not used

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1051,7 +1051,7 @@ export default async function build(
       const hasPublicDir = existsSync(publicDir)
 
       telemetry.record(
-        eventCliSession(dir, config, {
+        eventCliSession(config, {
           webpackVersion: 5,
           cliCommand: 'build',
           isSrcDir,

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -100,7 +100,7 @@ async function exportAppImpl(
 
   if (telemetry) {
     telemetry.record(
-      eventCliSession(distDir, nextConfig, {
+      eventCliSession(nextConfig, {
         webpackVersion: null,
         cliCommand: 'export',
         isSrcDir: null,

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1193,20 +1193,16 @@ export async function setupDevBundler(opts: SetupOpts) {
   })
 
   opts.telemetry.record(
-    eventCliSession(
-      path.join(opts.dir, opts.nextConfig.distDir),
-      opts.nextConfig,
-      {
-        webpackVersion: 5,
-        isSrcDir,
-        turboFlag: !!opts.turbo,
-        cliCommand: 'dev',
-        appDir: !!opts.appDir,
-        pagesDir: !!opts.pagesDir,
-        isCustomServer: !!opts.isCustomServer,
-        hasNowJson: !!(await findUp('now.json', { cwd: opts.dir })),
-      }
-    )
+    eventCliSession(opts.nextConfig, {
+      webpackVersion: 5,
+      isSrcDir,
+      turboFlag: !!opts.turbo,
+      cliCommand: 'dev',
+      appDir: !!opts.appDir,
+      pagesDir: !!opts.pagesDir,
+      isCustomServer: !!opts.isCustomServer,
+      hasNowJson: !!(await findUp('now.json', { cwd: opts.dir })),
+    })
   )
 
   // Track build features for dev server here:

--- a/packages/next/src/telemetry/events/version.ts
+++ b/packages/next/src/telemetry/events/version.ts
@@ -1,5 +1,4 @@
 import type { NextConfigComplete } from '../../server/config-shared'
-import path from 'path'
 
 const EVENT_VERSION = 'NEXT_CLI_SESSION_STARTED'
 
@@ -43,28 +42,7 @@ type EventCliSessionStarted = {
   reactCompilerPanicThreshold: string | null
 }
 
-function hasBabelConfig(dir: string): boolean {
-  try {
-    const noopFile = path.join(dir, 'noop.js')
-    const res = (
-      require('next/dist/compiled/babel/core') as typeof import('next/dist/compiled/babel/core')
-    ).loadPartialConfig({
-      cwd: dir,
-      filename: noopFile,
-      sourceFileName: noopFile,
-    }) as any
-    const isForTooling =
-      res.options?.presets?.every(
-        (e: any) => e?.file?.request === 'next/babel'
-      ) && res.options?.plugins?.length === 0
-    return res.hasFilesystemConfig() && !isForTooling
-  } catch {
-    return false
-  }
-}
-
 export function eventCliSession(
-  dir: string,
   nextConfig: NextConfigComplete,
   event: Omit<
     EventCliSessionStarted,
@@ -116,7 +94,7 @@ export function eventCliSession(
     hasNextConfig: nextConfig.configOrigin !== 'default',
     buildTarget: 'default',
     hasWebpackConfig: typeof nextConfig?.webpack === 'function',
-    hasBabelConfig: hasBabelConfig(dir),
+    hasBabelConfig: false,
     imageEnabled: !!images,
     imageFutureEnabled: !!images,
     basePathEnabled: !!nextConfig?.basePath,

--- a/test/integration/telemetry/test/index.test.js
+++ b/test/integration/telemetry/test/index.test.js
@@ -236,7 +236,7 @@ describe('Telemetry CLI', () => {
         expect(event).toMatch(/"hasNextConfig": false/)
         expect(event).toMatch(/"buildTarget": "default"/)
         expect(event).toMatch(/"hasWebpackConfig": false/)
-        expect(event).toMatch(/"hasBabelConfig": true/)
+        expect(event).toMatch(/"hasBabelConfig": false/)
       })
 
       it('cli session: package.json custom babel config (plugin)', async () => {
@@ -262,7 +262,7 @@ describe('Telemetry CLI', () => {
         expect(event).toMatch(/"hasNextConfig": false/)
         expect(event).toMatch(/"buildTarget": "default"/)
         expect(event).toMatch(/"hasWebpackConfig": false/)
-        expect(event).toMatch(/"hasBabelConfig": true/)
+        expect(event).toMatch(/"hasBabelConfig": false/)
       })
 
       it('cli session: custom babel config (preset)', async () => {
@@ -288,7 +288,7 @@ describe('Telemetry CLI', () => {
         expect(event).toMatch(/"hasNextConfig": false/)
         expect(event).toMatch(/"buildTarget": "default"/)
         expect(event).toMatch(/"hasWebpackConfig": false/)
-        expect(event).toMatch(/"hasBabelConfig": true/)
+        expect(event).toMatch(/"hasBabelConfig": false/)
       })
 
       it('cli session: next config with webpack', async () => {


### PR DESCRIPTION
## What?

Currently Babel always gets loaded in order to check for a babel config. This event is no longer that useful to track so removing it in favor of performance.

Closes PACK-5432