### PR TITLE
Development: Don't load hot-reloader-webpack when using Turbopack

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-shared-utils.ts
+++ b/packages/next/src/server/dev/hot-reloader-shared-utils.ts
@@ -1,0 +1,31 @@
+import { getPathMatch } from '../../shared/lib/router/utils/path-match'
+import { parseVersionInfo, type VersionInfo } from './parse-version-info'
+
+export const matchNextPageBundleRequest = getPathMatch(
+  '/_next/static/chunks/pages/:path*.js(\\.map|)'
+)
+export async function getVersionInfo(): Promise<VersionInfo> {
+  let installed = '0.0.0'
+
+  try {
+    installed = require('next/package.json').version
+
+    let res
+
+    try {
+      // use NPM registry regardless user using Yarn
+      res = await fetch('https://registry.npmjs.org/-/package/next/dist-tags')
+    } catch {
+      // ignore fetch errors
+    }
+
+    if (!res || !res.ok) return { installed, staleness: 'unknown' }
+
+    const { latest, canary } = await res.json()
+
+    return parseVersionInfo({ installed, latest, canary })
+  } catch (e: any) {
+    console.error(e)
+    return { installed, staleness: 'unknown' }
+  }
+}

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -26,10 +26,6 @@ import type {
 } from '../../build/swc/types'
 import { createDefineEnv } from '../../build/swc'
 import * as Log from '../../build/output/log'
-import {
-  getVersionInfo,
-  matchNextPageBundleRequest,
-} from './hot-reloader-webpack'
 import { BLOCKED_PAGES } from '../../shared/lib/constants'
 import {
   getOverlayMiddleware,
@@ -111,6 +107,10 @@ import {
   deleteReactDebugChannel,
   setReactDebugChannel,
 } from './debug-channel'
+import {
+  getVersionInfo,
+  matchNextPageBundleRequest,
+} from './hot-reloader-shared-utils'
 
 const wsServer = new ws.Server({ noServer: true })
 const isTestMode = !!(

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -42,7 +42,6 @@ import {
   RSC_MODULE_TYPES,
 } from '../../shared/lib/constants'
 import type { __ApiPreviewProps } from '../api-utils'
-import { getPathMatch } from '../../shared/lib/router/utils/path-match'
 import { findPageFile } from '../lib/find-page-file'
 import {
   BUILDING,
@@ -66,7 +65,6 @@ import { getProperError } from '../../lib/is-error'
 import ws from 'next/dist/compiled/ws'
 import { existsSync, promises as fs } from 'fs'
 import type { UnwrapPromise } from '../../lib/coalesced-function'
-import { parseVersionInfo } from './parse-version-info'
 import type { VersionInfo } from './parse-version-info'
 import { isAPIRoute } from '../../lib/is-api-route'
 import { getRouteLoaderEntry } from '../../build/webpack/loaders/next-route-loader'
@@ -102,6 +100,10 @@ import {
   setReactDebugChannel,
   type ReactDebugChannelForBrowser,
 } from './debug-channel'
+import {
+  getVersionInfo,
+  matchNextPageBundleRequest,
+} from './hot-reloader-shared-utils'
 
 const MILLISECONDS_IN_NANOSECOND = BigInt(1_000_000)
 
@@ -163,10 +165,6 @@ function addCorsSupport(req: IncomingMessage, res: ServerResponse) {
   return { preflight: false }
 }
 
-export const matchNextPageBundleRequest = getPathMatch(
-  '/_next/static/chunks/pages/:path*.js(\\.map|)'
-)
-
 // Iteratively look up the issuer till it ends up at the root
 function findEntryModule(
   module: webpack.Module,
@@ -207,32 +205,6 @@ function erroredPages(compilation: webpack.Compilation) {
   }
 
   return failedPages
-}
-
-export async function getVersionInfo(): Promise<VersionInfo> {
-  let installed = '0.0.0'
-
-  try {
-    installed = require('next/package.json').version
-
-    let res
-
-    try {
-      // use NPM registry regardless user using Yarn
-      res = await fetch('https://registry.npmjs.org/-/package/next/dist-tags')
-    } catch {
-      // ignore fetch errors
-    }
-
-    if (!res || !res.ok) return { installed, staleness: 'unknown' }
-
-    const { latest, canary } = await res.json()
-
-    return parseVersionInfo({ installed, latest, canary })
-  } catch (e: any) {
-    console.error(e)
-    return { installed, staleness: 'unknown' }
-  }
 }
 
 export default class HotReloaderWebpack implements NextJsHotReloaderInterface {


### PR DESCRIPTION
## What?

Follow-up to #83609. hot-reloader-webpack was imported from hot-reloader-turbopack, causing it to be loaded even when not used.

Closes PACK-5433