### PR TITLE
Development: Only require loadJsConfig when using webpack

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -767,6 +767,7 @@ async function startWatcher(
             >
           | undefined
 
+        // This is not relevant for Turbopack because tsconfig/jsconfig is handled internally.
         if (!hotReloader.turbopackProject) {
           if (tsconfigChange) {
             try {

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -19,7 +19,6 @@ import * as Log from '../../../build/output/log'
 import { setGlobal } from '../../../trace/shared'
 import type { Telemetry } from '../../../telemetry/storage'
 import type { IncomingMessage, ServerResponse } from 'http'
-import loadJsConfig from '../../../build/load-jsconfig'
 import { createValidFileMatcher } from '../find-page-file'
 import {
   EVENT_BUILD_FEATURE_USAGE,
@@ -763,14 +762,21 @@ async function startWatcher(
           ])
         }
         let tsconfigResult:
-          | UnwrapPromise<ReturnType<typeof loadJsConfig>>
+          | UnwrapPromise<
+              ReturnType<typeof import('../../../build/load-jsconfig').default>
+            >
           | undefined
 
-        if (tsconfigChange) {
-          try {
-            tsconfigResult = await loadJsConfig(dir, nextConfig)
-          } catch (_) {
-            /* do we want to log if there are syntax errors in tsconfig while editing? */
+        if (!hotReloader.turbopackProject) {
+          if (tsconfigChange) {
+            try {
+              const loadJsConfig = (
+                require('../../../build/load-jsconfig') as typeof import('../../../build/load-jsconfig')
+              ).default
+              tsconfigResult = await loadJsConfig(dir, nextConfig)
+            } catch (_) {
+              /* do we want to log if there are syntax errors in tsconfig while editing? */
+            }
           }
         }
 


### PR DESCRIPTION
## What?

Don't require/call loadJsConfig when using Turbopack, as it's handled internally. loadJsConfig is one of the places where TypeScript gets loaded. There's still the TS verify as well, this narrows the amount of places where TypeScript gets loaded to make it easier to remove that loading of TypeScript in a future PR.

Closes PACK-5435