### PR TITLE
Turbopack: Skip loading webpack hook

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1307,7 +1307,7 @@ export default async function loadConfig(
   }
 
   // Original implementation continues below...
-  if (!process.env.__NEXT_PRIVATE_RENDER_WORKER) {
+  if (!process.env.__NEXT_PRIVATE_RENDER_WORKER && !process.env.TURBOPACK) {
     try {
       loadWebpackHook()
     } catch (err) {


### PR DESCRIPTION
## What?

Webpack still gets `require()`ed currently when you're using Turbopack. There's a good reason to do this which is that your `next.config.js` could be depending on webpack (i.e. loading webpack plugins in module scope). We'll want to rework this so opening this draft to see what tests fail with the simple "don't load it" change.

Closes PACK-5628