### PR TITLE
[Turbopack] Remove `ssr-data` module context

### DIFF
--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -403,17 +403,6 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    pub(super) fn ssr_data_module_context(self: Vc<Self>) -> Vc<ModuleAssetContext> {
-        ModuleAssetContext::new(
-            self.server_transitions(),
-            self.project().server_compile_time_info(),
-            self.ssr_data_module_options_context(),
-            self.ssr_resolve_options_context(),
-            Layer::new(rcstr!("ssr-data")),
-        )
-    }
-
-    #[turbo_tasks::function]
     pub(super) fn edge_ssr_module_context(self: Vc<Self>) -> Vc<ModuleAssetContext> {
         ModuleAssetContext::new(
             Default::default(),
@@ -432,17 +421,6 @@ impl PagesProject {
             self.edge_api_module_options_context(),
             self.edge_ssr_resolve_options_context(),
             Layer::new_with_user_friendly_name(rcstr!("edge-api"), rcstr!("Edge Route")),
-        )
-    }
-
-    #[turbo_tasks::function]
-    pub(super) fn edge_ssr_data_module_context(self: Vc<Self>) -> Vc<ModuleAssetContext> {
-        ModuleAssetContext::new(
-            Default::default(),
-            self.project().edge_compile_time_info(),
-            self.edge_ssr_data_module_options_context(),
-            self.edge_ssr_resolve_options_context(),
-            Layer::new(rcstr!("edge-ssr-data")),
         )
     }
 
@@ -503,42 +481,6 @@ impl PagesProject {
             self.project().project_path().owned().await?,
             self.project().execution_context(),
             ServerContextType::PagesApi {
-                pages_dir: self.pages_dir().owned().await?,
-            },
-            self.project().next_mode(),
-            self.project().next_config(),
-            NextRuntime::Edge,
-            self.project().encryption_key(),
-            self.project().edge_compile_time_info().environment(),
-            self.project().client_compile_time_info().environment(),
-        ))
-    }
-
-    #[turbo_tasks::function]
-    async fn ssr_data_module_options_context(self: Vc<Self>) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
-            self.project().project_path().owned().await?,
-            self.project().execution_context(),
-            ServerContextType::PagesData {
-                pages_dir: self.pages_dir().owned().await?,
-            },
-            self.project().next_mode(),
-            self.project().next_config(),
-            NextRuntime::NodeJs,
-            self.project().encryption_key(),
-            self.project().server_compile_time_info().environment(),
-            self.project().client_compile_time_info().environment(),
-        ))
-    }
-
-    #[turbo_tasks::function]
-    async fn edge_ssr_data_module_options_context(
-        self: Vc<Self>,
-    ) -> Result<Vc<ModuleOptionsContext>> {
-        Ok(get_server_module_options_context(
-            self.project().project_path().owned().await?,
-            self.project().execution_context(),
-            ServerContextType::PagesData {
                 pages_dir: self.pages_dir().owned().await?,
             },
             self.project().next_mode(),
@@ -652,7 +594,10 @@ struct PageEndpoint {
 enum PageEndpointType {
     Api,
     Html,
+    // A development only type that is used in pages router so we can differentiate between
+    // components changing and server props changing.
     Data,
+    // for _document.js
     SsrOnly,
 }
 
@@ -701,8 +646,15 @@ impl PageEndpoint {
 
     #[turbo_tasks::function]
     async fn source(&self) -> Result<Vc<Box<dyn Source>>> {
-        Ok(Vc::upcast(FileSource::new(
+        Ok(Vc::upcast(FileSource::new_with_query(
             self.page.file_path().owned().await?,
+            // When creating a data endpoint we also create an Html endpoint for the same source
+            // So add a query parameter to differentiate between the two.
+            if self.ty == PageEndpointType::Data {
+                rcstr!("?server-data")
+            } else {
+                RcStr::default()
+            },
         )))
     }
 
@@ -873,10 +825,10 @@ impl PageEndpoint {
                 this.pages_project.edge_ssr_module_context(),
             ),
             PageEndpointType::Data => (
-                ReferenceType::Entry(EntryReferenceSubType::Page),
+                ReferenceType::Entry(EntryReferenceSubType::PageData),
                 this.pages_project.project().project_path().owned().await?,
-                this.pages_project.ssr_data_module_context(),
-                this.pages_project.edge_ssr_data_module_context(),
+                this.pages_project.ssr_module_context(),
+                this.pages_project.edge_ssr_module_context(),
             ),
             PageEndpointType::Api => (
                 ReferenceType::Entry(EntryReferenceSubType::PagesApi),
@@ -885,10 +837,6 @@ impl PageEndpoint {
                 this.pages_project.edge_api_module_context(),
             ),
         };
-
-        let ssr_module = module_context
-            .process(self.source(), reference_type.clone())
-            .module();
 
         let config =
             parse_segment_config_from_source(self.source(), ParseSegmentMode::Base).await?;
@@ -900,6 +848,9 @@ impl PageEndpoint {
             // wrapped in the route module, and don't need to be handled as edge runtime as the
             // rendering for edge is part of the page bundle.
             if this.pathname == "/_app" || this.pathname == "/_document" {
+                let ssr_module = module_context
+                    .process(self.source(), reference_type)
+                    .module();
                 InternalSsrChunkModule {
                     ssr_module: ssr_module.to_resolved().await?,
                     app_module: None,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -6,8 +6,8 @@ use next_core::{
     hmr_entry::HmrEntryModule,
     mode::NextMode,
     next_client::{
-        ClientContextType, RuntimeEntries, get_client_module_options_context,
-        get_client_resolve_options_context, get_client_runtime_entries,
+        ClientContextType, get_client_module_options_context, get_client_resolve_options_context,
+        get_client_runtime_entries,
     },
     next_dynamic::NextDynamicTransition,
     next_edge::route_regex::get_named_middleware_regex,
@@ -18,7 +18,6 @@ use next_core::{
     next_pages::create_page_ssr_entry_module,
     next_server::{
         ServerContextType, get_server_module_options_context, get_server_resolve_options_context,
-        get_server_runtime_entries,
     },
     pages_structure::{
         PagesDirectoryStructure, PagesStructure, PagesStructureItem, find_pages_structure,
@@ -600,50 +599,6 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
-        Ok(get_server_runtime_entries(
-            ServerContextType::Pages {
-                pages_dir: self.pages_dir().owned().await?,
-            },
-            self.project().next_mode(),
-        ))
-    }
-
-    #[turbo_tasks::function]
-    async fn data_runtime_entries(self: Vc<Self>) -> Result<Vc<RuntimeEntries>> {
-        Ok(get_server_runtime_entries(
-            ServerContextType::PagesData {
-                pages_dir: self.pages_dir().owned().await?,
-            },
-            self.project().next_mode(),
-        ))
-    }
-
-    #[turbo_tasks::function]
-    fn ssr_runtime_entries(self: Vc<Self>) -> Vc<EvaluatableAssets> {
-        let ssr_runtime_entries = self.runtime_entries();
-        ssr_runtime_entries.resolve_entries(Vc::upcast(self.ssr_module_context()))
-    }
-
-    #[turbo_tasks::function]
-    fn ssr_data_runtime_entries(self: Vc<Self>) -> Vc<EvaluatableAssets> {
-        let ssr_data_runtime_entries = self.data_runtime_entries();
-        ssr_data_runtime_entries.resolve_entries(Vc::upcast(self.ssr_module_context()))
-    }
-
-    #[turbo_tasks::function]
-    fn edge_ssr_runtime_entries(self: Vc<Self>) -> Vc<EvaluatableAssets> {
-        let ssr_runtime_entries = self.runtime_entries();
-        ssr_runtime_entries.resolve_entries(Vc::upcast(self.edge_ssr_module_context()))
-    }
-
-    #[turbo_tasks::function]
-    fn edge_ssr_data_runtime_entries(self: Vc<Self>) -> Vc<EvaluatableAssets> {
-        let ssr_data_runtime_entries = self.data_runtime_entries();
-        ssr_data_runtime_entries.resolve_entries(Vc::upcast(self.edge_ssr_module_context()))
-    }
-
-    #[turbo_tasks::function]
     pub async fn client_main_module(self: Vc<Self>) -> Result<Vc<Box<dyn Module>>> {
         let client_module_context = Vc::upcast(self.client_module_context());
 
@@ -1008,8 +963,6 @@ impl PageEndpoint {
         node_path: FileSystemPath,
         node_chunking_context: Vc<NodeJsChunkingContext>,
         edge_chunking_context: Vc<Box<dyn ChunkingContext>>,
-        runtime_entries: Vc<EvaluatableAssets>,
-        edge_runtime_entries: Vc<EvaluatableAssets>,
     ) -> Result<Vc<SsrChunk>> {
         async move {
             let this = self.await?;
@@ -1126,15 +1079,9 @@ impl PageEndpoint {
                 .context("could not process page loader entry module")?;
             let is_edge = matches!(runtime, NextRuntime::Edge);
             if is_edge {
-                let edge_runtime_entries = edge_runtime_entries.await?;
-                let evaluatable_assets = edge_runtime_entries
-                    .iter()
-                    .map(|m| ResolvedVc::upcast(*m))
-                    .chain(std::iter::once(ResolvedVc::upcast(ssr_module_evaluatable)));
-
                 let edge_files = edge_chunking_context.evaluated_chunk_group_assets(
                     ssr_module.ident(),
-                    ChunkGroup::Entry(evaluatable_assets.collect()),
+                    ChunkGroup::Entry(vec![ResolvedVc::upcast(ssr_module_evaluatable)]),
                     ssr_module_graph,
                     current_availability_info,
                 );
@@ -1155,7 +1102,7 @@ impl PageEndpoint {
                 let ssr_entry_chunk = node_chunking_context
                     .entry_chunk_group_asset(
                         ssr_entry_chunk_path,
-                        runtime_entries.with_entry(*ssr_module_evaluatable),
+                        EvaluatableAssets::empty().with_entry(*ssr_module_evaluatable),
                         ssr_module_graph,
                         current_chunks,
                         current_availability_info,
@@ -1224,8 +1171,6 @@ impl PageEndpoint {
                 .join("server")?,
             project.server_chunking_context(true),
             project.edge_chunking_context(true),
-            this.pages_project.ssr_runtime_entries(),
-            this.pages_project.edge_ssr_runtime_entries(),
         ))
     }
 
@@ -1242,8 +1187,6 @@ impl PageEndpoint {
                 .join("server/data")?,
             this.pages_project.project().server_chunking_context(true),
             this.pages_project.project().edge_chunking_context(true),
-            this.pages_project.ssr_data_runtime_entries(),
-            this.pages_project.edge_ssr_data_runtime_entries(),
         ))
     }
 
@@ -1260,8 +1203,6 @@ impl PageEndpoint {
                 .join("server")?,
             this.pages_project.project().server_chunking_context(false),
             this.pages_project.project().edge_chunking_context(false),
-            this.pages_project.ssr_runtime_entries(),
-            this.pages_project.edge_ssr_runtime_entries(),
         ))
     }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1838,17 +1838,15 @@ async fn any_output_changed(
                     && (!server || !asset_path.path.ends_with(".css"))
                     && asset_path.is_inside_ref(&path)
                 {
-                    anyhow::Ok(Some(content_changed(*ResolvedVc::upcast(m))))
+                    anyhow::Ok(Some(
+                        content_changed(*ResolvedVc::upcast(m))
+                            .to_resolved()
+                            .await?,
+                    ))
                 } else {
                     Ok(None)
                 }
             }
-        })
-        .map(|v| async move {
-            Ok(match v.await? {
-                Some(v) => Some(v.to_resolved().await?),
-                None => None,
-            })
         })
         .try_flat_join()
         .await?;

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -54,14 +54,12 @@ pub async fn get_next_client_transforms_rules(
     match &context_ty {
         ClientContextType::Pages { pages_dir } => {
             if !foreign_code {
-                rules.push(
-                    get_next_pages_transforms_rule(
-                        pages_dir.clone(),
-                        ExportFilter::StripDataExports,
-                        enable_mdx_rs,
-                    )
-                    .await?,
-                );
+                rules.push(get_next_pages_transforms_rule(
+                    pages_dir.clone(),
+                    ExportFilter::StripDataExports,
+                    enable_mdx_rs,
+                    vec![],
+                )?);
                 rules.push(get_next_disallow_export_all_in_page_rule(
                     enable_mdx_rs,
                     pages_dir.clone(),

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -124,7 +124,6 @@ pub async fn get_edge_resolve_options_context(
         ty,
         ServerContextType::AppRSC { .. }
             | ServerContextType::AppRoute { .. }
-            | ServerContextType::PagesData { .. }
             | ServerContextType::Middleware { .. }
             | ServerContextType::Instrumentation { .. }
     ) {

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -345,9 +345,7 @@ pub async fn get_next_server_import_map(
 
     import_map.insert_exact_alias(rcstr!("next/dist/server/require-hook"), external);
     match ty {
-        ServerContextType::Pages { .. }
-        | ServerContextType::PagesData { .. }
-        | ServerContextType::PagesApi { .. } => {
+        ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {
             import_map.insert_exact_alias(rcstr!("react"), external);
             import_map.insert_wildcard_alias(rcstr!("react/"), external);
             import_map.insert_exact_alias(rcstr!("react-dom"), external);
@@ -494,7 +492,6 @@ pub async fn get_next_edge_import_map(
 
     match &ty {
         ServerContextType::Pages { .. }
-        | ServerContextType::PagesData { .. }
         | ServerContextType::PagesApi { .. }
         | ServerContextType::Middleware { .. }
         | ServerContextType::Instrumentation { .. } => {}
@@ -547,7 +544,6 @@ pub async fn get_next_edge_import_map(
         | ServerContextType::Middleware { .. }
         | ServerContextType::Instrumentation { .. }
         | ServerContextType::Pages { .. }
-        | ServerContextType::PagesData { .. }
         | ServerContextType::PagesApi { .. } => {
             insert_unsupported_node_internal_aliases(&mut import_map).await?;
         }
@@ -705,7 +701,6 @@ async fn insert_next_server_special_aliases(
 
     match &ty {
         ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {}
-        ServerContextType::PagesData { .. } => {}
         // the logic closely follows the one in createRSCAliases in webpack-config.ts
         ServerContextType::AppSSR { app_dir }
         | ServerContextType::AppRSC { app_dir, .. }
@@ -759,8 +754,7 @@ async fn insert_next_server_special_aliases(
                 },
             );
         }
-        ServerContextType::PagesData { .. }
-        | ServerContextType::PagesApi { .. }
+        ServerContextType::PagesApi { .. }
         | ServerContextType::AppRSC { .. }
         | ServerContextType::AppRoute { .. }
         | ServerContextType::Middleware { .. }
@@ -1243,11 +1237,12 @@ async fn insert_next_shared_aliases(
 
 #[turbo_tasks::function]
 pub async fn get_next_package(context_directory: FileSystemPath) -> Result<Vc<FileSystemPath>> {
+    let root = context_directory.root().owned().await?;
     let result = resolve(
-        context_directory.clone(),
+        context_directory,
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
         Request::parse(Pattern::Constant(rcstr!("next/package.json"))),
-        node_cjs_resolve_options(context_directory.root().owned().await?),
+        node_cjs_resolve_options(root),
     );
     let source = result
         .first_source()

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -51,7 +51,8 @@ pub async fn create_page_ssr_entry_module(
         .await?;
 
     let template_file = match (&reference_type, runtime) {
-        (ReferenceType::Entry(EntryReferenceSubType::Page), _) => {
+        (ReferenceType::Entry(EntryReferenceSubType::Page), _)
+        | (ReferenceType::Entry(EntryReferenceSubType::PageData), _) => {
             // Load the Page entry file.
             "pages.js"
         }
@@ -77,7 +78,9 @@ pub async fn create_page_ssr_entry_module(
         ("VAR_USERLAND", &inner),
     ];
 
-    if reference_type == ReferenceType::Entry(EntryReferenceSubType::Page) {
+    if reference_type == ReferenceType::Entry(EntryReferenceSubType::Page)
+        || reference_type == ReferenceType::Entry(EntryReferenceSubType::PageData)
+    {
         replacements.push(("VAR_MODULE_DOCUMENT", &inner_document));
         replacements.push(("VAR_MODULE_APP", &inner_app));
     }
@@ -89,7 +92,8 @@ pub async fn create_page_ssr_entry_module(
     // When we're building the instrumentation page (only when the
     // instrumentation file conflicts with a page also labeled
     // /instrumentation) hoist the `register` method.
-    if reference_type == ReferenceType::Entry(EntryReferenceSubType::Page)
+    if (reference_type == ReferenceType::Entry(EntryReferenceSubType::Page)
+        || reference_type == ReferenceType::Entry(EntryReferenceSubType::PageData))
         && (definition_page == "/instrumentation" || definition_page == "/src/instrumentation")
     {
         let file = &*file_content_rope(source.content().file_content()).await?;
@@ -116,28 +120,30 @@ pub async fn create_page_ssr_entry_module(
 
     let pages_structure_ref = pages_structure.await?;
 
-    let (app_module, document_module) =
-        if reference_type == ReferenceType::Entry(EntryReferenceSubType::Page) {
-            let document_module = process_global_item(
-                *pages_structure_ref.document,
-                reference_type.clone(),
-                ssr_module_context,
-            )
-            .to_resolved()
-            .await?;
-            let app_module = process_global_item(
-                *pages_structure_ref.app,
-                reference_type.clone(),
-                ssr_module_context,
-            )
-            .to_resolved()
-            .await?;
-            inner_assets.insert(inner_document, document_module);
-            inner_assets.insert(inner_app, app_module);
-            (Some(app_module), Some(document_module))
-        } else {
-            (None, None)
-        };
+    let (app_module, document_module) = if reference_type
+        == ReferenceType::Entry(EntryReferenceSubType::Page)
+        || reference_type == ReferenceType::Entry(EntryReferenceSubType::PageData)
+    {
+        let document_module = process_global_item(
+            *pages_structure_ref.document,
+            reference_type.clone(),
+            ssr_module_context,
+        )
+        .to_resolved()
+        .await?;
+        let app_module = process_global_item(
+            *pages_structure_ref.app,
+            reference_type.clone(),
+            ssr_module_context,
+        )
+        .to_resolved()
+        .await?;
+        inner_assets.insert(inner_document, document_module);
+        inner_assets.insert(inner_app, app_module);
+        (Some(app_module), Some(document_module))
+    } else {
+        (None, None)
+    };
 
     let mut ssr_module = ssr_module_context
         .process(
@@ -147,7 +153,9 @@ pub async fn create_page_ssr_entry_module(
         .module();
 
     if matches!(runtime, NextRuntime::Edge) {
-        if reference_type == ReferenceType::Entry(EntryReferenceSubType::Page) {
+        if reference_type == ReferenceType::Entry(EntryReferenceSubType::Page)
+            || reference_type == ReferenceType::Entry(EntryReferenceSubType::PageData)
+        {
             ssr_module = wrap_edge_page(
                 ssr_module_context,
                 project_root,

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -78,9 +78,12 @@ pub async fn create_page_ssr_entry_module(
         ("VAR_USERLAND", &inner),
     ];
 
-    if reference_type == ReferenceType::Entry(EntryReferenceSubType::Page)
-        || reference_type == ReferenceType::Entry(EntryReferenceSubType::PageData)
-    {
+    let is_page = matches!(
+        reference_type,
+        ReferenceType::Entry(EntryReferenceSubType::Page)
+            | ReferenceType::Entry(EntryReferenceSubType::PageData)
+    );
+    if is_page {
         replacements.push(("VAR_MODULE_DOCUMENT", &inner_document));
         replacements.push(("VAR_MODULE_APP", &inner_app));
     }
@@ -92,8 +95,7 @@ pub async fn create_page_ssr_entry_module(
     // When we're building the instrumentation page (only when the
     // instrumentation file conflicts with a page also labeled
     // /instrumentation) hoist the `register` method.
-    if (reference_type == ReferenceType::Entry(EntryReferenceSubType::Page)
-        || reference_type == ReferenceType::Entry(EntryReferenceSubType::PageData))
+    if is_page
         && (definition_page == "/instrumentation" || definition_page == "/src/instrumentation")
     {
         let file = &*file_content_rope(source.content().file_content()).await?;
@@ -108,8 +110,8 @@ pub async fn create_page_ssr_entry_module(
 
         let file = File::from(result.build());
 
-        source = Vc::upcast(VirtualSource::new(
-            source.ident().path().owned().await?,
+        source = Vc::upcast(VirtualSource::new_with_ident(
+            source.ident(),
             AssetContent::file(file.into()),
         ));
     }
@@ -120,10 +122,8 @@ pub async fn create_page_ssr_entry_module(
 
     let pages_structure_ref = pages_structure.await?;
 
-    let (app_module, document_module) = if reference_type
-        == ReferenceType::Entry(EntryReferenceSubType::Page)
-        || reference_type == ReferenceType::Entry(EntryReferenceSubType::PageData)
-    {
+    let (app_module, document_module) = if is_page {
+        // We process the document and app modules in the same context and reference type.
         let document_module = process_global_item(
             *pages_structure_ref.document,
             reference_type.clone(),
@@ -153,9 +153,7 @@ pub async fn create_page_ssr_entry_module(
         .module();
 
     if matches!(runtime, NextRuntime::Edge) {
-        if reference_type == ReferenceType::Entry(EntryReferenceSubType::Page)
-            || reference_type == ReferenceType::Entry(EntryReferenceSubType::PageData)
-        {
+        if is_page {
             ssr_module = wrap_edge_page(
                 ssr_module_context,
                 project_root,

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -87,6 +87,11 @@ pub async fn create_page_ssr_entry_module(
         replacements.push(("VAR_MODULE_DOCUMENT", &inner_document));
         replacements.push(("VAR_MODULE_APP", &inner_app));
     }
+    let source_ident = source.ident().await?;
+    // for PagesData we apply a ?server-data query parameter to avoid conflicts with the Page
+    // module.
+    // We need to copy that to all the modules we create.
+    let source_query = source_ident.query.clone();
 
     // Load the file from the next.js codebase.
     let mut source =
@@ -127,6 +132,7 @@ pub async fn create_page_ssr_entry_module(
         let document_module = process_global_item(
             *pages_structure_ref.document,
             reference_type.clone(),
+            source_query.clone(),
             ssr_module_context,
         )
         .to_resolved()
@@ -134,6 +140,7 @@ pub async fn create_page_ssr_entry_module(
         let app_module = process_global_item(
             *pages_structure_ref.app,
             reference_type.clone(),
+            source_query.clone(),
             ssr_module_context,
         )
         .to_resolved()
@@ -163,6 +170,7 @@ pub async fn create_page_ssr_entry_module(
                 reference_type,
                 pages_structure,
                 next_config,
+                source_query.clone(),
             );
         } else {
             ssr_module = wrap_edge_entry(
@@ -186,9 +194,13 @@ pub async fn create_page_ssr_entry_module(
 async fn process_global_item(
     item: Vc<PagesStructureItem>,
     reference_type: ReferenceType,
+    source_query: RcStr,
     module_context: Vc<Box<dyn AssetContext>>,
 ) -> Result<Vc<Box<dyn Module>>> {
-    let source = Vc::upcast(FileSource::new(item.file_path().owned().await?));
+    let source = Vc::upcast(FileSource::new_with_query(
+        item.file_path().owned().await?,
+        source_query,
+    ));
     Ok(module_context.process(source, reference_type).module())
 }
 
@@ -202,6 +214,7 @@ async fn wrap_edge_page(
     reference_type: ReferenceType,
     pages_structure: Vc<PagesStructure>,
     next_config: Vc<NextConfig>,
+    source_query: RcStr,
 ) -> Result<Vc<Box<dyn Module>>> {
     const INNER: &str = "INNER_PAGE_ENTRY";
 
@@ -260,16 +273,19 @@ async fn wrap_edge_page(
         INNER_DOCUMENT.into() => process_global_item(
             *pages_structure_ref.document,
             reference_type.clone(),
+            source_query.clone(),
             asset_context,
         ).to_resolved().await?,
         INNER_APP.into() => process_global_item(
             *pages_structure_ref.app,
             reference_type.clone(),
+            source_query.clone(),
             asset_context,
         ).to_resolved().await?,
         INNER_ERROR.into() => process_global_item(
             *pages_structure_ref.error,
             reference_type.clone(),
+            source_query.clone(),
             asset_context,
         ).to_resolved().await?,
     };
@@ -277,9 +293,14 @@ async fn wrap_edge_page(
     if let Some(error_500) = pages_structure_ref.error_500 {
         inner_assets.insert(
             INNER_ERROR_500.into(),
-            process_global_item(*error_500, reference_type.clone(), asset_context)
-                .to_resolved()
-                .await?,
+            process_global_item(
+                *error_500,
+                reference_type.clone(),
+                source_query.clone(),
+                asset_context,
+            )
+            .to_resolved()
+            .await?,
         );
     }
 

--- a/crates/next-core/src/next_root_params/mod.rs
+++ b/crates/next-core/src/next_root_params/mod.rs
@@ -111,8 +111,7 @@ impl NextRootParamsMapper {
                                 })?;
                             Self::valid_import_map_result(collected_root_params)
                         }
-                        ServerContextType::PagesData { .. }
-                        | ServerContextType::PagesApi { .. }
+                        ServerContextType::PagesApi { .. }
                         | ServerContextType::Instrumentation { .. }
                         | ServerContextType::Middleware { .. } => {
                             // There's no sensible way to use root params outside of the app

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -87,9 +87,6 @@ pub enum ServerContextType {
     PagesApi {
         pages_dir: FileSystemPath,
     },
-    PagesData {
-        pages_dir: FileSystemPath,
-    },
     AppSSR {
         app_dir: FileSystemPath,
     },
@@ -251,8 +248,7 @@ pub async fn get_server_resolve_options_context(
                 ResolvedVc::upcast(module_feature_report_resolve_plugin),
             ]
         }
-        ServerContextType::PagesData { .. }
-        | ServerContextType::PagesApi { .. }
+        ServerContextType::PagesApi { .. }
         | ServerContextType::AppRoute { .. }
         | ServerContextType::Middleware { .. }
         | ServerContextType::Instrumentation { .. } => {
@@ -261,9 +257,7 @@ pub async fn get_server_resolve_options_context(
     };
 
     let after_resolve_plugins = match ty {
-        ServerContextType::Pages { .. }
-        | ServerContextType::PagesApi { .. }
-        | ServerContextType::PagesData { .. } => {
+        ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {
             vec![
                 ResolvedVc::upcast(next_node_shared_runtime_plugin),
                 ResolvedVc::upcast(external_cjs_modules_plugin),
@@ -299,8 +293,7 @@ pub async fn get_server_resolve_options_context(
         ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {
             //noop
         }
-        ServerContextType::PagesData { .. }
-        | ServerContextType::AppRSC { .. }
+        ServerContextType::AppRSC { .. }
         | ServerContextType::AppRoute { .. }
         | ServerContextType::Middleware { .. }
         | ServerContextType::Instrumentation { .. } => {
@@ -614,9 +607,7 @@ pub async fn get_server_module_options_context(
     };
 
     let module_options_context = match ty {
-        ServerContextType::Pages { .. }
-        | ServerContextType::PagesData { .. }
-        | ServerContextType::PagesApi { .. } => {
+        ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {
             let mut custom_source_transform_rules: Vec<ModuleRule> =
                 vec![styled_components_transform_rule, styled_jsx_transform_rule]
                     .into_iter()

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -46,7 +46,6 @@ use crate::{
     app_structure::CollectedRootParams,
     mode::NextMode,
     next_build::get_postcss_package_mapping,
-    next_client::RuntimeEntries,
     next_config::NextConfig,
     next_font::local::NextFontLocalResolvePlugin,
     next_import_map::{get_next_edge_and_server_fallback_import_map, get_next_server_import_map},
@@ -1007,15 +1006,6 @@ pub async fn get_server_module_options_context(
     .cell();
 
     Ok(module_options_context)
-}
-
-#[turbo_tasks::function]
-pub fn get_server_runtime_entries(
-    _ty: ServerContextType,
-    _mode: Vc<NextMode>,
-) -> Vc<RuntimeEntries> {
-    let runtime_entries = vec![];
-    Vc::cell(runtime_entries)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, TaskInput, TraceRawVcs, Serialize, Deserialize)]

--- a/crates/next-core/src/next_server/mod.rs
+++ b/crates/next-core/src/next_server/mod.rs
@@ -6,5 +6,5 @@ pub use context::{
     ServerChunkingContextOptions, ServerContextType, get_server_chunking_context,
     get_server_chunking_context_with_client_assets, get_server_compile_time_info,
     get_server_module_options_context, get_server_resolve_options_context,
-    get_server_runtime_entries, get_tracing_compile_time_info,
+    get_tracing_compile_time_info,
 };

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -3,7 +3,9 @@ use next_custom_transforms::transforms::strip_page_exports::ExportFilter;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, RuleCondition};
-use turbopack_core::reference_type::{CssReferenceSubType, ReferenceType, UrlReferenceSubType};
+use turbopack_core::reference_type::{
+    CssReferenceSubType, EntryReferenceSubType, ReferenceType, UrlReferenceSubType,
+};
 
 use crate::{
     mode::NextMode,
@@ -75,26 +77,18 @@ pub async fn get_next_server_transforms_rules(
                     mdx_rs,
                     pages_dir.clone(),
                 ));
-            }
-            false
-        }
-        ServerContextType::PagesData { pages_dir } => {
-            if !foreign_code {
-                rules.push(
-                    get_next_pages_transforms_rule(
-                        pages_dir.clone(),
-                        ExportFilter::StripDefaultExport,
-                        mdx_rs,
-                    )
-                    .await?,
-                );
-                rules.push(get_next_disallow_export_all_in_page_rule(
-                    mdx_rs,
+                rules.push(get_next_pages_transforms_rule(
                     pages_dir.clone(),
-                ));
+                    ExportFilter::StripDefaultExport,
+                    mdx_rs,
+                    vec![RuleCondition::ReferenceType(ReferenceType::Entry(
+                        EntryReferenceSubType::PageData,
+                    ))],
+                )?);
             }
             false
         }
+
         ServerContextType::AppSSR { .. } => {
             // Yah, this is SSR, but this is still treated as a Client transform layer.
             // need to apply to foreign code too
@@ -232,7 +226,6 @@ pub async fn get_next_server_internal_transforms_rules(
             rules.push(get_next_font_transform_rule(mdx_rs));
         }
         ServerContextType::PagesApi { .. } => {}
-        ServerContextType::PagesData { .. } => {}
         ServerContextType::AppSSR { .. } => {
             rules.push(get_next_font_transform_rule(mdx_rs));
         }

--- a/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/crates/next-core/src/next_shared/transforms/mod.rs
@@ -71,7 +71,7 @@ pub async fn get_next_image_rule() -> Result<ModuleRule> {
     ))
 }
 
-fn match_js_extension(enable_mdx_rs: bool) -> Vec<RuleCondition> {
+fn match_js_extension(enable_mdx_rs: bool) -> RuleCondition {
     let mut conditions = vec![
         RuleCondition::ResourcePathEndsWith(".js".to_string()),
         RuleCondition::ResourcePathEndsWith(".jsx".to_string()),
@@ -98,20 +98,18 @@ fn match_js_extension(enable_mdx_rs: bool) -> Vec<RuleCondition> {
             .as_mut(),
         );
     }
-    conditions
+    RuleCondition::any(conditions)
 }
 
 /// Returns a module rule condition matches to any ecmascript (with mdx if
 /// enabled) except url reference type. This is a typical custom rule matching
 /// condition for custom ecma specific transforms.
 pub(crate) fn module_rule_match_js_no_url(enable_mdx_rs: bool) -> RuleCondition {
-    let conditions = match_js_extension(enable_mdx_rs);
-
     RuleCondition::all(vec![
         RuleCondition::not(RuleCondition::ReferenceType(ReferenceType::Url(
             UrlReferenceSubType::Undefined,
         ))),
-        RuleCondition::any(conditions),
+        match_js_extension(enable_mdx_rs),
     ])
 }
 
@@ -119,14 +117,9 @@ pub(crate) fn module_rule_match_pages_page_file(
     enable_mdx_rs: bool,
     pages_directory: FileSystemPath,
 ) -> RuleCondition {
-    let conditions = match_js_extension(enable_mdx_rs);
-
     RuleCondition::all(vec![
-        RuleCondition::not(RuleCondition::ReferenceType(ReferenceType::Url(
-            UrlReferenceSubType::Undefined,
-        ))),
+        module_rule_match_js_no_url(enable_mdx_rs),
         RuleCondition::ResourcePathInExactDirectory(pages_directory),
-        RuleCondition::any(conditions),
     ])
 }
 

--- a/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -12,33 +12,37 @@ use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform, Transfor
 use super::module_rule_match_js_no_url;
 
 /// Returns a rule which applies the Next.js page export stripping transform.
-pub async fn get_next_pages_transforms_rule(
+pub fn get_next_pages_transforms_rule(
     pages_dir: FileSystemPath,
     export_filter: ExportFilter,
     enable_mdx_rs: bool,
+    extra_conditions: impl IntoIterator<Item = RuleCondition>,
 ) -> Result<ModuleRule> {
     // Apply the Next SSG transform to all pages.
     let strip_transform =
         EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextJsStripPageExports {
             export_filter,
         }) as _));
-    Ok(ModuleRule::new(
+    let mut conditions = RuleCondition::all(vec![
         RuleCondition::all(vec![
-            RuleCondition::all(vec![
-                RuleCondition::ResourcePathInExactDirectory(pages_dir.clone()),
-                RuleCondition::not(RuleCondition::ResourcePathInExactDirectory(
-                    pages_dir.join("api")?,
-                )),
-                RuleCondition::not(RuleCondition::any(vec![
-                    // TODO(alexkirsz): Possibly ignore _app as well?
-                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.js")?),
-                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.jsx")?),
-                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.ts")?),
-                    RuleCondition::ResourcePathEquals(pages_dir.join("_document.tsx")?),
-                ])),
-            ]),
-            module_rule_match_js_no_url(enable_mdx_rs),
+            RuleCondition::ResourcePathInExactDirectory(pages_dir.clone()),
+            RuleCondition::not(RuleCondition::ResourcePathInExactDirectory(
+                pages_dir.join("api")?,
+            )),
+            RuleCondition::not(RuleCondition::any(vec![
+                // TODO(alexkirsz): Possibly ignore _app as well?
+                RuleCondition::ResourcePathEquals(pages_dir.join("_document.js")?),
+                RuleCondition::ResourcePathEquals(pages_dir.join("_document.jsx")?),
+                RuleCondition::ResourcePathEquals(pages_dir.join("_document.ts")?),
+                RuleCondition::ResourcePathEquals(pages_dir.join("_document.tsx")?),
+            ])),
         ]),
+        module_rule_match_js_no_url(enable_mdx_rs),
+        RuleCondition::all(extra_conditions.into_iter().collect()),
+    ]);
+    conditions.flatten();
+    Ok(ModuleRule::new(
+        conditions,
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {
             preprocess: ResolvedVc::cell(vec![]),
             main: ResolvedVc::cell(vec![]),

--- a/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -16,14 +16,14 @@ pub fn get_next_pages_transforms_rule(
     pages_dir: FileSystemPath,
     export_filter: ExportFilter,
     enable_mdx_rs: bool,
-    extra_conditions: impl IntoIterator<Item = RuleCondition>,
+    extra_conditions: Vec<RuleCondition>,
 ) -> Result<ModuleRule> {
     // Apply the Next SSG transform to all pages.
     let strip_transform =
         EcmascriptInputTransform::Plugin(ResolvedVc::cell(Box::new(NextJsStripPageExports {
             export_filter,
         }) as _));
-    let mut conditions = RuleCondition::all(vec![
+    let conditions = RuleCondition::all(vec![
         RuleCondition::all(vec![
             RuleCondition::ResourcePathInExactDirectory(pages_dir.clone()),
             RuleCondition::not(RuleCondition::ResourcePathInExactDirectory(
@@ -38,9 +38,8 @@ pub fn get_next_pages_transforms_rule(
             ])),
         ]),
         module_rule_match_js_no_url(enable_mdx_rs),
-        RuleCondition::all(extra_conditions.into_iter().collect()),
+        RuleCondition::all(extra_conditions),
     ]);
-    conditions.flatten();
     Ok(ModuleRule::new(
         conditions,
         vec![ModuleRuleEffect::ExtendEcmascriptTransforms {

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -271,17 +271,14 @@ async fn get_pages_structure_for_root_directory(
 
     // Only skip user pages routes during build mode when there are no user pages
     let should_create_pages_entries = has_user_pages || next_mode.await?.is_development();
+    let next_package = get_next_package(project_root.clone()).await?;
 
     let app_item = {
         let app_router_path = next_router_path.join("_app")?;
         PagesStructureItem::new(
             pages_path.join("_app")?,
             page_extensions,
-            Some(
-                get_next_package(project_root.clone())
-                    .await?
-                    .join("app.js")?,
-            ),
+            Some(next_package.join("app.js")?),
             app_router_path.clone(),
             app_router_path,
         )
@@ -292,11 +289,7 @@ async fn get_pages_structure_for_root_directory(
         PagesStructureItem::new(
             pages_path.join("_document")?,
             page_extensions,
-            Some(
-                get_next_package(project_root.clone())
-                    .await?
-                    .join("document.js")?,
-            ),
+            Some(next_package.join("document.js")?),
             document_router_path.clone(),
             document_router_path,
         )
@@ -307,11 +300,7 @@ async fn get_pages_structure_for_root_directory(
         PagesStructureItem::new(
             pages_path.join("_error")?,
             page_extensions,
-            Some(
-                get_next_package(project_root.clone())
-                    .await?
-                    .join("error.js")?,
-            ),
+            Some(next_package.join("error.js")?),
             error_router_path.clone(),
             error_router_path,
         )

--- a/crates/next-taskless/src/lib.rs
+++ b/crates/next-taskless/src/lib.rs
@@ -30,7 +30,7 @@ pub fn expand_next_js_template<'a>(
     fn replace_all<E>(
         re: &regex::Regex,
         haystack: &str,
-        mut replacement: impl FnMut(&regex::Captures) -> Result<String, E>,
+        mut replacement: impl FnMut(&regex::Captures<'_>) -> Result<String, E>,
     ) -> Result<String, E> {
         let mut new = String::with_capacity(haystack.len());
         let mut last_match = 0;

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -37,6 +37,7 @@ impl InnerAssets {
     Debug,
     Default,
     Clone,
+    Copy,
     Hash,
     TaskInput,
 )]
@@ -55,6 +56,7 @@ pub enum CommonJsReferenceSubType {
     serde::Deserialize,
     Debug,
     Clone,
+    Copy,
     Hash,
     TaskInput,
 )]
@@ -212,6 +214,7 @@ impl ImportContext {
     Debug,
     Default,
     Clone,
+    Copy,
     Hash,
     TaskInput,
 )]
@@ -239,6 +242,7 @@ pub enum CssReferenceSubType {
     Debug,
     Default,
     Clone,
+    Copy,
     Hash,
     TaskInput,
 )]
@@ -259,6 +263,7 @@ pub enum UrlReferenceSubType {
     serde::Deserialize,
     Debug,
     Clone,
+    Copy,
     Hash,
     TaskInput,
 )]
@@ -276,6 +281,7 @@ pub enum TypeScriptReferenceSubType {
     serde::Deserialize,
     Debug,
     Clone,
+    Copy,
     Hash,
     TaskInput,
 )]
@@ -298,12 +304,16 @@ pub enum WorkerReferenceSubType {
     serde::Deserialize,
     Debug,
     Clone,
+    Copy,
     Hash,
     TaskInput,
 )]
 pub enum EntryReferenceSubType {
     Web,
     Page,
+    // A development only type that is used in pages router to differentiate between server prop
+    // changes and template changes.
+    PageData,
     PagesApi,
     AppPage,
     AppRoute,

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -490,10 +490,10 @@ async fn process_default_internal(
     reference_type: ReferenceType,
     processed_rules: Vec<usize>,
 ) -> Result<Vc<ProcessResult>> {
-    let ident = source.ident().resolve().await?;
+    let ident = source.ident().to_resolved().await?;
     let path_ref = ident.path().await?;
     let options = ModuleOptions::new(
-        ident.path().await?.parent(),
+        path_ref.parent(),
         module_asset_context.module_options_context(),
         module_asset_context.resolve_options_context(),
     );
@@ -539,7 +539,7 @@ async fn process_default_internal(
                     ModuleRuleEffect::SourceTransforms(transforms) => {
                         current_source =
                             transforms.transform(*current_source).to_resolved().await?;
-                        if current_source.ident().resolve().await? != ident {
+                        if current_source.ident().to_resolved().await? != ident {
                             // The ident has been changed, so we need to apply new rules.
                             if let Some(transition) = module_asset_context
                                 .await?
@@ -615,7 +615,7 @@ async fn process_default_internal(
                             }),
                             Some(module_type) => {
                                 ModuleIssue {
-                                    ident: ident.to_resolved().await?,
+                                    ident,
                                     title: StyledString::Text(rcstr!("Invalid module type"))
                                         .resolved_cell(),
                                     description: StyledString::Text(rcstr!(
@@ -631,7 +631,7 @@ async fn process_default_internal(
                             }
                             None => {
                                 ModuleIssue {
-                                    ident: ident.to_resolved().await?,
+                                    ident,
                                     title: StyledString::Text(rcstr!("Missing module type"))
                                         .resolved_cell(),
                                     description: StyledString::Text(rcstr!(

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -21,7 +21,8 @@ pub struct ModuleRule {
 
 impl ModuleRule {
     /// Creates a new module rule. Will not match internal references.
-    pub fn new(condition: RuleCondition, effects: Vec<ModuleRuleEffect>) -> Self {
+    pub fn new(mut condition: RuleCondition, effects: Vec<ModuleRuleEffect>) -> Self {
+        condition.flatten();
         ModuleRule {
             condition,
             effects,
@@ -30,7 +31,8 @@ impl ModuleRule {
     }
 
     /// Creates a new module rule. Will only match internal references.
-    pub fn new_internal(condition: RuleCondition, effects: Vec<ModuleRuleEffect>) -> Self {
+    pub fn new_internal(mut condition: RuleCondition, effects: Vec<ModuleRuleEffect>) -> Self {
+        condition.flatten();
         ModuleRule {
             condition,
             effects,
@@ -39,7 +41,8 @@ impl ModuleRule {
     }
 
     /// Creates a new module rule. Will match all references.
-    pub fn new_all(condition: RuleCondition, effects: Vec<ModuleRuleEffect>) -> Self {
+    pub fn new_all(mut condition: RuleCondition, effects: Vec<ModuleRuleEffect>) -> Self {
+        condition.flatten();
         ModuleRule {
             condition,
             effects,


### PR DESCRIPTION
SSR data is a special module context for development usecases to help with HMR of pages router pages.  This allows us to transform pages to strip the Component export, then the dev server can tell the difference between server side and client side changes which informs what kind of refresh we need to do.

Instead, create a new `ReferenceEntrySubType` and configure the `export stripping` transform to trigger using that.  This is a better approach since we only need to transform that module instead of putting a lot of dependencies in the new module-context and assert layer.

This should be a development time performance improvement for pages router

Finally delete a number of the `_runtime_entries` functions for server contexts.  These were always empty and were a user of the `ServerContextType::PagesData` enum varient that was being deleted.  

Closes PACK-4155