### PR TITLE
Development: Make 'ready in' 195ms faster

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -333,6 +333,8 @@ async function startWatcher(
     files.push(...tsconfigPaths)
 
     const wp = new Watchpack({
+      // Watchpack default is 200ms which adds 200ms of dead time on bootup.
+      aggregateTimeout: 5, // Matches webpack-config.ts.
       ignored: (pathname: string) => {
         return (
           !files.some((file) => file.startsWith(pathname)) &&


### PR DESCRIPTION
## What?

The Watchpack instance created defaulted to `aggregateTimeout: 200` which causes 200ms of dead time during bootup, affecting the `ready in`  logline.

Before:

```
 ✓ Starting...
 ✓ Ready in 583ms
```

After: 
```
 ✓ Starting...
 ✓ Ready in 355ms // -39.1%
```

Next up:
- `~50ms`: Remove loading webpack when Turbopack is used (it still gets required currently for `next.config.js`)
- `~110ms`: Figure out how to avoid loading TypeScript which is used to check `tsconfig.json` options. 

Closes PACK-5437