### PR TITLE
Remove clientParamParsing requirement from RDC for Navigations

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1574,12 +1574,7 @@ export default async function build(
                 // Once we've made RDC for Navigations the default for PPR, we
                 // can remove the check for `config.experimental.rdcForNavigations`.
                 isAppPPREnabled &&
-                config.experimental.rdcForNavigations === true &&
-                // Temporarily we require that clientParamParsing is enabled for
-                // RDC for Navigations. This is due to a builder configuration
-                // bug that manifests as invalid query params being passed to
-                // the resume lambdas.
-                config.experimental.clientParamParsing === true,
+                config.experimental.rdcForNavigations === true,
             },
             rewriteHeaders: {
               pathHeader: NEXT_REWRITTEN_PATH_HEADER,
@@ -2199,7 +2194,8 @@ export default async function build(
 
                       if (pageType === 'app' && originalAppPath) {
                         appNormalizedPaths.set(originalAppPath, page)
-                        // TODO-APP: handle prerendering with edge
+
+                        // Edge runtime doesn't support static generation.
                         if (isEdgeRuntime(pageRuntime)) {
                           isStatic = false
                           isSSG = false

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -294,13 +294,7 @@ export async function handler(
   // When a page supports PPR, we can support RSC for Navigations so long as the
   // feature is not disabled.
   const supportsRSCForNavigations =
-    isRoutePPREnabled &&
-    nextConfig.experimental.rdcForNavigations === true &&
-    // Temporarily we require that clientParamParsing is enabled for
-    // RDC for Navigations. This is due to a builder configuration
-    // bug that manifests as invalid query params being passed to
-    // the resume lambdas.
-    nextConfig.experimental.clientParamParsing === true
+    isRoutePPREnabled && nextConfig.experimental.rdcForNavigations === true
 
   // In development, we always want to generate dynamic HTML.
   const supportsDynamicResponse: boolean =


### PR DESCRIPTION
### What?

Removes the temporary constraint that required `clientParamParsing` to be enabled for Resume Data Cache (RDC) for Navigations in PPR-enabled applications.

### Why?

The upstream builder configuration issue that caused invalid query parameters to be passed to resume lambdas has been resolved. The `clientParamParsing` requirement was a temporary workaround that can now be safely removed.

This enhancement allows more users on PPR to automatically benefit from RDC for RSC requests, improving performance by eliminating waterfalls when resuming prerendered pages without requiring additional feature flags.

### How?

- Removed the `clientParamParsing` check from both build configuration and app-page template
- Simplified the feature enablement logic for RDC in navigation scenarios

The change affects two files:
- `packages/next/src/build/index.ts`: Build-time configuration logic
- `packages/next/src/build/templates/app-page.ts`: Runtime navigation support detection

NAR-385