### PR TITLE
Cherry-pick v15.5.3 release commit

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -16,5 +16,5 @@
       "registry": "https://registry.npmjs.org/"
     }
   },
-  "version": "15.5.1-canary.39"
+  "version": "15.5.3"
 }

--- a/packages/create-next-app/package.json
+++ b/packages/create-next-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-next-app",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "keywords": [
     "react",
     "next",

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-next",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "description": "ESLint configuration used by Next.js.",
   "main": "index.js",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "homepage": "https://nextjs.org/docs/app/api-reference/config/eslint",
   "dependencies": {
-    "@next/eslint-plugin-next": "15.5.1-canary.39",
+    "@next/eslint-plugin-next": "15.5.3",
     "@rushstack/eslint-patch": "^1.10.3",
     "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
     "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",

--- a/packages/eslint-plugin-internal/package.json
+++ b/packages/eslint-plugin-internal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@next/eslint-plugin-internal",
   "private": true,
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "description": "ESLint plugin for working on Next.js.",
   "exports": {
     ".": "./src/eslint-plugin-internal.js"

--- a/packages/eslint-plugin-next/package.json
+++ b/packages/eslint-plugin-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/eslint-plugin-next",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "description": "ESLint plugin for Next.js.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@next/font",
   "private": true,
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "repository": {
     "url": "vercel/next.js",
     "directory": "packages/font"

--- a/packages/next-bundle-analyzer/package.json
+++ b/packages/next-bundle-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/bundle-analyzer",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "main": "index.js",
   "types": "index.d.ts",
   "license": "MIT",

--- a/packages/next-codemod/package.json
+++ b/packages/next-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/codemod",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/next-env/package.json
+++ b/packages/next-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/env",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "keywords": [
     "react",
     "next",

--- a/packages/next-mdx/package.json
+++ b/packages/next-mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/mdx",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "main": "index.js",
   "license": "MIT",
   "repository": {

--- a/packages/next-plugin-storybook/package.json
+++ b/packages/next-plugin-storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/plugin-storybook",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "repository": {
     "url": "vercel/next.js",
     "directory": "packages/next-plugin-storybook"

--- a/packages/next-polyfill-module/package.json
+++ b/packages/next-polyfill-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/polyfill-module",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "description": "A standard library polyfill for ES Modules supporting browsers (Edge 16+, Firefox 60+, Chrome 61+, Safari 10.1+)",
   "main": "dist/polyfill-module.js",
   "license": "MIT",

--- a/packages/next-polyfill-nomodule/package.json
+++ b/packages/next-polyfill-nomodule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/polyfill-nomodule",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "description": "A polyfill for non-dead, nomodule browsers.",
   "main": "dist/polyfill-nomodule.js",
   "license": "MIT",

--- a/packages/next-rspack/package.json
+++ b/packages/next-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-rspack",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "repository": {
     "url": "vercel/next.js",
     "directory": "packages/next-rspack"

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/swc",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "private": true,
   "files": [
     "native/"

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "description": "The React Framework",
   "main": "./dist/server/next.js",
   "license": "MIT",
@@ -102,7 +102,7 @@
     ]
   },
   "dependencies": {
-    "@next/env": "15.5.1-canary.39",
+    "@next/env": "15.5.3",
     "@swc/helpers": "0.5.15",
     "caniuse-lite": "^1.0.30001579",
     "postcss": "8.4.31",
@@ -166,11 +166,11 @@
     "@jest/types": "29.5.0",
     "@mswjs/interceptors": "0.23.0",
     "@napi-rs/triples": "1.2.0",
-    "@next/font": "15.5.1-canary.39",
-    "@next/polyfill-module": "15.5.1-canary.39",
-    "@next/polyfill-nomodule": "15.5.1-canary.39",
-    "@next/react-refresh-utils": "15.5.1-canary.39",
-    "@next/swc": "15.5.1-canary.39",
+    "@next/font": "15.5.3",
+    "@next/polyfill-module": "15.5.3",
+    "@next/polyfill-nomodule": "15.5.3",
+    "@next/react-refresh-utils": "15.5.3",
+    "@next/swc": "15.5.3",
     "@opentelemetry/api": "1.6.0",
     "@playwright/test": "1.51.1",
     "@rspack/core": "1.5.0",

--- a/packages/react-refresh-utils/package.json
+++ b/packages/react-refresh-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/react-refresh-utils",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "description": "An experimental package providing utilities for React Refresh.",
   "repository": {
     "url": "vercel/next.js",

--- a/packages/third-parties/package.json
+++ b/packages/third-parties/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/third-parties",
-  "version": "15.5.1-canary.39",
+  "version": "15.5.3",
   "repository": {
     "url": "vercel/next.js",
     "directory": "packages/third-parties"
@@ -26,7 +26,7 @@
     "third-party-capital": "1.0.20"
   },
   "devDependencies": {
-    "next": "15.5.1-canary.39",
+    "next": "15.5.3",
     "outdent": "0.8.0",
     "prettier": "2.5.1",
     "typescript": "5.8.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -856,7 +856,7 @@ importers:
   packages/eslint-config-next:
     dependencies:
       '@next/eslint-plugin-next':
-        specifier: 15.5.1-canary.39
+        specifier: 15.5.3
         version: link:../eslint-plugin-next
       '@rushstack/eslint-patch':
         specifier: ^1.10.3
@@ -926,7 +926,7 @@ importers:
   packages/next:
     dependencies:
       '@next/env':
-        specifier: 15.5.1-canary.39
+        specifier: 15.5.3
         version: link:../next-env
       '@swc/helpers':
         specifier: 0.5.15
@@ -1051,19 +1051,19 @@ importers:
         specifier: 1.2.0
         version: 1.2.0
       '@next/font':
-        specifier: 15.5.1-canary.39
+        specifier: 15.5.3
         version: link:../font
       '@next/polyfill-module':
-        specifier: 15.5.1-canary.39
+        specifier: 15.5.3
         version: link:../next-polyfill-module
       '@next/polyfill-nomodule':
-        specifier: 15.5.1-canary.39
+        specifier: 15.5.3
         version: link:../next-polyfill-nomodule
       '@next/react-refresh-utils':
-        specifier: 15.5.1-canary.39
+        specifier: 15.5.3
         version: link:../react-refresh-utils
       '@next/swc':
-        specifier: 15.5.1-canary.39
+        specifier: 15.5.3
         version: link:../next-swc
       '@opentelemetry/api':
         specifier: 1.6.0
@@ -1766,7 +1766,7 @@ importers:
         version: 1.0.20
     devDependencies:
       next:
-        specifier: 15.5.1-canary.39
+        specifier: 15.5.3
         version: link:../next
       outdent:
         specifier: 0.8.0


### PR DESCRIPTION
### Why?

v15.5.3 was released by https://github.com/vercel/next.js/actions/runs/17626862581/job/50085836950, but the version of `lerna.json` was not updated back on the `canary` branch. This resulted in `canary` branch publishing canaries on 15.5.1. 

### How?

Cherry-pick the commit 07d1cbc9c6393b5e7972edc7c0e33587b79f9943