### PR TITLE
Turbopack: mode to disable tracing

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -28,7 +28,7 @@ use turbopack_core::{
     module_graph::export_usage::OptionExportUsageInfo,
     resolve::{parse::Request, pattern::Pattern},
 };
-use turbopack_ecmascript::{TracingMode, TypeofWindow, chunk::EcmascriptChunkType};
+use turbopack_ecmascript::{AnalyzeMode, TypeofWindow, chunk::EcmascriptChunkType};
 use turbopack_node::{
     execution_context::ExecutionContext,
     transforms::postcss::{PostCssConfigLocation, PostCssTransformOptions},
@@ -338,12 +338,12 @@ pub async fn get_client_module_options_context(
         side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
         keep_last_successful_parse: next_mode.is_development(),
         tracing_mode: if next_mode.is_development() {
-            TracingMode::Bundling
+            AnalyzeMode::CodeGeneration
         } else {
             // Technically, this doesn't need to tracing for the client context. But this will
             // result in more cache hits for the analysis for modules which are loaded for both ssr
             // and client
-            TracingMode::BundlingWithTracing
+            AnalyzeMode::CodeGenerationAndTracing
         },
         ..Default::default()
     };

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -337,7 +337,7 @@ pub async fn get_client_module_options_context(
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
         keep_last_successful_parse: next_mode.is_development(),
-        tracing_mode: if next_mode.is_development() {
+        analyze_mode: if next_mode.is_development() {
             AnalyzeMode::CodeGeneration
         } else {
             // Technically, this doesn't need to tracing for the client context. But this will

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -28,7 +28,7 @@ use turbopack_core::{
     module_graph::export_usage::OptionExportUsageInfo,
     resolve::{parse::Request, pattern::Pattern},
 };
-use turbopack_ecmascript::{TypeofWindow, chunk::EcmascriptChunkType};
+use turbopack_ecmascript::{TracingMode, TypeofWindow, chunk::EcmascriptChunkType};
 use turbopack_node::{
     execution_context::ExecutionContext,
     transforms::postcss::{PostCssConfigLocation, PostCssTransformOptions},
@@ -337,6 +337,14 @@ pub async fn get_client_module_options_context(
         enable_postcss_transform,
         side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
         keep_last_successful_parse: next_mode.is_development(),
+        tracing_mode: if next_mode.is_development() {
+            TracingMode::Bundling
+        } else {
+            // Technically, this doesn't need to tracing for the client context. But this will
+            // result in more cache hits for the analysis for modules which are loaded for both ssr
+            // and client
+            TracingMode::BundlingWithTracing
+        },
         ..Default::default()
     };
 

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -27,7 +27,7 @@ use turbopack_core::{
     target::CompileTarget,
 };
 use turbopack_ecmascript::{
-    TypeofWindow, chunk::EcmascriptChunkType, references::esm::UrlRewriteBehavior,
+    TracingMode, TypeofWindow, chunk::EcmascriptChunkType, references::esm::UrlRewriteBehavior,
 };
 use turbopack_ecmascript_plugins::transform::directives::{
     client::ClientDirectiveTransformer, client_disallowed::ClientDisallowedDirectiveTransformer,
@@ -592,6 +592,11 @@ pub async fn get_server_module_options_context(
         },
         tree_shaking_mode: tree_shaking_mode_for_user_code,
         side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
+        tracing_mode: if next_mode.is_development() {
+            TracingMode::Bundling
+        } else {
+            TracingMode::BundlingWithTracing
+        },
         enable_externals_tracing: if next_mode.is_production() {
             Some(
                 ExternalsTracingOptions {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -592,7 +592,7 @@ pub async fn get_server_module_options_context(
         },
         tree_shaking_mode: tree_shaking_mode_for_user_code,
         side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
-        tracing_mode: if next_mode.is_development() {
+        analyze_mode: if next_mode.is_development() {
             AnalyzeMode::CodeGeneration
         } else {
             AnalyzeMode::CodeGenerationAndTracing

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -27,7 +27,7 @@ use turbopack_core::{
     target::CompileTarget,
 };
 use turbopack_ecmascript::{
-    TracingMode, TypeofWindow, chunk::EcmascriptChunkType, references::esm::UrlRewriteBehavior,
+    AnalyzeMode, TypeofWindow, chunk::EcmascriptChunkType, references::esm::UrlRewriteBehavior,
 };
 use turbopack_ecmascript_plugins::transform::directives::{
     client::ClientDirectiveTransformer, client_disallowed::ClientDisallowedDirectiveTransformer,
@@ -593,9 +593,9 @@ pub async fn get_server_module_options_context(
         tree_shaking_mode: tree_shaking_mode_for_user_code,
         side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
         tracing_mode: if next_mode.is_development() {
-            TracingMode::Bundling
+            AnalyzeMode::CodeGeneration
         } else {
-            TracingMode::BundlingWithTracing
+            AnalyzeMode::CodeGenerationAndTracing
         },
         enable_externals_tracing: if next_mode.is_production() {
             Some(

--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -17,11 +17,14 @@ use turbopack_core::{
     environment::{Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
     target::CompileTarget,
 };
-use turbopack_ecmascript::analyzer::{
-    graph::{EvalContext, VarGraph, VarMeta, create_graph},
-    imports::ImportAttributes,
-    linker::link,
-    test_utils::{early_visitor, visitor},
+use turbopack_ecmascript::{
+    TracingMode,
+    analyzer::{
+        graph::{EvalContext, VarGraph, VarMeta, create_graph},
+        imports::ImportAttributes,
+        linker::link,
+        test_utils::{early_visitor, visitor},
+    },
 };
 
 pub fn benchmark(c: &mut Criterion) {
@@ -62,7 +65,8 @@ pub fn benchmark(c: &mut Criterion) {
                     None,
                     None,
                 );
-                let var_graph = create_graph(&program, &eval_context, false);
+                let var_graph =
+                    create_graph(&program, &eval_context, TracingMode::BundlingWithTracing);
 
                 let input = BenchInput {
                     program,
@@ -88,7 +92,13 @@ struct BenchInput {
 }
 
 fn bench_create_graph(b: &mut Bencher, input: &BenchInput) {
-    b.iter(|| create_graph(&input.program, &input.eval_context, false));
+    b.iter(|| {
+        create_graph(
+            &input.program,
+            &input.eval_context,
+            TracingMode::BundlingWithTracing,
+        )
+    });
 }
 
 fn bench_link(b: &mut Bencher, input: &BenchInput) {

--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -18,7 +18,7 @@ use turbopack_core::{
     target::CompileTarget,
 };
 use turbopack_ecmascript::{
-    TracingMode,
+    AnalyzeMode,
     analyzer::{
         graph::{EvalContext, VarGraph, VarMeta, create_graph},
         imports::ImportAttributes,
@@ -65,8 +65,11 @@ pub fn benchmark(c: &mut Criterion) {
                     None,
                     None,
                 );
-                let var_graph =
-                    create_graph(&program, &eval_context, TracingMode::BundlingWithTracing);
+                let var_graph = create_graph(
+                    &program,
+                    &eval_context,
+                    AnalyzeMode::CodeGenerationAndTracing,
+                );
 
                 let input = BenchInput {
                     program,
@@ -96,7 +99,7 @@ fn bench_create_graph(b: &mut Bencher, input: &BenchInput) {
         create_graph(
             &input.program,
             &input.eval_context,
-            TracingMode::BundlingWithTracing,
+            AnalyzeMode::CodeGenerationAndTracing,
         )
     });
 }

--- a/turbopack/crates/turbopack-ecmascript/benches/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/references.rs
@@ -50,7 +50,7 @@ pub fn benchmark(c: &mut Criterion) {
             .resolved_cell();
 
             let mut cases = vec![];
-            for (file, is_tracing) in [
+            for (file, tracing_mode) in [
                 (r#"packages-bundle.js"#, false),
                 (r#"packages-bundle.js"#, true),
                 (r#"app-page-turbo.runtime.prod.js"#, false),
@@ -68,7 +68,11 @@ pub fn benchmark(c: &mut Criterion) {
                     EcmascriptInputTransforms::empty().to_resolved().await?,
                     EcmascriptOptions {
                         tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
-                        is_tracing,
+                        tracing_mode: if tracing_mode {
+                            turbopack_ecmascript::TracingMode::TracingOnly
+                        } else {
+                            turbopack_ecmascript::TracingMode::BundlingWithTracing
+                        },
                         ..Default::default()
                     }
                     .resolved_cell(),
@@ -80,7 +84,7 @@ pub fn benchmark(c: &mut Criterion) {
 
                 cases.push((
                     file.rsplit("/").next().unwrap(),
-                    if is_tracing { "tracing" } else { "full" },
+                    if tracing_mode { "tracing" } else { "full" },
                     module,
                 ));
             }

--- a/turbopack/crates/turbopack-ecmascript/benches/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/references.rs
@@ -69,9 +69,9 @@ pub fn benchmark(c: &mut Criterion) {
                     EcmascriptOptions {
                         tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
                         tracing_mode: if tracing_mode {
-                            turbopack_ecmascript::TracingMode::TracingOnly
+                            turbopack_ecmascript::AnalyzeMode::Tracing
                         } else {
-                            turbopack_ecmascript::TracingMode::BundlingWithTracing
+                            turbopack_ecmascript::AnalyzeMode::CodeGenerationAndTracing
                         },
                         ..Default::default()
                     }

--- a/turbopack/crates/turbopack-ecmascript/benches/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/references.rs
@@ -50,7 +50,7 @@ pub fn benchmark(c: &mut Criterion) {
             .resolved_cell();
 
             let mut cases = vec![];
-            for (file, tracing_mode) in [
+            for (file, analyze_mode) in [
                 (r#"packages-bundle.js"#, false),
                 (r#"packages-bundle.js"#, true),
                 (r#"app-page-turbo.runtime.prod.js"#, false),
@@ -68,7 +68,7 @@ pub fn benchmark(c: &mut Criterion) {
                     EcmascriptInputTransforms::empty().to_resolved().await?,
                     EcmascriptOptions {
                         tree_shaking_mode: Some(TreeShakingMode::ReexportsOnly),
-                        tracing_mode: if tracing_mode {
+                        analyze_mode: if analyze_mode {
                             turbopack_ecmascript::AnalyzeMode::Tracing
                         } else {
                             turbopack_ecmascript::AnalyzeMode::CodeGenerationAndTracing
@@ -84,7 +84,7 @@ pub fn benchmark(c: &mut Criterion) {
 
                 cases.push((
                     file.rsplit("/").next().unwrap(),
-                    if tracing_mode { "tracing" } else { "full" },
+                    if analyze_mode { "tracing" } else { "full" },
                     module,
                 ));
             }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -29,7 +29,7 @@ use super::{
     is_unresolved_id,
 };
 use crate::{
-    SpecifiedModuleType,
+    SpecifiedModuleType, TracingMode,
     analyzer::{WellKnownObjectKind, is_unresolved},
     references::constant_value::parse_single_expr_lit,
     utils::{AstPathRange, unparen},
@@ -330,7 +330,11 @@ impl VarGraph {
 
 /// You should use same [Mark] for this function and
 /// [swc_ecma_transforms_base::resolver::resolver_with_mark]
-pub fn create_graph(m: &Program, eval_context: &EvalContext, is_tracing: bool) -> VarGraph {
+pub fn create_graph(
+    m: &Program,
+    eval_context: &EvalContext,
+    tracing_mode: TracingMode,
+) -> VarGraph {
     let mut graph = VarGraph {
         values: Default::default(),
         free_var_ids: Default::default(),
@@ -339,7 +343,7 @@ pub fn create_graph(m: &Program, eval_context: &EvalContext, is_tracing: bool) -
 
     m.visit_with_ast_path(
         &mut Analyzer {
-            is_tracing,
+            tracing_mode,
             data: &mut graph,
             state: analyzer_state::AnalyzerState::new(),
             eval_context,
@@ -860,7 +864,7 @@ pub fn as_parent_path_skip(
 }
 
 struct Analyzer<'a> {
-    is_tracing: bool,
+    tracing_mode: TracingMode,
 
     data: &'a mut VarGraph,
     state: analyzer_state::AnalyzerState,
@@ -1467,7 +1471,7 @@ impl Analyzer<'_> {
         member_expr: &'ast MemberExpr,
         ast_path: &AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        if self.is_tracing {
+        if !self.tracing_mode.is_code_gen() {
             return;
         }
 
@@ -1501,7 +1505,7 @@ impl Analyzer<'_> {
                     start_ast_path,
                 } => {
                     self.effects = prev_effects;
-                    if !self.is_tracing {
+                    if self.tracing_mode.is_code_gen() {
                         self.effects.push(Effect::Unreachable { start_ast_path });
                     }
                     always_returns = true;
@@ -2229,7 +2233,7 @@ impl VisitAstPath for Analyzer<'_> {
         }
 
         // If this identifier is free, produce an effect so we can potentially replace it later.
-        if !self.is_tracing
+        if self.tracing_mode.is_code_gen()
             && let JsValue::FreeVar(var) = self.eval_context.eval_ident(ident)
         {
             // TODO(lukesandberg): we should consider filtering effects here, e.g. there is no
@@ -2267,7 +2271,7 @@ impl VisitAstPath for Analyzer<'_> {
             return;
         }
 
-        if !self.is_tracing {
+        if self.tracing_mode.is_code_gen() {
             // Otherwise 'this' is free
             self.add_effect(Effect::FreeVar {
                 var: atom!("this"),
@@ -2282,7 +2286,7 @@ impl VisitAstPath for Analyzer<'_> {
         expr: &'ast MetaPropExpr,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        if !self.is_tracing && expr.kind == MetaPropKind::ImportMeta {
+        if self.tracing_mode.is_code_gen() && expr.kind == MetaPropKind::ImportMeta {
             // MetaPropExpr also covers `new.target`. Only consider `import.meta`
             // an effect.
             self.add_effect(Effect::ImportMeta {
@@ -2533,7 +2537,7 @@ impl VisitAstPath for Analyzer<'_> {
         n: &'ast UnaryExpr,
         ast_path: &mut swc_core::ecma::visit::AstNodePath<'r>,
     ) {
-        if n.op == UnaryOp::TypeOf && !self.is_tracing {
+        if n.op == UnaryOp::TypeOf && self.tracing_mode.is_code_gen() {
             let arg_value = Box::new(self.eval_context.eval(&n.arg));
 
             self.add_effect(Effect::TypeOf {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -333,7 +333,7 @@ impl VarGraph {
 pub fn create_graph(
     m: &Program,
     eval_context: &EvalContext,
-    tracing_mode: AnalyzeMode,
+    analyze_mode: AnalyzeMode,
 ) -> VarGraph {
     let mut graph = VarGraph {
         values: Default::default(),
@@ -343,7 +343,7 @@ pub fn create_graph(
 
     m.visit_with_ast_path(
         &mut Analyzer {
-            tracing_mode,
+            analyze_mode,
             data: &mut graph,
             state: analyzer_state::AnalyzerState::new(),
             eval_context,
@@ -864,7 +864,7 @@ pub fn as_parent_path_skip(
 }
 
 struct Analyzer<'a> {
-    tracing_mode: AnalyzeMode,
+    analyze_mode: AnalyzeMode,
 
     data: &'a mut VarGraph,
     state: analyzer_state::AnalyzerState,
@@ -1471,7 +1471,7 @@ impl Analyzer<'_> {
         member_expr: &'ast MemberExpr,
         ast_path: &AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        if !self.tracing_mode.is_code_gen() {
+        if !self.analyze_mode.is_code_gen() {
             return;
         }
 
@@ -1505,7 +1505,7 @@ impl Analyzer<'_> {
                     start_ast_path,
                 } => {
                     self.effects = prev_effects;
-                    if self.tracing_mode.is_code_gen() {
+                    if self.analyze_mode.is_code_gen() {
                         self.effects.push(Effect::Unreachable { start_ast_path });
                     }
                     always_returns = true;
@@ -2233,7 +2233,7 @@ impl VisitAstPath for Analyzer<'_> {
         }
 
         // If this identifier is free, produce an effect so we can potentially replace it later.
-        if self.tracing_mode.is_code_gen()
+        if self.analyze_mode.is_code_gen()
             && let JsValue::FreeVar(var) = self.eval_context.eval_ident(ident)
         {
             // TODO(lukesandberg): we should consider filtering effects here, e.g. there is no
@@ -2271,7 +2271,7 @@ impl VisitAstPath for Analyzer<'_> {
             return;
         }
 
-        if self.tracing_mode.is_code_gen() {
+        if self.analyze_mode.is_code_gen() {
             // Otherwise 'this' is free
             self.add_effect(Effect::FreeVar {
                 var: atom!("this"),
@@ -2286,7 +2286,7 @@ impl VisitAstPath for Analyzer<'_> {
         expr: &'ast MetaPropExpr,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        if self.tracing_mode.is_code_gen() && expr.kind == MetaPropKind::ImportMeta {
+        if self.analyze_mode.is_code_gen() && expr.kind == MetaPropKind::ImportMeta {
             // MetaPropExpr also covers `new.target`. Only consider `import.meta`
             // an effect.
             self.add_effect(Effect::ImportMeta {
@@ -2537,7 +2537,7 @@ impl VisitAstPath for Analyzer<'_> {
         n: &'ast UnaryExpr,
         ast_path: &mut swc_core::ecma::visit::AstNodePath<'r>,
     ) {
-        if n.op == UnaryOp::TypeOf && self.tracing_mode.is_code_gen() {
+        if n.op == UnaryOp::TypeOf && self.analyze_mode.is_code_gen() {
             let arg_value = Box::new(self.eval_context.eval(&n.arg));
 
             self.add_effect(Effect::TypeOf {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -29,7 +29,7 @@ use super::{
     is_unresolved_id,
 };
 use crate::{
-    SpecifiedModuleType, TracingMode,
+    AnalyzeMode, SpecifiedModuleType,
     analyzer::{WellKnownObjectKind, is_unresolved},
     references::constant_value::parse_single_expr_lit,
     utils::{AstPathRange, unparen},
@@ -333,7 +333,7 @@ impl VarGraph {
 pub fn create_graph(
     m: &Program,
     eval_context: &EvalContext,
-    tracing_mode: TracingMode,
+    tracing_mode: AnalyzeMode,
 ) -> VarGraph {
     let mut graph = VarGraph {
         values: Default::default(),
@@ -864,7 +864,7 @@ pub fn as_parent_path_skip(
 }
 
 struct Analyzer<'a> {
-    tracing_mode: TracingMode,
+    tracing_mode: AnalyzeMode,
 
     data: &'a mut VarGraph,
     state: analyzer_state::AnalyzerState,

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3814,7 +3814,7 @@ mod tests {
         linker::link,
     };
     use crate::{
-        TracingMode,
+        AnalyzeMode,
         analyzer::{
             graph::{AssignmentScopes, VarMeta},
             imports::ImportAttributes,
@@ -3861,7 +3861,7 @@ mod tests {
                 );
 
                 let mut var_graph =
-                    create_graph(&m, &eval_context, TracingMode::BundlingWithTracing);
+                    create_graph(&m, &eval_context, AnalyzeMode::CodeGenerationAndTracing);
                 let var_cache = Default::default();
 
                 let mut named_values = var_graph

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -3813,9 +3813,12 @@ mod tests {
         graph::{ConditionalKind, Effect, EffectArg, EvalContext, VarGraph, create_graph},
         linker::link,
     };
-    use crate::analyzer::{
-        graph::{AssignmentScopes, VarMeta},
-        imports::ImportAttributes,
+    use crate::{
+        TracingMode,
+        analyzer::{
+            graph::{AssignmentScopes, VarMeta},
+            imports::ImportAttributes,
+        },
     };
 
     #[fixture("tests/analyzer/graph/**/input.js")]
@@ -3857,7 +3860,8 @@ mod tests {
                     None,
                 );
 
-                let mut var_graph = create_graph(&m, &eval_context, false);
+                let mut var_graph =
+                    create_graph(&m, &eval_context, TracingMode::BundlingWithTracing);
                 let var_cache = Default::default();
 
                 let mut named_values = var_graph

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -264,7 +264,7 @@ pub struct EcmascriptOptions {
     pub keep_last_successful_parse: bool,
     /// Whether the modules in this context are never chunked/codegen-ed, but only used for
     /// tracing.
-    pub tracing_mode: AnalyzeMode,
+    pub analyze_mode: AnalyzeMode,
     // TODO this should just be handled via CompileTimeInfo FreeVarReferences, but then it
     // (currently) wouldn't be possible to have different replacement values in user code vs
     // node_modules.

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -189,28 +189,29 @@ pub enum TreeShakingMode {
     TraceRawVcs,
     NonLocalValue,
 )]
-pub enum TracingMode {
-    /// Only bundling, no tracing of referenced files.
+pub enum AnalyzeMode {
+    /// For bundling only, no tracing of referenced files.
     #[default]
-    Bundling,
-    /// Bundling and tracing of referenced files.
-    BundlingWithTracing,
-    /// Only tracing of referenced files, no bundling (= no codegen).
-    TracingOnly,
+    CodeGeneration,
+    /// For bundling and tracing of referenced files.
+    CodeGenerationAndTracing,
+    /// For tracing of referenced files only, no bundling (i.e. no codegen).
+    Tracing,
 }
 
-impl TracingMode {
+impl AnalyzeMode {
     pub fn is_tracing(self) -> bool {
-        matches!(
-            self,
-            TracingMode::BundlingWithTracing | TracingMode::TracingOnly
-        )
+        match self {
+            AnalyzeMode::Tracing | AnalyzeMode::CodeGenerationAndTracing => true,
+            AnalyzeMode::CodeGeneration => false,
+        }
     }
+
     pub fn is_code_gen(self) -> bool {
-        matches!(
-            self,
-            TracingMode::Bundling | TracingMode::BundlingWithTracing
-        )
+        match self {
+            AnalyzeMode::CodeGeneration | AnalyzeMode::CodeGenerationAndTracing => true,
+            AnalyzeMode::Tracing => false,
+        }
     }
 }
 
@@ -263,7 +264,7 @@ pub struct EcmascriptOptions {
     pub keep_last_successful_parse: bool,
     /// Whether the modules in this context are never chunked/codegen-ed, but only used for
     /// tracing.
-    pub tracing_mode: TracingMode,
+    pub tracing_mode: AnalyzeMode,
     // TODO this should just be handled via CompileTimeInfo FreeVarReferences, but then it
     // (currently) wouldn't be possible to have different replacement values in user code vs
     // node_modules.

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -173,6 +173,47 @@ pub enum TreeShakingMode {
     ReexportsOnly,
 }
 
+#[derive(
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    Serialize,
+    Deserialize,
+    TaskInput,
+    TraceRawVcs,
+    NonLocalValue,
+)]
+pub enum TracingMode {
+    /// Only bundling, no tracing of referenced files.
+    #[default]
+    Bundling,
+    /// Bundling and tracing of referenced files.
+    BundlingWithTracing,
+    /// Only tracing of referenced files, no bundling (= no codegen).
+    TracingOnly,
+}
+
+impl TracingMode {
+    pub fn is_tracing(self) -> bool {
+        matches!(
+            self,
+            TracingMode::BundlingWithTracing | TracingMode::TracingOnly
+        )
+    }
+    pub fn is_code_gen(self) -> bool {
+        matches!(
+            self,
+            TracingMode::Bundling | TracingMode::BundlingWithTracing
+        )
+    }
+}
+
 #[turbo_tasks::value(transparent)]
 pub struct OptionTreeShaking(pub Option<TreeShakingMode>);
 
@@ -222,7 +263,7 @@ pub struct EcmascriptOptions {
     pub keep_last_successful_parse: bool,
     /// Whether the modules in this context are never chunked/codegen-ed, but only used for
     /// tracing.
-    pub is_tracing: bool,
+    pub tracing_mode: TracingMode,
     // TODO this should just be handled via CompileTimeInfo FreeVarReferences, but then it
     // (currently) wouldn't be possible to have different replacement values in user code vs
     // node_modules.

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -84,7 +84,7 @@ impl Display for CachedExternalType {
 pub struct CachedExternalModule {
     request: RcStr,
     external_type: CachedExternalType,
-    tracing_mode: CachedExternalTracingMode,
+    analyze_mode: CachedExternalTracingMode,
 }
 
 #[turbo_tasks::value_impl]
@@ -93,12 +93,12 @@ impl CachedExternalModule {
     pub fn new(
         request: RcStr,
         external_type: CachedExternalType,
-        tracing_mode: CachedExternalTracingMode,
+        analyze_mode: CachedExternalTracingMode,
     ) -> Vc<Self> {
         Self::cell(CachedExternalModule {
             request,
             external_type,
-            tracing_mode,
+            analyze_mode,
         })
     }
 
@@ -226,7 +226,7 @@ impl Module for CachedExternalModule {
 
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<ModuleReferences>> {
-        Ok(match &self.tracing_mode {
+        Ok(match &self.analyze_mode {
             CachedExternalTracingMode::Untraced => ModuleReferences::empty(),
             CachedExternalTracingMode::Traced {
                 externals_context,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1928,7 +1928,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             );
         }
 
-        JsValue::WellKnownFunction(WellKnownFunctionKind::FsReadMethod(name)) => {
+        JsValue::WellKnownFunction(WellKnownFunctionKind::FsReadMethod(name))
+            if analysis.tracing_mode.is_tracing() =>
+        {
             let args = linked_args(args).await?;
             if !args.is_empty() {
                 let pat = js_value_to_pattern(&args[0]);
@@ -1960,7 +1962,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             )
         }
 
-        JsValue::WellKnownFunction(WellKnownFunctionKind::PathResolve(..)) => {
+        JsValue::WellKnownFunction(WellKnownFunctionKind::PathResolve(..))
+            if analysis.tracing_mode.is_tracing() =>
+        {
             let parent_path = origin.origin_path().owned().await?.parent();
             let args = linked_args(args).await?;
 
@@ -2000,7 +2004,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             return Ok(());
         }
 
-        JsValue::WellKnownFunction(WellKnownFunctionKind::PathJoin) => {
+        JsValue::WellKnownFunction(WellKnownFunctionKind::PathJoin)
+            if analysis.tracing_mode.is_tracing() =>
+        {
             let context_path = source.ident().path().await?;
             // ignore path.join in `node-gyp`, it will includes too many files
             if context_path.path.contains("node_modules/node-gyp") {
@@ -2037,7 +2043,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             );
             return Ok(());
         }
-        JsValue::WellKnownFunction(WellKnownFunctionKind::ChildProcessSpawnMethod(name)) => {
+        JsValue::WellKnownFunction(WellKnownFunctionKind::ChildProcessSpawnMethod(name))
+            if analysis.tracing_mode.is_tracing() =>
+        {
             let args = linked_args(args).await?;
 
             // Is this specifically `spawn(process.argv[0], ['-e', ...])`?
@@ -2104,7 +2112,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 ),
             )
         }
-        JsValue::WellKnownFunction(WellKnownFunctionKind::ChildProcessFork) => {
+        JsValue::WellKnownFunction(WellKnownFunctionKind::ChildProcessFork)
+            if analysis.tracing_mode.is_tracing() =>
+        {
             let args = linked_args(args).await?;
             if !args.is_empty() {
                 let first_arg = &args[0];
@@ -2143,7 +2153,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 ),
             )
         }
-        JsValue::WellKnownFunction(WellKnownFunctionKind::NodePreGypFind) => {
+        JsValue::WellKnownFunction(WellKnownFunctionKind::NodePreGypFind)
+            if analysis.tracing_mode.is_tracing() =>
+        {
             use turbopack_resolve::node_native_binding::NodePreGypConfigReference;
 
             let args = linked_args(args).await?;
@@ -2185,7 +2197,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 ),
             )
         }
-        JsValue::WellKnownFunction(WellKnownFunctionKind::NodeGypBuild) => {
+        JsValue::WellKnownFunction(WellKnownFunctionKind::NodeGypBuild)
+            if analysis.tracing_mode.is_tracing() =>
+        {
             use turbopack_resolve::node_native_binding::NodeGypBuildReference;
 
             let args = linked_args(args).await?;
@@ -2223,7 +2237,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 ),
             )
         }
-        JsValue::WellKnownFunction(WellKnownFunctionKind::NodeBindings) => {
+        JsValue::WellKnownFunction(WellKnownFunctionKind::NodeBindings)
+            if analysis.tracing_mode.is_tracing() =>
+        {
             use turbopack_resolve::node_native_binding::NodeBindingsReference;
 
             let args = linked_args(args).await?;
@@ -2249,7 +2265,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 ),
             )
         }
-        JsValue::WellKnownFunction(WellKnownFunctionKind::NodeExpressSet) => {
+        JsValue::WellKnownFunction(WellKnownFunctionKind::NodeExpressSet)
+            if analysis.tracing_mode.is_tracing() =>
+        {
             let args = linked_args(args).await?;
             if args.len() == 2
                 && let Some(s) = args.first().and_then(|arg| arg.as_str())
@@ -2328,7 +2346,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 ),
             )
         }
-        JsValue::WellKnownFunction(WellKnownFunctionKind::NodeStrongGlobalizeSetRootDir) => {
+        JsValue::WellKnownFunction(WellKnownFunctionKind::NodeStrongGlobalizeSetRootDir)
+            if analysis.tracing_mode.is_tracing() =>
+        {
             let args = linked_args(args).await?;
             if let Some(p) = args.first().and_then(|arg| arg.as_str()) {
                 let abs_pattern = if p.starts_with("/ROOT/") {
@@ -2370,7 +2390,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 ),
             )
         }
-        JsValue::WellKnownFunction(WellKnownFunctionKind::NodeResolveFrom) => {
+        JsValue::WellKnownFunction(WellKnownFunctionKind::NodeResolveFrom)
+            if analysis.tracing_mode.is_tracing() =>
+        {
             let args = linked_args(args).await?;
             if args.len() == 2 && args.get(1).and_then(|arg| arg.as_str()).is_some() {
                 analysis.add_reference(
@@ -2394,7 +2416,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 ),
             )
         }
-        JsValue::WellKnownFunction(WellKnownFunctionKind::NodeProtobufLoad) => {
+        JsValue::WellKnownFunction(WellKnownFunctionKind::NodeProtobufLoad)
+            if analysis.tracing_mode.is_tracing() =>
+        {
             let args = linked_args(args).await?;
             if args.len() == 2
                 && let Some(JsValue::Object { parts, .. }) = args.get(1)

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -212,7 +212,7 @@ impl AnalyzeEcmascriptModuleResult {
 /// A temporary analysis result builder to pass around, to be turned into an
 /// `Vc<AnalyzeEcmascriptModuleResult>` eventually.
 pub struct AnalyzeEcmascriptModuleResultBuilder {
-    tracing_mode: AnalyzeMode,
+    analyze_mode: AnalyzeMode,
 
     references: FxIndexSet<ResolvedVc<Box<dyn ModuleReference>>>,
 
@@ -234,9 +234,9 @@ pub struct AnalyzeEcmascriptModuleResultBuilder {
 }
 
 impl AnalyzeEcmascriptModuleResultBuilder {
-    pub fn new(tracing_mode: AnalyzeMode) -> Self {
+    pub fn new(analyze_mode: AnalyzeMode) -> Self {
         Self {
-            tracing_mode,
+            analyze_mode,
             references: Default::default(),
             esm_references: Default::default(),
             esm_local_references: Default::default(),
@@ -290,7 +290,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     where
         C: Into<CodeGen>,
     {
-        if self.tracing_mode.is_code_gen() {
+        if self.analyze_mode.is_code_gen() {
             self.code_gens.push(code_gen.into())
         }
     }
@@ -510,11 +510,11 @@ pub async fn analyse_ecmascript_module_internal(
     let options = raw_module.options;
     let options = options.await?;
     let import_externals = options.import_externals;
-    let tracing_mode = options.tracing_mode;
+    let analyze_mode = options.analyze_mode;
 
     let origin = ResolvedVc::upcast::<Box<dyn ResolveOrigin>>(module);
 
-    let mut analysis = AnalyzeEcmascriptModuleResultBuilder::new(tracing_mode);
+    let mut analysis = AnalyzeEcmascriptModuleResultBuilder::new(analyze_mode);
     let path = &*origin.origin_path().await?;
 
     // Is this a typescript file that requires analyzing type references?
@@ -687,7 +687,7 @@ pub async fn analyse_ecmascript_module_internal(
     let mut var_graph = {
         let _span = tracing::info_span!("analyze variable values").entered();
         set_handler_and_globals(&handler, globals, || {
-            create_graph(program, eval_context, tracing_mode)
+            create_graph(program, eval_context, analyze_mode)
         })
     };
 
@@ -754,7 +754,7 @@ pub async fn analyse_ecmascript_module_internal(
                     eval_context,
                     &import_references,
                     &mut analysis,
-                    tracing_mode,
+                    analyze_mode,
                     &var_graph,
                 );
                 // ModuleReferencesVisitor has already called analysis.add_esm_reexport_reference
@@ -1008,7 +1008,7 @@ pub async fn analyse_ecmascript_module_internal(
             match effect {
                 Effect::Unreachable { start_ast_path } => {
                     debug_assert!(
-                        tracing_mode.is_code_gen(),
+                        analyze_mode.is_code_gen(),
                         "unexpected Effect::Unreachable in tracing mode"
                     );
 
@@ -1031,14 +1031,14 @@ pub async fn analyse_ecmascript_module_internal(
 
                     macro_rules! inactive {
                         ($block:ident) => {
-                            if tracing_mode.is_code_gen() {
+                            if analyze_mode.is_code_gen() {
                                 analysis.add_code_gen(Unreachable::new($block.range.clone()));
                             }
                         };
                     }
                     macro_rules! condition {
                         ($expr:expr) => {
-                            if tracing_mode.is_code_gen() && !condition_has_side_effects {
+                            if analyze_mode.is_code_gen() && !condition_has_side_effects {
                                 analysis.add_code_gen(ConstantConditionCodeGen::new(
                                     $expr,
                                     condition_ast_path.to_vec().into(),
@@ -1287,7 +1287,7 @@ pub async fn analyse_ecmascript_module_internal(
                     span,
                 } => {
                     debug_assert!(
-                        tracing_mode.is_code_gen(),
+                        analyze_mode.is_code_gen(),
                         "unexpected Effect::FreeVar in tracing mode"
                     );
 
@@ -1318,7 +1318,7 @@ pub async fn analyse_ecmascript_module_internal(
                     span,
                 } => {
                     debug_assert!(
-                        tracing_mode.is_code_gen(),
+                        analyze_mode.is_code_gen(),
                         "unexpected Effect::Member in tracing mode"
                     );
 
@@ -1394,7 +1394,7 @@ pub async fn analyse_ecmascript_module_internal(
                     span,
                 } => {
                     debug_assert!(
-                        tracing_mode.is_code_gen(),
+                        analyze_mode.is_code_gen(),
                         "unexpected Effect::TypeOf in tracing mode"
                     );
                     let arg = analysis_state
@@ -1404,7 +1404,7 @@ pub async fn analyse_ecmascript_module_internal(
                 }
                 Effect::ImportMeta { ast_path, span: _ } => {
                     debug_assert!(
-                        tracing_mode.is_code_gen(),
+                        analyze_mode.is_code_gen(),
                         "unexpected Effect::ImportMeta in tracing mode"
                     );
                     if analysis_state.first_import_meta {
@@ -1929,7 +1929,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
         }
 
         JsValue::WellKnownFunction(WellKnownFunctionKind::FsReadMethod(name))
-            if analysis.tracing_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing() =>
         {
             let args = linked_args(args).await?;
             if !args.is_empty() {
@@ -1963,7 +1963,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
         }
 
         JsValue::WellKnownFunction(WellKnownFunctionKind::PathResolve(..))
-            if analysis.tracing_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing() =>
         {
             let parent_path = origin.origin_path().owned().await?.parent();
             let args = linked_args(args).await?;
@@ -2005,7 +2005,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
         }
 
         JsValue::WellKnownFunction(WellKnownFunctionKind::PathJoin)
-            if analysis.tracing_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing() =>
         {
             let context_path = source.ident().path().await?;
             // ignore path.join in `node-gyp`, it will includes too many files
@@ -2044,7 +2044,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             return Ok(());
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::ChildProcessSpawnMethod(name))
-            if analysis.tracing_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing() =>
         {
             let args = linked_args(args).await?;
 
@@ -2113,7 +2113,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             )
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::ChildProcessFork)
-            if analysis.tracing_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing() =>
         {
             let args = linked_args(args).await?;
             if !args.is_empty() {
@@ -2154,7 +2154,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             )
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::NodePreGypFind)
-            if analysis.tracing_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing() =>
         {
             use turbopack_resolve::node_native_binding::NodePreGypConfigReference;
 
@@ -2198,7 +2198,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             )
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::NodeGypBuild)
-            if analysis.tracing_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing() =>
         {
             use turbopack_resolve::node_native_binding::NodeGypBuildReference;
 
@@ -2238,7 +2238,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             )
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::NodeBindings)
-            if analysis.tracing_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing() =>
         {
             use turbopack_resolve::node_native_binding::NodeBindingsReference;
 
@@ -2266,7 +2266,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             )
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::NodeExpressSet)
-            if analysis.tracing_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing() =>
         {
             let args = linked_args(args).await?;
             if args.len() == 2
@@ -2347,7 +2347,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             )
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::NodeStrongGlobalizeSetRootDir)
-            if analysis.tracing_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing() =>
         {
             let args = linked_args(args).await?;
             if let Some(p) = args.first().and_then(|arg| arg.as_str()) {
@@ -2391,7 +2391,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             )
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::NodeResolveFrom)
-            if analysis.tracing_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing() =>
         {
             let args = linked_args(args).await?;
             if args.len() == 2 && args.get(1).and_then(|arg| arg.as_str()).is_some() {
@@ -2417,7 +2417,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             )
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::NodeProtobufLoad)
-            if analysis.tracing_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing() =>
         {
             let args = linked_args(args).await?;
             if args.len() == 2
@@ -3238,7 +3238,7 @@ impl StaticAnalyser {
 /// A visitor that walks the AST and collects information about the various
 /// references a module makes to other parts of the code.
 struct ModuleReferencesVisitor<'a> {
-    tracing_mode: AnalyzeMode,
+    analyze_mode: AnalyzeMode,
     eval_context: &'a EvalContext,
     old_analyser: StaticAnalyser,
     import_references: &'a [ResolvedVc<EsmAssetReference>],
@@ -3255,11 +3255,11 @@ impl<'a> ModuleReferencesVisitor<'a> {
         eval_context: &'a EvalContext,
         import_references: &'a [ResolvedVc<EsmAssetReference>],
         analysis: &'a mut AnalyzeEcmascriptModuleResultBuilder,
-        tracing_mode: AnalyzeMode,
+        analyze_mode: AnalyzeMode,
         var_graph: &'a VarGraph,
     ) -> Self {
         Self {
-            tracing_mode,
+            analyze_mode,
             eval_context,
             old_analyser: StaticAnalyser::default(),
             import_references,
@@ -3339,7 +3339,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
         export: &'ast ExportAll,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        if self.tracing_mode.is_code_gen() {
+        if self.analyze_mode.is_code_gen() {
             self.analysis
                 .add_code_gen(EsmModuleItem::new(as_parent_path(ast_path).into()));
         }
@@ -3427,7 +3427,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
             }
         }
 
-        if self.tracing_mode.is_code_gen() {
+        if self.analyze_mode.is_code_gen() {
             self.analysis
                 .add_code_gen(EsmModuleItem::new(as_parent_path(ast_path).into()));
         }
@@ -3475,7 +3475,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 }
             }
         };
-        if self.tracing_mode.is_code_gen() {
+        if self.analyze_mode.is_code_gen() {
             self.analysis
                 .add_code_gen(EsmModuleItem::new(as_parent_path(ast_path).into()));
         }
@@ -3495,7 +3495,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 Liveness::Constant,
             ),
         );
-        if self.tracing_mode.is_code_gen() {
+        if self.analyze_mode.is_code_gen() {
             self.analysis
                 .add_code_gen(EsmModuleItem::new(as_parent_path(ast_path).into()));
         }
@@ -3530,7 +3530,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 // ignore
             }
         }
-        if self.tracing_mode.is_code_gen() {
+        if self.analyze_mode.is_code_gen() {
             self.analysis
                 .add_code_gen(EsmModuleItem::new(as_parent_path(ast_path).into()));
         }
@@ -3578,7 +3578,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 }
             }
         }
-        if self.tracing_mode.is_code_gen() {
+        if self.analyze_mode.is_code_gen() {
             self.analysis.add_code_gen(EsmModuleItem::new(path));
         }
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -128,8 +128,8 @@ use super::{
 };
 pub use crate::references::esm::export::{FollowExportsResult, follow_reexports};
 use crate::{
-    EcmascriptInputTransforms, EcmascriptModuleAsset, EcmascriptParsable, SpecifiedModuleType,
-    TracingMode, TreeShakingMode, TypeofWindow,
+    AnalyzeMode, EcmascriptInputTransforms, EcmascriptModuleAsset, EcmascriptParsable,
+    SpecifiedModuleType, TreeShakingMode, TypeofWindow,
     analyzer::{
         ConstantNumber, ConstantString, JsValueUrlKind, RequireContextValue,
         builtin::early_replace_builtin,
@@ -212,7 +212,7 @@ impl AnalyzeEcmascriptModuleResult {
 /// A temporary analysis result builder to pass around, to be turned into an
 /// `Vc<AnalyzeEcmascriptModuleResult>` eventually.
 pub struct AnalyzeEcmascriptModuleResultBuilder {
-    tracing_mode: TracingMode,
+    tracing_mode: AnalyzeMode,
 
     references: FxIndexSet<ResolvedVc<Box<dyn ModuleReference>>>,
 
@@ -234,7 +234,7 @@ pub struct AnalyzeEcmascriptModuleResultBuilder {
 }
 
 impl AnalyzeEcmascriptModuleResultBuilder {
-    pub fn new(tracing_mode: TracingMode) -> Self {
+    pub fn new(tracing_mode: AnalyzeMode) -> Self {
         Self {
             tracing_mode,
             references: Default::default(),
@@ -3238,7 +3238,7 @@ impl StaticAnalyser {
 /// A visitor that walks the AST and collects information about the various
 /// references a module makes to other parts of the code.
 struct ModuleReferencesVisitor<'a> {
-    tracing_mode: TracingMode,
+    tracing_mode: AnalyzeMode,
     eval_context: &'a EvalContext,
     old_analyser: StaticAnalyser,
     import_references: &'a [ResolvedVc<EsmAssetReference>],
@@ -3255,7 +3255,7 @@ impl<'a> ModuleReferencesVisitor<'a> {
         eval_context: &'a EvalContext,
         import_references: &'a [ResolvedVc<EsmAssetReference>],
         analysis: &'a mut AnalyzeEcmascriptModuleResultBuilder,
-        tracing_mode: TracingMode,
+        tracing_mode: AnalyzeMode,
         var_graph: &'a VarGraph,
     ) -> Self {
         Self {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -129,7 +129,7 @@ use super::{
 pub use crate::references::esm::export::{FollowExportsResult, follow_reexports};
 use crate::{
     EcmascriptInputTransforms, EcmascriptModuleAsset, EcmascriptParsable, SpecifiedModuleType,
-    TreeShakingMode, TypeofWindow,
+    TracingMode, TreeShakingMode, TypeofWindow,
     analyzer::{
         ConstantNumber, ConstantString, JsValueUrlKind, RequireContextValue,
         builtin::early_replace_builtin,
@@ -212,7 +212,7 @@ impl AnalyzeEcmascriptModuleResult {
 /// A temporary analysis result builder to pass around, to be turned into an
 /// `Vc<AnalyzeEcmascriptModuleResult>` eventually.
 pub struct AnalyzeEcmascriptModuleResultBuilder {
-    is_tracing: bool,
+    tracing_mode: TracingMode,
 
     references: FxIndexSet<ResolvedVc<Box<dyn ModuleReference>>>,
 
@@ -234,9 +234,9 @@ pub struct AnalyzeEcmascriptModuleResultBuilder {
 }
 
 impl AnalyzeEcmascriptModuleResultBuilder {
-    pub fn new(is_tracing: bool) -> Self {
+    pub fn new(tracing_mode: TracingMode) -> Self {
         Self {
-            is_tracing,
+            tracing_mode,
             references: Default::default(),
             esm_references: Default::default(),
             esm_local_references: Default::default(),
@@ -290,7 +290,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     where
         C: Into<CodeGen>,
     {
-        if !self.is_tracing {
+        if self.tracing_mode.is_code_gen() {
             self.code_gens.push(code_gen.into())
         }
     }
@@ -510,11 +510,11 @@ pub async fn analyse_ecmascript_module_internal(
     let options = raw_module.options;
     let options = options.await?;
     let import_externals = options.import_externals;
-    let is_tracing = options.is_tracing;
+    let tracing_mode = options.tracing_mode;
 
     let origin = ResolvedVc::upcast::<Box<dyn ResolveOrigin>>(module);
 
-    let mut analysis = AnalyzeEcmascriptModuleResultBuilder::new(is_tracing);
+    let mut analysis = AnalyzeEcmascriptModuleResultBuilder::new(tracing_mode);
     let path = &*origin.origin_path().await?;
 
     // Is this a typescript file that requires analyzing type references?
@@ -687,7 +687,7 @@ pub async fn analyse_ecmascript_module_internal(
     let mut var_graph = {
         let _span = tracing::info_span!("analyze variable values").entered();
         set_handler_and_globals(&handler, globals, || {
-            create_graph(program, eval_context, is_tracing)
+            create_graph(program, eval_context, tracing_mode)
         })
     };
 
@@ -754,7 +754,7 @@ pub async fn analyse_ecmascript_module_internal(
                     eval_context,
                     &import_references,
                     &mut analysis,
-                    is_tracing,
+                    tracing_mode,
                     &var_graph,
                 );
                 // ModuleReferencesVisitor has already called analysis.add_esm_reexport_reference
@@ -1008,7 +1008,7 @@ pub async fn analyse_ecmascript_module_internal(
             match effect {
                 Effect::Unreachable { start_ast_path } => {
                     debug_assert!(
-                        !is_tracing,
+                        tracing_mode.is_code_gen(),
                         "unexpected Effect::Unreachable in tracing mode"
                     );
 
@@ -1031,14 +1031,14 @@ pub async fn analyse_ecmascript_module_internal(
 
                     macro_rules! inactive {
                         ($block:ident) => {
-                            if !is_tracing {
+                            if tracing_mode.is_code_gen() {
                                 analysis.add_code_gen(Unreachable::new($block.range.clone()));
                             }
                         };
                     }
                     macro_rules! condition {
                         ($expr:expr) => {
-                            if !is_tracing && !condition_has_side_effects {
+                            if tracing_mode.is_code_gen() && !condition_has_side_effects {
                                 analysis.add_code_gen(ConstantConditionCodeGen::new(
                                     $expr,
                                     condition_ast_path.to_vec().into(),
@@ -1286,7 +1286,10 @@ pub async fn analyse_ecmascript_module_internal(
                     ast_path,
                     span,
                 } => {
-                    debug_assert!(!is_tracing, "unexpected Effect::FreeVar in tracing mode");
+                    debug_assert!(
+                        tracing_mode.is_code_gen(),
+                        "unexpected Effect::FreeVar in tracing mode"
+                    );
 
                     // FreeVar("require") might be turbopackIgnore-d
                     if !analysis_state
@@ -1314,7 +1317,10 @@ pub async fn analyse_ecmascript_module_internal(
                     ast_path,
                     span,
                 } => {
-                    debug_assert!(!is_tracing, "unexpected Effect::Member in tracing mode");
+                    debug_assert!(
+                        tracing_mode.is_code_gen(),
+                        "unexpected Effect::Member in tracing mode"
+                    );
 
                     // Intentionally not awaited because `handle_member` reads this only when needed
                     let obj = analysis_state.link_value(*obj, ImportAttributes::empty_ref());
@@ -1387,14 +1393,20 @@ pub async fn analyse_ecmascript_module_internal(
                     ast_path,
                     span,
                 } => {
-                    debug_assert!(!is_tracing, "unexpected Effect::TypeOf in tracing mode");
+                    debug_assert!(
+                        tracing_mode.is_code_gen(),
+                        "unexpected Effect::TypeOf in tracing mode"
+                    );
                     let arg = analysis_state
                         .link_value(*arg, ImportAttributes::empty_ref())
                         .await?;
                     handle_typeof(&ast_path, arg, span, &analysis_state, &mut analysis).await?;
                 }
                 Effect::ImportMeta { ast_path, span: _ } => {
-                    debug_assert!(!is_tracing, "unexpected Effect::ImportMeta in tracing mode");
+                    debug_assert!(
+                        tracing_mode.is_code_gen(),
+                        "unexpected Effect::ImportMeta in tracing mode"
+                    );
                     if analysis_state.first_import_meta {
                         analysis_state.first_import_meta = false;
                         analysis.add_code_gen(ImportMetaBinding::new(
@@ -3202,7 +3214,7 @@ impl StaticAnalyser {
 /// A visitor that walks the AST and collects information about the various
 /// references a module makes to other parts of the code.
 struct ModuleReferencesVisitor<'a> {
-    is_tracing: bool,
+    tracing_mode: TracingMode,
     eval_context: &'a EvalContext,
     old_analyser: StaticAnalyser,
     import_references: &'a [ResolvedVc<EsmAssetReference>],
@@ -3219,11 +3231,11 @@ impl<'a> ModuleReferencesVisitor<'a> {
         eval_context: &'a EvalContext,
         import_references: &'a [ResolvedVc<EsmAssetReference>],
         analysis: &'a mut AnalyzeEcmascriptModuleResultBuilder,
-        is_tracing: bool,
+        tracing_mode: TracingMode,
         var_graph: &'a VarGraph,
     ) -> Self {
         Self {
-            is_tracing,
+            tracing_mode,
             eval_context,
             old_analyser: StaticAnalyser::default(),
             import_references,
@@ -3303,7 +3315,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
         export: &'ast ExportAll,
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
-        if !self.is_tracing {
+        if self.tracing_mode.is_code_gen() {
             self.analysis
                 .add_code_gen(EsmModuleItem::new(as_parent_path(ast_path).into()));
         }
@@ -3391,7 +3403,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
             }
         }
 
-        if !self.is_tracing {
+        if self.tracing_mode.is_code_gen() {
             self.analysis
                 .add_code_gen(EsmModuleItem::new(as_parent_path(ast_path).into()));
         }
@@ -3439,7 +3451,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 }
             }
         };
-        if !self.is_tracing {
+        if self.tracing_mode.is_code_gen() {
             self.analysis
                 .add_code_gen(EsmModuleItem::new(as_parent_path(ast_path).into()));
         }
@@ -3459,7 +3471,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 Liveness::Constant,
             ),
         );
-        if !self.is_tracing {
+        if self.tracing_mode.is_code_gen() {
             self.analysis
                 .add_code_gen(EsmModuleItem::new(as_parent_path(ast_path).into()));
         }
@@ -3494,7 +3506,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 // ignore
             }
         }
-        if !self.is_tracing {
+        if self.tracing_mode.is_code_gen() {
             self.analysis
                 .add_code_gen(EsmModuleItem::new(as_parent_path(ast_path).into()));
         }
@@ -3542,7 +3554,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                 }
             }
         }
-        if !self.is_tracing {
+        if self.tracing_mode.is_code_gen() {
             self.analysis.add_code_gen(EsmModuleItem::new(path));
         }
     }

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -96,7 +96,7 @@ async fn node_file_trace_operation(
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
-            tracing_mode: AnalyzeMode::Tracing,
+            analyze_mode: AnalyzeMode::Tracing,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -6,6 +6,7 @@ use turbo_tasks::{ResolvedVc, TransientInstance, TryJoinIterExt, ValueToString, 
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 use turbopack::{
     ModuleAssetContext,
+    ecmascript::TracingMode,
     module_options::{
         CssOptionsContext, EcmascriptOptionsContext, ModuleOptionsContext,
         TypescriptTransformOptions,
@@ -95,7 +96,7 @@ async fn node_file_trace_operation(
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
-            is_tracing: true,
+            tracing_mode: TracingMode::TracingOnly,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{ResolvedVc, TransientInstance, TryJoinIterExt, ValueToString, 
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 use turbopack::{
     ModuleAssetContext,
-    ecmascript::TracingMode,
+    ecmascript::AnalyzeMode,
     module_options::{
         CssOptionsContext, EcmascriptOptionsContext, ModuleOptionsContext,
         TypescriptTransformOptions,
@@ -96,7 +96,7 @@ async fn node_file_trace_operation(
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
-            tracing_mode: TracingMode::TracingOnly,
+            tracing_mode: AnalyzeMode::Tracing,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -20,7 +20,9 @@ use turbo_tasks_fs::{
 use turbo_unix_path::sys_to_unix;
 use turbopack::{
     ModuleAssetContext,
-    ecmascript::{EcmascriptInputTransform, TreeShakingMode, chunk::EcmascriptChunkType},
+    ecmascript::{
+        AnalyzeMode, EcmascriptInputTransform, TreeShakingMode, chunk::EcmascriptChunkType,
+    },
     module_options::{
         EcmascriptOptionsContext, JsxTransformOptions, ModuleOptionsContext, ModuleRule,
         ModuleRuleEffect, RuleCondition, TypescriptTransformOptions,
@@ -356,12 +358,14 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 ModuleOptionsContext {
                     environment: Some(env),
                     tree_shaking_mode: options.tree_shaking_mode,
+                    analyze_mode: AnalyzeMode::CodeGenerationAndTracing,
                     ..Default::default()
                 }
                 .resolved_cell(),
             )],
             module_rules: vec![module_rules],
             tree_shaking_mode: options.tree_shaking_mode,
+            analyze_mode: AnalyzeMode::CodeGenerationAndTracing,
             ..Default::default()
         }
         .into(),

--- a/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
@@ -33,7 +33,9 @@ use turbo_tasks::{
 use turbo_tasks_backend::TurboTasksBackend;
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 use turbopack::{
-    ModuleAssetContext, emit_with_completion_operation,
+    ModuleAssetContext,
+    ecmascript::TracingMode,
+    emit_with_completion_operation,
     module_options::{
         CssOptionsContext, EcmascriptOptionsContext, ModuleOptionsContext,
         TypescriptTransformOptions,
@@ -373,7 +375,7 @@ async fn node_file_trace_operation(
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
-            is_tracing: true,
+            tracing_mode: TracingMode::TracingOnly,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
@@ -34,7 +34,7 @@ use turbo_tasks_backend::TurboTasksBackend;
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 use turbopack::{
     ModuleAssetContext,
-    ecmascript::TracingMode,
+    ecmascript::AnalyzeMode,
     emit_with_completion_operation,
     module_options::{
         CssOptionsContext, EcmascriptOptionsContext, ModuleOptionsContext,
@@ -375,7 +375,7 @@ async fn node_file_trace_operation(
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
-            tracing_mode: TracingMode::TracingOnly,
+            tracing_mode: AnalyzeMode::Tracing,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
@@ -375,7 +375,7 @@ async fn node_file_trace_operation(
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
-            tracing_mode: AnalyzeMode::Tracing,
+            analyze_mode: AnalyzeMode::Tracing,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack-tracing/tests/unit.rs
+++ b/turbopack/crates/turbopack-tracing/tests/unit.rs
@@ -15,7 +15,7 @@ use turbo_tasks_backend::TurboTasksBackend;
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 use turbopack::{
     ModuleAssetContext,
-    ecmascript::TracingMode,
+    ecmascript::AnalyzeMode,
     module_options::{
         CssOptionsContext, EcmascriptOptionsContext, ModuleOptionsContext,
         TypescriptTransformOptions,
@@ -211,7 +211,7 @@ async fn node_file_trace_operation(package_root: RcStr, input: RcStr) -> Result<
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
-            tracing_mode: TracingMode::TracingOnly,
+            tracing_mode: AnalyzeMode::Tracing,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack-tracing/tests/unit.rs
+++ b/turbopack/crates/turbopack-tracing/tests/unit.rs
@@ -15,6 +15,7 @@ use turbo_tasks_backend::TurboTasksBackend;
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 use turbopack::{
     ModuleAssetContext,
+    ecmascript::TracingMode,
     module_options::{
         CssOptionsContext, EcmascriptOptionsContext, ModuleOptionsContext,
         TypescriptTransformOptions,
@@ -210,7 +211,7 @@ async fn node_file_trace_operation(package_root: RcStr, input: RcStr) -> Result<
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
-            is_tracing: true,
+            tracing_mode: TracingMode::TracingOnly,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack-tracing/tests/unit.rs
+++ b/turbopack/crates/turbopack-tracing/tests/unit.rs
@@ -211,7 +211,7 @@ async fn node_file_trace_operation(package_root: RcStr, input: RcStr) -> Result<
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
-            tracing_mode: AnalyzeMode::Tracing,
+            analyze_mode: AnalyzeMode::Tracing,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -56,6 +56,7 @@ use turbopack_core::{
 pub use turbopack_css as css;
 pub use turbopack_ecmascript as ecmascript;
 use turbopack_ecmascript::{
+    TracingMode,
     inlined_bytes_module::InlinedBytesJsModule,
     references::external_module::{
         CachedExternalModule, CachedExternalTracingMode, CachedExternalType,
@@ -719,7 +720,7 @@ pub async fn externals_tracing_module_context(
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
-            is_tracing: true,
+            tracing_mode: TracingMode::TracingOnly,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -720,7 +720,7 @@ pub async fn externals_tracing_module_context(
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
-            tracing_mode: AnalyzeMode::Tracing,
+            analyze_mode: AnalyzeMode::Tracing,
             ..Default::default()
         }
         .cell(),
@@ -825,7 +825,7 @@ impl AssetContext for ModuleAssetContext {
                         }
                         ResolveResultItem::External { name, ty, traced } => {
                             let replacement = if replace_externals {
-                                let tracing_mode = if traced == ExternalTraced::Traced
+                                let analyze_mode = if traced == ExternalTraced::Traced
                                     && let Some(options) = &self
                                         .module_options_context()
                                         .await?
@@ -851,7 +851,7 @@ impl AssetContext for ModuleAssetContext {
                                     CachedExternalTracingMode::Untraced
                                 };
 
-                                replace_external(&name, ty, import_externals, tracing_mode).await?
+                                replace_external(&name, ty, import_externals, analyze_mode).await?
                             } else {
                                 None
                             };
@@ -1004,7 +1004,7 @@ pub async fn replace_external(
     name: &RcStr,
     ty: ExternalType,
     import_externals: bool,
-    tracing_mode: CachedExternalTracingMode,
+    analyze_mode: CachedExternalTracingMode,
 ) -> Result<Option<ModuleResolveResultItem>> {
     let external_type = match ty {
         ExternalType::CommonJs => CachedExternalType::CommonJs,
@@ -1023,7 +1023,7 @@ pub async fn replace_external(
         }
     };
 
-    let module = CachedExternalModule::new(name.clone(), external_type, tracing_mode)
+    let module = CachedExternalModule::new(name.clone(), external_type, analyze_mode)
         .to_resolved()
         .await?;
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -56,7 +56,7 @@ use turbopack_core::{
 pub use turbopack_css as css;
 pub use turbopack_ecmascript as ecmascript;
 use turbopack_ecmascript::{
-    TracingMode,
+    AnalyzeMode,
     inlined_bytes_module::InlinedBytesJsModule,
     references::external_module::{
         CachedExternalModule, CachedExternalTracingMode, CachedExternalType,
@@ -720,7 +720,7 @@ pub async fn externals_tracing_module_context(
             // Environment is not passed in order to avoid downleveling JS / CSS for
             // node-file-trace.
             environment: None,
-            tracing_mode: TracingMode::TracingOnly,
+            tracing_mode: AnalyzeMode::Tracing,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -227,7 +227,7 @@ impl ModuleOptions {
             execution_context,
             tree_shaking_mode,
             keep_last_successful_parse,
-            is_tracing,
+            tracing_mode,
             ..
         } = *module_options_context.await?;
 
@@ -280,7 +280,7 @@ impl ModuleOptions {
             ignore_dynamic_requests,
             extract_source_map: matches!(ecmascript_source_maps, SourceMapsType::Full),
             keep_last_successful_parse,
-            is_tracing,
+            tracing_mode,
             enable_typeof_window_inlining,
             ..Default::default()
         };

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -227,7 +227,7 @@ impl ModuleOptions {
             execution_context,
             tree_shaking_mode,
             keep_last_successful_parse,
-            tracing_mode,
+            analyze_mode,
             ..
         } = *module_options_context.await?;
 
@@ -280,7 +280,7 @@ impl ModuleOptions {
             ignore_dynamic_requests,
             extract_source_map: matches!(ecmascript_source_maps, SourceMapsType::Full),
             keep_last_successful_parse,
-            tracing_mode,
+            analyze_mode,
             enable_typeof_window_inlining,
             ..Default::default()
         };

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -10,7 +10,7 @@ use turbopack_core::{
     environment::Environment, resolve::options::ImportMapping,
 };
 use turbopack_ecmascript::{
-    TracingMode, TreeShakingMode, TypeofWindow, references::esm::UrlRewriteBehavior,
+    AnalyzeMode, TreeShakingMode, TypeofWindow, references::esm::UrlRewriteBehavior,
 };
 pub use turbopack_mdx::MdxTransformOptions;
 use turbopack_node::{
@@ -209,7 +209,7 @@ pub struct ModuleOptionsContext {
 
     /// Whether the modules in this context are never chunked/codegen-ed, but only used for
     /// tracing.
-    pub tracing_mode: TracingMode,
+    pub tracing_mode: AnalyzeMode,
 
     pub placeholder_for_future_extensions: (),
 }

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -9,7 +9,9 @@ use turbopack_core::{
     chunk::SourceMapsType, compile_time_info::CompileTimeInfo, condition::ContextCondition,
     environment::Environment, resolve::options::ImportMapping,
 };
-use turbopack_ecmascript::{TreeShakingMode, TypeofWindow, references::esm::UrlRewriteBehavior};
+use turbopack_ecmascript::{
+    TracingMode, TreeShakingMode, TypeofWindow, references::esm::UrlRewriteBehavior,
+};
 pub use turbopack_mdx::MdxTransformOptions;
 use turbopack_node::{
     execution_context::ExecutionContext,
@@ -207,7 +209,7 @@ pub struct ModuleOptionsContext {
 
     /// Whether the modules in this context are never chunked/codegen-ed, but only used for
     /// tracing.
-    pub is_tracing: bool,
+    pub tracing_mode: TracingMode,
 
     pub placeholder_for_future_extensions: (),
 }

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -209,7 +209,7 @@ pub struct ModuleOptionsContext {
 
     /// Whether the modules in this context are never chunked/codegen-ed, but only used for
     /// tracing.
-    pub tracing_mode: AnalyzeMode,
+    pub analyze_mode: AnalyzeMode,
 
     pub placeholder_for_future_extensions: (),
 }


### PR DESCRIPTION
This means that the default is `TracingMode::Bundling` which has no tracing.

This is what you want for most normal bundler use cases, and what we want for our execution contexts for the Node.js loader runners.

This should help with #83613

Closes PACK-5530