### PR TITLE
Turbopack: Use readFileSync / writeFileSync for manifest writing

### DIFF
--- a/packages/next/src/build/handle-entrypoints.ts
+++ b/packages/next/src/build/handle-entrypoints.ts
@@ -109,14 +109,14 @@ export async function handleRouteType({
         manifestLoader.deleteMiddlewareManifest(key)
       }
 
-      await manifestLoader.loadAppBuildManifest(page)
-      await manifestLoader.loadBuildManifest(page, 'app')
-      await manifestLoader.loadAppPathsManifest(page)
-      await manifestLoader.loadActionManifest(page)
-      await manifestLoader.loadFontManifest(page, 'app')
+      manifestLoader.loadAppBuildManifest(page)
+      manifestLoader.loadBuildManifest(page, 'app')
+      manifestLoader.loadAppPathsManifest(page)
+      manifestLoader.loadActionManifest(page)
+      manifestLoader.loadFontManifest(page, 'app')
 
       if (shouldCreateWebpackStats) {
-        await manifestLoader.loadWebpackStats(page, 'app')
+        manifestLoader.loadWebpackStats(page, 'app')
       }
 
       break
@@ -124,10 +124,12 @@ export async function handleRouteType({
     case 'app-route': {
       const key = getEntryKey('app', 'server', page)
 
-      await manifestLoader.loadAppPathsManifest(page)
+      manifestLoader.loadAppPathsManifest(page)
 
-      const middlewareManifestWritten =
-        await manifestLoader.loadMiddlewareManifest(page, 'app')
+      const middlewareManifestWritten = manifestLoader.loadMiddlewareManifest(
+        page,
+        'app'
+      )
 
       if (!middlewareManifestWritten) {
         manifestLoader.deleteMiddlewareManifest(key)

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -202,7 +202,7 @@ export async function turbopackBuild(): Promise<{
         )),
     ])
 
-    await manifestLoader.writeManifests({
+    manifestLoader.writeManifests({
       devRewrites: undefined,
       productionRewrites: rewrites,
       entrypoints: currentEntrypoints,

--- a/packages/next/src/lib/fs/write-atomic.ts
+++ b/packages/next/src/lib/fs/write-atomic.ts
@@ -1,17 +1,14 @@
-import { unlink, writeFile } from 'fs/promises'
-import { rename } from './rename'
+import { unlinkSync, writeFileSync } from 'fs'
+import { renameSync } from './rename'
 
-export async function writeFileAtomic(
-  filePath: string,
-  content: string
-): Promise<void> {
+export function writeFileAtomic(filePath: string, content: string): void {
   const tempPath = filePath + '.tmp.' + Math.random().toString(36).slice(2)
   try {
-    await writeFile(tempPath, content, 'utf-8')
-    await rename(tempPath, filePath)
+    writeFileSync(tempPath, content, 'utf-8')
+    renameSync(tempPath, filePath)
   } catch (e) {
     try {
-      await unlink(tempPath)
+      unlinkSync(tempPath)
     } catch {
       // ignore
     }

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -382,7 +382,7 @@ export async function handleRouteType({
       const type = writtenEndpoint.type
 
       if (type === 'edge') {
-        await manifestLoader.loadMiddlewareManifest(page, 'app')
+        manifestLoader.loadMiddlewareManifest(page, 'app')
       } else {
         manifestLoader.deleteMiddlewareManifest(key)
       }
@@ -394,7 +394,7 @@ export async function handleRouteType({
       manifestLoader.loadFontManifest(page, 'app')
 
       if (shouldCreateWebpackStats) {
-        await manifestLoader.loadWebpackStats(page, 'app')
+        manifestLoader.loadWebpackStats(page, 'app')
       }
 
       manifestLoader.writeManifests({
@@ -418,7 +418,7 @@ export async function handleRouteType({
       manifestLoader.loadAppPathsManifest(page)
 
       if (type === 'edge') {
-        await manifestLoader.loadMiddlewareManifest(page, 'app')
+        manifestLoader.loadMiddlewareManifest(page, 'app')
       } else {
         manifestLoader.deleteMiddlewareManifest(key)
       }

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -243,7 +243,7 @@ export async function handleRouteType({
           await manifestLoader.loadWebpackStats(page, 'pages')
         }
 
-        await manifestLoader.writeManifests({
+        manifestLoader.writeManifests({
           devRewrites,
           productionRewrites,
           entrypoints,
@@ -334,7 +334,7 @@ export async function handleRouteType({
         manifestLoader.deleteMiddlewareManifest(key)
       }
 
-      await manifestLoader.writeManifests({
+      manifestLoader.writeManifests({
         devRewrites,
         productionRewrites,
         entrypoints,
@@ -387,17 +387,17 @@ export async function handleRouteType({
         manifestLoader.deleteMiddlewareManifest(key)
       }
 
-      await manifestLoader.loadAppBuildManifest(page)
-      await manifestLoader.loadBuildManifest(page, 'app')
-      await manifestLoader.loadAppPathsManifest(page)
-      await manifestLoader.loadActionManifest(page)
-      await manifestLoader.loadFontManifest(page, 'app')
+      manifestLoader.loadAppBuildManifest(page)
+      manifestLoader.loadBuildManifest(page, 'app')
+      manifestLoader.loadAppPathsManifest(page)
+      manifestLoader.loadActionManifest(page)
+      manifestLoader.loadFontManifest(page, 'app')
 
       if (shouldCreateWebpackStats) {
         await manifestLoader.loadWebpackStats(page, 'app')
       }
 
-      await manifestLoader.writeManifests({
+      manifestLoader.writeManifests({
         devRewrites,
         productionRewrites,
         entrypoints,
@@ -415,7 +415,7 @@ export async function handleRouteType({
 
       const type = writtenEndpoint.type
 
-      await manifestLoader.loadAppPathsManifest(page)
+      manifestLoader.loadAppPathsManifest(page)
 
       if (type === 'edge') {
         await manifestLoader.loadMiddlewareManifest(page, 'app')
@@ -423,7 +423,7 @@ export async function handleRouteType({
         manifestLoader.deleteMiddlewareManifest(key)
       }
 
-      await manifestLoader.writeManifests({
+      manifestLoader.writeManifests({
         devRewrites,
         productionRewrites,
         entrypoints,
@@ -690,7 +690,7 @@ export async function handleEntrypoints({
       'instrumentation',
       'instrumentation'
     )
-    await manifestLoader.writeManifests({
+    manifestLoader.writeManifests({
       devRewrites,
       productionRewrites: undefined,
       entrypoints: currentEntrypoints,
@@ -758,7 +758,7 @@ export async function handleEntrypoints({
             'middleware',
             dev.serverFields.middleware
           )
-          await manifestLoader.writeManifests({
+          manifestLoader.writeManifests({
             devRewrites,
             productionRewrites: undefined,
             entrypoints: currentEntrypoints,
@@ -956,7 +956,7 @@ export async function handlePagesErrorRoute({
   await manifestLoader.loadPagesManifest('_error')
   await manifestLoader.loadFontManifest('_error')
 
-  await manifestLoader.writeManifests({
+  manifestLoader.writeManifests({
     devRewrites,
     productionRewrites,
     entrypoints,


### PR DESCRIPTION
## What?

Use sync fs methods for reading/writing manifests after a Turbopack writeToDisk. Next step will be not calling it when nothing changed.

Before:

```
 GET / 200 in 41ms
 GET / 200 in 54ms
 GET / 200 in 57ms
 GET / 200 in 165ms
 GET / 200 in 44ms
 GET / 200 in 52ms
 GET / 200 in 42ms
 GET / 200 in 50ms
 GET / 200 in 39ms
 GET / 200 in 53ms
 GET / 200 in 39ms
 GET / 200 in 49ms
 GET / 200 in 40ms
 GET / 200 in 49ms
 GET / 200 in 40ms
 GET / 200 in 54ms
 GET / 200 in 39ms
 GET / 200 in 52ms
 GET / 200 in 47ms
 GET / 200 in 50ms
 GET / 200 in 45ms
 GET / 200 in 59ms
 GET / 200 in 44ms
 GET / 200 in 55ms
 GET / 200 in 46ms
 GET / 200 in 51ms
```


After:

```
 GET / 200 in 31ms
 GET / 200 in 29ms
 GET / 200 in 32ms
 GET / 200 in 33ms
 GET / 200 in 33ms
 GET / 200 in 34ms
 GET / 200 in 32ms
 GET / 200 in 30ms
 GET / 200 in 33ms
 GET / 200 in 30ms
 GET / 200 in 31ms
 GET / 200 in 32ms
 GET / 200 in 31ms
 GET / 200 in 31ms
 GET / 200 in 30ms
 GET / 200 in 33ms
 GET / 200 in 33ms
 GET / 200 in 32ms
 GET / 200 in 29ms
 GET / 200 in 30ms
 GET / 200 in 36ms
 GET / 200 in 35ms
 GET / 200 in 34ms
 GET / 200 in 32ms
 GET / 200 in 30ms
```

Closes PACK-5446