### PR TITLE
Don't create client-side debug channel if the feature is disabled

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -333,6 +333,8 @@ export function getDefineEnv({
       !isTurbopack || (config.experimental.turbopackPersistentCaching ?? false),
     'process.env.__NEXT_OPTIMIZE_ROUTER_SCROLL':
       config.experimental.optimizeRouterScrolling ?? false,
+    'process.env.__NEXT_REACT_DEBUG_CHANNEL':
+      config.experimental.reactDebugChannel ?? false,
   }
 
   const userDefines = config.compiler?.define ?? {}

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -162,7 +162,11 @@ let debugChannel:
   | { readable?: ReadableStream; writable?: WritableStream }
   | undefined
 
-if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
+if (
+  process.env.NODE_ENV !== 'production' &&
+  process.env.__NEXT_REACT_DEBUG_CHANNEL &&
+  typeof window !== 'undefined'
+) {
   const { createDebugChannel } =
     require('./dev/debug-channel') as typeof import('./dev/debug-channel')
 


### PR DESCRIPTION
Creating the client-side debug channel when `experimental.reactDebugChannel` is falsy went unnoticed in the [original PR](https://github.com/vercel/next.js/pull/82748), because this doesn't provoke any obvious errors. The debug info is still correctly received through the main RSC stream. But it does create a memory leak, because it prevents React from closing the Flight response.

On the server side, we were already guarding the feature properly using the feature flag.