### PR TITLE
fix: dev should produce the correct default fallback regex to match builds/Turbopack

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -474,7 +474,7 @@ async function startWatcher(
             serverFields.actualMiddlewareFile
           )
           middlewareMatchers = staticInfo.middleware?.matchers || [
-            { regexp: '.*', originalSource: '/:path*' },
+            { regexp: '^/.*$', originalSource: '/:path*' },
           ]
           continue
         }

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -200,7 +200,9 @@ describe('Middleware Runtime', () => {
           `/_next/static/${next.buildId}/_devMiddlewareManifest.json`
         )
         const matchers = await res.json()
-        expect(matchers).toEqual([{ regexp: '.*', originalSource: '/:path*' }])
+        expect(matchers).toEqual([
+          { regexp: '^/.*$', originalSource: '/:path*' },
+        ])
       })
     }
 


### PR DESCRIPTION
`test/e2e/middleware-general/test/index.test.ts` has been frequently flaking recently in dev likely due to a timing change. If a default middleware matcher isn't written to disk, `setup-dev-bundler` returns a default regex of `.*`. However in webpack [prod builds](https://github.com/vercel/next.js/blob/5abb663b96493292031b04ef977686949f0a4445/packages/next/src/build/webpack/plugins/middleware-plugin.ts#L207-L212)/[Turbopack dev,](https://github.com/vercel/next.js/blob/5abb663b96493292031b04ef977686949f0a4445/crates/next-api/src/middleware.rs#L245-L249) this value is `^/.*$`. 

This updates dev to produce the same values in both environments. This should have no behavioral difference because all routes should start with `/`, anyway. 


### Test plan
This change passes [flake detection](https://github.com/vercel/next.js/actions/runs/17656597547/job/50181663593?pr=83701#step:34:187).