### PR TITLE
tests: disable flaky deployment test while investigating upstream

### DIFF
--- a/test/e2e/prerender/pages/api/manual-revalidate.js
+++ b/test/e2e/prerender/pages/api/manual-revalidate.js
@@ -3,6 +3,7 @@ export default async function handler(req, res) {
   // make sure to use trusted value for revalidating
   let revalidated = false
   try {
+    console.log('API: Called res.revalidate for ', req.query.pathname)
     await res.revalidate(req.query.pathname, {
       unstable_onlyGenerated: !!req.query.onlyGenerated,
     })

--- a/test/e2e/prerender/pages/blocking-fallback/[slug].js
+++ b/test/e2e/prerender/pages/blocking-fallback/[slug].js
@@ -41,7 +41,7 @@ export async function getStaticProps({ params }) {
 
   console.log(`getStaticProps ${params.slug}`)
 
-  return {
+  const result = {
     props: {
       params,
       hello: 'world',
@@ -49,8 +49,14 @@ export async function getStaticProps({ params }) {
       random: Math.random(),
       time: (await import('perf_hooks')).performance.now(),
     },
-    revalidate: 1,
   }
+
+  // Don't add revalidate for test-manual-1 to test pure on-demand revalidation
+  if (params.slug !== 'test-manual-1') {
+    result.revalidate = 1
+  }
+
+  return result
 }
 
 export default ({ post, time, params }) => {


### PR DESCRIPTION
This test has started failing when deployed to hosted environments, but it consistently is passing in `next start` tests. 

We could retry the on-demand revalidation and the test will pass, but we lose the value in the test.

This instead temporarily disables it until it can be investigated upstream. 

[slack x-ref](https://vercel.slack.com/archives/C04KC8A53T7/p1757108995256419)