### PR TITLE
[test] Update snapshots for Rspack + React 18

### DIFF
--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -11,6 +11,7 @@ import path from 'path'
 import { outdent } from 'outdent'
 
 const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+const isRspack = !!process.env.NEXT_RSPACK
 
 describe('ReactRefreshLogBox', () => {
   const { isTurbopack, next } = nextTestSetup({
@@ -286,6 +287,33 @@ describe('ReactRefreshLogBox', () => {
          },
        ]
       `)
+    } else if (isReact18 && isRspack) {
+      await expect(browser).toDisplayRedbox(`
+       [
+         {
+           "description": "no",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "FunctionDefault.js (1:51) @ FunctionDefault
+       > 1 | export default function FunctionDefault() { throw new Error('no'); }
+           |                                                   ^",
+           "stack": [
+             "FunctionDefault FunctionDefault.js (1:51)",
+           ],
+         },
+         {
+           "description": "no",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "FunctionDefault.js (1:51) @ FunctionDefault
+       > 1 | export default function FunctionDefault() { throw new Error('no'); }
+           |                                                   ^",
+           "stack": [
+             "FunctionDefault FunctionDefault.js (1:51)",
+           ],
+         },
+       ]
+      `)
     } else {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
@@ -495,6 +523,33 @@ describe('ReactRefreshLogBox', () => {
              "ClickCount.render Child.js (4:11)",
              "<FIXME-file-protocol>",
              "<FIXME-file-protocol>",
+           ],
+         },
+       ]
+      `)
+    } else if (isReact18 && isRspack) {
+      await expect(browser).toDisplayRedbox(`
+       [
+         {
+           "description": "",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "Child.js (4:11) @ ClickCount.render
+       > 4 |     throw new Error()
+           |           ^",
+           "stack": [
+             "ClickCount.render Child.js (4:11)",
+           ],
+         },
+         {
+           "description": "",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "Child.js (4:11) @ ClickCount.render
+       > 4 |     throw new Error()
+           |           ^",
+           "stack": [
+             "ClickCount.render Child.js (4:11)",
            ],
          },
        ]

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -64,14 +64,14 @@ describe('pages/ error recovery', () => {
          "label": "Build Error",
          "source": "./index.js
          × Module build failed:
-         ├─▶   ×
-         │     │   x Unexpected eof
-         │     │    ,-[<FIXME-project-root>/index.js:1:1]
-         │     │  1 | export default () => <div/
-         │     │    \`----
-         │     │
-         │
-         ╰─▶ Syntax Error
+         ╰─▶   × Error:   x Expected '>', got '<eof>'
+               │    ,----
+               │  1 | export default () => <div/
+               │    \`----
+               │
+               │
+               │ Caused by:
+               │     Syntax Error
        Import trace for requested module:
        ./index.js
        ./pages/index.js",
@@ -245,7 +245,7 @@ describe('pages/ error recovery', () => {
     )
 
     // TODO(veil): Don't bail in Turbopack for sources outside of the project (https://linear.app/vercel/issue/NDX-944)
-    // Somehow we end up with two in React 18 + Turbopack due to React's attempt to recover from this error.
+    // Somehow we end up with two in React 18 + Turbopack/Rspack due to React's attempt to recover from this error.
     if (isReact18 && isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        [
@@ -273,6 +273,33 @@ describe('pages/ error recovery', () => {
              "Child child.js (3:9)",
              "<FIXME-file-protocol>",
              "<FIXME-file-protocol>",
+           ],
+         },
+       ]
+      `)
+    } else if (isReact18 && isRspack) {
+      await expect(browser).toDisplayRedbox(`
+       [
+         {
+           "description": "oops",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "child.js (3:9) @ Child
+       > 3 |   throw new Error('oops')
+           |         ^",
+           "stack": [
+             "Child child.js (3:9)",
+           ],
+         },
+         {
+           "description": "oops",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "child.js (3:9) @ Child
+       > 3 |   throw new Error('oops')
+           |         ^",
+           "stack": [
+             "Child child.js (3:9)",
            ],
          },
        ]
@@ -388,20 +415,20 @@ describe('pages/ error recovery', () => {
          "label": "Build Error",
          "source": "./index.js
          × Module build failed:
-         ├─▶   ×
-         │     │   x Expected '{', got 'return'
-         │     │    ,-[<FIXME-project-root>/index.js:5:1]
-         │     │  2 |
-         │     │  3 | class ClassDefault extends React.Component {
-         │     │  4 |   render()
-         │     │  5 |     return <h1>Default Export</h1>;
-         │     │    :     ^^^^^^
-         │     │  6 |   }
-         │     │  7 | }
-         │     │    \`----
-         │     │
-         │
-         ╰─▶ Syntax Error
+         ╰─▶   × Error:   x Expected '{', got 'return'
+               │    ,-[5:1]
+               │  2 |
+               │  3 | class ClassDefault extends React.Component {
+               │  4 |   render()
+               │  5 |     return <h1>Default Export</h1>;
+               │    :     ^^^^^^
+               │  6 |   }
+               │  7 | }
+               │    \`----
+               │
+               │
+               │ Caused by:
+               │     Syntax Error
        Import trace for requested module:
        ./index.js
        ./pages/index.js",
@@ -473,21 +500,21 @@ describe('pages/ error recovery', () => {
          "label": "Build Error",
          "source": "./index.js
          × Module build failed:
-         ├─▶   ×
-         │     │   x Expected '{', got 'throw'
-         │     │    ,-[<FIXME-project-root>/index.js:5:1]
-         │     │  2 |
-         │     │  3 | class ClassDefault extends React.Component {
-         │     │  4 |   render()
-         │     │  5 |     throw new Error('nooo');
-         │     │    :     ^^^^^
-         │     │  6 |     return <h1>Default Export</h1>;
-         │     │  7 |   }
-         │     │  8 | }
-         │     │    \`----
-         │     │
-         │
-         ╰─▶ Syntax Error
+         ╰─▶   × Error:   x Expected '{', got 'throw'
+               │    ,-[5:1]
+               │  2 |
+               │  3 | class ClassDefault extends React.Component {
+               │  4 |   render()
+               │  5 |     throw new Error('nooo');
+               │    :     ^^^^^
+               │  6 |     return <h1>Default Export</h1>;
+               │  7 |   }
+               │  8 | }
+               │    \`----
+               │
+               │
+               │ Caused by:
+               │     Syntax Error
        Import trace for requested module:
        ./index.js
        ./pages/index.js",
@@ -673,7 +700,7 @@ describe('pages/ error recovery', () => {
 
     // TODO(veil): Don't bail in Turbopack for sources outside of the project (https://linear.app/vercel/issue/NDX-944)
     // We get an error because Foo didn't import React. Fair.
-    // Somehow we end up with two in React 18 due to React's attempt to recover from this error.
+    // Somehow we end up with two in React 18 + Turbopack/Rspack due to React's attempt to recover from this error.
     if (isReact18 && isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        [
@@ -701,6 +728,33 @@ describe('pages/ error recovery', () => {
              "Foo Foo.js (3:3)",
              "<FIXME-file-protocol>",
              "<FIXME-file-protocol>",
+           ],
+         },
+       ]
+      `)
+    } else if (isReact18 && isRspack) {
+      await expect(browser).toDisplayRedbox(`
+       [
+         {
+           "description": "React is not defined",
+           "environmentLabel": null,
+           "label": "Runtime ReferenceError",
+           "source": "Foo.js (3:3) @ Foo
+       > 3 |   return React.createElement('h1', null, 'Foo');
+           |   ^",
+           "stack": [
+             "Foo Foo.js (3:3)",
+           ],
+         },
+         {
+           "description": "React is not defined",
+           "environmentLabel": null,
+           "label": "Runtime ReferenceError",
+           "source": "Foo.js (3:3) @ Foo
+       > 3 |   return React.createElement('h1', null, 'Foo');
+           |   ^",
+           "stack": [
+             "Foo Foo.js (3:3)",
            ],
          },
        ]
@@ -855,18 +909,17 @@ describe('pages/ error recovery', () => {
          "label": "Build Error",
          "source": "./index.js
          × Module build failed:
-         ├─▶   ×
-         │     │   x Expected '}', got '<eof>'
-         │     │    ,-[<FIXME-project-root>/index.js:7:1]
-         │     │  4 |   i++
-         │     │  5 |   throw Error('no ' + i)
-         │     │  6 | }, 1000)
-         │     │  7 | export default function FunctionNamed() {
-         │     │    :                                         ^
-         │     │    \`----
-         │     │
-         │
-         ╰─▶ Syntax Error
+         ╰─▶   × Error:   x Expected '}', got '<eof>'
+               │    ,-[7:1]
+               │  4 |   i++
+               │  5 |   throw Error('no ' + i)
+               │  6 | }, 1000)
+               │  7 | export default function FunctionNamed() {
+               │    \`----
+               │
+               │
+               │ Caused by:
+               │     Syntax Error
        Import trace for requested module:
        ./index.js
        ./pages/index.js",
@@ -922,18 +975,17 @@ describe('pages/ error recovery', () => {
          "label": "Build Error",
          "source": "./index.js
          × Module build failed:
-         ├─▶   ×
-         │     │   x Expected '}', got '<eof>'
-         │     │    ,-[<FIXME-project-root>/index.js:7:1]
-         │     │  4 |   i++
-         │     │  5 |   throw Error('no ' + i)
-         │     │  6 | }, 1000)
-         │     │  7 | export default function FunctionNamed() {
-         │     │    :                                         ^
-         │     │    \`----
-         │     │
-         │
-         ╰─▶ Syntax Error
+         ╰─▶   × Error:   x Expected '}', got '<eof>'
+               │    ,-[7:1]
+               │  4 |   i++
+               │  5 |   throw Error('no ' + i)
+               │  6 | }, 1000)
+               │  7 | export default function FunctionNamed() {
+               │    \`----
+               │
+               │
+               │ Caused by:
+               │     Syntax Error
        Import trace for requested module:
        ./index.js
        ./pages/index.js",


### PR DESCRIPTION
After fixing the workflow config for Rspack in #83677, we're now running more Rspack tests with React 18 on the `canary` branch. A few snapshot tests now need to be updated because of that. The special cases are the same as what we already had for Turbopack + React 18.