### PR TITLE
Turbopack: Remove matchers.reload() call on each request

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -606,6 +606,10 @@ export default abstract class Server<
     this.responseCache = this.getResponseCache({ dev })
   }
 
+  protected reloadMatchers() {
+    return this.matchers.reload()
+  }
+
   private handleRSCRequest: RouteHandler<ServerRequest, ServerResponse> = (
     req,
     _res,

--- a/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
+++ b/packages/next/src/server/route-matcher-managers/dev-route-matcher-manager.ts
@@ -65,10 +65,6 @@ export class DevRouteMatcherManager extends DefaultRouteMatcherManager {
     pathname: string,
     options: MatchOptions
   ): AsyncGenerator<RouteMatch<RouteDefinition<RouteKind>>, null, undefined> {
-    // Compile the development routes.
-    // TODO: we may want to only run this during testing, users won't be fast enough to require this many dir scans
-    await super.reload()
-
     // Iterate over the development matches to see if one of them match the
     // request path.
     for await (const developmentMatch of super.matchAll(pathname, options)) {


### PR DESCRIPTION
## What?

It's likely that because of the bug in #83628 this logic existed in order to make the tests pass but it adds significant overhead depending on the size of your `app` directory. Since #83628 matches the watcher no longer wait for 200ms it should no longer be needed. Let's see how the tests do with the change.

Closes PACK-5448