### PR TITLE
Revert "Remove clientParamParsing requirement from RDC for Navigations"

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1574,7 +1574,12 @@ export default async function build(
                 // Once we've made RDC for Navigations the default for PPR, we
                 // can remove the check for `config.experimental.rdcForNavigations`.
                 isAppPPREnabled &&
-                config.experimental.rdcForNavigations === true,
+                config.experimental.rdcForNavigations === true &&
+                // Temporarily we require that clientParamParsing is enabled for
+                // RDC for Navigations. This is due to a builder configuration
+                // bug that manifests as invalid query params being passed to
+                // the resume lambdas.
+                config.experimental.clientParamParsing === true,
             },
             rewriteHeaders: {
               pathHeader: NEXT_REWRITTEN_PATH_HEADER,
@@ -2194,8 +2199,7 @@ export default async function build(
 
                       if (pageType === 'app' && originalAppPath) {
                         appNormalizedPaths.set(originalAppPath, page)
-
-                        // Edge runtime doesn't support static generation.
+                        // TODO-APP: handle prerendering with edge
                         if (isEdgeRuntime(pageRuntime)) {
                           isStatic = false
                           isSSG = false

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -294,7 +294,13 @@ export async function handler(
   // When a page supports PPR, we can support RSC for Navigations so long as the
   // feature is not disabled.
   const supportsRSCForNavigations =
-    isRoutePPREnabled && nextConfig.experimental.rdcForNavigations === true
+    isRoutePPREnabled &&
+    nextConfig.experimental.rdcForNavigations === true &&
+    // Temporarily we require that clientParamParsing is enabled for
+    // RDC for Navigations. This is due to a builder configuration
+    // bug that manifests as invalid query params being passed to
+    // the resume lambdas.
+    nextConfig.experimental.clientParamParsing === true
 
   // In development, we always want to generate dynamic HTML.
   const supportsDynamicResponse: boolean =


### PR DESCRIPTION
Reverts vercel/next.js#83661

This appears to be causing performance regressions and failing deployment tests. 

[Failures](https://github.com/vercel/next.js/actions/runs/17660037496/job/50193288746)