### PR TITLE
Only enable unhandledRejection filtering when opted in

### DIFF
--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -10,6 +10,9 @@ describe('Cache Components Errors', () => {
     files: __dirname + '/fixtures/default',
     skipStart: !isNextDev,
     skipDeployment: true,
+    env: {
+      __NEXT_USE_UNHANDLED_REJECTION_FILTER: 'enabled',
+    },
   })
   const isRspack = !!process.env.NEXT_RSPACK
 


### PR DESCRIPTION
We need to debug some unexpected process crashes in front. This change makes the unhandled rejection filter only enabled when configred with the __NEXT_USE_UNHANDLED_REJECTION_FILTER environment variable.
