### PR TITLE
Fix index data route for adapter build-complete

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -851,7 +851,10 @@ export async function handleBuildComplete({
         outputs.prerenders.push(initialOutput)
 
         if (dataRoute) {
-          let dataFilePath = path.join(pagesDistDir, `${route}.json`)
+          let dataFilePath = path.join(
+            pagesDistDir,
+            `${route === '/' ? 'index' : route}.json`
+          )
 
           if (isAppPage) {
             // When experimental PPR is enabled, we expect that the data


### PR DESCRIPTION
Fixes another case caught by testing ensuring we normalize the `_next/data` filename correctly for `index`.