### PR TITLE
[Turbopack] Fix AST traversal for `this` in function default parameters

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -2059,6 +2059,7 @@ impl VisitAstPath for Analyzer<'_> {
                     | AstParentKind::ClassDecl(ClassDeclField::Class)
                     | AstParentKind::ClassExpr(ClassExprField::Class)
                     | AstParentKind::Function(FunctionField::Body)
+                    | AstParentKind::Function(FunctionField::Params(_))
             )
         }) {
             // We are in some scope that will rebind this

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/this-in-default-params/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/this-in-default-params/input/index.js
@@ -1,0 +1,38 @@
+it('should handle this in default parameters for function declaration', () => {
+  function withDefault(value = this.prop) {
+    return value
+  }
+
+  const obj = { prop: 42 }
+  expect(withDefault.call(obj)).toBe(42)
+})
+
+it('should handle this in default parameters for function expression', () => {
+  const funcExpr = function (value = this.prop) {
+    return value
+  }
+
+  const obj = { prop: 55 }
+  expect(funcExpr.call(obj)).toBe(55)
+})
+
+it('should handle this in default parameters for arrow function', () => {
+  const obj = {
+    prop: 77,
+    test() {
+      const arrow = (value = this.prop) => value
+      return arrow()
+    },
+  }
+  expect(obj.test()).toBe(77)
+})
+
+it('should handle this in default parameters for object method', () => {
+  const obj = {
+    prop: 100,
+    method(value = this.prop) {
+      return value
+    },
+  }
+  expect(obj.method()).toBe(100)
+})


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

Include FunctionField::Params in the AST traversal check to correctly identify when `this` appears within a function's scope. Previously only checked FunctionField::Body, missing `this` usage in default parameters.

Fixes #83739