### PR TITLE
perf(dev): skip static path generation for routes without `generateStaticParams`

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2290,7 +2290,8 @@ export default abstract class Server<
     if (
       routeModule?.isDev &&
       isDynamicRoute(pathname) &&
-      (components.getStaticPaths || isAppPath)
+      (components.getStaticPaths ||
+        (isAppPath && components.hasGenerateStaticParams))
     ) {
       const pathsResults = await this.getStaticPaths({
         pathname,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2291,7 +2291,13 @@ export default abstract class Server<
       routeModule?.isDev &&
       isDynamicRoute(pathname) &&
       (components.getStaticPaths ||
-        (isAppPath && components.hasGenerateStaticParams))
+        // In export mode, static path generation is required. Therefore, we need to run
+        // generateStaticParams in order to identify which paths are currently not generated.
+        this.nextConfig.output === 'export' ||
+        // Only run if the module has generateStaticParams defined because it spawns a worker and
+        // loads the whole app into memory, resulting in any side effects being executed as well,
+        // which can be fairly expensive in large apps.
+        components.hasGenerateStaticParams)
     ) {
       const pathsResults = await this.getStaticPaths({
         pathname,

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -34,6 +34,12 @@ import { createServerModuleMap } from './app-render/action-utils'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
 import { isStaticMetadataRoute } from '../lib/metadata/is-metadata-route'
+import {
+  isAppPageRouteModule,
+  isAppRouteRouteModule,
+} from './route-modules/checks'
+import { collectSegments } from '../build/segment-config/app/app-segments'
+import { isDynamicRoute } from '../shared/lib/router/utils'
 
 export type ManifestItem = {
   id: number | string
@@ -76,6 +82,7 @@ export type LoadComponentsReturnType<NextModule = any> = {
   ComponentMod: NextModule
   routeModule: RouteModule
   isAppPath?: boolean
+  hasGenerateStaticParams?: boolean
   page: string
   multiZoneDraftMode?: boolean
 }
@@ -298,6 +305,30 @@ async function loadComponentsImpl<N = any>({
     const { getServerSideProps, getStaticProps, getStaticPaths, routeModule } =
       ComponentMod
 
+    // In dev, static path generation runs on-demand. Unlike getStaticPaths which is a
+    // 1:1 export from the page component module, generateStaticParams can be defined in
+    // page/layout/route files and the params cascade down the tree. Therefore to verify
+    // if this module is eligible to run generateStaticParams, we need to check the segments.
+    let hasGenerateStaticParams: boolean | undefined
+    if (
+      isDev &&
+      isAppPath &&
+      isDynamicRoute(page) &&
+      routeModule &&
+      (isAppPageRouteModule(routeModule) || isAppRouteRouteModule(routeModule))
+    ) {
+      try {
+        const segments = await collectSegments(routeModule)
+        hasGenerateStaticParams = segments.some(
+          (segment) => typeof segment.generateStaticParams === 'function'
+        )
+      } catch (cause) {
+        throw new Error(`Failed to collect configuration for ${page}`, {
+          cause,
+        })
+      }
+    }
+
     return {
       App,
       Document,
@@ -316,6 +347,7 @@ async function loadComponentsImpl<N = any>({
       isAppPath,
       page,
       routeModule,
+      hasGenerateStaticParams,
     }
   } else {
     const ComponentMod = await requirePage(page, distDir, isAppPath)
@@ -326,6 +358,30 @@ async function loadComponentsImpl<N = any>({
 
     const { getServerSideProps, getStaticProps, getStaticPaths, routeModule } =
       ComponentMod
+
+    // In dev, static path generation runs on-demand. Unlike getStaticPaths which is a
+    // 1:1 export from the page component module, generateStaticParams can be defined in
+    // page/layout/route files and the params cascade down the tree. Therefore to verify
+    // if this module is eligible to run generateStaticParams, we need to check the segments.
+    let hasGenerateStaticParams: boolean | undefined
+    if (
+      isDev &&
+      isAppPath &&
+      isDynamicRoute(page) &&
+      routeModule &&
+      (isAppPageRouteModule(routeModule) || isAppRouteRouteModule(routeModule))
+    ) {
+      try {
+        const segments = await collectSegments(routeModule)
+        hasGenerateStaticParams = segments.some(
+          (segment) => typeof segment.generateStaticParams === 'function'
+        )
+      } catch (cause) {
+        throw new Error(`Failed to collect configuration for ${page}`, {
+          cause,
+        })
+      }
+    }
 
     return {
       App,
@@ -339,6 +395,7 @@ async function loadComponentsImpl<N = any>({
       isAppPath,
       page,
       routeModule,
+      hasGenerateStaticParams,
     } as any // temporary `as any` to make TypeScript not fail so that the tests will run on the PR.
   }
 }


### PR DESCRIPTION
### Why?

In dev, generateStaticParams runs whenever there's a code change, regardless of whether generateStaticParams is present. While this doesn't block the render, it can be fairly expensive to do in a large app, as it will spin up a worker and load the whole app into memory, resulting in any side effects being executed as well.

### How?

In load-component, check the module's segments and see if they have `generateStaticParams`.

Closes NEXT-4634