### PR TITLE
[backport] Turbopack: don't treat metadata routes as RSC

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1133,8 +1133,8 @@ impl AppEndpoint {
         next_config: Vc<NextConfig>,
     ) -> Result<Vc<AppEntry>> {
         Ok(get_app_metadata_route_entry(
-            self.app_project.rsc_module_context(),
-            self.app_project.edge_rsc_module_context(),
+            self.app_project.route_module_context(),
+            self.app_project.edge_route_module_context(),
             self.app_project.project().project_path().owned().await?,
             self.page.clone(),
             *self.app_project.project().next_mode().await?,
@@ -1193,11 +1193,7 @@ impl AppEndpoint {
                 AppEndpointType::Metadata { metadata } => (
                     false,
                     false,
-                    if matches!(metadata, MetadataItem::Dynamic { .. }) {
-                        EmitManifests::Full
-                    } else {
-                        EmitManifests::Minimal
-                    },
+                    EmitManifests::Minimal,
                     matches!(metadata, MetadataItem::Dynamic { .. }),
                 ),
             };

--- a/test/e2e/app-dir/dynamic/app/api/route.js
+++ b/test/e2e/app-dir/dynamic/app/api/route.js
@@ -1,0 +1,5 @@
+import { DynamicComponent } from '../client-reference'
+
+export async function GET() {
+  return new Response('Hello ' + typeof DynamicComponent)
+}

--- a/test/e2e/app-dir/dynamic/app/client-reference.js
+++ b/test/e2e/app-dir/dynamic/app/client-reference.js
@@ -1,0 +1,5 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+export const DynamicComponent = dynamic(() => import('./dynamic-component'))

--- a/test/e2e/app-dir/dynamic/app/dynamic-component.js
+++ b/test/e2e/app-dir/dynamic/app/dynamic-component.js
@@ -1,0 +1,7 @@
+const DynamicImportComponent = () => {
+  return (
+    <div id="dynamic-component">This is a dynamically imported component</div>
+  )
+}
+
+export default DynamicImportComponent

--- a/test/e2e/app-dir/dynamic/app/sitemap.js
+++ b/test/e2e/app-dir/dynamic/app/sitemap.js
@@ -1,0 +1,14 @@
+import { DynamicComponent } from './client-reference'
+
+globalThis.foo = DynamicComponent
+
+export default function sitemap() {
+  return [
+    {
+      url: 'https://acme.com',
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 1,
+    },
+  ]
+}

--- a/test/e2e/app-dir/dynamic/dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic/dynamic.test.ts
@@ -64,6 +64,16 @@ describe('app dir - next/dynamic', () => {
     expect($('#dynamic-component').text()).not.toContain('loading')
   })
 
+  it('should ignore next/dynamic in routes', async () => {
+    const response = await next.fetch('/api')
+    expect(await response.text()).toEqual('Hello function')
+  })
+
+  it('should ignore next/dynamic in sitemap', async () => {
+    const response = await next.fetch('/sitemap.xml')
+    expect(await response.text()).toInclude('<changefreq>yearly</changefreq>')
+  })
+
   if (isNextDev) {
     it('should directly raise error when dynamic component error on server', async () => {
       const pagePath = 'app/default-loading/dynamic-component.js'


### PR DESCRIPTION
Backport #82911

Closes PACK-5480