### PR TITLE
Remove references to size metrics in next build from our docs

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/devIndicators.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/devIndicators.mdx
@@ -25,9 +25,9 @@ If you expect a route to be static and the indicator has marked it as dynamic, i
 You can confirm if a route is [static](/docs/app/getting-started/partial-prerendering#static-rendering) or [dynamic](/docs/app/getting-started/partial-prerendering#dynamic-rendering) by building your application using `next build --debug`, and checking the output in your terminal. Static (or prerendered) routes will display a `○` symbol, whereas dynamic routes will display a `ƒ` symbol. For example:
 
 ```bash filename="Build Output"
-Route (app)                              Size     First Load JS
-┌ ○ /_not-found                          0 B               0 kB
-└ ƒ /products/[id]                       0 B               0 kB
+Route (app)
+┌ ○ /_not-found
+└ ƒ /products/[id]
 
 ○  (Static)   prerendered as static content
 ƒ  (Dynamic)  server-rendered on demand

--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -60,18 +60,15 @@ The following commands are available:
 `next build` creates an optimized production build of your application. The output displays information about each route. For example:
 
 ```bash filename="Terminal"
-Route (app)                              Size     First Load JS
-┌ ○ /_not-found                          0 B               0 kB
-└ ƒ /products/[id]                       0 B               0 kB
+Route (app)
+┌ ○ /_not-found
+└ ƒ /products/[id]
 
 ○  (Static)   prerendered as static content
 ƒ  (Dynamic)  server-rendered on demand
 ```
 
-- **Size**: The size of assets downloaded when navigating to the page client-side. The size for each route only includes its dependencies.
-- **First Load JS**: The size of assets downloaded when visiting the page from the server. The amount of JS shared by all is shown as a separate metric.
-
-Both of these values are [**compressed with gzip**](/docs/app/api-reference/config/next-config-js/compress). The first load is indicated by green, yellow, or red. Aim for green for performant applications.
+If your application uses [caching features](/docs/app/building-your-application/caching) like `revalidate` or `expire`, additional columns will be shown in the routes table with detailed information.
 
 The following options are available for the `next build` command:
 

--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -304,5 +304,6 @@ NODE_OPTIONS='--inspect' next
 
 | Version   | Changes                                                                         |
 | --------- | ------------------------------------------------------------------------------- |
+| `v16.0.0` | The JS bundle size metrics have been removed from `next build`                  |
 | `v15.5.0` | Add the `next typegen` command                                                  |
 | `v15.4.0` | Add `--debug-prerender` option for `next build` to help debug prerender errors. |

--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -68,8 +68,6 @@ Route (app)
 ƒ  (Dynamic)  server-rendered on demand
 ```
 
-If your application uses [caching features](/docs/app/building-your-application/caching) like `revalidate` or `expire`, additional columns will be shown in the routes table with detailed information.
-
 The following options are available for the `next build` command:
 
 | Option                             | Description                                                                                                                                                                        |


### PR DESCRIPTION
Update docs to account for the removal of JS size metrics.  See #83815 for full context

Closes PACK-5599