### PR TITLE
[test] Disable flaky navigation test

### DIFF
--- a/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
+++ b/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
@@ -100,7 +100,8 @@ describe('back/forward cache', () => {
     expect(await counterDisplay2AfterNav.text()).toBe('Count: 9')
   })
 
-  it('React state is preserved when navigating back to a page with different search params than before ', async () => {
+  // FIXME: Flaky test: https://vercel.slack.com/archives/C07CJPHL49E/p1758009379720479
+  it.skip('React state is preserved when navigating back to a page with different search params than before ', async () => {
     const browser = await next.browser('/page/1')
 
     // Accumulate some state on page 1.


### PR DESCRIPTION
Not test flake but implementation flake: [dashboard of failed tests](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3Atest%2Fe2e%2Fapp-dir%2Fback-forward-cache%2Fback-forward-cache.test.ts%20%40test.status%3Afail%20%40test_session.name%3Atest-deploy-%2A%20%40test.name%3A%22back%2Fforward%20cache%20React%20state%20is%20preserved%20when%20navigating%20back%20to%20a%20page%20with%20different%20search%20params%20than%20before%20%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1757403957449&end=1758008757449&paused=false). Disabling since it blocks too many syncs and we don't have the flag on internally anyway.