### PR TITLE
[next-config-ts] Set Node.js native TS loader fallback flag to process.env

### DIFF
--- a/packages/next/src/build/next-config-ts/transpile-config.ts
+++ b/packages/next/src/build/next-config-ts/transpile-config.ts
@@ -105,8 +105,6 @@ async function getTsConfig(cwd: string): Promise<CompilerOptions> {
   return parsedCommandLine.options
 }
 
-let useNodeNativeTSLoader = true
-
 export async function transpileConfig({
   nextConfigPath,
   configFileName,
@@ -117,7 +115,8 @@ export async function transpileConfig({
   cwd: string
 }) {
   try {
-    if (useNodeNativeTSLoader) {
+    // envs are passed to the workers and preserve the flag
+    if (process.env.__NEXT_NODE_NATIVE_TS_LOADER_FAILED !== '1') {
       try {
         // Node.js v22.10.0+
         // Value is 'strip' or 'transform' based on how the feature is enabled.
@@ -140,7 +139,7 @@ export async function transpileConfig({
         }
 
         // Feature is not enabled, fallback to legacy resolution for current session.
-        useNodeNativeTSLoader = false
+        process.env.__NEXT_NODE_NATIVE_TS_LOADER_FAILED = '1'
       } catch (cause) {
         warnOnce(
           `Failed to import "${configFileName}" using Node.js native TypeScript resolution.` +
@@ -148,7 +147,7 @@ export async function transpileConfig({
           { cause }
         )
         // Once failed, fallback to legacy resolution for current session.
-        useNodeNativeTSLoader = false
+        process.env.__NEXT_NODE_NATIVE_TS_LOADER_FAILED = '1'
       }
     }
 


### PR DESCRIPTION
Since local variables aren't passed to the workers, the fallback flag wasn't passed correctly. Since `process.env` is passed, use that to set the flag.

#### Before

```
    running pnpm next build

 ⚠ Failed to import "next.config.ts" using Node.js native TypeScript resolution. Falling back to legacy resolution. {
  cause: TypeError: Module "file:///private/var/folders/cm/328vyfy92k194zkm0jpl5sqw0000gn/T/next-install-0b4875510d429ddf1727b03e3cbba84cb61013dfee0914f9812b7608c029a47f/foo.json" needs an import attribute of "type: json"
      at ignore-listed frames {
    code: 'ERR_IMPORT_ATTRIBUTE_MISSING'
  }
}

   Creating an optimized production build ...
 ⚠ Failed to import "next.config.ts" using Node.js native TypeScript resolution. Falling back to legacy resolution. {
  cause: TypeError: Module "file:///private/var/folders/cm/328vyfy92k194zkm0jpl5sqw0000gn/T/next-install-0b4875510d429ddf1727b03e3cbba84cb61013dfee0914f9812b7608c029a47f/foo.json" needs an import attribute of "type: json"
      at ignore-listed frames {
    code: 'ERR_IMPORT_ATTRIBUTE_MISSING'
  }
}
 ⚠ Failed to import "next.config.ts" using Node.js native TypeScript resolution. Falling back to legacy resolution. {
  cause: TypeError: Module "file:///private/var/folders/cm/328vyfy92k194zkm0jpl5sqw0000gn/T/next-install-0b4875510d429ddf1727b03e3cbba84cb61013dfee0914f9812b7608c029a47f/foo.json" needs an import attribute of "type: json"
      at ignore-listed frames {
    code: 'ERR_IMPORT_ATTRIBUTE_MISSING'
  }
}
 ⚠ Failed to import "next.config.ts" using Node.js native TypeScript resolution. Falling back to legacy resolution. {
  cause: TypeError: Module "file:///private/var/folders/cm/328vyfy92k194zkm0jpl5sqw0000gn/T/next-install-0b4875510d429ddf1727b03e3cbba84cb61013dfee0914f9812b7608c029a47f/foo.json" needs an import attribute of "type: json"
      at ignore-listed frames {
    code: 'ERR_IMPORT_ATTRIBUTE_MISSING'
  }
}

 ✓ Starting...
 ⚠ Failed to import "next.config.ts" using Node.js native TypeScript resolution. Falling back to legacy resolution. {
  cause: TypeError: Module "file:///private/var/folders/cm/328vyfy92k194zkm0jpl5sqw0000gn/T/next-install-0b4875510d429ddf1727b03e3cbba84cb61013dfee0914f9812b7608c029a47f/foo.json" needs an import attribute of "type: json"
      at ignore-listed frames {
    code: 'ERR_IMPORT_ATTRIBUTE_MISSING'
  }
}
 ✓ Ready in 316ms
```

#### After

```
    running pnpm next build

 ⚠ Failed to import "next.config.ts" using Node.js native TypeScript resolution. Falling back to legacy resolution. {
  cause: TypeError: Module "file:///private/var/folders/cm/328vyfy92k194zkm0jpl5sqw0000gn/T/next-install-baa26127b75b4c408a5e1a471c7b7908c7cd11e4843c7a9d850a2c0d8ca2eadb/foo.json" needs an import attribute of "type: json"
      at ignore-listed frames {
    code: 'ERR_IMPORT_ATTRIBUTE_MISSING'
  }
}
 ✓ Starting...
 ⚠ Failed to import "next.config.ts" using Node.js native TypeScript resolution. Falling back to legacy resolution. {
  cause: TypeError: Module "file:///private/var/folders/cm/328vyfy92k194zkm0jpl5sqw0000gn/T/next-install-baa26127b75b4c408a5e1a471c7b7908c7cd11e4843c7a9d850a2c0d8ca2eadb/foo.json" needs an import attribute of "type: json"
      at ignore-listed frames {
    code: 'ERR_IMPORT_ATTRIBUTE_MISSING'
  }
}
 ✓ Ready in 309ms
```