### PR TITLE
[Cache Components] Allow sync IO inside console methods 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,6 +62,7 @@
     "packages/next/src/server/app-render/dynamic-access-async-storage-instance.ts",
     "packages/next/src/server/app-render/work-async-storage-instance.ts",
     "packages/next/src/server/app-render/work-unit-async-storage-instance.ts",
+    "packages/next/src/server/app-render/dev-logs-async-storage-instance.ts",
     "packages/next/src/client/components/segment-cache-impl/*"
   ],
   // Disable TypeScript surveys.

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -174,6 +174,7 @@ import {
   workUnitAsyncStorage,
   type PrerenderStore,
 } from './work-unit-async-storage.external'
+import { devLogsAsyncStorage } from './dev-logs-async-storage.external'
 import { CacheSignal } from './cache-signal'
 import { getTracedMetadata } from '../lib/trace/utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
@@ -2302,7 +2303,9 @@ async function renderToStream(
         }
       )
 
-      spawnDynamicValidationInDev(
+      devLogsAsyncStorage.run(
+        { dim: true },
+        spawnDynamicValidationInDev,
         resolveValidation,
         tree,
         ctx,

--- a/packages/next/src/server/app-render/dev-logs-async-storage-instance.ts
+++ b/packages/next/src/server/app-render/dev-logs-async-storage-instance.ts
@@ -1,0 +1,5 @@
+import { createAsyncLocalStorage } from './async-local-storage'
+import type { DevLogsAsyncStorage } from './dev-logs-async-storage.external'
+
+export const devLogsAsyncStorageInstance: DevLogsAsyncStorage =
+  createAsyncLocalStorage()

--- a/packages/next/src/server/app-render/dev-logs-async-storage.external.ts
+++ b/packages/next/src/server/app-render/dev-logs-async-storage.external.ts
@@ -1,0 +1,17 @@
+import type { AsyncLocalStorage } from 'async_hooks'
+
+// Share the instance module in the next-shared layer
+import { devLogsAsyncStorageInstance } from './dev-logs-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+
+export interface DevLogsStore {
+  /**
+   * if true the color of logs output will be dimmed to indicate the log is
+   * from a repeat or validation render that is not typically relevant to
+   * the primary action the server is taking.
+   */
+  readonly dim: boolean
+}
+
+export type DevLogsAsyncStorage = AsyncLocalStorage<DevLogsStore>
+
+export { devLogsAsyncStorageInstance as devLogsAsyncStorage }

--- a/packages/next/src/server/node-environment-extensions/console-exit.test.ts
+++ b/packages/next/src/server/node-environment-extensions/console-exit.test.ts
@@ -1,0 +1,689 @@
+/**
+ * Testing console patching in Jest requires isolation since console methods are heavily used
+ * by the test runner itself. We use the same worker thread strategy as unhandled-rejection.test.ts
+ * to ensure our patches don't interfere with Jest's own console usage.
+ *
+ * @jest-environment node
+ */
+
+/* eslint-disable @next/internal/typechecked-require */
+
+type ReportableResult =
+  | ConsoleCallReport
+  | ErrorReport
+  | OutputReport
+  | SerializableDataReport
+
+type ConsoleCallReport = {
+  type: 'console-call'
+  method: string
+  input: string
+}
+
+type ErrorReport = { type: 'error'; message: string }
+type OutputReport = { type: 'output'; message: string }
+type SerializableDataReport = {
+  type: 'serialized'
+  key: string
+  data: string | number | boolean
+}
+
+declare global {
+  function reportResult(result: ReportableResult): void
+}
+
+import type { WorkUnitStore } from '../app-render/work-unit-async-storage.external'
+import { Worker } from 'node:worker_threads'
+
+type WorkerResult = {
+  exitCode: number
+  stderr: string
+  consoleCalls: Array<{ method: string; input: string }>
+  data: Record<string, unknown>
+  messages: Array<ReportableResult>
+}
+
+export function runWorkerCode(fn: Function): Promise<WorkerResult> {
+  return new Promise((resolve, reject) => {
+    const script = `
+      const { parentPort } = require('node:worker_threads');
+      (async () => {
+        const { AsyncLocalStorage } = require('node:async_hooks');
+        // We need to put this on the global because Next.js does not import it
+        // from node directly to be compatible with edge runtimes.
+        globalThis.AsyncLocalStorage = AsyncLocalStorage;
+
+        global.reportResult = (value) => {
+          parentPort?.postMessage(value);
+        };
+
+        const fn = (${fn.toString()});
+        try {
+          const out = await fn();
+          await new Promise(r => setImmediate(r));
+          reportResult({ type: 'result', out });
+        } catch (e) {
+          reportResult({ type: 'error', message: String(e && e.message || e) });
+        }
+      })();
+    `
+
+    const w = new Worker(script, {
+      eval: true,
+      workerData: null,
+      argv: [],
+      execArgv: [],
+      stderr: true,
+      stdout: false,
+    })
+
+    const messages: Array<ReportableResult> = []
+    const consoleCalls: Array<{ method: string; input: string }> = []
+    const data = {} as Record<string, unknown>
+    let stderr = ''
+
+    w.on('message', (m) => {
+      messages.push(m)
+      switch (m.type) {
+        case 'console-call':
+          consoleCalls.push({
+            method: m.method,
+            input: m.input,
+          })
+          break
+        case 'serialized':
+          data[m.key] = JSON.parse(m.data)
+          break
+        default:
+          break
+      }
+    })
+    w.on('error', (err) => console.error('Worker error', err))
+    w.on('error', reject)
+    w.stderr?.on('data', (b) => (stderr += String(b)))
+    w.on('exit', (code) =>
+      resolve({
+        exitCode: code ?? -1,
+        consoleCalls,
+        data,
+        messages,
+        stderr,
+      })
+    )
+  })
+}
+
+describe('console-exit patches', () => {
+  describe('basic functionality', () => {
+    it('should wrap existing console methods to exit workUnit storage', async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        // First, replace console.log to track what storage context it runs in
+        console.log = function (...args) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'log',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        // Install patches - this wraps the current console.log
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        // Test outside storage context
+        console.log('outside')
+
+        // Test inside storage context - should show [No Store] because wrapping exits storage
+        workUnitAsyncStorage.run({ type: 'prerender' } as WorkUnitStore, () => {
+          console.log('inside')
+        })
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      // Both should show [No Store] because the wrapped console.log exits storage
+      expect(consoleCalls).toEqual([
+        { method: 'log', input: '[No Store]: outside' },
+        { method: 'log', input: '[No Store]: inside' },
+      ])
+    })
+
+    it('should not wrap console methods assigned after patching', async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        // Install patches first
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        // Assign a new console.log after patching - this will NOT be wrapped
+        console.log = function (...args) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'log',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        // Test outside storage context
+        console.log('outside')
+
+        // Test inside storage context - should show [Store] because new assignment is not wrapped
+        workUnitAsyncStorage.run({ type: 'prerender' } as WorkUnitStore, () => {
+          console.log('inside')
+        })
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      // New assignments after patching are NOT wrapped, so they preserve storage context
+      expect(consoleCalls).toEqual([
+        { method: 'log', input: '[No Store]: outside' },
+        { method: 'log', input: '[Store]: inside' },
+      ])
+    })
+
+    it('should preserve function properties and behavior', async () => {
+      async function testForWorker() {
+        reportResult({
+          type: 'serialized',
+          key: 'originalName',
+          data: JSON.stringify(console.log.name),
+        })
+
+        reportResult({
+          type: 'serialized',
+          key: 'originalLength',
+          data: JSON.stringify(console.log.length),
+        })
+
+        // install patch
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        // Test that patched methods preserve name and other properties
+        reportResult({
+          type: 'serialized',
+          key: 'patchedName',
+          data: JSON.stringify(console.log.name),
+        })
+
+        reportResult({
+          type: 'serialized',
+          key: 'patchedLength',
+          data: JSON.stringify(console.log.length),
+        })
+      }
+
+      const { data, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(data.patchedName).toBe('log')
+      expect(data.patchedName).toBe(data.originalName)
+      expect(data.patchedLength).toBe(data.originalLength)
+    })
+  })
+
+  describe('multiple console methods', () => {
+    it(`should patch the log method`, async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        console.log = function (...args: Array<any>) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'log',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          console.log('inside')
+        })
+        console.log('outside')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'log', input: `[No Store]: inside` },
+        { method: 'log', input: `[No Store]: outside` },
+      ])
+    })
+
+    it(`should patch the error method`, async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        console.error = function (...args: Array<any>) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'error',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          console.error('inside')
+        })
+        console.error('outside')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'error', input: `[No Store]: inside` },
+        { method: 'error', input: `[No Store]: outside` },
+      ])
+    })
+
+    it(`should patch the warn method`, async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        console.warn = function (...args: Array<any>) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'warn',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          console.warn('inside')
+        })
+        console.warn('outside')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'warn', input: `[No Store]: inside` },
+        { method: 'warn', input: `[No Store]: outside` },
+      ])
+    })
+
+    it(`should patch the info method`, async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        console.info = function (...args: Array<any>) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'info',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          console.info('inside')
+        })
+        console.info('outside')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'info', input: `[No Store]: inside` },
+        { method: 'info', input: `[No Store]: outside` },
+      ])
+    })
+
+    it(`should patch the debug method`, async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        console.debug = function (...args: Array<any>) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'debug',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          console.debug('inside')
+        })
+        console.debug('outside')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'debug', input: `[No Store]: inside` },
+        { method: 'debug', input: `[No Store]: outside` },
+      ])
+    })
+
+    it(`should patch the trace method`, async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        console.trace = function (...args: Array<any>) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'trace',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          console.trace('inside')
+        })
+        console.trace('outside')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'trace', input: `[No Store]: inside` },
+        { method: 'trace', input: `[No Store]: outside` },
+      ])
+    })
+
+    it(`should patch the dir method`, async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        console.dir = function (...args: Array<any>) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'dir',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          console.dir('inside')
+        })
+        console.dir('outside')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'dir', input: `[No Store]: inside` },
+        { method: 'dir', input: `[No Store]: outside` },
+      ])
+    })
+
+    it(`should patch the dirxml method`, async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        console.dirxml = function (...args: Array<any>) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'dirxml',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          console.dirxml('inside')
+        })
+        console.dirxml('outside')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'dirxml', input: `[No Store]: inside` },
+        { method: 'dirxml', input: `[No Store]: outside` },
+      ])
+    })
+
+    it(`should patch the table method`, async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        console.table = function (...args: Array<any>) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'table',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          console.table('inside')
+        })
+        console.table('outside')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'table', input: `[No Store]: inside` },
+        { method: 'table', input: `[No Store]: outside` },
+      ])
+    })
+
+    it(`should patch the assert method`, async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        console.assert = function (...args: Array<any>) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'assert',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          console.assert('inside')
+        })
+        console.assert('outside')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'assert', input: `[No Store]: inside` },
+        { method: 'assert', input: `[No Store]: outside` },
+      ])
+    })
+
+    it(`should patch the group method`, async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        console.group = function (...args: Array<any>) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'group',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          console.group('inside')
+        })
+        console.group('outside')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'group', input: `[No Store]: inside` },
+        { method: 'group', input: `[No Store]: outside` },
+      ])
+    })
+
+    it(`should patch the groupCollapsed method`, async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        console.groupCollapsed = function (...args: Array<any>) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'groupCollapsed',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          console.groupCollapsed('inside')
+        })
+        console.groupCollapsed('outside')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'groupCollapsed', input: `[No Store]: inside` },
+        { method: 'groupCollapsed', input: `[No Store]: outside` },
+      ])
+    })
+
+    it(`should patch the groupEnd method`, async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        console.groupEnd = function () {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'groupEnd',
+            input: `${store ? '[Store]' : '[No Store]'}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          console.groupEnd()
+        })
+        console.groupEnd()
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'groupEnd', input: `[No Store]` },
+        { method: 'groupEnd', input: `[No Store]` },
+      ])
+    })
+
+    it('should not wrap arbitrary function property assignments', async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        // Assign an arbitrary function property that shouldn't be wrapped
+        // @ts-expect-error - intentionally assigning a custom property
+        console.customFunc = function customFunc(...args: Array<any>) {
+          const store = workUnitAsyncStorage.getStore()
+          reportResult({
+            type: 'console-call',
+            method: 'customFunc',
+            input: `${store ? '[Store]' : '[No Store]'}: ${args.join(' ')}`,
+          })
+        }
+
+        require('next/dist/server/node-environment-extensions/console-exit')
+
+        workUnitAsyncStorage.run({ type: 'request' } as WorkUnitStore, () => {
+          // @ts-expect-error - calling our custom property
+          console.customFunc('inside')
+        })
+
+        // @ts-expect-error - calling our custom property
+        console.customFunc('outside')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      // The custom function should NOT be wrapped, so it should execute WITH store context
+      expect(consoleCalls).toEqual([
+        { method: 'customFunc', input: `[Store]: inside` },
+        { method: 'customFunc', input: `[No Store]: outside` },
+      ])
+    })
+  })
+})

--- a/packages/next/src/server/node-environment-extensions/console-exit.tsx
+++ b/packages/next/src/server/node-environment-extensions/console-exit.tsx
@@ -1,0 +1,55 @@
+/**
+ * Patches console methods to exit the workUnitAsyncStorage so that inside the host implementation
+ * sync IO can be called. This is relevant for example with runtimes that patch console methods to
+ * prepend a timestamp to the log output.
+ *
+ * Note that this will only exit for already installed patched console methods. If you further patch
+ * the console method after this and add any sync IO there it will trigger sync IO warnings while prerendering.
+ *
+ * This is a pragmatic concession because layering the patches if you install your own log implementation
+ * after they are installed is very tricky to do correctly because the order matters
+ */
+
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+
+type ConsoleMethodName = keyof Console
+
+function patchConsoleMethod(methodName: ConsoleMethodName): void {
+  const descriptor = Object.getOwnPropertyDescriptor(console, methodName)
+  if (
+    descriptor &&
+    (descriptor.configurable || descriptor.writable) &&
+    typeof descriptor.value === 'function'
+  ) {
+    const originalMethod = descriptor.value
+    const originalName = Object.getOwnPropertyDescriptor(originalMethod, 'name')
+    let wrapperMethod = function (...args: any[]) {
+      return workUnitAsyncStorage.exit(() =>
+        originalMethod.apply(console, args)
+      )
+    }
+    if (originalName) {
+      Object.defineProperty(wrapperMethod, 'name', originalName)
+    }
+    Object.defineProperty(console, methodName, {
+      value: wrapperMethod,
+    })
+  }
+}
+
+// We patch the same methods that React and our dev patch do.
+// We may find other methods that could benefit from patching but if
+// they exist we ought to consider patching them in all three places
+patchConsoleMethod('error')
+patchConsoleMethod('assert')
+patchConsoleMethod('debug')
+patchConsoleMethod('dir')
+patchConsoleMethod('dirxml')
+patchConsoleMethod('group')
+patchConsoleMethod('groupCollapsed')
+patchConsoleMethod('groupEnd')
+patchConsoleMethod('info')
+patchConsoleMethod('log')
+patchConsoleMethod('table')
+patchConsoleMethod('trace')
+patchConsoleMethod('warn')

--- a/packages/next/src/server/node-environment.ts
+++ b/packages/next/src/server/node-environment.ts
@@ -5,6 +5,7 @@ import './node-environment-baseline'
 // Import as early as possible so that unexpected errors in other extensions are properly formatted.
 // Has to come after baseline since error-inspect requires AsyncLocalStorage that baseline provides.
 import './node-environment-extensions/error-inspect'
+import './node-environment-extensions/console-exit'
 import './node-environment-extensions/unhandled-rejection'
 import './node-environment-extensions/random'
 import './node-environment-extensions/date'

--- a/test/e2e/app-dir/cache-components-errors/cache-components-console-patch.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-console-patch.test.ts
@@ -1,0 +1,81 @@
+import { isNextDev, nextTestSetup } from 'e2e-utils'
+import { getPrerenderOutput } from './utils'
+
+describe('Cache Components Errors', () => {
+  const { next, isTurbopack, isNextStart, skipped } = nextTestSetup({
+    files: __dirname + '/fixtures/console-patch',
+    skipDeployment: true,
+    skipStart: !isNextDev,
+    env: {
+      NEXT_USE_UNHANDLED_REJECTION_FILTER: 'enabled',
+      NODE_OPTIONS: '--require ./patch-console.js',
+    },
+  })
+
+  if (skipped) {
+    return
+  }
+
+  let cliOutputLength: number
+
+  beforeEach(async () => {
+    cliOutputLength = next.cliOutput.length
+  })
+
+  afterEach(async () => {
+    if (isNextStart) {
+      await next.stop()
+    }
+  })
+
+  describe('Sync IO in console methods', () => {
+    describe('Console Patching', () => {
+      if (isNextDev) {
+        it('does not warn about sync IO if console.log is patched to call new Date() internally', async () => {
+          await next.browser('/')
+          let output = next.cliOutput
+          expect(output).toContain('[<timestamp>]  ✓ Compiled')
+          let index = output.indexOf('[<timestamp>]  ✓ Compiled')
+          output = output.slice(index).trim()
+          index = output.indexOf('\n')
+          output = output.slice(index).trim()
+          expect(output).toContain('GET / 200')
+          index = output.indexOf('GET / 200')
+          const snapshot = output.slice(0, index).trim()
+
+          expect(snapshot).toMatchInlineSnapshot(`
+           "[<timestamp>] This is a console log from a server component page
+           [<timestamp>] This is a console log from a server component page
+           [<timestamp>] This is a console log from a server component page"
+          `)
+        })
+      } else {
+        it('does not fail the build for Sync IO if console.log is patched to call new Date() internally', async () => {
+          try {
+            await next.build()
+          } catch {}
+
+          const output = getPrerenderOutput(
+            next.cliOutput.slice(cliOutputLength),
+            { isMinified: true }
+          )
+
+          if (isTurbopack) {
+            expect(output).toMatchInlineSnapshot(`
+             "[<timestamp>] This is a console log from a server component page
+             [<timestamp>] This is a console log from a server component page
+             [<timestamp>]"
+            `)
+          } else {
+            expect(output).toMatchInlineSnapshot(`
+                        "[<timestamp>] This is a console log from a server component page
+                        [<timestamp>] This is a console log from a server component page
+                        [<timestamp>]    Collecting build traces ...
+                        [<timestamp>]"
+                      `)
+          }
+        })
+      }
+    })
+  })
+})

--- a/test/e2e/app-dir/cache-components-errors/fixtures/console-patch/app/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/console-patch/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/console-patch/app/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/console-patch/app/page.tsx
@@ -1,0 +1,12 @@
+export default async function Page() {
+  console.log('This is a console log from a server component page')
+  return (
+    <div>
+      This page uses a console.log that has been patched before Next.js runs to
+      include a timestamp in the log line. It does not actually print the
+      timestamp because we want the assertions to be stable but we are asserting
+      that this sync IO does not interrupt the prerender when Cache Components
+      are enabled
+    </div>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/console-patch/next.config.js
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/console-patch/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    cacheComponents: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/cache-components-errors/fixtures/console-patch/patch-console.js
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/console-patch/patch-console.js
@@ -1,0 +1,12 @@
+const originalLog = console.log.bind(console)
+
+console.log = (...args) => {
+  new Date()
+  Math.random()
+  if (typeof args[0] === 'string') {
+    const firstArg = '[<timestamp>] ' + args[0]
+    originalLog(firstArg, ...args.slice(1))
+  } else {
+    originalLog('[<timestamp>] ', ...args)
+  }
+}


### PR DESCRIPTION
console methods may be patched to do things like add a timestamp to the log row. While we can't determine the meaning of reading the current time in arbitrary contexts we can know with reasonable certainty that any sync IO inside a console method is not being used in the logical output of the program. To account for this we can make a special affordance for sync IO inside of these methods that allows them to run without interrupting the prerender early.

To do this we patch these properties on the console global and set up a wrapper in the setter. This wrapper will make any assigned function into another function that exits the `workUnitAsyncStorage` scope before executing the wrapped function. This will allow `new Date()` and other sync IO APIs to be called in the internal implementation of these methods without triggering an error while prerendering.

Fixes NAR-403