### PR TITLE
Turbopack: Change run once signature to avoid exposing TaskId

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -32,9 +32,8 @@ use tracing::Instrument;
 use tracing_subscriber::{Registry, layer::SubscriberExt, util::SubscriberInitExt};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Completion, Effects, FxIndexSet, NonLocalValue, OperationValue, OperationVc, ReadRef,
-    ResolvedVc, TaskInput, TransientInstance, TryJoinIterExt, TurboTasksApi, UpdateInfo, Vc,
-    get_effects,
+    Effects, FxIndexSet, NonLocalValue, OperationValue, OperationVc, ReadRef, ResolvedVc,
+    TaskInput, TransientInstance, TryJoinIterExt, TurboTasksApi, UpdateInfo, Vc, get_effects,
     message_queue::{CompilationEvent, Severity, TimingEvent},
     trace::TraceRawVcs,
 };
@@ -465,13 +464,18 @@ pub fn project_new(
             .or_else(|e| turbopack_ctx.throw_turbopack_internal_result(&e))
             .await?;
 
-        turbo_tasks.spawn_once_task({
+        turbo_tasks.start_once_process({
             let tt = turbo_tasks.clone();
-            async move {
-                benchmark_file_io(tt, container.project().node_root().owned().await?)
-                    .await
-                    .inspect_err(|err| tracing::warn!(%err, "failed to benchmark file IO"))
-            }
+            Box::pin(async move {
+                let future = async move {
+                    benchmark_file_io(tt, container.project().node_root().owned().await?).await
+                };
+                if let Err(err) = future.await {
+                    // TODO this tracing warn will go into the void. Should we change this to
+                    // stdout?
+                    tracing::warn!(%err, "failed to benchmark file IO");
+                }
+            })
         });
 
         Ok(External::new(ProjectInstance {
@@ -519,10 +523,7 @@ impl CompilationEvent for SlowFilesystemEvent {
 /// - https://x.com/jarredsumner/status/1637549427677364224
 /// - https://github.com/oven-sh/bun/blob/06a9aa80c38b08b3148bfeabe560/src/install/install.zig#L3038
 #[tracing::instrument(skip(turbo_tasks))]
-async fn benchmark_file_io(
-    turbo_tasks: NextTurboTasks,
-    directory: FileSystemPath,
-) -> Result<Vc<Completion>> {
+async fn benchmark_file_io(turbo_tasks: NextTurboTasks, directory: FileSystemPath) -> Result<()> {
     // try to get the real file path on disk so that we can use it with tokio
     let fs = ResolvedVc::try_downcast_type::<DiskFileSystem>(directory.fs)
         .context(anyhow!(
@@ -567,7 +568,7 @@ async fn benchmark_file_io(
         }));
     }
 
-    Ok(Completion::new())
+    Ok(())
 }
 
 #[napi]

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -471,9 +471,9 @@ pub fn project_new(
                     benchmark_file_io(tt, container.project().node_root().owned().await?).await
                 };
                 if let Err(err) = future.await {
-                    // TODO this tracing warn will go into the void. Should we change this to
-                    // stdout?
-                    tracing::warn!(%err, "failed to benchmark file IO");
+                    // TODO Not ideal to print directly to stdout.
+                    // We should use a compilation event instead to report async errors.
+                    println!("Failed to benchmark file IO: {err}");
                 }
             })
         });

--- a/turbopack/crates/turbo-tasks-backend/benches/scope_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/scope_stress.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use criterion::{BenchmarkId, Criterion};
-use turbo_tasks::{Completion, ReadConsistency, TryJoinIterExt, TurboTasks, Vc};
+use turbo_tasks::{Completion, TryJoinIterExt, TurboTasks, Vc};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 
 pub fn scope_stress(c: &mut Criterion) {
@@ -47,12 +47,11 @@ pub fn scope_stress(c: &mut Criterion) {
                             .map(|(a, b)| {
                                 let tt = &tt;
                                 async move {
-                                    let task = tt.spawn_once_task(async move {
+                                    tt.run_once(async move {
                                         rectangle(a, b).strongly_consistent().await?;
-                                        Ok::<Vc<()>, _>(Default::default())
-                                    });
-                                    tt.wait_task_completion(task, ReadConsistency::Eventual)
-                                        .await
+                                        Ok(())
+                                    })
+                                    .await
                                 }
                             })
                             .try_join()

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
     future::Future,
     mem::replace,
     panic::AssertUnwindSafe,
+    pin::Pin,
     sync::{Arc, Mutex, Weak},
 };
 
@@ -120,7 +121,11 @@ impl TurboTasksCallApi for VcStorage {
     fn run_once(
         &self,
         _future: std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
-    ) -> TaskId {
+    ) -> Pin<
+        Box<
+            (dyn futures::Future<Output = Result<(), anyhow::Error>> + std::marker::Send + 'static),
+        >,
+    > {
         unreachable!()
     }
 
@@ -128,14 +133,18 @@ impl TurboTasksCallApi for VcStorage {
         &self,
         _reason: StaticOrArc<dyn InvalidationReason>,
         _future: std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
-    ) -> TaskId {
+    ) -> Pin<
+        Box<
+            (dyn futures::Future<Output = Result<(), anyhow::Error>> + std::marker::Send + 'static),
+        >,
+    > {
         unreachable!()
     }
 
-    fn run_once_process(
+    fn start_once_process(
         &self,
-        _future: std::pin::Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
-    ) -> TaskId {
+        _future: std::pin::Pin<Box<dyn Future<Output = ()> + Send + 'static>>,
+    ) {
         unreachable!()
     }
 }

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -9,9 +9,7 @@ use anyhow::{Context, Result, bail};
 use rustc_hash::FxHashSet;
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{
-    ReadConsistency, ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasks, Vc, apply_effects,
-};
+use turbo_tasks::{ResolvedVc, TransientInstance, TryJoinIterExt, TurboTasks, Vc, apply_effects};
 use turbo_tasks_backend::{
     BackendOptions, NoopBackingStorage, TurboTasksBackend, noop_backing_storage,
 };
@@ -143,51 +141,47 @@ impl TurbopackBuildBuilder {
     }
 
     pub async fn build(self) -> Result<()> {
-        let task = self.turbo_tasks.spawn_once_task::<(), _>(async move {
-            let build_result_op = build_internal(
-                self.project_dir.clone(),
-                self.root_dir,
-                self.entry_requests.clone(),
-                self.browserslist_query,
-                self.source_maps_type,
-                self.minify_type,
-                self.target,
-                self.scope_hoist,
-            );
+        self.turbo_tasks
+            .run_once(async move {
+                let build_result_op = build_internal(
+                    self.project_dir.clone(),
+                    self.root_dir,
+                    self.entry_requests.clone(),
+                    self.browserslist_query,
+                    self.source_maps_type,
+                    self.minify_type,
+                    self.target,
+                    self.scope_hoist,
+                );
 
-            // Await the result to propagate any errors.
-            build_result_op.read_strongly_consistent().await?;
+                // Await the result to propagate any errors.
+                build_result_op.read_strongly_consistent().await?;
 
-            apply_effects(build_result_op)
-                .instrument(tracing::info_span!("apply effects"))
+                apply_effects(build_result_op)
+                    .instrument(tracing::info_span!("apply effects"))
+                    .await?;
+
+                let issue_reporter: Vc<Box<dyn IssueReporter>> =
+                    Vc::upcast(ConsoleUi::new(TransientInstance::new(LogOptions {
+                        project_dir: PathBuf::from(self.project_dir),
+                        current_dir: current_dir().unwrap(),
+                        show_all: self.show_all,
+                        log_detail: self.log_detail,
+                        log_level: self.log_level,
+                    })));
+
+                handle_issues(
+                    build_result_op,
+                    issue_reporter,
+                    IssueSeverity::Error,
+                    None,
+                    None,
+                )
                 .await?;
 
-            let issue_reporter: Vc<Box<dyn IssueReporter>> =
-                Vc::upcast(ConsoleUi::new(TransientInstance::new(LogOptions {
-                    project_dir: PathBuf::from(self.project_dir),
-                    current_dir: current_dir().unwrap(),
-                    show_all: self.show_all,
-                    log_detail: self.log_detail,
-                    log_level: self.log_level,
-                })));
-
-            handle_issues(
-                build_result_op,
-                issue_reporter,
-                IssueSeverity::Error,
-                None,
-                None,
-            )
-            .await?;
-
-            Ok(Default::default())
-        });
-
-        self.turbo_tasks
-            .wait_task_completion(task, ReadConsistency::Strong)
-            .await?;
-
-        Ok(())
+                Ok(())
+            })
+            .await
     }
 }
 

--- a/turbopack/crates/turbopack-dev-server/src/update/server.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/server.rs
@@ -52,11 +52,10 @@ where
 
     /// Run the update server loop.
     pub fn run(self, tt: &dyn TurboTasksApi, ws: HyperWebsocket) {
-        tt.run_once_process(Box::pin(async move {
+        tt.start_once_process(Box::pin(async move {
             if let Err(err) = self.run_internal(ws).await {
                 println!("[UpdateServer]: error {err:#}");
             }
-            Ok(())
         }));
     }
 


### PR DESCRIPTION
### What?

change signature of run_once to make the behavior more clear

simplify stuff

Closes PACK-5476