### PR TITLE
Turbopack: remove Backend TaskState

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2873,9 +2873,6 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
         self.0.get_task_description(task)
     }
 
-    type TaskState = ();
-    fn new_task_state(&self, _task: TaskId) -> Self::TaskState {}
-
     fn task_execution_canceled(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi<Self>) {
         self.0.task_execution_canceled(task, turbo_tasks)
     }

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -530,29 +530,6 @@ pub trait Backend: Sync + Send {
 
     fn get_task_description(&self, task: TaskId) -> String;
 
-    /// Task-local state that stored inside of [`TurboTasksBackendApi`]. Constructed with
-    /// [`Self::new_task_state`].
-    ///
-    /// This value that can later be written to or read from using
-    /// [`crate::TurboTasksBackendApiExt::write_task_state`] or
-    /// [`crate::TurboTasksBackendApiExt::read_task_state`]
-    ///
-    /// This data may be shared across multiple threads (must be `Sync`) in order to support
-    /// detached futures ([`crate::TurboTasksApi::detached_for_testing`]) and [pseudo-tasks using
-    /// `local` execution][crate::function]. A [`RwLock`][std::sync::RwLock] is used to provide
-    /// concurrent access.
-    type TaskState: Send + Sync + 'static;
-
-    /// Constructs a new task-local [`Self::TaskState`] for the given `task_id`.
-    ///
-    /// If a task is re-executed (e.g. because it is invalidated), this function will be called
-    /// again with the same [`TaskId`].
-    ///
-    /// This value can be written to or read from using
-    /// [`crate::TurboTasksBackendApiExt::write_task_state`] and
-    /// [`crate::TurboTasksBackendApiExt::read_task_state`]
-    fn new_task_state(&self, task: TaskId) -> Self::TaskState;
-
     fn try_start_task_execution<'a>(
         &'a self,
         task: TaskId,

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -109,9 +109,9 @@ pub use key_value_pair::KeyValuePair;
 pub use magic_any::MagicAny;
 pub use manager::{
     CurrentCellRef, ReadConsistency, TaskPersistence, TurboTasks, TurboTasksApi,
-    TurboTasksBackendApi, TurboTasksBackendApiExt, TurboTasksCallApi, Unused, UpdateInfo,
-    dynamic_call, emit, mark_finished, mark_root, mark_session_dependent, mark_stateful,
-    prevent_gc, run_once, run_once_with_reason, trait_call, turbo_tasks, turbo_tasks_scope,
+    TurboTasksBackendApi, TurboTasksCallApi, Unused, UpdateInfo, dynamic_call, emit, mark_finished,
+    mark_root, mark_session_dependent, mark_stateful, prevent_gc, run_once, run_once_with_reason,
+    trait_call, turbo_tasks, turbo_tasks_scope,
 };
 pub use output::OutputContent;
 pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};


### PR DESCRIPTION
### What?

Backend TaskState is no longer used with the new backend.

Closes PACK-5470