### PR TITLE
Turbopack: add turbo_tasks::run to run in turbo tasks scope without a task

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2928,45 +2928,24 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
     fn try_read_task_output(
         &self,
         task_id: TaskId,
-        reader: TaskId,
+        reader: Option<TaskId>,
         consistency: ReadConsistency,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<RawVc, EventListener>> {
         self.0
-            .try_read_task_output(task_id, Some(reader), consistency, turbo_tasks)
-    }
-
-    fn try_read_task_output_untracked(
-        &self,
-        task_id: TaskId,
-        consistency: ReadConsistency,
-        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
-    ) -> Result<Result<RawVc, EventListener>> {
-        self.0
-            .try_read_task_output(task_id, None, consistency, turbo_tasks)
+            .try_read_task_output(task_id, reader, consistency, turbo_tasks)
     }
 
     fn try_read_task_cell(
         &self,
         task_id: TaskId,
         cell: CellId,
-        reader: TaskId,
+        reader: Option<TaskId>,
         options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<TypedCellContent, EventListener>> {
         self.0
-            .try_read_task_cell(task_id, Some(reader), cell, options, turbo_tasks)
-    }
-
-    fn try_read_task_cell_untracked(
-        &self,
-        task_id: TaskId,
-        cell: CellId,
-        options: ReadCellOptions,
-        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
-    ) -> Result<Result<TypedCellContent, EventListener>> {
-        self.0
-            .try_read_task_cell(task_id, None, cell, options, turbo_tasks)
+            .try_read_task_cell(task_id, reader, cell, options, turbo_tasks)
     }
 
     fn try_read_own_task_cell_untracked(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -415,7 +415,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
     unsafe fn connect_child_with_tx<'l, 'tx: 'l>(
         &'l self,
         tx: Option<&'l B::ReadTransaction<'tx>>,
-        parent_task: TaskId,
+        parent_task: Option<TaskId>,
         child_task: TaskId,
         turbo_tasks: &'l dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) {
@@ -426,7 +426,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
     fn connect_child(
         &self,
-        parent_task: TaskId,
+        parent_task: Option<TaskId>,
         child_task: TaskId,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) {
@@ -444,9 +444,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         consistency: ReadConsistency,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> Result<Result<RawVc, EventListener>> {
-        if let Some(reader) = reader {
-            self.assert_not_persistent_calling_transient(reader, task_id, /* cell_id */ None);
-        }
+        self.assert_not_persistent_calling_transient(reader, task_id, /* cell_id */ None);
 
         let mut ctx = self.execute_context(turbo_tasks);
         let mut task = ctx.task(task_id, TaskDataCategory::All);
@@ -754,9 +752,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> Result<Result<TypedCellContent, EventListener>> {
-        if let Some(reader) = reader {
-            self.assert_not_persistent_calling_transient(reader, task_id, Some(cell));
-        }
+        self.assert_not_persistent_calling_transient(reader, task_id, Some(cell));
 
         fn add_cell_dependency<B: BackingStorage>(
             backend: &TurboTasksBackendInner<B>,
@@ -1268,7 +1264,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
     fn get_or_create_persistent_task(
         &self,
         task_type: CachedTaskType,
-        parent_task: TaskId,
+        parent_task: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> TaskId {
         if let Some(task_id) = self.task_cache.lookup_forward(&task_type) {
@@ -1328,10 +1324,12 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
     fn get_or_create_transient_task(
         &self,
         task_type: CachedTaskType,
-        parent_task: TaskId,
+        parent_task: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> TaskId {
-        if !parent_task.is_transient() {
+        if let Some(parent_task) = parent_task
+            && !parent_task.is_transient()
+        {
             self.panic_persistent_calling_transient(
                 self.lookup_task_type(parent_task).as_deref(),
                 Some(&task_type),
@@ -2264,7 +2262,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         &self,
         task_id: TaskId,
         collectible_type: TraitTypeId,
-        reader_id: TaskId,
+        reader_id: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> AutoMap<RawVc, i32, BuildHasherDefault<FxHasher>, 1> {
         let mut ctx = self.execute_context(turbo_tasks);
@@ -2312,13 +2310,15 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     .entry(RawVc::TaskCell(collectible.task, collectible.cell))
                     .or_insert(0) += count;
             }
-            let _ = task.add(CachedDataItem::CollectiblesDependent {
-                collectible_type,
-                task: reader_id,
-                value: (),
-            });
+            if let Some(reader_id) = reader_id {
+                let _ = task.add(CachedDataItem::CollectiblesDependent {
+                    collectible_type,
+                    task: reader_id,
+                    value: (),
+                });
+            }
         }
-        {
+        if let Some(reader_id) = reader_id {
             let mut reader = ctx.task(reader_id, TaskDataCategory::Data);
             let target = CollectiblesRef {
                 task: task_id,
@@ -2480,7 +2480,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
     fn connect_task(
         &self,
         task: TaskId,
-        parent_task: TaskId,
+        parent_task: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) {
         self.assert_not_persistent_calling_transient(parent_task, task, None);
@@ -2737,13 +2737,15 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
     fn assert_not_persistent_calling_transient(
         &self,
-        parent_id: TaskId,
+        parent_id: Option<TaskId>,
         child_id: TaskId,
         cell_id: Option<CellId>,
     ) {
-        if !parent_id.is_transient() && child_id.is_transient() {
+        if !parent_id.is_none_or(|id| id.is_transient()) && child_id.is_transient() {
             self.panic_persistent_calling_transient(
-                self.lookup_task_type(parent_id).as_deref(),
+                parent_id
+                    .and_then(|id| self.lookup_task_type(id))
+                    .as_deref(),
                 self.lookup_task_type(child_id).as_deref(),
                 cell_id,
             );
@@ -2828,7 +2830,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
     fn get_or_create_persistent_task(
         &self,
         task_type: CachedTaskType,
-        parent_task: TaskId,
+        parent_task: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> TaskId {
         self.0
@@ -2838,7 +2840,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
     fn get_or_create_transient_task(
         &self,
         task_type: CachedTaskType,
-        parent_task: TaskId,
+        parent_task: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> TaskId {
         self.0
@@ -2963,7 +2965,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
         &self,
         task_id: TaskId,
         collectible_type: TraitTypeId,
-        reader: TaskId,
+        reader: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> AutoMap<RawVc, i32, BuildHasherDefault<FxHasher>, 1> {
         self.0
@@ -3035,7 +3037,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
         parent_task: TaskId,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) {
-        self.0.connect_task(task, parent_task, turbo_tasks);
+        self.0.connect_task(task, Some(parent_task), turbo_tasks);
     }
 
     fn create_transient_task(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -23,31 +23,37 @@ pub enum ConnectChildOperation {
 }
 
 impl ConnectChildOperation {
-    pub fn run(parent_task_id: TaskId, child_task_id: TaskId, mut ctx: impl ExecuteContext) {
-        let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::All);
-        let Some(InProgressState::InProgress(box InProgressStateInner { new_children, .. })) =
-            get_mut!(parent_task, InProgress)
-        else {
-            panic!("Task is not in progress while calling another task");
-        };
+    pub fn run(
+        parent_task_id: Option<TaskId>,
+        child_task_id: TaskId,
+        mut ctx: impl ExecuteContext,
+    ) {
+        if let Some(parent_task_id) = parent_task_id {
+            let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::All);
+            let Some(InProgressState::InProgress(box InProgressStateInner {
+                new_children, ..
+            })) = get_mut!(parent_task, InProgress)
+            else {
+                panic!("Task is not in progress while calling another task");
+            };
 
-        // Quick skip if the child was already connected before
-        if !new_children.insert(child_task_id) {
-            return;
-        }
+            // Quick skip if the child was already connected before
+            if !new_children.insert(child_task_id) {
+                return;
+            }
 
-        if parent_task.has_key(&CachedDataItemKey::Child {
-            task: child_task_id,
-        }) {
-            // It is already connected, we can skip the rest
-            return;
+            if parent_task.has_key(&CachedDataItemKey::Child {
+                task: child_task_id,
+            }) {
+                // It is already connected, we can skip the rest
+                return;
+            }
         }
-        drop(parent_task);
 
         let mut queue = AggregationUpdateQueue::new();
 
         // Handle the transient to persistent boundary by making the persistent task a root task
-        if parent_task_id.is_transient() && !child_task_id.is_transient() {
+        if parent_task_id.is_none_or(|id| id.is_transient()) && !child_task_id.is_transient() {
             queue.push(AggregationUpdateJob::UpdateAggregationNumber {
                 task_id: child_task_id,
                 base_aggregation_number: u32::MAX,
@@ -56,7 +62,7 @@ impl ConnectChildOperation {
         }
 
         // Immutable tasks cannot be invalidated, meaning that we never reschedule them.
-        if ctx.should_track_activeness() {
+        if ctx.should_track_activeness() && parent_task_id.is_some() {
             queue.push(AggregationUpdateJob::IncreaseActiveCount {
                 task: child_task_id,
             });

--- a/turbopack/crates/turbo-tasks-backend/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/all_in_one.rs
@@ -5,13 +5,13 @@
 use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TaskInput, ValueToString, Vc};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn all_in_one() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let a: Vc<u32> = Vc::cell(4242);
         assert_eq!(*a.await?, 4242);
 

--- a/turbopack/crates/turbo-tasks-backend/tests/basic.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/basic.rs
@@ -4,13 +4,13 @@
 
 use anyhow::Result;
 use turbo_tasks::Vc;
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn basic() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let output1 = func_without_args();
         assert_eq!(output1.await?.value, 123);
 

--- a/turbopack/crates/turbo-tasks-backend/tests/bug.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/bug.rs
@@ -5,7 +5,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, Vc, trace::TraceRawVcs};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
@@ -27,7 +27,7 @@ struct TasksSpec(Vec<TaskSpec>);
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn graph_bug() {
     // see https://github.com/vercel/next.js/pull/79451
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let spec = vec![
             TaskSpec {
                 references: vec![

--- a/turbopack/crates/turbo-tasks-backend/tests/bug2.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/bug2.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, State, TaskInput, Vc, trace::TraceRawVcs};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
@@ -35,7 +35,7 @@ struct Iteration(State<usize>);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn graph_bug() {
-    run(&REGISTRATION, move || async move {
+    run_once(&REGISTRATION, move || async move {
         let spec = vec![
             TaskSpec {
                 references: vec![TaskReferenceSpec {

--- a/turbopack/crates/turbo-tasks-backend/tests/call_types.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/call_types.rs
@@ -4,13 +4,13 @@
 
 use anyhow::Result;
 use turbo_tasks::Vc;
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn functions() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         assert_eq!(*fn_plain().await?, 42);
         assert_eq!(*fn_arg(43).await?, 43);
         assert_eq!(*fn_vc_arg(Vc::cell(44)).await?, 44);
@@ -55,7 +55,7 @@ async fn async_fn_vc_arg(n: Vc<u32>) -> Result<Vc<u32>> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn methods() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         assert_eq!(*Value::static_method().await?, 42);
         assert_eq!(*Value::async_static_method().await?, 42);
 
@@ -108,7 +108,7 @@ impl Value {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn trait_methods() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         assert_eq!(*Value::static_trait_method().await?, 42);
         assert_eq!(*Value::async_static_trait_method().await?, 42);
 

--- a/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
@@ -10,13 +10,13 @@ use rustc_hash::FxHashSet;
 use tokio::time::sleep;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{CollectiblesSource, ResolvedVc, ValueToString, Vc, emit};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn transitive_emitting() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
         let result_val = result_op.connect().strongly_consistent().await?;
         let list = result_op.peek_collectibles::<Box<dyn ValueToString>>();
@@ -34,7 +34,7 @@ async fn transitive_emitting() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn transitive_emitting_indirect() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
         let collectibles_op = my_transitive_emitting_function_collectibles(rcstr!(""), rcstr!(""));
         let list = collectibles_op.connect().strongly_consistent().await?;
@@ -52,7 +52,7 @@ async fn transitive_emitting_indirect() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn multi_emitting() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let result_op = my_multi_emitting_function();
         let result_val = result_op.connect().strongly_consistent().await?;
         let list = result_op.peek_collectibles::<Box<dyn ValueToString>>();
@@ -70,7 +70,7 @@ async fn multi_emitting() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn taking_collectibles() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let result_op = my_collecting_function();
         let result_val = result_op.connect().strongly_consistent().await?;
         let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
@@ -86,7 +86,7 @@ async fn taking_collectibles() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn taking_collectibles_extra_layer() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let result_op = my_collecting_function_indirect();
         let result_val = result_op.connect().strongly_consistent().await?;
         let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
@@ -102,7 +102,7 @@ async fn taking_collectibles_extra_layer() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn taking_collectibles_parallel() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!("a"));
         let result_val = result_op.connect().strongly_consistent().await?;
         let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
@@ -144,7 +144,7 @@ async fn taking_collectibles_parallel() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn taking_collectibles_with_resolve() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let result_op = my_transitive_emitting_function_with_resolve(rcstr!("resolve"));
         result_op.connect().strongly_consistent().await?;
         let list = result_op.take_collectibles::<Box<dyn ValueToString>>();

--- a/turbopack/crates/turbo-tasks-backend/tests/debug.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/debug.rs
@@ -5,13 +5,13 @@
 use std::sync::Mutex;
 
 use turbo_tasks::{ResolvedVc, Vc, debug::ValueDebug};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn primitive_debug() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let a: Vc<u32> = Vc::cell(42);
         assert_eq!(format!("{:?}", a.dbg().await?), "42");
         anyhow::Ok(())
@@ -22,7 +22,7 @@ async fn primitive_debug() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn transparent_debug() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let a: Vc<Transparent> = Transparent(42).cell();
         assert_eq!(format!("{:?}", a.dbg().await?), "42");
 
@@ -34,7 +34,7 @@ async fn transparent_debug() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn enum_none_debug() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let a: Vc<Enum> = Enum::None.cell();
         assert_eq!(format!("{:?}", a.dbg().await?), "Enum :: None");
 
@@ -46,7 +46,7 @@ async fn enum_none_debug() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn enum_transparent_debug() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let a: Vc<Enum> = Enum::Transparent(Transparent(42).resolved_cell()).cell();
         assert_eq!(
             format!("{:?}", a.dbg().await?),
@@ -62,7 +62,7 @@ async fn enum_transparent_debug() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn enum_inner_vc_debug() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let a: Vc<Enum> = Enum::Enum(Enum::None.resolved_cell()).cell();
         assert_eq!(
             format!("{:?}", a.dbg().await?),
@@ -78,7 +78,7 @@ async fn enum_inner_vc_debug() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn struct_unit_debug() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let a: Vc<StructUnit> = StructUnit.cell();
         assert_eq!(format!("{:?}", a.dbg().await?), "StructUnit");
         anyhow::Ok(())
@@ -89,7 +89,7 @@ async fn struct_unit_debug() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn struct_transparent_debug() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let a: Vc<StructWithTransparent> = StructWithTransparent {
             transparent: Transparent(42).resolved_cell(),
         }
@@ -108,7 +108,7 @@ async fn struct_transparent_debug() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn struct_vec_debug() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let a: Vc<StructWithVec> = StructWithVec { vec: vec![] }.cell();
         assert_eq!(
             format!("{:?}", a.dbg().await?),
@@ -137,7 +137,7 @@ async fn struct_vec_debug() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn struct_ignore_debug() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let a: Vc<StructWithIgnore> = StructWithIgnore {
             dont_ignore: 42,
             ignore: Mutex::new(()),

--- a/turbopack/crates/turbo-tasks-backend/tests/detached.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/detached.rs
@@ -11,13 +11,13 @@ use turbo_tasks::{
     trace::{TraceRawVcs, TraceRawVcsContext},
     turbo_tasks,
 };
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_spawns_detached() -> anyhow::Result<()> {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         // HACK: The watch channel we use has an incorrect implementation of `TraceRawVcs`, just
         // disable GC for the test so this can't cause any problems.
         prevent_gc();
@@ -84,7 +84,7 @@ async fn spawns_detached(
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_spawns_detached_changing() -> anyhow::Result<()> {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         // HACK: The watch channel we use has an incorrect implementation of `TraceRawVcs`
         prevent_gc();
         // timeout: prevent the test from hanging, and fail instead if this is broken

--- a/turbopack/crates/turbo-tasks-backend/tests/dirty_in_progress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/dirty_in_progress.rs
@@ -7,13 +7,13 @@ use std::time::Duration;
 use anyhow::{Result, bail};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{CollectiblesSource, ResolvedVc, State, ValueToString, Vc, emit};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn dirty_in_progress() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let cases = [
             (1, 3, 2, 2, ""),
             (11, 13, 12, 42, "12"),

--- a/turbopack/crates/turbo-tasks-backend/tests/emptied_cells.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/emptied_cells.rs
@@ -4,13 +4,13 @@
 
 use anyhow::Result;
 use turbo_tasks::{State, Vc};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recompute() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let input = ChangingInput {
             state: State::new(1),
         }

--- a/turbopack/crates/turbo-tasks-backend/tests/filter_unused_args.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/filter_unused_args.rs
@@ -4,13 +4,13 @@
 
 use anyhow::Result;
 use turbo_tasks::Vc;
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn filtered_trait_method_args() -> Result<()> {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let uses_arg = UsesArg.cell();
         assert_eq!(
             uses_arg.method_with_arg(0).to_resolved().await?,

--- a/turbopack/crates/turbo-tasks-backend/tests/immutable.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/immutable.rs
@@ -4,13 +4,13 @@
 
 use anyhow::Result;
 use turbo_tasks::{State, Vc};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn hidden_mutate() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let input = create_input().resolve().await?;
         input.await?.state.set(1);
         let changing_value = compute(input);

--- a/turbopack/crates/turbo-tasks-backend/tests/panics.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/panics.rs
@@ -14,7 +14,7 @@ use turbo_tasks::{
     backend::TurboTasksExecutionError,
     panic_hooks::{handle_panic, register_panic_hook},
 };
-use turbo_tasks_testing::{Registration, register, run_without_cache_check};
+use turbo_tasks_testing::{Registration, register, run_once_without_cache_check};
 
 static REGISTRATION: Registration = register!();
 
@@ -40,7 +40,8 @@ async fn test_panic_hook() {
     });
 
     let result =
-        run_without_cache_check(&REGISTRATION, async move { anyhow::Ok(*double(3).await?) }).await;
+        run_once_without_cache_check(&REGISTRATION, async move { anyhow::Ok(*double(3).await?) })
+            .await;
 
     assert!(hook_was_called.load(Ordering::SeqCst));
 

--- a/turbopack/crates/turbo-tasks-backend/tests/performance.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/performance.rs
@@ -6,7 +6,7 @@ use std::{future::Future, time::Duration};
 
 use anyhow::Result;
 use turbo_tasks::{TransientInstance, Vc};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
@@ -147,7 +147,7 @@ async fn many_calls_to_many_children() {
     if check_skip() {
         return;
     }
-    run(&REGISTRATION, || {
+    run_once(&REGISTRATION, || {
         run_test(
             || calls_many_children(TransientInstance::new(()), None).strongly_consistent(),
             Duration::from_micros(100),
@@ -162,7 +162,7 @@ async fn many_calls_to_uncached_many_children() {
     if check_skip() {
         return;
     }
-    run(&REGISTRATION, || {
+    run_once(&REGISTRATION, || {
         run_test(
             || {
                 calls_many_children(TransientInstance::new(()), Some(TransientInstance::new(())))
@@ -194,7 +194,7 @@ async fn many_calls_to_big_graph_1() {
     if check_skip() {
         return;
     }
-    run(&REGISTRATION, || run_big_graph_test(vec![5, 8, 10, 15, 20]))
+    run_once(&REGISTRATION, || run_big_graph_test(vec![5, 8, 10, 15, 20]))
         .await
         .unwrap();
 }
@@ -204,7 +204,7 @@ async fn many_calls_to_big_graph_2() {
     if check_skip() {
         return;
     }
-    run(&REGISTRATION, || {
+    run_once(&REGISTRATION, || {
         run_big_graph_test(vec![2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2])
     })
     .await
@@ -216,7 +216,7 @@ async fn many_calls_to_big_graph_3() {
     if check_skip() {
         return;
     }
-    run(&REGISTRATION, || run_big_graph_test(vec![1000, 3, 3, 3, 3]))
+    run_once(&REGISTRATION, || run_big_graph_test(vec![1000, 3, 3, 3, 3]))
         .await
         .unwrap();
 }
@@ -226,7 +226,7 @@ async fn many_calls_to_big_graph_4() {
     if check_skip() {
         return;
     }
-    run(&REGISTRATION, || run_big_graph_test(vec![3, 3, 3, 3, 1000]))
+    run_once(&REGISTRATION, || run_big_graph_test(vec![3, 3, 3, 3, 1000]))
         .await
         .unwrap();
 }
@@ -236,7 +236,7 @@ async fn many_calls_to_big_graph_5() {
     if check_skip() {
         return;
     }
-    run(&REGISTRATION, || {
+    run_once(&REGISTRATION, || {
         run_big_graph_test(vec![10, 10, 10, 10, 10])
     })
     .await
@@ -248,7 +248,7 @@ async fn many_calls_to_big_graph_6() {
     if check_skip() {
         return;
     }
-    run(&REGISTRATION, || {
+    run_once(&REGISTRATION, || {
         run_big_graph_test(vec![2, 2, 2, 1000, 2, 2, 2])
     })
     .await
@@ -260,7 +260,7 @@ async fn many_calls_to_big_graph_7() {
     if check_skip() {
         return;
     }
-    run(&REGISTRATION, || {
+    run_once(&REGISTRATION, || {
         run_big_graph_test(vec![
             1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 3, 1, 1, 1, 3, 2, 1, 1, 1, 1, 5, 1, 1, 1, 200, 2, 1,
             1, 1, 1, 1, 1, 1, 1, 1,
@@ -275,7 +275,7 @@ async fn many_calls_to_big_graph_8() {
     if check_skip() {
         return;
     }
-    run(&REGISTRATION, || {
+    run_once(&REGISTRATION, || {
         run_big_graph_test(vec![200, 2, 2, 2, 2, 200])
     })
     .await
@@ -287,7 +287,7 @@ async fn many_calls_to_big_graph_9() {
     if check_skip() {
         return;
     }
-    run(&REGISTRATION, || {
+    run_once(&REGISTRATION, || {
         run_big_graph_test(vec![10000, 1, 1, 2, 1, 1, 2, 2, 1, 1, 1, 1])
     })
     .await

--- a/turbopack/crates/turbo-tasks-backend/tests/random_change.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/random_change.rs
@@ -5,13 +5,13 @@
 use anyhow::{Result, bail};
 use rand::Rng;
 use turbo_tasks::{State, Vc};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn random_change() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let state = make_state();
         let value = rand::rng().random_range(0..100);
         state.await?.state.set(value);

--- a/turbopack/crates/turbo-tasks-backend/tests/read_ref_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/read_ref_cell.rs
@@ -6,13 +6,13 @@ use std::{collections::HashSet, mem::take, sync::Mutex};
 
 use anyhow::Result;
 use turbo_tasks::{Invalidator, ReadRef, Vc, get_invalidator};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn read_ref() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let counter = Counter::cell(Counter {
             value: Mutex::new((0, Default::default())),
         });

--- a/turbopack/crates/turbo-tasks-backend/tests/recompute.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/recompute.rs
@@ -4,13 +4,13 @@
 
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, State, Vc};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recompute() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let input = ChangingInput {
             state: State::new(1),
         }
@@ -60,7 +60,7 @@ async fn recompute() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn immutable_analysis() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let input = ChangingInput {
             state: State::new(1),
         }

--- a/turbopack/crates/turbo-tasks-backend/tests/recompute_collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/recompute_collectibles.rs
@@ -5,13 +5,13 @@
 use anyhow::{Result, bail};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{CollectiblesSource, ResolvedVc, State, ValueToString, Vc, emit};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recompute() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let input = ChangingInput::new(1).resolve().await?;
         let input2 = ChangingInput::new(2).resolve().await?;
         input.await?.state.set(1);

--- a/turbopack/crates/turbo-tasks-backend/tests/resolved_vc.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/resolved_vc.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use turbo_tasks::{ReadRef, ResolvedVc, Vc};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
@@ -25,7 +25,7 @@ fn assert_resolved(input: ResolvedVc<u32>) {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_conversion() -> Result<()> {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let unresolved: Vc<u32> = Vc::cell(42);
         let resolved: ResolvedVc<u32> = unresolved.to_resolved().await?;
         let _: Vc<u32> = *resolved;
@@ -40,7 +40,7 @@ async fn test_conversion() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_cell_construction() -> Result<()> {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let a: ResolvedVc<u32> = ResolvedVc::cell(42);
         assert_eq!(*a.await?, 42);
         let b: ResolvedVc<Wrapper> = Wrapper(42).resolved_cell();
@@ -52,7 +52,7 @@ async fn test_cell_construction() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_resolved_vc_as_arg() -> Result<()> {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let unresolved: Vc<u32> = returns_int(42);
         assert!(!unresolved.is_resolved());
         // calling a function should cause it's arguments to get resolved automatically
@@ -64,7 +64,7 @@ async fn test_resolved_vc_as_arg() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_into_future() -> Result<()> {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let mut resolved = ResolvedVc::cell(42);
         let _: ReadRef<u32> = resolved.await?;
         let _: ReadRef<u32> = (&resolved).await?;
@@ -80,7 +80,7 @@ async fn test_into_future() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_sidecast() -> Result<()> {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let concrete_value = ImplementsAAndB.resolved_cell();
         let as_a = ResolvedVc::upcast::<Box<dyn TraitA>>(concrete_value);
         let as_b = ResolvedVc::try_sidecast::<Box<dyn TraitB>>(as_a);

--- a/turbopack/crates/turbo-tasks-backend/tests/shrink_to_fit.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/shrink_to_fit.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use turbo_tasks::Vc;
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
@@ -13,7 +13,7 @@ struct Wrapper(Vec<u32>);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_shrink_to_fit() -> Result<()> {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         // `Vec::shrink_to_fit` is implicitly called when a cell is constructed.
         let a: Vc<Wrapper> = Vc::cell(Vec::with_capacity(100));
         assert_eq!(a.await?.capacity(), 0);

--- a/turbopack/crates/turbo-tasks-backend/tests/trace_transient.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trace_transient.rs
@@ -4,7 +4,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
-use turbo_tasks_testing::{Registration, register, run_without_cache_check};
+use turbo_tasks_testing::{Registration, register, run_once_without_cache_check};
 
 static REGISTRATION: Registration = register!();
 
@@ -20,7 +20,7 @@ Adder::add_method (read cell of type turbo-tasks@turbo_tasks::primitives::u64)
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trace_transient() {
-    let result = run_without_cache_check(&REGISTRATION, async {
+    let result = run_once_without_cache_check(&REGISTRATION, async {
         read_incorrect_task_input_operation(IncorrectTaskInput(
             Adder::new(Vc::cell(()))
                 .add_method(Vc::cell(2), Vc::cell(3))

--- a/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell.rs
@@ -6,13 +6,13 @@ use std::{collections::HashSet, mem::take, sync::Mutex};
 
 use anyhow::Result;
 use turbo_tasks::{IntoTraitRef, Invalidator, TraitRef, Vc, get_invalidator};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn trait_ref() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let counter = Counter::cell(Counter {
             value: Mutex::new((0, Default::default())),
         });

--- a/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell_mode.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell_mode.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use turbo_tasks::{IntoTraitRef, State, TraitRef, Upcast, Vc};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
@@ -11,7 +11,7 @@ static REGISTRATION: Registration = register!();
 // value is equal.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trait_ref_shared_cell_mode() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let input = CellIdSelector {
             value: 42,
             cell_idx: State::new(0),
@@ -46,7 +46,7 @@ async fn test_trait_ref_shared_cell_mode() {
 // value is equal.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trait_ref_new_cell_mode() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let input = CellIdSelector {
             value: 42,
             cell_idx: State::new(0),

--- a/turbopack/crates/turbo-tasks-backend/tests/transient_collectible.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/transient_collectible.rs
@@ -3,7 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, trace::TraceRawVcs};
-use turbo_tasks_testing::{Registration, register, run_without_cache_check};
+use turbo_tasks_testing::{Registration, register, run_once_without_cache_check};
 
 static REGISTRATION: Registration = register!();
 
@@ -12,7 +12,7 @@ const EXPECTED_MSG: &str =
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_transient_emit_from_persistent() {
-    let result = run_without_cache_check(&REGISTRATION, async {
+    let result = run_once_without_cache_check(&REGISTRATION, async {
         emit_incorrect_task_input_operation(IncorrectTaskInput(U32Wrapper(123).resolved_cell()))
             .read_strongly_consistent()
             .await?;

--- a/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -9,7 +9,7 @@ use turbo_tasks_fetch::{
     FetchErrorKind,
 };
 use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 use turbopack_core::issue::{Issue, IssueSeverity, StyledString};
 
 static REGISTRATION: Registration = register!(turbo_tasks_fetch::register);
@@ -21,7 +21,7 @@ static GLOBAL_TEST_LOCK: TokioMutex<()> = TokioMutex::const_new(());
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn basic_get() {
     let _guard = GLOBAL_TEST_LOCK.lock().await;
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let mut server = mockito::Server::new_async().await;
         let resource_mock = server
             .mock("GET", "/foo.woff")
@@ -52,7 +52,7 @@ async fn basic_get() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sends_user_agent() {
     let _guard = GLOBAL_TEST_LOCK.lock().await;
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let mut server = mockito::Server::new_async().await;
         let resource_mock = server
             .mock("GET", "/foo.woff")
@@ -88,7 +88,7 @@ async fn sends_user_agent() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn invalidation_does_not_invalidate() {
     let _guard = GLOBAL_TEST_LOCK.lock().await;
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let mut server = mockito::Server::new_async().await;
         let resource_mock = server
             .mock("GET", "/foo.woff")
@@ -133,7 +133,7 @@ fn get_issue_context() -> Vc<FileSystemPath> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn errors_on_failed_connection() {
     let _guard = GLOBAL_TEST_LOCK.lock().await;
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         // Try to connect to port 0 on localhost, which is never valid and immediately returns
         // `ECONNREFUSED`.
         // Other values (e.g. domain name, reserved IP address block) may result in long timeouts.
@@ -164,7 +164,7 @@ async fn errors_on_failed_connection() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn errors_on_404() {
     let _guard = GLOBAL_TEST_LOCK.lock().await;
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let mut server = mockito::Server::new_async().await;
         let resource_mock = server
             .mock("GET", "/")
@@ -227,7 +227,7 @@ async fn client_cache() {
     }
 
     let _guard = GLOBAL_TEST_LOCK.lock().await;
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         __test_only_reqwest_client_cache_clear();
         assert_eq!(__test_only_reqwest_client_cache_len(), 0);
 

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/task_input.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/task_input.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{Completion, ReadRef, TaskInput, Vc, trace::TraceRawVcs};
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
@@ -20,7 +20,7 @@ fn one_unnamed_field(input: OneUnnamedField) -> Vc<Completion> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn tests() {
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         assert!(ReadRef::ptr_eq(
             &one_unnamed_field(OneUnnamedField(42)).await?,
             &Completion::immutable().await?,

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value_debug.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value_debug.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
 use turbo_tasks::debug::ValueDebugFormat;
-use turbo_tasks_testing::{Registration, register, run};
+use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
@@ -19,7 +19,7 @@ async fn ignored_indexes() {
         i32,
     );
 
-    run(&REGISTRATION, || async {
+    run_once(&REGISTRATION, || async {
         let input = IgnoredIndexes(-1, 2, -3);
         let debug = input.value_debug_format(usize::MAX).try_to_string().await?;
         assert!(!debug.contains("-1"));

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -25,7 +25,9 @@ use turbo_tasks::{
     util::{SharedError, StaticOrArc},
 };
 
-pub use crate::run::{Registration, run, run_with_tt, run_without_cache_check};
+pub use crate::run::{
+    Registration, run, run_once, run_once_without_cache_check, run_with_tt, run_without_cache_check,
+};
 
 enum Task {
     Spawned(Event),
@@ -115,6 +117,15 @@ impl TurboTasksCallApi for VcStorage {
         _arg: Box<dyn MagicAny>,
         _persistence: TaskPersistence,
     ) -> RawVc {
+        unreachable!()
+    }
+
+    fn run(
+        &self,
+        _future: Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
+    ) -> Pin<
+        Box<dyn Future<Output = Result<(), turbo_tasks::backend::TurboTasksExecutionError>> + Send>,
+    > {
         unreachable!()
     }
 

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -600,11 +600,13 @@ pub trait Backend: Sync + Send {
         }
     }
 
+    /// INVALIDATION: Be careful with this, when reader is None, it will not track dependencies, so
+    /// using it could break cache invalidation.
     fn read_task_collectibles(
         &self,
         task: TaskId,
         trait_id: TraitTypeId,
-        reader: TaskId,
+        reader: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> TaskCollectiblesMap;
 
@@ -636,14 +638,14 @@ pub trait Backend: Sync + Send {
     fn get_or_create_persistent_task(
         &self,
         task_type: CachedTaskType,
-        parent_task: TaskId,
+        parent_task: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> TaskId;
 
     fn get_or_create_transient_task(
         &self,
         task_type: CachedTaskType,
-        parent_task: TaskId,
+        parent_task: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> TaskId;
 

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -564,38 +564,23 @@ pub trait Backend: Sync + Send {
         turbo_tasks: &'a dyn TurboTasksBackendApi<Self>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 
+    /// INVALIDATION: Be careful with this, when reader is None, it will not track dependencies, so
+    /// using it could break cache invalidation.
     fn try_read_task_output(
         &self,
         task: TaskId,
-        reader: TaskId,
+        reader: Option<TaskId>,
         consistency: ReadConsistency,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<RawVc, EventListener>>;
 
-    /// INVALIDATION: Be careful with this, it will not track dependencies, so
+    /// INVALIDATION: Be careful with this, when reader is None, it will not track dependencies, so
     /// using it could break cache invalidation.
-    fn try_read_task_output_untracked(
-        &self,
-        task: TaskId,
-        consistency: ReadConsistency,
-        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
-    ) -> Result<Result<RawVc, EventListener>>;
-
     fn try_read_task_cell(
         &self,
         task: TaskId,
         index: CellId,
-        reader: TaskId,
-        options: ReadCellOptions,
-        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
-    ) -> Result<Result<TypedCellContent, EventListener>>;
-
-    /// INVALIDATION: Be careful with this, it will not track dependencies, so
-    /// using it could break cache invalidation.
-    fn try_read_task_cell_untracked(
-        &self,
-        task: TaskId,
-        index: CellId,
+        reader: Option<TaskId>,
         options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<TypedCellContent, EventListener>>;
@@ -609,7 +594,7 @@ pub trait Backend: Sync + Send {
         options: ReadCellOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<TypedCellContent> {
-        match self.try_read_task_cell_untracked(current_task, index, options, turbo_tasks)? {
+        match self.try_read_task_cell(current_task, index, None, options, turbo_tasks)? {
             Ok(content) => Ok(content),
             Err(_) => Ok(TypedCellContent(index.type_id, CellContent(None))),
         }

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -110,8 +110,8 @@ pub use magic_any::MagicAny;
 pub use manager::{
     CurrentCellRef, ReadConsistency, TaskPersistence, TurboTasks, TurboTasksApi,
     TurboTasksBackendApi, TurboTasksCallApi, Unused, UpdateInfo, dynamic_call, emit, mark_finished,
-    mark_root, mark_session_dependent, mark_stateful, prevent_gc, run_once, run_once_with_reason,
-    trait_call, turbo_tasks, turbo_tasks_scope,
+    mark_root, mark_session_dependent, mark_stateful, prevent_gc, run, run_once,
+    run_once_with_reason, trait_call, turbo_tasks, turbo_tasks_scope,
 };
 pub use output::OutputContent;
 pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1170,8 +1170,12 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         task: TaskId,
         consistency: ReadConsistency,
     ) -> Result<Result<RawVc, EventListener>> {
-        self.backend
-            .try_read_task_output(task, current_task("reading Vcs"), consistency, self)
+        self.backend.try_read_task_output(
+            task,
+            Some(current_task("reading Vcs")),
+            consistency,
+            self,
+        )
     }
 
     fn try_read_task_output_untracked(
@@ -1180,7 +1184,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         consistency: ReadConsistency,
     ) -> Result<Result<RawVc, EventListener>> {
         self.backend
-            .try_read_task_output_untracked(task, consistency, self)
+            .try_read_task_output(task, None, consistency, self)
     }
 
     fn try_read_task_cell(
@@ -1189,8 +1193,13 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         index: CellId,
         options: ReadCellOptions,
     ) -> Result<Result<TypedCellContent, EventListener>> {
-        self.backend
-            .try_read_task_cell(task, index, current_task("reading Vcs"), options, self)
+        self.backend.try_read_task_cell(
+            task,
+            index,
+            Some(current_task("reading Vcs")),
+            options,
+            self,
+        )
     }
 
     fn try_read_task_cell_untracked(
@@ -1200,7 +1209,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         options: ReadCellOptions,
     ) -> Result<Result<TypedCellContent, EventListener>> {
         self.backend
-            .try_read_task_cell_untracked(task, index, options, self)
+            .try_read_task_cell(task, index, None, options, self)
     }
 
     fn try_read_own_task_cell_untracked(

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -556,13 +556,11 @@ impl<B: Backend + 'static> TurboTasks<B> {
                     ltt.close();
                     ltt.wait().await;
 
-                    let result = match result {
+                    match result {
                         Ok(Ok(raw_vc)) => Ok(raw_vc),
                         Ok(Err(err)) => Err(err.into()),
                         Err(err) => Err(TurboTasksExecutionError::Panic(Arc::new(err))),
-                    };
-
-                    result
+                    }
                 }),
             )
             .await

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -40,7 +40,6 @@ use crate::{
     task_statistics::TaskStatisticsApi,
     trace::TraceRawVcs,
     util::{IdFactory, StaticOrArc},
-    vc::ReadVcFuture,
 };
 
 /// Common base trait for [`TurboTasksApi`] and [`TurboTasksBackendApi`]. Provides APIs for creating
@@ -74,6 +73,10 @@ pub trait TurboTasksCallApi: Sync + Send {
         persistence: TaskPersistence,
     ) -> RawVc;
 
+    fn run(
+        &self,
+        future: Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), TurboTasksExecutionError>> + Send>>;
     fn run_once(
         &self,
         future: Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
@@ -342,7 +345,7 @@ pub struct TurboTasks<B: Backend + 'static> {
 /// - Is potentially cached.
 /// - The backend is aware of.
 struct CurrentTaskState {
-    task_id: TaskId,
+    task_id: Option<TaskId>,
     execution_id: ExecutionId,
 
     /// True if the current task has state in cells
@@ -368,11 +371,23 @@ struct CurrentTaskState {
 impl CurrentTaskState {
     fn new(task_id: TaskId, execution_id: ExecutionId) -> Self {
         Self {
-            task_id,
+            task_id: Some(task_id),
             execution_id,
             stateful: false,
             has_invalidator: false,
             cell_counters: Some(AutoMap::default()),
+            local_tasks: Vec::new(),
+            local_task_tracker: TaskTracker::new(),
+        }
+    }
+
+    fn new_temporary(execution_id: ExecutionId) -> Self {
+        Self {
+            task_id: None,
+            execution_id,
+            stateful: false,
+            has_invalidator: false,
+            cell_counters: None,
             local_tasks: Vec::new(),
             local_task_tracker: TaskTracker::new(),
         }
@@ -490,7 +505,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
     /// Creates a new root task, that is only executed once.
     /// Dependencies will not invalidate the task.
     #[track_caller]
-    fn spawn_once_task<T, Fut>(&self, future: Fut) -> TaskId
+    fn spawn_once_task<T, Fut>(&self, future: Fut)
     where
         T: ?Sized,
         Fut: Future<Output = Result<Vc<T>>> + Send + 'static,
@@ -503,7 +518,6 @@ impl<B: Backend + 'static> TurboTasks<B> {
             self,
         );
         self.schedule(id);
-        id
     }
 
     pub async fn run_once<T: TraceRawVcs + Send + 'static>(
@@ -511,23 +525,47 @@ impl<B: Backend + 'static> TurboTasks<B> {
         future: impl Future<Output = Result<T>> + Send + 'static,
     ) -> Result<T> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        let task_id = self.spawn_once_task(async move {
+        self.spawn_once_task(async move {
             let result = future.await?;
             tx.send(result)
                 .map_err(|_| anyhow!("unable to send result"))?;
             Ok(Completion::new())
         });
-        // INVALIDATION: A Once task will never invalidate, therefore we don't need to
-        // track a dependency
-        let raw_result =
-            read_task_output_untracked(self, task_id, ReadConsistency::Eventual).await?;
-        turbo_tasks_future_scope(
-            self.pin(),
-            ReadVcFuture::<Completion>::from(raw_result.into_read().untracked()),
-        )
-        .await?;
 
         Ok(rx.await?)
+    }
+
+    pub async fn run<T: TraceRawVcs + Send + 'static>(
+        &self,
+        future: impl Future<Output = Result<T>> + Send + 'static,
+    ) -> Result<T, TurboTasksExecutionError> {
+        // it's okay for execution ids to overflow and wrap, they're just used for an assert
+        let execution_id = self.execution_id_factory.wrapping_get();
+        let current_task_state =
+            Arc::new(RwLock::new(CurrentTaskState::new_temporary(execution_id)));
+
+        TURBO_TASKS
+            .scope(
+                self.pin(),
+                CURRENT_TASK_STATE.scope(current_task_state, async {
+                    let (result, _duration, _alloc_info) = CaptureFuture::new(future).await;
+
+                    // wait for all spawned local tasks using `local` to finish
+                    let ltt =
+                        CURRENT_TASK_STATE.with(|ts| ts.read().unwrap().local_task_tracker.clone());
+                    ltt.close();
+                    ltt.wait().await;
+
+                    let result = match result {
+                        Ok(Ok(raw_vc)) => Ok(raw_vc),
+                        Ok(Err(err)) => Err(err.into()),
+                        Err(err) => Err(TurboTasksExecutionError::Panic(Arc::new(err))),
+                    };
+
+                    result
+                }),
+            )
+            .await
     }
 
     pub fn start_once_process(&self, future: impl Future<Output = ()> + Send + 'static) {
@@ -570,7 +608,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
 
                 RawVc::TaskOutput(self.backend.get_or_create_transient_task(
                     task_type,
-                    current_task("turbo_function calls"),
+                    current_task_if_available("turbo_function calls"),
                     self,
                 ))
             }
@@ -583,7 +621,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
 
                 RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
                     task_type,
-                    current_task("turbo_function calls"),
+                    current_task_if_available("turbo_function calls"),
                     self,
                 ))
             }
@@ -1118,6 +1156,15 @@ impl<B: Backend + 'static> TurboTasksCallApi for TurboTasks<B> {
     }
 
     #[track_caller]
+    fn run(
+        &self,
+        future: Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), TurboTasksExecutionError>> + Send>> {
+        let this = self.pin();
+        Box::pin(async move { this.run(future).await })
+    }
+
+    #[track_caller]
     fn run_once(
         &self,
         future: Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
@@ -1172,7 +1219,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
     ) -> Result<Result<RawVc, EventListener>> {
         self.backend.try_read_task_output(
             task,
-            Some(current_task("reading Vcs")),
+            current_task_if_available("reading Vcs"),
             consistency,
             self,
         )
@@ -1196,7 +1243,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         self.backend.try_read_task_cell(
             task,
             index,
-            Some(current_task("reading Vcs")),
+            current_task_if_available("reading Vcs"),
             options,
             self,
         )
@@ -1247,7 +1294,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         self.backend.read_task_collectibles(
             task,
             trait_id,
-            current_task("reading collectibles"),
+            current_task_if_available("reading collectibles"),
             self,
         )
     }
@@ -1300,8 +1347,9 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
     }
 
     fn connect_task(&self, task: TaskId) {
-        self.backend
-            .connect_task(task, current_task("connecting task"), self);
+        if let Some(current_task) = current_task_if_available("connecting task") {
+            self.backend.connect_task(task, current_task, self);
+        }
     }
 
     fn mark_own_task_as_finished(&self, task: TaskId) {
@@ -1423,11 +1471,40 @@ impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
     }
 }
 
-pub(crate) fn current_task(from: &str) -> TaskId {
+pub(crate) fn current_task_if_available(from: &str) -> Option<TaskId> {
     match CURRENT_TASK_STATE.try_with(|ts| ts.read().unwrap().task_id) {
         Ok(id) => id,
-        Err(_) => panic!("{from} can only be used in the context of turbo_tasks task execution"),
+        Err(_) => panic!(
+            "{from} can only be used in the context of a turbo_tasks task execution or \
+             turbo_tasks run"
+        ),
     }
+}
+
+pub(crate) fn current_task(from: &str) -> TaskId {
+    match CURRENT_TASK_STATE.try_with(|ts| ts.read().unwrap().task_id) {
+        Ok(Some(id)) => id,
+        Ok(None) | Err(_) => {
+            panic!("{from} can only be used in the context of a turbo_tasks task execution")
+        }
+    }
+}
+
+pub async fn run<T: Send + 'static>(
+    tt: Arc<dyn TurboTasksApi>,
+    future: impl Future<Output = Result<T>> + Send + 'static,
+) -> Result<T> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    tt.run(Box::pin(async move {
+        let result = future.await?;
+        tx.send(result)
+            .map_err(|_| anyhow!("unable to send result"))?;
+        Ok(())
+    }))
+    .await?;
+
+    Ok(rx.await?)
 }
 
 pub async fn run_once<T: Send + 'static>(
@@ -1537,7 +1614,7 @@ pub fn spawn_detached_for_testing(f: impl Future<Output = Result<()>> + Send + '
     tokio::spawn(turbo_tasks().detached_for_testing(Box::pin(f.in_current_span())));
 }
 
-pub fn current_task_for_testing() -> TaskId {
+pub fn current_task_for_testing() -> Option<TaskId> {
     CURRENT_TASK_STATE.with(|ts| ts.read().unwrap().task_id)
 }
 
@@ -1575,7 +1652,12 @@ pub fn mark_stateful() -> SerializationInvalidator {
             stateful, task_id, ..
         } = &mut *cell.write().unwrap();
         *stateful = true;
-        SerializationInvalidator::new(*task_id)
+        let Some(task_id) = *task_id else {
+            panic!(
+                "mark_stateful() can only be used in the context of a turbo_tasks task execution"
+            );
+        };
+        SerializationInvalidator::new(task_id)
     })
 }
 


### PR DESCRIPTION
# What?

refactor try_read_task_cell to take option arguments instead of having an _untracked method

add turbo_tasks::run to run in turbo tasks scope without a task

use the new method in some test cases where it was possible


Closes PACK-5482