### PR TITLE
Turbopack: use turbo_tasks::run in next.js to avoid task memory leak

### DIFF
--- a/crates/napi/src/next_api/endpoint.rs
+++ b/crates/napi/src/next_api/endpoint.rs
@@ -131,7 +131,7 @@ pub async fn endpoint_write_to_disk(
     let (written, issues, diags) = endpoint
         .turbopack_ctx()
         .turbo_tasks()
-        .run_once(async move {
+        .run(async move {
             let written_entrypoint_with_issues_op =
                 get_written_endpoint_with_issues_operation(endpoint_op);
             let WrittenEndpointWithIssues {
@@ -146,7 +146,7 @@ pub async fn endpoint_write_to_disk(
 
             Ok((written.clone(), issues.clone(), diagnostics.clone()))
         })
-        .or_else(|e| ctx.throw_turbopack_internal_result(&e))
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
         .await?;
     Ok(TurbopackResult {
         result: NapiWrittenEndpoint::from(written.map(ReadRef::into_owned)),

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -1579,7 +1579,7 @@ pub async fn project_trace_source(
     let container = project.container;
     let ctx = &project.turbopack_ctx;
     ctx.turbo_tasks()
-        .run_once(async move {
+        .run(async move {
             let traced_frame = project_trace_source_operation(
                 container,
                 frame,
@@ -1593,7 +1593,7 @@ pub async fn project_trace_source(
         // source files may have changed or been deleted), so these probably aren't internal errors?
         // Ideally we should differentiate.
         .await
-        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e.into()).to_string()))
 }
 
 #[napi]

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -1604,7 +1604,7 @@ pub async fn project_get_source_for_asset(
     let container = project.container;
     let ctx = &project.turbopack_ctx;
     ctx.turbo_tasks()
-        .run_once(async move {
+        .run(async move {
             let source_content = &*container
                 .project()
                 .project_path()
@@ -1626,7 +1626,7 @@ pub async fn project_get_source_for_asset(
         // source files may have changed or been deleted), so these probably aren't internal errors?
         // Ideally we should differentiate.
         .await
-        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e.into()).to_string()))
 }
 
 #[napi]

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -1637,7 +1637,7 @@ pub async fn project_get_source_map(
     let container = project.container;
     let ctx = &project.turbopack_ctx;
     ctx.turbo_tasks()
-        .run_once(async move {
+        .run(async move {
             let Some(map) = &*get_source_map_rope_operation(container, file_path)
                 .read_strongly_consistent()
                 .await?
@@ -1650,7 +1650,7 @@ pub async fn project_get_source_map(
         // source files may have changed or been deleted), so these probably aren't internal errors?
         // Ideally we should differentiate.
         .await
-        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e).to_string()))
+        .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e.into()).to_string()))
 }
 
 #[napi]

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -885,7 +885,7 @@ pub async fn project_write_all_entrypoints_to_disk(
     let tt_clone = tt.clone();
 
     let (entrypoints, issues, diags) = tt
-        .run_once(async move {
+        .run(async move {
             let entrypoints_with_issues_op =
                 get_all_written_entrypoints_with_issues_operation(container, app_dir_only);
 
@@ -913,7 +913,7 @@ pub async fn project_write_all_entrypoints_to_disk(
 
             Ok((entrypoints.clone(), issues.clone(), diagnostics.clone()))
         })
-        .or_else(|e| ctx.throw_turbopack_internal_result(&e))
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
         .await?;
 
     Ok(TurbopackResult {

--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -38,7 +38,7 @@ pub async fn main_inner(
     }
 
     let project = tt
-        .run_once(async {
+        .run(async {
             let project = ProjectContainer::new(rcstr!("next-build-test"), options.dev);
             let project = project.to_resolved().await?;
             project.initialize(options).await?;
@@ -47,9 +47,7 @@ pub async fn main_inner(
         .await?;
 
     tracing::info!("collecting endpoints");
-    let entrypoints = tt
-        .run_once(async move { project.entrypoints().await })
-        .await?;
+    let entrypoints = tt.run(async move { project.entrypoints().await }).await?;
 
     let mut routes = if let Some(files) = files {
         tracing::info!("building only the files:");
@@ -170,7 +168,7 @@ pub async fn render_routes(
 
             let memory = TurboMalloc::memory_usage();
 
-            tt.run_once({
+            tt.run({
                 let name = name.clone();
                 async move {
                     match route {
@@ -259,7 +257,7 @@ async fn hmr(
     tracing::info!("HMR...");
     let session = TransientInstance::new(());
     let idents = tt
-        .run_once(async move { project.hmr_identifiers().await })
+        .run(async move { project.hmr_identifiers().await })
         .await?;
     let start = Instant::now();
     for ident in idents {

--- a/turbopack/crates/turbo-tasks-backend/benches/overhead.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/overhead.rs
@@ -191,7 +191,7 @@ fn run_turbo<Mode: TurboMode>(
         ));
 
         async move {
-            tt.run_once(async move {
+            tt.run(async move {
                 // If cached run once outside the loop to ensure the tasks are cached.
                 if Mode::is_cached() {
                     for i in 0..iters {

--- a/turbopack/crates/turbo-tasks-backend/benches/scope_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/scope_stress.rs
@@ -47,11 +47,12 @@ pub fn scope_stress(c: &mut Criterion) {
                             .map(|(a, b)| {
                                 let tt = &tt;
                                 async move {
-                                    tt.run_once(async move {
-                                        rectangle(a, b).strongly_consistent().await?;
-                                        Ok(())
-                                    })
-                                    .await
+                                    Ok(tt
+                                        .run(async move {
+                                            rectangle(a, b).strongly_consistent().await?;
+                                            Ok(())
+                                        })
+                                        .await?)
                                 }
                             })
                             .try_join()

--- a/turbopack/crates/turbo-tasks-backend/benches/stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/stress.rs
@@ -37,7 +37,7 @@ pub fn fibonacci(c: &mut Criterion) {
                     noop_backing_storage(),
                 ));
                 async move {
-                    tt.run_once(async move {
+                    tt.run(async move {
                         // Number of tasks:
                         // 1 root task
                         // size >= 1 => + fib(0) = 1

--- a/turbopack/crates/turbo-tasks-backend/fuzz/src/graph.rs
+++ b/turbopack/crates/turbo-tasks-backend/fuzz/src/graph.rs
@@ -145,7 +145,7 @@ fn actual_operation(spec: Arc<Vec<TaskSpec>>, iterations: usize) {
         .block_on(async {
             for i in 0..iterations {
                 let spec = spec.clone();
-                tt.run_once(async move {
+                tt.run(async move {
                     let it = create_state().resolve().await?;
                     it.await?.set(i);
                     let task = run_task(spec.clone(), it, 0);


### PR DESCRIPTION
### What?

Replace run_once calls with `run` to avoid task memory overhead.

Closes PACK-5496