### PR TITLE
docs: Fix self-referential link to Middleware in middleware.mdx

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
@@ -8,7 +8,7 @@ related:
     - app/api-reference/functions/next-response
 ---
 
-The `middleware.js|ts` file is used to write [Middleware](/docs/app/api-reference/file-conventions/middleware) and run code on the server before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
+The `middleware.js|ts` file is used to write [Middleware](/docs/app/getting-started/route-handlers-and-middleware#middleware) and run code on the server before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
 
 Middleware executes before routes are rendered. It's particularly useful for implementing custom server-side logic like authentication, logging, or handling redirects.
 


### PR DESCRIPTION
This link was to the current page, which isn't very useful.

Link to the getting started page (https://nextjs.org/docs/app/getting-started/route-handlers-and-middleware#middleware) instead

Closes PACK-5464