### PR TITLE
fix: isRevalidate -> isStaticGeneration in fetch cache / unstable cache

### DIFF
--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -935,7 +935,7 @@ export function createPatchedFetcher(
             if (entry?.value && entry.value.kind === CachedRouteKind.FETCH) {
               // when stale and is revalidating we wait for fresh data
               // so the revalidated entry has the updated data
-              if (workStore.isRevalidate && entry.isStale) {
+              if (workStore.isStaticGeneration && entry.isStale) {
                 isForegroundRevalidate = true
               } else {
                 if (entry.isStale) {

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -273,7 +273,7 @@ export function unstable_cache<T extends Callback>(
 
                   // Attach the empty catch here so we don't get a "unhandled promise
                   // rejection" warning. (Behavior is matched with patch-fetch)
-                  if (workStore.isRevalidate) {
+                  if (workStore.isStaticGeneration) {
                     revalidationPromise.catch(() => {})
                   }
 
@@ -282,7 +282,7 @@ export function unstable_cache<T extends Callback>(
                 }
 
                 // Check if we need to do foreground revalidation
-                if (workStore.isRevalidate) {
+                if (workStore.isStaticGeneration) {
                   // When the page is revalidating and the cache entry is stale,
                   // we need to wait for fresh data (blocking revalidate)
                   return workStore.pendingRevalidates[invocationKey]


### PR DESCRIPTION
When fetch/`unstable_cache` are stale during ISR, we leverage `workStore.isRevalidate` to determine if we're in an ISR revalidation scope and if so, we perform a blocking revalidation.

This same scenario could happen at build time if the data cache were being leveraged during build (ie with a custom cache handler, or once we enable it in the default Next cache handler). 

There's no need to distinguish between an ISR revalidation and build time prerender when checking to see if the cache entry needs to perform a blocking revalidate, so this refactors to switch to `isStaticGeneration` instead. This matches what we do in `use cache`: https://github.com/vercel/next.js/blob/1fc18244547263409a82db35edbe5908ba403410/packages/next/src/server/use-cache/use-cache-wrapper.ts#L1418