### PR TITLE
refactor: remove isRevalidate from work store

### DIFF
--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -828,7 +828,6 @@ export async function buildAppStaticPaths({
       incrementalCache,
       cacheLifeProfiles,
       supportsDynamicResponse: true,
-      isRevalidate: false,
       experimental: {
         cacheComponents,
         authInterrupts,

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -539,7 +539,6 @@ export async function handler(
                 )
               : `${process.cwd()}/${routeModule.relativeProjectDir}`,
           isDraftMode,
-          isRevalidate: isSSG && !postponed && !isDynamicRSCRequest,
           botType,
           isOnDemandRevalidate,
           isPossibleServerAction,
@@ -566,7 +565,6 @@ export async function handler(
                 nextExport: true,
                 supportsDynamicResponse: false,
                 isStaticGeneration: true,
-                isRevalidate: true,
                 isDebugDynamicAccesses: isDebugDynamicAccesses,
               }
             : {}),
@@ -612,7 +610,6 @@ export async function handler(
       if (isDebugStaticShell || isDebugDynamicAccesses) {
         context.renderOpts.nextExport = true
         context.renderOpts.supportsDynamicResponse = false
-        context.renderOpts.isRevalidate = true
         context.renderOpts.isDebugDynamicAccesses = isDebugDynamicAccesses
       }
 
@@ -1417,7 +1414,7 @@ export async function handler(
           routePath: srcPage,
           routeType: 'render',
           revalidateReason: getRevalidateReason({
-            isRevalidate: isSSG,
+            isStaticGeneration: isSSG,
             isOnDemandRevalidate,
           }),
         },

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -162,7 +162,7 @@ export async function handler(
   // page and it is not being resumed from a postponed render and
   // it is not a dynamic RSC request then it is a revalidation
   // request.
-  const isRevalidate = isIsr && !supportsDynamicResponse
+  const isStaticGeneration = isIsr && !supportsDynamicResponse
 
   // Before rendering (which initializes component tree modules), we have to
   // set the reference manifests to our global store so Server Action's
@@ -193,7 +193,6 @@ export async function handler(
       supportsDynamicResponse,
       incrementalCache: getRequestMeta(req, 'incrementalCache'),
       cacheLifeProfiles: nextConfig.experimental?.cacheLife,
-      isRevalidate,
       waitUntil: ctx.waitUntil,
       onClose: (cb) => {
         res.on('close', cb)
@@ -358,7 +357,7 @@ export async function handler(
                 routePath: srcPage,
                 routeType: 'route',
                 revalidateReason: getRevalidateReason({
-                  isRevalidate,
+                  isStaticGeneration,
                   isOnDemandRevalidate,
                 }),
               },
@@ -473,7 +472,7 @@ export async function handler(
         routePath: normalizedSrcPage,
         routeType: 'route',
         revalidateReason: getRevalidateReason({
-          isRevalidate,
+          isStaticGeneration,
           isOnDemandRevalidate,
         }),
       })

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -138,7 +138,6 @@ async function requestHandler(
       dir: pageRouteModule.relativeProjectDir,
       botType,
       isDraftMode: false,
-      isRevalidate: false,
       isOnDemandRevalidate,
       isPossibleServerAction,
       assetPrefix: nextConfig.assetPrefix,

--- a/packages/next/src/client/components/handle-isr-error.tsx
+++ b/packages/next/src/client/components/handle-isr-error.tsx
@@ -11,7 +11,7 @@ const workAsyncStorage =
 export function HandleISRError({ error }: { error: any }) {
   if (workAsyncStorage) {
     const store = workAsyncStorage.getStore()
-    if (store?.isRevalidate || store?.isStaticGeneration) {
+    if (store?.isStaticGeneration) {
       if (error) {
         console.error(error)
       }

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -20,7 +20,6 @@ import type {
   MockedResponse,
 } from '../../server/lib/mock-request'
 import { isDynamicUsageError } from '../helpers/is-dynamic-usage-error'
-import { hasNextSupport } from '../../server/ci-info'
 import { isStaticGenEnabled } from '../../server/route-modules/app-route/helpers/is-static-gen-enabled'
 import type { ExperimentalConfig } from '../../server/config-shared'
 import { isMetadataRoute } from '../../lib/metadata/is-metadata-route'
@@ -92,10 +91,6 @@ export async function exportAppRoute(
     sharedContext: {
       buildId,
     },
-  }
-
-  if (hasNextSupport) {
-    context.renderOpts.isRevalidate = true
   }
 
   try {

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -282,10 +282,6 @@ async function exportPageImpl(
     renderResumeDataCache,
   }
 
-  if (hasNextSupport) {
-    renderOpts.isRevalidate = true
-  }
-
   // Handle App Pages
   if (isAppDir) {
     const sharedContext: AppSharedContext = { buildId }

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -99,7 +99,6 @@ export interface RenderOptsPartial {
     htmlRequestId: string,
     requestId: string
   ) => void
-  isRevalidate?: boolean
   nextExport?: boolean
   nextConfigOutput?: 'standalone' | 'export'
   onInstrumentationRequestError?: ServerOnInstrumentationRequestError

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -38,8 +38,6 @@ export interface WorkStore {
    */
   readonly hasReadableErrorStacks?: boolean
 
-  readonly isRevalidate?: boolean
-
   forceDynamic?: boolean
   fetchCache?: AppSegmentConfig['fetchCache']
 

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -54,7 +54,6 @@ export type WorkStoreContext = {
     | 'assetPrefix'
     | 'supportsDynamicResponse'
     | 'shouldWaitOnAllReady'
-    | 'isRevalidate'
     | 'nextExport'
     | 'isDraftMode'
     | 'isDebugDynamicAccesses'
@@ -125,7 +124,6 @@ export function createWorkStore({
       // so that it can access the fs cache without mocks
       renderOpts.incrementalCache || (globalThis as any).__incrementalCache,
     cacheLifeProfiles: renderOpts.cacheLifeProfiles,
-    isRevalidate: renderOpts.isRevalidate,
     isBuildTimePrerendering: renderOpts.nextExport,
     hasReadableErrorStacks: renderOpts.hasReadableErrorStacks,
     fetchCache: renderOpts.fetchCache,

--- a/packages/next/src/server/instrumentation/utils.ts
+++ b/packages/next/src/server/instrumentation/utils.ts
@@ -1,11 +1,11 @@
 export function getRevalidateReason(params: {
   isOnDemandRevalidate?: boolean
-  isRevalidate?: boolean
+  isStaticGeneration?: boolean
 }): 'on-demand' | 'stale' | undefined {
   if (params.isOnDemandRevalidate) {
     return 'on-demand'
   }
-  if (params.isRevalidate) {
+  if (params.isStaticGeneration) {
     return 'stale'
   }
   return undefined

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -427,7 +427,7 @@ export const getHandler = ({
                     routePath: srcPage,
                     routeType: 'render',
                     revalidateReason: getRevalidateReason({
-                      isRevalidate: hasStaticProps,
+                      isStaticGeneration: hasStaticProps,
                       isOnDemandRevalidate,
                     }),
                   },
@@ -755,7 +755,7 @@ export const getHandler = ({
             routePath: srcPage,
             routeType: 'render',
             revalidateReason: getRevalidateReason({
-              isRevalidate: hasStaticProps,
+              isStaticGeneration: hasStaticProps,
               isOnDemandRevalidate,
             }),
           },


### PR DESCRIPTION
With the refactor in #83858 there's no longer a reason to distinguish between `isRevalidate` and `isStaticGeneration` and most likely doing so would be a bug, as you'd likely want to apply the same handling to build time generation that you would during a later regeneration.

This PR removes `isRevalidate` from the `WorkStore`.