### PR TITLE
docs: the as prop is still available in Pages Router

### DIFF
--- a/docs/01-app/03-api-reference/02-components/link.mdx
+++ b/docs/01-app/03-api-reference/02-components/link.mdx
@@ -58,7 +58,7 @@ The following props can be passed to the `<Link>` component:
 | Prop                        | Example                  | Type              | Required |
 | --------------------------- | ------------------------ | ----------------- | -------- |
 | [`href`](#href-required)    | `href="/dashboard"`      | String or Object  | Yes      |
-| [`as`](#as)                 | `as="/post/abc"`         | String            | -        |
+| [`as`](#as)                 | `as="/post/abc"`         | String or Object  | -        |
 | [`replace`](#replace)       | `replace={false}`        | Boolean           | -        |
 | [`scroll`](#scroll)         | `scroll={false}`         | Boolean           | -        |
 | [`prefetch`](#prefetch)     | `prefetch={false}`       | Boolean           | -        |

--- a/docs/01-app/03-api-reference/02-components/link.mdx
+++ b/docs/01-app/03-api-reference/02-components/link.mdx
@@ -58,6 +58,7 @@ The following props can be passed to the `<Link>` component:
 | Prop                        | Example                  | Type              | Required |
 | --------------------------- | ------------------------ | ----------------- | -------- |
 | [`href`](#href-required)    | `href="/dashboard"`      | String or Object  | Yes      |
+| [`as`](#as)                 | `as="/post/abc"`         | String            | -        |
 | [`replace`](#replace)       | `replace={false}`        | Boolean           | -        |
 | [`scroll`](#scroll)         | `scroll={false}`         | Boolean           | -        |
 | [`prefetch`](#prefetch)     | `prefetch={false}`       | Boolean           | -        |
@@ -437,6 +438,12 @@ export default function Home() {
   )
 }
 ```
+
+### `as`
+
+Optional decorator for the path that will be shown in the browser URL bar. Before Next.js 9.5.3 this was used for dynamic routes, check our [previous docs](https://github.com/vercel/next.js/blob/v9.5.2/docs/api-reference/next/link.md#dynamic-routes) to see how it worked.
+
+When this path differs from the one provided in `href` the previous `href`/`as` behavior is used as shown in the [previous docs](https://github.com/vercel/next.js/blob/v9.5.2/docs/api-reference/next/link.md#dynamic-routes).
 
 </PagesOnly>
 


### PR DESCRIPTION
We accidentally removed the documentation for `as` prop in Pages Router `next/link`.

Closes: https://linear.app/vercel/issue/DOC-3140/add-missing-props-as-to-nextlink-reference-page