### PR TITLE
Fix validateTurboNextConfig isDev field

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -465,7 +465,7 @@ export async function startServer(
         if (process.env.TURBOPACK) {
           await validateTurboNextConfig({
             dir: serverOptions.dir,
-            isDev: true,
+            isDev: serverOptions.isDev,
           })
         }
       } catch (err) {


### PR DESCRIPTION
Noticed the `phase` value being provided to `loadConfig` was incorrect with turbopack and `next start` which was due to this field being hard coded. 