### PR TITLE
Fix router has/missing header matching behavior with Vercel router

### DIFF
--- a/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
@@ -1,4 +1,5 @@
-import { parseDestination } from './prepare-destination'
+import type { IncomingMessage } from 'http'
+import { parseDestination, matchHas } from './prepare-destination'
 
 describe('parseDestination', () => {
   it('should parse the destination', () => {
@@ -80,5 +81,147 @@ describe('parseDestination', () => {
        "slashes": true,
      }
     `)
+  })
+})
+
+describe('matchHas', () => {
+  it('should handle a has with an empty string value', () => {
+    let req = {
+      headers: {
+        'x-now-route-matches': '',
+      },
+    } as unknown as IncomingMessage
+
+    let result = matchHas(
+      req,
+      {},
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+          value: '',
+        },
+      ],
+      []
+    )
+
+    expect(result).toEqual({})
+
+    result = matchHas(
+      req,
+      {},
+      [],
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+          value: '',
+        },
+      ]
+    )
+
+    expect(result).toEqual(false)
+
+    // Remove the header entirely.
+    delete req.headers['x-now-route-matches']
+
+    result = matchHas(
+      req,
+      {},
+      [],
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+          value: '',
+        },
+      ]
+    )
+
+    expect(result).toEqual({})
+
+    result = matchHas(
+      req,
+      {},
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+          value: '',
+        },
+      ],
+      []
+    )
+
+    expect(result).toEqual(false)
+  })
+
+  it('should handle a has without a value', () => {
+    let req = {
+      headers: {
+        'x-now-route-matches': '',
+      },
+    } as unknown as IncomingMessage
+
+    let result = matchHas(
+      req,
+      {},
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+        },
+      ],
+      []
+    )
+
+    expect(result).toEqual({
+      xnowroutematches: '',
+    })
+
+    result = matchHas(
+      req,
+      {},
+      [],
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+        },
+      ]
+    )
+
+    expect(result).toEqual(false)
+
+    // Remove the header entirely.
+    delete req.headers['x-now-route-matches']
+
+    result = matchHas(
+      req,
+      {},
+      [],
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+        },
+      ]
+    )
+
+    expect(result).toEqual({})
+
+    result = matchHas(
+      req,
+      {},
+      [
+        {
+          type: 'header',
+          key: 'x-now-route-matches',
+        },
+      ],
+      []
+    )
+
+    expect(result).toEqual(false)
   })
 })

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.ts
@@ -89,10 +89,22 @@ export function matchHas(
       }
     }
 
-    if (!hasItem.value && value) {
+    if (
+      // Aligning this logic with the Vercel router, we consider empty strings
+      // as valid values.
+      typeof hasItem.value !== 'string' &&
+      (typeof value === 'string' || Array.isArray(value))
+    ) {
       params[getSafeParamName(key!)] = value
       return true
-    } else if (value) {
+    } else if (
+      // Aligning this logic with the Vercel router, we consider empty strings
+      // as valid values.
+      typeof value === 'string' ||
+      // The code below uses slice, grabbing the last item in the array. This
+      // check prevents a runtime error that would occur with an empty array.
+      (Array.isArray(value) && value.length > 0)
+    ) {
       const matcher = new RegExp(`^${hasItem.value}$`)
       const matches = Array.isArray(value)
         ? value.slice(-1)[0].match(matcher)


### PR DESCRIPTION
### Fixing a bug

- Tests added for edge cases with empty string values and missing header values
- Aligns Next.js router behavior with Vercel router for consistency

### What?

This PR fixes inconsistencies in header matching behavior between Next.js and the Vercel router when using `has`/`missing` configurations with empty string values or without specifying a value.

### Why?

The Next.js router was handling edge cases differently than the Vercel router, causing inconsistent behavior when:
1. Using `has` configurations with empty string header values
2. Using `has` configurations without specifying a value to check for header existence
3. Processing empty arrays in header matching logic

This misalignment could lead to routing decisions working differently in development/local testing versus production on Vercel.

### How?

- Updated the `matchHas` function in `prepare-destination.ts` to properly handle empty string values as valid
- Added type checking to prevent runtime errors with empty arrays
- Enhanced the matching logic to align with Vercel router behavior
- Added comprehensive test coverage for these edge cases in `prepare-destination.test.ts`

The changes ensure that:
- Empty strings are treated as valid header values (consistent with Vercel router)
- Header existence checks work without specifying a value
- Runtime errors from empty arrays are prevented

NAR-434