### PR TITLE
Turbopack: only generate error string in error case

### DIFF
--- a/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
@@ -492,9 +492,12 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
                     let after_index = lists.len();
                     lists.push(after_list.clone());
                     for (i, &m) in after_list.iter().enumerate() {
-                        let occurrences = lists_reverse_indices
-                            .get_mut(&m)
-                            .context(format!("{:?}", m.ident().to_string().await?))?;
+                        let Some(occurrences) = lists_reverse_indices.get_mut(&m) else {
+                            bail!(
+                                "Couldn't find module in list {:?}",
+                                m.ident().to_string().await?,
+                            );
+                        };
 
                         let removed = occurrences.swap_remove(&ListOccurrence {
                             list: common_occurrence.list,

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batch.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batch.rs
@@ -31,6 +31,18 @@ pub enum ModuleOrBatch {
     None(usize),
 }
 
+impl ModuleOrBatch {
+    pub async fn ident_strings(self) -> Result<IdentStrings> {
+        Ok(match self {
+            ModuleOrBatch::Module(module) => {
+                IdentStrings::Single(module.ident().to_string().await?)
+            }
+            ModuleOrBatch::Batch(batch) => IdentStrings::Multiple(batch.ident_strings().await?),
+            ModuleOrBatch::None(_) => IdentStrings::None,
+        })
+    }
+}
+
 #[derive(
     Debug,
     Copy,


### PR DESCRIPTION
Don't create gigabytes of unused strings here.

Closes PACK-5474