### PR TITLE
[prod] Serve static metadata from filesystem

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -114,7 +114,10 @@ export async function collectAppFiles(
   const appPaths = []
   const layoutPaths = []
   const defaultPaths = []
-  // requestPath => relativePath
+  // Map of "requestPath" => "relativePath".
+  // "requestPath" will be used for the output path "{distDir}/static/metadata/{requestPath}" and
+  // its matcher. When the request comes in, the filesystem handler will look for the output path
+  // and serve the file if exists. "relativePath" will be used to copy the file to the output path.
   const staticMetadataFiles = new Map<string, string>()
 
   for (const relativePath of allAppFiles) {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1236,6 +1236,27 @@ export default async function build(
           appPaths = result.appPaths
           layoutPaths = result.layoutPaths
           // Note: defaultPaths are not used in the build process, only for slot detection in generating route types
+
+          // Copy static metadata files for production filesystem serving.
+          // Not using a loader so that it works on all bundlers.
+          if (result.staticMetadataFiles.size > 0) {
+            await nextBuildSpan
+              .traceChild('copy-static-metadata-files')
+              .traceAsyncFn(async () => {
+                for (const [
+                  requestPath,
+                  relativePath,
+                ] of result.staticMetadataFiles) {
+                  const outPath = path.join(
+                    distDir,
+                    'static/metadata',
+                    requestPath
+                  )
+                  await fs.mkdir(path.dirname(outPath), { recursive: true })
+                  await fs.copyFile(path.join(appDir, relativePath), outPath)
+                }
+              })
+          }
         }
 
         mappedAppPages = await nextBuildSpan

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -519,7 +519,7 @@ export async function setupFsCheck(opts: {
             }
           }
         } else {
-          const reqPath = path.join('/_next/static/metadata', itemPath)
+          const reqPath = path.posix.join('/_next/static/metadata', itemPath)
           if (nextStaticFolderItems.has(reqPath)) {
             const fsPath = path.join(distDir, 'static/metadata', itemPath)
             return {

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -507,14 +507,26 @@ export async function setupFsCheck(opts: {
         }
       }
 
-      if (opts.dev && isMetadataRouteFile(itemPath, [], false)) {
-        const fsPath = staticMetadataFiles.get(itemPath)
-        if (fsPath) {
-          return {
-            // "nextStaticFolder" sets Cache-Control "no-store" on dev.
-            type: 'nextStaticFolder',
-            fsPath,
-            itemPath: fsPath,
+      if (isMetadataRouteFile(itemPath, [], false)) {
+        if (opts.dev) {
+          const fsPath = staticMetadataFiles.get(itemPath)
+          if (fsPath) {
+            return {
+              // "nextStaticFolder" sets Cache-Control "no-store" on dev.
+              type: 'nextStaticFolder',
+              fsPath,
+              itemPath: fsPath,
+            }
+          }
+        } else {
+          const reqPath = path.join('/_next/static/metadata', itemPath)
+          if (nextStaticFolderItems.has(reqPath)) {
+            const fsPath = path.join(distDir, 'static/metadata', itemPath)
+            return {
+              type: 'nextStaticFolder',
+              fsPath,
+              itemPath: fsPath,
+            }
           }
         }
       }

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -710,7 +710,11 @@ describe('app dir - metadata', () => {
 
     it('should support root dir robots.txt', async () => {
       const res = await next.fetch('/robots.txt')
-      expect(res.headers.get('content-type')).toBe('text/plain; charset=UTF-8')
+      expect(res.headers.get('content-type')).toBe(
+        // In deploy, it still uses route.js to serve metadata file.
+        // Otherwise, it uses sendStatic() to send static files, which adds MIME type.
+        isNextDeploy ? 'text/plain' : 'text/plain; charset=UTF-8'
+      )
       expect(await res.text()).toContain('User-Agent: *\nDisallow:')
       const invalidRobotsResponse = await next.fetch('/title/robots.txt')
       expect(invalidRobotsResponse.status).toBe(404)

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -710,10 +710,7 @@ describe('app dir - metadata', () => {
 
     it('should support root dir robots.txt', async () => {
       const res = await next.fetch('/robots.txt')
-      expect(res.headers.get('content-type')).toBe(
-        // In dev, sendStatic() is used to send static files, which adds MIME type.
-        isNextDev ? 'text/plain; charset=UTF-8' : 'text/plain'
-      )
+      expect(res.headers.get('content-type')).toBe('text/plain; charset=UTF-8')
       expect(await res.text()).toContain('User-Agent: *\nDisallow:')
       const invalidRobotsResponse = await next.fetch('/title/robots.txt')
       expect(invalidRobotsResponse.status).toBe(404)

--- a/test/integration/app-dir-export/test/utils.ts
+++ b/test/integration/app-dir-export/test/utils.ts
@@ -37,6 +37,8 @@ export const expectedWhenTrailingSlashTrue = [
     ? [expect.stringMatching(/_next\/static\/media\/favicon\.[0-9a-f]+\.ico/)]
     : []),
   expect.stringMatching(/_next\/static\/media\/test\.[0-9a-f]+\.png/),
+  '_next/static/metadata/favicon.ico',
+  '_next/static/metadata/robots.txt',
   '_next/static/test-build-id/_buildManifest.js',
   ...(process.env.IS_TURBOPACK_TEST
     ? ['_next/static/test-build-id/_clientMiddlewareManifest.json']
@@ -69,6 +71,8 @@ const expectedWhenTrailingSlashFalse = [
     ? [expect.stringMatching(/_next\/static\/media\/favicon\.[0-9a-f]+\.ico/)]
     : []),
   expect.stringMatching(/_next\/static\/media\/test\.[0-9a-f]+\.png/),
+  '_next/static/metadata/favicon.ico',
+  '_next/static/metadata/robots.txt',
   '_next/static/test-build-id/_buildManifest.js',
   ...(process.env.IS_TURBOPACK_TEST
     ? ['_next/static/test-build-id/_clientMiddlewareManifest.json']


### PR DESCRIPTION
### Why?

Follow up on https://github.com/vercel/next.js/pull/83460 to match the behavior of dev and prod. 

The goal of serving static metadata from the filesystem in prod is to not generate any unnecessary files like `route.js` or `.body` files, and to serve directly from the filesystem.

This PR is a stepping stone to achieve that goal. While serving from the filesystem, this PR does not stop generating `route.js` files.

It is intended to not break compatibility with Vercel CLI and to use `route.js` as a fallback. Once we confirm the static file in prod works for both `next start` and Vercel CLI, we will follow up to not generate `route.js` files for static metadata.

The follow-ups should also include how Turbopack emits `_next/static/media/` files and the export mode that relies on the `.body` file generated from `route.js` files.

### How?

Terms:

- request path: The actual request path to the app.
- output path: The path where the static metadata file will be stored.

The request path of a metadata file can be known during the build time. Using this, we can make the output path of a static file based on the expected request path: `{distDir}/static/metadata/{requestPath}` (e.g. `.next/static/metadata/favicon.ico`)

When the request is `/favicon.ico`, the filesystem will look for `{distDir}/static/metadata/favicon.ico` and return the path to serve static if it exists.