### PR TITLE
OTel: use `srcPage` for templates when `next.route` is unavailable

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -459,7 +459,7 @@ export async function handler(
           })
           span.updateName(name)
         } else {
-          span.updateName(`${method}`)
+          span.updateName(`${method} ${srcPage}`)
         }
       })
     }
@@ -1393,7 +1393,7 @@ export async function handler(
         tracer.trace(
           BaseServerSpan.handleRequest,
           {
-            spanName: `${method}`,
+            spanName: `${method} ${srcPage}`,
             kind: SpanKind.SERVER,
             attributes: {
               'http.method': method,

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -257,7 +257,7 @@ export async function handler(
           })
           span.updateName(name)
         } else {
-          span.updateName(`${method}`)
+          span.updateName(`${method} ${srcPage}`)
         }
       })
     }
@@ -454,7 +454,7 @@ export async function handler(
         tracer.trace(
           BaseServerSpan.handleRequest,
           {
-            spanName: `${method}`,
+            spanName: `${method} ${srcPage}`,
             kind: SpanKind.SERVER,
             attributes: {
               'http.method': method,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -316,7 +316,7 @@ async function requestHandler(
             })
             span.updateName(name)
           } else {
-            span.updateName(`${req.method}`)
+            span.updateName(`${req.method} ${srcPage}`)
           }
         })
 
@@ -339,7 +339,7 @@ async function requestHandler(
     tracer.trace(
       BaseServerSpan.handleRequest,
       {
-        spanName: `${req.method}`,
+        spanName: `${req.method} ${srcPage}`,
         kind: SpanKind.SERVER,
         attributes: {
           'http.method': req.method,

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -296,7 +296,7 @@ async function requestHandler(
             })
             span.updateName(name)
           } else {
-            span.updateName(`${req.method}`)
+            span.updateName(`${req.method} ${srcPage}`)
           }
         })
 
@@ -343,7 +343,7 @@ async function requestHandler(
     tracer.trace(
       BaseServerSpan.handleRequest,
       {
-        spanName: `${req.method}`,
+        spanName: `${req.method} ${srcPage}`,
         kind: SpanKind.SERVER,
         attributes: {
           'http.method': req.method,

--- a/packages/next/src/build/templates/pages-api.ts
+++ b/packages/next/src/build/templates/pages-api.ts
@@ -133,7 +133,7 @@ export async function handler(
             })
             span.updateName(name)
           } else {
-            span.updateName(`${method}`)
+            span.updateName(`${method} ${srcPage}`)
           }
         })
 
@@ -146,7 +146,7 @@ export async function handler(
         tracer.trace(
           BaseServerSpan.handleRequest,
           {
-            spanName: `${method}`,
+            spanName: `${method} ${srcPage}`,
             kind: SpanKind.SERVER,
             attributes: {
               'http.method': method,


### PR DESCRIPTION
### Why?

We changed the span name at https://github.com/vercel/next.js/pull/75416 to have low cardinality.

However, srcPage is relatively lower cardinality, so use this if available.

In the base-server handleRequest, it is the entry of the request, so no low-cardinality target is available.

https://github.com/vercel/next.js/pull/75416/files#diff-6f4291cc2bfc5073fdca12a014011769e840ee68583db1468acef075f037015aR891