### PR TITLE
Error on invalid param keys in `generateStaticParams`

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -809,6 +809,6 @@
   "808": "Invalid binary HMR message: insufficient data (expected %s bytes, got %s)",
   "809": "Invalid binary HMR message of type %s",
   "810": "React debug channel stream error",
-  "811": "Invalid param keys found in generateStaticParams for \"%s\":\\n%s",
+  "811": "Invalid params keys found in generateStaticParams for \"%s\":\\n%s",
   "812": "generateStaticParams returned a non-object \"%s\" value \"%s\" while processing page \"%s\"."
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -808,5 +808,7 @@
   "807": "Expected a %s response header.",
   "808": "Invalid binary HMR message: insufficient data (expected %s bytes, got %s)",
   "809": "Invalid binary HMR message of type %s",
-  "810": "React debug channel stream error"
+  "810": "React debug channel stream error",
+  "811": "Invalid param keys found in generateStaticParams for \"%s\":\\n%s",
+  "812": "generateStaticParams returned a non-object \"%s\" value \"%s\" while processing page \"%s\"."
 }

--- a/packages/next/src/build/static-paths/app.test.ts
+++ b/packages/next/src/build/static-paths/app.test.ts
@@ -834,7 +834,7 @@ describe('generateRouteStaticParams', () => {
   describe('Basic functionality', () => {
     it('should return empty array for empty segments', async () => {
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams([], store, __filename)
+      const result = await generateRouteStaticParams([], store)
       expect(result).toEqual([])
     })
 
@@ -844,11 +844,7 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toEqual([])
     })
 
@@ -857,11 +853,7 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async () => [{ id: '1' }, { id: '2' }]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toEqual([{ id: '1' }, { id: '2' }])
     })
 
@@ -877,11 +869,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toEqual([
         { category: 'tech', slug: 'tech-post-1' },
         { category: 'tech', slug: 'tech-post-2' },
@@ -900,11 +888,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toEqual([
         { lang: 'en', category: 'en-tech' },
         { lang: 'fr', category: 'fr-tech' },
@@ -920,11 +904,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toEqual([{ lang: 'en', slug: 'en-slug' }])
     })
   })
@@ -933,11 +913,7 @@ describe('generateRouteStaticParams', () => {
     it('should handle empty generateStaticParams results', async () => {
       const segments: TestAppSegment[] = [createMockSegment(async () => [])]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toEqual([])
     })
 
@@ -947,11 +923,7 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async () => []), // Empty result
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toEqual([{ lang: 'en' }])
     })
 
@@ -963,11 +935,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toEqual([
         { lang: 'en', category: 'en-tech' },
         { category: 'default-tech' },
@@ -983,7 +951,7 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await generateRouteStaticParams(segments, store, __filename)
+      await generateRouteStaticParams(segments, store)
       expect(store.fetchCache).toBe('force-cache')
     })
 
@@ -992,7 +960,7 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async () => [{ id: '1' }]),
       ]
       const store = createMockWorkStore('force-cache')
-      await generateRouteStaticParams(segments, store, __filename)
+      await generateRouteStaticParams(segments, store)
       expect(store.fetchCache).toBe('force-cache')
     })
 
@@ -1006,7 +974,7 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await generateRouteStaticParams(segments, store, __filename)
+      await generateRouteStaticParams(segments, store)
       // Should have the last fetchCache value
       expect(store.fetchCache).toBe('default-cache')
     })
@@ -1021,11 +989,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toEqual([{ slug: ['a', 'b'] }, { slug: ['c', 'd', 'e'] }])
     })
 
@@ -1037,11 +1001,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toEqual([{ lang: 'en', slug: ['en', 'post'] }])
     })
   })
@@ -1055,11 +1015,7 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async ({ params }) => [{ d: `${params?.c}-4` }]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toEqual([{ a: '1', b: '1-2', c: '1-2-3', d: '1-2-3-4' }])
     })
 
@@ -1070,11 +1026,7 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async () => [{ z: 'i' }, { z: 'ii' }]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toEqual([
         { x: '1', y: 'a', z: 'i' },
         { x: '1', y: 'a', z: 'ii' },
@@ -1096,9 +1048,9 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await expect(
-        generateRouteStaticParams(segments, store, __filename)
-      ).rejects.toThrow('Test error')
+      await expect(generateRouteStaticParams(segments, store)).rejects.toThrow(
+        'Test error'
+      )
     })
 
     it('should handle generateStaticParams returning a rejected promise', async () => {
@@ -1108,9 +1060,9 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await expect(
-        generateRouteStaticParams(segments, store, __filename)
-      ).rejects.toThrow('Async error')
+      await expect(generateRouteStaticParams(segments, store)).rejects.toThrow(
+        'Async error'
+      )
     })
 
     it('should handle partially failing generateStaticParams', async () => {
@@ -1124,9 +1076,9 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await expect(
-        generateRouteStaticParams(segments, store, __filename)
-      ).rejects.toThrow('Tech not allowed')
+      await expect(generateRouteStaticParams(segments, store)).rejects.toThrow(
+        'Tech not allowed'
+      )
     })
   })
 
@@ -1148,11 +1100,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toHaveLength(12) // 3 langs × 2 categories × 2 slugs
       expect(result).toContainEqual({
         lang: 'en',
@@ -1184,11 +1132,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toEqual([
         {
           category: 'electronics',
@@ -1223,11 +1167,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toHaveLength(8) // 2 years × 2 months × 2 slug variations
       expect(result).toContainEqual({
         year: '2023',
@@ -1247,11 +1187,7 @@ describe('generateRouteStaticParams', () => {
         )
       }
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(
-        segments,
-        store,
-        __filename
-      )
+      const result = await generateRouteStaticParams(segments, store)
       expect(result).toHaveLength(1)
       expect(Object.keys(result[0])).toHaveLength(5000)
     })

--- a/packages/next/src/build/static-paths/app.test.ts
+++ b/packages/next/src/build/static-paths/app.test.ts
@@ -834,7 +834,7 @@ describe('generateRouteStaticParams', () => {
   describe('Basic functionality', () => {
     it('should return empty array for empty segments', async () => {
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams([], store)
+      const result = await generateRouteStaticParams([], store, __filename)
       expect(result).toEqual([])
     })
 
@@ -844,7 +844,11 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toEqual([])
     })
 
@@ -853,7 +857,11 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async () => [{ id: '1' }, { id: '2' }]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toEqual([{ id: '1' }, { id: '2' }])
     })
 
@@ -869,7 +877,11 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toEqual([
         { category: 'tech', slug: 'tech-post-1' },
         { category: 'tech', slug: 'tech-post-2' },
@@ -888,7 +900,11 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toEqual([
         { lang: 'en', category: 'en-tech' },
         { lang: 'fr', category: 'fr-tech' },
@@ -904,7 +920,11 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toEqual([{ lang: 'en', slug: 'en-slug' }])
     })
   })
@@ -913,7 +933,11 @@ describe('generateRouteStaticParams', () => {
     it('should handle empty generateStaticParams results', async () => {
       const segments: TestAppSegment[] = [createMockSegment(async () => [])]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toEqual([])
     })
 
@@ -923,7 +947,11 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async () => []), // Empty result
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toEqual([{ lang: 'en' }])
     })
 
@@ -935,7 +963,11 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toEqual([
         { lang: 'en', category: 'en-tech' },
         { category: 'default-tech' },
@@ -951,7 +983,7 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await generateRouteStaticParams(segments, store)
+      await generateRouteStaticParams(segments, store, __filename)
       expect(store.fetchCache).toBe('force-cache')
     })
 
@@ -960,7 +992,7 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async () => [{ id: '1' }]),
       ]
       const store = createMockWorkStore('force-cache')
-      await generateRouteStaticParams(segments, store)
+      await generateRouteStaticParams(segments, store, __filename)
       expect(store.fetchCache).toBe('force-cache')
     })
 
@@ -974,7 +1006,7 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await generateRouteStaticParams(segments, store)
+      await generateRouteStaticParams(segments, store, __filename)
       // Should have the last fetchCache value
       expect(store.fetchCache).toBe('default-cache')
     })
@@ -989,7 +1021,11 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toEqual([{ slug: ['a', 'b'] }, { slug: ['c', 'd', 'e'] }])
     })
 
@@ -1001,7 +1037,11 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toEqual([{ lang: 'en', slug: ['en', 'post'] }])
     })
   })
@@ -1015,7 +1055,11 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async ({ params }) => [{ d: `${params?.c}-4` }]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toEqual([{ a: '1', b: '1-2', c: '1-2-3', d: '1-2-3-4' }])
     })
 
@@ -1026,7 +1070,11 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async () => [{ z: 'i' }, { z: 'ii' }]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toEqual([
         { x: '1', y: 'a', z: 'i' },
         { x: '1', y: 'a', z: 'ii' },
@@ -1048,9 +1096,9 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await expect(generateRouteStaticParams(segments, store)).rejects.toThrow(
-        'Test error'
-      )
+      await expect(
+        generateRouteStaticParams(segments, store, __filename)
+      ).rejects.toThrow('Test error')
     })
 
     it('should handle generateStaticParams returning a rejected promise', async () => {
@@ -1060,9 +1108,9 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await expect(generateRouteStaticParams(segments, store)).rejects.toThrow(
-        'Async error'
-      )
+      await expect(
+        generateRouteStaticParams(segments, store, __filename)
+      ).rejects.toThrow('Async error')
     })
 
     it('should handle partially failing generateStaticParams', async () => {
@@ -1076,9 +1124,9 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await expect(generateRouteStaticParams(segments, store)).rejects.toThrow(
-        'Tech not allowed'
-      )
+      await expect(
+        generateRouteStaticParams(segments, store, __filename)
+      ).rejects.toThrow('Tech not allowed')
     })
   })
 
@@ -1100,7 +1148,11 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toHaveLength(12) // 3 langs × 2 categories × 2 slugs
       expect(result).toContainEqual({
         lang: 'en',
@@ -1132,7 +1184,11 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toEqual([
         {
           category: 'electronics',
@@ -1167,7 +1223,11 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toHaveLength(8) // 2 years × 2 months × 2 slug variations
       expect(result).toContainEqual({
         year: '2023',
@@ -1187,7 +1247,11 @@ describe('generateRouteStaticParams', () => {
         )
       }
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(
+        segments,
+        store,
+        __filename
+      )
       expect(result).toHaveLength(1)
       expect(Object.keys(result[0])).toHaveLength(5000)
     })

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -638,8 +638,7 @@ export async function generateRouteStaticParams(
   segments: ReadonlyArray<
     Readonly<Pick<AppSegment, 'config' | 'generateStaticParams'>>
   >,
-  store: Pick<WorkStore, 'fetchCache'>,
-  page: string
+  store: Pick<WorkStore, 'fetchCache'>
 ): Promise<Params[]> {
   // Early return if no segments to process
   if (segments.length === 0) return []
@@ -703,14 +702,6 @@ export async function generateRouteStaticParams(
 
     // Add next segment to work queue
     queue.push({ segmentIndex: segmentIndex + 1, params: nextParams })
-  }
-
-  for (const params of currentParams) {
-    if (typeof params !== 'object' || params === null) {
-      throw new Error(
-        `generateStaticParams returned a non-object "${typeof params}" value "${params}" while processing page "${page}".`
-      )
-    }
   }
 
   return currentParams
@@ -850,7 +841,7 @@ export async function buildAppStaticPaths({
   })
 
   const routeParams = await ComponentMod.workAsyncStorage.run(store, () =>
-    generateRouteStaticParams(segments, store, page)
+    generateRouteStaticParams(segments, store)
   )
 
   // Early validation for unexpected parameter keys in routeParams.
@@ -860,6 +851,11 @@ export async function buildAppStaticPaths({
   )
   const invalidParamKeys = new Set<string>()
   for (const params of routeParams) {
+    if (typeof params !== 'object' || params === null) {
+      throw new Error(
+        `generateStaticParams returned a non-object "${typeof params}" value "${params}" while processing page "${page}".`
+      )
+    }
     for (const key in params) {
       if (!expectedParamKeys.has(key)) {
         invalidParamKeys.add(key)

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -869,7 +869,7 @@ export async function buildAppStaticPaths({
 
   if (invalidParamKeys.size > 0) {
     throw new Error(
-      `Invalid param keys found in generateStaticParams for "${page}":\n${[
+      `Invalid params keys found in generateStaticParams for "${page}":\n${[
         ...invalidParamKeys,
       ]
         .map((key) => `  - "${key}"`)

--- a/test/e2e/app-dir/generate-static-params-invalid-params-key/app/[id]/page.tsx
+++ b/test/e2e/app-dir/generate-static-params-invalid-params-key/app/[id]/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return <p>hello world</p>
+}
+
+export function generateStaticParams() {
+  return [{ id1: '1' }, { id2: '2' }]
+}

--- a/test/e2e/app-dir/generate-static-params-invalid-params-key/app/layout.tsx
+++ b/test/e2e/app-dir/generate-static-params-invalid-params-key/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/generate-static-params-invalid-params-key/generate-static-params-invalid-params-key.test.ts
+++ b/test/e2e/app-dir/generate-static-params-invalid-params-key/generate-static-params-invalid-params-key.test.ts
@@ -1,0 +1,38 @@
+import { nextTestSetup } from 'e2e-utils'
+import { assertHasRedbox, getRedboxDescription } from 'next-test-utils'
+
+describe('generate-static-params-invalid-params-key', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (isNextDev) {
+    it('should error and list the invalid params keys', async () => {
+      await next.start()
+      const browser = await next.browser('/1')
+      await assertHasRedbox(browser)
+      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(`
+       "Invalid params keys found in generateStaticParams for "/[id]":
+         - "id1"
+         - "id2""
+      `)
+    })
+  } else {
+    it('should throw and list the invalid params keys', async () => {
+      const buildResult = await next.build()
+      expect(buildResult?.exitCode).toBe(1)
+
+      expect(next.cliOutput).toContain(
+        `Error: Invalid params keys found in generateStaticParams for "/[id]":
+  - "id1"
+  - "id2"`
+      )
+    })
+  }
+})

--- a/test/e2e/app-dir/generate-static-params-invalid-params-key/next.config.js
+++ b/test/e2e/app-dir/generate-static-params-invalid-params-key/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/generate-static-params-invalid-params-type/app/[id]/page.tsx
+++ b/test/e2e/app-dir/generate-static-params-invalid-params-type/app/[id]/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return <p>hello world</p>
+}
+
+export function generateStaticParams() {
+  return ["should be obj but I'm string", null]
+}

--- a/test/e2e/app-dir/generate-static-params-invalid-params-type/app/layout.tsx
+++ b/test/e2e/app-dir/generate-static-params-invalid-params-type/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/generate-static-params-invalid-params-type/generate-static-params-invalid-params-type.test.ts
+++ b/test/e2e/app-dir/generate-static-params-invalid-params-type/generate-static-params-invalid-params-type.test.ts
@@ -1,0 +1,34 @@
+import { nextTestSetup } from 'e2e-utils'
+import { assertHasRedbox, getRedboxDescription } from 'next-test-utils'
+
+describe('generate-static-params-invalid-params-type', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (isNextDev) {
+    it('should error on invalid params type', async () => {
+      await next.start()
+      const browser = await next.browser('/1')
+      await assertHasRedbox(browser)
+      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+        `"generateStaticParams returned a non-object "string" value "should be obj but I'm string" while processing page "/[id]"."`
+      )
+    })
+  } else {
+    it('should throw on invalid params type', async () => {
+      const buildResult = await next.build()
+      expect(buildResult?.exitCode).toBe(1)
+
+      expect(next.cliOutput).toContain(
+        `Error: generateStaticParams returned a non-object "string" value "should be obj but I'm string" while processing page "/[id]".`
+      )
+    })
+  }
+})

--- a/test/e2e/app-dir/generate-static-params-invalid-params-type/next.config.js
+++ b/test/e2e/app-dir/generate-static-params-invalid-params-type/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
`generateStaticParams` allowed invalid params keys for the value, which can slip for the users when they call an API for a value that was invalid. For example, when a page `/[id]` had `generateStaticParams` value with `[{ foo: 'foo' }]`, the build succeeded. This can be hard to debug when the build output collapses the paths due to multiple routes.

Therefore, we add two validations: 1) the type of the params and 2) the key of the params meets the expected params.

1. The type of the params should be an object, and not null. Values like `['foo']` are not allowed.
2. The key of the params should be in the expected params. `/[id]` would expect only an array of `{ id: ... }`.

Closes NEXT-4380