### PR TITLE
Remove inline CSS sourcemaps from next-devtools

### DIFF
--- a/packages/next/next-devtools.webpack-config.js
+++ b/packages/next/next-devtools.webpack-config.js
@@ -125,7 +125,7 @@ module.exports = ({ dev, ...rest }) => {
                 ),
               },
             },
-            'css-loader',
+            { loader: 'css-loader', options: { sourceMap: false } },
           ],
         },
       ],


### PR DESCRIPTION
This shrinks `next/dist/compiled/next-devtools/index.js` from
864kb -> 808kb

Closes PACK-5485