### PR TITLE
[turbopack] Conditionally collect affecting sources

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1411,6 +1411,8 @@ impl Project {
         Ok(find_context_file(
             self.project_path().owned().await?,
             middleware_files(self.next_config().page_extensions()),
+            // our callers do not care about affecting sources
+            false,
         ))
     }
 
@@ -1570,6 +1572,8 @@ impl Project {
         Ok(find_context_file(
             self.project_path().owned().await?,
             instrumentation_files(self.next_config().page_extensions()),
+            // our callers do not care about affecting sources
+            false,
         ))
     }
 

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -182,7 +182,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                     // for .js extension in cjs context, we need to check the actual module type via
                     // package.json
                     let FindContextFileResult::Found(package_json, _) =
-                        &*find_context_file(fs_path.parent(), package_json()).await?
+                        &*find_context_file(fs_path.parent(), package_json(), false).await?
                     else {
                         // can't find package.json
                         return Ok(FileType::CommonJs);
@@ -283,10 +283,11 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
 
         if result_from_original_location != result {
             let package_json_file =
-                find_context_file(result.ident().path().await?.parent(), package_json());
+                find_context_file(result.ident().path().await?.parent(), package_json(), false);
             let package_json_from_original_location = find_context_file(
                 result_from_original_location.ident().path().await?.parent(),
                 package_json(),
+                false,
             );
             let FindContextFileResult::Found(package_json_file, _) = &*package_json_file.await?
             else {

--- a/crates/next-core/src/transform_options.rs
+++ b/crates/next-core/src/transform_options.rs
@@ -33,7 +33,7 @@ async fn get_typescript_options(
 
         Ok(tsconfigs)
     } else {
-        let tsconfig = find_context_file(project_path, tsconfig());
+        let tsconfig = find_context_file(project_path, tsconfig(), false);
         Ok(match tsconfig.await.ok().as_deref() {
             Some(FindContextFileResult::Found(path, _)) => read_tsconfigs(
                 path.read(),

--- a/turbopack/crates/turbopack-core/src/context.rs
+++ b/turbopack/crates/turbopack-core/src/context.rs
@@ -12,6 +12,7 @@ use crate::{
     resolve::{ModuleResolveResult, ResolveResult, options::ResolveOptions, parse::Request},
     source::Source,
 };
+
 #[turbo_tasks::value(shared)]
 pub enum ProcessResult {
     /// A module was created.

--- a/turbopack/crates/turbopack-core/src/context.rs
+++ b/turbopack/crates/turbopack-core/src/context.rs
@@ -12,7 +12,6 @@ use crate::{
     resolve::{ModuleResolveResult, ResolveResult, options::ResolveOptions, parse::Request},
     source::Source,
 };
-
 #[turbo_tasks::value(shared)]
 pub enum ProcessResult {
     /// A module was created.

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -13,7 +13,7 @@ use tracing::{Instrument, Level};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, SliceMap, TaskInput,
-    TryJoinIterExt, ValueToString, Vc, trace::TraceRawVcs,
+    TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileSystemEntryType, FileSystemPath};
 use turbo_unix_path::normalize_request;
@@ -1402,26 +1402,60 @@ fn merge_results_with_affecting_sources(
     }
 }
 
-// Resolves the pattern without collecting affecting sources
+// Resolves the pattern
 #[turbo_tasks::function]
 pub async fn resolve_raw(
     lookup_dir: FileSystemPath,
     path: Vc<Pattern>,
+    collect_affecting_sources: bool,
     force_in_lookup_dir: bool,
 ) -> Result<Vc<ResolveResult>> {
-    async fn to_result(request: RcStr, path: FileSystemPath) -> Result<Vc<ResolveResult>> {
+    async fn to_result(
+        request: RcStr,
+        path: FileSystemPath,
+        collect_affecting_sources: bool,
+    ) -> Result<Vc<ResolveResult>> {
         let result = &*path.realpath_with_links().await?;
         let path = match &result.path_result {
             Ok(path) => path,
             Err(e) => bail!(e.as_error_message(&path, result)),
         };
-        // NOTE: we do not collect affecting sources here because we are not interested in them
-        // for this function.  Even if we did collect them here, our caller immediately discards
-        // them.
-        Ok(*ResolveResult::source_with_key(
-            RequestKey::new(request),
-            ResolvedVc::upcast(FileSource::new(path.clone()).to_resolved().await?),
-        ))
+        let request_key = RequestKey::new(request);
+        let source = ResolvedVc::upcast(FileSource::new(path.clone()).to_resolved().await?);
+        Ok(*if collect_affecting_sources {
+            ResolveResult::source_with_affecting_sources(
+                request_key,
+                source,
+                result
+                    .symlinks
+                    .iter()
+                    .map(|symlink| {
+                        Vc::upcast::<Box<dyn Source>>(FileSource::new(symlink.clone()))
+                            .to_resolved()
+                    })
+                    .try_join()
+                    .await?,
+            )
+        } else {
+            ResolveResult::source_with_key(request_key, source)
+        })
+    }
+
+    async fn collect_matches(
+        matches: &[PatternMatch],
+        collect_affecting_sources: bool,
+    ) -> Result<Vec<Vc<ResolveResult>>> {
+        matches
+            .iter()
+            .map(|m| async move {
+                Ok(if let PatternMatch::File(request, path) = m {
+                    Some(to_result(request.clone(), path.clone(), collect_affecting_sources).await?)
+                } else {
+                    None
+                })
+            })
+            .try_flat_join()
+            .await
     }
 
     let mut results = Vec::new();
@@ -1449,11 +1483,11 @@ pub async fn resolve_raw(
                 matches.len()
             );
         } else {
-            for m in matches.iter() {
-                if let PatternMatch::File(request, path) = m {
-                    results.push(to_result(request.clone(), path.clone()).await?);
-                }
-            }
+            results.extend(
+                collect_matches(&matches, collect_affecting_sources)
+                    .await?
+                    .into_iter(),
+            );
         }
     }
 
@@ -1467,11 +1501,11 @@ pub async fn resolve_raw(
                 matches.len()
             );
         }
-        for m in matches.iter() {
-            if let PatternMatch::File(request, path) = m {
-                results.push(to_result(request.clone(), path.clone()).await?);
-            }
-        }
+        results.extend(
+            collect_matches(&matches, collect_affecting_sources)
+                .await?
+                .into_iter(),
+        );
     }
 
     Ok(merge_results(results))

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -158,16 +158,6 @@ impl ModuleResolveResult {
         .resolved_cell()
     }
 
-    pub fn unresolvable_with_affecting_sources(
-        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
-    ) -> ResolvedVc<Self> {
-        ModuleResolveResult {
-            primary: Default::default(),
-            affecting_sources: affecting_sources.into_boxed_slice(),
-        }
-        .resolved_cell()
-    }
-
     pub fn module(module: ResolvedVc<Box<dyn Module>>) -> ResolvedVc<Self> {
         Self::module_with_key(RequestKey::default(), module)
     }
@@ -239,7 +229,7 @@ impl ModuleResolveResult {
     }
 
     pub fn affecting_sources_iter(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Source>>> + '_ {
-        self.affecting_sources.iter().copied()
+        self.affecting_sources.as_ref().iter().copied()
     }
 
     pub fn is_unresolvable_ref(&self) -> bool {
@@ -293,61 +283,6 @@ impl ModuleResolveResultBuilder {
 #[turbo_tasks::value_impl]
 impl ModuleResolveResult {
     #[turbo_tasks::function]
-    pub fn with_affecting_source(&self, source: ResolvedVc<Box<dyn Source>>) -> Result<Vc<Self>> {
-        Ok(Self {
-            primary: self.primary.clone(),
-            affecting_sources: self
-                .affecting_sources
-                .iter()
-                .copied()
-                .chain(std::iter::once(source))
-                .collect(),
-        }
-        .cell())
-    }
-
-    #[turbo_tasks::function]
-    pub fn with_affecting_sources(
-        &self,
-        sources: Vec<ResolvedVc<Box<dyn Source>>>,
-    ) -> Result<Vc<Self>> {
-        Ok(Self {
-            primary: self.primary.clone(),
-            affecting_sources: self
-                .affecting_sources
-                .iter()
-                .copied()
-                .chain(sources)
-                .collect(),
-        }
-        .cell())
-    }
-
-    /// Returns the first [ModuleResolveResult] that is not
-    /// [ModuleResolveResult::Unresolvable] in the given list, while keeping
-    /// track of all the affecting_sources in all the [ModuleResolveResult]s.
-    #[turbo_tasks::function]
-    async fn select_first(results: Vec<Vc<ModuleResolveResult>>) -> Result<Vc<Self>> {
-        let mut affecting_sources = vec![];
-        for result in &results {
-            affecting_sources.extend(result.await?.affecting_sources_iter());
-        }
-        for result in results {
-            let result_ref = result.await?;
-            if !result_ref.is_unresolvable_ref() {
-                return Ok(Self {
-                    primary: result_ref.primary.clone(),
-                    affecting_sources: affecting_sources.into_boxed_slice(),
-                }
-                .cell());
-            }
-        }
-        Ok(*ModuleResolveResult::unresolvable_with_affecting_sources(
-            affecting_sources,
-        ))
-    }
-
-    #[turbo_tasks::function]
     pub async fn alternatives(results: Vec<Vc<ModuleResolveResult>>) -> Result<Vc<Self>> {
         if results.len() == 1 {
             return Ok(results.into_iter().next().unwrap());
@@ -363,38 +298,6 @@ impl ModuleResolveResult {
             Ok(Self::cell(current.into()))
         } else {
             Ok(*ModuleResolveResult::unresolvable())
-        }
-    }
-
-    #[turbo_tasks::function]
-    async fn alternatives_with_affecting_sources(
-        results: Vec<Vc<ModuleResolveResult>>,
-        affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
-    ) -> Result<Vc<Self>> {
-        if affecting_sources.is_empty() {
-            return Ok(Self::alternatives(results));
-        }
-        if results.len() == 1 {
-            return Ok(results
-                .into_iter()
-                .next()
-                .unwrap()
-                .with_affecting_sources(affecting_sources.into_iter().map(|src| *src).collect()));
-        }
-        let mut iter = results.into_iter().try_join().await?.into_iter();
-        if let Some(current) = iter.next() {
-            let mut current: ModuleResolveResultBuilder = ReadRef::into_owned(current).into();
-            for result in iter {
-                // For clippy -- This explicit deref is necessary
-                let other = &*result;
-                current.merge_alternatives(other);
-            }
-            current.affecting_sources.extend(affecting_sources);
-            Ok(Self::cell(current.into()))
-        } else {
-            Ok(*ModuleResolveResult::unresolvable_with_affecting_sources(
-                affecting_sources,
-            ))
         }
     }
 
@@ -696,6 +599,8 @@ impl ResolveResult {
 }
 
 impl ResolveResult {
+    /// Returns the affecting sources for this result. Will be empty if affecting sources are
+    /// disabled for this result.
     pub fn get_affecting_sources(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Source>>> + '_ {
         self.affecting_sources.iter().copied()
     }
@@ -866,20 +771,6 @@ impl ResolveResult {
     }
 
     #[turbo_tasks::function]
-    fn with_affecting_source(&self, source: ResolvedVc<Box<dyn Source>>) -> Result<Vc<Self>> {
-        Ok(Self {
-            primary: self.primary.clone(),
-            affecting_sources: self
-                .affecting_sources
-                .iter()
-                .copied()
-                .chain(std::iter::once(source))
-                .collect(),
-        }
-        .cell())
-    }
-
-    #[turbo_tasks::function]
     fn with_affecting_sources(
         &self,
         sources: Vec<ResolvedVc<Box<dyn Source>>>,
@@ -894,30 +785,6 @@ impl ResolveResult {
                 .collect(),
         }
         .cell())
-    }
-
-    /// Returns the first [ResolveResult] that is not
-    /// [ResolveResult::Unresolvable] in the given list, while keeping track
-    /// of all the affecting_sources in all the [ResolveResult]s.
-    #[turbo_tasks::function]
-    async fn select_first(results: Vec<Vc<ResolveResult>>) -> Result<Vc<Self>> {
-        let mut affecting_sources = vec![];
-        for result in &results {
-            affecting_sources.extend(result.await?.get_affecting_sources());
-        }
-        for result in results {
-            let result_ref = result.await?;
-            if !result_ref.is_unresolvable_ref() {
-                return Ok(Self {
-                    primary: result_ref.primary.clone(),
-                    affecting_sources: affecting_sources.into_boxed_slice(),
-                }
-                .cell());
-            }
-        }
-        Ok(*ResolveResult::unresolvable_with_affecting_sources(
-            affecting_sources,
-        ))
     }
 
     #[turbo_tasks::function]
@@ -944,9 +811,10 @@ impl ResolveResult {
         results: Vec<Vc<ResolveResult>>,
         affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> Result<Vc<Self>> {
-        if affecting_sources.is_empty() {
-            return Ok(Self::alternatives(results));
-        }
+        debug_assert!(
+            !affecting_sources.is_empty(),
+            "Caller should not call this function if there are no affecting sources"
+        );
         if results.len() == 1 {
             return Ok(results
                 .into_iter()
@@ -1143,14 +1011,14 @@ impl ResolveResultOption {
 
 async fn exists(
     fs_path: &FileSystemPath,
-    refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
+    refs: Option<&mut Vec<ResolvedVc<Box<dyn Source>>>>,
 ) -> Result<Option<FileSystemPath>> {
     type_exists(fs_path, FileSystemEntryType::File, refs).await
 }
 
 async fn dir_exists(
     fs_path: &FileSystemPath,
-    refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
+    refs: Option<&mut Vec<ResolvedVc<Box<dyn Source>>>>,
 ) -> Result<Option<FileSystemPath>> {
     type_exists(fs_path, FileSystemEntryType::Directory, refs).await
 }
@@ -1158,7 +1026,7 @@ async fn dir_exists(
 async fn type_exists(
     fs_path: &FileSystemPath,
     ty: FileSystemEntryType,
-    refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
+    refs: Option<&mut Vec<ResolvedVc<Box<dyn Source>>>>,
 ) -> Result<Option<FileSystemPath>> {
     let path = realpath(fs_path, refs).await?;
     Ok(if *path.get_type().await? == ty {
@@ -1170,21 +1038,23 @@ async fn type_exists(
 
 async fn realpath(
     fs_path: &FileSystemPath,
-    refs: &mut Vec<ResolvedVc<Box<dyn Source>>>,
+    refs: Option<&mut Vec<ResolvedVc<Box<dyn Source>>>>,
 ) -> Result<FileSystemPath> {
     let result = fs_path.realpath_with_links().await?;
-    refs.extend(
-        result
-            .symlinks
-            .iter()
-            .map(|path| async move {
-                Ok(ResolvedVc::upcast(
-                    FileSource::new(path.clone()).to_resolved().await?,
-                ))
-            })
-            .try_join()
-            .await?,
-    );
+    if let Some(refs) = refs {
+        refs.extend(
+            result
+                .symlinks
+                .iter()
+                .map(|path| async move {
+                    Ok(ResolvedVc::upcast(
+                        FileSource::new(path.clone()).to_resolved().await?,
+                    ))
+                })
+                .try_join()
+                .await?,
+        );
+    }
     match &result.path_result {
         Ok(path) => Ok(path.clone()),
         Err(e) => bail!(e.as_error_message(fs_path, &result)),
@@ -1240,7 +1110,8 @@ enum ImportsFieldResult {
 /// into an appropriate [AliasMap] for lookups.
 #[turbo_tasks::function]
 async fn imports_field(lookup_path: FileSystemPath) -> Result<Vc<ImportsFieldResult>> {
-    let package_json_context = find_context_file(lookup_path, package_json()).await?;
+    // We don't need to collect affecting sources here because we don't use them
+    let package_json_context = find_context_file(lookup_path, package_json(), false).await?;
     let FindContextFileResult::Found(package_json_path, _refs) = &*package_json_context else {
         return Ok(ImportsFieldResult::None.cell());
     };
@@ -1287,11 +1158,21 @@ pub enum FindContextFileResult {
 pub async fn find_context_file(
     lookup_path: FileSystemPath,
     names: Vc<Vec<RcStr>>,
+    collect_affecting_sources: bool,
 ) -> Result<Vc<FindContextFileResult>> {
     let mut refs = Vec::new();
     for name in &*names.await? {
         let fs_path = lookup_path.join(name)?;
-        if let Some(fs_path) = exists(&fs_path, &mut refs).await? {
+        if let Some(fs_path) = exists(
+            &fs_path,
+            if collect_affecting_sources {
+                Some(&mut refs)
+            } else {
+                None
+            },
+        )
+        .await?
+        {
             return Ok(FindContextFileResult::Found(fs_path, refs).cell());
         }
     }
@@ -1301,13 +1182,13 @@ pub async fn find_context_file(
     if refs.is_empty() {
         // Tailcall
         Ok(find_context_file(
-            // Hot codepath optimization: resolve all arguments to avoid an automatically-created
-            // intermediate task
             lookup_path.parent(),
             names,
+            collect_affecting_sources,
         ))
     } else {
-        let parent_result = find_context_file(lookup_path.parent(), names).await?;
+        let parent_result =
+            find_context_file(lookup_path.parent(), names, collect_affecting_sources).await?;
         Ok(match &*parent_result {
             FindContextFileResult::Found(p, r) => {
                 refs.extend(r.iter().copied());
@@ -1323,47 +1204,32 @@ pub async fn find_context_file(
 }
 
 // Same as find_context_file, but also stop for package.json with the specified key
+// This function never collects affecting sources
 #[turbo_tasks::function]
 pub async fn find_context_file_or_package_key(
     lookup_path: FileSystemPath,
     names: Vc<Vec<RcStr>>,
     package_key: RcStr,
 ) -> Result<Vc<FindContextFileResult>> {
-    let mut refs = Vec::new();
     let package_json_path = lookup_path.join("package.json")?;
-    if let Some(package_json_path) = exists(&package_json_path, &mut refs).await?
+    if let Some(package_json_path) = exists(&package_json_path, None).await?
         && let Some(json) =
             &*read_package_json(Vc::upcast(FileSource::new(package_json_path.clone()))).await?
         && json.get(&*package_key).is_some()
     {
-        return Ok(FindContextFileResult::Found(package_json_path, refs).into());
+        return Ok(FindContextFileResult::Found(package_json_path, Vec::new()).into());
     }
     for name in &*names.await? {
         let fs_path = lookup_path.join(name)?;
-        if let Some(fs_path) = exists(&fs_path, &mut refs).await? {
-            return Ok(FindContextFileResult::Found(fs_path, refs).into());
+        if let Some(fs_path) = exists(&fs_path, None).await? {
+            return Ok(FindContextFileResult::Found(fs_path, Vec::new()).into());
         }
     }
     if lookup_path.is_root() {
-        return Ok(FindContextFileResult::NotFound(refs).into());
+        return Ok(FindContextFileResult::NotFound(Vec::new()).into());
     }
-    if refs.is_empty() {
-        // Tailcall
-        Ok(find_context_file(lookup_path.parent(), names))
-    } else {
-        let parent_result = find_context_file(lookup_path.parent(), names).await?;
-        Ok(match &*parent_result {
-            FindContextFileResult::Found(p, r) => {
-                refs.extend(r.iter().copied());
-                FindContextFileResult::Found(p.clone(), refs)
-            }
-            FindContextFileResult::NotFound(r) => {
-                refs.extend(r.iter().copied());
-                FindContextFileResult::NotFound(refs)
-            }
-        }
-        .into())
-    }
+
+    Ok(find_context_file(lookup_path.parent(), names, false))
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, Debug, NonLocalValue)]
@@ -1376,6 +1242,7 @@ enum FindPackageItem {
 #[derive(Debug)]
 struct FindPackageResult {
     packages: Vec<FindPackageItem>,
+    // Only populated if collect_affecting_sources is true
     affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
 }
 
@@ -1384,6 +1251,7 @@ async fn find_package(
     lookup_path: FileSystemPath,
     package_name: Pattern,
     options: Vc<ResolveModulesOptions>,
+    collect_affecting_sources: bool,
 ) -> Result<Vc<FindPackageResult>> {
     let mut packages = vec![];
     let mut affecting_sources = vec![];
@@ -1406,7 +1274,12 @@ async fn find_package(
                 while lookup_path_value.is_inside_ref(root) {
                     for name in names.iter() {
                         let fs_path = lookup_path.join(name)?;
-                        if let Some(fs_path) = dir_exists(&fs_path, &mut affecting_sources).await? {
+                        if let Some(fs_path) = dir_exists(
+                            &fs_path,
+                            collect_affecting_sources.then_some(&mut affecting_sources),
+                        )
+                        .await?
+                        {
                             let matches =
                                 read_matches(fs_path.clone(), rcstr!(""), true, package_name_cell)
                                     .await?;
@@ -1414,7 +1287,12 @@ async fn find_package(
                                 if let PatternMatch::Directory(_, package_dir) = m {
                                     packages.push(FindPackageItem::PackageDirectory {
                                         name: get_package_name(&fs_path, package_dir)?,
-                                        dir: realpath(package_dir, &mut affecting_sources).await?,
+                                        dir: realpath(
+                                            package_dir,
+                                            collect_affecting_sources
+                                                .then_some(&mut affecting_sources),
+                                        )
+                                        .await?,
                                     });
                                 }
                             }
@@ -1439,13 +1317,21 @@ async fn find_package(
                         PatternMatch::Directory(_, package_dir) => {
                             packages.push(FindPackageItem::PackageDirectory {
                                 name: get_package_name(dir, package_dir)?,
-                                dir: realpath(package_dir, &mut affecting_sources).await?,
+                                dir: realpath(
+                                    package_dir,
+                                    collect_affecting_sources.then_some(&mut affecting_sources),
+                                )
+                                .await?,
                             });
                         }
                         PatternMatch::File(_, package_file) => {
                             packages.push(FindPackageItem::PackageFile {
                                 name: get_package_name(dir, package_file)?,
-                                file: realpath(package_file, &mut affecting_sources).await?,
+                                file: realpath(
+                                    package_file,
+                                    collect_affecting_sources.then_some(&mut affecting_sources),
+                                )
+                                .await?,
                             });
                         }
                     }
@@ -1470,7 +1356,11 @@ async fn find_package(
                     if let PatternMatch::File(_, package_file) = m {
                         packages.push(FindPackageItem::PackageFile {
                             name: get_package_name(dir, package_file)?,
-                            file: realpath(package_file, &mut affecting_sources).await?,
+                            file: realpath(
+                                package_file,
+                                collect_affecting_sources.then_some(&mut affecting_sources),
+                            )
+                            .await?,
                         });
                     }
                 }
@@ -1512,6 +1402,7 @@ fn merge_results_with_affecting_sources(
     }
 }
 
+// Resolves the pattern without collecting affecting sources
 #[turbo_tasks::function]
 pub async fn resolve_raw(
     lookup_dir: FileSystemPath,
@@ -1524,19 +1415,12 @@ pub async fn resolve_raw(
             Ok(path) => path,
             Err(e) => bail!(e.as_error_message(&path, result)),
         };
-        Ok(*ResolveResult::source_with_affecting_sources(
+        // NOTE: we do not collect affecting sources here because we are not interested in them
+        // for this function.  Even if we did collect them here, our caller immediately discards
+        // them.
+        Ok(*ResolveResult::source_with_key(
             RequestKey::new(request),
             ResolvedVc::upcast(FileSource::new(path.clone()).to_resolved().await?),
-            result
-                .symlinks
-                .iter()
-                .map(|symlink| async move {
-                    anyhow::Ok(ResolvedVc::upcast(
-                        FileSource::new(symlink.clone()).to_resolved().await?,
-                    ))
-                })
-                .try_join()
-                .await?,
         ))
     }
 
@@ -1664,19 +1548,23 @@ pub async fn url_resolve(
     );
     let result = if *rel_result.is_unresolvable().await? && rel_request.resolve().await? != request
     {
-        resolve(
+        let result = resolve(
             origin.origin_path().await?.parent(),
             reference_type.clone(),
             request,
             resolve_options,
-        )
-        .with_affecting_sources(
-            rel_result
-                .await?
-                .get_affecting_sources()
-                .map(|src| *src)
-                .collect(),
-        )
+        );
+        if resolve_options.await?.collect_affecting_sources {
+            result.with_affecting_sources(
+                rel_result
+                    .await?
+                    .get_affecting_sources()
+                    .map(|src| *src)
+                    .collect(),
+            )
+        } else {
+            result
+        }
     } else {
         rel_result
     };
@@ -2146,8 +2034,15 @@ async fn resolve_into_folder(
     let options_value = options.await?;
 
     let mut affecting_sources = vec![];
-    if let Some(package_json_path) =
-        exists(&package_path.join("package.json")?, &mut affecting_sources).await?
+    if let Some(package_json_path) = exists(
+        &package_path.join("package.json")?,
+        if options_value.collect_affecting_sources {
+            Some(&mut affecting_sources)
+        } else {
+            None
+        },
+    )
+    .await?
     {
         for resolve_into_package in options_value.into_package.iter() {
             match resolve_into_package {
@@ -2181,10 +2076,12 @@ async fn resolve_into_folder(
                         if !result.is_unresolvable_ref() {
                             let mut result: ResolveResultBuilder =
                                 result.with_request_ref(rcstr!(".")).into();
-                            result.affecting_sources.push(ResolvedVc::upcast(
-                                FileSource::new(package_json_path).to_resolved().await?,
-                            ));
-                            result.affecting_sources.extend(affecting_sources);
+                            if options_value.collect_affecting_sources {
+                                result.affecting_sources.push(ResolvedVc::upcast(
+                                    FileSource::new(package_json_path).to_resolved().await?,
+                                ));
+                                result.affecting_sources.extend(affecting_sources);
+                            }
                             return Ok(ResolveResult::from(result).cell());
                         }
                     };
@@ -2217,13 +2114,15 @@ async fn resolve_into_folder(
     };
 
     let request = Request::parse(pattern);
+    let result = resolve_internal_inline(package_path.clone(), request, options)
+        .await?
+        .with_request(rcstr!("."));
 
-    Ok(
-        resolve_internal_inline(package_path.clone(), request, options)
-            .await?
-            .with_request(rcstr!("."))
-            .with_affecting_sources(ResolvedVc::deref_vec(affecting_sources)),
-    )
+    Ok(if !affecting_sources.is_empty() {
+        result.with_affecting_sources(ResolvedVc::deref_vec(affecting_sources))
+    } else {
+        result
+    })
 }
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
@@ -2449,8 +2348,12 @@ async fn apply_in_package(
             continue;
         };
 
-        let FindContextFileResult::Found(package_json_path, refs) =
-            &*find_context_file(lookup_path.clone(), package_json().resolve().await?).await?
+        let FindContextFileResult::Found(package_json_path, refs) = &*find_context_file(
+            lookup_path.clone(),
+            package_json().resolve().await?,
+            options_value.collect_affecting_sources,
+        )
+        .await?
         else {
             continue;
         };
@@ -2498,17 +2401,18 @@ async fn apply_in_package(
                 // This would be a cycle, so we ignore it
                 return Ok(None);
             }
-            return Ok(Some(
-                resolve_internal(
-                    package_path,
-                    Request::parse(Pattern::Constant(value.into()))
-                        .with_query(query.clone())
-                        .with_fragment(fragment.clone()),
-                    options,
-                )
-                .with_replaced_request_key(value.into(), request_key)
-                .with_affecting_sources(refs.into_iter().map(|src| *src).collect()),
-            ));
+            let mut result = resolve_internal(
+                package_path,
+                Request::parse(Pattern::Constant(value.into()))
+                    .with_query(query.clone())
+                    .with_fragment(fragment.clone()),
+                options,
+            )
+            .with_replaced_request_key(value.into(), request_key);
+            if options_value.collect_affecting_sources && !refs.is_empty() {
+                result = result.with_affecting_sources(refs.into_iter().map(|src| *src).collect());
+            }
+            return Ok(Some(result));
         }
 
         ResolvingIssue {
@@ -2547,7 +2451,7 @@ enum FindSelfReferencePackageResult {
 async fn find_self_reference(
     lookup_path: FileSystemPath,
 ) -> Result<Vc<FindSelfReferencePackageResult>> {
-    let package_json_context = find_context_file(lookup_path, package_json()).await?;
+    let package_json_context = find_context_file(lookup_path, package_json(), false).await?;
     if let FindContextFileResult::Found(package_json_path, _refs) = &*package_json_context {
         let read =
             read_package_json(Vc::upcast(FileSource::new(package_json_path.clone()))).await?;
@@ -2618,6 +2522,7 @@ async fn resolve_module_request(
         lookup_path.clone(),
         module.clone(),
         resolve_modules_options(options).resolve().await?,
+        options_value.collect_affecting_sources,
     )
     .await?;
 
@@ -2912,25 +2817,29 @@ async fn resolved(
             return Ok(result);
         }
     }
-
-    Ok(*ResolveResult::source_with_affecting_sources(
-        request_key,
-        ResolvedVc::upcast(
-            FileSource::new_with_query_and_fragment(path.clone(), query, fragment)
-                .to_resolved()
-                .await?,
-        ),
-        result
-            .symlinks
-            .iter()
-            .map(|symlink| async move {
-                anyhow::Ok(ResolvedVc::upcast(
-                    FileSource::new(symlink.clone()).to_resolved().await?,
-                ))
-            })
-            .try_join()
+    let source = ResolvedVc::upcast(
+        FileSource::new_with_query_and_fragment(path.clone(), query, fragment)
+            .to_resolved()
             .await?,
-    ))
+    );
+    if options_value.collect_affecting_sources {
+        Ok(*ResolveResult::source_with_affecting_sources(
+            request_key,
+            source,
+            result
+                .symlinks
+                .iter()
+                .map(|symlink| async move {
+                    anyhow::Ok(ResolvedVc::upcast(
+                        FileSource::new(symlink.clone()).to_resolved().await?,
+                    ))
+                })
+                .try_join()
+                .await?,
+        ))
+    } else {
+        Ok(*ResolveResult::source_with_key(request_key, source))
+    }
 }
 
 async fn handle_exports_imports_field(

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -146,6 +146,8 @@ impl ExportUsage {
 #[derive(Clone)]
 pub struct ModuleResolveResult {
     pub primary: SliceMap<RequestKey, ModuleResolveResultItem>,
+    /// Affecting sources are other files that influence the resolve result.  For example,
+    /// traversed symlinks
     pub affecting_sources: Box<[ResolvedVc<Box<dyn Source>>]>,
 }
 
@@ -229,7 +231,7 @@ impl ModuleResolveResult {
     }
 
     pub fn affecting_sources_iter(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Source>>> + '_ {
-        self.affecting_sources.as_ref().iter().copied()
+        self.affecting_sources.iter().copied()
     }
 
     pub fn is_unresolvable_ref(&self) -> bool {
@@ -466,6 +468,8 @@ impl RequestKey {
 #[derive(Clone)]
 pub struct ResolveResult {
     pub primary: SliceMap<RequestKey, ResolveResultItem>,
+    /// Affecting sources are other files that influence the resolve result.  For example,
+    /// traversed symlinks
     pub affecting_sources: Box<[ResolvedVc<Box<dyn Source>>]>,
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -621,6 +621,8 @@ pub struct ResolveOptions {
     pub enable_typescript_with_output_extension: bool,
     /// Warn instead of error for resolve errors
     pub loose_errors: bool,
+    /// Collect affecting sources for each resolve result.  Useful for tracing.
+    pub collect_affecting_sources: bool,
     /// Whether to parse data URIs into modules (as opposed to keeping them as externals)
     pub parse_data_uris: bool,
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -198,7 +198,7 @@ pub async fn is_marked_as_side_effect_free(
         return Ok(Vc::cell(true));
     }
 
-    let find_package_json = find_context_file(path.parent(), package_json()).await?;
+    let find_package_json = find_context_file(path.parent(), package_json(), false).await?;
 
     if let FindContextFileResult::Found(package_json, _) = &*find_package_json {
         match *side_effects_from_package_json(package_json.clone()).await? {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -582,7 +582,7 @@ async fn determine_module_type_for_directory(
     context_path: FileSystemPath,
 ) -> Result<Vc<ModuleTypeResult>> {
     let find_package_json =
-        find_context_file(context_path, package_json().resolve().await?).await?;
+        find_context_file(context_path, package_json().resolve().await?, false).await?;
     let FindContextFileResult::Found(package_json, _) = &*find_package_json else {
         return Ok(ModuleTypeResult::new(SpecifiedModuleType::Automatic));
     };

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -440,6 +440,8 @@ struct AnalysisState<'a> {
     ignore_dynamic_requests: bool,
     url_rewrite_behavior: Option<UrlRewriteBehavior>,
     free_var_references: ReadRef<FreeVarReferencesIndividual>,
+    // Whether we should collect affecting sources from referenced files. Only usedful when
+    // tracing.
     collect_affecting_sources: bool,
 }
 
@@ -514,12 +516,6 @@ pub async fn analyse_ecmascript_module_internal(
     let analyze_mode = options.analyze_mode;
 
     let origin = ResolvedVc::upcast::<Box<dyn ResolveOrigin>>(module);
-    let collect_affecting_sources = origin
-        .resolve_options(ReferenceType::Undefined)
-        .await?
-        .await?
-        .collect_affecting_sources;
-
     let mut analysis = AnalyzeEcmascriptModuleResultBuilder::new(analyze_mode);
     let path = &*origin.origin_path().await?;
 
@@ -980,7 +976,7 @@ pub async fn analyse_ecmascript_module_internal(
                 .free_var_references
                 .individual()
                 .await?,
-            collect_affecting_sources,
+            collect_affecting_sources: options.analyze_mode.is_tracing(),
         };
 
         enum Action {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -440,6 +440,7 @@ struct AnalysisState<'a> {
     ignore_dynamic_requests: bool,
     url_rewrite_behavior: Option<UrlRewriteBehavior>,
     free_var_references: ReadRef<FreeVarReferencesIndividual>,
+    collect_affecting_sources: bool,
 }
 
 impl AnalysisState<'_> {
@@ -513,6 +514,11 @@ pub async fn analyse_ecmascript_module_internal(
     let analyze_mode = options.analyze_mode;
 
     let origin = ResolvedVc::upcast::<Box<dyn ResolveOrigin>>(module);
+    let collect_affecting_sources = origin
+        .resolve_options(ReferenceType::Undefined)
+        .await?
+        .await?
+        .collect_affecting_sources;
 
     let mut analysis = AnalyzeEcmascriptModuleResultBuilder::new(analyze_mode);
     let path = &*origin.origin_path().await?;
@@ -974,6 +980,7 @@ pub async fn analyse_ecmascript_module_internal(
                 .free_var_references
                 .individual()
                 .await?,
+            collect_affecting_sources,
         };
 
         enum Action {
@@ -1603,6 +1610,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
         compile_time_info,
         ignore_dynamic_requests,
         url_rewrite_behavior,
+        collect_affecting_sources,
         ..
     } = state;
     fn explain_args(args: &[JsValue]) -> (String, String) {
@@ -1948,7 +1956,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     }
                 }
                 analysis.add_reference(
-                    FileSourceReference::new(*source, Pattern::new(pat))
+                    FileSourceReference::new(*source, Pattern::new(pat), collect_affecting_sources)
                         .to_resolved()
                         .await?,
                 );
@@ -1997,7 +2005,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 }
             }
             analysis.add_reference(
-                FileSourceReference::new(*source, Pattern::new(pat))
+                FileSourceReference::new(*source, Pattern::new(pat), collect_affecting_sources)
                     .to_resolved()
                     .await?,
             );
@@ -2086,9 +2094,13 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 }
                 if !dynamic || !ignore_dynamic_requests {
                     analysis.add_reference(
-                        FileSourceReference::new(*source, Pattern::new(pat))
-                            .to_resolved()
-                            .await?,
+                        FileSourceReference::new(
+                            *source,
+                            Pattern::new(pat),
+                            collect_affecting_sources,
+                        )
+                        .to_resolved()
+                        .await?,
                     );
                 }
                 if show_dynamic_warning {
@@ -2179,6 +2191,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         origin.origin_path().await?.parent(),
                         Pattern::new(pat),
                         compile_time_info.environment().compile_target(),
+                        collect_affecting_sources,
                     )
                     .to_resolved()
                     .await?,
@@ -2218,7 +2231,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     analysis.add_reference(
                         NodeGypBuildReference::new(
                             current_context,
-                            origin.resolve_options(ReferenceType::Undefined).await?,
+                            collect_affecting_sources,
                             compile_time_info.environment().compile_target(),
                         )
                         .to_resolved()
@@ -2250,9 +2263,13 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     .await?;
                 if let Some(s) = first_arg.as_str() {
                     analysis.add_reference(
-                        NodeBindingsReference::new(origin.origin_path().owned().await?, s.into())
-                            .to_resolved()
-                            .await?,
+                        NodeBindingsReference::new(
+                            origin.origin_path().owned().await?,
+                            s.into(),
+                            collect_affecting_sources,
+                        )
+                        .to_resolved()
+                        .await?,
                     );
                     return Ok(());
                 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -554,7 +554,7 @@ pub async fn analyse_ecmascript_module_internal(
     if analyze_types {
         let span = tracing::info_span!("tsconfig reference");
         async {
-            match &*find_context_file(path.parent(), tsconfig()).await? {
+            match &*find_context_file(path.parent(), tsconfig(), false).await? {
                 FindContextFileResult::Found(tsconfig, _) => {
                     analysis.add_reference(
                         TsConfigReference::new(*origin, tsconfig.clone())
@@ -2218,6 +2218,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     analysis.add_reference(
                         NodeGypBuildReference::new(
                             current_context,
+                            origin.resolve_options(ReferenceType::Undefined).await?,
                             compile_time_info.environment().compile_target(),
                         )
                         .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -70,7 +70,6 @@ impl DirAssetReference {
     }
 }
 
-#[turbo_tasks::function]
 async fn resolve_reference_from_dir(
     parent_path: FileSystemPath,
     path: Vc<Pattern>,
@@ -126,7 +125,7 @@ async fn resolve_reference_from_dir(
                 }
                 let path: FileSystemPath = match &realpath.path_result {
                     Ok(path) => path.clone(),
-                    Err(e) => bail!(e.as_error_message(file, &realpath)),
+                    Err(e) => bail!(e.as_error_message(&file, &realpath)),
                 };
                 results.push((
                     RequestKey::new(matched_path.clone()),
@@ -155,13 +154,9 @@ impl ModuleReference for DirAssetReference {
             "trace directory",
             pattern = display(self.path.to_string().await?)
         );
-        async {
-            resolve_reference_from_dir(parent_path, *self.path)
-                .resolve()
-                .await
-        }
-        .instrument(span)
-        .await
+        resolve_reference_from_dir(parent_path, *self.path)
+            .instrument(span)
+            .await
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -125,7 +125,7 @@ async fn resolve_reference_from_dir(
                 }
                 let path: FileSystemPath = match &realpath.path_result {
                     Ok(path) => path.clone(),
-                    Err(e) => bail!(e.as_error_message(&file, &realpath)),
+                    Err(e) => bail!(e.as_error_message(file, &realpath)),
                 };
                 results.push((
                     RequestKey::new(matched_path.clone()),

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -14,13 +14,22 @@ use turbopack_core::{
 pub struct FileSourceReference {
     pub source: ResolvedVc<Box<dyn Source>>,
     pub path: ResolvedVc<Pattern>,
+    pub collect_affecting_sources: bool,
 }
 
 #[turbo_tasks::value_impl]
 impl FileSourceReference {
     #[turbo_tasks::function]
-    pub fn new(source: ResolvedVc<Box<dyn Source>>, path: ResolvedVc<Pattern>) -> Vc<Self> {
-        Self::cell(FileSourceReference { source, path })
+    pub fn new(
+        source: ResolvedVc<Box<dyn Source>>,
+        path: ResolvedVc<Pattern>,
+        collect_affecting_sources: bool,
+    ) -> Vc<Self> {
+        Self::cell(FileSourceReference {
+            source,
+            path,
+            collect_affecting_sources,
+        })
     }
 }
 
@@ -35,11 +44,15 @@ impl ModuleReference for FileSourceReference {
             pattern = display(self.path.to_string().await?)
         );
         async {
-            // `resolve_raw` does not collect affecting sources, is that correct?
-            resolve_raw(context_dir, *self.path, false)
-                .as_raw_module_result()
-                .resolve()
-                .await
+            resolve_raw(
+                context_dir,
+                *self.path,
+                self.collect_affecting_sources,
+                false,
+            )
+            .as_raw_module_result()
+            .resolve()
+            .await
         }
         .instrument(span)
         .await

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -35,6 +35,7 @@ impl ModuleReference for FileSourceReference {
             pattern = display(self.path.to_string().await?)
         );
         async {
+            // `resolve_raw` does not collect affecting sources, is that correct?
             resolve_raw(context_dir, *self.path, false)
                 .as_raw_module_result()
                 .resolve()

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -105,6 +105,7 @@ async fn node_file_trace_operation(
             enable_node_modules: Some(input_dir.clone()),
             custom_conditions: vec![rcstr!("node")],
             loose_errors: true,
+            collect_affecting_sources: true,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -14,10 +14,7 @@ use turbopack_core::{
     file_source::FileSource,
     raw_module::RawModule,
     reference::ModuleReference,
-    resolve::{
-        ModuleResolveResult, RequestKey, ResolveResultItem, options::ResolveOptions,
-        pattern::Pattern, resolve_raw,
-    },
+    resolve::{ModuleResolveResult, RequestKey, ResolveResultItem, pattern::Pattern, resolve_raw},
     source::Source,
     target::{CompileTarget, Platform},
 };
@@ -40,6 +37,7 @@ pub struct NodePreGypConfigReference {
     pub context_dir: FileSystemPath,
     pub config_file_pattern: ResolvedVc<Pattern>,
     pub compile_target: ResolvedVc<CompileTarget>,
+    pub collect_affecting_sources: bool,
 }
 
 #[turbo_tasks::value_impl]
@@ -49,11 +47,13 @@ impl NodePreGypConfigReference {
         context_dir: FileSystemPath,
         config_file_pattern: ResolvedVc<Pattern>,
         compile_target: ResolvedVc<CompileTarget>,
+        collect_affecting_sources: bool,
     ) -> Vc<Self> {
         Self::cell(NodePreGypConfigReference {
             context_dir,
             config_file_pattern,
             compile_target,
+            collect_affecting_sources,
         })
     }
 }
@@ -61,12 +61,14 @@ impl NodePreGypConfigReference {
 #[turbo_tasks::value_impl]
 impl ModuleReference for NodePreGypConfigReference {
     #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
+    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         resolve_node_pre_gyp_files(
             self.context_dir.clone(),
             *self.config_file_pattern,
             *self.compile_target,
+            self.collect_affecting_sources,
         )
+        .await
     }
 }
 
@@ -84,11 +86,11 @@ impl ValueToString for NodePreGypConfigReference {
     }
 }
 
-#[turbo_tasks::function]
-pub async fn resolve_node_pre_gyp_files(
+async fn resolve_node_pre_gyp_files(
     context_dir: FileSystemPath,
     config_file_pattern: Vc<Pattern>,
     compile_target: Vc<CompileTarget>,
+    collect_affecting_sources: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
     static NAPI_VERSION_TEMPLATE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"\{(napi_build_version|node_napi_label)\}")
@@ -100,9 +102,14 @@ pub async fn resolve_node_pre_gyp_files(
         LazyLock::new(|| Regex::new(r"\{arch\}").expect("create node_arch regex failed"));
     static LIBC_TEMPLATE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"\{libc\}").expect("create node_libc regex failed"));
-    let config = resolve_raw(context_dir, config_file_pattern, true)
-        .first_source()
-        .await?;
+    let config = resolve_raw(
+        context_dir,
+        config_file_pattern,
+        collect_affecting_sources,
+        true,
+    )
+    .first_source()
+    .await?;
     let compile_target = compile_target.await?;
     if let Some(config_asset) = *config
         && let AssetContent::File(file) = &*config_asset.content().await?
@@ -225,7 +232,7 @@ pub async fn resolve_node_pre_gyp_files(
 #[derive(Hash, Clone, Debug)]
 pub struct NodeGypBuildReference {
     pub context_dir: FileSystemPath,
-    pub resolve_options: ResolvedVc<ResolveOptions>,
+    collect_affecting_sources: bool,
     pub compile_target: ResolvedVc<CompileTarget>,
 }
 
@@ -234,12 +241,12 @@ impl NodeGypBuildReference {
     #[turbo_tasks::function]
     pub fn new(
         context_dir: FileSystemPath,
-        resolve_options: ResolvedVc<ResolveOptions>,
+        collect_affecting_sources: bool,
         compile_target: ResolvedVc<CompileTarget>,
     ) -> Vc<Self> {
         Self::cell(NodeGypBuildReference {
             context_dir,
-            resolve_options,
+            collect_affecting_sources,
             compile_target,
         })
     }
@@ -248,12 +255,13 @@ impl NodeGypBuildReference {
 #[turbo_tasks::value_impl]
 impl ModuleReference for NodeGypBuildReference {
     #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
+    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         resolve_node_gyp_build_files(
             self.context_dir.clone(),
-            *self.resolve_options,
-            *self.compile_target,
+            self.collect_affecting_sources,
+            self.compile_target,
         )
+        .await
     }
 }
 
@@ -269,20 +277,23 @@ impl ValueToString for NodeGypBuildReference {
     }
 }
 
-#[turbo_tasks::function]
-pub async fn resolve_node_gyp_build_files(
+async fn resolve_node_gyp_build_files(
     context_dir: FileSystemPath,
-    resolve_options: Vc<ResolveOptions>,
-    compile_target: Vc<CompileTarget>,
+    collect_affecting_sources: bool,
+    compile_target: ResolvedVc<CompileTarget>,
 ) -> Result<Vc<ModuleResolveResult>> {
     // TODO Proper parser
     static GYP_BUILD_TARGET_NAME: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r#"['"]target_name['"]\s*:\s*(?:"(.*?)"|'(.*?)')"#)
             .expect("create napi_build_version regex failed")
     });
-    let collect_affecting_sources = resolve_options.await?.collect_affecting_sources;
     let binding_gyp_pat = Pattern::new(Pattern::Constant(rcstr!("binding.gyp")));
-    let gyp_file = resolve_raw(context_dir.clone(), binding_gyp_pat, true);
+    let gyp_file = resolve_raw(
+        context_dir.clone(),
+        binding_gyp_pat,
+        collect_affecting_sources,
+        true,
+    );
     if let [binding_gyp] = &gyp_file.primary_sources().await?[..] {
         let mut merged_affecting_sources = if collect_affecting_sources {
             gyp_file.await?.get_affecting_sources().collect::<Vec<_>>()
@@ -301,6 +312,7 @@ pub async fn resolve_node_gyp_build_files(
                 let resolved_prebuilt_file = resolve_raw(
                     target_path,
                     Pattern::new(Pattern::Constant(format!("{name}.node").into())),
+                    collect_affecting_sources,
                     true,
                 )
                 .await?;
@@ -343,6 +355,7 @@ pub async fn resolve_node_gyp_build_files(
             Pattern::Dynamic,
             Pattern::Constant(rcstr!(".node")),
         ])),
+        collect_affecting_sources,
         true,
     )
     .as_raw_module_result())
@@ -353,15 +366,21 @@ pub async fn resolve_node_gyp_build_files(
 pub struct NodeBindingsReference {
     pub context_dir: FileSystemPath,
     pub file_name: RcStr,
+    pub collect_affecting_sources: bool,
 }
 
 #[turbo_tasks::value_impl]
 impl NodeBindingsReference {
     #[turbo_tasks::function]
-    pub fn new(context_dir: FileSystemPath, file_name: RcStr) -> Vc<Self> {
+    pub fn new(
+        context_dir: FileSystemPath,
+        file_name: RcStr,
+        collect_affecting_sources: bool,
+    ) -> Vc<Self> {
         Self::cell(NodeBindingsReference {
             context_dir,
             file_name,
+            collect_affecting_sources,
         })
     }
 }
@@ -369,8 +388,13 @@ impl NodeBindingsReference {
 #[turbo_tasks::value_impl]
 impl ModuleReference for NodeBindingsReference {
     #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        resolve_node_bindings_files(self.context_dir.clone(), self.file_name.clone())
+    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+        resolve_node_bindings_files(
+            self.context_dir.clone(),
+            self.file_name.clone(),
+            self.collect_affecting_sources,
+        )
+        .await
     }
 }
 
@@ -384,10 +408,10 @@ impl ValueToString for NodeBindingsReference {
     }
 }
 
-#[turbo_tasks::function]
-pub async fn resolve_node_bindings_files(
+async fn resolve_node_bindings_files(
     context_dir: FileSystemPath,
     file_name: RcStr,
+    collect_affecting_sources: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
     static BINDINGS_TRY: LazyLock<[&'static str; 5]> = LazyLock::new(|| {
         [
@@ -403,6 +427,7 @@ pub async fn resolve_node_bindings_files(
         let resolved = resolve_raw(
             root_context_dir.clone(),
             Pattern::new(Pattern::Constant(rcstr!("package.json"))),
+            collect_affecting_sources,
             true,
         )
         .first_source()

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -14,7 +14,10 @@ use turbopack_core::{
     file_source::FileSource,
     raw_module::RawModule,
     reference::ModuleReference,
-    resolve::{ModuleResolveResult, RequestKey, ResolveResultItem, pattern::Pattern, resolve_raw},
+    resolve::{
+        ModuleResolveResult, RequestKey, ResolveResultItem, options::ResolveOptions,
+        pattern::Pattern, resolve_raw,
+    },
     source::Source,
     target::{CompileTarget, Platform},
 };
@@ -222,15 +225,21 @@ pub async fn resolve_node_pre_gyp_files(
 #[derive(Hash, Clone, Debug)]
 pub struct NodeGypBuildReference {
     pub context_dir: FileSystemPath,
+    pub resolve_options: ResolvedVc<ResolveOptions>,
     pub compile_target: ResolvedVc<CompileTarget>,
 }
 
 #[turbo_tasks::value_impl]
 impl NodeGypBuildReference {
     #[turbo_tasks::function]
-    pub fn new(context_dir: FileSystemPath, compile_target: ResolvedVc<CompileTarget>) -> Vc<Self> {
+    pub fn new(
+        context_dir: FileSystemPath,
+        resolve_options: ResolvedVc<ResolveOptions>,
+        compile_target: ResolvedVc<CompileTarget>,
+    ) -> Vc<Self> {
         Self::cell(NodeGypBuildReference {
             context_dir,
+            resolve_options,
             compile_target,
         })
     }
@@ -240,7 +249,11 @@ impl NodeGypBuildReference {
 impl ModuleReference for NodeGypBuildReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        resolve_node_gyp_build_files(self.context_dir.clone(), *self.compile_target)
+        resolve_node_gyp_build_files(
+            self.context_dir.clone(),
+            *self.resolve_options,
+            *self.compile_target,
+        )
     }
 }
 
@@ -259,6 +272,7 @@ impl ValueToString for NodeGypBuildReference {
 #[turbo_tasks::function]
 pub async fn resolve_node_gyp_build_files(
     context_dir: FileSystemPath,
+    resolve_options: Vc<ResolveOptions>,
     compile_target: Vc<CompileTarget>,
 ) -> Result<Vc<ModuleResolveResult>> {
     // TODO Proper parser
@@ -266,11 +280,15 @@ pub async fn resolve_node_gyp_build_files(
         Regex::new(r#"['"]target_name['"]\s*:\s*(?:"(.*?)"|'(.*?)')"#)
             .expect("create napi_build_version regex failed")
     });
+    let collect_affecting_sources = resolve_options.await?.collect_affecting_sources;
     let binding_gyp_pat = Pattern::new(Pattern::Constant(rcstr!("binding.gyp")));
     let gyp_file = resolve_raw(context_dir.clone(), binding_gyp_pat, true);
     if let [binding_gyp] = &gyp_file.primary_sources().await?[..] {
-        let mut merged_affecting_sources =
-            gyp_file.await?.get_affecting_sources().collect::<Vec<_>>();
+        let mut merged_affecting_sources = if collect_affecting_sources {
+            gyp_file.await?.get_affecting_sources().collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
         if let AssetContent::File(file) = &*binding_gyp.content().await?
             && let FileContent::Content(config_file) = &*file.await?
             && let Some(captured) = GYP_BUILD_TARGET_NAME.captures(&config_file.content().to_str()?)
@@ -290,8 +308,10 @@ pub async fn resolve_node_gyp_build_files(
                     resolved_prebuilt_file.primary.first()
                 {
                     resolved.insert(format!("build/Release/{name}.node").into(), *source);
-                    merged_affecting_sources
-                        .extend(resolved_prebuilt_file.affecting_sources.iter().copied());
+                    if collect_affecting_sources {
+                        merged_affecting_sources
+                            .extend(resolved_prebuilt_file.affecting_sources.iter().copied());
+                    }
                 }
             }
             if !resolved.is_empty() {

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -204,6 +204,7 @@ async fn base_resolve_options(
         after_resolve_plugins: opt.after_resolve_plugins.clone(),
         before_resolve_plugins: opt.before_resolve_plugins.clone(),
         loose_errors: opt.loose_errors,
+        collect_affecting_sources: opt.collect_affecting_sources,
         ..Default::default()
     }
     .into())
@@ -228,7 +229,12 @@ pub async fn resolve_options(
     let resolve_options = if options_context_value.enable_typescript {
         let find_tsconfig = async || {
             // Otherwise, attempt to find a tsconfig up the file tree
-            let tsconfig = find_context_file(resolve_path.clone(), tsconfig()).await?;
+            let tsconfig = find_context_file(
+                resolve_path.clone(),
+                tsconfig(),
+                options_context_value.collect_affecting_sources,
+            )
+            .await?;
             anyhow::Ok::<Vc<ResolveOptions>>(match &*tsconfig {
                 FindContextFileResult::Found(path, _) => apply_tsconfig_resolve_options(
                     resolve_options,

--- a/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
@@ -79,6 +79,8 @@ pub struct ResolveOptionsContext {
     pub before_resolve_plugins: Vec<ResolvedVc<Box<dyn BeforeResolvePlugin>>>,
     /// Warn instead of error for resolve errors
     pub loose_errors: bool,
+    /// Collect affecting sources for each resolve result.  Useful for tracing.
+    pub collect_affecting_sources: bool,
 
     #[serde(default)]
     pub placeholder_for_future_extensions: (),

--- a/turbopack/crates/turbopack-tracing/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack-tracing/benches/node_file_trace.rs
@@ -108,6 +108,7 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                         emulate_environment: Some(
                             compile_time_info.environment().to_resolved().await?,
                         ),
+                        collect_affecting_sources: true,
                         ..Default::default()
                     }
                     .cell(),

--- a/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
@@ -383,6 +383,7 @@ async fn node_file_trace_operation(
             enable_node_native_modules: true,
             enable_node_modules: Some(input_dir.clone()),
             custom_conditions: vec![rcstr!("node")],
+            collect_affecting_sources: true,
             ..Default::default()
         }
         .cell(),

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -688,6 +688,7 @@ pub async fn externals_tracing_module_context(
         enable_node_native_modules: true,
         emulate_environment: Some(compile_time_info.await?.environment),
         loose_errors: true,
+        collect_affecting_sources: true,
         custom_conditions: match ty {
             ExternalType::CommonJs => vec![rcstr!("require"), rcstr!("node")],
             ExternalType::EcmaScriptModule => vec![rcstr!("import"), rcstr!("node")],


### PR DESCRIPTION
The `affecting_sources` field on `ResolveResult` and `ModuleResolveResult`  are used for file tracing, but not for normal builds.  So make tracking this information conditional.

This will be a minor performance win for a few reasons
* no allocations to store these lists
* no storing this data in the PC database
* changes to affecting sources won't invalidate resolution results.

Closes PACK-5438


