### PR TITLE
[turbopack] drop the turbo tasks function from the `ResolveResult::is_unresolvable()` function

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -278,7 +278,7 @@ impl ReferencedAsset {
     pub async fn from_resolve_result(resolve_result: Vc<ModuleResolveResult>) -> Result<Vc<Self>> {
         // TODO handle multiple keyed results
         let result = resolve_result.await?;
-        if result.is_unresolvable_ref() {
+        if result.is_unresolvable() {
             return Ok(ReferencedAsset::Unresolvable.cell());
         }
         for (_, result) in result.primary.iter() {

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -449,7 +449,7 @@ pub async fn type_resolve(
             request,
             options,
         );
-        if !*result1.is_unresolvable().await? {
+        if !result1.await?.is_unresolvable() {
             result1
         } else {
             resolve(


### PR DESCRIPTION
In theory this is a 'maximally projecting' turbotask since we are querying a single boolean value from a complex result.  This should reduce invalidations for the turbotasks that call it. 

However, it is also a trivial task so we aren't saving any work from caching it, thus invalidations are the only real concern.  

