### PR TITLE
fix: add the missing comma in the document example

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/layout.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/layout.mdx
@@ -61,7 +61,7 @@ A promise that resolves to an object containing the [dynamic route parameters](/
 
 ```tsx filename="app/dashboard/[team]/layout.tsx" switcher
 export default async function Layout({
-  children
+  children,
   params,
 }: {
   children: React.ReactNode


### PR DESCRIPTION
### What?
This PR fixes a missing comma in the function parameter in `03-api-reference/03-file-conventions/layout.mdx`. 

The comma between `children` and `params` parameters was missing in the documentation example, showing incorrect syntax.

### Why?
The missing comma in the documentation example shows invalid JavaScript/TypeScript syntax.

### How?
- Added missing comma after `children` parameter .

**Before:**
```tsx filename="app/dashboard/[team]/layout.tsx" switcher
export default async function Layout({
  children
  params,
}: {
```

**After:**
```tsx filename="app/dashboard/[team]/layout.tsx" switcher
export default async function Layout({
  children,
  params,
}: {
  children: React.ReactNode
```
