### PR TITLE
Turbopack: enable nodelay for node.js pool socket

### DIFF
--- a/turbopack/crates/turbopack-node/js/src/ipc/index.ts
+++ b/turbopack/crates/turbopack-node/js/src/ipc/index.ts
@@ -80,6 +80,7 @@ function createIpc<TIncoming, TOutgoing>(
   let state: State = { type: 'waiting' }
   let buffer: Buffer = Buffer.alloc(0)
   socket.once('connect', () => {
+    socket.setNoDelay(true)
     socket.on('data', (chunk) => {
       buffer = Buffer.concat([buffer, chunk])
 

--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -431,6 +431,7 @@ impl NodeJsPoolProcess {
                 bail!("timed out waiting for the Node.js process to connect ({timeout:?} timeout)\nProcess output:\n{stdout}\nProcess error output:\n{stderr}");
             },
         };
+        connection.set_nodelay(true)?;
 
         let child_stdout = BufReader::new(child.stdout.take().unwrap());
         let child_stderr = BufReader::new(child.stderr.take().unwrap());

--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -541,6 +541,10 @@ impl NodeJsPoolProcess {
             .write_all(&packet_data)
             .await
             .context("writing packet data")?;
+        self.connection
+            .flush()
+            .await
+            .context("flushing packet data")?;
         Ok(())
     }
 }


### PR DESCRIPTION
### What?

Removes delays from sending data from and to the worker process.

Closes PACK-5490