### PR TITLE
Turbopack: speedup link calls

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/analyzer.rs
@@ -117,6 +117,7 @@ fn bench_link(b: &mut Bencher, input: &BenchInput) {
                 link(
                     &input.var_graph,
                     val.clone(),
+                    &|v| v,
                     &early_visitor,
                     &(|val| visitor(val, compile_time_info, ImportAttributes::empty_ref())),
                     &Default::default(),

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -4,94 +4,134 @@ use anyhow::Result;
 use parking_lot::Mutex;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::ecma::ast::Id;
-use turbo_tasks::TryJoinIterExt;
 
 use super::{JsValue, graph::VarGraph};
 
-// Resolves variable references only, doesn't exhaustively evaluate everything inside of the value.
-pub async fn link_shallow<'a, B, RB, F, RF>(
-    graph: &VarGraph,
-    mut current_val: JsValue,
-    early_visitor: &B,
-    visitor: &F,
-    fun_args_values: &Mutex<FxHashMap<u32, Vec<JsValue>>>,
-    var_cache: &Mutex<FxHashMap<Id, JsValue>>,
-) -> Result<JsValue>
-where
-    RB: 'a + Future<Output = Result<(JsValue, bool)>> + Send,
-    B: 'a + Fn(JsValue) -> RB + Sync,
-    RF: 'a + Future<Output = Result<(JsValue, bool)>> + Send,
-    F: 'a + Fn(JsValue) -> RF + Sync,
-{
-    current_val.normalize();
+// // Resolves variable references only, doesn't exhaustively evaluate everything inside of the
+// value. pub async fn link_shallow<'a, B, RB, F, RF>(
+//     graph: &VarGraph,
+//     mut current_val: JsValue,
+//     early_visitor: &B,
+//     visitor: &F,
+//     fun_args_values: &Mutex<FxHashMap<u32, Vec<JsValue>>>,
+//     var_cache: &Mutex<FxHashMap<Id, JsValue>>,
+// ) -> Result<JsValue>
+// where
+//     RB: 'a + Future<Output = Result<(JsValue, bool)>> + Send,
+//     B: 'a + Fn(JsValue) -> RB + Sync,
+//     RF: 'a + Future<Output = Result<(JsValue, bool)>> + Send,
+//     F: 'a + Fn(JsValue) -> RF + Sync,
+// {
+//     current_val.normalize();
 
-    if let JsValue::Alternatives {
-        values,
-        logical_property,
-        ..
-    } = current_val
-    {
-        let values = values
-            .into_iter()
-            .map(|v| link_shallow(graph, v, early_visitor, visitor, fun_args_values, var_cache))
-            .try_join()
-            .await?;
-        return Ok(if let Some(logical_property) = logical_property {
-            JsValue::alternatives_with_additional_property(values, logical_property)
-        } else {
-            JsValue::alternatives(values)
-        });
-    }
+//     if let JsValue::Alternatives {
+//         values,
+//         logical_property,
+//         ..
+//     } = current_val
+//     {
+//         let values = values
+//             .into_iter()
+//             .map(|v| link_shallow(graph, v, early_visitor, visitor, fun_args_values, var_cache))
+//             .try_join()
+//             .await?;
+//         return Ok(if let Some(logical_property) = logical_property {
+//             JsValue::alternatives_with_additional_property(values, logical_property)
+//         } else {
+//             JsValue::alternatives(values)
+//         });
+//     }
 
-    // Resolve variable references, don't do anything else.
-    loop {
-        match current_val {
-            JsValue::Variable(var) => {
-                if let Some(val) = graph.values.get(&var) {
-                    current_val = val.clone();
-                    continue;
-                } else {
-                    current_val = JsValue::unknown(
-                        JsValue::Variable(var),
-                        false,
-                        "no value of this variable analysed",
-                    );
-                }
-            }
-            JsValue::Argument(func_ident, index) => {
-                if let Some(args) = fun_args_values.lock().get(&func_ident) {
-                    if let Some(val) = args.get(index) {
-                        current_val = val.clone();
-                        continue;
-                    } else {
-                        current_val = JsValue::unknown_empty(
-                            false,
-                            "unknown function argument (out of bounds)",
-                        );
-                    }
-                } else {
-                    current_val = JsValue::unknown(
-                        JsValue::Argument(func_ident, index),
-                        false,
-                        "function calls are not analysed yet",
-                    );
-                }
-            }
-            val => {
-                current_val = val;
-            }
-        };
-        break;
-    }
+//     let before = current_val.clone();
 
-    let val = early_visitor(current_val).await?.0;
-    let val = visitor(val).await?.0;
-    Ok(val)
-}
+//     // Resolve variable references, don't do anything else.
+//     loop {
+//         match current_val {
+//             JsValue::Variable(var) => {
+//                 if let Some(val) = graph.values.get(&var) {
+//                     current_val = val.clone();
+//                     continue;
+//                 } else {
+//                     current_val = JsValue::unknown(
+//                         JsValue::Variable(var),
+//                         false,
+//                         "no value of this variable analysed",
+//                     );
+//                 }
+//             }
+//             JsValue::Argument(func_ident, index) => {
+//                 if let Some(args) = fun_args_values.lock().get(&func_ident) {
+//                     if let Some(val) = args.get(index) {
+//                         current_val = val.clone();
+//                         continue;
+//                     } else {
+//                         current_val = JsValue::unknown_empty(
+//                             false,
+//                             "unknown function argument (out of bounds)",
+//                         );
+//                     }
+//                 } else {
+//                     current_val = JsValue::unknown(
+//                         JsValue::Argument(func_ident, index),
+//                         false,
+//                         "function calls are not analysed yet",
+//                     );
+//                 }
+//             }
+//             val => {
+//                 current_val = val;
+//             }
+//         };
+//         break;
+//     }
+
+//     // async fn visit_member_recursively<'a, B, RB, F, RF>(
+//     //     early_visitor: &B,
+//     //     visitor: &F,
+//     //     value: JsValue,
+//     // ) -> Result<JsValue>
+//     // where
+//     //     RB: 'a + Future<Output = Result<(JsValue, bool)>> + Send,
+//     //     B: 'a + Fn(JsValue) -> RB + Sync,
+//     //     RF: 'a + Future<Output = Result<(JsValue, bool)>> + Send,
+//     //     F: 'a + Fn(JsValue) -> RF + Sync,
+//     // {
+//     //     anyhow::Ok(if let JsValue::Member(_, obj, prop) = value {
+//     //         let obj = visit_member_recursively(early_visitor, visitor, *obj).await?;
+//     //         let prop
+//     //         let value = JsValue::member(obj, prop);
+//     //     } else {
+//     //         value
+//     //     })
+//     // }
+
+//     let after = current_val.clone();
+
+//     let val = early_visitor(current_val).await?.0;
+//     let val = visitor(val).await?.0;
+//     println!(
+//         "shallow {:?} {:?} {:?} {:?}",
+//         before,
+//         after,
+//         val,
+//         link(
+//             graph,
+//             before.clone(),
+//             early_visitor,
+//             visitor,
+//             fun_args_values,
+//             var_cache,
+//         )
+//         .await?
+//         .0
+//     );
+//     Ok(val)
+// }
 
 pub async fn link<'a, B, RB, F, RF>(
     graph: &VarGraph,
     mut val: JsValue,
+    earliest_toplevel_visitor: &impl Fn(JsValue) -> JsValue,
     early_visitor: &B,
     visitor: &F,
     fun_args_values: &Mutex<FxHashMap<u32, Vec<JsValue>>>,
@@ -110,6 +150,7 @@ where
         link_internal_iterative(
             graph,
             val,
+            earliest_toplevel_visitor,
             early_visitor,
             visitor,
             fun_args_values,
@@ -131,15 +172,15 @@ const LIMIT_LINK_STEPS: u32 = 1500;
 enum Step {
     /// Take all chlidren out of the value (replacing temporarily with unknown) and queue them
     /// for processing using individual `Enter`s.
-    Enter(JsValue),
+    Enter(JsValue, bool),
     /// Pop however many children there are from `done` and reinsert them into the value
-    Leave(JsValue),
+    Leave(JsValue, bool),
     /// Remove the variable from `cycle_stack` which detects e.g. circular reassignments
     LeaveVar(Id),
-    LeaveLate(JsValue),
+    LeaveLate(JsValue, bool),
     /// Call the visitor callbacks, and requeue the value for further processing if it changed.
-    Visit(JsValue),
-    EarlyVisit(JsValue),
+    Visit(JsValue, bool),
+    EarlyVisit(JsValue, bool),
     /// Remove the call from `fun_args_values`
     LeaveCall(u32),
     /// Placeholder that is used to momentarily reserve a slot that is only filled after
@@ -150,12 +191,12 @@ enum Step {
 impl Display for Step {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Step::Enter(val) => write!(f, "Enter({val})"),
-            Step::EarlyVisit(val) => write!(f, "EarlyVisit({val})"),
-            Step::Leave(val) => write!(f, "Leave({val})"),
+            Step::Enter(val, top_level) => write!(f, "Enter({val}, {top_level})"),
+            Step::EarlyVisit(val, top_level) => write!(f, "EarlyVisit({val}, {top_level})"),
+            Step::Leave(val, top_level) => write!(f, "Leave({val}, {top_level})"),
             Step::LeaveVar(var) => write!(f, "LeaveVar({var:?})"),
-            Step::LeaveLate(val) => write!(f, "LeaveLate({val})"),
-            Step::Visit(val) => write!(f, "Visit({val})"),
+            Step::LeaveLate(val, top_level) => write!(f, "LeaveLate({val}, {top_level})"),
+            Step::Visit(val, top_level) => write!(f, "Visit({val}, {top_level})"),
             Step::LeaveCall(func_ident) => write!(f, "LeaveCall({func_ident})"),
             Step::TemporarySlot => write!(f, "TemporarySlot"),
         }
@@ -166,6 +207,7 @@ impl Display for Step {
 pub(crate) async fn link_internal_iterative<'a, B, RB, F, RF>(
     graph: &'a VarGraph,
     val: JsValue,
+    earliest_toplevel_visitor: &impl Fn(JsValue) -> JsValue,
     early_visitor: &'a B,
     visitor: &'a F,
     fun_args_values: &Mutex<FxHashMap<u32, Vec<JsValue>>>,
@@ -186,7 +228,7 @@ where
     let mut steps = 0;
 
     total_nodes += val.total_nodes();
-    work_queue_stack.push(Step::Enter(val));
+    work_queue_stack.push(Step::Enter(val, true));
 
     while let Some(step) = work_queue_stack.pop() {
         steps += 1;
@@ -196,7 +238,7 @@ where
             // - replace it with value from graph
             // - process value
             // - (Step::LeaveVar potentially caches the value)
-            Step::Enter(JsValue::Variable(var)) => {
+            Step::Enter(JsValue::Variable(var), top_level) => {
                 if cycle_stack.contains(&var) {
                     done.push(JsValue::unknown(
                         JsValue::Variable(var.clone()),
@@ -215,7 +257,7 @@ where
                         cycle_stack.insert(var.clone());
                         work_queue_stack.push(Step::LeaveVar(var));
                         total_nodes += val.total_nodes();
-                        work_queue_stack.push(Step::Enter(val.clone()));
+                        work_queue_stack.push(Step::Enter(val.clone(), top_level));
                     } else {
                         total_nodes += 1;
                         done.push(JsValue::unknown(
@@ -235,7 +277,7 @@ where
             }
             // Enter a function argument
             // We want to replace the argument with the value from the function call
-            Step::Enter(JsValue::Argument(func_ident, index)) => {
+            Step::Enter(JsValue::Argument(func_ident, index), _) => {
                 total_nodes -= 1;
                 if let Some(args) = fun_args_values.lock().get(&func_ident) {
                     if let Some(val) = args.get(index) {
@@ -260,11 +302,10 @@ where
             // Visit a function call
             // This need special handling, since we want to replace the function call and process
             // the function return value after that.
-            Step::Visit(JsValue::Call(
+            Step::Visit(
+                JsValue::Call(_, box JsValue::Function(_, func_ident, return_value), args),
                 _,
-                box JsValue::Function(_, func_ident, return_value),
-                args,
-            )) => {
+            ) => {
                 total_nodes -= 2; // Call + Function
                 if let Entry::Vacant(entry) = fun_args_values.lock().entry(func_ident) {
                     // Return value will stay in total_nodes
@@ -273,7 +314,7 @@ where
                     }
                     entry.insert(args);
                     work_queue_stack.push(Step::LeaveCall(func_ident));
-                    work_queue_stack.push(Step::Enter(*return_value));
+                    work_queue_stack.push(Step::Enter(*return_value, false));
                 } else {
                     total_nodes -= return_value.total_nodes();
                     for arg in args.iter() {
@@ -296,13 +337,19 @@ where
             // We don't want to process the function return value yet, this will happen after
             // function calls
             // - just put it into done
-            Step::Enter(func @ JsValue::Function(..)) => {
+            Step::Enter(func @ JsValue::Function(..), _) => {
                 done.push(func);
             }
             // Enter a value
             // - take and queue children for processing
             // - on leave: insert children again and optimize
-            Step::Enter(mut val) => {
+            Step::Enter(mut val, top_level) => {
+                if top_level {
+                    total_nodes -= val.total_nodes();
+                    val = earliest_toplevel_visitor(val);
+                    total_nodes += val.total_nodes();
+                }
+
                 if !val.has_children() {
                     visit(
                         &mut total_nodes,
@@ -310,6 +357,7 @@ where
                         &mut work_queue_stack,
                         visitor,
                         val,
+                        top_level,
                     )
                     .await?;
                 } else {
@@ -318,17 +366,19 @@ where
                     let mut has_early_children = false;
                     val.for_each_early_children_mut(&mut |child| {
                         has_early_children = true;
-                        work_queue_stack.push(Step::Enter(take(child)));
+                        work_queue_stack.push(Step::Enter(take(child), false));
                         false
                     });
                     if has_early_children {
-                        work_queue_stack[i] = Step::EarlyVisit(val);
+                        work_queue_stack[i] = Step::EarlyVisit(val, top_level);
                     } else {
+                        let child_top_level =
+                            top_level && matches!(val, JsValue::Alternatives { .. });
                         val.for_each_children_mut(&mut |child| {
-                            work_queue_stack.push(Step::Enter(take(child)));
+                            work_queue_stack.push(Step::Enter(take(child), child_top_level));
                             false
                         });
-                        work_queue_stack[i] = Step::Leave(val);
+                        work_queue_stack[i] = Step::Leave(val, top_level);
                     }
                 }
             }
@@ -336,7 +386,7 @@ where
             // - reconstruct the value from early children
             // - visit the value
             // - insert late children and process for Leave
-            Step::EarlyVisit(mut val) => {
+            Step::EarlyVisit(mut val, top_level) => {
                 val.for_each_early_children_mut(&mut |child| {
                     let val = done.pop().unwrap();
                     *child = val;
@@ -373,20 +423,21 @@ where
 
                 if visit_modified {
                     // When the early visitor has changed the value, we need to enter it again
-                    work_queue_stack.push(Step::Enter(val));
+                    work_queue_stack.push(Step::Enter(val, top_level));
                 } else {
                     // Otherwise we can just process the late children
                     let i = work_queue_stack.len();
                     work_queue_stack.push(Step::TemporarySlot);
+                    let child_top_level = top_level && matches!(val, JsValue::Alternatives { .. });
                     val.for_each_late_children_mut(&mut |child| {
-                        work_queue_stack.push(Step::Enter(take(child)));
+                        work_queue_stack.push(Step::Enter(take(child), child_top_level));
                         false
                     });
-                    work_queue_stack[i] = Step::LeaveLate(val);
+                    work_queue_stack[i] = Step::LeaveLate(val, top_level);
                 }
             }
             // Leave a value
-            Step::Leave(mut val) => {
+            Step::Leave(mut val, top_level) => {
                 val.for_each_children_mut(&mut |child| {
                     let val = done.pop().unwrap();
                     *child = val;
@@ -406,10 +457,10 @@ where
                 val.debug_assert_total_nodes_up_to_date();
 
                 total_nodes += val.total_nodes();
-                work_queue_stack.push(Step::Visit(val));
+                work_queue_stack.push(Step::Visit(val, top_level));
             }
             // Leave a value from EarlyVisit
-            Step::LeaveLate(mut val) => {
+            Step::LeaveLate(mut val, top_level) => {
                 val.for_each_late_children_mut(&mut |child| {
                     let val = done.pop().unwrap();
                     *child = val;
@@ -429,17 +480,18 @@ where
                 val.debug_assert_total_nodes_up_to_date();
 
                 total_nodes += val.total_nodes();
-                work_queue_stack.push(Step::Visit(val));
+                work_queue_stack.push(Step::Visit(val, top_level));
             }
             // Visit a value with the visitor
             // - visited value is put into done
-            Step::Visit(val) => {
+            Step::Visit(val, top_level) => {
                 visit(
                     &mut total_nodes,
                     &mut done,
                     &mut work_queue_stack,
                     visitor,
                     val,
+                    top_level,
                 )
                 .await?;
             }
@@ -488,6 +540,7 @@ async fn visit<'a, F, RF>(
     work_queue_stack: &mut Vec<Step>,
     visitor: &'a F,
     val: JsValue,
+    top_level: bool,
 ) -> Result<()>
 where
     RF: 'a + Future<Output = Result<(JsValue, bool)>> + Send,
@@ -520,7 +573,7 @@ where
     }
     *total_nodes += count;
     if visit_modified {
-        work_queue_stack.push(Step::Enter(val));
+        work_queue_stack.push(Step::Enter(val, top_level));
     } else {
         done.push(val);
     }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -4199,6 +4199,7 @@ mod tests {
             link(
                 var_graph,
                 val,
+                &|v| v,
                 &super::test_utils::early_visitor,
                 &(|val| {
                     Box::pin(super::test_utils::visitor(

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
@@ -12,6 +12,55 @@ use super::{
 };
 use crate::analyzer::RequireContextValue;
 
+pub fn is_well_known_function_prop(value: &str) -> bool {
+    // TODO this separate list is very brittle
+    matches!(
+        value,
+        "arch"
+            | "argv"
+            | "assign"
+            | "cache"
+            | "context"
+            | "createReadStream"
+            | "cwd"
+            | "default"
+            | "dirname"
+            | "endianness"
+            | "env"
+            | "execFile"
+            | "execFileSync"
+            | "exists"
+            | "existsSync"
+            | "filter"
+            | "find"
+            | "forEach"
+            | "fork"
+            | "join"
+            | "keys"
+            | "load"
+            | "loadSync"
+            | "map"
+            | "meta"
+            | "open"
+            | "openSync"
+            | "pathToFileURL"
+            | "platform"
+            | "promises"
+            | "readFile"
+            | "readFileSync"
+            | "realpath"
+            | "realpathSync"
+            | "resolve"
+            | "set"
+            | "SetRootDir"
+            | "silent"
+            | "spawn"
+            | "spawnSync"
+            | "stat"
+            | "statSync"
+    )
+}
+
 pub async fn replace_well_known(
     value: JsValue,
     compile_time_info: Vc<CompileTimeInfo>,


### PR DESCRIPTION
If we want to see whether a given value is `WellKnownFunction(WellKnownFunctionKind::Require)`, there is no need to spend a long time do evaluate the whole object if it's not actually a `WellKnownFunction`.