### PR TITLE
feat: implement GoogleAd and GooglePublisherTag components for ad management

### DIFF
--- a/packages/third-parties/src/google/gpt-ad.tsx
+++ b/packages/third-parties/src/google/gpt-ad.tsx
@@ -1,0 +1,63 @@
+"use client";
+import { useEffect } from "react";
+import { pushGPTCommand } from "./gpt";
+
+type Size = readonly [number, number];
+
+interface GoogleAdProps {
+    id: string;
+    adUnit: string;
+    sizes: Size | Size[];
+    sizeMapping?: { viewport: Size; sizes: Size[] }[];
+}
+
+export function GoogleAd({ id, adUnit, sizes, sizeMapping }: GoogleAdProps) {
+    useEffect(() => {
+        let slot: googletag.Slot | null = null;
+
+        pushGPTCommand(() => {
+            const googletag = (window as any).googletag;
+
+            slot = googletag.defineSlot(adUnit, sizes, id);
+
+            if (slot) {
+                if (sizeMapping) {
+                    const mapping = googletag.sizeMapping();
+                    sizeMapping.forEach(({ viewport, sizes }) => {
+                        mapping.addSize(viewport, sizes);
+                    });
+                    slot.defineSizeMapping(mapping.build());
+                }
+
+                slot.addService(googletag.pubads()).setTargeting("pagepos", id);
+            }
+
+            googletag.display(id);
+        });
+
+        return () => {
+            pushGPTCommand(() => {
+                if (slot) {
+                    window.googletag.destroySlots([slot]);
+                }
+            });
+        };
+    }, [id, adUnit, sizes, sizeMapping]);
+
+    const sizeArray = Array.isArray(sizes[0])
+        ? (sizes as [number, number][])
+        : [sizes as [number, number]];
+
+    return (
+        <div
+            id={id}
+            style={{
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                width: "100%",
+                height: "100%",
+            }}
+        />
+    );
+}

--- a/packages/third-parties/src/google/gpt.tsx
+++ b/packages/third-parties/src/google/gpt.tsx
@@ -1,0 +1,56 @@
+"use client";
+import Script from "next/script";
+import { useEffect } from "react";
+
+interface GPTParams {
+    gptScriptUrl?: string;
+    /**
+     * Number used once (nonce) for Content Security Policy (CSP)
+     */
+    nonce?: string;
+}
+
+export function GooglePublisherTag({
+    gptScriptUrl = "https://securepubads.g.doubleclick.net/tag/js/gpt.js",
+    nonce,
+}: GPTParams) {
+    useEffect(() => {
+        initGPT();
+        performance.mark("mark_feature_usage", {
+            detail: {
+                feature: "next-third-parties-gpt",
+            },
+        });
+    }, []);
+
+    return (
+        <Script
+            id="_next-gpt"
+            src={gptScriptUrl}
+            async
+            nonce={nonce}
+            strategy="afterInteractive"
+            type="text/javascript"
+        />
+    );
+}
+
+// Helper to safely push commands to googletag.cmd
+export const pushGPTCommand = (cmd: () => void) => {
+    if (typeof window !== "undefined") {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        window.googletag = window.googletag ?? ({ cmd: [] } as any);
+        window.googletag?.cmd.push(cmd);
+    }
+};
+
+export const initGPT = () => {
+    if (typeof window !== "undefined" && !window.gptInitialized) {
+        window.googletag = window.googletag || { cmd: [] };
+        window.googletag.cmd.push(() => {
+            window.googletag.pubads().enableSingleRequest();
+            window.googletag.enableServices();
+        });
+        window.gptInitialized = true;
+    }
+};


### PR DESCRIPTION
I'm not a good documentator, but I thought it's worthy to have this PR open as a reference on how to fix most of the issues with GPT ad.

## Usage
### Layout

```tsx
export default function RootLayout({
  children,
}: Readonly<{
  children: React.ReactNode;
}>) {
  return (
    <html lang="en">
      <head>
        <GooglePublisherTag /> {/* Add this */}
      </head>
      <body
        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
      >
        {children}
      </body>
    </html>
  );
}
```

### Pages
```tsx
import { GoogleAd } from "@/components/GoogleAd";
import Link from "next/link";

export default function HomePage() {
  return (
    <>
      <h1>HOME PAGE</h1>

      <Link href="/ns/events/upcoming">events page</Link>
      <h4>AD</h4>
      <GoogleAd // use as you want the ad
        adUnit="/6355419/Travel/America/Brazil/Recife"
        sizes={[300, 250]}
        id="banner-ad"
      />
    </>
  );
}

```