### PR TITLE
Build: Add .next/trace-build with high level trace

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4098,14 +4098,18 @@ export default async function build(
       }
 
       if (config.output === 'export') {
-        await writeFullyStaticExport(
-          config,
-          dir,
-          enabledDirectories,
-          configOutDir,
-          nextBuildSpan,
-          appDirOnly
-        )
+        await nextBuildSpan
+          .traceChild('output-export-full-static-export')
+          .traceAsyncFn(async () => {
+            await writeFullyStaticExport(
+              config,
+              dir,
+              enabledDirectories,
+              configOutDir,
+              nextBuildSpan,
+              appDirOnly
+            )
+          })
       }
 
       if (config.experimental.adapterPath) {

--- a/packages/next/src/build/turbopack-build/index.ts
+++ b/packages/next/src/build/turbopack-build/index.ts
@@ -52,15 +52,13 @@ export function turbopackBuild(
   withWorker: boolean
 ): ReturnType<typeof import('./impl').turbopackBuild> {
   const nextBuildSpan = NextBuildContext.nextBuildSpan!
-  return nextBuildSpan
-    .traceChild('run-turbopack-compiler')
-    .traceAsyncFn(async () => {
-      if (withWorker) {
-        return await turbopackBuildWithWorker()
-      } else {
-        const build = (require('./impl') as typeof import('./impl'))
-          .turbopackBuild
-        return await build()
-      }
-    })
+  return nextBuildSpan.traceChild('run-turbopack').traceAsyncFn(async () => {
+    if (withWorker) {
+      return await turbopackBuildWithWorker()
+    } else {
+      const build = (require('./impl') as typeof import('./impl'))
+        .turbopackBuild
+      return await build()
+    }
+  })
 }

--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -128,7 +128,7 @@ export async function startTypeChecking({
 
   try {
     const [[verifyResult, typeCheckEnd]] = await Promise.all([
-      nextBuildSpan.traceChild('verify-typescript-setup').traceAsyncFn(() =>
+      nextBuildSpan.traceChild('run-typescript').traceAsyncFn(() =>
         verifyTypeScriptSetup(
           dir,
           config.distDir,
@@ -146,7 +146,7 @@ export async function startTypeChecking({
         })
       ),
       shouldLint &&
-        nextBuildSpan.traceChild('verify-and-lint').traceAsyncFn(async () => {
+        nextBuildSpan.traceChild('run-eslint').traceAsyncFn(async () => {
           await verifyAndLint(
             dir,
             eslintCacheDir,

--- a/packages/next/src/trace/report/index.ts
+++ b/packages/next/src/trace/report/index.ts
@@ -1,6 +1,7 @@
 import type { TraceEvent } from '../types'
 import reportToTelemetry from './to-telemetry'
 import reportToJson from './to-json'
+import reportToJsonBuild from './to-json-build'
 import type { Reporter } from './types'
 
 class MultiReporter implements Reporter {
@@ -20,4 +21,8 @@ class MultiReporter implements Reporter {
 }
 
 // JSON is always reported to allow for diagnostics
-export const reporter = new MultiReporter([reportToJson, reportToTelemetry])
+export const reporter = new MultiReporter([
+  reportToJson,
+  reportToJsonBuild,
+  reportToTelemetry,
+])

--- a/packages/next/src/trace/trace-uploader.ts
+++ b/packages/next/src/trace/trace-uploader.ts
@@ -28,7 +28,7 @@ const DEV_ALLOWED_EVENTS = new Set([
 const BUILD_ALLOWED_EVENTS = new Set([
   ...COMMON_ALLOWED_EVENTS,
   'next-build',
-  'run-turbopack-compiler',
+  'run-turbopack',
   'webpack-compilation',
   'run-webpack-compiler',
   'create-entrypoints',
@@ -50,14 +50,14 @@ const BUILD_ALLOWED_EVENTS = new Set([
   'node-file-trace-build',
   'static-generation',
   'next-export',
-  'verify-typescript-setup',
-  'verify-and-lint',
+  'run-typescript',
+  'run-eslint',
 ])
 
 const {
   NEXT_TRACE_UPLOAD_DEBUG,
   // An external env to allow to upload full trace without picking up the relavant spans.
-  // This is mainly for the debugging purpose, to allwo manual audit for full trace for the given build.
+  // This is mainly for the debugging purpose, to allow manual audit for full trace for the given build.
   // [NOTE] This may fail if build is large and generated trace is excessively large.
   NEXT_TRACE_UPLOAD_FULL,
 } = process.env

--- a/test/e2e/app-dir/trace-build-file/app/layout.tsx
+++ b/test/e2e/app-dir/trace-build-file/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/trace-build-file/app/page.tsx
+++ b/test/e2e/app-dir/trace-build-file/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/trace-build-file/next.config.js
+++ b/test/e2e/app-dir/trace-build-file/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
+++ b/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
@@ -1,0 +1,221 @@
+import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
+import { join } from 'path'
+import { existsSync, readFileSync } from 'fs'
+
+type SpanId = number
+
+type TraceEvent = {
+  traceId?: string
+  parentId?: SpanId
+  name: string
+  id: SpanId
+  timestamp: number
+  duration: number
+  tags?: Object
+  startTime?: number
+}
+
+interface TraceStructure {
+  events: TraceEvent[]
+  eventsByName: Map<string, TraceEvent[]>
+  eventsById: Map<string, TraceEvent>
+  rootEvents: TraceEvent[]
+  orphanedEvents: TraceEvent[]
+}
+
+function parseTraceFile(traceBuildPath: string): TraceStructure {
+  const traceContent = readFileSync(traceBuildPath, 'utf8')
+  const traceLines = traceContent
+    .trim()
+    .split('\n')
+    .filter((line) => line.trim())
+
+  const allEvents: TraceEvent[] = []
+
+  for (const line of traceLines) {
+    const events = JSON.parse(line) as TraceEvent[]
+    allEvents.push(...events)
+  }
+
+  const eventsByName = new Map<string, TraceEvent[]>()
+  const eventsById = new Map<string, TraceEvent>()
+  const rootEvents: TraceEvent[] = []
+  const orphanedEvents: TraceEvent[] = []
+
+  // Index all events
+  for (const event of allEvents) {
+    if (!eventsByName.has(event.name)) {
+      eventsByName.set(event.name, [])
+    }
+    eventsByName.get(event.name).push(event)
+    eventsById.set(event.id.toString(), event)
+  }
+
+  // Categorize events as root or orphaned
+  for (const event of allEvents) {
+    if (!event.parentId) {
+      rootEvents.push(event)
+    } else if (!eventsById.has(event.parentId.toString())) {
+      orphanedEvents.push(event)
+    }
+  }
+
+  return {
+    events: allEvents,
+    eventsByName,
+    eventsById,
+    rootEvents,
+    orphanedEvents,
+  }
+}
+
+describe('trace-build-file', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: !isNextDev,
+    skipDeployment: true,
+  })
+
+  if (isNextStart) {
+    it('should create .next/trace-build file during production build', async () => {
+      // Build the app to trigger trace generation
+      await next.build()
+
+      // Check that trace-build file exists
+      const traceBuildPath = join(next.testDir, '.next/trace-build')
+      expect(existsSync(traceBuildPath)).toBe(true)
+    })
+
+    it('should contain high-level build trace events', async () => {
+      // Ensure we have a fresh build
+      await next.build()
+
+      const traceBuildPath = join(next.testDir, '.next/trace-build')
+      expect(existsSync(traceBuildPath)).toBe(true)
+
+      const traceStructure = parseTraceFile(traceBuildPath)
+
+      // Should have events
+      expect(traceStructure.events.length).toBeGreaterThan(0)
+
+      // Should contain the main next-build event
+      const nextBuildEvents = traceStructure.eventsByName.get('next-build')
+      expect(nextBuildEvents).toBeDefined()
+      expect(nextBuildEvents.length).toBe(1)
+
+      const nextBuildEvent = nextBuildEvents[0]
+      expect(nextBuildEvent).toHaveProperty('name', 'next-build')
+      expect(nextBuildEvent).toHaveProperty('traceId')
+      expect(nextBuildEvent).toHaveProperty('id')
+      expect(nextBuildEvent).toHaveProperty('duration')
+      expect(typeof nextBuildEvent.duration).toBe('number')
+      expect(typeof nextBuildEvent.traceId).toBe('string')
+      expect(typeof nextBuildEvent.id).toBe('number')
+    })
+
+    it('should only contain allowlisted events', async () => {
+      await next.build()
+
+      const traceBuildPath = join(next.testDir, '.next/trace-build')
+      const traceStructure = parseTraceFile(traceBuildPath)
+
+      const allowlistedEvents = new Set([
+        'next-build',
+        'run-turbopack',
+        'run-webpack',
+        'run-typescript',
+        'run-eslint',
+        'static-check',
+        'static-generation',
+        'output-export-full-static-export',
+      ])
+
+      for (const event of traceStructure.events) {
+        expect(allowlistedEvents.has(event.name)).toBe(true)
+      }
+    })
+
+    it('should have next-build as root span with proper hierarchy', async () => {
+      await next.build()
+
+      const traceBuildPath = join(next.testDir, '.next/trace-build')
+      const traceStructure = parseTraceFile(traceBuildPath)
+
+      // Should have no orphaned events (all events should have valid parent references)
+      expect(traceStructure.orphanedEvents).toHaveLength(0)
+
+      // Should have at one root event
+      expect(traceStructure.rootEvents.length).toBe(1)
+
+      // next-build should be the main root event
+      const nextBuildEvents = traceStructure.eventsByName.get('next-build')
+      expect(nextBuildEvents).toBeDefined()
+      expect(nextBuildEvents.length).toBe(1)
+
+      const nextBuildEvent = nextBuildEvents[0]
+      expect(nextBuildEvent.parentId).toBeUndefined() // Should be root
+      expect(traceStructure.rootEvents).toContain(nextBuildEvent)
+
+      // Other build events should be children of next-build or have valid parent references
+      const buildEvents = ['run-webpack', 'run-typescript', 'run-eslint']
+      for (const eventName of buildEvents) {
+        const events = traceStructure.eventsByName.get(eventName)
+        if (events && events.length > 0) {
+          for (const event of events) {
+            if (event.parentId) {
+              // Should have a valid parent
+              expect(
+                traceStructure.eventsById.has(event.parentId.toString())
+              ).toBe(true)
+              const parent = traceStructure.eventsById.get(
+                event.parentId.toString()
+              )
+
+              // Parent should either be next-build or another valid event
+              expect(parent).toBeDefined()
+              expect(parent.traceId).toBe(event.traceId) // Same trace
+            }
+          }
+        }
+      }
+    })
+
+    it('should have consistent traceId across all events', async () => {
+      await next.build()
+
+      const traceBuildPath = join(next.testDir, '.next/trace-build')
+      const traceStructure = parseTraceFile(traceBuildPath)
+
+      expect(traceStructure.events.length).toBeGreaterThan(0)
+
+      const firstEvent = traceStructure.events[0]
+      expect(firstEvent.traceId).toBeDefined()
+      expect(typeof firstEvent.traceId).toBe('string')
+      expect(firstEvent.traceId.length).toBeGreaterThan(0)
+
+      // All events should have the same traceId
+      for (const event of traceStructure.events) {
+        expect(event.traceId).toBe(firstEvent.traceId)
+      }
+    })
+  }
+
+  if (isNextDev) {
+    it('should not create trace-build file in development mode', async () => {
+      // Make a request to trigger some activity
+      await next.render('/')
+
+      // Check that trace-build file does not exist
+      const traceBuildPath = join(next.testDir, '.next/trace-build')
+      expect(existsSync(traceBuildPath)).toBe(false)
+    })
+  }
+
+  it('should work with basic page rendering', async () => {
+    if (isNextStart) {
+      await next.start()
+    }
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
+})


### PR DESCRIPTION
## What?

- Adds a new file `.next/trace-build` with a high level overview of the build process. This is an extra file next to `.next/trace`. `.next/trace` includes a lower level trace when using webpack. `.next/trace-build` is the same between webpack/Turbopack in terms of spans emitted (though `run-turbopack` vs `run-webpack` span).

Included trace spans are:

```
  'next-build',
  'run-turbopack',
  'run-webpack',
  'run-typescript',
  'run-eslint',
  'static-check',
  'static-generation',
  'output-export-full-static-export',
```

`run-turbopack` is only included when Turbopack is used. `run-webpack` when webpack is used.

`run-typescript` and `run-eslint` are concurrent.

`output-export-full-static-export` is only included when using `output: 'export'`.

Closes PACK-5493