### PR TITLE
Only send notification if canary fails on required jobs

### DIFF
--- a/.github/workflows/retry_test.yml
+++ b/.github/workflows/retry_test.yml
@@ -93,7 +93,51 @@ jobs:
       }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check conclusion of required job
+        id: required_job_conclusion
+        uses: actions/github-script@v7
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            // See build-and-test.yml and build-and-deploy.yml for the required job names
+            const requiredJobName = {
+              'build-and-test': 'thank you, next',
+              'build-and-deploy': 'thank you, build',
+            }[context.workflow]
+
+            async function rerunIfRequiredNotSuccessful() {
+              const result = await github.paginate.iterator(
+                'GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs',
+                {
+                  attempt_number: context.payload.workflow_run.run_attempt,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: context.payload.workflow_run.id,
+                }
+              )
+
+              for await (const { data: jobs } of result) {
+                for (const job of jobs) {
+                  if (job.name === requiredJobName) {
+                    console.log(
+                      "Using conclusion '%s' from %s",
+                      job.conclusion,
+                      job.html_url
+                    )
+                    return job.conclusion
+                  }
+                }
+              }
+
+              console.log("Couldn't find job with name '%s'", requiredJobName)
+              return null
+            }
+
+            return await rerunIfRequiredNotSuccessful()
       - name: send webhook
+        if: ${{ steps.required_job_conclusion.outputs.result != 'success' }}
         uses: slackapi/slack-github-action@v1.25.0
         with:
           # These urls are intentionally missing the protocol,

--- a/.github/workflows/retry_test.yml
+++ b/.github/workflows/retry_test.yml
@@ -39,7 +39,7 @@ jobs:
             const requiredJobName = {
               'build-and-test': 'thank you, next',
               'build-and-deploy': 'thank you, build',
-            }[context.workflow]
+            }[github.event.workflow_run.name]
 
             async function rerunIfRequiredNotSuccessful() {
               const result = await github.paginate.iterator(
@@ -105,7 +105,7 @@ jobs:
             const requiredJobName = {
               'build-and-test': 'thank you, next',
               'build-and-deploy': 'thank you, build',
-            }[context.workflow]
+            }[github.event.workflow_run.name]
 
             async function rerunIfRequiredNotSuccessful() {
               const result = await github.paginate.iterator(


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/83851/

The 2nd attempt can fail with required jobs and then the final attempt only fails on optional. So we need to duplicate the logic for retry and notification job.