### PR TITLE
Turbopack: allow to read State from turbo_tasks::run

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/tests/read_ref_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/read_ref_cell.rs
@@ -73,7 +73,7 @@ impl Counter {
     #[turbo_tasks::function]
     fn get_value(&self) -> Result<Vc<CounterValue>> {
         let mut lock = self.value.lock().unwrap();
-        lock.1.insert(get_invalidator());
+        lock.1.insert(get_invalidator().unwrap());
         Ok(Vc::cell(lock.0))
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell.rs
@@ -90,7 +90,7 @@ impl CounterTrait for Counter {
     #[turbo_tasks::function]
     fn get_value(&self) -> Result<Vc<CounterValue>> {
         let mut lock = self.value.lock().unwrap();
-        lock.1.insert(get_invalidator());
+        lock.1.insert(get_invalidator().unwrap());
         Ok(Vc::cell(lock.0))
     }
 

--- a/turbopack/crates/turbo-tasks/src/state.rs
+++ b/turbopack/crates/turbo-tasks/src/state.rs
@@ -170,7 +170,9 @@ impl<T> State<T> {
     pub fn get(&self) -> StateRef<'_, T> {
         let invalidator = get_invalidator();
         let mut inner = self.inner.lock();
-        inner.add_invalidator(invalidator);
+        if let Some(invalidator) = invalidator {
+            inner.add_invalidator(invalidator);
+        }
         StateRef {
             serialization_invalidator: Some(&self.serialization_invalidator),
             inner,
@@ -295,7 +297,9 @@ impl<T> TransientState<T> {
         mark_session_dependent();
         let invalidator = get_invalidator();
         let mut inner = self.inner.lock();
-        inner.add_invalidator(invalidator);
+        if let Some(invalidator) = invalidator {
+            inner.add_invalidator(invalidator);
+        }
         StateRef {
             serialization_invalidator: None,
             inner,


### PR DESCRIPTION
### What?

Automatically switch reading from state to untracked mode when in `turbo_tasks::run` (similar to reading from cells).

Closes PACK-5492