### PR TITLE
Fix conclusion check for retry_test workflow

### DIFF
--- a/.github/workflows/retry_test.yml
+++ b/.github/workflows/retry_test.yml
@@ -39,7 +39,7 @@ jobs:
             const requiredJobName = {
               'build-and-test': 'thank you, next',
               'build-and-deploy': 'thank you, build',
-            }[github.event.workflow_run.name]
+            }[context.payload.workflow_run.name]
 
             async function rerunIfRequiredNotSuccessful() {
               const result = await github.paginate.iterator(
@@ -105,7 +105,7 @@ jobs:
             const requiredJobName = {
               'build-and-test': 'thank you, next',
               'build-and-deploy': 'thank you, build',
-            }[github.event.workflow_run.name]
+            }[context.payload.workflow_run.name]
 
             async function rerunIfRequiredNotSuccessful() {
               const result = await github.paginate.iterator(


### PR DESCRIPTION
Vade lied to me. Fixes
```
Error: Unhandled error: TypeError: Cannot read properties of undefined (reading 'workflow_run')
```
-- https://github.com/vercel/next.js/actions/runs/17835748140/job/50712367293#step:2:51