### PR TITLE
feat: Isolate dev build from prod

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1123,7 +1123,7 @@ export default async function build(
       }
 
       if (config.cleanDistDir && !isGenerateMode) {
-        await recursiveDelete(distDir, /^cache/)
+        await recursiveDelete(distDir, /^(cache|dev)/)
       }
 
       if (appDir && 'exportPathMap' in config) {

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -414,6 +414,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         prerenderEarlyExit: z.boolean().optional(),
         proxyTimeout: z.number().gte(0).optional(),
         rootParams: z.boolean().optional(),
+        isolatedDevBuild: z.boolean().optional(),
         routerBFCache: z.boolean().optional(),
         removeUncaughtErrorAndRejectionListeners: z.boolean().optional(),
         validateRSCRequestHeaders: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -804,6 +804,13 @@ export interface ExperimentalConfig {
    * Enable accessing root params via the `next/root-params` module.
    */
   rootParams?: boolean
+
+  /**
+   * Use an isolated directory for development builds to prevent conflicts
+   * with production builds. Development builds will use `{distDir}/dev`
+   * instead of `{distDir}`.
+   */
+  isolatedDevBuild?: boolean
 }
 
 export type ExportPathMap = {
@@ -1496,6 +1503,7 @@ export const defaultConfig = Object.freeze({
     globalNotFound: false,
     browserDebugInfoInTerminal: false,
     optimizeRouterScrolling: false,
+    isolatedDevBuild: false,
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -215,7 +215,8 @@ function assignDefaultsAndValidate(
   dir: string,
   userConfig: NextConfig & { configFileName: string },
   silent: boolean,
-  configuredExperimentalFeatures: ConfiguredExperimentalFeature[]
+  configuredExperimentalFeatures: ConfiguredExperimentalFeature[],
+  phase: PHASE_TYPE
 ): NextConfigComplete {
   const configFileName = userConfig.configFileName
   if (typeof userConfig.exportTrailingSlash !== 'undefined') {
@@ -1198,6 +1199,13 @@ function assignDefaultsAndValidate(
     )
   }
 
+  if (
+    phase === PHASE_DEVELOPMENT_SERVER &&
+    result.experimental?.isolatedDevBuild
+  ) {
+    result.distDir = join(result.distDir, 'dev')
+  }
+
   return result as NextConfigComplete
 }
 
@@ -1362,7 +1370,8 @@ export default async function loadConfig(
           ...customConfig,
         },
         silent,
-        configuredExperimentalFeatures
+        configuredExperimentalFeatures,
+        phase
       ) as NextConfigComplete,
       phase,
       silent
@@ -1569,7 +1578,8 @@ export default async function loadConfig(
         ...userConfig,
       },
       silent,
-      configuredExperimentalFeatures
+      configuredExperimentalFeatures,
+      phase
     ) as NextConfigComplete
 
     const finalConfig = await applyModifyConfig(completeConfig, phase, silent)
@@ -1624,7 +1634,8 @@ export default async function loadConfig(
     dir,
     { ...clonedDefaultConfig, configFileName },
     silent,
-    configuredExperimentalFeatures
+    configuredExperimentalFeatures,
+    phase
   ) as NextConfigComplete
 
   setHttpClientAndAgentOptions(completeConfig)

--- a/test/development/app-dir/isolated-dev-build/app/layout.tsx
+++ b/test/development/app-dir/isolated-dev-build/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/isolated-dev-build/app/page.tsx
+++ b/test/development/app-dir/isolated-dev-build/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/isolated-dev-build/isolated-dev-build.test.ts
+++ b/test/development/app-dir/isolated-dev-build/isolated-dev-build.test.ts
@@ -1,0 +1,26 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('isolated-dev-build', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should create dev artifacts in .next/dev/ directory', async () => {
+    expect(await next.hasFile('.next/dev')).toBe(true)
+    expect(await next.hasFile('.next/server')).toBe(false)
+  })
+
+  it('should work with HMR', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+
+    await next.patchFile('app/page.tsx', (content) => {
+      return content.replace('hello world', 'hello updated world')
+    })
+
+    await retry(async () => {
+      expect(await browser.elementByCss('p').text()).toBe('hello updated world')
+    })
+  })
+})

--- a/test/development/app-dir/isolated-dev-build/next.config.js
+++ b/test/development/app-dir/isolated-dev-build/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    isolatedDevBuild: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
Enable it by `experimental.isolatedDevBuild` on next config.

### Why?

When running a dev server, it currently gets interrupted when running `next build`.
This is very common when using AI for app development,  where it runs `next build` for whatever reason while the user is working on a dev server.

### How?

This PR creates an isolated `dev/` directory inside the `distDir` to be isolated from the build, and will not be cleared out during the `next build` like the `cache/` directory. Since the cache between the dev and prod isn't shared at the moment, it makes sense to let them have separate `cache/` directories.

https://github.com/user-attachments/assets/2005ba70-861c-4763-b47f-cf17c62c0571