### PR TITLE
Remove force writing **/*.mts to tsconfig

### DIFF
--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.test.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.test.ts
@@ -176,7 +176,7 @@ describe('writeConfigurationDefaults()', () => {
       })
 
       it('should replace includes when base is missing appTypes', async () => {
-        const include = ['**/*.ts', '**/*.tsx']
+        const include = ['**/*.ts', '**/*.tsx', '**/*.mts']
         const content = { extends: './tsconfig.base.json' }
         const baseContent = { include }
 

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -228,9 +228,6 @@ export async function writeConfigurationDefaults(
     if (!rawConfig.include.includes(nextAppTypes)) {
       missingFromResolved.push(nextAppTypes)
     }
-    if (!rawConfig.include.includes('**/*.mts')) {
-      missingFromResolved.push('**/*.mts')
-    }
 
     if (missingFromResolved.length > 0) {
       if (!Array.isArray(userTsConfig.include)) {


### PR DESCRIPTION
It was added at https://github.com/vercel/next.js/pull/83556. We don't force writing `**/*.tsx` or `**/*.ts` to tsconfig, but forcing `**/*.mts` is too harsh, when its intention was to support `next.config.mts`. Just for the empty tsconfig or empty include was enough.