### PR TITLE
Turbopack: "connect" tasks in turbo_tasks::run too

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -3044,10 +3044,10 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
     fn connect_task(
         &self,
         task: TaskId,
-        parent_task: TaskId,
+        parent_task: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) {
-        self.0.connect_task(task, Some(parent_task), turbo_tasks);
+        self.0.connect_task(task, parent_task, turbo_tasks);
     }
 
     fn create_transient_task(

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -652,7 +652,7 @@ pub trait Backend: Sync + Send {
     fn connect_task(
         &self,
         task: TaskId,
-        parent_task: TaskId,
+        parent_task: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     );
 

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1345,9 +1345,8 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
     }
 
     fn connect_task(&self, task: TaskId) {
-        if let Some(current_task) = current_task_if_available("connecting task") {
-            self.backend.connect_task(task, current_task, self);
-        }
+        self.backend
+            .connect_task(task, current_task_if_available("connecting task"), self);
     }
 
     fn mark_own_task_as_finished(&self, task: TaskId) {


### PR DESCRIPTION
### What?

Calling turbo tasks functions in `turbo_tasks::run` leads to a minimal connect, which schedules the task when it has not yet been computed.

Connecting OperationVc should lead to the same behavior. 

Closes PACK-5508