### PR TITLE
Turbopack: Make transient tasks root tasks too when called in turbo_tasks::run

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -53,7 +53,7 @@ impl ConnectChildOperation {
         let mut queue = AggregationUpdateQueue::new();
 
         // Handle the transient to persistent boundary by making the persistent task a root task
-        if parent_task_id.is_none_or(|id| id.is_transient()) && !child_task_id.is_transient() {
+        if parent_task_id.is_none_or(|id| id.is_transient() && !child_task_id.is_transient()) {
             queue.push(AggregationUpdateJob::UpdateAggregationNumber {
                 task_id: child_task_id,
                 base_aggregation_number: u32::MAX,
@@ -61,7 +61,6 @@ impl ConnectChildOperation {
             });
         }
 
-        // Immutable tasks cannot be invalidated, meaning that we never reschedule them.
         if ctx.should_track_activeness() && parent_task_id.is_some() {
             queue.push(AggregationUpdateJob::IncreaseActiveCount {
                 task: child_task_id,


### PR DESCRIPTION
### What?

When calling a turbo tasks function from a turbo_tasks::run it should been made a root aggregating tasks for better efficiency.

Closes PACK-5510