### PR TITLE
Turbopack: fix test case and update project_update to turbo_tasks::run too

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -455,13 +455,13 @@ pub fn project_new(
 
         let options: ProjectOptions = options.into();
         let container = turbo_tasks
-            .run_once(async move {
+            .run(async move {
                 let project = ProjectContainer::new(rcstr!("next.js"), options.dev);
                 let project = project.to_resolved().await?;
                 project.initialize(options).await?;
                 Ok(project)
             })
-            .or_else(|e| turbopack_ctx.throw_turbopack_internal_result(&e))
+            .or_else(|e| turbopack_ctx.throw_turbopack_internal_result(&e.into()))
             .await?;
 
         turbo_tasks.start_once_process({
@@ -580,11 +580,11 @@ pub async fn project_update(
     let options = options.into();
     let container = project.container;
     ctx.turbo_tasks()
-        .run_once(async move {
+        .run(async move {
             container.update(options).await?;
             Ok(())
         })
-        .or_else(|e| ctx.throw_turbopack_internal_result(&e))
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
         .await
 }
 

--- a/test/development/app-hmr/hmr-env.test.ts
+++ b/test/development/app-hmr/hmr-env.test.ts
@@ -17,32 +17,9 @@ describe(`app-dir hmr-env`, () => {
       expect(await browser.elementByCss('p').text()).toBe('mac')
 
       await next.patchFile(envFile, 'MY_DEVICE="ipad"', async () => {
-        let logs
-
-        await retry(async () => {
-          logs = await browser.log()
-          expect(logs).toEqual(
-            expect.arrayContaining([
-              expect.objectContaining({
-                message: expect.stringContaining('[Fast Refresh] done'),
-                source: 'log',
-              }),
-            ])
-          )
-        })
-
         await retry(async () => {
           expect(await browser.elementByCss('p').text()).toBe('ipad')
         })
-
-        expect(logs).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              message: expect.stringContaining('[Fast Refresh] done in'),
-              source: 'log',
-            }),
-          ])
-        )
       })
 
       // ensure it's restored back to "mac" before the next test

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -76,26 +76,8 @@ describe(`app-dir-hmr`, () => {
           expect(await browser.elementByCss('p').text()).toBe('ipad')
         }, 5000 /* ms */)
 
-        expect(
-          await browser.eval('window.__TEST_NO_RELOAD === undefined')
-        ).toBe(false)
-
-        const logs = await browser.log()
-        const fastRefreshLogs = logs.filter((log) => {
-          return log.message.startsWith('[Fast Refresh]')
-        })
-
-        // The exact ordering and number of these messages is implementation
-        // dependent and subject to race conditions, just check that we have at
-        // least one "rebuilding" and "done in" message in the logs, the exact
-        // details are unimportant.
-        expect(fastRefreshLogs).toEqual(
-          expect.arrayContaining([
-            {
-              source: 'log',
-              message: expect.stringContaining('[Fast Refresh] done in '),
-            },
-          ])
+        expect(await browser.eval('window.__TEST_NO_RELOAD === true')).toBe(
+          true
         )
       })
 


### PR DESCRIPTION
### What?

Changing an env var that is used in an RSC doesn't lead to HMR updates. It only refetches the RSC stream and no compilation happens at all since the env var is consumed only at runtime.

This test did pass before as the `run_once` created a task for the `project_update` and we counted that as computation. Changing this to `turbo_tasks::run` removes the once task and no computation happens at all.

Closes PACK-5519