### PR TITLE
Use serialized next config for prod server

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -956,6 +956,7 @@ jobs:
       afterBuild: |
         export __NEXT_EXPERIMENTAL_PPR=true # for compatibility with the existing tests
         export __NEXT_EXPERIMENTAL_CACHE_COMPONENTS=true
+        export __NEXT_EXPERIMENTAL_SERIALIZE_NEXT_CONFIG_FOR_PRODUCTION=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/experimental-tests-manifest.json"
 
         node run-tests.js \
@@ -978,6 +979,7 @@ jobs:
       afterBuild: |
         export __NEXT_EXPERIMENTAL_PPR=true # for compatibility with the existing tests
         export __NEXT_EXPERIMENTAL_CACHE_COMPONENTS=true
+        export __NEXT_EXPERIMENTAL_SERIALIZE_NEXT_CONFIG_FOR_PRODUCTION=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/experimental-tests-manifest.json"
         export NEXT_TEST_MODE=dev
 
@@ -1002,6 +1004,7 @@ jobs:
       afterBuild: |
         export __NEXT_EXPERIMENTAL_PPR=true # for compatibility with the existing tests
         export __NEXT_EXPERIMENTAL_CACHE_COMPONENTS=true
+        export __NEXT_EXPERIMENTAL_SERIALIZE_NEXT_CONFIG_FOR_PRODUCTION=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/experimental-tests-manifest.json"
         export NEXT_TEST_MODE=start
 

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -809,5 +809,5 @@
   "808": "Invalid binary HMR message: insufficient data (expected %s bytes, got %s)",
   "809": "Invalid binary HMR message of type %s",
   "810": "React debug channel stream error",
-  "811": "Failed to load the serialized config file \"%s\" in \"%s\"."
+  "811": "Failed to load serialized config \"%s\"."
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -808,5 +808,6 @@
   "807": "Expected a %s response header.",
   "808": "Invalid binary HMR message: insufficient data (expected %s bytes, got %s)",
   "809": "Invalid binary HMR message of type %s",
-  "810": "React debug channel stream error"
+  "810": "React debug channel stream error",
+  "811": "Failed to load the serialized config file \"%s\" in \"%s\"."
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -61,6 +61,7 @@ import {
   PRERENDER_MANIFEST,
   REACT_LOADABLE_MANIFEST,
   ROUTES_MANIFEST,
+  SERIALIZED_CONFIG_FILE,
   SERVER_DIRECTORY,
   SERVER_FILES_MANIFEST,
   STATIC_STATUS_PAGES,
@@ -2722,6 +2723,19 @@ export default async function build(
         distDir,
         requiredServerFilesManifest
       )
+
+      // Write serialized config to project root for normal production mode with custom distDir
+      if (config.output !== 'standalone' && config.distDir !== '.next') {
+        const serializedConfigPath = path.join(
+          // Write to the same directory as the config file
+          config.configFile ? path.dirname(config.configFile) : dir,
+          SERIALIZED_CONFIG_FILE
+        )
+        await fs.writeFile(
+          serializedConfigPath,
+          JSON.stringify(requiredServerFilesManifest.config)
+        )
+      }
 
       // we don't need to inline for turbopack build as
       // it will handle it's own caching separate of compile

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2732,7 +2732,11 @@ export default async function build(
       if (
         config.output !== 'standalone' &&
         config.distDir !== '.next' &&
-        config.experimental?.serializeNextConfigForProduction
+        (config.experimental?.serializeNextConfigForProduction ||
+          // This flag is used to be enabled on the tests.
+          process.env
+            .__NEXT_EXPERIMENTAL_SERIALIZE_NEXT_CONFIG_FOR_PRODUCTION ===
+            'true')
       ) {
         const serializedConfigPath = path.join(
           // Write to the same directory as the original config file.

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2729,7 +2729,11 @@ export default async function build(
       // the prod server will not know the distDir until loading the config.
       // Therefore we write the serialized config to the same directory as the
       // original config file.
-      if (config.output !== 'standalone' && config.distDir !== '.next' && config.experimental?.serializeNextConfigForProduction) {
+      if (
+        config.output !== 'standalone' &&
+        config.distDir !== '.next' &&
+        config.experimental?.serializeNextConfigForProduction
+      ) {
         const serializedConfigPath = path.join(
           // Write to the same directory as the original config file.
           config.configFile ? path.dirname(config.configFile) : dir,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2732,7 +2732,8 @@ export default async function build(
       if (
         config.output !== 'standalone' &&
         config.distDir !== '.next' &&
-        (config.experimental?.serializeNextConfigForProduction ||
+        // Use nullish coalescing (??) since we don't want to return when it's false.
+        (config.experimental?.serializeNextConfigForProduction ??
           // This flag is used to be enabled on the tests.
           process.env
             .__NEXT_EXPERIMENTAL_SERIALIZE_NEXT_CONFIG_FOR_PRODUCTION ===

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2729,7 +2729,7 @@ export default async function build(
       // the prod server will not know the distDir until loading the config.
       // Therefore we write the serialized config to the same directory as the
       // original config file.
-      if (config.output !== 'standalone' && config.distDir !== '.next') {
+      if (config.output !== 'standalone' && config.distDir !== '.next' && config.experimental?.serializeNextConfigForProduction) {
         const serializedConfigPath = path.join(
           // Write to the same directory as the original config file.
           config.configFile ? path.dirname(config.configFile) : dir,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2724,16 +2724,24 @@ export default async function build(
         requiredServerFilesManifest
       )
 
-      // Write serialized config to project root for normal production mode with custom distDir
+      // The required-server-files manifest contains serialized config, which can
+      // be loaded by the prod server. However, when a custom distDir is set,
+      // the prod server will not know the distDir until loading the config.
+      // Therefore we write the serialized config to the same directory as the
+      // original config file.
       if (config.output !== 'standalone' && config.distDir !== '.next') {
         const serializedConfigPath = path.join(
-          // Write to the same directory as the config file
+          // Write to the same directory as the original config file.
           config.configFile ? path.dirname(config.configFile) : dir,
           SERIALIZED_CONFIG_FILE
         )
         await fs.writeFile(
           serializedConfigPath,
-          JSON.stringify(requiredServerFilesManifest.config)
+          JSON.stringify({
+            // To match the format of required server files manifest.
+            version: 1,
+            config: requiredServerFilesManifest.config,
+          })
         )
       }
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -526,6 +526,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
           ])
           .optional(),
         optimizeRouterScrolling: z.boolean().optional(),
+        serializeNextConfigForProduction: z.boolean().optional(),
       })
       .optional(),
     exportPathMap: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -823,8 +823,9 @@ export interface ExperimentalConfig {
    * When enabled, the produciton server will use the serialized config file
    * instead of the original config file. This can save the time of loading the
    * config file, especially when you are using `next.config.ts`. When the `distDir`
-   * is set, the serialized config file will be written to the same directory as the
-   * original config file.
+   * is set, the serialized config `next-config-serialized.json` will be written to
+   * the same directory as the original config file. This is because Next.js doesn't
+   * know the `distDir` until loading the config.
    *
    * @default true
    */

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1507,6 +1507,7 @@ export const defaultConfig = Object.freeze({
     browserDebugInfoInTerminal: false,
     optimizeRouterScrolling: false,
     isolatedDevBuild: false,
+    serializeNextConfigForProduction: true,
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -826,8 +826,6 @@ export interface ExperimentalConfig {
    * is set, the serialized config `next-config-serialized.json` will be written to
    * the same directory as the original config file. This is because Next.js doesn't
    * know the `distDir` until loading the config.
-   *
-   * @default true
    */
   serializeNextConfigForProduction?: boolean
 }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -818,6 +818,17 @@ export interface ExperimentalConfig {
    * instead of `{distDir}`.
    */
   isolatedDevBuild?: boolean
+
+  /**
+   * When enabled, the produciton server will use the serialized config file
+   * instead of the original config file. This can save the time of loading the
+   * config file, especially when you are using `next.config.ts`. When the `distDir`
+   * is set, the serialized config file will be written to the same directory as the
+   * original config file.
+   *
+   * @default true
+   */
+  serializeNextConfigForProduction?: boolean
 }
 
 export type ExportPathMap = {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -820,7 +820,7 @@ export interface ExperimentalConfig {
   isolatedDevBuild?: boolean
 
   /**
-   * When enabled, the produciton server will use the serialized config file
+   * When enabled, the production server will use the serialized config file
    * instead of the original config file. This can save the time of loading the
    * config file, especially when you are using `next.config.ts`. When the `distDir`
    * is set, the serialized config `next-config-serialized.json` will be written to
@@ -1507,7 +1507,10 @@ export const defaultConfig = Object.freeze({
     browserDebugInfoInTerminal: false,
     optimizeRouterScrolling: false,
     isolatedDevBuild: false,
-    serializeNextConfigForProduction: true,
+    serializeNextConfigForProduction:
+      // This flag is used to be enabled on the tests.
+      process.env.__NEXT_EXPERIMENTAL_SERIALIZE_NEXT_CONFIG_FOR_PRODUCTION ===
+      'true',
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1355,9 +1355,8 @@ export default async function loadConfig(
     return standaloneConfig
   }
 
-  // Try to load from serialized config files in production
+  // During prod server, we can load from the serialized config.
   if (phase === PHASE_PRODUCTION_SERVER) {
-    // Helper to try loading serialized config
     const tryLoadSerializedConfig = (
       configPath: string
     ): NextConfigComplete | null => {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1390,7 +1390,10 @@ export default async function loadConfig(
     if (
       fromManifest &&
       // Don't return here and will eventually fall back to loading the config.
-      fromManifest.experimental?.serializeNextConfigForProduction
+      (fromManifest.experimental?.serializeNextConfigForProduction ||
+        // This flag is used to be enabled on the tests.
+        process.env.__NEXT_EXPERIMENTAL_SERIALIZE_NEXT_CONFIG_FOR_PRODUCTION ===
+          'true')
     ) {
       return fromManifest
     }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1357,9 +1357,9 @@ export default async function loadConfig(
 
   // During prod server, we can load from the serialized config.
   if (phase === PHASE_PRODUCTION_SERVER) {
-    const tryLoadSerializedConfig = (
+    function tryLoadSerializedConfig(
       configPath: string
-    ): NextConfigComplete | null => {
+    ): NextConfigComplete | null {
       try {
         if (!existsSync(configPath)) {
           return null
@@ -1403,9 +1403,7 @@ export default async function loadConfig(
       return fromSerialized
     }
 
-    throw new Error(
-      `Failed to load the serialized config file "${SERIALIZED_CONFIG_FILE}" in "${targetDir}".`
-    )
+    // Fall back to loading the config.
   }
 
   const curLog = silent

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1374,7 +1374,8 @@ export default async function loadConfig(
 
         if (
           // Don't return here and will eventually fall back to loading the config.
-          config?.experimental?.serializeNextConfigForProduction ||
+          // Use nullish coalescing (??) since we don't want to return when it's false.
+          config?.experimental?.serializeNextConfigForProduction ??
           // This flag is used to be enabled on the tests.
           process.env
             .__NEXT_EXPERIMENTAL_SERIALIZE_NEXT_CONFIG_FOR_PRODUCTION === 'true'
@@ -1409,7 +1410,8 @@ export default async function loadConfig(
 
         if (
           // Don't return here and will eventually fall back to loading the config.
-          config?.experimental?.serializeNextConfigForProduction ||
+          // Use nullish coalescing (??) since we don't want to return when it's false.
+          config?.experimental?.serializeNextConfigForProduction ??
           // This flag is used to be enabled on the tests.
           process.env
             .__NEXT_EXPERIMENTAL_SERIALIZE_NEXT_CONFIG_FOR_PRODUCTION === 'true'

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1387,7 +1387,11 @@ export default async function loadConfig(
     const fromManifest = tryLoadSerializedConfig(
       join(dir, '.next', SERVER_FILES_MANIFEST)
     )
-    if (fromManifest) {
+    if (
+      fromManifest &&
+      // Don't return here and will eventually fall back to loading the config.
+      fromManifest.experimental?.serializeNextConfigForProduction
+    ) {
       return fromManifest
     }
 
@@ -1396,6 +1400,9 @@ export default async function loadConfig(
     const configPath = await findUp(CONFIG_FILES, { cwd: dir })
     const targetDir = configPath ? dirname(configPath) : dir
 
+    // Even though serializeNextConfigForProduction is enabled, we still need to check
+    // the existSync because there's no way to know if serializeNextConfigForProduction
+    // is enabled until we load the config.
     const fromSerialized = tryLoadSerializedConfig(
       join(targetDir, SERIALIZED_CONFIG_FILE)
     )

--- a/packages/next/src/shared/lib/constants.ts
+++ b/packages/next/src/shared/lib/constants.ts
@@ -96,6 +96,7 @@ export const PRERENDER_MANIFEST = 'prerender-manifest.json'
 export const ROUTES_MANIFEST = 'routes-manifest.json'
 export const IMAGES_MANIFEST = 'images-manifest.json'
 export const SERVER_FILES_MANIFEST = 'required-server-files.json'
+export const SERIALIZED_CONFIG_FILE = 'next-config-serialized.json'
 export const DEV_CLIENT_PAGES_MANIFEST = '_devPagesManifest.json'
 export const MIDDLEWARE_MANIFEST = 'middleware-manifest.json'
 export const TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST =

--- a/test/e2e/app-dir/nx-handling/apps/next-nx-test/next.config.js
+++ b/test/e2e/app-dir/nx-handling/apps/next-nx-test/next.config.js
@@ -10,6 +10,13 @@ const nextConfig = {
   // Use this to set Nx-specific options
   // See: https://nx.dev/recipes/next/next-config-setup
   nx: {},
+  experimental: {
+    // Disable because nx tries to copy the config to the dist dir
+    // and expect to load the config inside the dist dir again.
+    // In this case, the serialized config file will be relative
+    // to the original config, not the one inside the dist dir.
+    serializeNextConfigForProduction: false,
+  },
 }
 
 const plugins = [

--- a/test/e2e/app-dir/nx-handling/apps/next-nx-test/next.config.js
+++ b/test/e2e/app-dir/nx-handling/apps/next-nx-test/next.config.js
@@ -13,8 +13,8 @@ const nextConfig = {
   experimental: {
     // Disable because nx tries to copy the config to the dist dir
     // and expect to load the config inside the dist dir again.
-    // In this case, the serialized config file will be relative
-    // to the original config, not the one inside the dist dir.
+    // In this case, the `distDir` will be relative to the original config,
+    // not the config inside the dist dir, and cause distDir path mismatch.
     serializeNextConfigForProduction: false,
   },
 }

--- a/test/e2e/config-schema-check/index.test.ts
+++ b/test/e2e/config-schema-check/index.test.ts
@@ -58,8 +58,8 @@ describe('next.config.js schema validating - invalid config', () => {
 
       expect(output).toContain('Invalid next.config.js options detected')
       expect(output).toContain('badKey')
-      // for next start and next build we both display the warnings
-      expect(warningTimes).toBe(isNextStart ? 2 : 1)
+      // With serialized config, warnings only appear during build, not during start
+      expect(warningTimes).toBe(1)
 
       return 'success'
     }, 'success')

--- a/test/e2e/config-schema-check/index.test.ts
+++ b/test/e2e/config-schema-check/index.test.ts
@@ -31,7 +31,7 @@ describe('next.config.js schema validating - defaultConfig', () => {
 })
 
 describe('next.config.js schema validating - invalid config', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, skipped } = nextTestSetup({
     files: {
       'pages/index.js': `
     export default function Page() {

--- a/test/e2e/config-schema-check/index.test.ts
+++ b/test/e2e/config-schema-check/index.test.ts
@@ -31,7 +31,7 @@ describe('next.config.js schema validating - defaultConfig', () => {
 })
 
 describe('next.config.js schema validating - invalid config', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next, isNextStart, skipped } = nextTestSetup({
     files: {
       'pages/index.js': `
     export default function Page() {
@@ -58,8 +58,16 @@ describe('next.config.js schema validating - invalid config', () => {
 
       expect(output).toContain('Invalid next.config.js options detected')
       expect(output).toContain('badKey')
-      // With serialized config, warnings only appear during build, not during start
-      expect(warningTimes).toBe(1)
+      if (
+        process.env.__NEXT_EXPERIMENTAL_SERIALIZE_NEXT_CONFIG_FOR_PRODUCTION ===
+        'true'
+      ) {
+        // With serialized config, warnings only appear during build, not during start
+        expect(warningTimes).toBe(1)
+      } else {
+        // for next start and next build we both display the warnings
+        expect(warningTimes).toBe(isNextStart ? 2 : 1)
+      }
 
       return 'success'
     }, 'success')

--- a/test/e2e/next-phase/index.test.ts
+++ b/test/e2e/next-phase/index.test.ts
@@ -23,11 +23,16 @@ describe('next-phase', () => {
   if (skipped) return
 
   it('should render page with next phase correctly', async () => {
+    const isSerializedNextConfigForProduction =
+      process.env.__NEXT_EXPERIMENTAL_SERIALIZE_NEXT_CONFIG_FOR_PRODUCTION ===
+      'true'
     const phases = {
       dev: 'phase-development-server',
       build: 'phase-production-build',
-      // Serialized next config will use the config from build.
-      start: 'phase-production-build',
+      start: isSerializedNextConfigForProduction
+        ? // Serialized next config will use the config from build.
+          'phase-production-build'
+        : 'phase-production-server',
     }
     const currentPhase = isNextDev ? phases.dev : phases.build
     const nonExistedPhase = isNextDev ? phases.build : phases.dev
@@ -40,6 +45,10 @@ describe('next-phase', () => {
 
     if (isNextDev) {
       expect(next.cliOutput).not.toContain(phases.start)
+    } else {
+      if (isSerializedNextConfigForProduction) {
+        expect(next.cliOutput).toContain(phases.start)
+      }
     }
   })
 })

--- a/test/e2e/next-phase/index.test.ts
+++ b/test/e2e/next-phase/index.test.ts
@@ -26,7 +26,8 @@ describe('next-phase', () => {
     const phases = {
       dev: 'phase-development-server',
       build: 'phase-production-build',
-      start: 'phase-production-server',
+      // Serialized next config will use the config from build.
+      start: 'phase-production-build',
     }
     const currentPhase = isNextDev ? phases.dev : phases.build
     const nonExistedPhase = isNextDev ? phases.build : phases.dev
@@ -39,8 +40,6 @@ describe('next-phase', () => {
 
     if (isNextDev) {
       expect(next.cliOutput).not.toContain(phases.start)
-    } else {
-      expect(next.cliOutput).toContain(phases.start)
     }
   })
 })

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -177,24 +177,6 @@ describe('Config Experimental Warning', () => {
     expect(stdout).toContain(' ✓ workerThreads')
     expect(stdout).toContain(' ✓ scrollRestoration')
   })
-
-  it('should show unrecognized experimental features in warning but not in start log experiments section during dev', async () => {
-    configFile.write(`
-        module.exports = {
-          experimental: {
-            appDir: true
-          }
-        }
-      `)
-
-    const { stdout, stderr } = await collectStdoutFromDev(appDir)
-    await check(() => {
-      expect(stripAnsi(stdout)).not.toContain(experimentalHeader)
-      expect(stripAnsi(stderr)).toContain(
-        `Unrecognized key(s) in object: 'appDir' at "experimental"`
-      )
-    })
-  })
   ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
     'production mode',
     () => {

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -194,7 +194,8 @@ describe('Config Experimental Warning', () => {
         `Unrecognized key(s) in object: 'appDir' at "experimental"`
       )
     })
-  })(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+  })
+  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
     'production mode',
     () => {
       it('should not show next app info in next start', async () => {

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -219,8 +219,10 @@ describe('Config Experimental Warning', () => {
         expect(stdout).toMatch(' ✓ parallelServerCompiles')
       })
 
-      it('should show unrecognized experimental features in warning but not in start log experiments section', async () => {
-        configFile.write(`
+      // In prod, it will load a serialized config, so the warning will not appear during start.
+      if (global.isNextDev) {
+        it('should show unrecognized experimental features in warning but not in start log experiments section', async () => {
+          configFile.write(`
         module.exports = {
           experimental: {
             appDir: true
@@ -228,28 +230,29 @@ describe('Config Experimental Warning', () => {
         }
       `)
 
-        await collectStdoutFromBuild(appDir)
-        const port = await findPort()
-        let stdout = ''
-        let stderr = ''
-        app = await nextStart(appDir, port, {
-          onStdout(msg) {
-            stdout += msg
-          },
-          onStderr(msg) {
-            stderr += msg
-          },
-        })
+          await collectStdoutFromBuild(appDir)
+          const port = await findPort()
+          let stdout = ''
+          let stderr = ''
+          app = await nextStart(appDir, port, {
+            onStdout(msg) {
+              stdout += msg
+            },
+            onStderr(msg) {
+              stderr += msg
+            },
+          })
 
-        await check(() => {
-          const cliOutput = stripAnsi(stdout)
-          const cliOutputErr = stripAnsi(stderr)
-          expect(cliOutput).not.toContain(experimentalHeader)
-          expect(cliOutputErr).toContain(
-            `Unrecognized key(s) in object: 'appDir' at "experimental"`
-          )
+          await check(() => {
+            const cliOutput = stripAnsi(stdout)
+            const cliOutputErr = stripAnsi(stderr)
+            expect(cliOutput).not.toContain(experimentalHeader)
+            expect(cliOutputErr).toContain(
+              `Unrecognized key(s) in object: 'appDir' at "experimental"`
+            )
+          })
         })
-      })
+      }
     }
   )
 })

--- a/test/integration/config-experimental-warning/test/index.test.js
+++ b/test/integration/config-experimental-warning/test/index.test.js
@@ -178,7 +178,7 @@ describe('Config Experimental Warning', () => {
     expect(stdout).toContain(' ✓ scrollRestoration')
   })
 
-  it('should show unrecognized experimental features in warning but not in start log experiments section', async () => {
+  it('should show unrecognized experimental features in warning but not in start log experiments section during dev', async () => {
     configFile.write(`
         module.exports = {
           experimental: {
@@ -190,12 +190,11 @@ describe('Config Experimental Warning', () => {
     const { stderr } = await collectStdoutFromDev(appDir)
     await check(() => {
       const cliOutput = stripAnsi(stderr)
-      expect(stderr).toContain(
+      expect(cliOutput).toContain(
         `Unrecognized key(s) in object: 'appDir' at "experimental"`
       )
     })
-  })
-  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+  })(process.env.TURBOPACK_DEV ? describe.skip : describe)(
     'production mode',
     () => {
       it('should not show next app info in next start', async () => {
@@ -243,7 +242,7 @@ describe('Config Experimental Warning', () => {
       })
 
       // In prod, it will load a serialized config, so the warning will not appear during start.
-      it('should show unrecognized experimental features in warning but not in start log experiments section', async () => {
+      it('should show unrecognized experimental features in warning but not in start log experiments section during build', async () => {
         configFile.write(`
         module.exports = {
           experimental: {
@@ -255,7 +254,7 @@ describe('Config Experimental Warning', () => {
         const { stderr } = await collectStdoutFromBuild(appDir)
         await check(() => {
           const cliOutput = stripAnsi(stderr)
-          expect(stderr).toContain(
+          expect(cliOutput).toContain(
             `Unrecognized key(s) in object: 'appDir' at "experimental"`
           )
         })

--- a/test/integration/custom-server/test/index.test.js
+++ b/test/integration/custom-server/test/index.test.js
@@ -145,9 +145,21 @@ describe.each([
       'production mode',
       () => {
         beforeAll(async () => {
-          // Set env during build for serialized next config.
-          await nextBuild(appDir, [], { env: { GENERATE_ETAGS: 'true' } })
-          await startServer({ NODE_ENV: 'production' })
+          if (
+            process.env
+              .__NEXT_EXPERIMENTAL_SERIALIZE_NEXT_CONFIG_FOR_PRODUCTION ===
+            'true'
+          ) {
+            // Set env during build for serialized next config.
+            await nextBuild(appDir, [], { env: { GENERATE_ETAGS: 'true' } })
+            await startServer({ NODE_ENV: 'production' })
+          } else {
+            await nextBuild(appDir)
+            await startServer({
+              GENERATE_ETAGS: 'true',
+              NODE_ENV: 'production',
+            })
+          }
         })
         afterAll(() => killApp(server))
 

--- a/test/integration/custom-server/test/index.test.js
+++ b/test/integration/custom-server/test/index.test.js
@@ -145,8 +145,9 @@ describe.each([
       'production mode',
       () => {
         beforeAll(async () => {
-          await nextBuild(appDir)
-          await startServer({ GENERATE_ETAGS: 'true', NODE_ENV: 'production' })
+          // Set env during build for serialized next config.
+          await nextBuild(appDir, [], { env: { GENERATE_ETAGS: 'true' } })
+          await startServer({ NODE_ENV: 'production' })
         })
         afterAll(() => killApp(server))
 

--- a/test/production/app-dir/next-config-serialized/app/layout.tsx
+++ b/test/production/app-dir/next-config-serialized/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/next-config-serialized/app/page.tsx
+++ b/test/production/app-dir/next-config-serialized/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/next-config-serialized/app/page.tsx
+++ b/test/production/app-dir/next-config-serialized/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <p>hello world</p>
+  return <p>hello world {process.env.foo}</p>
 }

--- a/test/production/app-dir/next-config-serialized/next-config-serialized.test.ts
+++ b/test/production/app-dir/next-config-serialized/next-config-serialized.test.ts
@@ -1,0 +1,59 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('next-config-serialized', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should use .next/required-server-files.json when distDir is .next', async () => {
+    await next.build()
+    expect(await next.hasFile('.next/required-server-files.json')).toBe(true)
+
+    // Rename the file so it can't be loaded.
+    await next.renameFile('next.config.js', 'next.config.noop.js')
+    await retry(async () => {
+      expect(await next.hasFile('next.config.noop.js')).toBe(true)
+    })
+
+    await next.start()
+
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+
+    // Restore the file for the next case.
+    await next.renameFile('next.config.noop.js', 'next.config.js')
+    await next.stop()
+  })
+
+  it('should use next-config-serialized.json when distDir is not .next', async () => {
+    await next.patchFile('next.config.js', (content) => {
+      return content.replace(`// distDir: 'out',`, `distDir: 'out',`)
+    })
+
+    await next.build()
+    expect(await next.hasFile('out/required-server-files.json')).toBe(true)
+    expect(await next.hasFile('next-config-serialized.json')).toBe(true)
+
+    // Rename the file so it can't be loaded.
+    await next.renameFile('next.config.js', 'next.config.noop.js')
+    await retry(async () => {
+      expect(await next.hasFile('next.config.noop.js')).toBe(true)
+    })
+
+    await next.start()
+
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+
+    // Restore the file for the next case.
+    await next.renameFile('next.config.noop.js', 'next.config.js')
+    await next.stop()
+  })
+})

--- a/test/production/app-dir/next-config-serialized/next-config-serialized.test.ts
+++ b/test/production/app-dir/next-config-serialized/next-config-serialized.test.ts
@@ -16,16 +16,16 @@ describe('next-config-serialized', () => {
     await next.build()
     expect(await next.hasFile('.next/required-server-files.json')).toBe(true)
 
-    // Rename the file so it can't be loaded.
+    // Rename the config file so it can't be loaded.
     await next.renameFile('next.config.js', 'next.config.noop.js')
     await retry(async () => {
       expect(await next.hasFile('next.config.noop.js')).toBe(true)
     })
 
-    await next.start()
+    await next.start({ skipBuild: true })
 
     const browser = await next.browser('/')
-    expect(await browser.elementByCss('p').text()).toBe('hello world')
+    expect(await browser.elementByCss('p').text()).toBe('hello world foo')
 
     // Restore the file for the next case.
     await next.renameFile('next.config.noop.js', 'next.config.js')
@@ -39,18 +39,19 @@ describe('next-config-serialized', () => {
 
     await next.build()
     expect(await next.hasFile('out/required-server-files.json')).toBe(true)
+    // next-config-serialized.json created next to next.config.js
     expect(await next.hasFile('next-config-serialized.json')).toBe(true)
 
-    // Rename the file so it can't be loaded.
+    // Rename the config file so it can't be loaded.
     await next.renameFile('next.config.js', 'next.config.noop.js')
     await retry(async () => {
       expect(await next.hasFile('next.config.noop.js')).toBe(true)
     })
 
-    await next.start()
+    await next.start({ skipBuild: true })
 
     const browser = await next.browser('/')
-    expect(await browser.elementByCss('p').text()).toBe('hello world')
+    expect(await browser.elementByCss('p').text()).toBe('hello world foo')
 
     // Restore the file for the next case.
     await next.renameFile('next.config.noop.js', 'next.config.js')

--- a/test/production/app-dir/next-config-serialized/next.config.js
+++ b/test/production/app-dir/next-config-serialized/next.config.js
@@ -6,6 +6,9 @@ const nextConfig = {
   env: {
     foo: 'foo',
   },
+  experimental: {
+    serializeNextConfigForProduction: true,
+  },
 }
 
 module.exports = nextConfig

--- a/test/production/app-dir/next-config-serialized/next.config.js
+++ b/test/production/app-dir/next-config-serialized/next.config.js
@@ -3,6 +3,9 @@
  */
 const nextConfig = {
   // distDir: 'out',
+  env: {
+    foo: 'foo',
+  },
 }
 
 module.exports = nextConfig

--- a/test/production/app-dir/next-config-serialized/next.config.js
+++ b/test/production/app-dir/next-config-serialized/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  // distDir: 'out',
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
> [!NOTE]
> The feature is under `__NEXT_EXPERIMENTAL_SERIALIZE_NEXT_CONFIG_FOR_PRODUCTION` flag, and `experimental.serializeNextConfigForProduction` next config option. This will be enabled by default on the tests.

### Why?

As we removed the runtime config at https://github.com/vercel/next.js/pull/83944, the next config can be 100% ready by build time and read from a serialized config on prod server. This can benefit from reducing the time spent reading the JS file and running unnecessary scripts that could be done during the build time. Also, when you're using `next.config.ts`, you would've needed TS to resolve the import alias, but you won't need TS anymore once it's serialized.

### How?

We already wrote a serialized config to the `required-server-files.json` manifest. However, there's a chicken-egg problem. Since this manifest is written instead of the distDir, we should know the distDir prior to reading a config file. Of course, you need to read the config file to know the distDir.

During build, when distDir is set, we'll create a new git-ignored file called `next-config-serialized.json` next to the original config file. This will be used during the prod server.

By the time we load the config on the prod server, we try to serve from the `.next/` dir for this manifest. If it does not exist, then we look for the `next-config-serialized.json` file. If none of them successfully loaded, we fall back to load the original config.

Fixes https://github.com/vercel/next.js/issues/81798

### Follow Up

Will follow up adding `next-config-serialized.json` to CNA template & examples gitignores.