### PR TITLE
Fix output comparison when checking conclusion of required jobs

### DIFF
--- a/.github/workflows/retry_test.yml
+++ b/.github/workflows/retry_test.yml
@@ -71,7 +71,7 @@ jobs:
 
             return await rerunIfRequiredNotSuccessful()
       - name: send retry request to GitHub API
-        if: ${{ steps.required_job_conclusion.outputs.result != 'success' }}
+        if: ${{ steps.required_job_conclusion.outputs.result != '"success"' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -137,7 +137,7 @@ jobs:
 
             return await rerunIfRequiredNotSuccessful()
       - name: send webhook
-        if: ${{ steps.required_job_conclusion.outputs.result != 'success' }}
+        if: ${{ steps.required_job_conclusion.outputs.result != '"success"' }}
         uses: slackapi/slack-github-action@v1.25.0
         with:
           # These urls are intentionally missing the protocol,


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/83953

Seems like outputs are always strings so an actual string gets additional quotes:

```
##[debug]....=> '"success"'
##[debug]....Evaluating String:
##[debug]....=> 'success'
```
-- https://github.com/vercel/next.js/actions/runs/17844906912/job/50766317187#step:3:28