### PR TITLE
Turbopack: correctly catch all issues for builds

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -69,7 +69,7 @@ use crate::{
         },
         utils::{
             DetachedVc, NapiDiagnostic, NapiIssue, RootTask, TurbopackResult, get_diagnostics,
-            get_issues, subscribe,
+            get_issues, strongly_consistent_catch_collectables, subscribe,
         },
     },
     util::DhatProfilerGuard,
@@ -883,7 +883,7 @@ fn project_container_entrypoints_operation(
 
 #[turbo_tasks::value(serialization = "none")]
 struct AllWrittenEntrypointsWithIssues {
-    entrypoints: Option<ReadRef<Entrypoints>>,
+    entrypoints: Option<ReadRef<EntrypointsOperation>>,
     issues: Arc<Vec<ReadRef<PlainIssue>>>,
     diagnostics: Arc<Vec<ReadRef<PlainDiagnostic>>>,
     effects: Arc<Effects>,
@@ -894,7 +894,7 @@ struct AllWrittenEntrypointsWithIssues {
 pub async fn project_write_all_entrypoints_to_disk(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
     app_dir_only: bool,
-) -> napi::Result<TurbopackResult<NapiEntrypoints>> {
+) -> napi::Result<TurbopackResult<Option<NapiEntrypoints>>> {
     let ctx = &project.turbopack_ctx;
     let container = project.container;
     let tt = ctx.turbo_tasks();
@@ -905,7 +905,7 @@ pub async fn project_write_all_entrypoints_to_disk(
                 get_all_written_entrypoints_with_issues_operation(container, app_dir_only);
 
             // Read and compile the files
-            let EntrypointsWithIssues {
+            let AllWrittenEntrypointsWithIssues {
                 entrypoints,
                 issues,
                 diagnostics,
@@ -923,7 +923,14 @@ pub async fn project_write_all_entrypoints_to_disk(
         .await?;
 
     Ok(TurbopackResult {
-        result: NapiEntrypoints::from_entrypoints_op(&entrypoints, &project.turbopack_ctx)?,
+        result: if let Some(entrypoints) = entrypoints {
+            Some(NapiEntrypoints::from_entrypoints_op(
+                &entrypoints,
+                &project.turbopack_ctx,
+            )?)
+        } else {
+            None
+        },
         issues: issues.iter().map(|i| NapiIssue::from(&**i)).collect(),
         diagnostics: diags.iter().map(|d| NapiDiagnostic::from(d)).collect(),
     })
@@ -933,16 +940,14 @@ pub async fn project_write_all_entrypoints_to_disk(
 async fn get_all_written_entrypoints_with_issues_operation(
     container: ResolvedVc<ProjectContainer>,
     app_dir_only: bool,
-) -> Result<Vc<EntrypointsWithIssues>> {
+) -> Result<Vc<AllWrittenEntrypointsWithIssues>> {
     let entrypoints_operation = EntrypointsOperation::new(all_entrypoints_write_to_disk_operation(
         container,
         app_dir_only,
     ));
-    let entrypoints = entrypoints_operation.read_strongly_consistent().await?;
-    let issues = get_issues(entrypoints_operation).await?;
-    let diagnostics = get_diagnostics(entrypoints_operation).await?;
-    let effects = Arc::new(get_effects(entrypoints_operation).await?);
-    Ok(EntrypointsWithIssues {
+    let (entrypoints, issues, diagnostics, effects) =
+        strongly_consistent_catch_collectables(entrypoints_operation).await?;
+    Ok(AllWrittenEntrypointsWithIssues {
         entrypoints,
         issues,
         diagnostics,

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -848,5 +848,6 @@
   "847": "Route %s with \\`dynamic = \"error\"\\` couldn't be rendered statically because it used \\`connection()\\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
   "848": "%sused %s. \\`searchParams\\` is a Promise and must be unwrapped with \\`await\\` or \\`React.use()\\` before accessing its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
   "849": "Route %s with \\`dynamic = \"error\"\\` couldn't be rendered statically because it used \\`cookies()\\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
-  "850": "metadataBase is not a valid URL: %s"
+  "850": "metadataBase is not a valid URL: %s",
+  "851": "Turbopack build failed"
 }

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -658,13 +658,20 @@ function bindingToApi(
 
     async writeAllEntrypointsToDisk(
       appDirOnly: boolean
-    ): Promise<TurbopackResult<RawEntrypoints>> {
+    ): Promise<TurbopackResult<RawEntrypoints | {}>> {
       const napiEndpoints = (await binding.projectWriteAllEntrypointsToDisk(
         this._nativeProject,
         appDirOnly
-      )) as TurbopackResult<NapiEntrypoints>
+      )) as TurbopackResult<NapiEntrypoints | {}>
 
-      return napiEntrypointsToRawEntrypoints(napiEndpoints)
+      if ('routes' in napiEndpoints) {
+        return napiEntrypointsToRawEntrypoints(napiEndpoints)
+      } else {
+        return {
+          issues: napiEndpoints.issues,
+          diagnostics: napiEndpoints.diagnostics,
+        }
+      }
     }
 
     entrypointsSubscribe() {

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -658,14 +658,16 @@ function bindingToApi(
 
     async writeAllEntrypointsToDisk(
       appDirOnly: boolean
-    ): Promise<TurbopackResult<RawEntrypoints | {}>> {
+    ): Promise<TurbopackResult<Partial<RawEntrypoints>>> {
       const napiEndpoints = (await binding.projectWriteAllEntrypointsToDisk(
         this._nativeProject,
         appDirOnly
-      )) as TurbopackResult<NapiEntrypoints | {}>
+      )) as TurbopackResult<Partial<NapiEntrypoints>>
 
       if ('routes' in napiEndpoints) {
-        return napiEntrypointsToRawEntrypoints(napiEndpoints)
+        return napiEntrypointsToRawEntrypoints(
+          napiEndpoints as TurbopackResult<NapiEntrypoints>
+        )
       } else {
         return {
           issues: napiEndpoints.issues,
@@ -773,7 +775,7 @@ function bindingToApi(
       )) as TurbopackResult<WrittenEndpoint>
     }
 
-    async clientChanged(): Promise<AsyncIterableIterator<TurbopackResult<{}>>> {
+    async clientChanged(): Promise<AsyncIterableIterator<TurbopackResult>> {
       const clientSubscription = subscribe<TurbopackResult>(
         false,
         async (callback) =>
@@ -785,7 +787,7 @@ function bindingToApi(
 
     async serverChanged(
       includeIssues: boolean
-    ): Promise<AsyncIterableIterator<TurbopackResult<{}>>> {
+    ): Promise<AsyncIterableIterator<TurbopackResult>> {
       const serverSubscription = subscribe<TurbopackResult>(
         false,
         async (callback) =>
@@ -1030,12 +1032,13 @@ function bindingToApi(
             type: 'conflict',
           }
           break
-        default:
+        default: {
           const _exhaustiveCheck: never = routeType
           invariant(
             nativeRoute,
             () => `Unknown route type: ${_exhaustiveCheck}`
           )
+        }
       }
       routes.set(pathname, route)
     }

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -225,7 +225,7 @@ export interface Project {
 
   writeAllEntrypointsToDisk(
     appDirOnly: boolean
-  ): Promise<TurbopackResult<RawEntrypoints>>
+  ): Promise<TurbopackResult<RawEntrypoints | {}>>
 
   entrypointsSubscribe(): AsyncIterableIterator<TurbopackResult<RawEntrypoints>>
 

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -225,7 +225,7 @@ export interface Project {
 
   writeAllEntrypointsToDisk(
     appDirOnly: boolean
-  ): Promise<TurbopackResult<RawEntrypoints | {}>>
+  ): Promise<TurbopackResult<Partial<RawEntrypoints>>>
 
   entrypointsSubscribe(): AsyncIterableIterator<TurbopackResult<RawEntrypoints>>
 

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -147,7 +147,7 @@ export async function turbopackBuild(): Promise<{
       )
     }
 
-    if (topLevelErrors.length > 0) {
+    if (topLevelErrors.length > 0 || !('routes' in entrypoints)) {
       throw new Error(
         `Turbopack build failed with ${
           topLevelErrors.length

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -22,6 +22,7 @@ import { isCI } from '../../server/ci-info'
 import { backgroundLogCompilationEvents } from '../../shared/lib/turbopack/compilation-events'
 import { getSupportedBrowsers } from '../utils'
 import { normalizePath } from '../../lib/normalize-path'
+import type { TurbopackResult, RawEntrypoints } from '../swc/types'
 
 export async function turbopackBuild(): Promise<{
   duration: number
@@ -107,27 +108,7 @@ export async function turbopackBuild(): Promise<{
     )
 
     let appDirOnly = NextBuildContext.appDirOnly!
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const entrypoints = await project.writeAllEntrypointsToDisk(appDirOnly)
-
-    const hasPagesEntries = Array.from(entrypoints.routes.values()).some(
-      (route) => {
-        if (route.type === 'page' || route.type === 'page-api') {
-          return true
-        }
-        return false
-      }
-    )
-    // If there's no pages entries, then we are in app-dir-only mode
-    if (!hasPagesEntries) {
-      appDirOnly = true
-    }
-
-    const manifestLoader = new TurbopackManifestLoader({
-      buildId,
-      distDir,
-      encryptionKey,
-    })
 
     const topLevelErrors = []
     const topLevelWarnings = []
@@ -159,15 +140,31 @@ export async function turbopackBuild(): Promise<{
       )
     }
 
-    if (!('routes' in entrypoints)) {
+    if (!entrypoints.routes) {
       // This should never ever happen, there should be an error issue, or the bindings call should
       // have thrown.
       throw new Error(`Turbopack build failed`)
     }
 
-    const currentEntrypoints = await rawEntrypointsToEntrypoints(entrypoints)
+    const hasPagesEntries = Array.from(entrypoints.routes.values()).some(
+      (route) => route.type === 'page' || route.type === 'page-api'
+    )
+    // If there's no pages entries, then we are in app-dir-only mode
+    if (!hasPagesEntries) {
+      appDirOnly = true
+    }
 
-    const promises: Promise<any>[] = []
+    const manifestLoader = new TurbopackManifestLoader({
+      buildId,
+      distDir,
+      encryptionKey,
+    })
+
+    const currentEntrypoints = await rawEntrypointsToEntrypoints(
+      entrypoints as TurbopackResult<RawEntrypoints>
+    )
+
+    const promises: Promise<void>[] = []
 
     if (!appDirOnly) {
       for (const [page, route] of currentEntrypoints.page) {

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -132,7 +132,11 @@ export async function turbopackBuild(): Promise<{
     const topLevelErrors = []
     const topLevelWarnings = []
     for (const issue of entrypoints.issues) {
-      if (issue.severity === 'error' || issue.severity === 'fatal') {
+      if (
+        issue.severity === 'bug' ||
+        issue.severity === 'error' ||
+        issue.severity === 'fatal'
+      ) {
         topLevelErrors.push(formatIssue(issue))
       } else if (isRelevantWarning(issue)) {
         topLevelWarnings.push(formatIssue(issue))
@@ -147,12 +151,18 @@ export async function turbopackBuild(): Promise<{
       )
     }
 
-    if (topLevelErrors.length > 0 || !('routes' in entrypoints)) {
+    if (topLevelErrors.length > 0) {
       throw new Error(
         `Turbopack build failed with ${
           topLevelErrors.length
         } errors:\n${topLevelErrors.join('\n')}`
       )
+    }
+
+    if (!('routes' in entrypoints)) {
+      // This should never ever happen, there should be an error issue, or the bindings call should
+      // have thrown.
+      throw new Error(`Turbopack build failed`)
     }
 
     const currentEntrypoints = await rawEntrypointsToEntrypoints(entrypoints)

--- a/test/e2e/app-dir/parallel-routes-layouts/app/nested/@bar/subroute/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-layouts/app/nested/@bar/subroute/page.tsx
@@ -1,3 +1,0 @@
-export default function Page() {
-  return <div>Subroute</div>
-}


### PR DESCRIPTION
`strongly_consistent_catch_collectables` has this nice behavior that it prefers outputting `Issues` with severity error or higher, and drops `bail!`s in that case (because `Issue`s are higher fidelity and look nicer)

This wasn't actually used for builds, only in dev

Closes PACK-5632