### PR TITLE
next-dev: Emit `next.config.js` warnings from child process upon restart

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -346,7 +346,7 @@ const nextDev = async (
             })
           }
 
-          return startServer({ ...startServerOptions, port })
+          return startServer({ ...startServerOptions, port, isRestart: true })
         }
         // Call handler (e.g. upload telemetry). Don't try to send a signal to
         // the child, as it has already exited.


### PR DESCRIPTION
This is a minor edge case. If you modify the `next.config.js`, we restart the dev server. When that happens, we should re-emit warnings about your configuration, in case you've added new options that are deprecated.

However, we don't currently do this, because we normally let the parent process emit the warnings, and the parent process does not restart.

This adds logic to let the child process know when it's being started as part of a restart, and log the warnings itself in that case.

I tested this in https://github.com/vercel/next.js/pull/84006. I'm abandoning that PR, but I still think this is an improvement.

Closes PACK-5533