### PR TITLE
docs: Fix the title/path of the turbopack page on pages router

### DIFF
--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/turbopack.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/turbopack.mdx
@@ -1,5 +1,5 @@
 ---
-title: turbo
+title: turbopack
 description: Configure Next.js with Turbopack-specific options
 version: experimental
 source: app/api-reference/config/next-config-js/turbopack


### PR DESCRIPTION
This option was renamed/stabilized from `experimental.turbo` to `turbopack` in 15.3.

The app router page title/path was correct, but pages router had the wrong thing.

Let me know if I should add a redirect for this somewhere?

Closes PACK-5538