### PR TITLE
Turbopack: Document automatic Babel config support

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -55,13 +55,13 @@ The following options are available for the `turbopack` configuration:
 
 The following loaders have been tested to work with Turbopack's webpack loader implementation, but many other webpack loaders should work as well even if not listed here:
 
-- [`babel-loader`](https://www.npmjs.com/package/babel-loader)
+- [`babel-loader`](https://www.npmjs.com/package/babel-loader) [_(Configured automatically if a Babel configuration file is found)_](/docs/app/api-reference/turbopack#language-features)
 - [`@svgr/webpack`](https://www.npmjs.com/package/@svgr/webpack)
 - [`svg-inline-loader`](https://www.npmjs.com/package/svg-inline-loader)
 - [`yaml-loader`](https://www.npmjs.com/package/yaml-loader)
 - [`string-replace-loader`](https://www.npmjs.com/package/string-replace-loader)
 - [`raw-loader`](https://www.npmjs.com/package/raw-loader)
-- [`sass-loader`](https://www.npmjs.com/package/sass-loader)
+- [`sass-loader`](https://www.npmjs.com/package/sass-loader) [_(Configured automatically)_](/docs/app/api-reference/turbopack#css-and-styling)
 - [`graphql-tag/loader`](https://www.npmjs.com/package/graphql-tag)
 
 ## Examples

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -38,13 +38,16 @@ Turbopack in Next.js has **zero-configuration** for the common use cases. Below 
 
 ### Language features
 
-| Feature                     | Status                | Notes                                                                                                                                                                                                   |
-| --------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **JavaScript & TypeScript** | **Supported**         | Uses SWC under the hood. Type-checking is not done by Turbopack (run `tsc --watch` or rely on your IDE for type checks).                                                                                |
-| **ECMAScript (ESNext)**     | **Supported**         | Turbopack supports the latest ECMAScript features, matching SWC’s coverage.                                                                                                                             |
-| **CommonJS**                | **Supported**         | `require()` syntax is handled out of the box.                                                                                                                                                           |
-| **ESM**                     | **Supported**         | Static and dynamic `import` are fully supported.                                                                                                                                                        |
-| **Babel**                   | Partially Unsupported | Turbopack does not include Babel by default. However, you can [configure `babel-loader` via the Turbopack config](/docs/app/api-reference/config/next-config-js/turbopack#configuring-webpack-loaders). |
+| Feature                     | Status        | Notes                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **JavaScript & TypeScript** | **Supported** | Uses SWC under the hood. Type-checking is not done by Turbopack (run `tsc --watch` or rely on your IDE for type checks).                                                                                                                                                                                                                                                                                                |
+| **ECMAScript (ESNext)**     | **Supported** | Turbopack supports the latest ECMAScript features, matching SWC’s coverage.                                                                                                                                                                                                                                                                                                                                             |
+| **CommonJS**                | **Supported** | `require()` syntax is handled out of the box.                                                                                                                                                                                                                                                                                                                                                                           |
+| **ESM**                     | **Supported** | Static and dynamic `import` are fully supported.                                                                                                                                                                                                                                                                                                                                                                        |
+| **Babel**                   | **Supported** | Starting in Next.js 16, Turbopack uses Babel automatically if it detects [a configuration file][babel-config]. Unlike in webpack, SWC is always used for Next.js's internal transforms and downleveling to older ECMAScript revisions. Next.js with webpack disables SWC if a Babel configuration file is present. Files in `node_modules` are excluded, unless you [manually configure `babel-loader`][manual-loader]. |
+
+[babel-config]: https://babeljs.io/docs/config-files
+[manual-loader]: /docs/app/api-reference/config/next-config-js/turbopack#configuring-webpack-loaders
 
 ### Framework and React features
 
@@ -220,8 +223,9 @@ Stay tuned for more updates as we continue to improve Turbopack and add producti
 
 ## Version Changes
 
-| Version   | Changes                            |
-| --------- | ---------------------------------- |
-| `v15.5.0` | Turbopack support for `build` beta |
-| `v15.3.0` | Experimental support for `build`   |
-| `v15.0.0` | Turbopack for `dev` stable         |
+| Version   | Changes                                                        |
+| --------- | -------------------------------------------------------------- |
+| `v16.0.0` | Automatic support for Babel when a configuration file is found |
+| `v15.5.0` | Turbopack support for `build` beta                             |
+| `v15.3.0` | Experimental support for `build`                               |
+| `v15.0.0` | Turbopack for `dev` stable                                     |


### PR DESCRIPTION
This will be in Next 16.0.

https://github.com/vercel/next.js/pull/82676 adds support for automatically enabling Babel if a babel config is found. Previously we'd exit the process with a hard error explaining that Babel is not supported.

Technically you could previously manually configure `babel-loader`, but we had heuristics to detect and warn against that, and you'd need to use a different path for the config file to work around our error message, so it didn't really work properly. (This seems like it was a mistake/oversight)

## Rendered

<img src="https://app.graphite.dev/user-attachments/assets/1b4712ba-c2f3-4b02-81ec-f1f9267a545e.png" width=700>

<img src="https://app.graphite.dev/user-attachments/assets/6ce60399-8623-4357-8cc1-6443d23eb3c2.png" width=700>

<img src="https://app.graphite.dev/user-attachments/assets/36ae8a63-5429-4134-bafd-e0f52b34f718.png" width=700>

Closes PACK-5534