### PR TITLE
[Cache Components] Dim logs after prerender aborts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,7 +62,7 @@
     "packages/next/src/server/app-render/dynamic-access-async-storage-instance.ts",
     "packages/next/src/server/app-render/work-async-storage-instance.ts",
     "packages/next/src/server/app-render/work-unit-async-storage-instance.ts",
-    "packages/next/src/server/app-render/dev-logs-async-storage-instance.ts",
+    "packages/next/src/server/app-render/console-async-storage-instance.ts",
     "packages/next/src/client/components/segment-cache-impl/*"
   ],
   // Disable TypeScript surveys.

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -174,7 +174,7 @@ import {
   workUnitAsyncStorage,
   type PrerenderStore,
 } from './work-unit-async-storage.external'
-import { devLogsAsyncStorage } from './dev-logs-async-storage.external'
+import { consoleAsyncStorage } from './console-async-storage.external'
 import { CacheSignal } from './cache-signal'
 import { getTracedMetadata } from '../lib/trace/utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
@@ -2303,7 +2303,7 @@ async function renderToStream(
         }
       )
 
-      devLogsAsyncStorage.run(
+      consoleAsyncStorage.run(
         { dim: true },
         spawnDynamicValidationInDev,
         resolveValidation,

--- a/packages/next/src/server/app-render/console-async-storage-instance.ts
+++ b/packages/next/src/server/app-render/console-async-storage-instance.ts
@@ -1,0 +1,5 @@
+import { createAsyncLocalStorage } from './async-local-storage'
+import type { ConsoleAsyncStorage } from './console-async-storage.external'
+
+export const consoleAsyncStorageInstance: ConsoleAsyncStorage =
+  createAsyncLocalStorage()

--- a/packages/next/src/server/app-render/console-async-storage.external.ts
+++ b/packages/next/src/server/app-render/console-async-storage.external.ts
@@ -1,9 +1,9 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 
 // Share the instance module in the next-shared layer
-import { devLogsAsyncStorageInstance } from './dev-logs-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+import { consoleAsyncStorageInstance } from './console-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
 
-export interface DevLogsStore {
+export interface ConsoleStore {
   /**
    * if true the color of logs output will be dimmed to indicate the log is
    * from a repeat or validation render that is not typically relevant to
@@ -12,6 +12,6 @@ export interface DevLogsStore {
   readonly dim: boolean
 }
 
-export type DevLogsAsyncStorage = AsyncLocalStorage<DevLogsStore>
+export type ConsoleAsyncStorage = AsyncLocalStorage<ConsoleStore>
 
-export { devLogsAsyncStorageInstance as devLogsAsyncStorage }
+export { consoleAsyncStorageInstance as consoleAsyncStorage }

--- a/packages/next/src/server/app-render/dev-logs-async-storage-instance.ts
+++ b/packages/next/src/server/app-render/dev-logs-async-storage-instance.ts
@@ -1,5 +1,0 @@
-import { createAsyncLocalStorage } from './async-local-storage'
-import type { DevLogsAsyncStorage } from './dev-logs-async-storage.external'
-
-export const devLogsAsyncStorageInstance: DevLogsAsyncStorage =
-  createAsyncLocalStorage()

--- a/packages/next/src/server/node-environment-extensions/console-dim.test.ts
+++ b/packages/next/src/server/node-environment-extensions/console-dim.test.ts
@@ -293,54 +293,5 @@ describe('console-exit patches', () => {
         { method: 'log', input: expect.stringMatching(/\[DIM\].*after abort/) },
       ])
     })
-
-    it('should enter a dimming context when a react cacheSignal exists and is aborted', async () => {
-      async function testForWorker() {
-        const originalLog = console.log
-        const controller = new AbortController()
-
-        // Hacky but we need to provide a cacheSignal for this test
-        require('react').__SERVER_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE.A =
-          {
-            cacheSignal() {
-              originalLog('cacheSignal called')
-              return controller.signal
-            },
-          }
-
-        // First, replace console.log to track what storage context it runs in
-        console.log = function (...args) {
-          originalLog(...args)
-          let dimmed = false
-          if (
-            args.find((a) =>
-              typeof a === 'string' ? a.includes('color:') : false
-            )
-          ) {
-            dimmed = true
-          }
-          reportResult({
-            type: 'console-call',
-            method: 'log',
-            input: `${dimmed ? '[DIM]' : '[BRIGHT]'}: ${args.join(' ')}`,
-          })
-        }
-
-        // Install patches - this wraps the current console.log
-        require('next/dist/server/node-environment-extensions/console-dim')
-
-        console.log('before abort')
-        controller.abort()
-        console.log('after abort')
-      }
-
-      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
-
-      expect(exitCode).toBe(0)
-      expect(consoleCalls).toEqual([
-        { method: 'log', input: '[BRIGHT]: before abort' },
-        { method: 'log', input: expect.stringMatching(/\[DIM\].*after abort/) },
-      ])
-    })
   })
 })

--- a/packages/next/src/server/node-environment-extensions/console-dim.test.ts
+++ b/packages/next/src/server/node-environment-extensions/console-dim.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Testing console patching in Jest requires isolation since console methods are heavily used
+ * by the test runner itself. We use the same worker thread strategy as unhandled-rejection.test.ts
+ * to ensure our patches don't interfere with Jest's own console usage.
+ *
+ * @jest-environment node
+ */
+
+/* eslint-disable @next/internal/typechecked-require */
+
+type ReportableResult =
+  | ConsoleCallReport
+  | ErrorReport
+  | OutputReport
+  | SerializableDataReport
+
+type ConsoleCallReport = {
+  type: 'console-call'
+  method: string
+  input: string
+}
+
+type ErrorReport = { type: 'error'; message: string }
+type OutputReport = { type: 'output'; message: string }
+type SerializableDataReport = {
+  type: 'serialized'
+  key: string
+  data: string | number | boolean
+}
+
+declare global {
+  function reportResult(result: ReportableResult): void
+}
+
+import { Worker } from 'node:worker_threads'
+
+type WorkerResult = {
+  exitCode: number
+  stderr: string
+  consoleCalls: Array<{ method: string; input: string }>
+  data: Record<string, unknown>
+  messages: Array<ReportableResult>
+}
+
+export function runWorkerCode(fn: Function): Promise<WorkerResult> {
+  return new Promise((resolve, reject) => {
+    const script = `
+      const { parentPort } = require('node:worker_threads');
+      (async () => {
+        const { AsyncLocalStorage } = require('node:async_hooks');
+        // We need to put this on the global because Next.js does not import it
+        // from node directly to be compatible with edge runtimes.
+        globalThis.AsyncLocalStorage = AsyncLocalStorage;
+
+        global.reportResult = (value) => {
+          parentPort?.postMessage(value);
+        };
+
+        const fn = (${fn.toString()});
+        try {
+          const out = await fn();
+          await new Promise(r => setImmediate(r));
+          reportResult({ type: 'result', out });
+        } catch (e) {
+          reportResult({ type: 'error', message: String(e && e.message || e) });
+        }
+      })();
+    `
+
+    const w = new Worker(script, {
+      eval: true,
+      workerData: null,
+      argv: [],
+      execArgv: ['--conditions=react-server'],
+      stderr: true,
+      stdout: false,
+    })
+
+    const messages: Array<ReportableResult> = []
+    const consoleCalls: Array<{ method: string; input: string }> = []
+    const data = {} as Record<string, unknown>
+    let stderr = ''
+
+    w.on('message', (m) => {
+      messages.push(m)
+      switch (m.type) {
+        case 'console-call':
+          consoleCalls.push({
+            method: m.method,
+            input: m.input,
+          })
+          break
+        case 'serialized':
+          data[m.key] = JSON.parse(m.data)
+          break
+        default:
+          break
+      }
+    })
+    w.on('error', (err) => console.error('Worker error', err))
+    w.on('error', reject)
+    w.stderr?.on('data', (b) => (stderr += String(b)))
+    w.on('exit', (code) =>
+      resolve({
+        exitCode: code ?? -1,
+        consoleCalls,
+        data,
+        messages,
+        stderr,
+      })
+    )
+  })
+}
+
+describe('console-exit patches', () => {
+  describe('basic functionality', () => {
+    it('should patch console methods to dim when instructed', async () => {
+      async function testForWorker() {
+        const {
+          consoleAsyncStorage,
+        } = require('next/dist/server/app-render/console-async-storage.external')
+
+        // First, replace console.log to track what storage context it runs in
+        console.log = function (...args) {
+          let dimmed = false
+          if (
+            args.find((a) =>
+              typeof a === 'string' ? a.includes('color:') : false
+            )
+          ) {
+            dimmed = true
+          }
+          reportResult({
+            type: 'console-call',
+            method: 'log',
+            input: `${dimmed ? '[DIM]' : '[BRIGHT]'}: ${args.join(' ')}`,
+          })
+        }
+
+        // Install patches - this wraps the current console.log
+        require('next/dist/server/node-environment-extensions/console-dim')
+
+        // Test outside storage context
+        console.log('outside')
+
+        consoleAsyncStorage.run({ dim: true }, () => {
+          console.log('inside')
+        })
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      // Both should show [No Store] because the wrapped console.log exits storage
+      expect(consoleCalls).toEqual([
+        { method: 'log', input: '[BRIGHT]: outside' },
+        // can't match the formatting characters easily
+        { method: 'log', input: expect.stringMatching(/\[DIM\].*inside/) },
+      ])
+    })
+
+    it('should not wrap console methods assigned after patching', async () => {
+      async function testForWorker() {
+        const {
+          consoleAsyncStorage,
+        } = require('next/dist/server/app-render/console-async-storage.external')
+
+        // Install patches first
+        require('next/dist/server/node-environment-extensions/console-dim')
+
+        // Assign a new console.log after patching - this will NOT be wrapped
+        console.log = function (...args) {
+          let dimmed = false
+          if (
+            args.find((a) =>
+              typeof a === 'string' ? a.includes('color:') : false
+            )
+          ) {
+            dimmed = true
+          }
+          reportResult({
+            type: 'console-call',
+            method: 'log',
+            input: `${dimmed ? '[DIM]' : '[BRIGHT]'}: ${args.join(' ')}`,
+          })
+        }
+
+        // Test outside storage context
+        console.log('outside')
+
+        consoleAsyncStorage.run({ dim: true }, () => {
+          console.log('inside')
+        })
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      // New assignments after patching are NOT wrapped, so they preserve storage context
+      expect(consoleCalls).toEqual([
+        { method: 'log', input: '[BRIGHT]: outside' },
+        { method: 'log', input: '[BRIGHT]: inside' },
+      ])
+    })
+
+    it('should preserve function properties and behavior', async () => {
+      async function testForWorker() {
+        reportResult({
+          type: 'serialized',
+          key: 'originalName',
+          data: JSON.stringify(console.log.name),
+        })
+
+        reportResult({
+          type: 'serialized',
+          key: 'originalLength',
+          data: JSON.stringify(console.log.length),
+        })
+
+        // install patch
+        require('next/dist/server/node-environment-extensions/console-dim')
+
+        // Test that patched methods preserve name and other properties
+        reportResult({
+          type: 'serialized',
+          key: 'patchedName',
+          data: JSON.stringify(console.log.name),
+        })
+
+        reportResult({
+          type: 'serialized',
+          key: 'patchedLength',
+          data: JSON.stringify(console.log.length),
+        })
+      }
+
+      const { data, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(data.patchedName).toBe('log')
+      expect(data.patchedName).toBe(data.originalName)
+      expect(data.patchedLength).toBe(data.originalLength)
+    })
+
+    it('should enter a dimming context when a prerender store exists with an aborted renderSignal', async () => {
+      async function testForWorker() {
+        const {
+          workUnitAsyncStorage,
+        } = require('next/dist/server/app-render/work-unit-async-storage.external')
+
+        // First, replace console.log to track what storage context it runs in
+        console.log = function (...args) {
+          let dimmed = false
+          if (
+            args.find((a) =>
+              typeof a === 'string' ? a.includes('color:') : false
+            )
+          ) {
+            dimmed = true
+          }
+          reportResult({
+            type: 'console-call',
+            method: 'log',
+            input: `${dimmed ? '[DIM]' : '[BRIGHT]'}: ${args.join(' ')}`,
+          })
+        }
+
+        // Install patches - this wraps the current console.log
+        require('next/dist/server/node-environment-extensions/console-dim')
+
+        // Test outside storage context
+        console.log('outside')
+
+        const controller = new AbortController()
+
+        workUnitAsyncStorage.run(
+          { type: 'prerender', renderSignal: controller.signal },
+          () => {
+            console.log('before abort')
+            controller.abort()
+            console.log('after abort')
+          }
+        )
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      // Both should show [No Store] because the wrapped console.log exits storage
+      expect(consoleCalls).toEqual([
+        { method: 'log', input: '[BRIGHT]: outside' },
+        { method: 'log', input: '[BRIGHT]: before abort' },
+        { method: 'log', input: expect.stringMatching(/\[DIM\].*after abort/) },
+      ])
+    })
+
+    it('should enter a dimming context when a react cacheSignal exists and is aborted', async () => {
+      async function testForWorker() {
+        const originalLog = console.log
+        const controller = new AbortController()
+
+        // Hacky but we need to provide a cacheSignal for this test
+        require('react').__SERVER_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE.A =
+          {
+            cacheSignal() {
+              originalLog('cacheSignal called')
+              return controller.signal
+            },
+          }
+
+        // First, replace console.log to track what storage context it runs in
+        console.log = function (...args) {
+          originalLog(...args)
+          let dimmed = false
+          if (
+            args.find((a) =>
+              typeof a === 'string' ? a.includes('color:') : false
+            )
+          ) {
+            dimmed = true
+          }
+          reportResult({
+            type: 'console-call',
+            method: 'log',
+            input: `${dimmed ? '[DIM]' : '[BRIGHT]'}: ${args.join(' ')}`,
+          })
+        }
+
+        // Install patches - this wraps the current console.log
+        require('next/dist/server/node-environment-extensions/console-dim')
+
+        console.log('before abort')
+        controller.abort()
+        console.log('after abort')
+      }
+
+      const { consoleCalls, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      expect(consoleCalls).toEqual([
+        { method: 'log', input: '[BRIGHT]: before abort' },
+        { method: 'log', input: expect.stringMatching(/\[DIM\].*after abort/) },
+      ])
+    })
+  })
+})

--- a/packages/next/src/server/node-environment-extensions/console-dim.tsx
+++ b/packages/next/src/server/node-environment-extensions/console-dim.tsx
@@ -4,7 +4,6 @@ import {
   type ConsoleStore,
 } from '../app-render/console-async-storage.external'
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
-import { cacheSignal } from 'react'
 
 type InterceptableConsoleMethod =
   | 'error'
@@ -182,56 +181,39 @@ function patchConsoleMethod(methodName: InterceptableConsoleMethod): void {
           args
         )
       } else {
-        const signal = cacheSignal()
-        if (signal) {
-          // We are in a React Server render and can consult the React cache signal to determine if logs
-          // are now dimmable.
-          if (signal.aborted) {
-            return applyWithDimming.call(
-              this,
-              consoleStore,
-              originalMethod,
-              methodName,
-              args
-            )
-          } else {
-            return originalMethod.apply(this, args)
-          }
-        } else {
-          // We are outside of a React Server render but we might be in a workUnitStore with a render
-          // signal. We can get rid of this once React implements cacheSignal for react-dom/server (SSR)
-          const workUnitStore = workUnitAsyncStorage.getStore()
-          switch (workUnitStore?.type) {
-            case 'prerender':
-            case 'prerender-runtime':
-            // These can be hit in a route handler. In the future we can use potential React.createCache API
-            // to create a cache scope for arbitrary computation and can move over to cacheSignal exclusively.
-            // fallthrough
-            case 'prerender-client':
-              // This is a react-dom/server render and won't have a cacheSignal until React adds this for the client world.
-              const renderSignal = workUnitStore.renderSignal
-              if (renderSignal.aborted) {
-                return applyWithDimming.call(
-                  this,
-                  consoleStore,
-                  originalMethod,
-                  methodName,
-                  args
-                )
-              } else {
-                return originalMethod.apply(this, args)
-              }
-            case 'prerender-legacy':
-            case 'prerender-ppr':
-            case 'cache':
-            case 'unstable-cache':
-            case 'private-cache':
-            case 'request':
-            case undefined:
+        // We are outside of a React Server render but we might be in a workUnitStore with a render
+        // signal. We can get rid of this once React implements cacheSignal for react-dom/server (SSR)
+        const workUnitStore = workUnitAsyncStorage.getStore()
+        switch (workUnitStore?.type) {
+          case 'prerender':
+          case 'prerender-runtime':
+          // These can be hit in a route handler. In the future we can use potential React.createCache API
+          // to create a cache scope for arbitrary computation and can move over to cacheSignal exclusively.
+          // fallthrough
+          case 'prerender-client':
+            // This is a react-dom/server render and won't have a cacheSignal until React adds this for the client world.
+            const renderSignal = workUnitStore.renderSignal
+            if (renderSignal.aborted) {
+              return applyWithDimming.call(
+                this,
+                consoleStore,
+                originalMethod,
+                methodName,
+                args
+              )
+            } else {
               return originalMethod.apply(this, args)
-            default:
-              workUnitStore satisfies never
-          }
+            }
+          case 'prerender-legacy':
+          case 'prerender-ppr':
+          case 'cache':
+          case 'unstable-cache':
+          case 'private-cache':
+          case 'request':
+          case undefined:
+            return originalMethod.apply(this, args)
+          default:
+            workUnitStore satisfies never
         }
       }
     }

--- a/packages/next/src/server/node-environment-extensions/console-dim.tsx
+++ b/packages/next/src/server/node-environment-extensions/console-dim.tsx
@@ -1,5 +1,10 @@
 import { dim } from '../../lib/picocolors'
-import { devLogsAsyncStorage } from '../app-render/dev-logs-async-storage.external'
+import {
+  consoleAsyncStorage,
+  type ConsoleStore,
+} from '../app-render/console-async-storage.external'
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import { cacheSignal } from 'react'
 
 type InterceptableConsoleMethod =
   | 'error'
@@ -122,7 +127,7 @@ function dimmedConsoleArgs(...inputArgs: any[]): any[] {
   return [dim(`%c${template}`), dimStyle, ...newArgs]
 }
 
-function dimConsoleCall(
+function convertToDimmedArgs(
   methodName: InterceptableConsoleMethod,
   args: any[]
 ): any[] {
@@ -153,7 +158,7 @@ function dimConsoleCall(
 }
 
 // Based on https://github.com/facebook/react/blob/28dc0776be2e1370fe217549d32aee2519f0cf05/packages/react-server/src/ReactFlightServer.js#L248
-function patchConsoleMethodDEV(methodName: InterceptableConsoleMethod): void {
+function patchConsoleMethod(methodName: InterceptableConsoleMethod): void {
   const descriptor = Object.getOwnPropertyDescriptor(console, methodName)
   if (
     descriptor &&
@@ -161,14 +166,73 @@ function patchConsoleMethodDEV(methodName: InterceptableConsoleMethod): void {
     typeof descriptor.value === 'function'
   ) {
     const originalMethod = descriptor.value
-    const originalName = Object.getOwnPropertyDescriptor(originalMethod, 'name')
+    const originalName = Object.getOwnPropertyDescriptor(
+      originalMethod,
+      'name'
+    ) as string
     const wrapperMethod = function (this: typeof console, ...args: any[]) {
-      const devLogsStore = devLogsAsyncStorage.getStore()
+      const consoleStore = consoleAsyncStorage.getStore()
 
-      if (devLogsStore?.dim === true) {
-        return originalMethod.apply(this, dimConsoleCall(methodName, args))
+      if (consoleStore?.dim === true) {
+        return applyWithDimming.call(
+          this,
+          consoleStore,
+          originalMethod,
+          methodName,
+          args
+        )
       } else {
-        return originalMethod.apply(this, args)
+        const signal = cacheSignal()
+        if (signal) {
+          // We are in a React Server render and can consult the React cache signal to determine if logs
+          // are now dimmable.
+          if (signal.aborted) {
+            return applyWithDimming.call(
+              this,
+              consoleStore,
+              originalMethod,
+              methodName,
+              args
+            )
+          } else {
+            return originalMethod.apply(this, args)
+          }
+        } else {
+          // We are outside of a React Server render but we might be in a workUnitStore with a render
+          // signal. We can get rid of this once React implements cacheSignal for react-dom/server (SSR)
+          const workUnitStore = workUnitAsyncStorage.getStore()
+          switch (workUnitStore?.type) {
+            case 'prerender':
+            case 'prerender-runtime':
+            // These can be hit in a route handler. In the future we can use potential React.createCache API
+            // to create a cache scope for arbitrary computation and can move over to cacheSignal exclusively.
+            // fallthrough
+            case 'prerender-client':
+              // This is a react-dom/server render and won't have a cacheSignal until React adds this for the client world.
+              const renderSignal = workUnitStore.renderSignal
+              if (renderSignal.aborted) {
+                return applyWithDimming.call(
+                  this,
+                  consoleStore,
+                  originalMethod,
+                  methodName,
+                  args
+                )
+              } else {
+                return originalMethod.apply(this, args)
+              }
+            case 'prerender-legacy':
+            case 'prerender-ppr':
+            case 'cache':
+            case 'unstable-cache':
+            case 'private-cache':
+            case 'request':
+            case undefined:
+              return originalMethod.apply(this, args)
+            default:
+              workUnitStore satisfies never
+          }
+        }
       }
     }
     if (originalName) {
@@ -180,16 +244,35 @@ function patchConsoleMethodDEV(methodName: InterceptableConsoleMethod): void {
   }
 }
 
-patchConsoleMethodDEV('error')
-patchConsoleMethodDEV('assert')
-patchConsoleMethodDEV('debug')
-patchConsoleMethodDEV('dir')
-patchConsoleMethodDEV('dirxml')
-patchConsoleMethodDEV('group')
-patchConsoleMethodDEV('groupCollapsed')
-patchConsoleMethodDEV('groupEnd')
-patchConsoleMethodDEV('info')
-patchConsoleMethodDEV('log')
-patchConsoleMethodDEV('table')
-patchConsoleMethodDEV('trace')
-patchConsoleMethodDEV('warn')
+function applyWithDimming<F extends (this: Console, ...args: any[]) => any>(
+  this: Console,
+  consoleStore: undefined | ConsoleStore,
+  method: F,
+  methodName: InterceptableConsoleMethod,
+  args: Parameters<F>
+): ReturnType<F> {
+  if (consoleStore?.dim === true) {
+    return method.apply(this, convertToDimmedArgs(methodName, args))
+  } else {
+    return consoleAsyncStorage.run(
+      DIMMED_STORE,
+      method.bind(this, ...convertToDimmedArgs(methodName, args))
+    )
+  }
+}
+
+const DIMMED_STORE = { dim: true }
+
+patchConsoleMethod('error')
+patchConsoleMethod('assert')
+patchConsoleMethod('debug')
+patchConsoleMethod('dir')
+patchConsoleMethod('dirxml')
+patchConsoleMethod('group')
+patchConsoleMethod('groupCollapsed')
+patchConsoleMethod('groupEnd')
+patchConsoleMethod('info')
+patchConsoleMethod('log')
+patchConsoleMethod('table')
+patchConsoleMethod('trace')
+patchConsoleMethod('warn')

--- a/packages/next/src/server/node-environment.ts
+++ b/packages/next/src/server/node-environment.ts
@@ -6,12 +6,9 @@ import './node-environment-baseline'
 // Has to come after baseline since error-inspect requires AsyncLocalStorage that baseline provides.
 import './node-environment-extensions/error-inspect'
 import './node-environment-extensions/console-exit'
+import './node-environment-extensions/console-dim'
 import './node-environment-extensions/unhandled-rejection'
 import './node-environment-extensions/random'
 import './node-environment-extensions/date'
 import './node-environment-extensions/web-crypto'
 import './node-environment-extensions/node-crypto'
-
-if (process.env.NODE_ENV === 'development') {
-  require('./node-environment-extensions/console-dev') as typeof import('./node-environment-extensions/console-dev')
-}


### PR DESCRIPTION
When prerenders abort we reject hanging promises so resources can clean up. This can lead to user code which logs errors from rejections reporting many more errors than expected and these logs are for semantically irrelevant errors.

To make it clearer that these errors are not semantically relevant we will dim them. This is a partial solution because 3rd party loggers will not necessarily interpret this and so these logs might continue to show up as normal logs in donwstream systems. We may need to ask that consumers of these logs interpret the dimmed nature and convey this status to the viewer.

We will follow up this work with a config that allows you to hide logs from aborted prerenders. This will completely suppress their emission to the underlying log system but it will run after any userland patches so you could still end up reporting errors for instance to an otel collector because the filtering would be applied after not before. The right way to solve this is for the log to check if there is a react cacheSignal that is aborted and do their own suppression.