### PR TITLE
Turbopack: Generate a warning if both react-compiler and styled-jsx are enabled, suggest manually configuring them with babelrc

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -203,6 +203,42 @@ function warnCustomizedOption(
   }
 }
 
+function warnReactCompilerStyledJsxIncompatibility(
+  config: NextConfig,
+  configFileName: string,
+  silent: boolean
+) {
+  if (
+    !silent &&
+    config.compiler?.styledJsx &&
+    config.experimental?.reactCompiler
+  ) {
+    Log.warnOnce(
+      'Due to an ordering incompatibility between SWC and Babel transformations, Next.js cannot ' +
+        'safely use both the built-in `styledJsx` and `reactCompiler` options. You should ' +
+        `disable both of these options in ${configFileName} and manually configure them as babel ` +
+        'plugins instead.\n' +
+        '\n' +
+        'See this page for how to configure babel: https://nextjs.org/docs/pages/guides/babel\n' +
+        '\n' +
+        'Details on configuring styled-jsx and React Compiler:\n' +
+        ' \u2022 https://github.com/vercel/styled-jsx#getting-started\n' +
+        ' \u2022 https://react.dev/reference/react-compiler/configuration\n' +
+        '\n' +
+        'You must configure the `styled-jsx/babel` plugin to run before ' +
+        '`babel-plugin-react-compiler`:\n' +
+        '\n' +
+        '  // babel.config.js\n' +
+        '  module.exports = {\n' +
+        '    "plugins": ["styled-jsx/babel", "babel-plugin-react-compiler"],\n' +
+        '  }\n' +
+        '\n' +
+        'The Babel implementation of styled-jsx may be slower and may have minor ' +
+        'incompabilities with the SWC version that Next.js uses by default.\n'
+    )
+  }
+}
+
 /**
  * Assigns defaults to the user config and validates the config.
  *
@@ -1205,6 +1241,8 @@ function assignDefaultsAndValidate(
   ) {
     result.distDir = join(result.distDir, 'dev')
   }
+
+  warnReactCompilerStyledJsxIncompatibility(result, configFileName, silent)
 
   return result as NextConfigComplete
 }

--- a/test/e2e/react-compiler-with-styled-jsx/app/layout.tsx
+++ b/test/e2e/react-compiler-with-styled-jsx/app/layout.tsx
@@ -1,0 +1,15 @@
+import StyledJsxRegistry from '../lib/registry'
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body>
+        <StyledJsxRegistry>{children}</StyledJsxRegistry>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/react-compiler-with-styled-jsx/app/page.tsx
+++ b/test/e2e/react-compiler-with-styled-jsx/app/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export default function Home() {
+  const [toggle, setToggle] = useState(false)
+
+  let $_: any
+  if (typeof window !== 'undefined') {
+    // eslint-disable-next-line no-eval
+    $_ = eval('typeof $ !== undefined ? $ : undefined')
+  }
+
+  useEffect(() => {
+    if (Array.isArray($_)) {
+      document.getElementById('react-compiler-enabled-message')!.textContent =
+        'React compiler is enabled'
+    }
+  })
+
+  return (
+    <>
+      <button className="hello" onClick={() => setToggle((dm) => !dm)}>
+        <p>Hello World</p>
+        <h1 id="react-compiler-enabled-message" />
+      </button>
+      <style jsx>{`
+        .hello {
+          background-color: ${toggle ? '#FF0000' : '#0000FF'};
+        }
+      `}</style>
+    </>
+  )
+}

--- a/test/e2e/react-compiler-with-styled-jsx/index.test.ts
+++ b/test/e2e/react-compiler-with-styled-jsx/index.test.ts
@@ -1,0 +1,162 @@
+import { nextTestSetup, isNextDev, FileRef } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import { join } from 'path'
+import stripAnsi from 'strip-ansi'
+
+function nextConfigFromJson(config) {
+  return `module.exports = ${JSON.stringify(config)}`
+}
+
+describe('react-compiler-with-styled-jsx', () => {
+  if (isNextDev) {
+    describe('config validation', () => {
+      const baseConfig = {
+        compiler: {
+          styledJsx: {
+            useLightningCss: true,
+          },
+        },
+      }
+
+      const { next } = nextTestSetup({
+        files: {
+          app: new FileRef(join(__dirname, 'app')),
+          lib: new FileRef(join(__dirname, 'lib')),
+          'next.config.js': nextConfigFromJson(baseConfig),
+        },
+        dependencies: {
+          'babel-plugin-react-compiler': '19.1.0-rc.2',
+        },
+      })
+
+      it('warns about combining `reactCompiler` with `styledJsx`', async () => {
+        const warningSnippet =
+          'cannot safely use both the built-in `styledJsx` and `reactCompiler`'
+
+        expect(stripAnsi(next.cliOutput)).not.toContain(warningSnippet)
+        const outputIndex = next.cliOutput.length
+
+        const configWithReactCompiler = {
+          ...baseConfig,
+          experimental: {
+            reactCompiler: true,
+          },
+        }
+
+        await next.patchFile(
+          'next.config.js',
+          nextConfigFromJson(configWithReactCompiler),
+          async () => {
+            await retry(async () => {
+              expect(stripAnsi(next.cliOutput.slice(outputIndex))).toContain(
+                warningSnippet
+              )
+            })
+          }
+        )
+      })
+    })
+  }
+
+  // this demonstrates the bug caused if you configure babel with the wrong plugin ordering
+  describe('incorrectly ordered manual babel config', () => {
+    const babelConfig = {
+      presets: ['next/babel'],
+      plugins: ['babel-plugin-react-compiler', 'styled-jsx/babel'],
+    }
+    const { next } = nextTestSetup({
+      files: {
+        app: new FileRef(join(__dirname, 'app')),
+        lib: new FileRef(join(__dirname, 'lib')),
+        'next.config.js': nextConfigFromJson({}),
+        '.babelrc': JSON.stringify(babelConfig),
+      },
+      dependencies: {
+        'babel-plugin-react-compiler': '19.1.0-rc.2',
+        'styled-jsx': '5.1.7',
+        'babel-loader': '10.0.0',
+      },
+    })
+
+    it('fails to update style on button click', async () => {
+      const session = await next.browser('/')
+      const button = await session.elementByCss('.hello')
+      for (let i = 0; i < 5; i++) {
+        await button.click()
+        // the style never changes from the original value (blue)
+        expect(await button.getComputedCss('background-color')).toBe(
+          'rgb(0, 0, 255)'
+        )
+      }
+    })
+  })
+
+  describe.each([
+    ['without react compiler', false, false],
+    ['with styled-jsx in babelrc, but without react compiler', true, false],
+    ['with babelrc and react compiler', true, true],
+  ])('%s', (_name, hasBabelrc, hasReactCompiler) => {
+    const babelFiles = hasBabelrc
+      ? {
+          '.babelrc': JSON.stringify({
+            presets: ['next/babel'],
+            plugins: [
+              'styled-jsx/babel',
+              // react compiler must run after the styled-jsx plugin
+              ...(hasReactCompiler ? ['babel-plugin-react-compiler'] : []),
+            ],
+          }),
+        }
+      : {}
+
+    const { next } = nextTestSetup({
+      files: {
+        app: new FileRef(join(__dirname, 'app')),
+        lib: new FileRef(join(__dirname, 'lib')),
+        'next.config.js': nextConfigFromJson(
+          hasBabelrc
+            ? {} // the babelrc will configure styled-jsx
+            : {
+                compiler: {
+                  styledJsx: {
+                    useLightningCss: true,
+                  },
+                },
+              }
+        ),
+        ...babelFiles,
+      },
+      dependencies: {
+        'babel-plugin-react-compiler': '19.1.0-rc.2',
+        'styled-jsx': '5.1.7',
+        'babel-loader': '10.0.0',
+      },
+    })
+
+    if (hasReactCompiler) {
+      it('applies the react compiler transform', async () => {
+        const session = await next.browser('/')
+        await retry(async () => {
+          const text = session
+            .elementByCss('#react-compiler-enabled-message')
+            .text()
+          expect(text).toMatch(/React compiler is enabled/)
+        })
+      })
+    }
+
+    it('updates style on state updates', async () => {
+      const session = await next.browser('/')
+      const button = await session.elementByCss('.hello')
+
+      // clicking on the button should change it from blue to red
+      expect(await button.getComputedCss('background-color')).toBe(
+        'rgb(0, 0, 255)'
+      )
+      await button.click()
+      expect(await button.getComputedCss('background-color')).toBe(
+        'rgb(255, 0, 0)'
+      )
+    })
+  })
+})

--- a/test/e2e/react-compiler-with-styled-jsx/lib/registry.tsx
+++ b/test/e2e/react-compiler-with-styled-jsx/lib/registry.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import React, { useState } from "react";
+import { useServerInsertedHTML } from "next/navigation";
+import { StyleRegistry, createStyleRegistry } from "styled-jsx";
+
+export default function StyledJsxRegistry({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Only create stylesheet once with lazy initial state
+  // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const [jsxStyleRegistry] = useState(() => createStyleRegistry());
+
+  useServerInsertedHTML(() => {
+    const styles = jsxStyleRegistry.styles();
+    jsxStyleRegistry.flush();
+    return <>{styles}</>;
+  });
+
+  return <StyleRegistry registry={jsxStyleRegistry}>{children}</StyleRegistry>;
+}

--- a/test/e2e/react-compiler-with-styled-jsx/lib/styled-jsx.d.ts
+++ b/test/e2e/react-compiler-with-styled-jsx/lib/styled-jsx.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="styled-jsx" />


### PR DESCRIPTION
**I've decided this approach is a dead-end, but I'm putting the PR up here for reference.**

Suggesting manual configuration of both babel plugins could serve as a stopgap solution for using react-compiler with styled-jsx.

But now I've realized that it's not really practical to ask the user to manually configure react-compiler with babel. We run babel transforms on both client+server, and there's no sane way to specify that a transform (`react-compiler`) is client-only in the babel configuration file format (the `next/babel` preset uses some webpack loader magic to pass down this information).

So instead, I need to go straight for the harder-but-"better" solution, which is to generate a warning, and to expose an option in `compiler.styledJsx` to use the babel implementation. Fortunately, https://github.com/vercel/next.js/pull/83502 already lays most of the groundwork needed for that.