### PR TITLE
[ESLint Next Plugin]: Remove recommended set from web-vitals flat config

### DIFF
--- a/packages/eslint-plugin-next/src/index.ts
+++ b/packages/eslint-plugin-next/src/index.ts
@@ -113,10 +113,7 @@ Object.assign(plugin.configs, {
     plugins: {
       '@next/next': plugin,
     },
-    rules: {
-      ...recommendedRules,
-      ...coreWebVitalsRules,
-    },
+    rules: coreWebVitalsRules,
   },
 } satisfies ESLintPluginConfigs)
 


### PR DESCRIPTION
### Why?

Based on PR #83763, It should only include web-vitals instead of the recommended set, since the recommended set already covers web-vitals?
