### PR TITLE
Fix: Include layout body in HTTP error fallback boundary for nested layouts

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -845,10 +845,22 @@ async function createComponentTreeInternal(
     ]
   } else {
     const SegmentComponent = Component
+
+    const hasErrorBoundaries = !!(
+      notFoundElement ||
+      forbiddenElement ||
+      unauthorizedElement
+    )
+
     const isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot =
       rootLayoutAtThisLevel &&
       'children' in parallelRoutes &&
       Object.keys(parallelRoutes).length > 1
+
+    const shouldWrapWithErrorBoundary =
+      hasErrorBoundaries &&
+      (isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot ||
+        !rootLayoutAtThisLevel)
 
     let segmentNode: React.ReactNode
 
@@ -877,63 +889,55 @@ async function createComponentTreeInternal(
         )
       }
 
-      if (isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot) {
+      if (shouldWrapWithErrorBoundary) {
         let notfoundClientSegment: React.ReactNode
         let forbiddenClientSegment: React.ReactNode
         let unauthorizedClientSegment: React.ReactNode
-        // TODO-APP: This is a hack to support unmatched parallel routes, which will throw `notFound()`.
-        // This ensures that a `HTTPAccessFallbackBoundary` is available for when that happens,
-        // but it's not ideal, as it needlessly invokes the `NotFound` component and renders the `RootLayout` twice.
-        // We should instead look into handling the fallback behavior differently in development mode so that it doesn't
-        // rely on the `NotFound` behavior.
-        notfoundClientSegment = createErrorBoundaryClientSegmentRoot({
-          ErrorBoundaryComponent: NotFound,
-          errorElement: notFoundElement,
-          ClientSegmentRoot,
-          layerAssets,
-          SegmentComponent,
-          currentParams,
-        })
-        forbiddenClientSegment = createErrorBoundaryClientSegmentRoot({
-          ErrorBoundaryComponent: Forbidden,
-          errorElement: forbiddenElement,
-          ClientSegmentRoot,
-          layerAssets,
-          SegmentComponent,
-          currentParams,
-        })
-        unauthorizedClientSegment = createErrorBoundaryClientSegmentRoot({
-          ErrorBoundaryComponent: Unauthorized,
-          errorElement: unauthorizedElement,
-          ClientSegmentRoot,
-          layerAssets,
-          SegmentComponent,
-          currentParams,
-        })
-        if (
-          notfoundClientSegment ||
-          forbiddenClientSegment ||
-          unauthorizedClientSegment
-        ) {
-          segmentNode = (
-            <HTTPAccessFallbackBoundary
-              key={cacheNodeKey}
-              notFound={notfoundClientSegment}
-              forbidden={forbiddenClientSegment}
-              unauthorized={unauthorizedClientSegment}
-            >
-              {layerAssets}
-              {clientSegment}
-            </HTTPAccessFallbackBoundary>
-          )
-        } else {
-          segmentNode = (
-            <React.Fragment key={cacheNodeKey}>
-              {layerAssets}
-              {clientSegment}
-            </React.Fragment>
-          )
-        }
+
+        notfoundClientSegment = notFoundElement
+          ? createErrorBoundaryClientSegmentRoot({
+              ErrorBoundaryComponent: NotFound,
+              errorElement: notFoundElement,
+              ClientSegmentRoot,
+              layerAssets,
+              SegmentComponent,
+              currentParams,
+            })
+          : undefined
+
+        forbiddenClientSegment = forbiddenElement
+          ? createErrorBoundaryClientSegmentRoot({
+              ErrorBoundaryComponent: Forbidden,
+              errorElement: forbiddenElement,
+              ClientSegmentRoot,
+              layerAssets,
+              SegmentComponent,
+              currentParams,
+            })
+          : undefined
+
+        unauthorizedClientSegment = unauthorizedElement
+          ? createErrorBoundaryClientSegmentRoot({
+              ErrorBoundaryComponent: Unauthorized,
+              errorElement: unauthorizedElement,
+              ClientSegmentRoot,
+              layerAssets,
+              SegmentComponent,
+              currentParams,
+            })
+          : undefined
+
+        segmentNode = (
+          <HTTPAccessFallbackBoundary
+            key={cacheNodeKey}
+            notFound={notfoundClientSegment}
+            forbidden={forbiddenClientSegment}
+            unauthorized={unauthorizedClientSegment}
+          >
+            {layerAssets}
+            {clientSegment}
+          </HTTPAccessFallbackBoundary>
+        )
       } else {
         segmentNode = (
           <React.Fragment key={cacheNodeKey}>
@@ -967,12 +971,7 @@ async function createComponentTreeInternal(
         )
       }
 
-      if (isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot) {
-        // TODO-APP: This is a hack to support unmatched parallel routes, which will throw `notFound()`.
-        // This ensures that a `HTTPAccessFallbackBoundary` is available for when that happens,
-        // but it's not ideal, as it needlessly invokes the `NotFound` component and renders the `RootLayout` twice.
-        // We should instead look into handling the fallback behavior differently in development mode so that it doesn't
-        // rely on the `NotFound` behavior.
+      if (shouldWrapWithErrorBoundary) {
         segmentNode = (
           <HTTPAccessFallbackBoundary
             key={cacheNodeKey}
@@ -983,6 +982,28 @@ async function createComponentTreeInternal(
                   <SegmentComponent params={params}>
                     {notFoundStyles}
                     {notFoundElement}
+                  </SegmentComponent>
+                </>
+              ) : undefined
+            }
+            forbidden={
+              forbiddenElement ? (
+                <>
+                  {layerAssets}
+                  <SegmentComponent params={params}>
+                    {forbiddenStyles}
+                    {forbiddenElement}
+                  </SegmentComponent>
+                </>
+              ) : undefined
+            }
+            unauthorized={
+              unauthorizedElement ? (
+                <>
+                  {layerAssets}
+                  <SegmentComponent params={params}>
+                    {unauthorizedStyles}
+                    {unauthorizedElement}
                   </SegmentComponent>
                 </>
               ) : undefined

--- a/test/e2e/app-dir/not-found/layout-boundary/app/layout.tsx
+++ b/test/e2e/app-dir/not-found/layout-boundary/app/layout.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/not-found/layout-boundary/app/nested/layout.tsx
+++ b/test/e2e/app-dir/not-found/layout-boundary/app/nested/layout.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { notFound } from 'next/navigation'
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  notFound()
+  return (
+    <html>
+      <body>
+        <div id="layout">Layout Wrapper</div>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/not-found/layout-boundary/app/nested/layout.tsx
+++ b/test/e2e/app-dir/not-found/layout-boundary/app/nested/layout.tsx
@@ -4,11 +4,9 @@ import { notFound } from 'next/navigation'
 export default function Layout({ children }: { children: React.ReactNode }) {
   notFound()
   return (
-    <html>
-      <body>
-        <div id="layout">Layout Wrapper</div>
-        {children}
-      </body>
-    </html>
+    <div id="layout">
+      Layout Wrapper
+      {children}
+    </div>
   )
 }

--- a/test/e2e/app-dir/not-found/layout-boundary/app/nested/not-found.tsx
+++ b/test/e2e/app-dir/not-found/layout-boundary/app/nested/not-found.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return (
+    <div>
+      <h1 id="local-not-found">Layout Level Not Found</h1>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/not-found/layout-boundary/app/nested/page.tsx
+++ b/test/e2e/app-dir/not-found/layout-boundary/app/nested/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div id="page">page content</div>
+}

--- a/test/e2e/app-dir/not-found/layout-boundary/app/not-found.tsx
+++ b/test/e2e/app-dir/not-found/layout-boundary/app/not-found.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return (
+    <div>
+      <h1 id="root-not-found">Root Level Not Found</h1>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/not-found/layout-boundary/app/page.tsx
+++ b/test/e2e/app-dir/not-found/layout-boundary/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>root page</div>
+}

--- a/test/e2e/app-dir/not-found/layout-boundary/layout-boundary.test.ts
+++ b/test/e2e/app-dir/not-found/layout-boundary/layout-boundary.test.ts
@@ -1,0 +1,20 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// This test is intended fail in this commit (before the fix) because the local
+// not-found.tsx component will not be used when notFound() is called inside
+// the layout body
+
+describe('app dir - not-found layout body boundary', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('renders the segment-level custom not-found.tsx component when notFound() is thrown inside a layout body (not children)', async () => {
+    const browser = await next.browser('/nested')
+
+    // Expect route segment not-found to have handled the throw.
+    const local = await browser.elementById('local-not-found')
+
+    expect(local).not.toBeNull()
+  })
+})

--- a/test/e2e/app-dir/not-found/layout-boundary/layout-boundary.test.ts
+++ b/test/e2e/app-dir/not-found/layout-boundary/layout-boundary.test.ts
@@ -1,9 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// This test is intended fail in this commit (before the fix) because the local
-// not-found.tsx component will not be used when notFound() is called inside
-// the layout body
-
 describe('app dir - not-found layout body boundary', () => {
   const { next } = nextTestSetup({
     files: __dirname,


### PR DESCRIPTION
### What?
When calling `notFound()`, `forbidden()` or `unauthorized()` from within a layout component's body (not its children), the error is caught by the parent route segment's error boundary instead of the current segment's boundary. 

Example:

```tsx
// app/dashboard/layout.tsx
export default function DashboardLayout({ children }) {

  if (!hasAccess) {
    notFound() // This calls the _parent_ segment's not-found.tsx, not dashboard's
  }
  
  return (
    <div>
      <nav>Dashboard Nav</nav>
      {children}
    </div>
  )
}

```


### Why?
This creates confusing behavior where the wrong `not-found.tsx`, `forbidden.tsx` and `unauthorized.tsx` files are rendered.

### How?
The `HTTPAccessFallbackBoundary` only wraps the children of layout segments, not the layout components themselves. When a layout throws an http error in its body, the error bubbles up to the parent segment's boundary. To fix this, I'm wrapping entire Layout with the `HTTPAccessFallbackBoundary` component.

**Note**: If this is an intentional behavior then we should clearly document it to reduce confusion, I'll be happy to create a PR for that instead

This should probably be considered a breaking change from a consumers perspective as it'll change what components are picked when any of these functions is called in a layout components body

Fixes #83671
