### PR TITLE
feat: Add performance marks and measures for app router

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -22,11 +22,52 @@ import { createInitialRouterState } from './components/router-reducer/create-ini
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
 import { setAppBuildId } from './app-build-id'
 import type { StaticIndicatorState } from './dev/hot-reloader/app/hot-reloader-app'
+import { ST } from '../shared/lib/utils'
 
 /// <reference types="react-dom/experimental" />
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
+
+const performanceMarks = {
+  /** Browser's built-in navigation start timestamp */
+  navigationStart: 'navigationStart',
+  /** Set before createRoot call during client-side rendering only */
+  beforeRender: 'beforeRender',
+  /** Set before hydrateRoot call during server-side rendering only */
+  beforeHydration: 'beforeHydration',
+  /** Set after initial React commit when hydration or render starts */
+  afterInitialCommit: 'afterInitialCommit',
+  /** Set when rsc stream processing begins */
+  rscStreamStart: 'rscStreamStart',
+  /** Set when rsc stream processing finishes */
+  rscStreamEnd: 'rscStreamEnd',
+} as const
+
+const performanceMeasures = {
+  /**
+   * Measures the time from navigation start to before client-side render begins.
+   * Only applicable for client-side rendering scenarios (error pages).
+   */
+  beforeRender: 'Next.js-before-render',
+
+  /**
+   * Measures the time from navigation start to before hydration begins.
+   * Tracks the initial loading phase before React takes over the SSRd HTML.
+   */
+  beforeHydration: 'Next.js-before-hydration',
+
+  /**
+   * Measures the time from hydration start to after the initial commit is complete.
+   */
+  initialCommit: 'Next.js-initial-commit',
+
+  /**
+   * Measures the complete duration of the rsc stream reader processing.
+   * Tracks from when the client begins reading the rsc stream until it finishes.
+   */
+  rscStream: 'Next.js-rsc-stream-reader',
+} as const
 
 const appElement: HTMLElement | Document = document
 
@@ -121,6 +162,7 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
         )
       } else {
         ctr.close()
+        markRscStreamEnd()
       }
       initialServerDataFlushed = true
       initialServerDataBuffer = undefined
@@ -134,6 +176,7 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
 const DOMContentLoaded = function () {
   if (initialServerDataWriter && !initialServerDataFlushed) {
     initialServerDataWriter.close()
+    markRscStreamEnd()
     initialServerDataFlushed = true
     initialServerDataBuffer = undefined
   }
@@ -171,6 +214,10 @@ if (
     require('./dev/debug-channel') as typeof import('./dev/debug-channel')
 
   debugChannel = createDebugChannel(undefined)
+}
+
+if (ST) {
+  performance.mark(performanceMarks.rscStreamStart)
 }
 
 const initialServerResponse = createFromReadableStream<InitialRSCPayload>(
@@ -216,7 +263,26 @@ const StrictModeIfEnabled = process.env.__NEXT_STRICT_MODE_APP
   ? React.StrictMode
   : React.Fragment
 
-function Root({ children }: React.PropsWithChildren<{}>) {
+function Root({
+  children,
+  callbacks,
+}: React.PropsWithChildren<{
+  callbacks?: Array<() => void>
+}>) {
+  const callbacksExecutedRef = React.useRef(false)
+
+  React.useEffect(() => {
+    if (callbacksExecutedRef.current || !callbacks) {
+      return
+    }
+
+    callbacksExecutedRef.current = true
+
+    for (const callback of callbacks) {
+      callback()
+    }
+  }, [callbacks])
+
   if (process.env.__NEXT_TEST_MODE) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {
@@ -227,6 +293,72 @@ function Root({ children }: React.PropsWithChildren<{}>) {
   }
 
   return children
+}
+
+function markRootCommitComplete(): void {
+  if (!ST) return
+
+  performance.mark(performanceMarks.afterInitialCommit)
+
+  const hasBeforeRenderMark = performance.getEntriesByName(
+    performanceMarks.beforeRender,
+    'mark'
+  ).length
+
+  const hasBeforeHydrationMark = performance.getEntriesByName(
+    performanceMarks.beforeHydration,
+    'mark'
+  ).length
+
+  if (hasBeforeRenderMark) {
+    performance.measure(
+      performanceMeasures.beforeRender,
+      performanceMarks.navigationStart,
+      performanceMarks.beforeRender
+    )
+
+    performance.measure(
+      performanceMeasures.initialCommit,
+      performanceMarks.beforeRender,
+      performanceMarks.afterInitialCommit
+    )
+  }
+
+  if (hasBeforeHydrationMark) {
+    performance.measure(
+      performanceMeasures.beforeHydration,
+      performanceMarks.navigationStart,
+      performanceMarks.beforeHydration
+    )
+
+    performance.measure(
+      performanceMeasures.initialCommit,
+      performanceMarks.beforeHydration,
+      performanceMarks.afterInitialCommit
+    )
+  }
+}
+
+function markRscStreamEnd() {
+  if (!ST) return
+
+  performance.mark(performanceMarks.rscStreamEnd)
+
+  const hasRSCStreamEndMark = performance.getEntriesByName(
+    performanceMarks.rscStreamEnd,
+    'mark'
+  ).length
+
+  if (
+    hasRSCStreamEndMark &&
+    performance.getEntriesByName(performanceMarks.rscStreamStart, 'mark').length
+  ) {
+    performance.measure(
+      performanceMeasures.rscStream,
+      performanceMarks.rscStreamStart,
+      performanceMarks.rscStreamEnd
+    )
+  }
 }
 
 function onDefaultTransitionIndicator() {
@@ -299,23 +431,32 @@ export function hydrate(
     }
   )
 
-  const reactEl = (
-    <StrictModeIfEnabled>
-      <HeadManagerContext.Provider value={{ appDir: true }}>
-        <Root>
-          <ServerRoot
-            pendingActionQueue={pendingActionQueue}
-            webSocket={webSocket}
-            staticIndicatorState={staticIndicatorState}
-          />
-        </Root>
-      </HeadManagerContext.Provider>
-    </StrictModeIfEnabled>
-  )
+  function createReactElement(callbacks?: Array<() => void>) {
+    return (
+      <StrictModeIfEnabled>
+        <HeadManagerContext.Provider value={{ appDir: true }}>
+          <Root callbacks={callbacks}>
+            <ServerRoot
+              pendingActionQueue={pendingActionQueue}
+              webSocket={webSocket}
+              staticIndicatorState={staticIndicatorState}
+            />
+          </Root>
+        </HeadManagerContext.Provider>
+      </StrictModeIfEnabled>
+    )
+  }
 
   if (document.documentElement.id === '__next_error__') {
-    let element = reactEl
     // Server rendering failed, fall back to client-side rendering
+    if (ST) {
+      performance.mark(performanceMarks.beforeRender)
+    }
+
+    const renderCallbacks = ST ? [markRootCommitComplete] : undefined
+    const reactEl = createReactElement(renderCallbacks)
+
+    let element = reactEl
     if (process.env.NODE_ENV !== 'production') {
       const { RootLevelDevOverlayElement } =
         require('../next-devtools/userspace/app/client-entry') as typeof import('../next-devtools/userspace/app/client-entry')
@@ -328,6 +469,13 @@ export function hydrate(
 
     ReactDOMClient.createRoot(appElement, reactRootOptions).render(element)
   } else {
+    if (ST) {
+      performance.mark(performanceMarks.beforeHydration)
+    }
+
+    const rootCommitCallbacks = ST ? [markRootCommitComplete] : undefined
+    const reactEl = createReactElement(rootCommitCallbacks)
+
     React.startTransition(() => {
       ReactDOMClient.hydrateRoot(appElement, reactEl, {
         ...reactRootOptions,

--- a/test/e2e/app-dir/performance-marks/app/client/page.tsx
+++ b/test/e2e/app-dir/performance-marks/app/client/page.tsx
@@ -1,0 +1,6 @@
+import { notFound } from 'next/navigation'
+
+export default function ClientPage() {
+  notFound()
+  return <div></div>
+}

--- a/test/e2e/app-dir/performance-marks/app/layout.tsx
+++ b/test/e2e/app-dir/performance-marks/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/performance-marks/app/page.tsx
+++ b/test/e2e/app-dir/performance-marks/app/page.tsx
@@ -1,0 +1,10 @@
+export default function HomePage() {
+  return (
+    <div>
+      <h1>Performance Marks Test</h1>
+      <p>
+        This page tests that performance marks and measures are properly set.
+      </p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/performance-marks/app/rsc/page.tsx
+++ b/test/e2e/app-dir/performance-marks/app/rsc/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+
+async function ServerComponent() {
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  return <div>RSC component loaded</div>
+}
+
+export default function RSCPage() {
+  return (
+    <div>
+      <h1>React Server Component Page</h1>
+      <p>This page includes RSC streaming to test RSC performance marks.</p>
+      <Suspense fallback={<div>Loading RSC...</div>}>
+        <ServerComponent />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/performance-marks/performance-marks.test.ts
+++ b/test/e2e/app-dir/performance-marks/performance-marks.test.ts
@@ -1,0 +1,160 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import { Playwright } from 'next-webdriver'
+
+describe('performance-marks', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  async function getPerformanceMarks(
+    browser: Playwright
+  ): Promise<(PerformanceEntry & { entryType: 'mark' })[]> {
+    return await browser.eval(`
+      window.performance.getEntriesByType('mark').map(entry => ({
+        name: entry.name,
+        entryType: entry.entryType,
+        startTime: entry.startTime,
+        duration: entry.duration
+      }))
+    `)
+  }
+
+  async function getPerformanceMeasures(
+    browser: Playwright
+  ): Promise<(PerformanceEntry & { entryType: 'measure' })[]> {
+    return await browser.eval(`
+      window.performance.getEntriesByType('measure').map(entry => ({
+        name: entry.name,
+        entryType: entry.entryType,
+        startTime: entry.startTime,
+        duration: entry.duration
+      }))
+    `)
+  }
+
+  async function hasPerformanceMark(browser: Playwright, markName: string) {
+    return await browser.eval(`
+      window.performance.getEntriesByName('${markName}', 'mark').length > 0
+    `)
+  }
+
+  async function hasPerformanceMeasure(
+    browser: Playwright,
+    measureName: string
+  ) {
+    return await browser.eval(`
+      window.performance.getEntriesByName('${measureName}', 'measure').length > 0
+    `)
+  }
+
+  describe('SSR with RSC', () => {
+    it('should create performance marks and measures during hydration and RSC streaming', async () => {
+      const browser = await next.browser('/')
+
+      await retry(async () => {
+        expect(await hasPerformanceMark(browser, 'beforeHydration')).toBe(true)
+        expect(
+          await hasPerformanceMeasure(browser, 'Next.js-before-hydration')
+        ).toBe(true)
+
+        expect(await hasPerformanceMark(browser, 'afterInitialCommit')).toBe(
+          true
+        )
+        expect(
+          await hasPerformanceMeasure(browser, 'Next.js-initial-commit')
+        ).toBe(true)
+
+        expect(await hasPerformanceMark(browser, 'rscStreamStart')).toBe(true)
+        expect(await hasPerformanceMark(browser, 'rscStreamEnd')).toBe(true)
+        expect(
+          await hasPerformanceMeasure(browser, 'Next.js-rsc-stream-reader')
+        ).toBe(true)
+      })
+
+      await browser.close()
+    })
+  })
+
+  describe('CSR (Client-Side Rendering)', () => {
+    it('should create performance marks and measures when rendering error pages', async () => {
+      const browser = await next.browser('/client')
+
+      await retry(async () => {
+        expect(await hasPerformanceMark(browser, 'beforeRender')).toBe(true)
+        expect(
+          await hasPerformanceMeasure(browser, 'Next.js-before-render')
+        ).toBe(true)
+      })
+
+      await browser.close()
+    })
+  })
+
+  describe('Performance entries validation', () => {
+    it('should have correct structure and chronological order for marks and measures', async () => {
+      const browser = await next.browser('/')
+
+      await retry(async () => {
+        expect(
+          await hasPerformanceMeasure(browser, 'Next.js-initial-commit')
+        ).toBe(true)
+      })
+
+      const marks = await getPerformanceMarks(browser)
+      const nextJsMarks = marks.filter((mark) =>
+        [
+          'beforeRender',
+          'beforeHydration',
+          'afterInitialCommit',
+          'rscStreamStart',
+          'rscStreamEnd',
+        ].includes(mark.name)
+      )
+
+      expect(nextJsMarks.length).toBeGreaterThan(0)
+
+      const measures = await getPerformanceMeasures(browser)
+      const nextJsMeasures = measures.filter((measure) =>
+        measure.name.startsWith('Next.js-')
+      )
+
+      expect(nextJsMeasures.length).toBeGreaterThan(0)
+
+      // Assert chronological order: rscStreamStart → beforeHydration → afterInitialCommit
+      const rscStreamStartMark = nextJsMarks.find(
+        (mark) => mark.name === 'rscStreamStart'
+      )
+      const beforeHydrationMark = nextJsMarks.find(
+        (mark) => mark.name === 'beforeHydration'
+      )
+      const afterInitialCommitMark = nextJsMarks.find(
+        (mark) => mark.name === 'afterInitialCommit'
+      )
+      const rscStreamEndMark = nextJsMarks.find(
+        (mark) => mark.name === 'rscStreamEnd'
+      )
+
+      if (
+        rscStreamStartMark &&
+        beforeHydrationMark &&
+        afterInitialCommitMark &&
+        rscStreamEndMark
+      ) {
+        expect(rscStreamStartMark.startTime).toBeLessThan(
+          beforeHydrationMark.startTime
+        )
+
+        expect(beforeHydrationMark.startTime).toBeLessThan(
+          afterInitialCommitMark.startTime
+        )
+
+        expect(rscStreamEndMark.startTime).toBeGreaterThan(
+          rscStreamStartMark.startTime
+        )
+      }
+
+      await browser.close()
+    })
+  })
+})


### PR DESCRIPTION
### What?
Adds user timing performance marks and measures for the app router

Marks:
`beforeHydration`:  Marks when hydration is about to begin (SSR scenarios)
`beforeRender`:  Marks when client-side rendering is about to begin (CSR scenarios like errors)
`afterInitialCommit`:  Marks when the initial React commit completes
`rscStreamStart`: Marks when RSC stream processing begins
`rscStreamEnd`: Marks when RSC stream processing finishes

Measures:
`Next.js-before-hydration`: Measures navigation start -> before hydration begins
`Next.js-before-render`: Measures navigation start -> before render begins (error pages)
`Next.js-initial-commit`: Measures hydration start -> initial commit completion
`Next.js-rsc-stream-reader`: Measures complete RSC stream processing duration

I can't add a hydrationComplete mark as it's not clear when React finishes commiting all RSC chunks, but this should be good enough.


Fixes #83957

