### PR TITLE
feat(otel): Update OpenTelemetry semantic conventions

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -426,6 +426,9 @@ export async function handler(
         if (!span) return
 
         span.setAttributes({
+          // Current OpenTelemetry semantic conventions
+          'http.response.status_code': res.statusCode,
+          // Legacy attributes for backward compatibility
           'http.status_code': res.statusCode,
           'next.rsc': false,
         })
@@ -1396,6 +1399,10 @@ export async function handler(
             spanName: `${method} ${srcPage}`,
             kind: SpanKind.SERVER,
             attributes: {
+              // Current OpenTelemetry semantic conventions
+              'http.request.method': method,
+              'url.path': req.url,
+              // Legacy attributes for backward compatibility
               'http.method': method,
               'http.target': req.url,
             },

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -224,6 +224,9 @@ export async function handler(
         if (!span) return
 
         span.setAttributes({
+          // Current OpenTelemetry semantic conventions
+          'http.response.status_code': res.statusCode,
+          // Legacy attributes for backward compatibility
           'http.status_code': res.statusCode,
           'next.rsc': false,
         })
@@ -457,6 +460,10 @@ export async function handler(
             spanName: `${method} ${srcPage}`,
             kind: SpanKind.SERVER,
             attributes: {
+              // Current OpenTelemetry semantic conventions
+              'http.request.method': method,
+              'url.path': req.url,
+              // Legacy attributes for backward compatibility
               'http.method': method,
               'http.target': req.url,
             },

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -283,6 +283,9 @@ async function requestHandler(
           if (!span) return
 
           span.setAttributes({
+            // Current OpenTelemetry semantic conventions
+            'http.response.status_code': finalStatus,
+            // Legacy attributes for backward compatibility
             'http.status_code': finalStatus,
             'next.rsc': false,
           })
@@ -342,9 +345,13 @@ async function requestHandler(
         spanName: `${req.method} ${srcPage}`,
         kind: SpanKind.SERVER,
         attributes: {
+          // Current OpenTelemetry semantic conventions
+          'http.request.method': req.method,
+          'url.path': relativeUrl,
+          'http.route': normalizedSrcPage,
+          // Legacy attributes for backward compatibility
           'http.method': req.method,
           'http.target': relativeUrl,
-          'http.route': normalizedSrcPage,
         },
       },
       invokeRender

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -263,6 +263,9 @@ async function requestHandler(
           if (!span) return
 
           span.setAttributes({
+            // Current OpenTelemetry semantic conventions
+            'http.response.status_code': finalStatus,
+            // Legacy attributes for backward compatibility
             'http.status_code': finalStatus,
             'next.rsc': false,
           })
@@ -346,9 +349,13 @@ async function requestHandler(
         spanName: `${req.method} ${srcPage}`,
         kind: SpanKind.SERVER,
         attributes: {
+          // Current OpenTelemetry semantic conventions
+          'http.request.method': req.method,
+          'url.path': relativeUrl,
+          'http.route': srcPage,
+          // Legacy attributes for backward compatibility
           'http.method': req.method,
           'http.target': relativeUrl,
-          'http.route': srcPage,
         },
       },
       invokeRender

--- a/packages/next/src/build/templates/pages-api.ts
+++ b/packages/next/src/build/templates/pages-api.ts
@@ -100,6 +100,9 @@ export async function handler(
           if (!span) return
 
           span.setAttributes({
+            // Current OpenTelemetry semantic conventions
+            'http.response.status_code': res.statusCode,
+            // Legacy attributes for backward compatibility
             'http.status_code': res.statusCode,
             'next.rsc': false,
           })
@@ -149,6 +152,10 @@ export async function handler(
             spanName: `${method} ${srcPage}`,
             kind: SpanKind.SERVER,
             attributes: {
+              // Current OpenTelemetry semantic conventions
+              'http.request.method': method,
+              'url.path': req.url,
+              // Legacy attributes for backward compatibility
               'http.method': method,
               'http.target': req.url,
             },

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -895,6 +895,10 @@ export default abstract class Server<
           spanName: `${method}`,
           kind: SpanKind.SERVER,
           attributes: {
+            // Current OpenTelemetry semantic conventions
+            'http.request.method': method,
+            'url.path': req.url,
+            // Legacy attributes for backward compatibility
             'http.method': method,
             'http.target': req.url,
           },
@@ -905,6 +909,9 @@ export default abstract class Server<
 
             const isRSCRequest = getRequestMeta(req, 'isRSCRequest') ?? false
             span.setAttributes({
+              // Current OpenTelemetry semantic conventions
+              'http.response.status_code': res.statusCode,
+              // Legacy attributes for backward compatibility
               'http.status_code': res.statusCode,
               'next.rsc': isRSCRequest,
             })

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -297,6 +297,12 @@ export function createPatchedFetcher(
         kind: SpanKind.CLIENT,
         spanName: ['fetch', method, fetchUrl].filter(Boolean).join(' '),
         attributes: {
+          // Current OpenTelemetry semantic conventions
+          'url.full': fetchUrl,
+          'http.request.method': method,
+          'server.address': url?.hostname,
+          'server.port': url?.port || undefined,
+          // Legacy attributes for backward compatibility
           'http.url': fetchUrl,
           'http.method': method,
           'net.peer.name': url?.hostname,

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -165,7 +165,11 @@ type NextAttributeNames =
   | 'next.span_name'
   | 'next.span_type'
   | 'next.clientComponentLoadCount'
-type OTELAttributeNames = `http.${string}` | `net.${string}`
+type OTELAttributeNames =
+  | `http.${string}`
+  | `net.${string}`
+  | `url.${string}`
+  | `server.${string}`
 type AttributeNames = NextAttributeNames | OTELAttributeNames
 
 /** we use this map to propagate attributes from nested spans to the top span */

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -379,6 +379,9 @@ export const getHandler = ({
                   if (!span) return
 
                   span.setAttributes({
+                    // Current OpenTelemetry semantic conventions
+                    'http.response.status_code': res.statusCode,
+                    // Legacy attributes for backward compatibility
                     'http.status_code': res.statusCode,
                     'next.rsc': false,
                   })
@@ -737,6 +740,10 @@ export const getHandler = ({
               spanName: `${method} ${req.url}`,
               kind: SpanKind.SERVER,
               attributes: {
+                // Current OpenTelemetry semantic conventions
+                'http.request.method': method,
+                'url.path': req.url,
+                // Legacy attributes for backward compatibility
                 'http.method': method,
                 'http.target': req.url,
               },

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -254,6 +254,10 @@ export async function adapter(
         {
           spanName: `middleware ${request.method} ${request.nextUrl.pathname}`,
           attributes: {
+            // Current OpenTelemetry semantic conventions
+            'url.path': request.nextUrl.pathname,
+            'http.request.method': request.method,
+            // Legacy attributes for backward compatibility
             'http.target': request.nextUrl.pathname,
             'http.method': request.method,
           },

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -74,6 +74,11 @@ describe('opentelemetry', () => {
               {
                 name: 'GET /app/[param]/rsc-fetch',
                 attributes: {
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'http.response.status_code': 200,
+                  'url.path': '/app/param/rsc-fetch',
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.route': '/app/[param]/rsc-fetch',
                   'http.status_code': 200,
@@ -136,6 +141,11 @@ describe('opentelemetry', () => {
                       {
                         name: 'fetch GET https://example.vercel.sh/',
                         attributes: {
+                          // Current OpenTelemetry semantic conventions
+                          'http.request.method': 'GET',
+                          'url.full': 'https://example.vercel.sh/',
+                          'server.address': 'example.vercel.sh',
+                          // Legacy attributes for backward compatibility
                           'http.method': 'GET',
                           'http.url': 'https://example.vercel.sh/',
                           'net.peer.name': 'example.vercel.sh',
@@ -235,6 +245,11 @@ describe('opentelemetry', () => {
                 attributes: {
                   'next.span_name': 'GET /app/[param]/rsc-fetch/edge',
                   'next.span_type': 'BaseServer.handleRequest',
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'url.path': '/app/param/rsc-fetch/edge?param=param',
+                  'http.response.status_code': 200,
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.target': '/app/param/rsc-fetch/edge?param=param',
                   'http.status_code': 200,
@@ -295,6 +310,11 @@ describe('opentelemetry', () => {
                           'next.span_name':
                             'fetch GET https://example.vercel.sh/',
                           'next.span_type': 'AppRender.fetch',
+                          // Current OpenTelemetry semantic conventions
+                          'url.full': 'https://example.vercel.sh/',
+                          'http.request.method': 'GET',
+                          'server.address': 'example.vercel.sh',
+                          // Legacy attributes for backward compatibility
                           'http.url': 'https://example.vercel.sh/',
                           'http.method': 'GET',
                           'net.peer.name': 'example.vercel.sh',
@@ -338,6 +358,11 @@ describe('opentelemetry', () => {
                 attributes: {
                   'next.span_name': 'GET',
                   'next.span_type': 'BaseServer.handleRequest',
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'url.path': '/app/param/rsc-fetch/edge',
+                  'http.response.status_code': 200,
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.target': '/app/param/rsc-fetch/edge',
                   'http.status_code': 200,
@@ -374,6 +399,11 @@ describe('opentelemetry', () => {
                 parentId: env.span.rootParentId,
                 name: 'RSC GET /app/[param]/rsc-fetch',
                 attributes: {
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'http.response.status_code': 200,
+                  'url.path': `/app/param/rsc-fetch?${NEXT_RSC_UNION_QUERY}`,
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.route': '/app/[param]/rsc-fetch',
                   'http.status_code': 200,
@@ -396,6 +426,11 @@ describe('opentelemetry', () => {
               {
                 name: 'GET /api/app/[param]/data',
                 attributes: {
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'http.response.status_code': 200,
+                  'url.path': '/api/app/param/data',
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.route': '/api/app/[param]/data',
                   'http.status_code': 200,
@@ -473,6 +508,11 @@ describe('opentelemetry', () => {
                 attributes: {
                   'next.span_name': 'GET',
                   'next.span_type': 'BaseServer.handleRequest',
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'url.path': '/api/app/param/data/edge',
+                  'http.response.status_code': 200,
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.target': '/api/app/param/data/edge',
                   'http.status_code': 200,
@@ -503,6 +543,10 @@ describe('opentelemetry', () => {
                 parentId: env.span.rootParentId,
                 name: 'middleware GET /behind-middleware',
                 attributes: {
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'url.path': '/behind-middleware',
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.target': '/behind-middleware',
                   'next.span_name': 'middleware GET /behind-middleware',
@@ -518,6 +562,11 @@ describe('opentelemetry', () => {
                 parentId: env.span.rootParentId,
                 name: 'GET /behind-middleware',
                 attributes: {
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'http.response.status_code': 200,
+                  'url.path': '/behind-middleware',
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.route': '/behind-middleware',
                   'http.status_code': 200,
@@ -540,6 +589,11 @@ describe('opentelemetry', () => {
               {
                 name: 'GET /app/[param]/rsc-fetch/error',
                 attributes: {
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'http.response.status_code': 500,
+                  'url.path': '/app/param/rsc-fetch/error?status=error',
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.route': '/app/[param]/rsc-fetch/error',
                   'http.status_code': 500,
@@ -669,6 +723,11 @@ describe('opentelemetry', () => {
               {
                 name: 'GET /pages/[param]/getServerSideProps',
                 attributes: {
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'http.response.status_code': 200,
+                  'url.path': '/pages/param/getServerSideProps',
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.route': '/pages/[param]/getServerSideProps',
                   'http.status_code': 200,
@@ -727,6 +786,11 @@ describe('opentelemetry', () => {
               {
                 name: `GET /pages/[param]/getStaticProps${v}`,
                 attributes: {
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'http.response.status_code': 200,
+                  'url.path': `/pages/param/getStaticProps${v}`,
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.route': `/pages/[param]/getStaticProps${v}`,
                   'http.status_code': 200,
@@ -866,6 +930,11 @@ describe('opentelemetry', () => {
               {
                 name: 'GET /pages/[param]/getServerSidePropsError',
                 attributes: {
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'http.response.status_code': 500,
+                  'url.path': '/pages/param/getServerSidePropsError',
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.route': '/pages/[param]/getServerSidePropsError',
                   'http.status_code': 500,
@@ -1049,6 +1118,11 @@ describe('opentelemetry', () => {
               {
                 name: 'GET /api/pages/[param]/basic',
                 attributes: {
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'http.response.status_code': 200,
+                  'url.path': '/api/pages/param/basic',
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.route': '/api/pages/[param]/basic',
                   'http.status_code': 200,
@@ -1105,6 +1179,11 @@ describe('opentelemetry', () => {
                 attributes: {
                   'next.span_name': 'GET',
                   'next.span_type': 'BaseServer.handleRequest',
+                  // Current OpenTelemetry semantic conventions
+                  'http.request.method': 'GET',
+                  'url.path': '/api/pages/param/edge',
+                  'http.response.status_code': 200,
+                  // Legacy attributes for backward compatibility
                   'http.method': 'GET',
                   'http.target': '/api/pages/param/edge',
                   'http.status_code': 200,


### PR DESCRIPTION

### What?

This PR updates OpenTelemetry attributes to align with current semantic conventions while maintaining backward compatibility. The current attributes are mostly legacy and will cause providers like Grafana Cloud to not be able to resolve outbound service.

I kept the old one for backwards compatibility for now.

### Changes Made

| **Legacy Attribute** | **Current Semantic Convention** |
|---------------------|--------------------------------|
| `http.url` | `url.full` |
| `http.method` | `http.request.method` |
| `http.target` | `url.path` |
| `http.status_code` | `http.response.status_code` |
| `net.peer.name` | `server.address` |
| `net.peer.port` | `server.port` |

### Why?
Many OpenTelemetry providers are now using the new semantic conventions and will fail to resolve outbound spans otherwise
