### PR TITLE
feat(jest): Add `additionalTranspilePackages` option for Jest-only transpilation

### DIFF
--- a/docs/01-app/02-guides/testing/jest.mdx
+++ b/docs/01-app/02-guides/testing/jest.mdx
@@ -53,6 +53,10 @@ import nextJest from 'next/jest.js'
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
   dir: './',
+  // Additional packages to transpile in addition to those specified in next.config.js transpilePackages.
+  // Useful for packages that need to be transformed in Jest tests but don't need be added to
+  // the main transpilePackages (e.g., test-only dependencies).
+  // additionalTranspilePackages: ['@faker-js/faker', 'lodash-es'],
 })
 
 // Add any custom config to be passed to Jest
@@ -74,6 +78,10 @@ const nextJest = require('next/jest')
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
   dir: './',
+  // Additional packages to transpile in addition to those specified in next.config.js transpilePackages.
+  // Useful for packages that need to be transformed in Jest tests but don't need be added to
+  // the main transpilePackages (e.g., test-only dependencies).
+  // additionalTranspilePackages: ['@faker-js/faker', 'lodash-es'],
 })
 
 // Add any custom config to be passed to Jest
@@ -96,6 +104,32 @@ Under the hood, `next/jest` is automatically configuring Jest for you, including
 - Ignoring `node_modules` from test resolving and transforms.
 - Ignoring `.next` from test resolving.
 - Loading `next.config.js` for flags that enable SWC transforms.
+
+## Transpiling packages for testing only
+
+Some packages may need to be transpiled for Jest tests but you don't want to add
+them to your `next.config.js` `transpilePackages` as this would affect your
+production build. This is common with test-only dependencies or packages that
+use modern JavaScript features (like ESM modules) that need transformation in
+the Jest environment.
+
+For these cases, you can use the `additionalTranspilePackages` option in `next/jest`:
+
+```ts filename="jest.config.ts" switcher
+const createJestConfig = nextJest({
+  dir: './',
+  additionalTranspilePackages: ['@faker-js/faker', 'lodash-es'],
+})
+```
+
+```js filename="jest.config.js" switcher
+const createJestConfig = nextJest({
+  dir: './',
+  additionalTranspilePackages: ['@faker-js/faker', 'lodash-es'],
+})
+```
+
+This option allows you to specify packages that should be transpiled only for Jest tests, without affecting your Next.js build configuration.
 
 > **Good to know**: To test environment variables directly, load them manually in a separate setup script or in your `jest.config.ts` file. For more information, please see [Test Environment Variables](/docs/app/guides/environment-variables#test-environment-variables).
 

--- a/packages/next/src/build/jest/jest.ts
+++ b/packages/next/src/build/jest/jest.ts
@@ -44,7 +44,11 @@ function setUpEnv(dir: string) {
  * const nextJest = require('next/jest');
  *
  * // Optionally provide path to Next.js app which will enable loading next.config.js and .env files
- * const createJestConfig = nextJest({ dir })
+ * const createJestConfig = nextJest({
+ *   dir,
+ *   // Additional packages to transpile for testing (e.g., ESM packages)
+ *   additionalTranspilePackages: ['@faker-js/faker', 'lodash-es']
+ * })
  *
  * // Any custom config you want to pass to Jest
  * const customJestConfig = {
@@ -57,7 +61,17 @@ function setUpEnv(dir: string) {
  *
  * Read more: [Next.js Docs: Setting up Jest with Next.js](https://nextjs.org/docs/app/building-your-application/testing/jest)
  */
-export default function nextJest(options: { dir?: string } = {}) {
+export default function nextJest(
+  options: {
+    dir?: string
+    /**
+     * Additional packages to transpile in addition to those specified in next.config.js transpilePackages.
+     * Useful for packages that need to be transformed in Jest tests but don't need to be added to
+     * the main transpilePackages (e.g., test-only dependencies).
+     */
+    additionalTranspilePackages?: string[]
+  } = {}
+) {
   // createJestConfig
   return (
     customJestConfig?:
@@ -102,9 +116,15 @@ export default function nextJest(options: { dir?: string } = {}) {
         await lockfilePatchPromise.cur
       }
 
-      const transpiled = (nextConfig?.transpilePackages ?? [])
-        .concat(DEFAULT_TRANSPILED_PACKAGES)
-        .join('|')
+      const allTranspiledPackages = [
+        ...(nextConfig?.transpilePackages ?? []),
+        ...DEFAULT_TRANSPILED_PACKAGES,
+        ...(options.additionalTranspilePackages || []),
+      ]
+        .map((pkg) => pkg.trim())
+        .filter(Boolean)
+
+      const transpiled = [...new Set(allTranspiledPackages)].join('|')
 
       const jestTransformerConfig: JestTransformerConfig = {
         modularizeImports: nextConfig?.modularizeImports,

--- a/test/production/jest/transpile-packages.test.ts
+++ b/test/production/jest/transpile-packages.test.ts
@@ -12,10 +12,19 @@ describe('next/jest', () => {
           return capitalize('test')
         }`,
         'index.test.ts': `import capitalize from '@hashicorp/platform-util/text/capitalize'
-        it('should work', () => {
+        import lodashEs from 'lodash-es/camelCase'
+        it('should work with next.config transpilePackages', () => {
           expect(capitalize('test')).toEqual('Test')
+        })
+        it('should work with additionalTranspilePackages in Jest only', () => {
+          expect(lodashEs('hello-world')).toEqual('helloWorld')
         })`,
-        'jest.config.js': `module.exports = require('next/jest')({ dir: './' })()`,
+        'jest.config.js': `const nextJest = require('next/jest')
+        const createJestConfig = nextJest({ 
+          dir: './',
+          additionalTranspilePackages: ['lodash-es']
+        })
+        module.exports = createJestConfig()`,
         'next.config.js': `module.exports = {
           transpilePackages: ['@hashicorp/platform-util'],
         }`,
@@ -30,6 +39,7 @@ describe('next/jest', () => {
       buildCommand: `pnpm build`,
       dependencies: {
         '@hashicorp/platform-util': '0.2.0',
+        'lodash-es': '4.17.21',
         '@types/react': 'latest',
         jest: '27.4.7',
       },


### PR DESCRIPTION
## What?

Adds a new `additionalTranspilePackages` option to `nextJest()` that allows transpiling additional packages for Jest tests without adding them to `next.config.js` `transpilePackages`. 

## Why?
Users sometimes need to transform additional packages, not provided in `transpilePackages`, like ESM only packages only used in tests.

Jest uses `transformIgnorePatterns` as an OR condition where if a file matches any pattern in the array, it gets ignored (not transformed). The Next Jest config automatically generates a negative lookahead regex for `transpilePackages` like `/node_modules/(?!.pnpm)(?!(transpiled-pkg)/)`, which means "ignore all node_modules except those in transpilePackages". However, when users add their own `transformIgnorePatterns` with negative lookaheads (e.g., `/node_modules/(?!@faker-js\\/faker)/`), Jest's OR logic causes conflicts - the default pattern can override the user pattern, preventing the intended packages from being transformed.


## How?

Added `additionalTranspilePackages` option to `nextJest()` function, these packages are combined with existing transpiled packages when generating Jest's `transformIgnorePatterns`. Instead of introducing a new API we could have theoretically parsed the user provided negative look-ahead regex and added it to the default one but this would be incredibly flakey and full of edge cases.

## Usage

```typescript
import nextJest from 'next/jest'

const createJestConfig = nextJest({
  dir: './',
  // Additional packages to transpile for testing (e.g., ESM packages)
  additionalTranspilePackages: ['@faker-js/faker', 'lodash-es']
})
```

Fixes #83397