### PR TITLE
Turbopack: add `evaluation` info to `EsmExports`

### DIFF
--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -21,6 +21,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemOptions,
         EcmascriptChunkPlaceable, EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
+    references::esm::EsmEvaluation,
     runtime_functions::TURBOPACK_REQUIRE,
     utils::StringifyJs,
 };
@@ -104,6 +105,7 @@ impl EcmascriptChunkPlaceable for HmrEntryModule {
     fn get_exports(self: Vc<Self>) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::None,
+            evaluation: EsmEvaluation::SideEffects,
         }
         .cell()
     }

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -21,7 +21,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemOptions,
         EcmascriptChunkPlaceable, EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
-    references::esm::EsmEvaluation,
+    references::esm::EcmascriptEvaluation,
     runtime_functions::TURBOPACK_REQUIRE,
     utils::StringifyJs,
 };
@@ -105,7 +105,7 @@ impl EcmascriptChunkPlaceable for HmrEntryModule {
     fn get_exports(self: Vc<Self>) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::None,
-            evaluation: EsmEvaluation::SideEffects,
+            evaluation: EcmascriptEvaluation::SideEffects,
         }
         .cell()
     }

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -10,6 +10,7 @@ use turbopack::{
     module_options::{
         CssOptionsContext, EcmascriptOptionsContext, JsxTransformOptions, ModuleRule,
         TypescriptTransformOptions, module_options_context::ModuleOptionsContext,
+        package_list_to_glob,
     },
     resolve_options_context::ResolveOptionsContext,
 };
@@ -335,7 +336,11 @@ pub async fn get_client_module_options_context(
         execution_context: Some(execution_context),
         tree_shaking_mode: tree_shaking_mode_for_user_code,
         enable_postcss_transform,
-        side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
+        side_effect_free_packages: Some(
+            package_list_to_glob(next_config.optimize_package_imports().owned().await?)
+                .to_resolved()
+                .await?,
+        ),
         keep_last_successful_parse: next_mode.is_development(),
         ..Default::default()
     };

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -18,7 +18,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
-    references::esm::{EsmExport, EsmExports},
+    references::esm::{EsmEvaluation, EsmExport, EsmExports},
     runtime_functions::{TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_IMPORT},
     utils::StringifyJs,
 };
@@ -118,6 +118,7 @@ impl EcmascriptChunkPlaceable for NextDynamicEntryModule {
                 EsmExports {
                     exports,
                     star_exports: vec![module_reference],
+                    evaluation: EsmEvaluation::DelegatedSideEffects(module_reference),
                 }
                 .resolved_cell(),
             ),

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -118,10 +118,10 @@ impl EcmascriptChunkPlaceable for NextDynamicEntryModule {
                 EsmExports {
                     exports,
                     star_exports: vec![module_reference],
-                    evaluation: EsmEvaluation::DelegatedSideEffects(module_reference),
                 }
                 .resolved_cell(),
             ),
+            evaluation: EsmEvaluation::DelegatedSideEffects(module_reference),
         }
         .cell())
     }

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -18,7 +18,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
-    references::esm::{EsmEvaluation, EsmExport, EsmExports},
+    references::esm::{EcmascriptEvaluation, EsmExport, EsmExports},
     runtime_functions::{TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_IMPORT},
     utils::StringifyJs,
 };
@@ -121,7 +121,7 @@ impl EcmascriptChunkPlaceable for NextDynamicEntryModule {
                 }
                 .resolved_cell(),
             ),
-            evaluation: EsmEvaluation::DelegatedSideEffects(module_reference),
+            evaluation: EcmascriptEvaluation::DelegatedSideEffects(module_reference),
         }
         .cell())
     }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -9,7 +9,7 @@ use turbopack::{
     css::chunk::CssChunkType,
     module_options::{
         CssOptionsContext, EcmascriptOptionsContext, ExternalsTracingOptions, JsxTransformOptions,
-        ModuleOptionsContext, ModuleRule, TypescriptTransformOptions,
+        ModuleOptionsContext, ModuleRule, TypescriptTransformOptions, package_list_to_glob,
     },
     resolve_options_context::ResolveOptionsContext,
     transition::Transition,
@@ -589,7 +589,11 @@ pub async fn get_server_module_options_context(
             ..Default::default()
         },
         tree_shaking_mode: tree_shaking_mode_for_user_code,
-        side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
+        side_effect_free_packages: Some(
+            package_list_to_glob(next_config.optimize_package_imports().owned().await?)
+                .to_resolved()
+                .await?,
+        ),
         enable_externals_tracing: if next_mode.is_production() {
             Some(
                 ExternalsTracingOptions {

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -111,10 +111,10 @@ impl EcmascriptChunkPlaceable for NextServerComponentModule {
                 EsmExports {
                     exports,
                     star_exports: vec![module_reference],
-                    evaluation: EsmEvaluation::DelegatedSideEffects(module_reference),
                 }
                 .resolved_cell(),
             ),
+            evaluation: EsmEvaluation::DelegatedSideEffects(module_reference),
         }
         .cell())
     }

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -18,7 +18,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
-    references::esm::{EsmExport, EsmExports},
+    references::esm::{EsmEvaluation, EsmExport, EsmExports},
     runtime_functions::{TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_IMPORT},
     utils::StringifyJs,
 };
@@ -111,6 +111,7 @@ impl EcmascriptChunkPlaceable for NextServerComponentModule {
                 EsmExports {
                     exports,
                     star_exports: vec![module_reference],
+                    evaluation: EsmEvaluation::DelegatedSideEffects(module_reference),
                 }
                 .resolved_cell(),
             ),

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -18,7 +18,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
-    references::esm::{EsmEvaluation, EsmExport, EsmExports},
+    references::esm::{EcmascriptEvaluation, EsmExport, EsmExports},
     runtime_functions::{TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_IMPORT},
     utils::StringifyJs,
 };
@@ -114,7 +114,7 @@ impl EcmascriptChunkPlaceable for NextServerComponentModule {
                 }
                 .resolved_cell(),
             ),
-            evaluation: EsmEvaluation::DelegatedSideEffects(module_reference),
+            evaluation: EcmascriptEvaluation::DelegatedSideEffects(module_reference),
         }
         .cell())
     }

--- a/crates/next-core/src/next_server_utility/server_utility_module.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_module.rs
@@ -18,7 +18,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
-    references::esm::{EsmEvaluation, EsmExport, EsmExports},
+    references::esm::{EcmascriptEvaluation, EsmExport, EsmExports},
     runtime_functions::{TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_IMPORT},
     utils::StringifyJs,
 };
@@ -114,7 +114,7 @@ impl EcmascriptChunkPlaceable for NextServerUtilityModule {
                 }
                 .resolved_cell(),
             ),
-            evaluation: EsmEvaluation::DelegatedSideEffects(module_reference),
+            evaluation: EcmascriptEvaluation::DelegatedSideEffects(module_reference),
         }
         .cell())
     }

--- a/crates/next-core/src/next_server_utility/server_utility_module.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_module.rs
@@ -111,10 +111,10 @@ impl EcmascriptChunkPlaceable for NextServerUtilityModule {
                 EsmExports {
                     exports,
                     star_exports: vec![module_reference],
-                    evaluation: EsmEvaluation::DelegatedSideEffects(module_reference),
                 }
                 .resolved_cell(),
             ),
+            evaluation: EsmEvaluation::DelegatedSideEffects(module_reference),
         }
         .cell())
     }

--- a/crates/next-core/src/next_server_utility/server_utility_module.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_module.rs
@@ -18,7 +18,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
-    references::esm::{EsmExport, EsmExports},
+    references::esm::{EsmEvaluation, EsmExport, EsmExports},
     runtime_functions::{TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_IMPORT},
     utils::StringifyJs,
 };
@@ -111,6 +111,7 @@ impl EcmascriptChunkPlaceable for NextServerUtilityModule {
                 EsmExports {
                     exports,
                     star_exports: vec![module_reference],
+                    evaluation: EsmEvaluation::DelegatedSideEffects(module_reference),
                 }
                 .resolved_cell(),
             ),

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -29,7 +29,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
     parse::generate_js_source_map,
-    references::esm::EsmEvaluation,
+    references::esm::EcmascriptEvaluation,
     runtime_functions::{TURBOPACK_EXPORT_VALUE, TURBOPACK_IMPORT},
     utils::StringifyJs,
 };
@@ -266,7 +266,7 @@ impl EcmascriptChunkPlaceable for ModuleCssAsset {
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::Value,
-            evaluation: EsmEvaluation::SideEffects,
+            evaluation: EcmascriptEvaluation::SideEffects,
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -29,6 +29,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
     parse::generate_js_source_map,
+    references::esm::EsmEvaluation,
     runtime_functions::{TURBOPACK_EXPORT_VALUE, TURBOPACK_IMPORT},
     utils::StringifyJs,
 };
@@ -265,6 +266,7 @@ impl EcmascriptChunkPlaceable for ModuleCssAsset {
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::Value,
+            evaluation: EsmEvaluation::SideEffects,
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -21,7 +21,7 @@ use turbopack_core::{
 
 use crate::references::{
     async_module::OptionAsyncModule,
-    esm::{EsmExport, EsmExports},
+    esm::{EsmEvaluation, EsmExport, EsmExports},
 };
 
 #[turbo_tasks::value_trait]
@@ -222,6 +222,7 @@ pub async fn is_marked_as_side_effect_free(
 #[turbo_tasks::value(shared)]
 pub struct EcmascriptExports {
     pub ty: EcmascriptExportsType,
+    pub evaluation: EsmEvaluation,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -21,7 +21,7 @@ use turbopack_core::{
 
 use crate::references::{
     async_module::OptionAsyncModule,
-    esm::{EsmEvaluation, EsmExport, EsmExports},
+    esm::{EcmascriptEvaluation, EsmExport, EsmExports},
 };
 
 #[turbo_tasks::value_trait]
@@ -31,6 +31,10 @@ pub trait EcmascriptChunkPlaceable: ChunkableModule + Module + Asset {
     #[turbo_tasks::function]
     fn get_async_module(self: Vc<Self>) -> Vc<OptionAsyncModule> {
         Vc::cell(None)
+    }
+    #[turbo_tasks::function]
+    async fn get_evaluation(self: Vc<Self>) -> Result<Vc<EcmascriptEvaluation>> {
+        Ok(self.get_exports().await?.evaluation.cell())
     }
     #[turbo_tasks::function]
     async fn is_marked_as_side_effect_free(
@@ -222,7 +226,7 @@ pub async fn is_marked_as_side_effect_free(
 #[turbo_tasks::value(shared)]
 pub struct EcmascriptExports {
     pub ty: EcmascriptExportsType,
-    pub evaluation: EsmEvaluation,
+    pub evaluation: EcmascriptEvaluation,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -39,7 +39,7 @@ pub trait EcmascriptChunkPlaceable: ChunkableModule + Module + Asset {
     ) -> Result<Vc<bool>> {
         Ok(is_marked_as_side_effect_free(
             self.ident().path().owned().await?,
-            side_effect_free_packages,
+            Some(side_effect_free_packages),
         ))
     }
 }
@@ -193,9 +193,11 @@ impl Issue for SideEffectsInPackageJsonIssue {
 #[turbo_tasks::function]
 pub async fn is_marked_as_side_effect_free(
     path: FileSystemPath,
-    side_effect_free_packages: Vc<Glob>,
+    side_effect_free_packages: Option<Vc<Glob>>,
 ) -> Result<Vc<bool>> {
-    if side_effect_free_packages.await?.matches(&path.path) {
+    if let Some(side_effect_free_packages) = side_effect_free_packages
+        && side_effect_free_packages.await?.matches(&path.path)
+    {
         return Ok(Vc::cell(true));
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/inlined_bytes_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/inlined_bytes_module.rs
@@ -16,7 +16,7 @@ use turbopack_core::{
 use crate::{
     chunk::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
-        EcmascriptChunkType, EcmascriptExports,
+        EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
     runtime_functions::TURBOPACK_EXPORT_VALUE,
     utils::StringifyJs,
@@ -72,7 +72,10 @@ impl ChunkableModule for InlinedBytesJsModule {
 impl EcmascriptChunkPlaceable for InlinedBytesJsModule {
     #[turbo_tasks::function]
     fn get_exports(&self) -> Vc<EcmascriptExports> {
-        EcmascriptExports::Value.cell()
+        EcmascriptExports {
+            ty: EcmascriptExportsType::Value,
+        }
+        .cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/inlined_bytes_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/inlined_bytes_module.rs
@@ -18,6 +18,7 @@ use crate::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
+    export::EcmascriptEvaluation,
     runtime_functions::TURBOPACK_EXPORT_VALUE,
     utils::StringifyJs,
 };
@@ -74,6 +75,7 @@ impl EcmascriptChunkPlaceable for InlinedBytesJsModule {
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::Value,
+            evaluation: EcmascriptEvaluation::SideEffects,
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -218,6 +218,8 @@ pub struct EcmascriptOptions {
     /// If true, it reads a sourceMappingURL comment from the end of the file,
     /// reads and generates a source map.
     pub extract_source_map: bool,
+    /// Packages that are considered side effect free.
+    pub side_effect_free_packages: Option<ResolvedVc<Glob>>,
     /// If true, it stores the last successful parse result in state and keeps using it when
     /// parsing fails. This is useful to keep the module graph structure intact when syntax errors
     /// are temporarily introduced.
@@ -736,7 +738,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleAsset {
         // Check package.json first, so that we can skip parsing the module if it's marked that way.
         let pkg_side_effect_free = is_marked_as_side_effect_free(
             self.ident().path().owned().await?,
-            side_effect_free_packages,
+            Some(side_effect_free_packages),
         );
         Ok(if *pkg_side_effect_free.await? {
             pkg_side_effect_free

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -18,7 +18,7 @@ use turbopack_core::{
 use super::chunk_item::ManifestChunkItem;
 use crate::{
     chunk::{EcmascriptChunkPlaceable, EcmascriptExports, EcmascriptExportsType},
-    references::esm::EsmEvaluation,
+    references::esm::EcmascriptEvaluation,
 };
 
 /// The manifest module is deferred until requested by the manifest loader
@@ -177,7 +177,7 @@ impl EcmascriptChunkPlaceable for ManifestAsyncModule {
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::Value,
-            evaluation: EsmEvaluation::SideEffects,
+            evaluation: EcmascriptEvaluation::SideEffects,
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -16,7 +16,10 @@ use turbopack_core::{
 };
 
 use super::chunk_item::ManifestChunkItem;
-use crate::chunk::{EcmascriptChunkPlaceable, EcmascriptExports, EcmascriptExportsType};
+use crate::{
+    chunk::{EcmascriptChunkPlaceable, EcmascriptExports, EcmascriptExportsType},
+    references::esm::EsmEvaluation,
+};
 
 /// The manifest module is deferred until requested by the manifest loader
 /// item when the dynamic `import()` expression is reached.
@@ -174,6 +177,7 @@ impl EcmascriptChunkPlaceable for ManifestAsyncModule {
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::Value,
+            evaluation: EsmEvaluation::SideEffects,
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -561,7 +561,6 @@ pub enum EsmEvaluation {
 pub struct EsmExports {
     pub exports: BTreeMap<RcStr, EsmExport>,
     pub star_exports: Vec<ResolvedVc<Box<dyn ModuleReference>>>,
-    pub evaluation: EsmEvaluation,
 }
 
 /// The expanded version of [`EsmExports`], the `exports` field here includes all exports that could

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -14,7 +14,7 @@ use swc_core::{
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, NonLocalValue, ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc,
-    debug::ValueDebugFormat, trace::TraceRawVcs,
+    trace::TraceRawVcs,
 };
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
@@ -526,21 +526,9 @@ async fn emit_star_exports_issue(source_ident: Vc<AssetIdent>, message: RcStr) -
     Ok(())
 }
 
-#[derive(
-    Debug,
-    Default,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Hash,
-    ValueDebugFormat,
-    Serialize,
-    Deserialize,
-    TraceRawVcs,
-    NonLocalValue,
-)]
-pub enum EsmEvaluation {
+#[turbo_tasks::value(shared)]
+#[derive(Default, Copy, Clone)]
+pub enum EcmascriptEvaluation {
     /// The module has module evaluation side effects.
     #[default]
     SideEffects,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/mod.rs
@@ -11,7 +11,7 @@ pub use self::{
     base::EsmAssetReference,
     binding::EsmBinding,
     dynamic::EsmAsyncAssetReference,
-    export::{EsmExport, EsmExports, FoundExportType, Liveness},
+    export::{EsmEvaluation, EsmExport, EsmExports, FoundExportType, Liveness},
     meta::{ImportMetaBinding, ImportMetaRef},
     module_item::EsmModuleItem,
     url::{UrlAssetReference, UrlRewriteBehavior},

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/mod.rs
@@ -11,7 +11,7 @@ pub use self::{
     base::EsmAssetReference,
     binding::EsmBinding,
     dynamic::EsmAsyncAssetReference,
-    export::{EsmEvaluation, EsmExport, EsmExports, FoundExportType, Liveness},
+    export::{EcmascriptEvaluation, EsmExport, EsmExports, FoundExportType, Liveness},
     meta::{ImportMetaBinding, ImportMetaRef},
     module_item::EsmModuleItem,
     url::{UrlAssetReference, UrlRewriteBehavior},

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     references::{
         async_module::{AsyncModule, OptionAsyncModule},
-        esm::EsmEvaluation,
+        esm::EcmascriptEvaluation,
     },
     runtime_functions::{
         TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_EXPORT_VALUE, TURBOPACK_EXTERNAL_IMPORT,
@@ -324,13 +324,13 @@ impl EcmascriptChunkPlaceable for CachedExternalModule {
         if self.external_type == CachedExternalType::CommonJs {
             EcmascriptExports {
                 ty: EcmascriptExportsType::CommonJs,
-                evaluation: EsmEvaluation::SideEffects,
+                evaluation: EcmascriptEvaluation::SideEffects,
             }
             .cell()
         } else {
             EcmascriptExports {
                 ty: EcmascriptExportsType::DynamicNamespace,
-                evaluation: EsmEvaluation::SideEffects,
+                evaluation: EcmascriptEvaluation::SideEffects,
             }
             .cell()
         }

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -26,7 +26,10 @@ use crate::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
-    references::async_module::{AsyncModule, OptionAsyncModule},
+    references::{
+        async_module::{AsyncModule, OptionAsyncModule},
+        esm::EsmEvaluation,
+    },
     runtime_functions::{
         TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_EXPORT_VALUE, TURBOPACK_EXTERNAL_IMPORT,
         TURBOPACK_EXTERNAL_REQUIRE, TURBOPACK_LOAD_BY_URL,
@@ -321,11 +324,13 @@ impl EcmascriptChunkPlaceable for CachedExternalModule {
         if self.external_type == CachedExternalType::CommonJs {
             EcmascriptExports {
                 ty: EcmascriptExportsType::CommonJs,
+                evaluation: EsmEvaluation::SideEffects,
             }
             .cell()
         } else {
             EcmascriptExports {
                 ty: EcmascriptExportsType::DynamicNamespace,
+                evaluation: EsmEvaluation::SideEffects,
             }
             .cell()
         }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -140,7 +140,7 @@ use crate::{
     },
     chunk::{EcmascriptExports, EcmascriptExportsType, placeable::is_marked_as_side_effect_free},
     code_gen::{CodeGen, CodeGens, IntoCodeGenReference},
-    export::{EsmEvaluation, Liveness},
+    export::{EcmascriptEvaluation, Liveness},
     magic_identifier,
     references::{
         async_module::{AsyncModule, OptionAsyncModule},
@@ -227,7 +227,7 @@ pub struct AnalyzeEcmascriptModuleResultBuilder {
 
     code_gens: Vec<CodeGen>,
     exports: EcmascriptExportsType,
-    evaluation: EsmEvaluation,
+    evaluation: EcmascriptEvaluation,
     async_module: ResolvedVc<OptionAsyncModule>,
     successful: bool,
     source_map: Option<ResolvedVc<Box<dyn GenerateSourceMap>>>,
@@ -246,7 +246,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
             esm_references_free_var: Default::default(),
             code_gens: Default::default(),
             exports: EcmascriptExportsType::Unknown,
-            evaluation: EsmEvaluation::SideEffects,
+            evaluation: EcmascriptEvaluation::SideEffects,
             async_module: ResolvedVc::cell(None),
             successful: false,
             source_map: None,
@@ -308,7 +308,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     }
 
     /// Sets the analysis result evaluation.
-    pub fn set_evaluation(&mut self, evaluation: EsmEvaluation) {
+    pub fn set_evaluation(&mut self, evaluation: EcmascriptEvaluation) {
         self.evaluation = evaluation;
     }
 
@@ -593,13 +593,15 @@ pub async fn analyse_ecmascript_module_internal(
     else {
         // Even a file that failed parsing can be side effect free.
         // That's important as
-        let marked_as_side_effect_free =
-            *is_marked_as_side_effect_free(path, options.side_effect_free_packages.map(|l| *l))
-                .await?;
+        let marked_as_side_effect_free = *is_marked_as_side_effect_free(
+            path.clone(),
+            options.side_effect_free_packages.map(|l| *l),
+        )
+        .await?;
         let evaluation = if marked_as_side_effect_free {
-            EsmEvaluation::SideEffectFree
+            EcmascriptEvaluation::SideEffectFree
         } else {
-            EsmEvaluation::SideEffects
+            EcmascriptEvaluation::SideEffects
         };
         analysis.set_evaluation(evaluation);
 
@@ -825,9 +827,9 @@ pub async fn analyse_ecmascript_module_internal(
             )
             .await?;
         let evaluation = if marked_as_side_effect_free {
-            EsmEvaluation::SideEffectFree
+            EcmascriptEvaluation::SideEffectFree
         } else {
-            EsmEvaluation::SideEffects
+            EcmascriptEvaluation::SideEffects
         };
         analysis.set_evaluation(evaluation);
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -47,6 +47,7 @@ use crate::{
     create_visitor,
     references::{
         AstPath,
+        esm::EsmEvaluation,
         pattern_mapping::{PatternMapping, ResolveType},
     },
     runtime_functions::{TURBOPACK_EXPORT_VALUE, TURBOPACK_MODULE_CONTEXT, TURBOPACK_REQUIRE},
@@ -458,6 +459,7 @@ impl EcmascriptChunkPlaceable for RequireContextAsset {
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::Value,
+            evaluation: EsmEvaluation::SideEffects,
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -47,7 +47,7 @@ use crate::{
     create_visitor,
     references::{
         AstPath,
-        esm::EsmEvaluation,
+        esm::EcmascriptEvaluation,
         pattern_mapping::{PatternMapping, ResolveType},
     },
     runtime_functions::{TURBOPACK_EXPORT_VALUE, TURBOPACK_MODULE_CONTEXT, TURBOPACK_REQUIRE},
@@ -459,7 +459,7 @@ impl EcmascriptChunkPlaceable for RequireContextAsset {
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::Value,
-            evaluation: EsmEvaluation::SideEffects,
+            evaluation: EcmascriptEvaluation::SideEffects,
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -238,7 +238,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
     async fn get_exports(&self) -> Result<Vc<EcmascriptExports>> {
         let mut exports = BTreeMap::new();
         let mut star_exports = Vec::new();
-        let mut evaluation = EsmEvaluation::SideEffects;
+        let evaluation;
 
         match &self.part {
             ModulePart::Facade => {
@@ -320,6 +320,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                         false,
                     ),
                 );
+                evaluation = EsmEvaluation::SideEffectFree;
             }
             ModulePart::RenamedNamespace { export } => {
                 exports.insert(
@@ -334,6 +335,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                         .await?,
                     )),
                 );
+                evaluation = EsmEvaluation::SideEffectFree;
             }
             _ => bail!("Unexpected ModulePart for EcmascriptModuleFacadeModule"),
         }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -22,7 +22,7 @@ use crate::{
     EcmascriptModuleContentOptions, EcmascriptOptions, MergedEcmascriptModule, SpecifiedModuleType,
     chunk::{EcmascriptChunkPlaceable, EcmascriptExports, EcmascriptExportsType},
     code_gen::CodeGens,
-    export::{EsmEvaluation, Liveness},
+    export::{EcmascriptEvaluation, Liveness},
     references::{
         async_module::{AsyncModule, OptionAsyncModule},
         esm::{EsmExport, EsmExports, base::EsmAssetReferences},
@@ -290,7 +290,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                     }
                 }
                 star_exports.extend(esm_exports.star_exports.iter().copied());
-                evaluation = EsmEvaluation::DelegatedSideEffects(ResolvedVc::upcast(
+                evaluation = EcmascriptEvaluation::DelegatedSideEffects(ResolvedVc::upcast(
                     EcmascriptModulePartReference::new_part(
                         *self.module,
                         ModulePart::locals(),
@@ -320,7 +320,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                         false,
                     ),
                 );
-                evaluation = EsmEvaluation::SideEffectFree;
+                evaluation = EcmascriptEvaluation::SideEffectFree;
             }
             ModulePart::RenamedNamespace { export } => {
                 exports.insert(
@@ -335,7 +335,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
                         .await?,
                     )),
                 );
-                evaluation = EsmEvaluation::SideEffectFree;
+                evaluation = EcmascriptEvaluation::SideEffectFree;
             }
             _ => bail!("Unexpected ModulePart for EcmascriptModuleFacadeModule"),
         }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -343,11 +343,11 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleFacadeModule {
         let exports = EsmExports {
             exports,
             star_exports,
-            evaluation,
         }
         .resolved_cell();
         Ok(EcmascriptExports {
             ty: EcmascriptExportsType::EsmExports(exports),
+            evaluation,
         }
         .cell())
     }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -133,7 +133,8 @@ impl EcmascriptAnalyzable for EcmascriptModuleLocalsModule {
 impl EcmascriptChunkPlaceable for EcmascriptModuleLocalsModule {
     #[turbo_tasks::function]
     async fn get_exports(&self) -> Result<Vc<EcmascriptExports>> {
-        let EcmascriptExportsType::EsmExports(exports) = self.module.get_exports().await?.ty else {
+        let module_exports = self.module.get_exports().await?;
+        let EcmascriptExportsType::EsmExports(exports) = &module_exports.ty else {
             bail!("EcmascriptModuleLocalsModule must only be used on modules with EsmExports");
         };
         let esm_exports = exports.await?;
@@ -159,11 +160,11 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleLocalsModule {
         let exports = EsmExports {
             exports,
             star_exports: vec![],
-            evaluation: esm_exports.evaluation,
         }
         .resolved_cell();
         Ok(EcmascriptExports {
             ty: EcmascriptExportsType::EsmExports(exports),
+            evaluation: module_exports.evaluation,
         }
         .cell())
     }

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -159,6 +159,7 @@ impl EcmascriptChunkPlaceable for EcmascriptModuleLocalsModule {
         let exports = EsmExports {
             exports,
             star_exports: vec![],
+            evaluation: esm_exports.evaluation,
         }
         .resolved_cell();
         Ok(EcmascriptExports {

--- a/turbopack/crates/turbopack-json/src/lib.rs
+++ b/turbopack/crates/turbopack-json/src/lib.rs
@@ -28,7 +28,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
-    references::esm::EsmEvaluation,
+    references::esm::EcmascriptEvaluation,
     runtime_functions::TURBOPACK_EXPORT_VALUE,
 };
 
@@ -82,7 +82,7 @@ impl EcmascriptChunkPlaceable for JsonModuleAsset {
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::Value,
-            evaluation: EsmEvaluation::SideEffects,
+            evaluation: EcmascriptEvaluation::SideEffects,
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-json/src/lib.rs
+++ b/turbopack/crates/turbopack-json/src/lib.rs
@@ -28,6 +28,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
+    references::esm::EsmEvaluation,
     runtime_functions::TURBOPACK_EXPORT_VALUE,
 };
 
@@ -81,6 +82,7 @@ impl EcmascriptChunkPlaceable for JsonModuleAsset {
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::Value,
+            evaluation: EsmEvaluation::SideEffects,
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -15,6 +15,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
+    references::esm::EsmEvaluation,
     runtime_functions::TURBOPACK_EXPORT_VALUE,
     utils::StringifyJs,
 };
@@ -88,6 +89,7 @@ impl EcmascriptChunkPlaceable for StaticUrlJsModule {
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::Value,
+            evaluation: EsmEvaluation::SideEffects,
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -15,7 +15,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
-    references::esm::EsmEvaluation,
+    references::esm::EcmascriptEvaluation,
     runtime_functions::TURBOPACK_EXPORT_VALUE,
     utils::StringifyJs,
 };
@@ -89,7 +89,7 @@ impl EcmascriptChunkPlaceable for StaticUrlJsModule {
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::Value,
-            evaluation: EsmEvaluation::SideEffects,
+            evaluation: EcmascriptEvaluation::SideEffects,
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -16,6 +16,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
+    references::esm::EsmEvaluation,
     runtime_functions::TURBOPACK_EXPORT_VALUE,
     utils::StringifyJs,
 };
@@ -94,6 +95,7 @@ impl EcmascriptChunkPlaceable for RawWebAssemblyModuleAsset {
     fn get_exports(self: Vc<Self>) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::Value,
+            evaluation: EsmEvaluation::SideEffects,
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -16,7 +16,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
         EcmascriptChunkType, EcmascriptExports, EcmascriptExportsType,
     },
-    references::esm::EsmEvaluation,
+    references::esm::EcmascriptEvaluation,
     runtime_functions::TURBOPACK_EXPORT_VALUE,
     utils::StringifyJs,
 };
@@ -95,7 +95,7 @@ impl EcmascriptChunkPlaceable for RawWebAssemblyModuleAsset {
     fn get_exports(self: Vc<Self>) -> Vc<EcmascriptExports> {
         EcmascriptExports {
             ty: EcmascriptExportsType::Value,
-            evaluation: EsmEvaluation::SideEffects,
+            evaluation: EcmascriptEvaluation::SideEffects,
         }
         .cell()
     }

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -899,14 +899,17 @@ impl AssetContext for ModuleAssetContext {
 
     #[turbo_tasks::function]
     async fn side_effect_free_packages(&self) -> Result<Vc<Glob>> {
-        let pkgs = &self.module_options_context.await?.side_effect_free_packages;
-
-        let mut globs = String::new();
-        globs.push_str("**/node_modules/{");
-        globs.push_str(&pkgs.join(","));
-        globs.push_str("}/**");
-
-        Ok(Glob::new(globs.into(), GlobOptions::default()))
+        Ok(self
+            .module_options_context
+            .await?
+            .side_effect_free_packages
+            .map_or_else(
+                || {
+                    // If no side effect free packages are configured, return an empty glob.
+                    Glob::new(rcstr!(""), GlobOptions::default())
+                },
+                |glob| *glob,
+            ))
     }
 }
 

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -227,6 +227,7 @@ impl ModuleOptions {
             execution_context,
             tree_shaking_mode,
             keep_last_successful_parse,
+            side_effect_free_packages,
             is_tracing,
             ..
         } = *module_options_context.await?;
@@ -281,6 +282,7 @@ impl ModuleOptions {
             ignore_dynamic_requests,
             extract_source_map: matches!(ecmascript_source_maps, SourceMapsType::Full),
             keep_last_successful_parse,
+            side_effect_free_packages,
             is_tracing,
             enable_typeof_window_inlining,
             ..Default::default()

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -4,7 +4,10 @@ use serde::{Deserialize, Serialize};
 use turbo_esregex::EsRegex;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, ValueDefault, Vc, trace::TraceRawVcs};
-use turbo_tasks_fs::FileSystemPath;
+use turbo_tasks_fs::{
+    FileSystemPath,
+    glob::{Glob, GlobOptions},
+};
 use turbopack_core::{
     chunk::SourceMapsType, compile_time_info::CompileTimeInfo, condition::ContextCondition,
     environment::Environment, resolve::options::ImportMapping,
@@ -187,7 +190,7 @@ pub struct ModuleOptionsContext {
 
     pub environment: Option<ResolvedVc<Environment>>,
     pub execution_context: Option<ResolvedVc<ExecutionContext>>,
-    pub side_effect_free_packages: Vec<RcStr>,
+    pub side_effect_free_packages: Option<ResolvedVc<Glob>>,
     pub tree_shaking_mode: Option<TreeShakingMode>,
 
     /// Generate (non-emitted) output assets for static assets and externals, to facilitate
@@ -268,4 +271,13 @@ impl ValueDefault for ModuleOptionsContext {
     fn value_default() -> Vc<Self> {
         Self::cell(Default::default())
     }
+}
+
+pub fn package_list_to_glob(pkgs: Vec<RcStr>) -> Vc<Glob> {
+    let mut globs = String::new();
+    globs.push_str("**/node_modules/{");
+    globs.push_str(&pkgs.join(","));
+    globs.push_str("}/**");
+
+    Glob::new(globs.into(), GlobOptions::default())
 }


### PR DESCRIPTION
Turbopack: add `evaluation` info to `EsmExports`

fixup

move evaluation to EcmascriptExports

expose evaluation as `get_evaluation`

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
