### PR TITLE
Turbopack: organize tree shaking code

### DIFF
--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -42,7 +42,7 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     EcmascriptParsable, chunk::EcmascriptChunkPlaceable, parse::ParseResult,
-    tree_shake::asset::EcmascriptModulePartAsset,
+    tree_shake::part::module::EcmascriptModulePartAsset,
 };
 
 #[turbo_tasks::value]

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -20,7 +20,7 @@ use crate::{
     SpecifiedModuleType,
     analyzer::{ConstantValue, ObjectPart},
     magic_identifier,
-    tree_shake::{PartId, find_turbopack_part_id_in_asserts},
+    tree_shake::find_turbopack_part_id_in_asserts,
 };
 
 #[turbo_tasks::value]
@@ -819,11 +819,8 @@ pub(crate) fn orig_name(n: &ModuleExportName) -> Atom {
 
 fn parse_with(with: Option<&ObjectLit>) -> Option<ImportedSymbol> {
     find_turbopack_part_id_in_asserts(with?).map(|v| match v {
-        PartId::Internal(index, true) => ImportedSymbol::PartEvaluation(index),
-        PartId::Internal(index, false) => ImportedSymbol::Part(index),
-        PartId::ModuleEvaluation => ImportedSymbol::ModuleEvaluation,
-        PartId::Export(e) => ImportedSymbol::Symbol(e.as_str().into()),
-        PartId::Exports => ImportedSymbol::Exports,
+        (index, true) => ImportedSymbol::PartEvaluation(index),
+        (index, false) => ImportedSymbol::Part(index),
     })
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -22,6 +22,7 @@ pub mod minify;
 pub mod parse;
 mod path_visitor;
 pub mod references;
+pub mod rename;
 pub mod runtime_functions;
 pub mod side_effect_optimization;
 pub mod source_map;

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -46,7 +46,7 @@ use crate::{
     magic_identifier,
     references::{esm::EsmExport, util::throw_module_not_found_expr},
     runtime_functions::{TURBOPACK_EXTERNAL_IMPORT, TURBOPACK_EXTERNAL_REQUIRE, TURBOPACK_IMPORT},
-    tree_shake::{TURBOPACK_PART_IMPORT_SOURCE, asset::EcmascriptModulePartAsset},
+    tree_shake::{TURBOPACK_PART_IMPORT_SOURCE, part::module::EcmascriptModulePartAsset},
     utils::module_id_to_lit,
 };
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -34,7 +34,7 @@ use crate::{
     code_gen::{CodeGeneration, CodeGenerationHoistedStmt},
     magic_identifier,
     runtime_functions::{TURBOPACK_DYNAMIC, TURBOPACK_ESM},
-    tree_shake::asset::EcmascriptModulePartAsset,
+    tree_shake::part::module::EcmascriptModulePartAsset,
     utils::module_id_to_lit,
 };
 

--- a/turbopack/crates/turbopack-ecmascript/src/rename/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/rename/chunk_item.rs
@@ -1,0 +1,79 @@
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, Vc};
+use turbopack_core::{
+    chunk::{AsyncModuleInfo, ChunkItem, ChunkType, ChunkingContext},
+    ident::AssetIdent,
+    module::Module,
+};
+
+use crate::{
+    EcmascriptAnalyzableExt,
+    chunk::{
+        EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkPlaceable,
+        EcmascriptChunkType,
+    },
+    rename::module::EcmascriptModuleRenameModule,
+};
+
+/// The chunk item for [EcmascriptModuleRenameModule].
+#[turbo_tasks::value(shared)]
+pub struct EcmascriptModuleRenameChunkItem {
+    pub(crate) module: ResolvedVc<EcmascriptModuleRenameModule>,
+    pub(crate) chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkItem for EcmascriptModuleRenameChunkItem {
+    #[turbo_tasks::function]
+    fn content(self: Vc<Self>) -> Vc<EcmascriptChunkItemContent> {
+        panic!("content() should never be called");
+    }
+
+    #[turbo_tasks::function]
+    fn content_with_async_module_info(
+        &self,
+        async_module_info: Option<Vc<AsyncModuleInfo>>,
+    ) -> Result<Vc<EcmascriptChunkItemContent>> {
+        let chunking_context = self.chunking_context;
+
+        let content = self
+            .module
+            .module_content(*chunking_context, async_module_info);
+
+        let async_module_options = self
+            .module
+            .get_async_module()
+            .module_options(async_module_info);
+
+        Ok(EcmascriptChunkItemContent::new(
+            content,
+            *chunking_context,
+            async_module_options,
+        ))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkItem for EcmascriptModuleRenameChunkItem {
+    #[turbo_tasks::function]
+    fn asset_ident(&self) -> Vc<AssetIdent> {
+        self.module.ident()
+    }
+
+    #[turbo_tasks::function]
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        *self.chunking_context
+    }
+
+    #[turbo_tasks::function]
+    async fn ty(&self) -> Result<Vc<Box<dyn ChunkType>>> {
+        Ok(Vc::upcast(
+            Vc::<EcmascriptChunkType>::default().resolve().await?,
+        ))
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        *ResolvedVc::upcast(self.module)
+    }
+}

--- a/turbopack/crates/turbopack-ecmascript/src/rename/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/rename/mod.rs
@@ -1,0 +1,2 @@
+pub mod chunk_item;
+pub mod module;

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -25,6 +25,7 @@ use crate::{
     chunk::EcmascriptChunkPlaceable,
     code_gen::{CodeGeneration, CodeGenerationHoistedStmt},
     references::esm::base::{ReferencedAsset, ReferencedAssetIdent},
+    rename::module::EcmascriptModuleRenameModule,
     runtime_functions::TURBOPACK_IMPORT,
     utils::module_id_to_lit,
 };
@@ -111,11 +112,15 @@ impl ModuleReference for EcmascriptModulePartReference {
                         };
                         Vc::upcast::<Box<dyn Module>>(EcmascriptModuleLocalsModule::new(*module))
                     }
-                    ModulePart::Facade
-                    | ModulePart::RenamedExport { .. }
-                    | ModulePart::RenamedNamespace { .. } => Vc::upcast(
-                        EcmascriptModuleFacadeModule::new(*self.module, self.part.clone()),
-                    ),
+                    ModulePart::Facade => {
+                        Vc::upcast(EcmascriptModuleFacadeModule::new(*self.module))
+                    }
+                    ModulePart::RenamedExport { .. } | ModulePart::RenamedNamespace { .. } => {
+                        Vc::upcast(EcmascriptModuleRenameModule::new(
+                            *self.module,
+                            self.part.clone(),
+                        ))
+                    }
                     _ => {
                         bail!(
                             "Unexpected ModulePart \"{}\" for EcmascriptModulePartReference",

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/merge.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/merge.rs
@@ -5,7 +5,7 @@ use swc_core::ecma::{
     atoms::Atom,
 };
 
-use super::{PartId, graph::find_turbopack_part_id_in_asserts};
+use super::graph::find_turbopack_part_id_in_asserts;
 
 /// A loader used to merge module items after splitting.
 pub trait Load {
@@ -53,7 +53,7 @@ where
                         .as_deref()
                         .and_then(find_turbopack_part_id_in_asserts);
 
-                    if let Some(PartId::Internal(part_id, _)) = part_id {
+                    if let Some((part_id, _)) = part_id {
                         if self.done.insert((import.src.value.clone(), part_id)) {
                             if let Some(dep) = self.loader.load(&import.src.value, part_id)? {
                                 let mut dep = self.merge_recursively(dep)?;

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -24,12 +24,11 @@ use crate::{
     EcmascriptModuleAsset, EcmascriptParsable, analyzer::graph::EvalContext, parse::ParseResult,
 };
 
-pub mod asset;
-pub mod chunk_item;
 mod graph;
 pub mod merge;
 mod optimizations;
-pub mod side_effect_module;
+pub mod part;
+pub mod side_effects;
 #[cfg(test)]
 mod tests;
 mod util;

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/chunk_item.rs
@@ -1,0 +1,76 @@
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, Vc};
+use turbopack_core::{
+    chunk::{AsyncModuleInfo, ChunkItem, ChunkType, ChunkingContext},
+    ident::AssetIdent,
+    module::Module,
+};
+
+use crate::{
+    EcmascriptAnalyzableExt,
+    chunk::{EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkType},
+    tree_shake::part::module::EcmascriptModulePartAsset,
+};
+
+/// This is an implementation of [ChunkItem] for
+/// [Vc<EcmascriptModulePartAsset>].
+///
+/// This is a pointer to a part of an ES module.
+#[turbo_tasks::value(shared)]
+pub struct EcmascriptModulePartChunkItem {
+    pub(super) module: ResolvedVc<EcmascriptModulePartAsset>,
+    pub(super) chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+}
+
+#[turbo_tasks::value_impl]
+impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
+    #[turbo_tasks::function]
+    fn content(self: Vc<Self>) -> Vc<EcmascriptChunkItemContent> {
+        panic!("content() should never be called");
+    }
+
+    #[turbo_tasks::function]
+    async fn content_with_async_module_info(
+        &self,
+        async_module_info: Option<Vc<AsyncModuleInfo>>,
+    ) -> Result<Vc<EcmascriptChunkItemContent>> {
+        let analyze = self.module.analyze();
+        let analyze_ref = analyze.await?;
+        let async_module_options = analyze_ref.async_module.module_options(async_module_info);
+
+        let content = self
+            .module
+            .module_content(*self.chunking_context, async_module_info);
+
+        Ok(EcmascriptChunkItemContent::new(
+            content,
+            *self.chunking_context,
+            async_module_options,
+        ))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ChunkItem for EcmascriptModulePartChunkItem {
+    #[turbo_tasks::function]
+    fn asset_ident(&self) -> Vc<AssetIdent> {
+        self.module.ident()
+    }
+
+    #[turbo_tasks::function]
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
+        *self.chunking_context
+    }
+
+    #[turbo_tasks::function]
+    async fn ty(&self) -> Result<Vc<Box<dyn ChunkType>>> {
+        Ok(Vc::upcast(
+            Vc::<EcmascriptChunkType>::default().resolve().await?,
+        ))
+    }
+
+    #[turbo_tasks::function]
+    fn module(&self) -> Vc<Box<dyn Module>> {
+        *ResolvedVc::upcast(self.module)
+    }
+}

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/mod.rs
@@ -1,0 +1,2 @@
+pub mod chunk_item;
+pub mod module;

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/module.rs
@@ -20,7 +20,7 @@ use crate::{
     references::{
         FollowExportsResult, analyse_ecmascript_module, esm::FoundExportType, follow_reexports,
     },
-    side_effect_optimization::facade::module::EcmascriptModuleFacadeModule,
+    rename::module::EcmascriptModuleRenameModule,
     tree_shake::{
         Key, SplitResult, get_part_id, part::chunk_item::EcmascriptModulePartChunkItem,
         part_of_module, side_effects::module::SideEffectsModule, split_module,
@@ -188,7 +188,7 @@ impl EcmascriptModulePartAsset {
                         *final_module
                     } else {
                         ResolvedVc::upcast(
-                            EcmascriptModuleFacadeModule::new(
+                            EcmascriptModuleRenameModule::new(
                                 **final_module,
                                 ModulePart::renamed_export(new_export.clone(), export.clone()),
                             )
@@ -198,7 +198,7 @@ impl EcmascriptModulePartAsset {
                     }
                 } else {
                     ResolvedVc::upcast(
-                        EcmascriptModuleFacadeModule::new(
+                        EcmascriptModuleRenameModule::new(
                             **final_module,
                             ModulePart::renamed_namespace(export.clone()),
                         )

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/module.rs
@@ -11,10 +11,6 @@ use turbopack_core::{
     resolve::{ExportUsage, ModulePart},
 };
 
-use super::{
-    SplitResult, chunk_item::EcmascriptModulePartChunkItem, get_part_id, part_of_module,
-    split_module,
-};
 use crate::{
     AnalyzeEcmascriptModuleResult, EcmascriptAnalyzable, EcmascriptModuleAsset,
     EcmascriptModuleAssetType, EcmascriptModuleContent, EcmascriptModuleContentOptions,
@@ -25,7 +21,10 @@ use crate::{
         FollowExportsResult, analyse_ecmascript_module, esm::FoundExportType, follow_reexports,
     },
     side_effect_optimization::facade::module::EcmascriptModuleFacadeModule,
-    tree_shake::{Key, side_effect_module::SideEffectsModule},
+    tree_shake::{
+        Key, SplitResult, get_part_id, part::chunk_item::EcmascriptModulePartChunkItem,
+        part_of_module, side_effects::module::SideEffectsModule, split_module,
+    },
 };
 
 /// A reference to part of an ES module.
@@ -42,6 +41,7 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     fn failsafe_parse(&self) -> Result<Vc<ParseResult>> {
         let split_data = split_module(*self.full_module);
+        assert_ne!(self.part, ModulePart::Facade);
         Ok(part_of_module(split_data, self.part.clone()))
     }
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effects/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effects/chunk_item.rs
@@ -2,87 +2,22 @@ use anyhow::Result;
 use turbo_tasks::{ResolvedVc, ValueDefault, Vc};
 use turbo_tasks_fs::rope::RopeBuilder;
 use turbopack_core::{
-    chunk::{AsyncModuleInfo, ChunkItem, ChunkType, ChunkingContext, ModuleChunkItemIdExt},
+    chunk::{ChunkItem, ChunkType, ChunkingContext, ModuleChunkItemIdExt},
     ident::AssetIdent,
     module::Module,
     module_graph::ModuleGraph,
 };
 
-use super::asset::EcmascriptModulePartAsset;
 use crate::{
-    EcmascriptAnalyzableExt,
     chunk::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemOptions,
         EcmascriptChunkPlaceable, EcmascriptChunkType,
     },
     references::async_module::AsyncModuleOptions,
     runtime_functions::{TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_IMPORT},
-    tree_shake::side_effect_module::SideEffectsModule,
+    tree_shake::side_effects::module::SideEffectsModule,
     utils::StringifyModuleId,
 };
-
-/// This is an implementation of [ChunkItem] for
-/// [Vc<EcmascriptModulePartAsset>].
-///
-/// This is a pointer to a part of an ES module.
-#[turbo_tasks::value(shared)]
-pub struct EcmascriptModulePartChunkItem {
-    pub(super) module: ResolvedVc<EcmascriptModulePartAsset>,
-    pub(super) chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
-}
-
-#[turbo_tasks::value_impl]
-impl EcmascriptChunkItem for EcmascriptModulePartChunkItem {
-    #[turbo_tasks::function]
-    fn content(self: Vc<Self>) -> Vc<EcmascriptChunkItemContent> {
-        panic!("content() should never be called");
-    }
-
-    #[turbo_tasks::function]
-    async fn content_with_async_module_info(
-        &self,
-        async_module_info: Option<Vc<AsyncModuleInfo>>,
-    ) -> Result<Vc<EcmascriptChunkItemContent>> {
-        let analyze = self.module.analyze();
-        let analyze_ref = analyze.await?;
-        let async_module_options = analyze_ref.async_module.module_options(async_module_info);
-
-        let content = self
-            .module
-            .module_content(*self.chunking_context, async_module_info);
-
-        Ok(EcmascriptChunkItemContent::new(
-            content,
-            *self.chunking_context,
-            async_module_options,
-        ))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ChunkItem for EcmascriptModulePartChunkItem {
-    #[turbo_tasks::function]
-    fn asset_ident(&self) -> Vc<AssetIdent> {
-        self.module.ident()
-    }
-
-    #[turbo_tasks::function]
-    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
-        *self.chunking_context
-    }
-
-    #[turbo_tasks::function]
-    async fn ty(&self) -> Result<Vc<Box<dyn ChunkType>>> {
-        Ok(Vc::upcast(
-            Vc::<EcmascriptChunkType>::default().resolve().await?,
-        ))
-    }
-
-    #[turbo_tasks::function]
-    fn module(&self) -> Vc<Box<dyn Module>> {
-        *ResolvedVc::upcast(self.module)
-    }
-}
 
 #[turbo_tasks::value(shared)]
 pub(super) struct SideEffectsModuleChunkItem {

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effects/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effects/mod.rs
@@ -1,0 +1,2 @@
+pub mod chunk_item;
+pub mod module;

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effects/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effects/module.rs
@@ -15,11 +15,11 @@ use crate::{
     EcmascriptModuleAsset,
     chunk::{EcmascriptChunkPlaceable, EcmascriptExports},
     export::EcmascriptEvaluation,
-    tree_shake::chunk_item::SideEffectsModuleChunkItem,
+    tree_shake::side_effects::chunk_item::SideEffectsModuleChunkItem,
 };
 
 #[turbo_tasks::value]
-pub(super) struct SideEffectsModule {
+pub struct SideEffectsModule {
     /// Original module
     pub module: ResolvedVc<EcmascriptModuleAsset>,
     /// The part of the original module that is the binding

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/bf321_tests_snapshot_basic-tree-shake_dynamic-import_input_lib_a280e616.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/output/bf321_tests_snapshot_basic-tree-shake_dynamic-import_input_lib_a280e616.js
@@ -167,16 +167,16 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 
 __turbopack_context__.s([
     "cat",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__["cat"],
+    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__["cat"],
     "dogRef",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__["dogRef"],
+    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__["dogRef"],
     "getChimera",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__["getChimera"],
+    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__["getChimera"],
     "initialCat",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__["initialCat"]
+    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__["initialCat"]
 ]);
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__2$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js [test] (ecmascript) <internal part 2>");
-var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js [test] (ecmascript) <exports>");
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$dynamic$2d$import$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/dynamic-import/input/lib.js [test] (ecmascript) <internal part 9>");
 ;
 ;
 }),

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/bf321_tests_snapshot_basic-tree-shake_require-side-effect_input_341cf5f1._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/output/bf321_tests_snapshot_basic-tree-shake_require-side-effect_input_341cf5f1._.js
@@ -167,16 +167,16 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 
 __turbopack_context__.s([
     "cat",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__["cat"],
+    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__["cat"],
     "dogRef",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__["dogRef"],
+    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__["dogRef"],
     "getChimera",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__["getChimera"],
+    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__["getChimera"],
     "initialCat",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__["initialCat"]
+    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__["initialCat"]
 ]);
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__2$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js [test] (ecmascript) <internal part 2>");
-var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js [test] (ecmascript) <exports>");
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$require$2d$side$2d$effect$2f$input$2f$lib$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/require-side-effect/input/lib.js [test] (ecmascript) <internal part 9>");
 ;
 ;
 }),

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/bf321_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_18e65124.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/output/bf321_tests_snapshot_basic-tree-shake_tree-shake-test-1_input_index_18e65124.js
@@ -167,16 +167,16 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 
 __turbopack_context__.s([
     "cat",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__["cat"],
+    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__["cat"],
     "dogRef",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__["dogRef"],
+    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__["dogRef"],
     "getChimera",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__["getChimera"],
+    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__["getChimera"],
     "initialCat",
-    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__["initialCat"]
+    ()=>__TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__["initialCat"]
 ]);
 var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__2$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <internal part 2>");
-var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$exports$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <exports>");
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2d$tree$2d$shake$2f$tree$2d$shake$2d$test$2d$1$2f$input$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$internal__part__9$3e$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic-tree-shake/tree-shake-test-1/input/index.js [test] (ecmascript) <internal part 9>");
 ;
 ;
 }),

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -58,6 +58,7 @@ use turbopack_ecmascript::{
     references::external_module::{
         CachedExternalModule, CachedExternalTracingMode, CachedExternalType,
     },
+    rename::module::EcmascriptModuleRenameModule,
     side_effect_optimization::locals::module::EcmascriptModuleLocalsModule,
     tree_shake::part::module::EcmascriptModulePartAsset,
 };
@@ -177,10 +178,9 @@ async fn apply_module_type(
                                     ModulePart::Export(_) => {
                                         apply_reexport_tree_shaking(
                                             Vc::upcast(
-                                                EcmascriptModuleFacadeModule::new(
-                                                    Vc::upcast(*module),
-                                                    ModulePart::facade(),
-                                                )
+                                                EcmascriptModuleFacadeModule::new(Vc::upcast(
+                                                    *module,
+                                                ))
                                                 .resolve()
                                                 .await?,
                                             ),
@@ -195,10 +195,7 @@ async fn apply_module_type(
                                     ),
                                 }
                             } else {
-                                Vc::upcast(EcmascriptModuleFacadeModule::new(
-                                    Vc::upcast(*module),
-                                    ModulePart::facade(),
-                                ))
+                                Vc::upcast(EcmascriptModuleFacadeModule::new(Vc::upcast(*module)))
                             }
                         } else {
                             Vc::upcast(*module)
@@ -273,13 +270,13 @@ async fn apply_reexport_tree_shaking(
             if *new_export == *export {
                 Vc::upcast(**final_module)
             } else {
-                Vc::upcast(EcmascriptModuleFacadeModule::new(
+                Vc::upcast(EcmascriptModuleRenameModule::new(
                     **final_module,
                     ModulePart::renamed_export(new_export.clone(), export.clone()),
                 ))
             }
         } else {
-            Vc::upcast(EcmascriptModuleFacadeModule::new(
+            Vc::upcast(EcmascriptModuleRenameModule::new(
                 **final_module,
                 ModulePart::renamed_namespace(export.clone()),
             ))

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -59,7 +59,7 @@ use turbopack_ecmascript::{
         CachedExternalModule, CachedExternalTracingMode, CachedExternalType,
     },
     side_effect_optimization::locals::module::EcmascriptModuleLocalsModule,
-    tree_shake::asset::EcmascriptModulePartAsset,
+    tree_shake::part::module::EcmascriptModulePartAsset,
 };
 use turbopack_json::JsonModuleAsset;
 pub use turbopack_resolve::{resolve::resolve_options, resolve_options_context};


### PR DESCRIPTION
Turbopack: organize tree shaking code

Turbopack: Extract rename module and share between side effects optimization and tree shaking

Turbopack: Tree Shaking imports only internal

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
