### PR TITLE
docs: We have dropped the CORS example linked

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/route.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/route.mdx
@@ -546,7 +546,6 @@ export async function GET(request) {
 > **Good to know**:
 >
 > - To add CORS headers to multiple Route Handlers, you can use [Middleware](/docs/app/api-reference/file-conventions/middleware#cors) or the [`next.config.js` file](/docs/app/api-reference/config/next-config-js/headers#cors).
-> - Alternatively, see our [CORS example](https://github.com/vercel/examples/blob/main/edge-functions/cors/lib/cors.ts) package.
 
 ### Webhooks
 


### PR DESCRIPTION
We have dropped the example linked in this page. I'll re-evaluate later if the section is still enough for a dev to understand how to set CORS related headers.