### PR TITLE
Flag excess properties in Next.js config with TypeScript

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2459,7 +2459,7 @@ export default async function getBaseWebpackConfig(
     assetPrefix: config.assetPrefix || '',
     sassOptions: config.sassOptions,
     productionBrowserSourceMaps: config.productionBrowserSourceMaps,
-    future: config.future,
+    future: (config as any).future,
     experimental: config.experimental,
     disableStaticImages: config.images.disableStaticImages,
     transpilePackages: config.transpilePackages,
@@ -2636,8 +2636,8 @@ export default async function getBaseWebpackConfig(
   }
 
   // Backwards compat with webpack-dev-middleware options object
-  if (typeof config.webpackDevMiddleware === 'function') {
-    const options = config.webpackDevMiddleware({
+  if (typeof (config as any).webpackDevMiddleware === 'function') {
+    const options = (config as any).webpackDevMiddleware({
       watchOptions: webpackConfig.watchOptions,
     })
     if (options.watchOptions) {

--- a/packages/next/src/build/webpack/config/index.ts
+++ b/packages/next/src/build/webpack/config/index.ts
@@ -39,9 +39,10 @@ export async function buildConfiguration(
     sassOptions: any
     productionBrowserSourceMaps: boolean
     transpilePackages: NextConfigComplete['transpilePackages']
+    // @ts-expect-error TODO: remove any
     future: NextConfigComplete['future']
     experimental: NextConfigComplete['experimental']
-    disableStaticImages: NextConfigComplete['disableStaticImages']
+    disableStaticImages: NextConfigComplete['images']['disableStaticImages']
     serverSourceMaps: NextConfigComplete['experimental']['serverSourceMaps']
   }
 ): Promise<webpack.Configuration> {

--- a/packages/next/src/build/webpack/config/utils.ts
+++ b/packages/next/src/build/webpack/config/utils.ts
@@ -26,6 +26,7 @@ export type ConfigurationContext = {
 
   transpilePackages: NextConfigComplete['transpilePackages']
 
+  // @ts-expect-error TODO: remove any
   future: NextConfigComplete['future']
   experimental: NextConfigComplete['experimental']
 }

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -127,7 +127,7 @@ async function exportAppImpl(
     )
   }
 
-  const customRoutes = ['rewrites', 'redirects', 'headers'].filter(
+  const customRoutes = (['rewrites', 'redirects', 'headers'] as const).filter(
     (config) => typeof nextConfig[config] === 'function'
   )
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -16,11 +16,10 @@ import { INFINITE_CACHE } from '../lib/constants'
 import { isStableBuild } from '../shared/lib/canary-only'
 import type { FallbackRouteParam } from '../build/static-paths/types'
 
-export type NextConfigComplete = Required<NextConfig> & {
+export type NextConfigComplete = Required<Omit<NextConfig, 'configFile'>> & {
   images: Required<ImageConfigComplete>
   typescript: TypeScriptConfig
-  configOrigin?: string
-  configFile?: string
+  configFile: string | undefined
   configFileName: string
   // override NextConfigComplete.experimental.htmlLimitedBots to string
   // because it's not defined in NextConfigComplete.experimental
@@ -916,7 +915,7 @@ export type ExportPathMap = {
  *
  * Read more: [Next.js Docs: `next.config.js`](https://nextjs.org/docs/app/api-reference/config/next-config-js)
  */
-export interface NextConfig extends Record<string, any> {
+export interface NextConfig {
   allowedDevOrigins?: string[]
 
   exportPathMap?: (
@@ -1331,6 +1330,26 @@ export interface NextConfig extends Record<string, any> {
    * /Mediapartners-Google|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview/i
    */
   htmlLimitedBots?: RegExp
+
+  /**
+   * @internal
+   */
+  configFile?: string | undefined
+
+  /**
+   * @internal
+   */
+  configOrigin?: string | undefined
+
+  /**
+   * @internal
+   */
+  _originalRedirects?: any
+
+  /**
+   * @internal
+   */
+  _originalRewrites?: any
 }
 
 export const defaultConfig = Object.freeze({

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -77,8 +77,8 @@ export function warnOptionHasBeenDeprecated(
     let found = true
     const nestedPropertyKeys = nestedPropertyKey.split('.')
     for (const key of nestedPropertyKeys) {
-      if (current[key] !== undefined) {
-        current = current[key]
+      if ((current as any)[key] !== undefined) {
+        current = (current as any)[key]
       } else {
         found = false
         break
@@ -168,10 +168,12 @@ export function warnOptionHasBeenMovedOutOfExperimental(
     const newKeys = newKey.split('.')
     while (newKeys.length > 1) {
       const key = newKeys.shift()!
-      current[key] = current[key] || {}
-      current = current[key]
+      ;(current as any)[key] = (current as any)[key] || {}
+      current = (current as any)[key]
     }
-    current[newKeys.shift()!] = (config.experimental as any)[oldExperimentalKey]
+    ;(current as any)[newKeys.shift()!] = (config.experimental as any)[
+      oldExperimentalKey
+    ]
   }
 
   return config
@@ -193,7 +195,7 @@ function warnCustomizedOption(
     if (!(seg in current)) {
       return
     }
-    current = current[seg]
+    current = (current as any)[seg]
   }
 
   if (!silent && current !== defaultValue) {
@@ -219,16 +221,16 @@ function assignDefaultsAndValidate(
   phase: PHASE_TYPE
 ): NextConfigComplete {
   const configFileName = userConfig.configFileName
-  if (typeof userConfig.exportTrailingSlash !== 'undefined') {
+  if (typeof (userConfig as any).exportTrailingSlash !== 'undefined') {
     if (!silent) {
       Log.warn(
         `The "exportTrailingSlash" option has been renamed to "trailingSlash". Please update your ${configFileName}.`
       )
     }
     if (typeof userConfig.trailingSlash === 'undefined') {
-      userConfig.trailingSlash = userConfig.exportTrailingSlash
+      userConfig.trailingSlash = (userConfig as any).exportTrailingSlash
     }
-    delete userConfig.exportTrailingSlash
+    delete (userConfig as any).exportTrailingSlash
   }
 
   // Handle migration of experimental.dynamicIO to experimental.cacheComponents
@@ -246,7 +248,7 @@ function assignDefaultsAndValidate(
 
   const config = Object.keys(userConfig).reduce<{ [key: string]: any }>(
     (currentConfig, key) => {
-      const value = userConfig[key]
+      const value = (userConfig as any)[key]
 
       if (value === undefined || value === null) {
         return currentConfig
@@ -1267,7 +1269,6 @@ function getCacheKey(
 
   return djb2Hash(keyData).toString(36)
 }
-
 export default async function loadConfig(
   phase: PHASE_TYPE,
   dir: string,
@@ -1372,7 +1373,7 @@ export default async function loadConfig(
         silent,
         configuredExperimentalFeatures,
         phase
-      ) as NextConfigComplete,
+      ),
       phase,
       silent
     )
@@ -1482,7 +1483,7 @@ export default async function loadConfig(
       validateConfigSchema(userConfig, configFileName, curLog.warn)
     }
 
-    if (userConfig.target && userConfig.target !== 'server') {
+    if ((userConfig as any).target && (userConfig as any).target !== 'server') {
       throw new Error(
         `The "target" property is no longer supported in ${configFileName}.\n` +
           'See more info here https://nextjs.org/docs/messages/deprecated-target-config'
@@ -1580,7 +1581,7 @@ export default async function loadConfig(
       silent,
       configuredExperimentalFeatures,
       phase
-    ) as NextConfigComplete
+    )
 
     const finalConfig = await applyModifyConfig(completeConfig, phase, silent)
 

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -23,17 +23,17 @@ describe('config', () => {
   })
   it('Should get the configuration', async () => {
     const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfig)
-    expect(config.customConfig).toBe(true)
+    expect((config as any).customConfig).toBe(true)
   })
 
   it('Should pass the phase correctly', async () => {
     const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
-    expect(config.phase).toBe(PHASE_DEVELOPMENT_SERVER)
+    expect((config as any).phase).toBe(PHASE_DEVELOPMENT_SERVER)
   })
 
   it('Should pass the defaultConfig correctly', async () => {
     const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
-    expect(config.defaultConfig).toBeDefined()
+    expect((config as any).defaultConfig).toBeDefined()
   })
 
   it('Should assign object defaults deeply to user config', async () => {
@@ -48,7 +48,7 @@ describe('config', () => {
         customConfigKey: 'customConfigValue',
       },
     })
-    expect(config.customConfigKey).toBe('customConfigValue')
+    expect((config as any).customConfigKey).toBe('customConfigValue')
   })
 
   it('Should assign object defaults deeply to customConfig', async () => {
@@ -58,7 +58,7 @@ describe('config', () => {
         onDemandEntries: { custom: true },
       },
     })
-    expect(config.customConfig).toBe(true)
+    expect((config as any).customConfig).toBe(true)
     expect(config.onDemandEntries.maxInactiveAge).toBeDefined()
   })
 
@@ -68,8 +68,8 @@ describe('config', () => {
         bogusSetting: { custom: true },
       },
     })
-    expect(config.bogusSetting).toBeDefined()
-    expect(config.bogusSetting.custom).toBe(true)
+    expect((config as any).bogusSetting).toBeDefined()
+    expect((config as any).bogusSetting.custom).toBe(true)
   })
 
   it('Should override defaults for arrays from user arrays', async () => {
@@ -107,7 +107,7 @@ describe('config', () => {
       PHASE_DEVELOPMENT_SERVER,
       join(__dirname, '_resolvedata', 'js-ts-config')
     )
-    expect(config.__test__ext).toBe('js')
+    expect((config as any).__test__ext).toBe('js')
   })
 
   it('Should not throw an error when next.config.ts is present', async () => {
@@ -115,7 +115,7 @@ describe('config', () => {
       PHASE_DEVELOPMENT_SERVER,
       join(__dirname, '_resolvedata', 'typescript-config')
     )
-    expect(config.__test__ext).toBe('ts')
+    expect((config as any).__test__ext).toBe('ts')
   })
 
   describe('outputFileTracingRoot and turbopack.root consistency', () => {


### PR DESCRIPTION
The config previously extended `Record<string, any>`. That means that you can read from any property without the typechecker flagging access. This hid the bug fixed in https://github.com/vercel/next.js/pull/84062.

It also hides any typo since that would be considered an excess property e.g. 

```
const config: NextConfig = {
  reactStrictMod: true
}
```
was previously not flagged. 

Now we no longer allow excess props by default so the above would give you this error:
```
Object literal may only specify known properties, but 'reactStrictMod' does not exist in type 'NextConfig'.
Did you mean to write 'reactStrictMode'?
```
Disallowing excess props could lead to new failures during type-checking if excess properties are specified. `next.config.ts` is relatively new so hopefully not too many excess props have crept int.

