### PR TITLE
Current behavior for either `--profile` or `config.reactProductionProfiling`

### DIFF
--- a/test/integration/react-profiling-mode/test/index.test.js
+++ b/test/integration/react-profiling-mode/test/index.test.js
@@ -35,8 +35,46 @@ describe('React Profiling Mode', () => {
 
       describe('with config enabled', () => {
         beforeAll(async () => {
-          await nextBuild(appDir, ['--profile'], {
+          await nextBuild(appDir, [], {
             env: { TEST_REACT_PRODUCTION_PROFILING: 'true' },
+          })
+          appPort = await findPort()
+          app = await nextStart(appDir, appPort)
+        })
+        afterAll(async () => {
+          await killApp(app)
+        })
+
+        it('should have used the react-dom profiling bundle for pages', async () => {
+          const browser = await webdriver(appPort, '/')
+          const results = await browser.eval('window.profileResults')
+
+          expect(results.length).toBe(1)
+          expect(results[0] && results[0][0]).toBe('hello')
+        })
+
+        it('should have used the react-dom profiling bundle for client component', async () => {
+          const browser = await webdriver(appPort, '/client')
+          const results = await browser.eval('window.profileResults')
+
+          expect(results.length).toBe(1)
+          expect(results[0] && results[0][0]).toBe('hello-app-client')
+        })
+
+        it('should have used the react-dom profiling bundle for server component', async () => {
+          // Can't test react Profiler API in server components but make sure rendering works
+          const browser = await webdriver(appPort, '/server')
+
+          expect(await browser.waitForElementByCss('p').text()).toBe(
+            'hello app server'
+          )
+        })
+      })
+
+      describe('with flag', () => {
+        beforeAll(async () => {
+          await nextBuild(appDir, ['--profile'], {
+            env: { TEST_REACT_PRODUCTION_PROFILING: 'false' },
           })
           appPort = await findPort()
           app = await nextStart(appDir, appPort)


### PR DESCRIPTION

For the behavior reported in https://github.com/vercel/next.js/issues/68276. `config.reactProductionProfiling` has no effect in Webpack. You have to specify `--profile`. Turbopack does use React's profiling build with just `config.reactProductionProfiling`.
