### PR TITLE
Turbopack: run tests with multiple threads

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -161,7 +161,7 @@ fn get_messages(js_results: JsResult) -> Vec<String> {
     messages
 }
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn run(resource: PathBuf, snapshot_mode: IssueSnapshotMode) -> Result<JsResult> {
     // Clean up old output files.
     let output_path = resource.join("output");

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -189,7 +189,7 @@ fn test(resource: PathBuf) {
     run(resource).unwrap();
 }
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn run(resource: PathBuf) -> Result<()> {
     let tt = TurboTasks::new(TurboTasksBackend::new(
         BackendOptions {


### PR DESCRIPTION
These tests were broken
```
➜  next.js-other git:(mischnic/parallelize-merged-module-info) UPDATE=1 cargo nextest run -p turbopack-tests -E 'test(test_tests__execution__turbopack__basic__esm_this__input__index_js)' --no-capture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.37s
────────────
 Nextest run ID 1a4f74a3-a8a3-4049-bd6d-aa55a30c6dc2 with nextest profile: default
    Starting 1 test across 3 binaries (247 tests skipped)
       START             turbopack-tests::execution test_tests__execution__turbopack__basic__esm_this__input__index_js

running 1 test
Input: turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/esm-this/input/index.js

thread 'test_tests__execution__turbopack__basic__esm_this__input__index_js' panicked at turbopack/crates/turbo-tasks/src/scope.rs:166:5:
can call blocking only when running on the multi-threaded runtime
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'test_tests__execution__turbopack__basic__esm_this__input__index_js' panicked at turbopack/crates/turbopack-tests/tests/execution.rs:99:77:
called `Result::unwrap()` on an `Err` value: channel closed
test test_tests__execution__turbopack__basic__esm_this__input__index_js ... FAILED

failures:

failures:
    test_tests__execution__turbopack__basic__esm_this__input__index_js

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 169 filtered out; finished in 0.18s

        FAIL [   0.195s] turbopack-tests::execution test_tests__execution__turbopack__basic__esm_this__input__index_js
  Cancelling due to test failure:
────────────
     Summary [   0.195s] 1 test run: 0 passed, 1 failed, 247 skipped
        FAIL [   0.195s] turbopack-tests::execution test_tests__execution__turbopack__basic__esm_this__input__index_js
error: test run failed
```

Closes PACK-5520