### PR TITLE
Turbopack: flush Node.js worker IPC on error

### DIFF
--- a/turbopack/crates/turbopack-node/js/src/ipc/index.ts
+++ b/turbopack/crates/turbopack-node/js/src/ipc/index.ts
@@ -169,18 +169,20 @@ function createIpc<TIncoming, TOutgoing>(
     sendReady,
 
     async sendError(error: Error): Promise<never> {
+      let failed = false
       try {
         await send({
           type: 'error',
           ...structuredError(error),
         })
       } catch (err) {
+        // There's nothing we can do about errors that happen after this point, we can't tell anyone
+        // about them.
         console.error('failed to send error back to rust:', err)
-        // ignore and exit anyway
-        process.exit(1)
+        failed = true
       }
-
-      process.exit(0)
+      await new Promise<void>((res) => socket.end(() => res()))
+      process.exit(failed ? 1 : 0)
     },
   }
 }


### PR DESCRIPTION
If the Nodejs process exited too quickly after `sendError`, Turbopack never received the error message and then  previously crashed with panics such as 
```
- Execution of PostCssTransformedAsset::process failed
- creating new process
- reading packet length
- unexpected end of file
```

Now, flush the socket before calling `process.exit()`

Closes PACK-5521