### PR TITLE
trace-build: Add missing spans

### DIFF
--- a/packages/next/src/trace/report/to-json-build.ts
+++ b/packages/next/src/trace/report/to-json-build.ts
@@ -81,8 +81,12 @@ const allowlistedEvents = new Set([
   'run-typescript',
   'run-eslint',
   'static-check',
+  'collect-build-traces',
   'static-generation',
   'output-export-full-static-export',
+  'adapter-handle-build-complete',
+  'output-standalone',
+  'telemetry-flush',
 ])
 
 function reportToJsonBuild(event: TraceEvent) {

--- a/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
+++ b/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
@@ -136,17 +136,32 @@ describe('trace-build-file', () => {
         foundEvents.add(event.name)
       }
 
-      expect([...foundEvents].sort()).toMatchInlineSnapshot(`
-       [
-         "next-build",
-         "run-eslint",
-         "run-turbopack",
-         "run-typescript",
-         "static-check",
-         "static-generation",
-         "telemetry-flush",
-       ]
-      `)
+      if (process.env.IS_TURBOPACK_TEST) {
+        expect([...foundEvents].sort()).toMatchInlineSnapshot(`
+                [
+                  "next-build",
+                  "run-eslint",
+                  "run-turbopack",
+                  "run-typescript",
+                  "static-check",
+                  "static-generation",
+                  "telemetry-flush",
+                ]
+              `)
+      } else {
+        expect([...foundEvents].sort()).toMatchInlineSnapshot(`
+         [
+           "collect-build-traces",
+           "next-build",
+           "run-eslint",
+           "run-typescript",
+           "run-webpack",
+           "static-check",
+           "static-generation",
+           "telemetry-flush",
+         ]
+        `)
+      }
     })
 
     it('should have next-build as root span with proper hierarchy', async () => {

--- a/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
+++ b/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
@@ -119,20 +119,34 @@ describe('trace-build-file', () => {
       const traceBuildPath = join(next.testDir, '.next/trace-build')
       const traceStructure = parseTraceFile(traceBuildPath)
 
-      const allowlistedEvents = new Set([
-        'next-build',
-        'run-turbopack',
-        'run-webpack',
-        'run-typescript',
-        'run-eslint',
-        'static-check',
-        'static-generation',
-        'output-export-full-static-export',
-      ])
+      // const allowlistedEvents = new Set([
+      //   'next-build',
+      //   'run-turbopack',
+      //   'run-webpack',
+      //   'run-typescript',
+      //   'run-eslint',
+      //   'static-check',
+      //   'static-generation',
+      //   'output-export-full-static-export',
+      // ])
+
+      const foundEvents = new Set<string>()
 
       for (const event of traceStructure.events) {
-        expect(allowlistedEvents.has(event.name)).toBe(true)
+        foundEvents.add(event.name)
       }
+
+      expect([...foundEvents].sort()).toMatchInlineSnapshot(`
+       [
+         "next-build",
+         "run-eslint",
+         "run-turbopack",
+         "run-typescript",
+         "static-check",
+         "static-generation",
+         "telemetry-flush",
+       ]
+      `)
     })
 
     it('should have next-build as root span with proper hierarchy', async () => {


### PR DESCRIPTION
## What?

Follow-up to #83949

While testing the changes I ran Turbopack builds and all time was captured, but for webpack there was some missing time related to tracing outputs (Turbopack does the tracing internally). This PR adds the missing spans to trace-build.

Closes PACK-5542