### PR TITLE
Turbopack: Deterministic builds (prerender-manifest, .next/package.json, ./next/postcss.js)

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -815,9 +815,9 @@ impl Project {
         let node_execution_chunking_context = Vc::upcast(
             NodeJsChunkingContext::builder(
                 self.project_root_path().owned().await?,
-                node_root.clone(),
+                node_root.join("build")?,
                 self.node_root_to_root_path().owned().await?,
-                node_root.clone(),
+                node_root.join("build")?,
                 node_root.join("build/chunks")?,
                 node_root.join("build/assets")?,
                 node_build_environment().to_resolved().await?,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2819,7 +2819,7 @@ export default async function build(
           )
 
           const sortedStaticPaths = Array.from(staticPaths.entries()).sort(
-            ([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)
+            ([a], [b]) => a.localeCompare(b)
           )
 
           const exportApp = (require('../export') as typeof import('../export'))

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2818,6 +2818,10 @@ export default async function build(
             )
           )
 
+          const sortedStaticPaths = Array.from(staticPaths.entries()).sort(
+            ([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)
+          )
+
           const exportApp = (require('../export') as typeof import('../export'))
             .default as typeof import('../export').default
 
@@ -2885,7 +2889,7 @@ export default async function build(
 
               // TODO: output manifest specific to app paths and their
               // revalidate periods and dynamicParams settings
-              staticPaths.forEach((routes, originalAppPath) => {
+              sortedStaticPaths.forEach(([originalAppPath, routes]) => {
                 const appConfig = appDefaultConfigs.get(originalAppPath)
                 const isDynamicError = appConfig?.dynamic === 'error'
 
@@ -3054,7 +3058,7 @@ export default async function build(
             await fs.unlink(serverBundle)
           }
 
-          staticPaths.forEach((prerenderedRoutes, originalAppPath) => {
+          sortedStaticPaths.forEach(([originalAppPath, prerenderedRoutes]) => {
             const page = appNormalizedPaths.get(originalAppPath)
             if (!page) throw new InvariantError('Page not found')
 

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -104,13 +104,7 @@ export async function turbopackBuild(): Promise<{
     })
     await fs.writeFile(
       path.join(distDir, 'package.json'),
-      JSON.stringify(
-        {
-          type: 'commonjs',
-        },
-        null,
-        2
-      )
+      '{"type": "commonjs"}'
     )
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
### What?

* Make order of routes in prerender manifest deterministic
* Write the same package.json content to distDir
* fix output directory for postcss/webpack loaders entrypoint


Closes PACK-5524