### PR TITLE
Turbopack: include availability hash in the ident of evaluated chunks groups

### DIFF
--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -573,13 +573,13 @@ impl ChunkingContext for BrowserChunkingContext {
         let span = tracing::info_span!("chunking", name = ident.to_string().await?.to_string());
         async move {
             let this = self.await?;
-            let modules = chunk_group.entries();
+            let entries = chunk_group.entries();
             let input_availability_info = availability_info;
             let MakeChunkGroupResult {
                 chunks,
                 availability_info,
             } = make_chunk_group(
-                modules,
+                entries,
                 module_graph,
                 ResolvedVc::upcast(self),
                 input_availability_info,
@@ -591,6 +591,7 @@ impl ChunkingContext for BrowserChunkingContext {
                 .map(|chunk| self.generate_chunk(**chunk).to_resolved())
                 .try_join()
                 .await?;
+            let other_assets = Vc::cell(assets.clone());
 
             if this.enable_hot_module_replacement {
                 let mut ident = ident;
@@ -608,7 +609,7 @@ impl ChunkingContext for BrowserChunkingContext {
                     self.generate_chunk_list_register_chunk(
                         ident,
                         EvaluatableAssets::empty(),
-                        Vc::cell(assets.clone()),
+                        other_assets,
                         EcmascriptDevChunkListSource::Dynamic,
                     )
                     .to_resolved()
@@ -632,7 +633,7 @@ impl ChunkingContext for BrowserChunkingContext {
         ident: Vc<AssetIdent>,
         chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
-        availability_info: AvailabilityInfo,
+        input_availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
         let span = {
             let ident = ident.to_string().await?.to_string();
@@ -640,9 +641,7 @@ impl ChunkingContext for BrowserChunkingContext {
         };
         async move {
             let this = self.await?;
-
             let entries = chunk_group.entries();
-
             let MakeChunkGroupResult {
                 chunks,
                 availability_info,
@@ -650,7 +649,7 @@ impl ChunkingContext for BrowserChunkingContext {
                 entries,
                 module_graph,
                 ResolvedVc::upcast(self),
-                availability_info,
+                input_availability_info,
             )
             .await?;
 
@@ -659,7 +658,6 @@ impl ChunkingContext for BrowserChunkingContext {
                 .map(|chunk| self.generate_chunk(**chunk).to_resolved())
                 .try_join()
                 .await?;
-
             let other_assets = Vc::cell(assets.clone());
 
             let entries = Vc::cell(
@@ -673,6 +671,17 @@ impl ChunkingContext for BrowserChunkingContext {
             );
 
             if this.enable_hot_module_replacement {
+                let mut ident = ident;
+                match input_availability_info {
+                    AvailabilityInfo::Root => {}
+                    AvailabilityInfo::Untracked => {
+                        ident = ident.with_modifier(rcstr!("untracked"));
+                    }
+                    AvailabilityInfo::Complete { available_modules } => {
+                        ident =
+                            ident.with_modifier(available_modules.hash().await?.to_string().into());
+                    }
+                }
                 assets.push(
                     self.generate_chunk_list_register_chunk(
                         ident,

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -659,6 +659,8 @@ impl ChunkingContext for BrowserChunkingContext {
                 .try_join()
                 .await?;
 
+            let other_assets = Vc::cell(assets.clone());
+
             let entries = Vc::cell(
                 chunk_group
                     .entries()
@@ -681,7 +683,6 @@ impl ChunkingContext for BrowserChunkingContext {
                             ident.with_modifier(available_modules.hash().await?.to_string().into());
                     }
                 }
-                let other_assets = Vc::cell(assets.clone());
                 assets.push(
                     self.generate_chunk_list_register_chunk(
                         ident,

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -591,7 +591,6 @@ impl ChunkingContext for BrowserChunkingContext {
                 .map(|chunk| self.generate_chunk(**chunk).to_resolved())
                 .try_join()
                 .await?;
-            let other_assets = Vc::cell(assets.clone());
 
             if this.enable_hot_module_replacement {
                 let mut ident = ident;
@@ -605,6 +604,7 @@ impl ChunkingContext for BrowserChunkingContext {
                             ident.with_modifier(available_modules.hash().await?.to_string().into());
                     }
                 }
+                let other_assets = Vc::cell(assets.clone());
                 assets.push(
                     self.generate_chunk_list_register_chunk(
                         ident,
@@ -658,7 +658,6 @@ impl ChunkingContext for BrowserChunkingContext {
                 .map(|chunk| self.generate_chunk(**chunk).to_resolved())
                 .try_join()
                 .await?;
-            let other_assets = Vc::cell(assets.clone());
 
             let entries = Vc::cell(
                 chunk_group
@@ -682,6 +681,7 @@ impl ChunkingContext for BrowserChunkingContext {
                             ident.with_modifier(available_modules.hash().await?.to_string().into());
                     }
                 }
+                let other_assets = Vc::cell(assets.clone());
                 assets.push(
                     self.generate_chunk_list_register_chunk(
                         ident,


### PR DESCRIPTION
### What?

include availability hash in the ident of evaluated chunks groups just like with normal chunk groups


Closes PACK-5540