### PR TITLE
Add deprecation warning to the deprecated `env` next config option

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -988,6 +988,7 @@ export interface NextConfig extends Record<string, any> {
    * Next.js comes with built-in support for environment variables
    *
    * @see [Environment Variables documentation](https://nextjs.org/docs/app/api-reference/config/next-config-js/env)
+   * @deprecated Use the `.env*` files instead. See https://nextjs.org/docs/app/guides/environment-variables
    */
   env?: Record<string, string | undefined>
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -115,7 +115,7 @@ function checkDeprecations(
   warnOptionHasBeenDeprecated(
     userConfig,
     'env',
-    `\`env\` configuration option is deprecated and will be removed in Next.js 16. Use the \`.env*\` files instead. See https://nextjs.org/docs/app/guides/environment-variables`,
+    `\`env\` configuration option is deprecated and will be removed in Next.js 16. Use \`.env*\` files instead. See https://nextjs.org/docs/app/guides/environment-variables`,
     silent
   )
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -112,6 +112,13 @@ function checkDeprecations(
     silent
   )
 
+  warnOptionHasBeenDeprecated(
+    userConfig,
+    'env',
+    `\`env\` configuration option is deprecated and will be removed in Next.js 16. Use the \`.env*\` files instead. See https://nextjs.org/docs/app/guides/environment-variables`,
+    silent
+  )
+
   if (userConfig.experimental?.dynamicIO !== undefined) {
     warnOptionHasBeenDeprecated(
       userConfig,


### PR DESCRIPTION
`env` property was deprecated in the docs, but hasn't had a deprecation warning. Add it so that we get fewer surprises on removal at v16.