### PR TITLE
Development: Remove TypeScript from the hot path during bootup

### DIFF
--- a/packages/next/src/lib/has-necessary-dependencies.ts
+++ b/packages/next/src/lib/has-necessary-dependencies.ts
@@ -43,6 +43,8 @@ export function hasNecessaryDependencies(
       )
       const pkgDir = dirname(pkgPath)
 
+      resolutions.set(join(p.pkg, 'package.json'), pkgPath)
+
       if (p.exportsRestrict) {
         const fileNameToVerify = relative(p.pkg, p.file)
         if (fileNameToVerify) {

--- a/packages/next/src/lib/typescript/getTypeScriptConfiguration.ts
+++ b/packages/next/src/lib/typescript/getTypeScriptConfiguration.ts
@@ -6,36 +6,41 @@ import { FatalError } from '../fatal-error'
 import isError from '../is-error'
 
 export async function getTypeScriptConfiguration(
-  ts: typeof import('typescript'),
+  typescript: typeof import('typescript'),
   tsConfigPath: string,
   metaOnly?: boolean
 ): Promise<import('typescript').ParsedCommandLine> {
   try {
     const formatDiagnosticsHost: import('typescript').FormatDiagnosticsHost = {
       getCanonicalFileName: (fileName: string) => fileName,
-      getCurrentDirectory: ts.sys.getCurrentDirectory,
+      getCurrentDirectory: typescript.sys.getCurrentDirectory,
       getNewLine: () => os.EOL,
     }
 
-    const { config, error } = ts.readConfigFile(tsConfigPath, ts.sys.readFile)
+    const { config, error } = typescript.readConfigFile(
+      tsConfigPath,
+      typescript.sys.readFile
+    )
     if (error) {
-      throw new FatalError(ts.formatDiagnostic(error, formatDiagnosticsHost))
+      throw new FatalError(
+        typescript.formatDiagnostic(error, formatDiagnosticsHost)
+      )
     }
 
     let configToParse: any = config
 
-    const result = ts.parseJsonConfigFileContent(
+    const result = typescript.parseJsonConfigFileContent(
       configToParse,
       // When only interested in meta info,
       // avoid enumerating all files (for performance reasons)
       metaOnly
         ? {
-            ...ts.sys,
+            ...typescript.sys,
             readDirectory(_path, extensions, _excludes, _includes, _depth) {
               return [extensions ? `file${extensions[0]}` : `file.ts`]
             },
           }
-        : ts.sys,
+        : typescript.sys,
       path.dirname(tsConfigPath)
     )
 
@@ -49,7 +54,7 @@ export async function getTypeScriptConfiguration(
 
     if (result.errors?.length) {
       throw new FatalError(
-        ts.formatDiagnostic(result.errors[0], formatDiagnosticsHost)
+        typescript.formatDiagnostic(result.errors[0], formatDiagnosticsHost)
       )
     }
 

--- a/packages/next/src/lib/typescript/getTypeScriptIntent.ts
+++ b/packages/next/src/lib/typescript/getTypeScriptIntent.ts
@@ -1,4 +1,4 @@
-import { existsSync, promises as fs } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import path from 'path'
 import { recursiveReadDir } from '../recursive-readdir'
 
@@ -15,12 +15,10 @@ export async function getTypeScriptIntent(
   // project.
   const hasTypeScriptConfiguration = existsSync(resolvedTsConfigPath)
   if (hasTypeScriptConfiguration) {
-    const content = await fs
-      .readFile(resolvedTsConfigPath, { encoding: 'utf8' })
-      .then(
-        (txt) => txt.trim(),
-        () => null
-      )
+    const content = readFileSync(resolvedTsConfigPath, {
+      encoding: 'utf8',
+    }).trim()
+
     return { firstTimeSetup: content === '' || content === '{}' }
   }
 

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.test.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.test.ts
@@ -40,7 +40,7 @@ describe('writeConfigurationDefaults()', () => {
       })
 
       await writeConfigurationDefaults(
-        ts,
+        ts.version,
         tsConfigPath,
         isFirstTimeSetup,
         hasAppDir,
@@ -128,7 +128,7 @@ describe('writeConfigurationDefaults()', () => {
       )
 
       await writeConfigurationDefaults(
-        ts,
+        ts.version,
         tsConfigPath,
         isFirstTimeSetup,
         hasAppDir,
@@ -150,7 +150,7 @@ describe('writeConfigurationDefaults()', () => {
         nextAppTypes = `${distDir}/types/**/*.ts`
       })
 
-      it('should support empty includes when base provides it', async () => {
+      it('should not change tsconfig with extends', async () => {
         const include = ['**/*.ts', '**/*.tsx', nextAppTypes, '**/*.mts']
         const content = { extends: './tsconfig.base.json' }
         const baseContent = { include }
@@ -160,7 +160,7 @@ describe('writeConfigurationDefaults()', () => {
 
         await expect(
           writeConfigurationDefaults(
-            ts,
+            ts.version,
             tsConfigPath,
             isFirstTimeSetup,
             hasAppDir,
@@ -173,62 +173,9 @@ describe('writeConfigurationDefaults()', () => {
         const parsed = JSON.parse(output)
 
         expect(parsed.include).toBeUndefined()
-      })
-
-      it('should replace includes when base is missing appTypes', async () => {
-        const include = ['**/*.ts', '**/*.tsx', '**/*.mts']
-        const content = { extends: './tsconfig.base.json' }
-        const baseContent = { include }
-
-        await writeFile(tsConfigPath, JSON.stringify(content, null, 2))
-        await writeFile(tsConfigBasePath, JSON.stringify(baseContent, null, 2))
-
-        await expect(
-          writeConfigurationDefaults(
-            ts,
-            tsConfigPath,
-            isFirstTimeSetup,
-            hasAppDir,
-            distDir,
-            hasPagesDir
-          )
-        ).resolves.not.toThrow()
-
-        const output = await readFile(tsConfigPath, 'utf8')
-        const parsed = JSON.parse(output)
-
-        expect(parsed.include.sort()).toMatchInlineSnapshot(`
-         [
-           "**/*.mts",
-           "**/*.ts",
-           "**/*.tsx",
-           ".next/types/**/*.ts",
-         ]
-        `)
-      })
-
-      it('should not add strictNullChecks if base provides it', async () => {
-        const content = { extends: './tsconfig.base.json' }
-
-        const baseContent = {
-          compilerOptions: { strictNullChecks: true, strict: true },
-        }
-
-        await writeFile(tsConfigPath, JSON.stringify(content, null, 2))
-        await writeFile(tsConfigBasePath, JSON.stringify(baseContent, null, 2))
-
-        await writeConfigurationDefaults(
-          ts,
-          tsConfigPath,
-          isFirstTimeSetup,
-          hasAppDir,
-          distDir,
-          hasPagesDir
-        )
-        const output = await readFile(tsConfigPath, 'utf8')
-        const parsed = JSON.parse(output)
-
-        expect(parsed.compilerOptions.strictNullChecks).toBeUndefined()
+        expect(parsed).toStrictEqual({
+          extends: './tsconfig.base.json',
+        })
       })
     })
   })

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -43,7 +43,7 @@ function getDesiredCompilerOptions(
   // Jsx
   const jsxEmitReactJSX = typescript.JsxEmit.ReactJSX
 
-  const o: DesiredCompilerOptionsShape = {
+  return {
     target: {
       suggested: 'ES2017',
       reason:
@@ -134,9 +134,7 @@ function getDesiredCompilerOptions(
       value: 'react-jsx',
       reason: 'next.js uses the React automatic runtime',
     },
-  }
-
-  return o
+  } satisfies DesiredCompilerOptionsShape
 }
 
 export function getRequiredConfiguration(
@@ -190,7 +188,7 @@ export async function writeConfigurationDefaults(
 
   const suggestedActions: string[] = []
   const requiredActions: string[] = []
-  for (const optionKey of Object.keys(desiredCompilerOptions)) {
+  for (const optionKey in desiredCompilerOptions) {
     const check = desiredCompilerOptions[optionKey]
     if ('suggested' in check) {
       if (!(optionKey in tsOptions)) {
@@ -207,13 +205,23 @@ export async function writeConfigurationDefaults(
       }
     } else if ('value' in check) {
       const ev = tsOptions[optionKey]
-      if (
-        !('parsedValues' in check
-          ? check.parsedValues?.includes(ev)
-          : 'parsedValue' in check
-            ? check.parsedValue === ev
-            : check.value === ev)
-      ) {
+
+      const decide = () => {
+        // Check if the option has multiple allowed values
+        if ('parsedValues' in check) {
+          return !check.parsedValues?.includes(ev)
+        }
+
+        // Check if the option has a single parsed value
+        if ('parsedValue' in check) {
+          return check.parsedValue !== ev
+        }
+
+        // Fall back to direct value comparison
+        return check.value !== ev
+      }
+
+      if (decide()) {
         if (!userTsConfig.compilerOptions) {
           userTsConfig.compilerOptions = {}
         }

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -19,9 +19,30 @@ type DesiredCompilerOptionsShape = {
 }
 
 function getDesiredCompilerOptions(
-  ts: typeof import('typescript'),
+  typescript: typeof import('typescript'),
   tsOptions?: CompilerOptions
 ): DesiredCompilerOptionsShape {
+  const typescriptVersion = typescript.version
+
+  // ModuleKind
+  const moduleKindESNext = typescript.ModuleKind.ESNext
+  const moduleKindES2020 = typescript.ModuleKind.ES2020
+  const moduleKindPreserve = typescript.ModuleKind.Preserve
+  const moduleKindNodeNext = typescript.ModuleKind.NodeNext
+  const moduleKindNode16 = typescript.ModuleKind.Node16
+  const moduleKindCommonJS = typescript.ModuleKind.CommonJS
+  const moduleKindAMD = typescript.ModuleKind.AMD
+
+  // ModuleResolutionKind
+  const moduleResolutionKindBundler = typescript.ModuleResolutionKind.Bundler
+  const moduleResolutionKindNode10 = typescript.ModuleResolutionKind.Node10
+  const moduleResolutionKindNode12 = (typescript.ModuleResolutionKind as any)
+    .Node12
+  const moduleResolutionKindNodeJs = typescript.ModuleResolutionKind.NodeJs
+
+  // Jsx
+  const jsxEmitReactJSX = typescript.JsxEmit.ReactJSX
+
   const o: DesiredCompilerOptionsShape = {
     target: {
       suggested: 'ES2017',
@@ -34,11 +55,11 @@ function getDesiredCompilerOptions(
     allowJs: { suggested: true },
     skipLibCheck: { suggested: true },
     strict: { suggested: false },
-    ...(semver.lt(ts.version, '5.0.0')
+    ...(semver.lt(typescriptVersion, '5.0.0')
       ? { forceConsistentCasingInFileNames: { suggested: true } }
       : undefined),
     noEmit: { suggested: true },
-    ...(semver.gte(ts.version, '4.4.2')
+    ...(semver.gte(typescriptVersion, '4.4.2')
       ? { incremental: { suggested: true } }
       : undefined),
 
@@ -46,23 +67,23 @@ function getDesiredCompilerOptions(
     // Keep this in sync with the webpack config
     // 'parsedValue' matches the output value from ts.parseJsonConfigFileContent()
     module: {
-      parsedValue: ts.ModuleKind.ESNext,
+      parsedValue: moduleKindESNext,
       // All of these values work:
       parsedValues: [
-        semver.gte(ts.version, '5.4.0') && (ts.ModuleKind as any).Preserve,
-        ts.ModuleKind.ES2020,
-        ts.ModuleKind.ESNext,
-        ts.ModuleKind.CommonJS,
-        ts.ModuleKind.AMD,
-        ts.ModuleKind.NodeNext,
-        ts.ModuleKind.Node16,
+        semver.gte(typescriptVersion, '5.4.0') && moduleKindPreserve,
+        moduleKindES2020,
+        moduleKindESNext,
+        moduleKindCommonJS,
+        moduleKindAMD,
+        moduleKindNodeNext,
+        moduleKindNode16,
       ],
       value: 'esnext',
       reason: 'for dynamic import() support',
     },
     // TODO: Semver check not needed once Next.js repo uses 5.4.
-    ...(semver.gte(ts.version, '5.4.0') &&
-    tsOptions?.module === (ts.ModuleKind as any).Preserve
+    ...(semver.gte(typescriptVersion, '5.4.0') &&
+    tsOptions?.module === moduleKindPreserve
       ? {
           // TypeScript 5.4 introduced `Preserve`. Using `Preserve` implies
           // - `moduleResolution` is `Bundler`
@@ -78,20 +99,19 @@ function getDesiredCompilerOptions(
           moduleResolution: {
             // In TypeScript 5.0, `NodeJs` has renamed to `Node10`
             parsedValue:
-              ts.ModuleResolutionKind.Bundler ??
-              ts.ModuleResolutionKind.NodeNext ??
-              (ts.ModuleResolutionKind as any).Node10 ??
-              ts.ModuleResolutionKind.NodeJs,
+              moduleResolutionKindBundler ??
+              moduleKindNodeNext ??
+              moduleResolutionKindNode10 ??
+              moduleResolutionKindNodeJs,
             // All of these values work:
             parsedValues: [
-              (ts.ModuleResolutionKind as any).Node10 ??
-                ts.ModuleResolutionKind.NodeJs,
+              moduleResolutionKindNode10 ?? moduleResolutionKindNodeJs,
               // only newer TypeScript versions have this field, it
               // will be filtered for new versions of TypeScript
-              (ts.ModuleResolutionKind as any).Node12,
-              ts.ModuleResolutionKind.Node16,
-              ts.ModuleResolutionKind.NodeNext,
-              ts.ModuleResolutionKind.Bundler,
+              moduleResolutionKindNode12,
+              moduleKindNode16,
+              moduleKindNodeNext,
+              moduleResolutionKindBundler,
             ].filter((val) => typeof val !== 'undefined'),
             value: 'node',
             reason: 'to match webpack resolution',
@@ -110,7 +130,7 @@ function getDesiredCompilerOptions(
           },
         }),
     jsx: {
-      parsedValue: ts.JsxEmit.ReactJSX,
+      parsedValue: jsxEmitReactJSX,
       value: 'react-jsx',
       reason: 'next.js uses the React automatic runtime',
     },
@@ -120,11 +140,11 @@ function getDesiredCompilerOptions(
 }
 
 export function getRequiredConfiguration(
-  ts: typeof import('typescript')
+  typescript: typeof import('typescript')
 ): Partial<import('typescript').CompilerOptions> {
   const res: Partial<import('typescript').CompilerOptions> = {}
 
-  const desiredCompilerOptions = getDesiredCompilerOptions(ts)
+  const desiredCompilerOptions = getDesiredCompilerOptions(typescript)
   for (const optionKey of Object.keys(desiredCompilerOptions)) {
     const ev = desiredCompilerOptions[optionKey]
     if (!('value' in ev)) {
@@ -140,7 +160,7 @@ const localDevTestFilesExcludeAction =
   'NEXT_PRIVATE_LOCAL_DEV_TEST_FILES_EXCLUDE'
 
 export async function writeConfigurationDefaults(
-  ts: typeof import('typescript'),
+  typescript: typeof import('typescript'),
   tsConfigPath: string,
   isFirstTimeSetup: boolean,
   hasAppDir: boolean,
@@ -152,7 +172,7 @@ export async function writeConfigurationDefaults(
   }
 
   const { options: tsOptions, raw: rawConfig } =
-    await getTypeScriptConfiguration(ts, tsConfigPath, true)
+    await getTypeScriptConfiguration(typescript, tsConfigPath, true)
 
   const userTsConfigContent = await fs.readFile(tsConfigPath, {
     encoding: 'utf8',
@@ -163,7 +183,10 @@ export async function writeConfigurationDefaults(
     isFirstTimeSetup = true
   }
 
-  const desiredCompilerOptions = getDesiredCompilerOptions(ts, tsOptions)
+  const desiredCompilerOptions = getDesiredCompilerOptions(
+    typescript,
+    tsOptions
+  )
 
   const suggestedActions: string[] = []
   const requiredActions: string[] = []

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -150,7 +150,9 @@ export function getRequiredConfiguration(
       const moduleMap: Record<string, import('typescript').ModuleKind> = {
         esnext: typescript.ModuleKind.ESNext,
         es2020: typescript.ModuleKind.ES2020,
-        preserve: typescript.ModuleKind.Preserve,
+        ...(typescript.ModuleKind.Preserve !== undefined
+          ? { preserve: typescript.ModuleKind.Preserve }
+          : {}),
         nodenext: typescript.ModuleKind.NodeNext,
         node16: typescript.ModuleKind.Node16,
         commonjs: typescript.ModuleKind.CommonJS,

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -1,10 +1,9 @@
-import { promises as fs } from 'fs'
+import { readFileSync, writeFileSync } from 'fs'
 import { bold, cyan, white } from '../picocolors'
 import * as CommentJson from 'next/dist/compiled/comment-json'
 import semver from 'next/dist/compiled/semver'
 import os from 'os'
 import type { CompilerOptions } from 'typescript'
-import { getTypeScriptConfiguration } from './getTypeScriptConfiguration'
 import * as Log from '../../build/output/log'
 
 type DesiredCompilerOptionsShape = {
@@ -19,29 +18,26 @@ type DesiredCompilerOptionsShape = {
 }
 
 function getDesiredCompilerOptions(
-  typescript: typeof import('typescript'),
-  tsOptions?: CompilerOptions
+  typescriptVersion: string,
+  userTsConfig?: Record<string, any>
 ): DesiredCompilerOptionsShape {
-  const typescriptVersion = typescript.version
-
   // ModuleKind
-  const moduleKindESNext = typescript.ModuleKind.ESNext
-  const moduleKindES2020 = typescript.ModuleKind.ES2020
-  const moduleKindPreserve = typescript.ModuleKind.Preserve
-  const moduleKindNodeNext = typescript.ModuleKind.NodeNext
-  const moduleKindNode16 = typescript.ModuleKind.Node16
-  const moduleKindCommonJS = typescript.ModuleKind.CommonJS
-  const moduleKindAMD = typescript.ModuleKind.AMD
+  const moduleKindESNext = 'esnext'
+  const moduleKindES2020 = 'es2020'
+  const moduleKindPreserve = 'preserve'
+  const moduleKindNodeNext = 'nodenext'
+  const moduleKindNode16 = 'node16'
+  const moduleKindCommonJS = 'commonjs'
+  const moduleKindAMD = 'amd'
 
   // ModuleResolutionKind
-  const moduleResolutionKindBundler = typescript.ModuleResolutionKind.Bundler
-  const moduleResolutionKindNode10 = typescript.ModuleResolutionKind.Node10
-  const moduleResolutionKindNode12 = (typescript.ModuleResolutionKind as any)
-    .Node12
-  const moduleResolutionKindNodeJs = typescript.ModuleResolutionKind.NodeJs
+  const moduleResolutionKindBundler = 'bundler'
+  const moduleResolutionKindNode10 = 'node10'
+  const moduleResolutionKindNode12 = 'node12'
+  const moduleResolutionKindNodeJs = 'node'
 
   // Jsx
-  const jsxEmitReactJSX = typescript.JsxEmit.ReactJSX
+  const jsxEmitReactJSX = 'react-jsx'
 
   return {
     target: {
@@ -83,7 +79,7 @@ function getDesiredCompilerOptions(
     },
     // TODO: Semver check not needed once Next.js repo uses 5.4.
     ...(semver.gte(typescriptVersion, '5.4.0') &&
-    tsOptions?.module === moduleKindPreserve
+    userTsConfig?.compilerOptions?.module?.toLowerCase() === moduleKindPreserve
       ? {
           // TypeScript 5.4 introduced `Preserve`. Using `Preserve` implies
           // - `moduleResolution` is `Bundler`
@@ -98,14 +94,11 @@ function getDesiredCompilerOptions(
           },
           moduleResolution: {
             // In TypeScript 5.0, `NodeJs` has renamed to `Node10`
-            parsedValue:
-              moduleResolutionKindBundler ??
-              moduleKindNodeNext ??
-              moduleResolutionKindNode10 ??
-              moduleResolutionKindNodeJs,
+            parsedValue: moduleResolutionKindBundler,
             // All of these values work:
             parsedValues: [
-              moduleResolutionKindNode10 ?? moduleResolutionKindNodeJs,
+              moduleResolutionKindNode10,
+              moduleResolutionKindNodeJs,
               // only newer TypeScript versions have this field, it
               // will be filtered for new versions of TypeScript
               moduleResolutionKindNode12,
@@ -121,7 +114,7 @@ function getDesiredCompilerOptions(
             reason: 'to match webpack resolution',
           },
         }),
-    ...(tsOptions?.verbatimModuleSyntax === true
+    ...(userTsConfig?.compilerOptions?.verbatimModuleSyntax === true
       ? undefined
       : {
           isolatedModules: {
@@ -141,8 +134,9 @@ export function getRequiredConfiguration(
   typescript: typeof import('typescript')
 ): Partial<import('typescript').CompilerOptions> {
   const res: Partial<import('typescript').CompilerOptions> = {}
+  const typescriptVersion = typescript.version
 
-  const desiredCompilerOptions = getDesiredCompilerOptions(typescript)
+  const desiredCompilerOptions = getDesiredCompilerOptions(typescriptVersion)
   for (const optionKey of Object.keys(desiredCompilerOptions)) {
     const ev = desiredCompilerOptions[optionKey]
     if (!('value' in ev)) {
@@ -158,7 +152,7 @@ const localDevTestFilesExcludeAction =
   'NEXT_PRIVATE_LOCAL_DEV_TEST_FILES_EXCLUDE'
 
 export async function writeConfigurationDefaults(
-  typescript: typeof import('typescript'),
+  typescriptVersion: string,
   tsConfigPath: string,
   isFirstTimeSetup: boolean,
   hasAppDir: boolean,
@@ -166,24 +160,27 @@ export async function writeConfigurationDefaults(
   hasPagesDir: boolean
 ): Promise<void> {
   if (isFirstTimeSetup) {
-    await fs.writeFile(tsConfigPath, '{}' + os.EOL)
+    writeFileSync(tsConfigPath, '{}' + os.EOL)
   }
 
-  const { options: tsOptions, raw: rawConfig } =
-    await getTypeScriptConfiguration(typescript, tsConfigPath, true)
-
-  const userTsConfigContent = await fs.readFile(tsConfigPath, {
+  const userTsConfigContent = readFileSync(tsConfigPath, {
     encoding: 'utf8',
   })
   const userTsConfig = CommentJson.parse(userTsConfigContent)
-  if (userTsConfig.compilerOptions == null && !('extends' in rawConfig)) {
+
+  // Bail automatic setup when the user has extended or referenced another config
+  if ('extends' in userTsConfig || 'references' in userTsConfig) {
+    return
+  }
+
+  if (userTsConfig?.compilerOptions == null) {
     userTsConfig.compilerOptions = {}
     isFirstTimeSetup = true
   }
 
   const desiredCompilerOptions = getDesiredCompilerOptions(
-    typescript,
-    tsOptions
+    typescriptVersion,
+    userTsConfig
   )
 
   const suggestedActions: string[] = []
@@ -191,10 +188,7 @@ export async function writeConfigurationDefaults(
   for (const optionKey in desiredCompilerOptions) {
     const check = desiredCompilerOptions[optionKey]
     if ('suggested' in check) {
-      if (!(optionKey in tsOptions)) {
-        if (!userTsConfig.compilerOptions) {
-          userTsConfig.compilerOptions = {}
-        }
+      if (!(optionKey in userTsConfig?.compilerOptions)) {
         userTsConfig.compilerOptions[optionKey] = check.suggested
         suggestedActions.push(
           cyan(optionKey) +
@@ -204,24 +198,28 @@ export async function writeConfigurationDefaults(
         )
       }
     } else if ('value' in check) {
-      const ev = tsOptions[optionKey]
+      let existingValue = userTsConfig?.compilerOptions?.[optionKey]
 
-      const decide = () => {
+      if (typeof existingValue === 'string') {
+        existingValue = existingValue.toLowerCase()
+      }
+
+      const shouldWriteRequiredValue = () => {
         // Check if the option has multiple allowed values
-        if ('parsedValues' in check) {
-          return !check.parsedValues?.includes(ev)
+        if (check.parsedValues) {
+          return !check.parsedValues.includes(existingValue)
         }
 
         // Check if the option has a single parsed value
-        if ('parsedValue' in check) {
-          return check.parsedValue !== ev
+        if (check.parsedValue) {
+          return check.parsedValue !== existingValue
         }
 
         // Fall back to direct value comparison
-        return check.value !== ev
+        return check.value !== existingValue
       }
 
-      if (decide()) {
+      if (shouldWriteRequiredValue()) {
         if (!userTsConfig.compilerOptions) {
           userTsConfig.compilerOptions = {}
         }
@@ -241,7 +239,7 @@ export async function writeConfigurationDefaults(
 
   const nextAppTypes = `${distDir}/types/**/*.ts`
 
-  if (!('include' in rawConfig)) {
+  if (!('include' in userTsConfig)) {
     userTsConfig.include = hasAppDir
       ? ['next-env.d.ts', nextAppTypes, '**/*.mts', '**/*.ts', '**/*.tsx']
       : ['next-env.d.ts', '**/*.mts', '**/*.ts', '**/*.tsx']
@@ -256,7 +254,7 @@ export async function writeConfigurationDefaults(
     )
   } else if (hasAppDir) {
     const missingFromResolved = []
-    if (!rawConfig.include.includes(nextAppTypes)) {
+    if (!userTsConfig.include.includes(nextAppTypes)) {
       missingFromResolved.push(nextAppTypes)
     }
 
@@ -264,32 +262,13 @@ export async function writeConfigurationDefaults(
       if (!Array.isArray(userTsConfig.include)) {
         userTsConfig.include = []
       }
-      // rawConfig will resolve all extends and include paths (ex: tsconfig.json, tsconfig.base.json, etc.)
-      // if it doesn't match userTsConfig then update the userTsConfig to add the
-      // rawConfig's includes in addition to missing items
-      if (
-        rawConfig.include.length !== userTsConfig.include.length ||
-        JSON.stringify(rawConfig.include.sort()) !==
-          JSON.stringify(userTsConfig.include.sort())
-      ) {
-        userTsConfig.include.push(...rawConfig.include, ...missingFromResolved)
+
+      missingFromResolved.forEach((item) => {
+        userTsConfig.include.push(item)
         suggestedActions.push(
-          cyan('include') +
-            ' was set to ' +
-            bold(
-              `[${[...rawConfig.include, ...missingFromResolved]
-                .map((i) => `'${i}'`)
-                .join(', ')}]`
-            )
+          cyan('include') + ' was updated to add ' + bold(`'${item}'`)
         )
-      } else {
-        missingFromResolved.forEach((item) => {
-          userTsConfig.include.push(item)
-          suggestedActions.push(
-            cyan('include') + ' was updated to add ' + bold(`'${item}'`)
-          )
-        })
-      }
+      })
     }
   }
 
@@ -297,7 +276,7 @@ export async function writeConfigurationDefaults(
   if (hasAppDir) {
     // Check if the config or the resolved config has the plugin already.
     const plugins = [
-      ...(Array.isArray(tsOptions.plugins) ? tsOptions.plugins : []),
+      ...(Array.isArray(userTsConfig?.plugins) ? userTsConfig.plugins : []),
       ...(userTsConfig.compilerOptions &&
       Array.isArray(userTsConfig.compilerOptions.plugins)
         ? userTsConfig.compilerOptions.plugins
@@ -314,8 +293,9 @@ export async function writeConfigurationDefaults(
       !userTsConfig.compilerOptions ||
       (plugins.length &&
         !hasNextPlugin &&
-        'extends' in rawConfig &&
-        (!rawConfig.compilerOptions || !rawConfig.compilerOptions.plugins))
+        'extends' in userTsConfig &&
+        (!userTsConfig.compilerOptions ||
+          !userTsConfig.compilerOptions.plugins))
     ) {
       Log.info(
         `\nYour ${bold(
@@ -339,8 +319,8 @@ export async function writeConfigurationDefaults(
     if (
       hasPagesDir &&
       hasAppDir &&
-      !tsOptions.strict &&
-      !('strictNullChecks' in tsOptions)
+      !userTsConfig?.compilerOptions?.strict &&
+      !('strictNullChecks' in userTsConfig?.compilerOptions)
     ) {
       userTsConfig.compilerOptions.strictNullChecks = true
       suggestedActions.push(
@@ -349,7 +329,7 @@ export async function writeConfigurationDefaults(
     }
   }
 
-  if (!('exclude' in rawConfig)) {
+  if (!('exclude' in userTsConfig)) {
     userTsConfig.exclude = ['node_modules']
     suggestedActions.push(
       cyan('exclude') + ' was set to ' + bold(`['node_modules']`)
@@ -379,7 +359,7 @@ export async function writeConfigurationDefaults(
     return
   }
 
-  await fs.writeFile(
+  writeFileSync(
     tsConfigPath,
     CommentJson.stringify(userTsConfig, null, 2) + os.EOL
   )

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -142,7 +142,40 @@ export function getRequiredConfiguration(
     if (!('value' in ev)) {
       continue
     }
-    res[optionKey] = ev.parsedValue ?? ev.value
+
+    const value = ev.parsedValue ?? ev.value
+
+    // Convert string values back to TypeScript enum values
+    if (optionKey === 'module' && typeof value === 'string') {
+      const moduleMap: Record<string, import('typescript').ModuleKind> = {
+        esnext: typescript.ModuleKind.ESNext,
+        es2020: typescript.ModuleKind.ES2020,
+        preserve: typescript.ModuleKind.Preserve,
+        nodenext: typescript.ModuleKind.NodeNext,
+        node16: typescript.ModuleKind.Node16,
+        commonjs: typescript.ModuleKind.CommonJS,
+        amd: typescript.ModuleKind.AMD,
+      }
+      res[optionKey] = moduleMap[value.toLowerCase()] ?? value
+    } else if (optionKey === 'moduleResolution' && typeof value === 'string') {
+      const moduleResolutionMap: Record<
+        string,
+        import('typescript').ModuleResolutionKind
+      > = {
+        bundler: typescript.ModuleResolutionKind.Bundler,
+        node10: typescript.ModuleResolutionKind.Node10,
+        node12: (typescript.ModuleResolutionKind as any).Node12,
+        node: typescript.ModuleResolutionKind.NodeJs,
+      }
+      res[optionKey] = moduleResolutionMap[value.toLowerCase()] ?? value
+    } else if (optionKey === 'jsx' && typeof value === 'string') {
+      const jsxMap: Record<string, import('typescript').JsxEmit> = {
+        'react-jsx': typescript.JsxEmit.ReactJSX,
+      }
+      res[optionKey] = jsxMap[value.toLowerCase()] ?? value
+    } else {
+      res[optionKey] = value
+    }
   }
 
   return res

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -107,19 +107,21 @@ export async function verifyTypeScriptSetup({
 
     // Load TypeScript after we're sure it exists:
     const tsPath = deps.resolved.get('typescript')!
-    const ts = (await Promise.resolve(
+    const typescript = (await Promise.resolve(
       require(tsPath)
     )) as typeof import('typescript')
 
-    if (semver.lt(ts.version, '4.5.2')) {
+    const typescriptVersion = typescript.version
+
+    if (semver.lt(typescriptVersion, '4.5.2')) {
       log.warn(
-        `Minimum recommended TypeScript version is v4.5.2, older versions can potentially be incompatible with Next.js. Detected: ${ts.version}`
+        `Minimum recommended TypeScript version is v4.5.2, older versions can potentially be incompatible with Next.js. Detected: ${typescriptVersion}`
       )
     }
 
     // Reconfigure (or create) the user's `tsconfig.json` for them:
     await writeConfigurationDefaults(
-      ts,
+      typescript,
       resolvedTsConfigPath,
       intent.firstTimeSetup,
       hasAppDir,
@@ -143,7 +145,7 @@ export async function verifyTypeScriptSetup({
 
       // Verify the project passes type-checking before we go to webpack phase:
       result = await runTypeCheck(
-        ts,
+        typescript,
         dir,
         distDir,
         resolvedTsConfigPath,
@@ -151,7 +153,7 @@ export async function verifyTypeScriptSetup({
         hasAppDir
       )
     }
-    return { result, version: ts.version }
+    return { result, version: typescriptVersion }
   } catch (err) {
     // These are special errors that should not show a stack trace:
     if (err instanceof CompileError) {

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -1,5 +1,5 @@
 import { bold, cyan, red, yellow } from './picocolors'
-import path from 'path'
+import path, { join } from 'path'
 
 import { hasNecessaryDependencies } from './has-necessary-dependencies'
 import type { NecessaryDependencies } from './has-necessary-dependencies'
@@ -106,12 +106,12 @@ export async function verifyTypeScriptSetup({
     }
 
     // Load TypeScript after we're sure it exists:
-    const tsPath = deps.resolved.get('typescript')!
-    const typescript = (await Promise.resolve(
-      require(tsPath)
-    )) as typeof import('typescript')
+    const tsPackageJsonPath = deps.resolved.get(
+      join('typescript', 'package.json')
+    )!
+    const typescriptPackageJson = require(tsPackageJsonPath)
 
-    const typescriptVersion = typescript.version
+    const typescriptVersion = typescriptPackageJson.version
 
     if (semver.lt(typescriptVersion, '4.5.2')) {
       log.warn(
@@ -121,7 +121,7 @@ export async function verifyTypeScriptSetup({
 
     // Reconfigure (or create) the user's `tsconfig.json` for them:
     await writeConfigurationDefaults(
-      typescript,
+      typescriptVersion,
       resolvedTsConfigPath,
       intent.firstTimeSetup,
       hasAppDir,
@@ -142,6 +142,11 @@ export async function verifyTypeScriptSetup({
     if (typeCheckPreflight) {
       const { runTypeCheck } =
         require('./typescript/runTypeCheck') as typeof import('./typescript/runTypeCheck')
+
+      const tsPath = deps.resolved.get('typescript')!
+      const typescript = (await Promise.resolve(
+        require(tsPath)
+      )) as typeof import('typescript')
 
       // Verify the project passes type-checking before we go to webpack phase:
       result = await runTypeCheck(

--- a/test/e2e/app-dir/next-config-ts/tsconfig-extends/tsconfig.test.json
+++ b/test/e2e/app-dir/next-config-ts/tsconfig-extends/tsconfig.test.json
@@ -1,3 +1,32 @@
 {
-  "extends": "./tsconfig.base.json"
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": false
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.mts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": ["node_modules"]
 }

--- a/test/integration/tsconfig-verifier/test/index.test.js
+++ b/test/integration/tsconfig-verifier/test/index.test.js
@@ -592,21 +592,9 @@ import path from 'path'
 
       await writeFile(
         tsConfigBase,
-        `{ "compilerOptions": { "verbatimModuleSyntax": true } }`
-      )
-      await writeFile(tsConfig, `{ "extends": "./tsconfig.base.json" }`)
-      await new Promise((resolve) => setTimeout(resolve, 500))
-      const { code, stderr, stdout } = await nextBuild(appDir, undefined, {
-        stderr: true,
-        stdout: true,
-      })
-      expect(stderr + stdout).not.toContain('isolatedModules')
-      expect(code).toBe(0)
-
-      expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`
-       "{
-         "extends": "./tsconfig.base.json",
-         "compilerOptions": {
+        `{ 
+        "compilerOptions": {
+           "verbatimModuleSyntax": true,
            "target": "ES2017",
            "lib": [
              "dom",
@@ -640,9 +628,21 @@ import path from 'path'
          "exclude": [
            "node_modules"
          ]
-       }
-       "
-      `)
+        }`
+      )
+      await writeFile(tsConfig, `{ "extends": "./tsconfig.base.json" }`)
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      const { code, stderr, stdout } = await nextBuild(appDir, undefined, {
+        stderr: true,
+        stdout: true,
+      })
+      console.log(stderr + stdout)
+      expect(stderr + stdout).not.toContain('isolatedModules')
+      expect(code).toBe(0)
+
+      expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(
+        `"{ "extends": "./tsconfig.base.json" }"`
+      )
     })
 
     it('allows you to extend another configuration file', async () => {
@@ -703,15 +703,9 @@ import path from 'path'
       expect(stderr + stdout).not.toContain('moduleResolution')
       expect(code).toBe(0)
 
-      expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`
-        "{
-          "extends": "./tsconfig.base.json",
-          "compilerOptions": {
-            "target": "ES2017"
-          }
-        }
-        "
-      `)
+      expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(
+        `"{ "extends": "./tsconfig.base.json" }"`
+      )
     })
 
     it('creates compilerOptions when you extend another config', async () => {
@@ -771,16 +765,9 @@ import path from 'path'
       expect(stderr + stdout).not.toContain('moduleResolution')
       expect(code).toBe(0)
 
-      expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(`
-        "{
-          "extends": "./tsconfig.base.json",
-          "compilerOptions": {
-            "target": "ES2017",
-            "incremental": true
-          }
-        }
-        "
-      `)
+      expect(await readFile(tsConfig, 'utf8')).toMatchInlineSnapshot(
+        `"{ "extends": "./tsconfig.base.json" }"`
+      )
     })
 
     // TODO: Enable this test when repo has upgraded to TypeScript 5.4. Currently tested as E2E: tsconfig-module-preserve

--- a/test/integration/tsconfig-verifier/test/index.test.js
+++ b/test/integration/tsconfig-verifier/test/index.test.js
@@ -636,7 +636,6 @@ import path from 'path'
         stderr: true,
         stdout: true,
       })
-      console.log(stderr + stdout)
       expect(stderr + stdout).not.toContain('isolatedModules')
       expect(code).toBe(0)
 


### PR DESCRIPTION
## What?

Changes the way TypeScript config validation behaves. It no longer does `require('typescript')` and instead reads the `tsconfig.json`. 

This introduces one new limitation which is that `extends` and `references` cause the automatic config rewriting to be skipped, i.e. it does not verify your `extends`​ / `references`​. 

In my opinion that tradeoff is fine though because if you're using these you likely already don't want Next.js to actively write into the project config file. At least that has been a common feedback from the community.

In cpu profiles this change shows 115ms -> 4ms.

Why does it take 115ms? TypeScript itself is quite large, lot of code to parse. However, we're only reading a few values from it like the version, some config options, and the config reading logic itself. In the CPU profile it really is showing 4ms spent in Next.js and the rest is the process of requiring TypeScript.

Closes PACK-5543