### PR TITLE
ci: Enable `experimental.isolatedDevBuild` for `test-experimental-dev`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -980,6 +980,7 @@ jobs:
         export __NEXT_EXPERIMENTAL_CACHE_COMPONENTS=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/experimental-tests-manifest.json"
         export NEXT_TEST_MODE=dev
+        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
 
         node run-tests.js \
           --timings \

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1511,7 +1511,8 @@ export const defaultConfig = Object.freeze({
     slowModuleDetection: undefined,
     globalNotFound: false,
     browserDebugInfoInTerminal: false,
-    isolatedDevBuild: false,
+    isolatedDevBuild:
+      process.env.__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD === 'true',
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/test/development/app-dir/typed-env/typed-env-prod.test.ts
+++ b/test/development/app-dir/typed-env/typed-env-prod.test.ts
@@ -11,7 +11,7 @@ describe('typed-env', () => {
 
   it('should have env types from next config', async () => {
     await retry(async () => {
-      const envDTS = await next.readFile('.next/types/env.d.ts')
+      const envDTS = await next.readFile('.next/dev/types/env.d.ts')
       // since NODE_ENV is production, env types will
       // not include development-specific env
       expect(envDTS).not.toContain('FROM_ENV_DEV')

--- a/test/development/app-dir/typed-env/typed-env-prod.test.ts
+++ b/test/development/app-dir/typed-env/typed-env-prod.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { getDistDir, retry } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('typed-env', () => {
   const { next } = nextTestSetup({
@@ -11,7 +11,7 @@ describe('typed-env', () => {
 
   it('should have env types from next config', async () => {
     await retry(async () => {
-      const envDTS = await next.readFile(`${getDistDir()}/types/env.d.ts`)
+      const envDTS = await next.readFile(`${next.distDir}/types/env.d.ts`)
       // since NODE_ENV is production, env types will
       // not include development-specific env
       expect(envDTS).not.toContain('FROM_ENV_DEV')

--- a/test/development/app-dir/typed-env/typed-env-prod.test.ts
+++ b/test/development/app-dir/typed-env/typed-env-prod.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry } from 'next-test-utils'
+import { getDistDir, retry } from 'next-test-utils'
 
 describe('typed-env', () => {
   const { next } = nextTestSetup({
@@ -11,7 +11,7 @@ describe('typed-env', () => {
 
   it('should have env types from next config', async () => {
     await retry(async () => {
-      const envDTS = await next.readFile('.next/dev/types/env.d.ts')
+      const envDTS = await next.readFile(`${getDistDir()}/types/env.d.ts`)
       // since NODE_ENV is production, env types will
       // not include development-specific env
       expect(envDTS).not.toContain('FROM_ENV_DEV')

--- a/test/development/app-dir/typed-env/typed-env.test.ts
+++ b/test/development/app-dir/typed-env/typed-env.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { retry } from 'next-test-utils'
+import { getDistDir, retry } from 'next-test-utils'
 
 describe('typed-env', () => {
   const { next } = nextTestSetup({
@@ -8,7 +8,7 @@ describe('typed-env', () => {
 
   it('should have env types from next config', async () => {
     await retry(async () => {
-      const envDTS = await next.readFile('.next/types/env.d.ts')
+      const envDTS = await next.readFile(`${getDistDir()}/types/env.d.ts`)
       // since NODE_ENV is development, env types will
       // not include production-specific env
       expect(envDTS).not.toContain('FROM_ENV_PROD')
@@ -39,7 +39,7 @@ describe('typed-env', () => {
 
   it('should rewrite env types if .env is modified', async () => {
     await retry(async () => {
-      const content = await next.readFile('.next/types/env.d.ts')
+      const content = await next.readFile(`${getDistDir()}/types/env.d.ts`)
       expect(content).toContain('FROM_ENV')
     })
 
@@ -50,7 +50,7 @@ describe('typed-env', () => {
     // e.g. FROM_ENV?: string
     // but have MODIFIED_ENV?: string
     await retry(async () => {
-      const content = await next.readFile('.next/types/env.d.ts')
+      const content = await next.readFile(`${getDistDir()}/types/env.d.ts`)
       expect(content).toMatchInlineSnapshot(`
         "// Type definitions for Next.js environment variables
         declare global {

--- a/test/development/app-dir/typed-env/typed-env.test.ts
+++ b/test/development/app-dir/typed-env/typed-env.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { getDistDir, retry } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('typed-env', () => {
   const { next } = nextTestSetup({
@@ -8,7 +8,7 @@ describe('typed-env', () => {
 
   it('should have env types from next config', async () => {
     await retry(async () => {
-      const envDTS = await next.readFile(`${getDistDir()}/types/env.d.ts`)
+      const envDTS = await next.readFile(`${next.distDir}/types/env.d.ts`)
       // since NODE_ENV is development, env types will
       // not include production-specific env
       expect(envDTS).not.toContain('FROM_ENV_PROD')
@@ -39,7 +39,7 @@ describe('typed-env', () => {
 
   it('should rewrite env types if .env is modified', async () => {
     await retry(async () => {
-      const content = await next.readFile(`${getDistDir()}/types/env.d.ts`)
+      const content = await next.readFile(`${next.distDir}/types/env.d.ts`)
       expect(content).toContain('FROM_ENV')
     })
 
@@ -50,7 +50,7 @@ describe('typed-env', () => {
     // e.g. FROM_ENV?: string
     // but have MODIFIED_ENV?: string
     await retry(async () => {
-      const content = await next.readFile(`${getDistDir()}/types/env.d.ts`)
+      const content = await next.readFile(`${next.distDir}/types/env.d.ts`)
       expect(content).toMatchInlineSnapshot(`
         "// Type definitions for Next.js environment variables
         declare global {

--- a/test/e2e/app-dir/css-server-chunks/css-server-chunks.test.ts
+++ b/test/e2e/app-dir/css-server-chunks/css-server-chunks.test.ts
@@ -1,5 +1,4 @@
 import { nextTestSetup } from 'e2e-utils'
-import { getDistDir } from 'next-test-utils'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
@@ -20,7 +19,7 @@ describe('css-server-chunks', () => {
     expect((await next.fetch('/pages')).status).toBe(200)
 
     let clientChunks = (
-      await fs.readdir(path.join(next.testDir, getDistDir(), 'static'), {
+      await fs.readdir(path.join(next.testDir, next.distDir, 'static'), {
         recursive: true,
       })
     ).filter((f) => f.endsWith('.js') || f.endsWith('.css'))
@@ -30,7 +29,7 @@ describe('css-server-chunks', () => {
 
     let serverChunks = (
       await Promise.all(
-        [`${getDistDir()}/server/app`, `${getDistDir()}/server/pages`].map(
+        [`${next.distDir}/server/app`, `${next.distDir}/server/pages`].map(
           (d) =>
             fs.readdir(path.join(next.testDir, d), {
               recursive: true,

--- a/test/e2e/app-dir/css-server-chunks/css-server-chunks.test.ts
+++ b/test/e2e/app-dir/css-server-chunks/css-server-chunks.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { getDistDir } from 'next-test-utils'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
@@ -19,7 +20,7 @@ describe('css-server-chunks', () => {
     expect((await next.fetch('/pages')).status).toBe(200)
 
     let clientChunks = (
-      await fs.readdir(path.join(next.testDir, '.next', 'static'), {
+      await fs.readdir(path.join(next.testDir, getDistDir(), 'static'), {
         recursive: true,
       })
     ).filter((f) => f.endsWith('.js') || f.endsWith('.css'))
@@ -29,11 +30,12 @@ describe('css-server-chunks', () => {
 
     let serverChunks = (
       await Promise.all(
-        ['.next/server/app', '.next/server/pages'].map((d) =>
-          fs.readdir(path.join(next.testDir, d), {
-            recursive: true,
-            encoding: 'utf8',
-          })
+        [`${getDistDir()}/server/app`, `${getDistDir()}/server/pages`].map(
+          (d) =>
+            fs.readdir(path.join(next.testDir, d), {
+              recursive: true,
+              encoding: 'utf8',
+            })
         )
       )
     )

--- a/test/e2e/app-dir/server-components-externals/index.test.ts
+++ b/test/e2e/app-dir/server-components-externals/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
+import { getDistDir } from 'next-test-utils'
 
 describe('app-dir - server components externals', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
@@ -34,12 +35,16 @@ describe('app-dir - server components externals', () => {
   if (!isTurbopack) {
     it('should externalize serversExternalPackages for server rendering layer', async () => {
       await next.fetch('/client')
-      const ssrBundle = await next.readFile('.next/server/app/client/page.js')
+      const ssrBundle = await next.readFile(
+        `${getDistDir()}/server/app/client/page.js`
+      )
       expect(ssrBundle).not.toContain('external-package-mark:index')
       expect(ssrBundle).not.toContain('external-package-mark:subpath')
 
       await next.fetch('/')
-      const rscBundle = await next.readFile('.next/server/app/page.js')
+      const rscBundle = await next.readFile(
+        `${getDistDir()}/server/app/page.js`
+      )
       expect(rscBundle).not.toContain('external-package-mark:index')
       expect(rscBundle).not.toContain('external-package-mark:subpath')
     })

--- a/test/e2e/app-dir/server-components-externals/index.test.ts
+++ b/test/e2e/app-dir/server-components-externals/index.test.ts
@@ -1,6 +1,5 @@
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
-import { getDistDir } from 'next-test-utils'
 
 describe('app-dir - server components externals', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
@@ -36,14 +35,14 @@ describe('app-dir - server components externals', () => {
     it('should externalize serversExternalPackages for server rendering layer', async () => {
       await next.fetch('/client')
       const ssrBundle = await next.readFile(
-        `${getDistDir()}/server/app/client/page.js`
+        `${next.distDir}/server/app/client/page.js`
       )
       expect(ssrBundle).not.toContain('external-package-mark:index')
       expect(ssrBundle).not.toContain('external-package-mark:subpath')
 
       await next.fetch('/')
       const rscBundle = await next.readFile(
-        `${getDistDir()}/server/app/page.js`
+        `${next.distDir}/server/app/page.js`
       )
       expect(rscBundle).not.toContain('external-package-mark:index')
       expect(rscBundle).not.toContain('external-package-mark:subpath')

--- a/test/e2e/app-dir/typed-routes/typed-links.test.ts
+++ b/test/e2e/app-dir/typed-routes/typed-links.test.ts
@@ -11,12 +11,12 @@ describe('typed-links', () => {
   }
 
   it('should generate types for next/link', async () => {
-    const dts = await next.readFile('.next/types/link.d.ts')
+    const dts = await next.readFile(`${next.distDir}/types/link.d.ts`)
     expect(dts).toContain(`declare module 'next/link'`)
   })
 
   it('should include handler route from app/api-test/route.ts in generated link route definitions', async () => {
-    const dts = await next.readFile('.next/types/link.d.ts')
+    const dts = await next.readFile(`${next.distDir}/types/link.d.ts`)
     // Ensure the app route handler at app/api-test/route.ts ("/api-test") is present
     expect(dts).toContain('`/api-test`')
   })

--- a/test/e2e/app-dir/typed-routes/typed-routes.test.ts
+++ b/test/e2e/app-dir/typed-routes/typed-routes.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { runNextCommand } from 'next-test-utils'
+import { getDistDir, runNextCommand } from 'next-test-utils'
 
 const expectedDts = `
 type AppRoutes = "/" | "/_shop/[[...category]]" | "/dashboard" | "/dashboard/settings" | "/docs/[...slug]" | "/gallery/photo/[id]" | "/project/[slug]"
@@ -22,12 +22,12 @@ describe('typed-routes', () => {
   }
 
   it('should generate route types correctly', async () => {
-    const dts = await next.readFile('.next/types/routes.d.ts')
+    const dts = await next.readFile(`${getDistDir()}/types/routes.d.ts`)
     expect(dts).toContain(expectedDts)
   })
 
   it('should correctly convert custom route patterns from path-to-regexp to bracket syntax', async () => {
-    const dts = await next.readFile('.next/types/routes.d.ts')
+    const dts = await next.readFile(`${getDistDir()}/types/routes.d.ts`)
 
     // Test standard dynamic segment: :slug -> [slug]
     expect(dts).toContain('"/project/[slug]"')
@@ -52,7 +52,9 @@ describe('typed-routes', () => {
     `
       )
 
-      const routeTypesContent = await next.readFile('.next/types/routes.d.ts')
+      const routeTypesContent = await next.readFile(
+        `${getDistDir()}/types/routes.d.ts`
+      )
 
       expect(routeTypesContent).toContain(
         'type LayoutRoutes = "/" | "/dashboard" | "/new-layout"'
@@ -61,7 +63,7 @@ describe('typed-routes', () => {
   }
 
   it('should generate RouteContext type for route handlers', async () => {
-    const dts = await next.readFile('.next/types/routes.d.ts')
+    const dts = await next.readFile(`${getDistDir()}/types/routes.d.ts`)
     expect(dts).toContain(
       'interface RouteContext<AppRouteHandlerRoute extends AppRouteHandlerRoutes>'
     )

--- a/test/e2e/app-dir/typed-routes/typed-routes.test.ts
+++ b/test/e2e/app-dir/typed-routes/typed-routes.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { getDistDir, runNextCommand } from 'next-test-utils'
+import { runNextCommand } from 'next-test-utils'
 
 const expectedDts = `
 type AppRoutes = "/" | "/_shop/[[...category]]" | "/dashboard" | "/dashboard/settings" | "/docs/[...slug]" | "/gallery/photo/[id]" | "/project/[slug]"
@@ -22,12 +22,12 @@ describe('typed-routes', () => {
   }
 
   it('should generate route types correctly', async () => {
-    const dts = await next.readFile(`${getDistDir()}/types/routes.d.ts`)
+    const dts = await next.readFile(`${next.distDir}/types/routes.d.ts`)
     expect(dts).toContain(expectedDts)
   })
 
   it('should correctly convert custom route patterns from path-to-regexp to bracket syntax', async () => {
-    const dts = await next.readFile(`${getDistDir()}/types/routes.d.ts`)
+    const dts = await next.readFile(`${next.distDir}/types/routes.d.ts`)
 
     // Test standard dynamic segment: :slug -> [slug]
     expect(dts).toContain('"/project/[slug]"')
@@ -53,7 +53,7 @@ describe('typed-routes', () => {
       )
 
       const routeTypesContent = await next.readFile(
-        `${getDistDir()}/types/routes.d.ts`
+        `${next.distDir}/types/routes.d.ts`
       )
 
       expect(routeTypesContent).toContain(
@@ -63,7 +63,7 @@ describe('typed-routes', () => {
   }
 
   it('should generate RouteContext type for route handlers', async () => {
-    const dts = await next.readFile(`${getDistDir()}/types/routes.d.ts`)
+    const dts = await next.readFile(`${next.distDir}/types/routes.d.ts`)
     expect(dts).toContain(
       'interface RouteContext<AppRouteHandlerRoute extends AppRouteHandlerRoutes>'
     )

--- a/test/e2e/edge-can-use-wasm-files/index.test.ts
+++ b/test/e2e/edge-can-use-wasm-files/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { fetchViaHTTP } from 'next-test-utils'
+import { fetchViaHTTP, getDistDir } from 'next-test-utils'
 import path from 'path'
 import fs from 'fs-extra'
 
@@ -103,7 +103,7 @@ describe('middleware can use wasm files', () => {
     it('lists the necessary wasm bindings in the manifest', async () => {
       const manifestPath = path.join(
         next.testDir,
-        '.next/server/middleware-manifest.json'
+        `${getDistDir()}/server/middleware-manifest.json`
       )
       const manifest = await fs.readJSON(manifestPath)
       if (process.env.IS_TURBOPACK_TEST) {

--- a/test/e2e/edge-can-use-wasm-files/index.test.ts
+++ b/test/e2e/edge-can-use-wasm-files/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { fetchViaHTTP, getDistDir } from 'next-test-utils'
+import { fetchViaHTTP } from 'next-test-utils'
 import path from 'path'
 import fs from 'fs-extra'
 
@@ -103,7 +103,7 @@ describe('middleware can use wasm files', () => {
     it('lists the necessary wasm bindings in the manifest', async () => {
       const manifestPath = path.join(
         next.testDir,
-        `${getDistDir()}/server/middleware-manifest.json`
+        `${next.distDir}/server/middleware-manifest.json`
       )
       const manifest = await fs.readJSON(manifestPath)
       if (process.env.IS_TURBOPACK_TEST) {

--- a/test/e2e/edge-compiler-can-import-blob-assets/index.test.ts
+++ b/test/e2e/edge-compiler-can-import-blob-assets/index.test.ts
@@ -56,7 +56,8 @@ describe('Edge Compiler can import asset assets', () => {
     it('extracts all the assets from the bundle', async () => {
       const manifestPath = path.join(
         next.testDir,
-        '.next/server/middleware-manifest.json'
+        next.distDir,
+        'server/middleware-manifest.json'
       )
       const manifest = await readJson(manifestPath)
       const orderedAssets = manifest.functions['/api/edge'].assets.sort(

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
@@ -44,7 +44,9 @@ describe('i18n-ignore-rewrite-source-locale with basepath', () => {
       'get _next/static/ files by skipping locale in rewrite, locale: %s',
       async (locale) => {
         const chunks = (
-          await fs.readdir(path.join(next.testDir, '.next', 'static', 'chunks'))
+          await fs.readdir(
+            path.join(next.testDir, next.distDir, 'static', 'chunks')
+          )
         ).filter((f) => f.endsWith('.js'))
 
         await Promise.all(

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
@@ -1,6 +1,6 @@
 import { createNext } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { fetchViaHTTP, getDistDir, renderViaHTTP } from 'next-test-utils'
+import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 import fs from 'fs-extra'
 
@@ -74,7 +74,7 @@ describe('i18n-ignore-rewrite-source-locale', () => {
       async (locale) => {
         const chunks = (
           await fs.readdir(
-            path.join(next.testDir, getDistDir(), 'static', 'chunks')
+            path.join(next.testDir, next.distDir, 'static', 'chunks')
           )
         ).filter((f) => f.endsWith('.js'))
 

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites.test.ts
@@ -1,6 +1,6 @@
 import { createNext } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
+import { fetchViaHTTP, getDistDir, renderViaHTTP } from 'next-test-utils'
 import path from 'path'
 import fs from 'fs-extra'
 
@@ -73,7 +73,9 @@ describe('i18n-ignore-rewrite-source-locale', () => {
       'get _next/static/ files by skipping locale in rewrite, locale: %s',
       async (locale) => {
         const chunks = (
-          await fs.readdir(path.join(next.testDir, '.next', 'static', 'chunks'))
+          await fs.readdir(
+            path.join(next.testDir, getDistDir(), 'static', 'chunks')
+          )
         ).filter((f) => f.endsWith('.js'))
 
         await Promise.all(

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -315,8 +315,10 @@ export class NextInstance {
             'utf8'
           )
           if (content.includes('distDir')) {
-            this.distDir =
-              content.match(/['"`]?distDir['"`]?:.*?['"`](.*?)['"`]/)?.[1] || ''
+            const match = content.match(/['"`]?distDir['"`]?:.*?['"`](.*?)['"`]/)?.[1]
+            if (match) {
+              this.distDir = match
+            }
           }
         }
 

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -315,7 +315,9 @@ export class NextInstance {
             'utf8'
           )
           if (content.includes('distDir')) {
-            const match = content.match(/['"`]?distDir['"`]?:.*?['"`](.*?)['"`]/)?.[1]
+            const match = content.match(
+              /['"`]?distDir['"`]?:.*?['"`](.*?)['"`]/
+            )?.[1]
             if (match) {
               this.distDir = match
             }

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -80,6 +80,7 @@ export class NextInstance {
   protected resolutions?: PackageJson['resolutions']
   protected events: { [eventName: string]: Set<any> } = {}
   public testDir: string
+  public distDir: string
   tmpRepoDir: string
   protected isStopping: boolean = false
   protected isDestroyed: boolean = false
@@ -209,6 +210,7 @@ export class NextInstance {
           `next-test-${Date.now()}-${(Math.random() * 1000) | 0}`,
           this.subDir
         )
+        this.distDir = getDistDir()
 
         const reactVersion =
           process.env.NEXT_TEST_REACT_VERSION || nextjsReactPeerVersion
@@ -241,7 +243,7 @@ export class NextInstance {
                 scripts: {
                   // since we can't get the build id as a build artifact, make it
                   // available under the static files
-                  'post-build': `cp ${getDistDir()}/BUILD_ID ${getDistDir()}/static/__BUILD_ID`,
+                  'post-build': `cp ${this.distDir}/BUILD_ID ${this.distDir}/static/__BUILD_ID`,
                   ...pkgScripts,
                   build:
                     (pkgScripts['build'] || this.buildCommand || 'next build') +
@@ -301,6 +303,21 @@ export class NextInstance {
           throw new Error(
             `nextConfig provided on "createNext()" and as a file "${nextConfigFile}", use one or the other to continue`
           )
+        }
+
+        if (this.nextConfig?.distDir) {
+          this.distDir = this.nextConfig.distDir
+        }
+        // Same logic as we get the basePath in isNextDeploy
+        if (nextConfigFile) {
+          const content = await fs.readFile(
+            path.join(this.testDir, nextConfigFile),
+            'utf8'
+          )
+          if (content.includes('distDir')) {
+            this.distDir =
+              content.match(/['"`]?distDir['"`]?:.*?['"`](.*?)['"`]/)?.[1] || ''
+          }
         }
 
         if (this.nextConfig || (isNextDeploy && !nextConfigFile)) {
@@ -511,7 +528,7 @@ export class NextInstance {
       if (process.env.TRACE_PLAYWRIGHT) {
         await fs
           .cp(
-            path.join(this.testDir, getDistDir(), 'trace'),
+            path.join(this.testDir, this.distDir, 'trace'),
             path.join(
               __dirname,
               '../../traces',

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -8,7 +8,12 @@ import { ChildProcess } from 'child_process'
 import { createNextInstall } from '../create-next-install'
 import { Span } from 'next/dist/trace'
 import webdriver from '../next-webdriver'
-import { renderViaHTTP, fetchViaHTTP, findPort } from 'next-test-utils'
+import {
+  renderViaHTTP,
+  fetchViaHTTP,
+  findPort,
+  getDistDir,
+} from 'next-test-utils'
 import cheerio from 'cheerio'
 import { once } from 'events'
 import { Playwright } from 'next-webdriver'
@@ -236,7 +241,7 @@ export class NextInstance {
                 scripts: {
                   // since we can't get the build id as a build artifact, make it
                   // available under the static files
-                  'post-build': 'cp .next/BUILD_ID .next/static/__BUILD_ID',
+                  'post-build': `cp ${getDistDir()}/BUILD_ID ${getDistDir()}/static/__BUILD_ID`,
                   ...pkgScripts,
                   build:
                     (pkgScripts['build'] || this.buildCommand || 'next build') +
@@ -506,7 +511,7 @@ export class NextInstance {
       if (process.env.TRACE_PLAYWRIGHT) {
         await fs
           .cp(
-            path.join(this.testDir, '.next/trace'),
+            path.join(this.testDir, getDistDir(), 'trace'),
             path.join(
               __dirname,
               '../../traces',

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -31,6 +31,7 @@ import { Playwright } from 'next-webdriver'
 import { shouldUseTurbopack } from './turbo'
 import stripAnsi from 'strip-ansi'
 import escapeRegex from 'escape-string-regexp'
+import { isNextDev } from 'e2e-utils'
 
 // TODO: Create dedicated Jest environment that sets up these matchers
 // Edge Runtime unit tests fail with "EvalError: Code generation from strings disallowed for this context" if these matchers are imported in those tests.
@@ -1885,4 +1886,8 @@ export function normalizeManifest<T>(
       JSON.stringify(manifest)
     )
   )
+}
+
+export function getDistDir(): '.next' | '.next/dev' {
+  return isNextDev ? '.next/dev' : '.next'
 }

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1891,7 +1891,7 @@ export function getDistDir(isNextDev?: boolean): '.next' | '.next/dev' {
   // global.isNextDev is set in e2e/development/production tests.
   // TODO: If a test utils that are used in integration/unit tests can set
   // global.isNextDev flag, we could possibly remove the parameter.
-  return (isNextDev ?? global.isNextDev) &&
+  return (isNextDev ?? (global as any).isNextDev) &&
     // Flag for incremental rollout of isolated dev build, set in CI.
     process.env.__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD === 'true'
     ? '.next/dev'

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -31,7 +31,6 @@ import { Playwright } from 'next-webdriver'
 import { shouldUseTurbopack } from './turbo'
 import stripAnsi from 'strip-ansi'
 import escapeRegex from 'escape-string-regexp'
-import { isNextDev } from 'e2e-utils'
 
 // TODO: Create dedicated Jest environment that sets up these matchers
 // Edge Runtime unit tests fail with "EvalError: Code generation from strings disallowed for this context" if these matchers are imported in those tests.
@@ -1888,6 +1887,9 @@ export function normalizeManifest<T>(
   )
 }
 
-export function getDistDir(): '.next' | '.next/dev' {
-  return isNextDev ? '.next/dev' : '.next'
+export function getDistDir(isNextDev?: boolean): '.next' | '.next/dev' {
+  // global.isNextDev is set in e2e/development/production tests.
+  // TODO: If a test utils that are used in integration/unit tests can set
+  // global.isNextDev flag, we could possibly remove the parameter.
+  return (isNextDev ?? global.isNextDev) ? '.next/dev' : '.next'
 }

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1891,5 +1891,9 @@ export function getDistDir(isNextDev?: boolean): '.next' | '.next/dev' {
   // global.isNextDev is set in e2e/development/production tests.
   // TODO: If a test utils that are used in integration/unit tests can set
   // global.isNextDev flag, we could possibly remove the parameter.
-  return (isNextDev ?? global.isNextDev) ? '.next/dev' : '.next'
+  return (isNextDev ?? global.isNextDev) &&
+    // Flag for incremental rollout of isolated dev build, set in CI.
+    process.env.__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD === 'true'
+    ? '.next/dev'
+    : '.next'
 }


### PR DESCRIPTION
Enabling `experimental.isolatedDevBuild` required many changes to the current workflow, so we will incrementally roll out to the tests.

1. test-experimental-dev (here)
2. test-experimental-prod
3. test-experimental-integration
4. test-unit
5. Enable by default, remove the flag and update the rest

x-ref: https://github.com/vercel/next.js/pull/84043