### PR TITLE
Fix layout for `ssgPageRoutes` in the file tree

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -383,7 +383,6 @@ export async function printTreeView(
                   ? ` (avg ${getPrettyDuration(avgDuration)})`
                   : ''
               }`,
-              '',
               showRevalidate && initialCacheControl
                 ? formatRevalidate(initialCacheControl)
                 : '',

--- a/test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts
+++ b/test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts
@@ -24,9 +24,9 @@ describe('build-output-tree-view', () => {
        ├ ○ /cache-life-hours           1h      1d
        ├ ƒ /dynamic
        ├ ◐ /ppr/[slug]                 1w     30d
-       ├   ├ /ppr/[slug]                       1w  30d
-       ├   ├ /ppr/days                         1d   1w
-       ├   └ /ppr/weeks                        1w  30d
+       ├   ├ /ppr/[slug]               1w     30d
+       ├   ├ /ppr/days                 1d      1w
+       ├   └ /ppr/weeks                1w     30d
        └ ○ /revalidate                15m      1y
 
        Route (pages)           Revalidate  Expire


### PR DESCRIPTION
Fix layout for ssgPageRoutes in the file tree

there was an extraneous column that messed with offsets accidentally left behind by #83815

Closes NEXT-4727


Closes PACK-5536