### PR TITLE
BREAKING CHANGE!: bump default `images.minimumCacheTTL` from 1 min to 4 hours

### DIFF
--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -765,7 +765,7 @@ If no configuration is provided, the default below is used.
 ```js filename="next.config.js"
 module.exports = {
   images: {
-    minimumCacheTTL: 86400, // 1 day
+    minimumCacheTTL: 14400, // 4 hours
   },
 }
 ```

--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -765,7 +765,7 @@ If no configuration is provided, the default below is used.
 ```js filename="next.config.js"
 module.exports = {
   images: {
-    minimumCacheTTL: 60, // 1 minute
+    minimumCacheTTL: 86400, // 1 day
   },
 }
 ```

--- a/docs/02-pages/04-api-reference/01-components/image-legacy.mdx
+++ b/docs/02-pages/04-api-reference/01-components/image-legacy.mdx
@@ -561,7 +561,7 @@ If no configuration is provided, the default below is used.
 ```js filename="next.config.js"
 module.exports = {
   images: {
-    minimumCacheTTL: 60, // 1 minute
+    minimumCacheTTL: 86400, // 1 day
   },
 }
 ```

--- a/docs/02-pages/04-api-reference/01-components/image-legacy.mdx
+++ b/docs/02-pages/04-api-reference/01-components/image-legacy.mdx
@@ -561,7 +561,7 @@ If no configuration is provided, the default below is used.
 ```js filename="next.config.js"
 module.exports = {
   images: {
-    minimumCacheTTL: 86400, // 1 day
+    minimumCacheTTL: 14400, // 4 hours
   },
 }
 ```

--- a/errors/invalid-images-config.mdx
+++ b/errors/invalid-images-config.mdx
@@ -28,7 +28,7 @@ module.exports = {
     // disable static imports for image files
     disableStaticImages: false,
     // minimumCacheTTL is in seconds, must be integer 0 or more
-    minimumCacheTTL: 86400, // (prev 60s then changed to 1d in next@16)
+    minimumCacheTTL: 14400, // 4 hours
     // ordered list of acceptable optimized image formats (mime types)
     formats: ['image/webp'],
     // enable dangerous use of SVG images

--- a/errors/invalid-images-config.mdx
+++ b/errors/invalid-images-config.mdx
@@ -28,7 +28,7 @@ module.exports = {
     // disable static imports for image files
     disableStaticImages: false,
     // minimumCacheTTL is in seconds, must be integer 0 or more
-    minimumCacheTTL: 60,
+    minimumCacheTTL: 86400, // (prev 60s then changed to 1d in next@16)
     // ordered list of acceptable optimized image formats (mime types)
     formats: ['image/webp'],
     // enable dangerous use of SVG images

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -323,7 +323,7 @@ export class ImageOptimizerCache {
       deviceSizes = [],
       imageSizes = [],
       domains = [],
-      minimumCacheTTL = 60,
+      minimumCacheTTL = 86400,
       formats = ['image/webp'],
     } = imageData
     const remotePatterns = nextConfig.images?.remotePatterns || []

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -323,7 +323,7 @@ export class ImageOptimizerCache {
       deviceSizes = [],
       imageSizes = [],
       domains = [],
-      minimumCacheTTL = 86400,
+      minimumCacheTTL = 14400,
       formats = ['image/webp'],
     } = imageData
     const remotePatterns = nextConfig.images?.remotePatterns || []

--- a/packages/next/src/shared/lib/image-config.ts
+++ b/packages/next/src/shared/lib/image-config.ts
@@ -135,7 +135,7 @@ export const imageConfigDefault: ImageConfigComplete = {
   loaderFile: '',
   domains: [],
   disableStaticImages: false,
-  minimumCacheTTL: 86400, // 1 day
+  minimumCacheTTL: 14400, // 4 hours
   formats: ['image/webp'],
   dangerouslyAllowSVG: false,
   contentSecurityPolicy: `script-src 'none'; frame-src 'none'; sandbox;`,

--- a/packages/next/src/shared/lib/image-config.ts
+++ b/packages/next/src/shared/lib/image-config.ts
@@ -135,7 +135,7 @@ export const imageConfigDefault: ImageConfigComplete = {
   loaderFile: '',
   domains: [],
   disableStaticImages: false,
-  minimumCacheTTL: 60,
+  minimumCacheTTL: 86400, // 1 day
   formats: ['image/webp'],
   dangerouslyAllowSVG: false,
   contentSecurityPolicy: `script-src 'none'; frame-src 'none'; sandbox;`,

--- a/test/integration/image-optimizer/test/index.test.ts
+++ b/test/integration/image-optimizer/test/index.test.ts
@@ -709,7 +709,7 @@ describe('Image Optimizer', () => {
               headers: [
                 {
                   key: 'Cache-Control',
-                  value: 'public, max-age=86400, must-revalidate',
+                  value: 'public, max-age=14400, must-revalidate',
                 },
               ],
             },
@@ -733,7 +733,7 @@ describe('Image Optimizer', () => {
           const res = await fetchViaHTTP(appPort, '/_next/image', query, opts)
           expect(res.status).toBe(200)
           expect(res.headers.get('Cache-Control')).toBe(
-            `public, max-age=86400, must-revalidate`
+            `public, max-age=14400, must-revalidate`
           )
           expect(res.headers.get('Content-Disposition')).toBe(
             `attachment; filename="test.webp"`
@@ -743,7 +743,7 @@ describe('Image Optimizer', () => {
             const files = await fsToJson(imagesDir)
 
             let found = false
-            const maxAge = '86400'
+            const maxAge = '14400'
 
             Object.keys(files).forEach((dir) => {
               if (
@@ -764,7 +764,7 @@ describe('Image Optimizer', () => {
           const res = await fetchViaHTTP(appPort, '/_next/image', query, opts)
           expect(res.status).toBe(200)
           expect(res.headers.get('Cache-Control')).toBe(
-            `public, max-age=86400, must-revalidate`
+            `public, max-age=14400, must-revalidate`
           )
           expect(res.headers.get('Content-Disposition')).toBe(
             `attachment; filename="test.webp"`

--- a/test/integration/image-optimizer/test/index.test.ts
+++ b/test/integration/image-optimizer/test/index.test.ts
@@ -764,7 +764,7 @@ describe('Image Optimizer', () => {
           const res = await fetchViaHTTP(appPort, '/_next/image', query, opts)
           expect(res.status).toBe(200)
           expect(res.headers.get('Cache-Control')).toBe(
-            `public, max-age=60, must-revalidate`
+            `public, max-age=86400, must-revalidate`
           )
           expect(res.headers.get('Content-Disposition')).toBe(
             `attachment; filename="test.webp"`

--- a/test/integration/image-optimizer/test/util.ts
+++ b/test/integration/image-optimizer/test/util.ts
@@ -161,7 +161,7 @@ export function runTests(ctx: RunTestsCtx) {
     contentDispositionType = 'attachment',
     domains = [],
     formats = [],
-    minimumCacheTTL = 60,
+    minimumCacheTTL = 86400,
   } = nextConfigImages || {}
   const avifEnabled = formats[0] === 'image/avif'
   let slowImageServer: Awaited<ReturnType<typeof serveSlowImage>>

--- a/test/integration/image-optimizer/test/util.ts
+++ b/test/integration/image-optimizer/test/util.ts
@@ -161,7 +161,7 @@ export function runTests(ctx: RunTestsCtx) {
     contentDispositionType = 'attachment',
     domains = [],
     formats = [],
-    minimumCacheTTL = 86400,
+    minimumCacheTTL = 14400,
   } = nextConfigImages || {}
   const avifEnabled = formats[0] === 'image/avif'
   let slowImageServer: Awaited<ReturnType<typeof serveSlowImage>>

--- a/test/integration/next-image-new/app-dir-localpatterns/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir-localpatterns/test/index.test.ts
@@ -96,7 +96,7 @@ function runTests(mode: 'dev' | 'server') {
               search: '',
             },
           ],
-          minimumCacheTTL: 60,
+          minimumCacheTTL: 86400,
           path: '/_next/image',
           qualities: [75],
           sizes: [

--- a/test/integration/next-image-new/app-dir-localpatterns/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir-localpatterns/test/index.test.ts
@@ -96,7 +96,7 @@ function runTests(mode: 'dev' | 'server') {
               search: '',
             },
           ],
-          minimumCacheTTL: 86400,
+          minimumCacheTTL: 14400,
           path: '/_next/image',
           qualities: [75],
           sizes: [

--- a/test/integration/next-image-new/app-dir-qualities/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir-qualities/test/index.test.ts
@@ -102,7 +102,7 @@ function runTests(mode: 'dev' | 'server') {
           loaderFile: '',
           remotePatterns: [],
           localPatterns: undefined,
-          minimumCacheTTL: 60,
+          minimumCacheTTL: 86400,
           path: '/_next/image',
           qualities: [42, 69, 88],
           sizes: [

--- a/test/integration/next-image-new/app-dir-qualities/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir-qualities/test/index.test.ts
@@ -102,7 +102,7 @@ function runTests(mode: 'dev' | 'server') {
           loaderFile: '',
           remotePatterns: [],
           localPatterns: undefined,
-          minimumCacheTTL: 86400,
+          minimumCacheTTL: 14400,
           path: '/_next/image',
           qualities: [42, 69, 88],
           sizes: [

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -1785,7 +1785,7 @@ function runTests(mode: 'dev' | 'server') {
           loaderFile: '',
           remotePatterns: [],
           localPatterns: undefined,
-          minimumCacheTTL: 60,
+          minimumCacheTTL: 86400,
           path: '/_next/image',
           qualities: [75],
           sizes: [

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -1785,7 +1785,7 @@ function runTests(mode: 'dev' | 'server') {
           loaderFile: '',
           remotePatterns: [],
           localPatterns: undefined,
-          minimumCacheTTL: 86400,
+          minimumCacheTTL: 14400,
           path: '/_next/image',
           qualities: [75],
           sizes: [

--- a/test/integration/next-image-new/unicode/test/index.test.ts
+++ b/test/integration/next-image-new/unicode/test/index.test.ts
@@ -94,7 +94,7 @@ function runTests(mode: 'server' | 'dev') {
               search: '',
             },
           ],
-          minimumCacheTTL: 86400,
+          minimumCacheTTL: 14400,
           path: '/_next/image',
           qualities: [75],
           sizes: [

--- a/test/integration/next-image-new/unicode/test/index.test.ts
+++ b/test/integration/next-image-new/unicode/test/index.test.ts
@@ -94,7 +94,7 @@ function runTests(mode: 'server' | 'dev') {
               search: '',
             },
           ],
-          minimumCacheTTL: 60,
+          minimumCacheTTL: 86400,
           path: '/_next/image',
           qualities: [75],
           sizes: [

--- a/test/integration/next-image-new/unoptimized/test/index.test.ts
+++ b/test/integration/next-image-new/unoptimized/test/index.test.ts
@@ -110,7 +110,7 @@ function runTests(url: string, mode: 'dev' | 'server') {
           loaderFile: '',
           remotePatterns: [],
           localPatterns: undefined,
-          minimumCacheTTL: 86400,
+          minimumCacheTTL: 14400,
           path: '/_next/image',
           qualities: [75],
           sizes: [

--- a/test/integration/next-image-new/unoptimized/test/index.test.ts
+++ b/test/integration/next-image-new/unoptimized/test/index.test.ts
@@ -110,7 +110,7 @@ function runTests(url: string, mode: 'dev' | 'server') {
           loaderFile: '',
           remotePatterns: [],
           localPatterns: undefined,
-          minimumCacheTTL: 60,
+          minimumCacheTTL: 86400,
           path: '/_next/image',
           qualities: [75],
           sizes: [


### PR DESCRIPTION
We have found many Next.js users are confused why images keep revalidating so frequently (increasing cpu and cost).

The reason is usually that their upstream source images are missing the `cache-control` header and thus fallback to the 60 second revalidation default. This its not a great default since most images don't change frequently.

This PR is a breaking change to bump the `images.minimumCacheTTL` config from 60 (1 min) to 14400 (4 hours).

Why 4 hours? Because its long enough to take advantage of the durable cache, but short enough that changing or deleting the upstream src image will take effect on the same day.

For advanced use cases where images are changing frequently, developers can change this behavior back by reducing `images.minimumCacheTTL` to a lower value.