### PR TITLE
Turbopack: Remove useless 'default' built-in webpack loader condition

### DIFF
--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -49,8 +49,6 @@ pub(crate) mod sass;
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum WebpackLoaderBuiltinCondition {
-    /// Treated as always-present.
-    Default,
     /// Client-side code.
     Browser,
     /// Code in `node_modules` that should typically not be modified by webpack loaders.
@@ -70,7 +68,6 @@ pub enum WebpackLoaderBuiltinCondition {
 impl WebpackLoaderBuiltinCondition {
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Default => "default",
             Self::Browser => "browser",
             Self::Foreign => "foreign",
             Self::Development => "development",
@@ -86,7 +83,6 @@ impl FromStr for WebpackLoaderBuiltinCondition {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "default" => Ok(Self::Default),
             "browser" => Ok(Self::Browser),
             "foreign" => Ok(Self::Foreign),
             "development" => Ok(Self::Development),

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -183,7 +183,6 @@ module.exports = {
 
 In addition, a number of built-in conditions are supported:
 
-- `default`: Always matched. A no-op.
 - `browser`: Matches code that will execute on the client. Server code can be matched using `{not: 'browser'}`.
 - `foreign`: Matches code in `node_modules`, as well as some Next.js internals. Usually you'll want to restrict loaders to `{not: 'foreign'}`. This can improve performance by reducing the number of files the loader is invoked on.
 - `development`: Matches when using `next dev --turbopack`.

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -114,7 +114,6 @@ const zTurbopackLoaderItem: zod.ZodType<TurbopackLoaderItem> = z.union([
 
 const zTurbopackLoaderBuiltinCondition: zod.ZodType<TurbopackLoaderBuiltinCondition> =
   z.union([
-    z.literal('default'),
     z.literal('browser'),
     z.literal('foreign'),
     z.literal('development'),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -107,7 +107,6 @@ export type TurbopackLoaderItem =
     }
 
 export type TurbopackLoaderBuiltinCondition =
-  | 'default'
   | 'browser'
   | 'foreign'
   | 'development'


### PR DESCRIPTION
Follow up to https://github.com/vercel/next.js/pull/83246#discussion_r2366553689

Discussed this with @lukesandberg and we can't find a place where it would be very useful, it seems it might've been useful with the old builtin condition syntax (which I removed).

It also looks like maybe I forgot to actually wire this up to anything? Whoops. Whelp, now it's gone.

Closes PACK-5537