### PR TITLE
[turbopack] s/analyse/analyze/g

### DIFF
--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -330,7 +330,7 @@ async fn get_pages_structure_for_directory(
 ) -> Result<Vc<PagesDirectoryStructure>> {
     let span = {
         let path = project_path.value_to_string().await?.to_string();
-        tracing::info_span!("analyse pages structure", name = path)
+        tracing::info_span!("analyze pages structure", name = path)
     };
     async move {
         let page_extensions_raw = &*page_extensions.await?;

--- a/turbopack/crates/turbopack-ecmascript/benches/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/references.rs
@@ -15,7 +15,7 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     EcmascriptInputTransforms, EcmascriptModuleAsset, EcmascriptOptions, TreeShakingMode,
-    references::analyse_ecmascript_module_internal,
+    references::analyze_ecmascript_module_internal,
 };
 use turbopack_test_utils::noop_asset_context::NoopAssetContext;
 
@@ -127,7 +127,7 @@ where
     b.to_async(rt).iter(async || {
         input
             .storage
-            .run_once(analyse_ecmascript_module_internal(input.module, None))
+            .run_once(analyze_ecmascript_module_internal(input.module, None))
             .await
             .unwrap()
     });

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/linker.rs
@@ -133,7 +133,7 @@ where
                         done.push(JsValue::unknown(
                             JsValue::Variable(var.clone()),
                             false,
-                            "no value of this variable analysed",
+                            "no value of this variable analyzed",
                         ));
                     }
                 };
@@ -165,7 +165,7 @@ where
                     done.push(JsValue::unknown(
                         JsValue::Argument(func_ident, index),
                         false,
-                        "function calls are not analysed yet",
+                        "function calls are not analyzed yet",
                     ));
                 }
             }

--- a/turbopack/crates/turbopack-ecmascript/src/errors.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/errors.rs
@@ -1,4 +1,4 @@
-pub mod failed_to_analyse {
+pub mod failed_to_analyze {
     pub mod ecmascript {
         pub const DYNAMIC_IMPORT: &str = "TP1001";
         pub const REQUIRE: &str = "TP1002";

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -120,7 +120,7 @@ use crate::{
     merged_module::MergedEcmascriptModule,
     parse::generate_js_source_map,
     references::{
-        analyse_ecmascript_module,
+        analyze_ecmascript_module,
         async_module::OptionAsyncModule,
         esm::{base::EsmAssetReferences, export},
     },
@@ -520,7 +520,7 @@ impl EcmascriptParsable for EcmascriptModuleAsset {
 impl EcmascriptAnalyzable for EcmascriptModuleAsset {
     #[turbo_tasks::function]
     fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult> {
-        analyse_ecmascript_module(self, None)
+        analyze_ecmascript_module(self, None)
     }
 
     /// Generates module contents without an analysis pass. This is useful for
@@ -671,7 +671,7 @@ impl EcmascriptModuleAsset {
 
     #[turbo_tasks::function]
     pub fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult> {
-        analyse_ecmascript_module(self, None)
+        analyze_ecmascript_module(self, None)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -190,7 +190,7 @@ impl CjsRequireAssetReferenceCodeGen {
                         Some(ExprOrSpread {
                             spread: Some(_),
                             expr: _,
-                        }) => "spread operator is not analyse-able in require() expressions.",
+                        }) => "spread operator is not analyze-able in require() expressions.",
                         _ => "require() expressions require at least 1 argument",
                     }
                 } else {
@@ -313,7 +313,7 @@ impl CjsRequireResolveAssetReferenceCodeGen {
                                     spread: Some(_),
                                     expr: _,
                                 }) => {
-                                    "spread operator is not analyse-able in require() expressions."
+                                    "spread operator is not analyze-able in require() expressions."
                                 }
                                 _ => "require() expressions require at least 1 argument",
                             };

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -502,7 +502,7 @@ pub struct EsmExports {
 #[derive(Hash, Debug)]
 pub struct ExpandedExports {
     pub exports: BTreeMap<RcStr, EsmExport>,
-    /// Modules we couldn't analyse all exports of.
+    /// Modules we couldn't analyze all exports of.
     pub dynamic_exports: Vec<ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>>,
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -477,28 +477,28 @@ where
 
 /// Analyse a provided [EcmascriptModuleAsset] and return a [AnalyzeEcmascriptModuleResult].
 #[turbo_tasks::function]
-pub(crate) async fn analyse_ecmascript_module(
+pub(crate) async fn analyze_ecmascript_module(
     module: ResolvedVc<EcmascriptModuleAsset>,
     part: Option<ModulePart>,
 ) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
     let span = {
         let module = module.ident().to_string().await?.to_string();
-        tracing::info_span!("analyse ecmascript module", name = module)
+        tracing::info_span!("analyze ecmascript module", name = module)
     };
-    let result = analyse_ecmascript_module_internal(module, part)
+    let result = analyze_ecmascript_module_internal(module, part)
         .instrument(span)
         .await;
 
     match result {
         Ok(result) => Ok(result),
         Err(err) => Err(err.context(format!(
-            "failed to analyse ecmascript module '{}'",
+            "failed to analyze ecmascript module '{}'",
             module.ident().to_string().await?
         ))),
     }
 }
 
-pub async fn analyse_ecmascript_module_internal(
+pub async fn analyze_ecmascript_module_internal(
     module: ResolvedVc<EcmascriptModuleAsset>,
     part: Option<ModulePart>,
 ) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
@@ -1651,7 +1651,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                             span,
                             &format!("new URL({args}) is very dynamic{hints}",),
                             DiagnosticId::Lint(
-                                errors::failed_to_analyse::ecmascript::NEW_URL_IMPORT_META
+                                errors::failed_to_analyze::ecmascript::NEW_URL_IMPORT_META
                                     .to_string(),
                             ),
                         );
@@ -1683,7 +1683,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                             span,
                             &format!("new Worker({args}) is very dynamic{hints}",),
                             DiagnosticId::Lint(
-                                errors::failed_to_analyse::ecmascript::NEW_WORKER.to_string(),
+                                errors::failed_to_analyze::ecmascript::NEW_WORKER.to_string(),
                             ),
                         );
                         if ignore_dynamic_requests {
@@ -1771,7 +1771,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         span,
                         &format!("import({args}) is very dynamic{hints}",),
                         DiagnosticId::Lint(
-                            errors::failed_to_analyse::ecmascript::DYNAMIC_IMPORT.to_string(),
+                            errors::failed_to_analyze::ecmascript::DYNAMIC_IMPORT.to_string(),
                         ),
                     );
                     if ignore_dynamic_requests {
@@ -1796,9 +1796,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             let (args, hints) = explain_args(&args);
             handler.span_warn_with_code(
                 span,
-                &format!("import({args}) is not statically analyse-able{hints}",),
+                &format!("import({args}) is not statically analyze-able{hints}",),
                 DiagnosticId::Error(
-                    errors::failed_to_analyse::ecmascript::DYNAMIC_IMPORT.to_string(),
+                    errors::failed_to_analyze::ecmascript::DYNAMIC_IMPORT.to_string(),
                 ),
             )
         }
@@ -1812,7 +1812,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         span,
                         &format!("require({args}) is very dynamic{hints}",),
                         DiagnosticId::Lint(
-                            errors::failed_to_analyse::ecmascript::REQUIRE.to_string(),
+                            errors::failed_to_analyze::ecmascript::REQUIRE.to_string(),
                         ),
                     );
                     if ignore_dynamic_requests {
@@ -1834,8 +1834,8 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             let (args, hints) = explain_args(&args);
             handler.span_warn_with_code(
                 span,
-                &format!("require({args}) is not statically analyse-able{hints}",),
-                DiagnosticId::Error(errors::failed_to_analyse::ecmascript::REQUIRE.to_string()),
+                &format!("require({args}) is not statically analyze-able{hints}",),
+                DiagnosticId::Error(errors::failed_to_analyze::ecmascript::REQUIRE.to_string()),
             )
         }
         JsValue::WellKnownFunction(WellKnownFunctionKind::Define) => {
@@ -1856,7 +1856,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             let args = linked_args(args).await?;
             if args.len() == 1 || args.len() == 2 {
                 // TODO error TP1003 require.resolve(???*0*, {"paths": [???*1*]}) is not statically
-                // analyse-able with ignore_dynamic_requests = true
+                // analyze-able with ignore_dynamic_requests = true
                 let pat = js_value_to_pattern(&args[0]);
                 if !pat.has_constant_parts() {
                     let (args, hints) = explain_args(&args);
@@ -1864,7 +1864,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         span,
                         &format!("require.resolve({args}) is very dynamic{hints}",),
                         DiagnosticId::Lint(
-                            errors::failed_to_analyse::ecmascript::REQUIRE_RESOLVE.to_string(),
+                            errors::failed_to_analyze::ecmascript::REQUIRE_RESOLVE.to_string(),
                         ),
                     );
                     if ignore_dynamic_requests {
@@ -1886,9 +1886,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             let (args, hints) = explain_args(&args);
             handler.span_warn_with_code(
                 span,
-                &format!("require.resolve({args}) is not statically analyse-able{hints}",),
+                &format!("require.resolve({args}) is not statically analyze-able{hints}",),
                 DiagnosticId::Error(
-                    errors::failed_to_analyse::ecmascript::REQUIRE_RESOLVE.to_string(),
+                    errors::failed_to_analyze::ecmascript::REQUIRE_RESOLVE.to_string(),
                 ),
             )
         }
@@ -1906,7 +1906,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                             PrettyPrintError(&err)
                         ),
                         DiagnosticId::Error(
-                            errors::failed_to_analyse::ecmascript::REQUIRE_CONTEXT.to_string(),
+                            errors::failed_to_analyze::ecmascript::REQUIRE_CONTEXT.to_string(),
                         ),
                     );
                     return Ok(());
@@ -1940,7 +1940,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         span,
                         &format!("fs.{name}({args}) is very dynamic{hints}",),
                         DiagnosticId::Lint(
-                            errors::failed_to_analyse::ecmascript::FS_METHOD.to_string(),
+                            errors::failed_to_analyze::ecmascript::FS_METHOD.to_string(),
                         ),
                     );
                     if ignore_dynamic_requests {
@@ -1957,8 +1957,8 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             let (args, hints) = explain_args(&args);
             handler.span_warn_with_code(
                 span,
-                &format!("fs.{name}({args}) is not statically analyse-able{hints}",),
-                DiagnosticId::Error(errors::failed_to_analyse::ecmascript::FS_METHOD.to_string()),
+                &format!("fs.{name}({args}) is not statically analyze-able{hints}",),
+                DiagnosticId::Error(errors::failed_to_analyze::ecmascript::FS_METHOD.to_string()),
             )
         }
 
@@ -1989,7 +1989,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     span,
                     &format!("path.resolve({args}) is very dynamic{hints}",),
                     DiagnosticId::Lint(
-                        errors::failed_to_analyse::ecmascript::PATH_METHOD.to_string(),
+                        errors::failed_to_analyze::ecmascript::PATH_METHOD.to_string(),
                     ),
                 );
                 if ignore_dynamic_requests {
@@ -2029,7 +2029,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     span,
                     &format!("path.join({args}) is very dynamic{hints}",),
                     DiagnosticId::Lint(
-                        errors::failed_to_analyse::ecmascript::PATH_METHOD.to_string(),
+                        errors::failed_to_analyze::ecmascript::PATH_METHOD.to_string(),
                     ),
                 );
                 if ignore_dynamic_requests {
@@ -2097,7 +2097,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         span,
                         &format!("child_process.{name}({args}) is very dynamic{hints}",),
                         DiagnosticId::Lint(
-                            errors::failed_to_analyse::ecmascript::CHILD_PROCESS_SPAWN.to_string(),
+                            errors::failed_to_analyze::ecmascript::CHILD_PROCESS_SPAWN.to_string(),
                         ),
                     );
                 }
@@ -2106,9 +2106,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             let (args, hints) = explain_args(&args);
             handler.span_warn_with_code(
                 span,
-                &format!("child_process.{name}({args}) is not statically analyse-able{hints}",),
+                &format!("child_process.{name}({args}) is not statically analyze-able{hints}",),
                 DiagnosticId::Error(
-                    errors::failed_to_analyse::ecmascript::CHILD_PROCESS_SPAWN.to_string(),
+                    errors::failed_to_analyze::ecmascript::CHILD_PROCESS_SPAWN.to_string(),
                 ),
             )
         }
@@ -2125,7 +2125,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         span,
                         &format!("child_process.fork({args}) is very dynamic{hints}",),
                         DiagnosticId::Lint(
-                            errors::failed_to_analyse::ecmascript::CHILD_PROCESS_SPAWN.to_string(),
+                            errors::failed_to_analyze::ecmascript::CHILD_PROCESS_SPAWN.to_string(),
                         ),
                     );
                     if ignore_dynamic_requests {
@@ -2147,9 +2147,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             let (args, hints) = explain_args(&args);
             handler.span_warn_with_code(
                 span,
-                &format!("child_process.fork({args}) is not statically analyse-able{hints}",),
+                &format!("child_process.fork({args}) is not statically analyze-able{hints}",),
                 DiagnosticId::Error(
-                    errors::failed_to_analyse::ecmascript::CHILD_PROCESS_SPAWN.to_string(),
+                    errors::failed_to_analyze::ecmascript::CHILD_PROCESS_SPAWN.to_string(),
                 ),
             )
         }
@@ -2168,7 +2168,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         span,
                         &format!("node-pre-gyp.find({args}) is very dynamic{hints}",),
                         DiagnosticId::Lint(
-                            errors::failed_to_analyse::ecmascript::NODE_PRE_GYP_FIND.to_string(),
+                            errors::failed_to_analyze::ecmascript::NODE_PRE_GYP_FIND.to_string(),
                         ),
                     );
                     // Always ignore this dynamic request
@@ -2190,10 +2190,10 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 span,
                 &format!(
                     "require('@mapbox/node-pre-gyp').find({args}) is not statically \
-                     analyse-able{hints}",
+                     analyze-able{hints}",
                 ),
                 DiagnosticId::Error(
-                    errors::failed_to_analyse::ecmascript::NODE_PRE_GYP_FIND.to_string(),
+                    errors::failed_to_analyze::ecmascript::NODE_PRE_GYP_FIND.to_string(),
                 ),
             )
         }
@@ -2230,10 +2230,10 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             handler.span_warn_with_code(
                 span,
                 &format!(
-                    "require('node-gyp-build')({args}) is not statically analyse-able{hints}",
+                    "require('node-gyp-build')({args}) is not statically analyze-able{hints}",
                 ),
                 DiagnosticId::Error(
-                    errors::failed_to_analyse::ecmascript::NODE_GYP_BUILD.to_string(),
+                    errors::failed_to_analyze::ecmascript::NODE_GYP_BUILD.to_string(),
                 ),
             )
         }
@@ -2259,9 +2259,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             let (args, hints) = explain_args(&args);
             handler.span_warn_with_code(
                 span,
-                &format!("require('bindings')({args}) is not statically analyse-able{hints}",),
+                &format!("require('bindings')({args}) is not statically analyze-able{hints}",),
                 DiagnosticId::Error(
-                    errors::failed_to_analyse::ecmascript::NODE_BINDINGS.to_string(),
+                    errors::failed_to_analyze::ecmascript::NODE_BINDINGS.to_string(),
                 ),
             )
         }
@@ -2280,7 +2280,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         span,
                         &format!("require('express')().set({args}) is very dynamic{hints}",),
                         DiagnosticId::Lint(
-                            errors::failed_to_analyse::ecmascript::NODE_EXPRESS.to_string(),
+                            errors::failed_to_analyze::ecmascript::NODE_EXPRESS.to_string(),
                         ),
                     );
                     // Always ignore this dynamic request
@@ -2340,9 +2340,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             let (args, hints) = explain_args(&args);
             handler.span_warn_with_code(
                 span,
-                &format!("require('express')().set({args}) is not statically analyse-able{hints}",),
+                &format!("require('express')().set({args}) is not statically analyze-able{hints}",),
                 DiagnosticId::Error(
-                    errors::failed_to_analyse::ecmascript::NODE_EXPRESS.to_string(),
+                    errors::failed_to_analyze::ecmascript::NODE_EXPRESS.to_string(),
                 ),
             )
         }
@@ -2383,10 +2383,10 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 span,
                 &format!(
                     "require('strong-globalize').SetRootDir({args}) is not statically \
-                     analyse-able{hints}",
+                     analyze-able{hints}",
                 ),
                 DiagnosticId::Error(
-                    errors::failed_to_analyse::ecmascript::NODE_GYP_BUILD.to_string(),
+                    errors::failed_to_analyze::ecmascript::NODE_GYP_BUILD.to_string(),
                 ),
             )
         }
@@ -2410,9 +2410,9 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             let (args, hints) = explain_args(&args);
             handler.span_warn_with_code(
                 span,
-                &format!("require('resolve-from')({args}) is not statically analyse-able{hints}",),
+                &format!("require('resolve-from')({args}) is not statically analyze-able{hints}",),
                 DiagnosticId::Error(
-                    errors::failed_to_analyse::ecmascript::NODE_RESOLVE_FROM.to_string(),
+                    errors::failed_to_analyze::ecmascript::NODE_RESOLVE_FROM.to_string(),
                 ),
             )
         }
@@ -2453,10 +2453,10 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 span,
                 &format!(
                     "require('@grpc/proto-loader').load({args}) is not statically \
-                     analyse-able{hints}",
+                     analyze-able{hints}",
                 ),
                 DiagnosticId::Error(
-                    errors::failed_to_analyse::ecmascript::NODE_PROTOBUF_LOADER.to_string(),
+                    errors::failed_to_analyze::ecmascript::NODE_PROTOBUF_LOADER.to_string(),
                 ),
             )
         }
@@ -2608,7 +2608,7 @@ async fn handle_free_var_reference(
             span,
             error_message,
             DiagnosticId::Error(
-                errors::failed_to_analyse::ecmascript::FREE_VAR_REFERENCE.to_string(),
+                errors::failed_to_analyze::ecmascript::FREE_VAR_REFERENCE.to_string(),
             ),
         ),
         FreeVarReference::Value(value) => {
@@ -2799,7 +2799,7 @@ async fn analyze_amd_define(
             handler.span_err_with_code(
                 span,
                 "unsupported AMD define() form",
-                DiagnosticId::Error(errors::failed_to_analyse::ecmascript::AMD_DEFINE.to_string()),
+                DiagnosticId::Error(errors::failed_to_analyze::ecmascript::AMD_DEFINE.to_string()),
             );
         }
     }
@@ -2830,7 +2830,7 @@ async fn analyze_amd_define_with_deps(
                         span,
                         "using \"require\" as dependency in an AMD define() is not yet supported",
                         DiagnosticId::Error(
-                            errors::failed_to_analyse::ecmascript::AMD_DEFINE.to_string(),
+                            errors::failed_to_analyze::ecmascript::AMD_DEFINE.to_string(),
                         ),
                     );
                     requests.push(AmdDefineDependencyElement::Require);
@@ -2861,7 +2861,7 @@ async fn analyze_amd_define_with_deps(
                 // `JsValue`s do not keep a hold of their original span.
                 span,
                 "unsupported AMD define() dependency element form",
-                DiagnosticId::Error(errors::failed_to_analyse::ecmascript::AMD_DEFINE.to_string()),
+                DiagnosticId::Error(errors::failed_to_analyze::ecmascript::AMD_DEFINE.to_string()),
             );
         }
     }
@@ -2870,7 +2870,7 @@ async fn analyze_amd_define_with_deps(
         handler.span_warn_with_code(
             span,
             "passing an ID to AMD define() is not yet fully supported",
-            DiagnosticId::Lint(errors::failed_to_analyse::ecmascript::AMD_DEFINE.to_string()),
+            DiagnosticId::Lint(errors::failed_to_analyze::ecmascript::AMD_DEFINE.to_string()),
         );
     }
 
@@ -3240,7 +3240,7 @@ impl StaticAnalyser {
 struct ModuleReferencesVisitor<'a> {
     analyze_mode: AnalyzeMode,
     eval_context: &'a EvalContext,
-    old_analyser: StaticAnalyser,
+    old_analyzer: StaticAnalyser,
     import_references: &'a [ResolvedVc<EsmAssetReference>],
     analysis: &'a mut AnalyzeEcmascriptModuleResultBuilder,
     esm_exports: BTreeMap<RcStr, EsmExport>,
@@ -3261,7 +3261,7 @@ impl<'a> ModuleReferencesVisitor<'a> {
         Self {
             analyze_mode,
             eval_context,
-            old_analyser: StaticAnalyser::default(),
+            old_analyzer: StaticAnalyser::default(),
             import_references,
             analysis,
             esm_exports: BTreeMap::new(),
@@ -3552,7 +3552,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
             match specifier {
                 ImportSpecifier::Named(named) => {
                     if !named.is_type_only {
-                        self.old_analyser.imports.insert(
+                        self.old_analyzer.imports.insert(
                             named.local.sym.to_string(),
                             (
                                 src.clone(),
@@ -3566,13 +3566,13 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
                     }
                 }
                 ImportSpecifier::Default(default_import) => {
-                    self.old_analyser.imports.insert(
+                    self.old_analyzer.imports.insert(
                         default_import.local.sym.to_string(),
                         (src.clone(), vec!["default".to_string()]),
                     );
                 }
                 ImportSpecifier::Namespace(namespace) => {
-                    self.old_analyser
+                    self.old_analyzer
                         .imports
                         .insert(namespace.local.sym.to_string(), (src.clone(), Vec::new()));
                 }
@@ -3610,7 +3610,7 @@ impl VisitAstPath for ModuleReferencesVisitor<'_> {
         ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
     ) {
         if let Callee::Expr(expr) = &call.callee
-            && let StaticExpr::FreeVar(var) = self.old_analyser.evaluate_expr(expr)
+            && let StaticExpr::FreeVar(var) = self.old_analyzer.evaluate_expr(expr)
         {
             match &var[..] {
                 [webpack_require, property]

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -24,7 +24,7 @@ use crate::{
     chunk::{EcmascriptChunkPlaceable, EcmascriptExports},
     parse::ParseResult,
     references::{
-        FollowExportsResult, analyse_ecmascript_module, esm::FoundExportType, follow_reexports,
+        FollowExportsResult, analyze_ecmascript_module, esm::FoundExportType, follow_reexports,
     },
     side_effect_optimization::facade::module::EcmascriptModuleFacadeModule,
     tree_shake::{Key, side_effect_module::SideEffectsModule},
@@ -61,7 +61,7 @@ impl EcmascriptParsable for EcmascriptModulePartAsset {
 impl EcmascriptAnalyzable for EcmascriptModulePartAsset {
     #[turbo_tasks::function]
     fn analyze(&self) -> Vc<AnalyzeEcmascriptModuleResult> {
-        analyse_ecmascript_module(*self.full_module, Some(self.part.clone()))
+        analyze_ecmascript_module(*self.full_module, Some(self.part.clone()))
     }
 
     #[turbo_tasks::function]
@@ -410,7 +410,7 @@ fn analyze(
     module: Vc<EcmascriptModuleAsset>,
     part: ModulePart,
 ) -> Vc<AnalyzeEcmascriptModuleResult> {
-    analyse_ecmascript_module(module, Some(part))
+    analyze_ecmascript_module(module, Some(part))
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/resolved-effects.snapshot
@@ -17,7 +17,7 @@
 8 -> 11 member call = require*0*["resolve"](???*1*)
 - *0* require: The require method from CommonJS
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 8 -> 12 unreachable = ???*0*
 - *0* unreachable
@@ -28,7 +28,7 @@
 0 -> 15 member call = require*0*["resolve"](???*1*)
 - *0* require: The require method from CommonJS
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 16 unreachable = ???*0*
 - *0* unreachable

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array-map/resolved-explained.snapshot
@@ -14,18 +14,18 @@ d = ["\"../lib/a.js\"/resolved/lib/index.js", "\"../lib/b.js\"/resolved/lib/inde
 
 file#3 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 file#4 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 file#5 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 file#6 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 func = (...) => FreeVar(require)["resolve"](file)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/resolved-explained.snapshot
@@ -10,4 +10,4 @@ SubClass = ???*0*
 
 fn = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/resolved-explained.snapshot
@@ -8,10 +8,10 @@ value = (???*0* | module<./module.js, {}>["named"])
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 value2 = (???*0* | module<./module.js, {}>["named"])
 - *0* ???*1*["value2"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/early-return/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/early-return/resolved-explained.snapshot
@@ -20,8 +20,8 @@ j#2 = (...) => (FreeVar(i1)() | FreeVar(i2)())
 
 j#25 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 j#26 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/resolved-explained.snapshot
@@ -1,10 +1,10 @@
 a = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c = (...) => [`${a}${x}`, a]
 
@@ -20,4 +20,4 @@ f = ("1" | ???*0*)
 
 x = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/resolved-explained.snapshot
@@ -1,10 +1,10 @@
 a = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c = (...) => [`${a}${b}`, a]
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife-2/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife-2/resolved-effects.snapshot
@@ -3,38 +3,38 @@
 0 -> 3 member call = Object*0*["keys"](???*1*)
 - *0* Object: The global Object variable
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7 free var = FreeVar(console)
 
 0 -> 8 conditional = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 9 member call = ???*0*["debug"]("####", ???*1*, (???*2* ? true : false))
 - *0* FreeVar(console)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 12 conditional = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 14 call = (...) => parent(???*0*, (???*2* ? ???*3* : (???*10* | undefined)), (???*15* | {}){truthy})
 - *0* ???*1*[key]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* `${???*4*}.${(???*5* | undefined)}`
   ⚠️  nested operation
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*[i]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -46,7 +46,7 @@
   ⚠️  This value might have side effects
 - *8* Object: The global Object variable
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*[i]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -58,11 +58,11 @@
   ⚠️  This value might have side effects
 - *13* Object: The global Object variable
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*[key]
   ⚠️  unknown object
 - *16* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 15 unreachable = ???*0*
 - *0* unreachable

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife-2/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife-2/resolved-explained.snapshot
@@ -16,7 +16,7 @@ key = (???*0* | undefined)
   ⚠️  This value might have side effects
 - *3* Object: The global Object variable
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 keys = ???*0*
 - *0* ???*1*(???*3*)
@@ -27,18 +27,18 @@ keys = ???*0*
   ⚠️  This value might have side effects
 - *2* Object: The global Object variable
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 namespace = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 parent = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 path = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 root = {}

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-75938/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-75938/resolved-effects.snapshot
@@ -33,7 +33,7 @@
 
 0 -> 14 call = ???*0*()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 15 unreachable = ???*0*
 - *0* unreachable

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-75938/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-75938/resolved-explained.snapshot
@@ -15,7 +15,7 @@ Home = (...) => module<https://esm.sh/preact/jsx-runtime, {}>["jsx"](
 
 cb = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 helloWorld = module<react, {}>["useMemo"]((...) => ???*0*, [])
 - *0* new HelloWorld()

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/resolved-effects.snapshot
@@ -16,7 +16,7 @@
 - *5* ???*6*[i]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -34,7 +34,7 @@
 - *5* ???*6*[(i + 1)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -52,7 +52,7 @@
 - *5* ???*6*[(i + 2)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 14 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, ???*7*)
 - *0* unsupported expression
@@ -68,7 +68,7 @@
 - *5* ???*6*[(i + 3)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -86,7 +86,7 @@
 - *5* ???*6*[(i + 4)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -104,7 +104,7 @@
 - *5* ???*6*[(i + 5)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 20 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, ???*7*)
 - *0* unsupported expression
@@ -120,7 +120,7 @@
 - *5* ???*6*[(i + 6)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -138,7 +138,7 @@
 - *5* ???*6*[(i + 7)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -156,7 +156,7 @@
 - *5* ???*6*[(i + 8)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 26 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, ???*7*)
 - *0* unsupported expression
@@ -172,7 +172,7 @@
 - *5* ???*6*[(i + 9)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -190,7 +190,7 @@
 - *5* ???*6*[(i + 10)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -208,7 +208,7 @@
 - *5* ???*6*[(i + 11)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -226,7 +226,7 @@
 - *5* ???*6*[(i + 12)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 34 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, ???*7*)
 - *0* unsupported expression
@@ -242,7 +242,7 @@
 - *5* ???*6*[(i + 13)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -260,7 +260,7 @@
 - *5* ???*6*[(i + 14)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -278,7 +278,7 @@
 - *5* ???*6*[(i + 15)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 39 unreachable = ???*0*
 - *0* unreachable
@@ -297,9 +297,9 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 45 free var = FreeVar(safeAdd)
 
@@ -308,9 +308,9 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 47 call = ???*0*(???*1*, ???*3*)
 - *0* FreeVar(safeAdd)
@@ -340,7 +340,7 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *3* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 49 call = ???*0*(???*1*, ???*3*)
 - *0* FreeVar(safeAdd)
@@ -356,7 +356,7 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 50 unreachable = ???*0*
 - *0* unreachable
@@ -372,15 +372,15 @@
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 52 unreachable = ???*0*
 - *0* unreachable

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/resolved-explained.snapshot
@@ -4,11 +4,11 @@ a#3 = ???*0*
 
 a#5 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#6 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#3 = ???*0*
 - *0* max number of linking steps reached
@@ -16,11 +16,11 @@ b#3 = ???*0*
 
 b#5 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#6 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#3 = ???*0*
 - *0* max number of linking steps reached
@@ -28,7 +28,7 @@ c#3 = ???*0*
 
 c#6 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#3 = ???*0*
 - *0* max number of linking steps reached
@@ -36,7 +36,7 @@ d#3 = ???*0*
 
 d#6 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 i = (???*0* | 0 | (???*1* + 16))
 - *0* i
@@ -46,7 +46,7 @@ i = (???*0* | 0 | (???*1* + 16))
 
 len = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 md5cmn = (...) => FreeVar(safeAdd)(
     FreeVar(bitRotateLeft)(
@@ -78,34 +78,34 @@ oldd = ???*0*
 
 q = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s#5 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s#6 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 t#5 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 t#6 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 wordsToMd5 = (...) => [a, b, c, d]
 
 x#3 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 x#5 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 x#6 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5/resolved-effects.snapshot
@@ -2,7 +2,7 @@
 
 0 -> 3 typeof = typeof((???*0* | new ???*1*((???*2* | undefined["length"]))))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* FreeVar(Array)
   ⚠️  unknown global
   ⚠️  This value might have side effects
@@ -20,7 +20,7 @@
 - *0* typeof((???*1* | ???*2*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* new ???*3*((???*4* | undefined["length"]))
   ⚠️  nested operation
 - *3* FreeVar(Array)
@@ -47,7 +47,7 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* FreeVar(Array)
   ⚠️  unknown global
   ⚠️  This value might have side effects
@@ -102,7 +102,7 @@
     (???*0* | new ???*1*((???*2* | undefined["length"])))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* FreeVar(Array)
   ⚠️  unknown global
   ⚠️  This value might have side effects
@@ -186,7 +186,7 @@
 - *5* ???*6*[i]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -204,7 +204,7 @@
 - *5* ???*6*[(i + 1)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -222,7 +222,7 @@
 - *5* ???*6*[(i + 2)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 42 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 22, ???*7*)
 - *0* unsupported expression
@@ -238,7 +238,7 @@
 - *5* ???*6*[(i + 3)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -256,7 +256,7 @@
 - *5* ???*6*[(i + 4)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -274,7 +274,7 @@
 - *5* ???*6*[(i + 5)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 48 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 17, ???*7*)
 - *0* unsupported expression
@@ -290,7 +290,7 @@
 - *5* ???*6*[(i + 6)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -308,7 +308,7 @@
 - *5* ???*6*[(i + 7)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -326,7 +326,7 @@
 - *5* ???*6*[(i + 8)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 54 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, ???*7*)
 - *0* unsupported expression
@@ -342,7 +342,7 @@
 - *5* ???*6*[(i + 9)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -360,7 +360,7 @@
 - *5* ???*6*[(i + 10)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -378,7 +378,7 @@
 - *5* ???*6*[(i + 11)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -396,7 +396,7 @@
 - *5* ???*6*[(i + 12)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 62 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 12, ???*7*)
 - *0* unsupported expression
@@ -412,7 +412,7 @@
 - *5* ???*6*[(i + 13)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -430,7 +430,7 @@
 - *5* ???*6*[(i + 14)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -448,7 +448,7 @@
 - *5* ???*6*[(i + 15)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 68 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 5, ???*7*)
 - *0* unsupported expression
@@ -464,7 +464,7 @@
 - *5* ???*6*[(i + 1)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -482,7 +482,7 @@
 - *5* ???*6*[(i + 6)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -500,7 +500,7 @@
 - *5* ???*6*[(i + 11)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 74 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 20, ???*7*)
 - *0* unsupported expression
@@ -516,7 +516,7 @@
 - *5* ???*6*[i]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -534,7 +534,7 @@
 - *5* ???*6*[(i + 5)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -552,7 +552,7 @@
 - *5* ???*6*[(i + 10)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 80 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 14, ???*7*)
 - *0* unsupported expression
@@ -568,7 +568,7 @@
 - *5* ???*6*[(i + 15)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -586,7 +586,7 @@
 - *5* ???*6*[(i + 4)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -604,7 +604,7 @@
 - *5* ???*6*[(i + 9)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 86 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 9, ???*7*)
 - *0* unsupported expression
@@ -620,7 +620,7 @@
 - *5* ???*6*[(i + 14)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -638,7 +638,7 @@
 - *5* ???*6*[(i + 3)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -656,7 +656,7 @@
 - *5* ???*6*[(i + 8)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 92 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 5, ???*7*)
 - *0* unsupported expression
@@ -672,7 +672,7 @@
 - *5* ???*6*[(i + 13)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -690,7 +690,7 @@
 - *5* ???*6*[(i + 2)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -708,7 +708,7 @@
 - *5* ???*6*[(i + 7)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 98 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 20, ???*7*)
 - *0* unsupported expression
@@ -724,7 +724,7 @@
 - *5* ???*6*[(i + 12)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -742,7 +742,7 @@
 - *5* ???*6*[(i + 5)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -760,7 +760,7 @@
 - *5* ???*6*[(i + 8)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -778,7 +778,7 @@
 - *5* ???*6*[(i + 11)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 106 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 23, ???*7*)
 - *0* unsupported expression
@@ -794,7 +794,7 @@
 - *5* ???*6*[(i + 14)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -812,7 +812,7 @@
 - *5* ???*6*[(i + 1)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -830,7 +830,7 @@
 - *5* ???*6*[(i + 4)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 112 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 16, ???*7*)
 - *0* unsupported expression
@@ -846,7 +846,7 @@
 - *5* ???*6*[(i + 7)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -864,7 +864,7 @@
 - *5* ???*6*[(i + 10)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -882,7 +882,7 @@
 - *5* ???*6*[(i + 13)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 118 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 11, ???*7*)
 - *0* unsupported expression
@@ -898,7 +898,7 @@
 - *5* ???*6*[i]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -916,7 +916,7 @@
 - *5* ???*6*[(i + 3)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -934,7 +934,7 @@
 - *5* ???*6*[(i + 6)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 124 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 4, ???*7*)
 - *0* unsupported expression
@@ -950,7 +950,7 @@
 - *5* ???*6*[(i + 9)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -968,7 +968,7 @@
 - *5* ???*6*[(i + 12)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -986,7 +986,7 @@
 - *5* ???*6*[(i + 15)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 130 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 23, ???*7*)
 - *0* unsupported expression
@@ -1002,7 +1002,7 @@
 - *5* ???*6*[(i + 2)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -1020,7 +1020,7 @@
 - *5* ???*6*[i]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -1038,7 +1038,7 @@
 - *5* ???*6*[(i + 7)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 136 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 15, ???*7*)
 - *0* unsupported expression
@@ -1054,7 +1054,7 @@
 - *5* ???*6*[(i + 14)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -1072,7 +1072,7 @@
 - *5* ???*6*[(i + 5)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -1090,7 +1090,7 @@
 - *5* ???*6*[(i + 12)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 142 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 10, ???*7*)
 - *0* unsupported expression
@@ -1106,7 +1106,7 @@
 - *5* ???*6*[(i + 3)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -1124,7 +1124,7 @@
 - *5* ???*6*[(i + 10)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -1142,7 +1142,7 @@
 - *5* ???*6*[(i + 1)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -1160,7 +1160,7 @@
 - *5* ???*6*[(i + 8)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 150 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 10, ???*7*)
 - *0* unsupported expression
@@ -1176,7 +1176,7 @@
 - *5* ???*6*[(i + 15)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -1194,7 +1194,7 @@
 - *5* ???*6*[(i + 6)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -1212,7 +1212,7 @@
 - *5* ???*6*[(i + 13)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 156 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 6, ???*7*)
 - *0* unsupported expression
@@ -1228,7 +1228,7 @@
 - *5* ???*6*[(i + 4)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -1246,7 +1246,7 @@
 - *5* ???*6*[(i + 11)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -1264,7 +1264,7 @@
 - *5* ???*6*[(i + 2)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 162 call = (...) => md5cmn(???*0*, a, b, x, s, t)(???*1*, ???*2*, ???*3*, ???*4*, ???*5*, 21, ???*7*)
 - *0* unsupported expression
@@ -1280,7 +1280,7 @@
 - *5* ???*6*[(i + 9)]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -1336,17 +1336,17 @@
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 179 call = (...) => ???*0*(???*1*, ???*2*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 180 call = (...) => ???*0*(???*1*, ???*2*)
 - *0* unsupported expression
@@ -1362,7 +1362,7 @@
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 182 call = (...) => ???*0*(???*1*, ???*2*)
 - *0* unsupported expression
@@ -1370,7 +1370,7 @@
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 183 unreachable = ???*0*
 - *0* unreachable
@@ -1383,15 +1383,15 @@
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 185 unreachable = ???*0*
 - *0* unreachable
@@ -1404,15 +1404,15 @@
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 187 unreachable = ???*0*
 - *0* unreachable
@@ -1425,15 +1425,15 @@
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 189 unreachable = ???*0*
 - *0* unreachable
@@ -1446,15 +1446,15 @@
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 191 unreachable = ???*0*
 - *0* unreachable

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5/resolved-explained.snapshot
@@ -1,22 +1,22 @@
 a#14 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#15 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#16 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#17 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#18 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#7 = ???*0*
 - *0* max number of linking steps reached
@@ -24,23 +24,23 @@ a#7 = ???*0*
 
 b#14 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#15 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#16 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#17 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#18 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#7 = ???*0*
 - *0* max number of linking steps reached
@@ -52,7 +52,7 @@ bitRotateLeft = (...) => ???*0*
 
 bytes = (???*0* | new ???*1*((???*2* | undefined["length"])))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* FreeVar(Array)
   ⚠️  unknown global
   ⚠️  This value might have side effects
@@ -70,19 +70,19 @@ bytesToWords = (...) => output
 
 c#15 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#16 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#17 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#18 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#7 = ???*0*
 - *0* max number of linking steps reached
@@ -90,23 +90,23 @@ c#7 = ???*0*
 
 cnt = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#15 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#16 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#17 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#18 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#7 = ???*0*
 - *0* max number of linking steps reached
@@ -157,15 +157,15 @@ i#9 = (???*0* | 0 | (???*1* + 1) | (???*2* + 8))
 
 input#5 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 input#9 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 len = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 length32 = ???*0*
 - *0* unsupported expression
@@ -226,7 +226,7 @@ msw = (???*0* + ???*1* + ???*2*)
 
 num = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 olda = ???*0*
 - *0* max number of linking steps reached
@@ -250,27 +250,27 @@ output#9 = []
 
 q = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s#14 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s#15 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s#16 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s#17 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s#18 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 safeAdd = (...) => ???*0*
 - *0* unsupported expression
@@ -278,49 +278,49 @@ safeAdd = (...) => ???*0*
 
 t#14 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 t#15 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 t#16 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 t#17 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 t#18 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 wordsToMd5 = (...) => [a, b, c, d]
 
 x#12 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 x#14 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 x#15 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 x#16 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 x#17 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 x#18 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 x#5 = (???*0* | ???*1*)
 - *0* x
@@ -330,8 +330,8 @@ x#5 = (???*0* | ???*1*)
 
 x#7 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 y = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/resolved-effects.snapshot
@@ -24,7 +24,7 @@
 - *0* ???*1*["constructor"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["constructor"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -46,11 +46,11 @@
 
 13 -> 15 conditional = (???*0* | (???*1* === "binary"))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["encoding"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 15 -> 17 member call = module<charenc, {}>["bin"]["stringToBytes"](
     (
@@ -62,7 +62,7 @@
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* message
   ⚠️  circular variable reference
 - *2* message
@@ -94,7 +94,7 @@
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* message
   ⚠️  circular variable reference
 - *2* message
@@ -126,7 +126,7 @@
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* message
   ⚠️  circular variable reference
 - *2* message
@@ -150,7 +150,7 @@
 
 13 -> 21 conditional = module<is-buffer, {}>((???*0* | ???*1* | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* module<charenc, {}>["bin"]["stringToBytes"](???*2*)
   ⚠️  nested operation
 - *2* message
@@ -190,7 +190,7 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* message
   ⚠️  circular variable reference
 - *5* message
@@ -227,7 +227,7 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* message
   ⚠️  circular variable reference
 - *3* message
@@ -265,7 +265,7 @@
   | ???*7*()
 )["toString"]()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* message
   ⚠️  circular variable reference
 - *2* message
@@ -297,7 +297,7 @@
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* message
   ⚠️  circular variable reference
 - *2* message
@@ -337,7 +337,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -381,7 +381,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -425,7 +425,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -467,7 +467,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -511,7 +511,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -555,7 +555,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -597,7 +597,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -641,7 +641,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -685,7 +685,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -727,7 +727,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -771,7 +771,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -815,7 +815,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -859,7 +859,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -901,7 +901,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -945,7 +945,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -989,7 +989,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1031,7 +1031,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1075,7 +1075,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1119,7 +1119,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1161,7 +1161,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1205,7 +1205,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1249,7 +1249,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1291,7 +1291,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1335,7 +1335,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1379,7 +1379,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1421,7 +1421,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1465,7 +1465,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1509,7 +1509,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1551,7 +1551,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1595,7 +1595,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1639,7 +1639,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1681,7 +1681,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1725,7 +1725,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1769,7 +1769,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1813,7 +1813,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1855,7 +1855,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1899,7 +1899,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1943,7 +1943,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -1985,7 +1985,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2029,7 +2029,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2073,7 +2073,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2115,7 +2115,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2159,7 +2159,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2203,7 +2203,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2245,7 +2245,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2289,7 +2289,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2333,7 +2333,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2375,7 +2375,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2419,7 +2419,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2463,7 +2463,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2505,7 +2505,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2549,7 +2549,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2593,7 +2593,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2635,7 +2635,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2679,7 +2679,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2723,7 +2723,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2767,7 +2767,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2809,7 +2809,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2853,7 +2853,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2897,7 +2897,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2939,7 +2939,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -2983,7 +2983,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -3027,7 +3027,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -3069,7 +3069,7 @@
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* module<charenc, {}>["bin"]["stringToBytes"](???*6*)
   ⚠️  nested operation
 - *6* message
@@ -3129,9 +3129,9 @@
 
 0 -> 192 conditional = ((???*0* === undefined) | (???*1* === null))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 192 -> 193 free var = FreeVar(Error)
 
@@ -3140,13 +3140,13 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 196 call = (...) => crypt["endian"]([a, b, c, d])(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 197 member call = module<crypt, {}>["wordsToBytes"](???*0*)
 - *0* max number of linking steps reached
@@ -3154,19 +3154,19 @@
 
 0 -> 199 conditional = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["asBytes"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 199 -> 201 conditional = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["asString"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 201 -> 203 member call = module<charenc, {}>["bin"]["bytesToString"](???*0*)
 - *0* max number of linking steps reached

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/resolved-explained.snapshot
@@ -28,7 +28,7 @@ II = (...) => crypt["endian"]([a, b, c, d])["_ii"]
 
 a#10 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#4 = ???*0*
 - *0* max number of linking steps reached
@@ -36,15 +36,15 @@ a#4 = ???*0*
 
 a#7 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#8 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#9 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 aa = ???*0*
 - *0* max number of linking steps reached
@@ -52,7 +52,7 @@ aa = ???*0*
 
 b#10 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#4 = ???*0*
 - *0* max number of linking steps reached
@@ -60,15 +60,15 @@ b#4 = ???*0*
 
 b#7 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#8 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#9 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 bb = ???*0*
 - *0* max number of linking steps reached
@@ -78,7 +78,7 @@ bin = module<charenc, {}>["bin"]
 
 c#10 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#4 = ???*0*
 - *0* max number of linking steps reached
@@ -86,15 +86,15 @@ c#4 = ???*0*
 
 c#7 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#8 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#9 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 cc = ???*0*
 - *0* max number of linking steps reached
@@ -104,7 +104,7 @@ crypt = module<crypt, {}>
 
 d#10 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#4 = ???*0*
 - *0* max number of linking steps reached
@@ -112,15 +112,15 @@ d#4 = ???*0*
 
 d#7 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#8 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#9 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 dd = ???*0*
 - *0* max number of linking steps reached
@@ -144,7 +144,7 @@ l = ???*0*
 
 m = module<crypt, {}>["bytesToWords"]((???*0* | ???*1* | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* module<charenc, {}>["bin"]["stringToBytes"](???*2*)
   ⚠️  nested operation
 - *2* message
@@ -166,7 +166,7 @@ md5 = (...) => crypt["endian"]([a, b, c, d])
 
 message#11 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 message#4 = (
   | ???*0*
@@ -176,7 +176,7 @@ message#4 = (
   | ???*7*()
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* message
   ⚠️  circular variable reference
 - *2* message
@@ -200,98 +200,98 @@ message#4 = (
 
 n#10 = (???*0* + ???*1* + ???*2* + ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 n#7 = (???*0* + ???*1* + ???*2* + ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 n#8 = (???*0* + ???*1* + ???*2* + ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 n#9 = (???*0* + ???*1* + ???*2* + ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 options#11 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 options#4 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s#10 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s#7 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s#8 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s#9 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 t#10 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 t#7 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 t#8 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 t#9 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 utf8 = module<charenc, {}>["utf8"]
 
 x#10 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 x#7 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 x#8 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 x#9 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/resolved-effects.snapshot
@@ -22,7 +22,7 @@
 
 6 -> 8 call = (...) => (a | (r((a + 1)) + 1))((???*0* + 1))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6 -> 9 unreachable = ???*0*
 - *0* unreachable

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/resolved-explained.snapshot
@@ -1,22 +1,22 @@
 a#3 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#6 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#9 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#10 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#5 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 inner = (...) => (a + b)
 
@@ -26,7 +26,7 @@ r = (...) => (a | (r((a + 1)) + 1))
 
 v1 = (???*0* + 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 v2 = (2 | (???*0* + 1))
 - *0* (...) => (a | (r((a + 1)) + 1))(3)

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/resolved-effects.snapshot
@@ -9,7 +9,7 @@
 - *0* ???*1*["__next_app__"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* spread
   ⚠️  This value might have side effects
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/resolved-explained.snapshot
@@ -4,7 +4,7 @@
 
 ComponentMod = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 args = ???*0*
 - *0* args

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/resolved-effects.snapshot
@@ -11,7 +11,7 @@
 - *0* ???*1*["variable"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7 member call = ???*0*["stringify"](
     {
@@ -25,13 +25,13 @@
 - *1* ???*2*["variable"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ((???*4* | "true") === "true")
   ⚠️  nested operation
 - *4* ???*5*["variable"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 8 unreachable = ???*0*
 - *0* unreachable

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2682/resolved-explained.snapshot
@@ -29,4 +29,4 @@ variable = (???*0* | "true")
 - *0* ???*1*["variable"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-effects.snapshot
@@ -49,11 +49,11 @@
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 24 call = (...) => (found ? `"${literalEscape(found)}"` : "end of input")(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 25 unreachable = ???*0*
 - *0* unreachable
@@ -63,7 +63,7 @@
 - *0* ???*1*["text"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 28 unreachable = ???*0*
 - *0* unreachable
@@ -79,7 +79,7 @@
 - *2* ???*3*["parts"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 41 call = (...) => ...[...](..., ...)["replace"](/\^/g, "\\^")["replace"](/-/g, "\\-")["replace"](/\0/g, "\\0")["replace"](/\t/g, "\\t")["replace"](/\n/g, "\\n")["replace"](/\r/g, "\\r")["replace"](/[\x00-\x0F]/g, *anonymous function 2287*)["replace"](/[\x10-\x1F\x7F-\x9F]/g, *anonymous function 2385*)(???*0*)
 - *0* ???*1*[1]
@@ -89,7 +89,7 @@
 - *2* ???*3*["parts"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 44 call = (...) => ...[...](..., ...)["replace"](/\^/g, "\\^")["replace"](/-/g, "\\-")["replace"](/\0/g, "\\0")["replace"](/\t/g, "\\t")["replace"](/\n/g, "\\n")["replace"](/\r/g, "\\r")["replace"](/[\x00-\x0F]/g, *anonymous function 2287*)["replace"](/[\x10-\x1F\x7F-\x9F]/g, *anonymous function 2385*)(???*0*)
 - *0* ???*1*[i]
@@ -97,13 +97,13 @@
 - *1* ???*2*["parts"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 46 conditional = ???*0*
 - *0* ???*1*["inverted"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 47 unreachable = ???*0*
 - *0* unreachable
@@ -123,13 +123,13 @@
 
 0 -> 55 member call = ???*0*["charCodeAt"](0)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 56 member call = ???*0*["toString"](16)
 - *0* ???*1*["charCodeAt"](0)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 57 member call = ???*0*["toUpperCase"]()
 - *0* ???*1*["toString"](16)
@@ -137,7 +137,7 @@
 - *1* ???*2*["charCodeAt"](0)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 58 unreachable = ???*0*
 - *0* unreachable
@@ -145,13 +145,13 @@
 
 0 -> 67 member call = ???*0*["replace"](/\\/g, "\\\\")
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 68 member call = ???*0*["replace"](/"/g, "\\\"")
 - *0* ???*1*["replace"](/\\/g, "\\\\")
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 69 member call = ???*0*["replace"](/\0/g, "\\0")
 - *0* ???*1*["replace"](/"/g, "\\\"")
@@ -159,7 +159,7 @@
 - *1* ???*2*["replace"](/\\/g, "\\\\")
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 70 member call = ???*0*["replace"](/\t/g, "\\t")
 - *0* ???*1*["replace"](/\0/g, "\\0")
@@ -169,7 +169,7 @@
 - *2* ???*3*["replace"](/\\/g, "\\\\")
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 71 member call = ???*0*["replace"](/\n/g, "\\n")
 - *0* ???*1*["replace"](/\t/g, "\\t")
@@ -181,7 +181,7 @@
 - *3* ???*4*["replace"](/\\/g, "\\\\")
   ⚠️  unknown callee object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 72 member call = ???*0*["replace"](/\r/g, "\\r")
 - *0* ???*1*["replace"](/\n/g, "\\n")
@@ -209,7 +209,7 @@
 
 73 -> 74 call = (...) => ch["charCodeAt"](0)["toString"](16)["toUpperCase"]()(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 73 -> 75 unreachable = ???*0*
 - *0* unreachable
@@ -229,7 +229,7 @@
 
 76 -> 77 call = (...) => ch["charCodeAt"](0)["toString"](16)["toUpperCase"]()(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 76 -> 78 unreachable = ???*0*
 - *0* unreachable
@@ -241,13 +241,13 @@
 
 0 -> 90 member call = ???*0*["replace"](/\\/g, "\\\\")
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 91 member call = ???*0*["replace"](/\]/g, "\\]")
 - *0* ???*1*["replace"](/\\/g, "\\\\")
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 92 member call = ???*0*["replace"](/\^/g, "\\^")
 - *0* ???*1*["replace"](/\]/g, "\\]")
@@ -255,7 +255,7 @@
 - *1* ???*2*["replace"](/\\/g, "\\\\")
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 93 member call = ???*0*["replace"](/-/g, "\\-")
 - *0* ???*1*["replace"](/\^/g, "\\^")
@@ -265,7 +265,7 @@
 - *2* ???*3*["replace"](/\\/g, "\\\\")
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 94 member call = ???*0*["replace"](/\0/g, "\\0")
 - *0* ???*1*["replace"](/-/g, "\\-")
@@ -277,7 +277,7 @@
 - *3* ???*4*["replace"](/\\/g, "\\\\")
   ⚠️  unknown callee object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 95 member call = ???*0*["replace"](/\t/g, "\\t")
 - *0* ???*1*["replace"](/\0/g, "\\0")
@@ -329,7 +329,7 @@
 
 98 -> 99 call = (...) => ch["charCodeAt"](0)["toString"](16)["toUpperCase"]()(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 98 -> 100 unreachable = ???*0*
 - *0* unreachable
@@ -349,7 +349,7 @@
 
 101 -> 102 call = (...) => ch["charCodeAt"](0)["toString"](16)["toUpperCase"]()(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 101 -> 103 unreachable = ???*0*
 - *0* unreachable
@@ -369,9 +369,9 @@
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 108 unreachable = ???*0*
 - *0* unreachable
@@ -386,13 +386,13 @@
 - *1* ???*2*["length"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 115 call = (...) => DESCRIBE_EXPECTATION_FNS[expectation["type"]](expectation)(???*0*)
 - *0* ???*1*[i]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 117 member call = new ???*0*(???*1*)["sort"]()
 - *0* FreeVar(Array)
@@ -401,7 +401,7 @@
 - *1* ???*2*["length"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 122 conditional = (???*0* !== ???*6*)
 - *0* ???*1*[???*5*]
@@ -415,7 +415,7 @@
 - *3* ???*4*["length"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* unsupported expression
   ⚠️  This value might have side effects
 - *6* ???*7*[(???*11* | 0 | ???*12* | 1)]
@@ -429,7 +429,7 @@
 - *9* ???*10*["length"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* i
   ⚠️  pattern without value
 - *12* updated with update expression
@@ -450,7 +450,7 @@
 - *1* ???*2*["length"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported expression
   ⚠️  This value might have side effects
 
@@ -468,7 +468,7 @@
 - *4* ???*5*["length"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* unsupported expression
   ⚠️  This value might have side effects
 
@@ -478,11 +478,11 @@
 
 0 -> 139 conditional = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 139 -> 140 call = (...) => s["replace"](/\\/g, "\\\\")["replace"](/"/g, "\\\"")["replace"](/\0/g, "\\0")["replace"](/\t/g, "\\t")["replace"](/\n/g, "\\n")["replace"](/\r/g, "\\r")["replace"](/[\x00-\x0F]/g, *anonymous function 1822*)["replace"](/[\x10-\x1F\x7F-\x9F]/g, *anonymous function 1920*)(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 141 unreachable = ???*0*
 - *0* unreachable
@@ -495,7 +495,7 @@
 - *1* ???*2*["startRule"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 144 conditional = ((???*0* !== {}) | (???*1* === ???*2*))
 - *0* max number of linking steps reached
@@ -505,7 +505,7 @@
 - *2* ???*3*["length"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 144 -> 146 conditional = ((???*0* !== {}) | ???*1*)
 - *0* max number of linking steps reached
@@ -519,7 +519,7 @@
 
 144 -> 151 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -547,7 +547,7 @@
 - *1* ???*2*["charAt"](peg$maxFailPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -557,7 +557,7 @@
 
 0 -> 157 conditional = ((???*0* | ???*1*) !== undefined)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? ???*4* : {})
   ⚠️  nested operation
 - *2* (???*3* !== undefined)
@@ -667,7 +667,7 @@
 
 0 -> 186 conditional = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 187 unreachable = ???*0*
 - *0* unreachable
@@ -707,7 +707,7 @@
 
 0 -> 199 conditional = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 199 -> 200 free var = FreeVar(parseInt)
 
@@ -720,7 +720,7 @@
 - *1* ???*2*["substring"](peg$savedPos, peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 199 -> 203 free var = FreeVar(parseFloat)
 
@@ -733,7 +733,7 @@
 - *1* ???*2*["substring"](peg$savedPos, peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 206 unreachable = ???*0*
 - *0* unreachable
@@ -743,7 +743,7 @@
 
 0 -> 209 member call = ???*0*["join"]("")
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 210 unreachable = ???*0*
 - *0* unreachable
@@ -839,7 +839,7 @@
 
 0 -> 248 member call = ???*0*["join"]("")
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 249 unreachable = ???*0*
 - *0* unreachable
@@ -918,7 +918,7 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 277 member call = ???*0*["fromCharCode"](???*1*)
 - *0* FreeVar(String)
@@ -974,9 +974,9 @@
     ???*1*
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 290 unreachable = ???*0*
 - *0* unreachable
@@ -998,9 +998,9 @@
 
 0 -> 296 call = (...) => tail["reduce"](*arrow function 169161*, head)(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 297 unreachable = ???*0*
 - *0* unreachable
@@ -1064,9 +1064,9 @@
     ???*1*
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 320 unreachable = ???*0*
 - *0* unreachable
@@ -1091,7 +1091,7 @@
 - *1* ???*2*["substring"](peg$savedPos, peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 326 unreachable = ???*0*
 - *0* unreachable
@@ -1099,7 +1099,7 @@
 
 0 -> 327 conditional = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 328 unreachable = ???*0*
 - *0* unreachable
@@ -1122,11 +1122,11 @@
 - *1* ???*2*["startRule"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 338 member call = ???*0*["substring"](???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
@@ -1164,11 +1164,11 @@
 
 0 -> 344 call = (...) => {"type": "other", "description": description}(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 346 member call = ???*0*["substring"](???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
@@ -1176,11 +1176,11 @@
 
 0 -> 347 call = (...) => new peg$SyntaxError(peg$SyntaxError["buildMessage"](expected, found), expected, found, location)([{"type": "other", "description": ???*0*}], ???*1*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["substring"](peg$savedPos, peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1199,7 +1199,7 @@
 
 0 -> 350 call = (...) => new peg$SyntaxError(message, null, null, location)(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1227,7 +1227,7 @@
 - *0* [][???*1*]
   ⚠️  unknown array prototype methods or values
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["line"]
   ⚠️  unknown object
 - *3* details
@@ -1243,7 +1243,7 @@
 
 357 -> 364 member call = ???*0*["charCodeAt"]((???*1* | ???*2* | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* p
   ⚠️  pattern without value
 - *2* unsupported expression
@@ -1255,7 +1255,7 @@
 - *0* ???*1*["charCodeAt"](p)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 357 -> 370 unreachable = ???*0*
 - *0* unreachable
@@ -1267,11 +1267,11 @@
 
 0 -> 372 call = (...) => details(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 373 call = (...) => details(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 378 unreachable = ???*0*
 - *0* unreachable
@@ -1283,13 +1283,13 @@
 
 0 -> 381 member call = []["push"](???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 382 call = new (...) => undefined(???*0*, null, null, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 383 unreachable = ???*0*
 - *0* unreachable
@@ -1297,21 +1297,21 @@
 
 0 -> 385 member call = (...) => undefined["buildMessage"](???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 386 call = new (...) => undefined((...) => undefined["buildMessage"](???*0*, ???*1*), ???*2*, ???*3*, ???*4*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 387 unreachable = ???*0*
 - *0* unreachable
@@ -1544,7 +1544,7 @@
 
 0 -> 449 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1552,7 +1552,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 450 -> 451 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -1626,7 +1626,7 @@
 
 471 -> 473 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1634,7 +1634,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 474 -> 475 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -1680,7 +1680,7 @@
 
 486 -> 488 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1688,7 +1688,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 489 -> 490 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -1958,7 +1958,7 @@
 
 565 -> 567 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -1966,7 +1966,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 568 -> 569 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2012,7 +2012,7 @@
 
 580 -> 582 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2020,7 +2020,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 583 -> 584 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2126,7 +2126,7 @@
 
 610 -> 612 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2134,7 +2134,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 613 -> 614 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2168,7 +2168,7 @@
 
 622 -> 624 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2176,7 +2176,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 625 -> 626 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2210,7 +2210,7 @@
 
 634 -> 636 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2218,7 +2218,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 637 -> 638 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2256,7 +2256,7 @@
 
 646 -> 648 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2264,7 +2264,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 649 -> 650 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2298,7 +2298,7 @@
 
 658 -> 660 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2306,7 +2306,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 661 -> 662 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2332,7 +2332,7 @@
 
 0 -> 668 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2340,7 +2340,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 669 -> 670 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2374,7 +2374,7 @@
 
 678 -> 680 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2382,7 +2382,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 681 -> 682 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2428,7 +2428,7 @@
 
 693 -> 695 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2436,7 +2436,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 696 -> 697 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2480,7 +2480,7 @@
 
 707 -> 709 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2488,7 +2488,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 710 -> 711 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2516,7 +2516,7 @@
 
 0 -> 717 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2524,7 +2524,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 718 -> 719 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2558,7 +2558,7 @@
 
 727 -> 729 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2566,7 +2566,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 730 -> 731 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2632,7 +2632,7 @@
 
 0 -> 751 member call = ???*0*["substr"](???*1*, 9)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2640,7 +2640,7 @@
 - *0* ???*1*["substr"](peg$currPos, 9)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 752 -> 753 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2698,7 +2698,7 @@
 
 0 -> 771 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2706,7 +2706,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 772 -> 773 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2738,7 +2738,7 @@
 
 775 -> 777 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2746,7 +2746,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 778 -> 779 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2762,7 +2762,7 @@
 
 781 -> 784 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2770,17 +2770,17 @@
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 781 -> 786 conditional = /^[0-9]/["test"](???*0*)
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 786 -> 788 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2804,7 +2804,7 @@
 
 791 -> 796 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2812,17 +2812,17 @@
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 791 -> 798 conditional = /^[0-9]/["test"](???*0*)
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 798 -> 800 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2840,7 +2840,7 @@
 
 803 -> 805 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2848,7 +2848,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 806 -> 807 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -2868,7 +2868,7 @@
 
 809 -> 812 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2876,17 +2876,17 @@
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 809 -> 814 conditional = /^[0-9]/["test"](???*0*)
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 814 -> 816 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2904,7 +2904,7 @@
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 819 -> 821 member call = (???*0* | [] | {})["push"]((???*1* | ???*2* | {}))
 - *0* s6
@@ -2914,11 +2914,11 @@
 - *2* ???*3*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 819 -> 824 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2926,17 +2926,17 @@
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 819 -> 826 conditional = /^[0-9]/["test"](???*0*)
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 826 -> 828 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2965,7 +2965,7 @@
 
 0 -> 835 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -2973,7 +2973,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 836 -> 837 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -3017,7 +3017,7 @@
 
 844 -> 846 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3025,7 +3025,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 847 -> 848 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -3049,7 +3049,7 @@
 
 852 -> 854 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3057,7 +3057,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 855 -> 856 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -3101,7 +3101,7 @@
 
 863 -> 865 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3109,7 +3109,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 866 -> 867 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -3133,7 +3133,7 @@
 
 0 -> 873 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3141,7 +3141,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 874 -> 875 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -3175,7 +3175,7 @@
 
 883 -> 885 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3183,7 +3183,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 886 -> 887 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -3229,7 +3229,7 @@
 
 898 -> 900 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3237,7 +3237,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 901 -> 902 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -3281,7 +3281,7 @@
 
 912 -> 914 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3289,7 +3289,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 915 -> 916 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -3317,7 +3317,7 @@
 
 0 -> 922 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3325,7 +3325,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 923 -> 924 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -3359,7 +3359,7 @@
 
 932 -> 934 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3367,7 +3367,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 935 -> 936 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -3413,7 +3413,7 @@
 
 947 -> 949 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3421,7 +3421,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 950 -> 951 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -3465,7 +3465,7 @@
 
 961 -> 963 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3473,7 +3473,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 964 -> 965 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -3527,7 +3527,7 @@
 
 0 -> 981 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3535,17 +3535,17 @@
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 983 conditional = /^[ \t\n\r]/["test"](???*0*)
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 983 -> 985 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3563,7 +3563,7 @@
 
 0 -> 990 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3571,7 +3571,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 991 -> 992 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -3591,7 +3591,7 @@
 
 994 -> 997 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3599,17 +3599,17 @@
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 994 -> 999 conditional = /^[\n\r]/["test"](???*0*)
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 999 -> 1001 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3635,7 +3635,7 @@
 
 994 -> 1010 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3643,17 +3643,17 @@
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 994 -> 1012 conditional = /^[\n\r]/["test"](???*0*)
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1012 -> 1014 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3677,7 +3677,7 @@
 
 0 -> 1022 member call = ???*0*["substr"](???*1*, 6)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3685,7 +3685,7 @@
 - *0* ???*1*["substr"](peg$currPos, 6)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1024 conditional = (???*0* === "select")
 - *0* ???*1*()
@@ -3695,11 +3695,11 @@
 - *2* ???*3*["substr"](peg$currPos, 6)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1024 -> 1026 member call = ???*0*["substr"](???*1*, 6)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3723,7 +3723,7 @@
 
 0 -> 1034 member call = ???*0*["substr"](???*1*, 3)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3731,7 +3731,7 @@
 - *0* ???*1*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1036 conditional = (???*0* === "top")
 - *0* ???*1*()
@@ -3741,11 +3741,11 @@
 - *2* ???*3*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1036 -> 1038 member call = ???*0*["substr"](???*1*, 3)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3769,7 +3769,7 @@
 
 0 -> 1046 member call = ???*0*["substr"](???*1*, 4)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3777,7 +3777,7 @@
 - *0* ???*1*["substr"](peg$currPos, 4)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1048 conditional = (???*0* === "from")
 - *0* ???*1*()
@@ -3787,11 +3787,11 @@
 - *2* ???*3*["substr"](peg$currPos, 4)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1048 -> 1050 member call = ???*0*["substr"](???*1*, 4)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3815,7 +3815,7 @@
 
 0 -> 1058 member call = ???*0*["substr"](???*1*, 5)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3823,7 +3823,7 @@
 - *0* ???*1*["substr"](peg$currPos, 5)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1060 conditional = (???*0* === "where")
 - *0* ???*1*()
@@ -3833,11 +3833,11 @@
 - *2* ???*3*["substr"](peg$currPos, 5)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1060 -> 1062 member call = ???*0*["substr"](???*1*, 5)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3861,7 +3861,7 @@
 
 0 -> 1070 member call = ???*0*["substr"](???*1*, 5)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3869,7 +3869,7 @@
 - *0* ???*1*["substr"](peg$currPos, 5)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1072 conditional = (???*0* === "order")
 - *0* ???*1*()
@@ -3879,11 +3879,11 @@
 - *2* ???*3*["substr"](peg$currPos, 5)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1072 -> 1074 member call = ???*0*["substr"](???*1*, 5)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3907,7 +3907,7 @@
 
 0 -> 1082 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3915,7 +3915,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1084 conditional = (???*0* === "by")
 - *0* ???*1*()
@@ -3925,11 +3925,11 @@
 - *2* ???*3*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1084 -> 1086 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3953,7 +3953,7 @@
 
 0 -> 1094 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3961,7 +3961,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1096 conditional = (???*0* === "as")
 - *0* ???*1*()
@@ -3971,11 +3971,11 @@
 - *2* ???*3*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1096 -> 1098 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -3999,7 +3999,7 @@
 
 0 -> 1106 member call = ???*0*["substr"](???*1*, 4)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4007,7 +4007,7 @@
 - *0* ???*1*["substr"](peg$currPos, 4)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1108 conditional = (???*0* === "join")
 - *0* ???*1*()
@@ -4017,11 +4017,11 @@
 - *2* ???*3*["substr"](peg$currPos, 4)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1108 -> 1110 member call = ???*0*["substr"](???*1*, 4)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4045,7 +4045,7 @@
 
 0 -> 1118 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4053,7 +4053,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1120 conditional = (???*0* === "in")
 - *0* ???*1*()
@@ -4063,11 +4063,11 @@
 - *2* ???*3*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1120 -> 1122 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4091,7 +4091,7 @@
 
 0 -> 1130 member call = ???*0*["substr"](???*1*, 5)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4099,7 +4099,7 @@
 - *0* ???*1*["substr"](peg$currPos, 5)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1132 conditional = (???*0* === "value")
 - *0* ???*1*()
@@ -4109,11 +4109,11 @@
 - *2* ???*3*["substr"](peg$currPos, 5)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1132 -> 1134 member call = ???*0*["substr"](???*1*, 5)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4137,7 +4137,7 @@
 
 0 -> 1142 member call = ???*0*["substr"](???*1*, 3)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4145,7 +4145,7 @@
 - *0* ???*1*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1144 conditional = (???*0* === "asc")
 - *0* ???*1*()
@@ -4155,11 +4155,11 @@
 - *2* ???*3*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1144 -> 1146 member call = ???*0*["substr"](???*1*, 3)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4177,7 +4177,7 @@
 - *1* ???*2*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1149 -> 1150 call = (...) => s0()
 
@@ -4193,7 +4193,7 @@
 
 0 -> 1156 member call = ???*0*["substr"](???*1*, 4)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4201,7 +4201,7 @@
 - *0* ???*1*["substr"](peg$currPos, 4)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1158 conditional = (???*0* === "desc")
 - *0* ???*1*()
@@ -4211,11 +4211,11 @@
 - *2* ???*3*["substr"](peg$currPos, 4)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1158 -> 1160 member call = ???*0*["substr"](???*1*, 4)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4233,7 +4233,7 @@
 - *1* ???*2*["substr"](peg$currPos, 4)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1163 -> 1164 call = (...) => s0()
 
@@ -4249,7 +4249,7 @@
 
 0 -> 1170 member call = ???*0*["substr"](???*1*, 3)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4257,7 +4257,7 @@
 - *0* ???*1*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1172 conditional = (???*0* === "and")
 - *0* ???*1*()
@@ -4267,11 +4267,11 @@
 - *2* ???*3*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1172 -> 1174 member call = ???*0*["substr"](???*1*, 3)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4289,7 +4289,7 @@
 - *1* ???*2*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1177 -> 1178 call = (...) => s0()
 
@@ -4305,7 +4305,7 @@
 
 0 -> 1184 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4313,7 +4313,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1186 conditional = (???*0* === "or")
 - *0* ???*1*()
@@ -4323,11 +4323,11 @@
 - *2* ???*3*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1186 -> 1188 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4345,7 +4345,7 @@
 - *1* ???*2*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1191 -> 1192 call = (...) => s0()
 
@@ -4361,7 +4361,7 @@
 
 0 -> 1198 member call = ???*0*["substr"](???*1*, 3)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4369,7 +4369,7 @@
 - *0* ???*1*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1200 conditional = (???*0* === "not")
 - *0* ???*1*()
@@ -4379,11 +4379,11 @@
 - *2* ???*3*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1200 -> 1202 member call = ???*0*["substr"](???*1*, 3)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4401,7 +4401,7 @@
 - *1* ???*2*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1205 -> 1206 call = (...) => s0()
 
@@ -4417,7 +4417,7 @@
 
 0 -> 1212 member call = ???*0*["substr"](???*1*, 7)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4425,7 +4425,7 @@
 - *0* ???*1*["substr"](peg$currPos, 7)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1214 conditional = (???*0* === "between")
 - *0* ???*1*()
@@ -4435,11 +4435,11 @@
 - *2* ???*3*["substr"](peg$currPos, 7)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1214 -> 1216 member call = ???*0*["substr"](???*1*, 7)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4463,7 +4463,7 @@
 
 0 -> 1224 member call = ???*0*["substr"](???*1*, 6)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4471,7 +4471,7 @@
 - *0* ???*1*["substr"](peg$currPos, 6)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1226 conditional = (???*0* === "exists")
 - *0* ???*1*()
@@ -4481,11 +4481,11 @@
 - *2* ???*3*["substr"](peg$currPos, 6)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1226 -> 1228 member call = ???*0*["substr"](???*1*, 6)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4509,7 +4509,7 @@
 
 0 -> 1236 member call = ???*0*["substr"](???*1*, 5)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4517,7 +4517,7 @@
 - *0* ???*1*["substr"](peg$currPos, 5)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1238 conditional = (???*0* === "array")
 - *0* ???*1*()
@@ -4527,11 +4527,11 @@
 - *2* ???*3*["substr"](peg$currPos, 5)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1238 -> 1240 member call = ???*0*["substr"](???*1*, 5)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4555,7 +4555,7 @@
 
 0 -> 1247 member call = ???*0*["substr"](???*1*, 4)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4563,7 +4563,7 @@
 - *0* ???*1*["substr"](peg$currPos, 4)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1248 -> 1249 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -4585,7 +4585,7 @@
 
 0 -> 1255 member call = ???*0*["substr"](???*1*, 4)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4593,7 +4593,7 @@
 - *0* ???*1*["substr"](peg$currPos, 4)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1256 -> 1257 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -4615,7 +4615,7 @@
 
 0 -> 1263 member call = ???*0*["substr"](???*1*, 5)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4623,7 +4623,7 @@
 - *0* ???*1*["substr"](peg$currPos, 5)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1264 -> 1265 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -4645,7 +4645,7 @@
 
 0 -> 1271 member call = ???*0*["substr"](???*1*, 3)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4653,7 +4653,7 @@
 - *0* ???*1*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1272 -> 1273 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -4827,7 +4827,7 @@
 
 0 -> 1330 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4835,17 +4835,17 @@
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1332 conditional = /^[a-zA-Z_]/["test"](???*0*)
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1332 -> 1334 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4869,7 +4869,7 @@
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (???*4* + (???*5* | ???*7*))
   ⚠️  nested operation
 - *4* s1
@@ -4885,7 +4885,7 @@
 
 1339 -> 1342 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4893,17 +4893,17 @@
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1339 -> 1344 conditional = /^[a-zA-Z0-9_]/["test"](???*0*)
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1344 -> 1346 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4928,11 +4928,11 @@
 - *2* ???*3*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1339 -> 1353 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4940,17 +4940,17 @@
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1339 -> 1355 conditional = /^[a-zA-Z0-9_]/["test"](???*0*)
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1355 -> 1357 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -4980,7 +4980,7 @@
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* s1
   ⚠️  circular variable reference
 - *4* ???*5*["join"]("")
@@ -5000,7 +5000,7 @@
 
 0 -> 1364 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5008,7 +5008,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1365 -> 1366 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5024,7 +5024,7 @@
 - *1* ???*2*["substring"](peg$savedPos, peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1368 -> 1369 call = (...) => s0()
 
@@ -5040,7 +5040,7 @@
 
 0 -> 1374 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5048,7 +5048,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1375 -> 1376 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5064,7 +5064,7 @@
 
 1378 -> 1380 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5072,7 +5072,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1381 -> 1382 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5088,7 +5088,7 @@
 
 1384 -> 1386 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5096,7 +5096,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1387 -> 1388 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5118,7 +5118,7 @@
 
 0 -> 1394 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5126,7 +5126,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1395 -> 1396 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5142,7 +5142,7 @@
 
 1398 -> 1400 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5150,7 +5150,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1401 -> 1402 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5178,7 +5178,7 @@
 
 1408 -> 1410 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5186,7 +5186,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1411 -> 1412 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5216,7 +5216,7 @@
 
 0 -> 1420 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5224,7 +5224,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1421 -> 1422 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5240,7 +5240,7 @@
 
 1424 -> 1426 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5248,7 +5248,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1427 -> 1428 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5276,7 +5276,7 @@
 
 1434 -> 1436 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5284,7 +5284,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1437 -> 1438 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5314,7 +5314,7 @@
 
 0 -> 1447 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5354,7 +5354,7 @@
 
 0 -> 1460 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5362,7 +5362,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1461 -> 1462 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5378,7 +5378,7 @@
 
 1464 -> 1466 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5386,7 +5386,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1467 -> 1468 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5402,7 +5402,7 @@
 
 1470 -> 1472 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5410,7 +5410,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1473 -> 1474 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5426,7 +5426,7 @@
 
 1476 -> 1478 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5434,7 +5434,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1479 -> 1480 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5456,7 +5456,7 @@
 
 1484 -> 1486 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5464,7 +5464,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1487 -> 1488 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5486,7 +5486,7 @@
 
 1492 -> 1494 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5494,7 +5494,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1495 -> 1496 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5516,7 +5516,7 @@
 
 1500 -> 1502 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5524,7 +5524,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1503 -> 1504 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5546,7 +5546,7 @@
 
 1508 -> 1510 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5554,7 +5554,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1511 -> 1512 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5600,7 +5600,7 @@
 
 1524 -> 1526 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5608,7 +5608,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1527 -> 1528 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5624,7 +5624,7 @@
 
 0 -> 1532 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5632,7 +5632,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1533 -> 1534 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5659,7 +5659,7 @@
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* s4
   ⚠️  circular variable reference
 - *4* s5
@@ -5667,19 +5667,19 @@
 - *5* ???*6*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* s6
   ⚠️  pattern without value
 - *8* ???*9*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* s7
   ⚠️  pattern without value
 - *11* ???*12*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1538 -> 1539 call = (...) => s0()
 
@@ -5689,7 +5689,7 @@
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1540 -> 1541 call = (...) => s0()
 
@@ -5699,7 +5699,7 @@
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1542 -> 1543 call = (...) => s0()
 
@@ -5709,7 +5709,7 @@
 
 1544 -> 1546 member call = ???*0*["substring"](???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* max number of linking steps reached
@@ -5729,7 +5729,7 @@
 
 0 -> 1552 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5737,17 +5737,17 @@
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1554 conditional = /^[0-9a-f]/i["test"](???*0*)
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1554 -> 1556 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5851,7 +5851,7 @@
 
 1585 -> 1587 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5859,7 +5859,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1588 -> 1589 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -5893,7 +5893,7 @@
 
 1597 -> 1599 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -5901,7 +5901,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1600 -> 1601 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6021,7 +6021,7 @@
 
 1635 -> 1637 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6029,7 +6029,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1638 -> 1639 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6079,7 +6079,7 @@
 
 1651 -> 1653 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6087,7 +6087,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1654 -> 1655 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6133,7 +6133,7 @@
 
 1667 -> 1669 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6141,7 +6141,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1670 -> 1671 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6175,7 +6175,7 @@
 
 1678 -> 1680 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6183,7 +6183,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1681 -> 1682 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6233,7 +6233,7 @@
 
 1694 -> 1696 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6241,7 +6241,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1697 -> 1698 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6287,7 +6287,7 @@
 
 1710 -> 1712 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6295,7 +6295,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1713 -> 1714 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6383,7 +6383,7 @@
 
 1736 -> 1738 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6391,7 +6391,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1739 -> 1740 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6425,7 +6425,7 @@
 
 1748 -> 1750 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6433,7 +6433,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1751 -> 1752 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6502,7 +6502,7 @@
 
 1768 -> 1770 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6510,7 +6510,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1771 -> 1772 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6552,7 +6552,7 @@
 
 1783 -> 1785 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6560,7 +6560,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1786 -> 1787 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6676,7 +6676,7 @@
 
 1820 -> 1822 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6684,7 +6684,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1823 -> 1824 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6700,7 +6700,7 @@
 
 1826 -> 1828 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6708,7 +6708,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1829 -> 1830 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6724,7 +6724,7 @@
 
 1832 -> 1834 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6732,7 +6732,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1835 -> 1836 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6768,7 +6768,7 @@
 
 1845 -> 1847 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6776,7 +6776,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1848 -> 1849 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6792,7 +6792,7 @@
 
 1851 -> 1853 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6800,7 +6800,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1854 -> 1855 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6816,7 +6816,7 @@
 
 1857 -> 1859 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6824,7 +6824,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1860 -> 1861 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6874,7 +6874,7 @@
 
 1873 -> 1875 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6882,7 +6882,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1876 -> 1877 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6898,7 +6898,7 @@
 
 1879 -> 1881 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6906,7 +6906,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1882 -> 1883 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6922,7 +6922,7 @@
 
 1885 -> 1887 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6930,7 +6930,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1888 -> 1889 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6946,7 +6946,7 @@
 
 1891 -> 1893 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6954,7 +6954,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1894 -> 1895 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -6990,7 +6990,7 @@
 
 1904 -> 1906 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -6998,7 +6998,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1907 -> 1908 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7014,7 +7014,7 @@
 
 1910 -> 1912 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7022,7 +7022,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1913 -> 1914 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7038,7 +7038,7 @@
 
 1916 -> 1918 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7046,7 +7046,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1919 -> 1920 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7062,7 +7062,7 @@
 
 1922 -> 1924 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7070,7 +7070,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1925 -> 1926 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7132,7 +7132,7 @@
 
 1942 -> 1944 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7140,7 +7140,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1945 -> 1946 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7174,7 +7174,7 @@
 
 1954 -> 1956 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7182,7 +7182,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1957 -> 1958 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7298,7 +7298,7 @@
 
 1990 -> 1992 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7306,7 +7306,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1993 -> 1994 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7342,7 +7342,7 @@
 
 2003 -> 2005 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7350,7 +7350,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2006 -> 2007 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7400,7 +7400,7 @@
 
 2019 -> 2021 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7408,7 +7408,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2022 -> 2023 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7444,7 +7444,7 @@
 
 2032 -> 2034 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7452,7 +7452,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2035 -> 2036 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7502,7 +7502,7 @@
 
 2048 -> 2050 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7510,7 +7510,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2051 -> 2052 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7546,7 +7546,7 @@
 
 2061 -> 2063 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7554,7 +7554,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2064 -> 2065 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7604,7 +7604,7 @@
 
 2077 -> 2079 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7612,7 +7612,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2080 -> 2081 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7628,7 +7628,7 @@
 
 2083 -> 2085 member call = ???*0*["substr"](???*1*, 3)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7636,7 +7636,7 @@
 - *0* ???*1*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2086 -> 2087 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7652,7 +7652,7 @@
 
 2089 -> 2091 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7660,7 +7660,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2092 -> 2093 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7696,7 +7696,7 @@
 
 2102 -> 2104 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7704,7 +7704,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2105 -> 2106 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7720,7 +7720,7 @@
 
 2108 -> 2110 member call = ???*0*["substr"](???*1*, 3)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7728,7 +7728,7 @@
 - *0* ???*1*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2111 -> 2112 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7744,7 +7744,7 @@
 
 2114 -> 2116 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7752,7 +7752,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2117 -> 2118 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7802,7 +7802,7 @@
 
 2130 -> 2132 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7810,7 +7810,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2133 -> 2134 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7826,7 +7826,7 @@
 
 2136 -> 2138 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7834,7 +7834,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2139 -> 2140 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7850,7 +7850,7 @@
 
 2142 -> 2144 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7858,7 +7858,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2145 -> 2146 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7894,7 +7894,7 @@
 
 2155 -> 2157 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7902,7 +7902,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2158 -> 2159 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7918,7 +7918,7 @@
 
 2161 -> 2163 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7926,7 +7926,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2164 -> 2165 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -7942,7 +7942,7 @@
 
 2167 -> 2169 member call = ???*0*["substr"](???*1*, 2)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -7950,7 +7950,7 @@
 - *0* ???*1*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2170 -> 2171 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8000,7 +8000,7 @@
 
 2183 -> 2185 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8008,7 +8008,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2186 -> 2187 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8024,7 +8024,7 @@
 
 2189 -> 2191 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8032,7 +8032,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2192 -> 2193 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8048,7 +8048,7 @@
 
 2195 -> 2197 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8056,7 +8056,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2198 -> 2199 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8092,7 +8092,7 @@
 
 2208 -> 2210 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8100,7 +8100,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2211 -> 2212 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8116,7 +8116,7 @@
 
 2214 -> 2216 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8124,7 +8124,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2217 -> 2218 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8140,7 +8140,7 @@
 
 2220 -> 2222 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8148,7 +8148,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2223 -> 2224 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8204,7 +8204,7 @@
 
 2238 -> 2240 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8212,7 +8212,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2241 -> 2242 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8268,7 +8268,7 @@
 
 2256 -> 2258 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8276,7 +8276,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2259 -> 2260 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8340,7 +8340,7 @@
 
 2276 -> 2278 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8348,7 +8348,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2279 -> 2280 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8398,7 +8398,7 @@
 
 2292 -> 2294 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8406,7 +8406,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2295 -> 2296 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8452,7 +8452,7 @@
 
 2308 -> 2310 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8460,7 +8460,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2311 -> 2312 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8498,7 +8498,7 @@
 
 2320 -> 2322 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8506,7 +8506,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2323 -> 2324 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8556,7 +8556,7 @@
 
 2336 -> 2338 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8564,7 +8564,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2339 -> 2340 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8610,7 +8610,7 @@
 
 2352 -> 2354 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8618,7 +8618,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2355 -> 2356 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8688,7 +8688,7 @@
 
 0 -> 2375 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8696,17 +8696,17 @@
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2377 conditional = /^[0-9]/["test"](???*0*)
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2377 -> 2379 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8724,7 +8724,7 @@
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2382 -> 2384 member call = (???*0* | [] | {} | {"type": "number_constant", "value": ???*1*})["push"]((???*3* | ???*4* | {}))
 - *0* s1
@@ -8740,11 +8740,11 @@
 - *4* ???*5*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2382 -> 2387 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8752,17 +8752,17 @@
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2382 -> 2389 conditional = /^[0-9]/["test"](???*0*)
 - *0* ???*1*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2389 -> 2391 member call = ???*0*["charAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8804,7 +8804,7 @@
 
 2400 -> 2402 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8812,7 +8812,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2403 -> 2404 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8858,7 +8858,7 @@
 
 2415 -> 2417 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8866,7 +8866,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2418 -> 2419 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8916,7 +8916,7 @@
 
 0 -> 2431 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8924,7 +8924,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2432 -> 2433 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8958,7 +8958,7 @@
 
 2441 -> 2443 member call = ???*0*["charCodeAt"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -8966,7 +8966,7 @@
 - *0* ???*1*["charCodeAt"](peg$currPos)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2444 -> 2445 conditional = ((0 | ???*0*) === 0)
 - *0* updated with update expression
@@ -8993,9 +8993,9 @@
     ???*1*
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2452 unreachable = ???*0*
 - *0* unreachable

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/peg/resolved-explained.snapshot
@@ -206,69 +206,69 @@ DESCRIBE_EXPECTATION_FNS = {
 
 alias#42 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 alias#44 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 alias#78 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 alternate = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 args#48 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 args#49 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 argument = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 begin = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 body = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 buildBinaryExpression = (...) => tail["reduce"](*arrow function 169161*, head)
 
 ch#14 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 ch#16 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 ch#17 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 ch#19 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 ch#20 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 chars = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 child = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 classEscape = (...) => ...[...](..., ...)["replace"](/\]/g, "\\]")["replace"](/\^/g, "\\^")["replace"](/-/g, "\\-")["replace"](/\0/g, "\\0")["replace"](/\t/g, "\\t")["replace"](/\n/g, "\\n")["replace"](/\r/g, "\\r")["replace"](/[\x00-\x0F]/g, *anonymous function 2287*)["replace"](/[\x10-\x1F\x7F-\x9F]/g, *anonymous function 2385*)
 
@@ -276,21 +276,21 @@ computed#86 = ???*0*
 - *0* ???*1*["computed"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 computed#95 = ???*0*
 - *0* ???*1*["computed"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 condition = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 consequent = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 ctor = (...) => undefined
 
@@ -311,11 +311,11 @@ describeFound = (...) => (found ? `"${literalEscape(found)}"` : "end of input")
 
 description#105 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 description#111 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 descriptions = new ???*0*(???*1*)
 - *0* FreeVar(Array)
@@ -324,13 +324,13 @@ descriptions = new ???*0*(???*1*)
 - *1* ???*2*["length"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 details = ({"line": 1, "column": 1} | ???*0* | {"line": ???*2*, "column": ???*4*})
 - *0* [][???*1*]
   ⚠️  unknown array prototype methods or values
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["line"]
   ⚠️  unknown object
 - *3* details
@@ -342,25 +342,25 @@ details = ({"line": 1, "column": 1} | ???*0* | {"line": ???*2*, "column": ???*4*
 
 digits = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 elements = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 end = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 endPos = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 endPosDetails = ({"line": 1, "column": 1} | ???*0* | {"line": ???*2*, "column": ???*4*})
 - *0* [][???*1*]
   ⚠️  unknown array prototype methods or values
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["line"]
   ⚠️  unknown object
 - *3* details
@@ -404,177 +404,177 @@ escapedParts = ("" | (???*0* + ???*1*))
 
 expectation#11 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expectation#12 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expectation#13 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expectation#21 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expectation#8 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expectation#9 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expected#120 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expected#124 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expected#22 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expected#28 = (...) => undefined
 
 expected#5 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expected#7 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expression#42 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expression#43 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expression#44 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expression#47 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expression#79 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expression#80 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expression#81 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expression#82 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expression#93 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 expression#96 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 found#124 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 found#27 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 found#5 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 found#7 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 from#32 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 from#33 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 from#34 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#1801 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#38 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#39 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#46 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#50 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#58 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#59 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#66 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#83 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#84 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#85 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#89 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#94 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 head#99 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 hex#56 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 hex#7 = (...) => ch["charCodeAt"](0)["toString"](16)["toUpperCase"]()
 
@@ -592,19 +592,19 @@ i#9 = (???*0* | 0 | ???*1*)
 
 ignoreCase#107 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 ignoreCase#108 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 input = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 inverted = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 j = (???*0* | 1 | ???*1*)
 - *0* j
@@ -614,19 +614,19 @@ j = (???*0* | 1 | ???*1*)
 
 joins = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 key = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 left = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 list = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 literalEscape = (...) => s["replace"](/\\/g, "\\\\")["replace"](/"/g, "\\\"")["replace"](/\0/g, "\\0")["replace"](/\t/g, "\\t")["replace"](/\n/g, "\\n")["replace"](/\r/g, "\\r")["replace"](/[\x00-\x0F]/g, *anonymous function 1822*)["replace"](/[\x10-\x1F\x7F-\x9F]/g, *anonymous function 1920*)
 
@@ -640,63 +640,63 @@ location#106 = ???*0*
 
 location#123 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 location#124 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 location#28 = (...) => peg$computeLocation(peg$savedPos, peg$currPos)
 
 location#5 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 message#106 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 message#123 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 message#5 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 name#48 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 name#49 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 name#65 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 object#86 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 object#95 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 operator#1802 = ???*0*
 - *0* ???*1*[1]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 operator#87 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 options = (???*0* | (???*1* ? ???*3* : {}))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* !== undefined)
   ⚠️  nested operation
 - *2* options
@@ -706,11 +706,11 @@ options = (???*0* | (???*1* ? ???*3* : {}))
 
 order = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 orderBy = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 p = (???*0* | ???*1* | ???*2*)
 - *0* p
@@ -722,11 +722,11 @@ p = (???*0* | ???*1* | ???*2*)
 
 parent = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 parts = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 peg$FAILED = {}
 
@@ -1434,7 +1434,7 @@ peg$startRuleFunction = ((...) => s0 | ???*0*)
 - *1* ???*2*["startRule"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 peg$startRuleFunctions = {"sql": (...) => s0}
 
@@ -1442,53 +1442,53 @@ peg$subclass = (...) => undefined
 
 pos = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 properties = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 property#77 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 property#78 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 property#83 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 property#84 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 property#86 = ???*0*
 - *0* ???*1*["property"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 property#95 = ???*0*
 - *0* ???*1*["property"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 right = ???*0*
 - *0* ???*1*[3]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s#15 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s#18 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s0#1019 = ???*0*
 - *0* max number of linking steps reached
@@ -1508,7 +1508,7 @@ s0#1049 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s0#1053 = ???*0*
 - *0* max number of linking steps reached
@@ -1724,7 +1724,7 @@ s0#613 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s0#617 = ???*0*
 - *0* max number of linking steps reached
@@ -1832,7 +1832,7 @@ s0#893 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s0#897 = ???*0*
 - *0* max number of linking steps reached
@@ -1860,7 +1860,7 @@ s0#974 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s0#978 = ???*0*
 - *0* max number of linking steps reached
@@ -2175,7 +2175,7 @@ s1#744 = (???*0* | ???*1* | {} | "ASC")
 - *1* ???*2*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s1#754 = (???*0* | ???*1* | {} | "DESC")
 - *0* s1
@@ -2183,7 +2183,7 @@ s1#754 = (???*0* | ???*1* | {} | "DESC")
 - *1* ???*2*["substr"](peg$currPos, 4)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s1#764 = (???*0* | ???*1* | {} | "AND")
 - *0* s1
@@ -2191,7 +2191,7 @@ s1#764 = (???*0* | ???*1* | {} | "AND")
 - *1* ???*2*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s1#774 = (???*0* | ???*1* | {} | "OR")
 - *0* s1
@@ -2199,7 +2199,7 @@ s1#774 = (???*0* | ???*1* | {} | "OR")
 - *1* ???*2*["substr"](peg$currPos, 2)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s1#784 = (???*0* | ???*1* | {} | "NOT")
 - *0* s1
@@ -2207,7 +2207,7 @@ s1#784 = (???*0* | ???*1* | {} | "NOT")
 - *1* ???*2*["substr"](peg$currPos, 3)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s1#794 = ???*0*
 - *0* max number of linking steps reached
@@ -2247,7 +2247,7 @@ s1#897 = (???*0* | ???*1* | {} | (???*3* + (???*4* | ???*6*)))
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* s1
   ⚠️  circular variable reference
 - *4* ???*5*["join"]("")
@@ -2265,7 +2265,7 @@ s1#909 = (???*0* | "@" | {} | {"type": "parameter_name", "name": ???*1*})
 - *1* ???*2*["substring"](peg$savedPos, peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s1#930 = ???*0*
 - *0* max number of linking steps reached
@@ -2425,7 +2425,7 @@ s2#1744 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s2#1755 = (???*0* | [])
 - *0* s2
@@ -2769,7 +2769,7 @@ s3#644 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#654 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2777,7 +2777,7 @@ s3#654 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#664 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2785,7 +2785,7 @@ s3#664 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#674 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2793,7 +2793,7 @@ s3#674 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#684 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2801,7 +2801,7 @@ s3#684 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#694 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2809,7 +2809,7 @@ s3#694 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#704 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2817,7 +2817,7 @@ s3#704 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#714 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2825,7 +2825,7 @@ s3#714 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#724 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2833,7 +2833,7 @@ s3#724 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#734 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2841,7 +2841,7 @@ s3#734 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#744 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2849,7 +2849,7 @@ s3#744 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#754 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2857,7 +2857,7 @@ s3#754 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#764 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2865,7 +2865,7 @@ s3#764 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#774 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2873,7 +2873,7 @@ s3#774 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#784 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2881,7 +2881,7 @@ s3#784 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#794 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2889,7 +2889,7 @@ s3#794 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#804 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2897,7 +2897,7 @@ s3#804 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#814 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2905,7 +2905,7 @@ s3#814 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#824 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2913,7 +2913,7 @@ s3#824 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#834 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2921,7 +2921,7 @@ s3#834 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#844 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2929,7 +2929,7 @@ s3#844 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#854 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2937,7 +2937,7 @@ s3#854 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s3#897 = (???*0* | ???*1* | {})
 - *0* s3
@@ -2945,7 +2945,7 @@ s3#897 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s4#1031 = (
   | ???*0*
@@ -2958,7 +2958,7 @@ s4#1031 = (
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* s4
   ⚠️  circular variable reference
 - *4* s5
@@ -2966,19 +2966,19 @@ s4#1031 = (
 - *5* ???*6*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* s6
   ⚠️  pattern without value
 - *8* ???*9*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* s7
   ⚠️  pattern without value
 - *11* ???*12*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s4#1053 = ???*0*
 - *0* max number of linking steps reached
@@ -3122,7 +3122,7 @@ s5#1031 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s5#1053 = ???*0*
 - *0* max number of linking steps reached
@@ -3262,7 +3262,7 @@ s5#617 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s6#1031 = (???*0* | ???*1* | {})
 - *0* s6
@@ -3270,7 +3270,7 @@ s6#1031 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s6#1112 = (???*0* | [])
 - *0* s6
@@ -3378,7 +3378,7 @@ s7#1031 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s7#1112 = ???*0*
 - *0* max number of linking steps reached
@@ -3474,7 +3474,7 @@ s7#454 = (???*0* | ???*1* | {})
 - *1* ???*2*["charAt"](peg$currPos)
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 s7#525 = (???*0* | "," | {})
 - *0* s7
@@ -3566,41 +3566,41 @@ s9#567 = ???*0*
 
 select#31 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 select#32 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 select#33 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 select#34 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 seq = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 source#40 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 source#41 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 startPos = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 startPosDetails = ({"line": 1, "column": 1} | ???*0* | {"line": ???*2*, "column": ???*4*})
 - *0* [][???*1*]
   ⚠️  unknown array prototype methods or values
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["line"]
   ⚠️  unknown object
 - *3* details
@@ -3612,134 +3612,134 @@ startPosDetails = ({"line": 1, "column": 1} | ???*0* | {"line": ???*2*, "column"
 
 subquery = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 tail#1801 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 tail#39 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 tail#46 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 tail#50 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 tail#58 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 tail#59 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 tail#66 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 tail#85 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 tail#89 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 tail#94 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 tail#99 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 test = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 text#107 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 text#28 = (...) => input["substring"](peg$savedPos, peg$currPos)
 
 top#31 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 top#32 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 top#33 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 top#34 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 v#30 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 v#31 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 v#32 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 v#33 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 v#38 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 v#40 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 v#43 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 v#77 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 value#37 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 value#90 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 value#91 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 value#92 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 value#97 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 where#33 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 where#34 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-effects.snapshot
@@ -8,7 +8,7 @@
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6 -> 8 call = (...) => (1 | 2 | 4 | 8 | 16 | 32 | ???*0* | 134217728 | 268435456 | 536870912 | 1073741824 | a | undefined)(???*1*)
 - *0* unsupported expression
@@ -18,13 +18,13 @@
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6 -> 9 call = (...) => undefined(???*0*, ???*2*)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
@@ -34,7 +34,7 @@
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6 -> 12 call = module<scheduler, {}>["unstable_now"]()
 
@@ -44,7 +44,7 @@
 
 14 -> 15 call = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)(???*0*, 1)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 14 -> 16 conditional = (null !== ???*0*)
 - *0* (???*1* ? ???*5* : null)
@@ -56,13 +56,13 @@
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 16 -> 17 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : B()))()
 - *0* unsupported expression
@@ -78,15 +78,15 @@
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["stateNode"]
   ⚠️  unknown object
 - *5* ???*6*["alternate"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* (0 !== ???*9*)
   ⚠️  nested operation
 - *9* unsupported expression
@@ -112,17 +112,17 @@
 
 0 -> 19 call = (...) => undefined(???*0*, 1)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 21 conditional = (13 === ???*0*)
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 21 -> 22 call = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)(???*0*, 134217728)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 21 -> 23 conditional = (null !== (???*0* | undefined))
 - *0* (???*1* ? ???*5* : null)
@@ -134,13 +134,13 @@
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 23 -> 24 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : B()))()
 - *0* unsupported expression
@@ -161,15 +161,15 @@
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["stateNode"]
   ⚠️  unknown object
 - *5* ???*6*["alternate"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* (0 !== ???*9*)
   ⚠️  nested operation
 - *9* unsupported expression
@@ -195,13 +195,13 @@
 
 21 -> 26 call = (...) => undefined(???*0*, 134217728)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 28 conditional = (13 === ???*0*)
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 28 -> 29 call = (...) => (1 | ???*0* | ???*1* | a)(???*2*)
 - *0* unsupported expression
@@ -210,7 +210,7 @@
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 28 -> 30 call = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)(
     ???*0*,
@@ -230,14 +230,14 @@
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* C
   ⚠️  circular variable reference
 - *5* (0 !== ???*6*)
@@ -265,11 +265,11 @@
 - *16* unsupported expression
   ⚠️  This value might have side effects
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["value"]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* ???*21*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -291,13 +291,13 @@
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 31 -> 32 call = (...) => ((0 !== ???*0*) ? B() : ((???*1* !== Bk) ? Bk : B()))()
 - *0* unsupported expression
@@ -331,22 +331,22 @@
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["stateNode"]
   ⚠️  unknown object
 - *5* ???*6*["alternate"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* C
   ⚠️  circular variable reference
 - *12* (0 !== ???*13*)
@@ -374,11 +374,11 @@
 - *23* unsupported expression
   ⚠️  This value might have side effects
 - *24* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*["value"]
   ⚠️  unknown object
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* ???*28*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -430,14 +430,14 @@
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* C
   ⚠️  circular variable reference
 - *5* (0 !== ???*6*)
@@ -465,11 +465,11 @@
 - *16* unsupported expression
   ⚠️  This value might have side effects
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["value"]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* ???*21*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -487,7 +487,7 @@
 
 0 -> 36 call = ???*0*()
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 37 unreachable = ???*0*
 - *0* unreachable
@@ -495,9 +495,9 @@
 
 0 -> 38 call = (...) => undefined(???*0*, (???*1* | ???*2* | ???*4*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["parentNode"]
   ⚠️  unknown object
 - *3* c
@@ -514,7 +514,7 @@
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["type"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -526,11 +526,11 @@
 - *4* c
   ⚠️  circular variable reference
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["name"]
   ⚠️  unknown object
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["name"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -551,11 +551,11 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["name"]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["name"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -571,7 +571,7 @@
 
 41 -> 48 member call = (???*0* | ???*1* | ???*3*)["querySelectorAll"](`input[name=${???*5*}][type="radio"]`)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["parentNode"]
   ⚠️  unknown object
 - *2* c
@@ -595,13 +595,13 @@
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["name"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["name"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -615,7 +615,7 @@
 - *8* updated with update expression
   ⚠️  This value might have side effects
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["form"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -623,13 +623,13 @@
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["name"]
   ⚠️  unknown object
 - *15* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["name"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -645,20 +645,20 @@
 - *20* ???*21*["form"]
   ⚠️  unknown object
 - *21* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 53 -> 54 call = (...) => (a[Pf] || null)((???*0* | undefined))
 - *0* ???*1*[(???*2* | ???*3* | ???*5* | 0 | ???*8*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["name"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["name"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -680,13 +680,13 @@
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["name"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["name"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -739,13 +739,13 @@
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["name"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["name"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -767,13 +767,13 @@
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["name"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["name"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -793,13 +793,13 @@
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["name"]
   ⚠️  unknown object
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["name"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -834,9 +834,9 @@
 
 0 -> 61 call = (...) => undefined(???*0*, (???*1* | ???*2* | ???*4*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["parentNode"]
   ⚠️  unknown object
 - *3* c
@@ -851,13 +851,13 @@
 
 0 -> 64 call = (...) => undefined(???*0*, !(???*1*), (???*7* | ???*8* | ???*10* | 0 | ???*13*), false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* !((???*2* | ???*4*))
   ⚠️  nested operation
 - *2* ???*3*["multiple"]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["multiple"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -869,11 +869,11 @@
 - *6* c
   ⚠️  circular variable reference
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["name"]
   ⚠️  unknown object
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["name"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -994,7 +994,7 @@
  || ((1 !== a["nodeType"]) && (9 !== a["nodeType"]) && (11 !== a["nodeType"]))
 ))(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 96 conditional = !(???*0*)
 - *0* !(???*1*)
@@ -1002,7 +1002,7 @@
 - *1* !(???*2*)
   ⚠️  nested operation
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 96 -> 97 free var = FreeVar(Error)
 
@@ -1025,9 +1025,9 @@
     "implementation": c
 }(???*0*, ???*1*, null, ((???*2* | ???*3*) ? ???*6* : null))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* (undefined !== ???*4*)
@@ -1056,7 +1056,7 @@
  || ((1 !== a["nodeType"]) && (9 !== a["nodeType"]) && (11 !== a["nodeType"]))
 ))(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 105 conditional = !(???*0*)
 - *0* !(???*1*)
@@ -1064,7 +1064,7 @@
 - *1* !(???*2*)
   ⚠️  nested operation
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 105 -> 106 free var = FreeVar(Error)
 
@@ -1099,11 +1099,11 @@
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["identifierPrefix"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* a
   ⚠️  circular variable reference
 - *4* unsupported assign operation
@@ -1139,7 +1139,7 @@
 - *17* ???*18*["onRecoverableError"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* a
   ⚠️  circular variable reference
 - *20* unsupported assign operation
@@ -1155,7 +1155,7 @@
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 120 call = (...) => undefined((???*0* ? ???*3* : ???*5*))
 - *0* (8 === ???*1*)
@@ -1163,13 +1163,13 @@
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["parentNode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 121 call = new (...) => undefined(
     (
@@ -1178,7 +1178,7 @@
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* unsupported assign operation
@@ -1311,7 +1311,7 @@
 
 0 -> 152 call = (...) => (a() | undefined)(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 153 unreachable = ???*0*
 - *0* unreachable
@@ -1332,7 +1332,7 @@
     )
 ))(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 157 conditional = !(???*0*)
 - *0* !(???*1*)
@@ -1340,7 +1340,7 @@
 - *1* !(???*2*)
   ⚠️  nested operation
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 157 -> 158 free var = FreeVar(Error)
 
@@ -1357,11 +1357,11 @@
 
 0 -> 161 call = (...) => hl(g)(null, ???*0*, ???*1*, true, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 162 unreachable = ???*0*
 - *0* unreachable
@@ -1374,7 +1374,7 @@
  || ((1 !== a["nodeType"]) && (9 !== a["nodeType"]) && (11 !== a["nodeType"]))
 ))((???*0* | 0 | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
@@ -1384,7 +1384,7 @@
 - *1* !((???*2* | 0 | ???*3*))
   ⚠️  nested operation
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 
@@ -1403,7 +1403,7 @@
 
 0 -> 176 conditional = (null != (???*0* | ???*1* | null[(???*6* | 0 | ???*7*)]))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*[(???*4* | 0 | ???*5*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -1412,11 +1412,11 @@
 - *3* c
   ⚠️  circular variable reference
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* updated with update expression
   ⚠️  This value might have side effects
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* updated with update expression
   ⚠️  This value might have side effects
 
@@ -1454,13 +1454,13 @@
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* updated with update expression
   ⚠️  This value might have side effects
 - *3* (null != (???*4* | ???*5* | null[(???*10* | 0 | ???*11*)]))
   ⚠️  nested operation
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*[(???*8* | 0 | ???*9*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -1469,15 +1469,15 @@
 - *7* c
   ⚠️  circular variable reference
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* updated with update expression
   ⚠️  This value might have side effects
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* updated with update expression
   ⚠️  This value might have side effects
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*[(???*16* | 0 | ???*17*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -1486,21 +1486,21 @@
 - *15* c
   ⚠️  circular variable reference
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* updated with update expression
   ⚠️  This value might have side effects
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* updated with update expression
   ⚠️  This value might have side effects
 - *20* ???*21*["_getVersion"]
   ⚠️  unknown object
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* c
   ⚠️  circular variable reference
 - *23* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* updated with update expression
   ⚠️  This value might have side effects
 - *25* ???*26*["_getVersion"]
@@ -1514,11 +1514,11 @@
 - *28* c
   ⚠️  circular variable reference
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* updated with update expression
   ⚠️  This value might have side effects
 - *31* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* updated with update expression
   ⚠️  This value might have side effects
 - *33* ???*34*(c["_source"])
@@ -1528,11 +1528,11 @@
 - *35* ???*36*["identifierPrefix"]
   ⚠️  unknown object
 - *36* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* c
   ⚠️  circular variable reference
 - *38* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *39* updated with update expression
   ⚠️  This value might have side effects
 - *40* ???*41*["identifierPrefix"]
@@ -1546,11 +1546,11 @@
 - *43* c
   ⚠️  circular variable reference
 - *44* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *45* updated with update expression
   ⚠️  This value might have side effects
 - *46* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *47* updated with update expression
   ⚠️  This value might have side effects
 - *48* ("function" === ???*49*)
@@ -1566,11 +1566,11 @@
 - *52* ???*53*["onRecoverableError"]
   ⚠️  unknown object
 - *53* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *54* c
   ⚠️  circular variable reference
 - *55* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *56* updated with update expression
   ⚠️  This value might have side effects
 - *57* ???*58*["onRecoverableError"]
@@ -1584,23 +1584,23 @@
 - *60* c
   ⚠️  circular variable reference
 - *61* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *62* updated with update expression
   ⚠️  This value might have side effects
 - *63* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *64* updated with update expression
   ⚠️  This value might have side effects
 
 0 -> 180 call = (...) => undefined((???*0* | 0 | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
 0 -> 181 conditional = ((null != (???*0* | ???*1*)) | ???*3* | null)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*[a]
   ⚠️  unknown object
 - *2* d
@@ -1608,7 +1608,7 @@
 - *3* ???*4*["hydratedSources"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 181 -> 186 call = (
   | false
@@ -1629,11 +1629,11 @@
 - *0* ???*1*["_getVersion"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* c
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 - *5* ???*6*["_getVersion"]
@@ -1647,11 +1647,11 @@
 - *8* c
   ⚠️  circular variable reference
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* updated with update expression
   ⚠️  This value might have side effects
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* updated with update expression
   ⚠️  This value might have side effects
 - *13* ???*14*(c["_source"])
@@ -1661,11 +1661,11 @@
 - *15* ???*16*["_source"]
   ⚠️  unknown object
 - *16* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* c
   ⚠️  circular variable reference
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* updated with update expression
   ⚠️  This value might have side effects
 - *20* ???*21*["_source"]
@@ -1679,11 +1679,11 @@
 - *23* c
   ⚠️  circular variable reference
 - *24* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* updated with update expression
   ⚠️  This value might have side effects
 - *26* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* updated with update expression
   ⚠️  This value might have side effects
 
@@ -1712,11 +1712,11 @@
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* c
   ⚠️  circular variable reference
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* updated with update expression
   ⚠️  This value might have side effects
 - *6* ???*7*[(???*9* | 0 | ???*10*)]
@@ -1727,21 +1727,21 @@
 - *8* c
   ⚠️  circular variable reference
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* updated with update expression
   ⚠️  This value might have side effects
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* updated with update expression
   ⚠️  This value might have side effects
 - *13* ???*14*["_getVersion"]
   ⚠️  unknown object
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* c
   ⚠️  circular variable reference
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* updated with update expression
   ⚠️  This value might have side effects
 - *18* ???*19*["_getVersion"]
@@ -1755,11 +1755,11 @@
 - *21* c
   ⚠️  circular variable reference
 - *22* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* updated with update expression
   ⚠️  This value might have side effects
 - *24* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* updated with update expression
   ⚠️  This value might have side effects
 - *26* ???*27*(c["_source"])
@@ -1790,7 +1790,7 @@
     )
 ))(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 198 conditional = !(???*0*)
 - *0* !(???*1*)
@@ -1798,7 +1798,7 @@
 - *1* !(???*2*)
   ⚠️  nested operation
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 198 -> 199 free var = FreeVar(Error)
 
@@ -1815,11 +1815,11 @@
 
 0 -> 202 call = (...) => hl(g)(null, ???*0*, ???*1*, false, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 203 unreachable = ???*0*
 - *0* unreachable
@@ -1840,7 +1840,7 @@
     )
 ))(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 207 conditional = !(???*0*)
 - *0* !(???*1*)
@@ -1848,7 +1848,7 @@
 - *1* !(???*2*)
   ⚠️  nested operation
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 207 -> 208 free var = FreeVar(Error)
 
@@ -1867,13 +1867,13 @@
 - *0* ???*1*["_reactRootContainer"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 212 -> 213 call = (...) => (a() | undefined)((...) => undefined)
 
 213 -> 214 call = (...) => hl(g)(null, null, ???*0*, false, (...) => undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 217 unreachable = ???*0*
 - *0* unreachable
@@ -1896,7 +1896,7 @@
     )
 ))(???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 223 conditional = !(???*0*)
 - *0* !(???*1*)
@@ -1904,7 +1904,7 @@
 - *1* !(???*2*)
   ⚠️  nested operation
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 223 -> 224 free var = FreeVar(Error)
 
@@ -1921,11 +1921,11 @@
 
 0 -> 228 conditional = ((null == ???*0*) | (undefined === ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 228 -> 229 free var = FreeVar(Error)
 
@@ -1942,13 +1942,13 @@
 
 0 -> 232 call = (...) => hl(g)(???*0*, ???*1*, ???*2*, false, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 233 unreachable = ???*0*
 - *0* unreachable
@@ -1996,15 +1996,15 @@
 
 0 -> 249 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 250 call = (...) => undefined(`${???*0*}Capture`, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 255 member call = new ???*0*()["add"](???*1*)
 - *0* FreeVar(Set)
@@ -2013,7 +2013,7 @@
 - *1* ???*2*[a]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 256 typeof = typeof(???*0*)
 - *0* FreeVar(window)
@@ -2056,7 +2056,7 @@
   ⚠️  This value might have side effects
 - *2* Object: The global Object variable
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 270 conditional = ???*0*
 - *0* ???*1*["call"](ma, a)
@@ -2083,7 +2083,7 @@
   ⚠️  This value might have side effects
 - *2* Object: The global Object variable
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 270 -> 274 conditional = ???*0*
 - *0* ???*1*["call"](la, a)
@@ -2103,11 +2103,11 @@
 
 274 -> 277 member call = /^[:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$/["test"](???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 274 -> 278 conditional = /^[:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$/["test"](???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 278 -> 280 unreachable = ???*0*
 - *0* unreachable
@@ -2119,11 +2119,11 @@
 
 0 -> 284 conditional = ((null !== ???*0*) | (0 === ???*1*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 284 -> 285 unreachable = ???*0*
 - *0* unreachable
@@ -2131,7 +2131,7 @@
 
 284 -> 286 typeof = typeof(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 284 -> 287 unreachable = ???*0*
 - *0* unreachable
@@ -2139,7 +2139,7 @@
 
 284 -> 288 conditional = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 288 -> 289 unreachable = ???*0*
 - *0* unreachable
@@ -2147,7 +2147,7 @@
 
 288 -> 290 conditional = (null !== ???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 290 -> 292 unreachable = ???*0*
 - *0* unreachable
@@ -2155,7 +2155,7 @@
 
 290 -> 295 member call = (???*0* | ???*1*)["toLowerCase"]()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*(0, 5)
   ⚠️  unknown callee
 - *2* ???*3*["slice"]
@@ -2171,7 +2171,7 @@
 - *0* ???*1*["toLowerCase"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 290 -> 297 unreachable = ???*0*
 - *0* unreachable
@@ -2183,17 +2183,17 @@
 
 0 -> 299 typeof = typeof(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 300 call = (...) => (!(1) | !(0) | !(c["acceptsBooleans"]) | (("data-" !== a) && ("aria-" !== a)) | undefined)(???*0*, ???*1*, ???*2*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 301 conditional = (
   | (null === ???*0*)
@@ -2206,17 +2206,17 @@
   | undefined
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* typeof(???*2*)
   ⚠️  nested operation
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["acceptsBooleans"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*(0, 5)
   ⚠️  unknown callee
 - *7* ???*8*["slice"]
@@ -2228,7 +2228,7 @@
 - *10* a
   ⚠️  circular variable reference
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*(0, 5)
   ⚠️  unknown callee
 - *13* ???*14*["slice"]
@@ -2246,7 +2246,7 @@
 
 301 -> 303 conditional = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 303 -> 304 unreachable = ???*0*
 - *0* unreachable
@@ -2254,7 +2254,7 @@
 
 303 -> 305 conditional = (null !== ???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 305 -> 307 unreachable = ???*0*
 - *0* unreachable
@@ -2271,7 +2271,7 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 305 -> 311 unreachable = ???*0*
 - *0* unreachable
@@ -2284,7 +2284,7 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 305 -> 314 unreachable = ???*0*
 - *0* unreachable
@@ -2300,9 +2300,9 @@
 
 327 -> 329 call = new (...) => undefined(???*0*, 0, false, ???*1*, null, false, false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 331 member call = [
     ["acceptCharset", "accept-charset"],
@@ -2315,33 +2315,33 @@
 - *0* ???*1*[0]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*[1]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 337 member call = ["contentEditable", "draggable", "spellCheck", "value"]["forEach"]((...) => undefined)
 
 337 -> 340 member call = ???*0*["toLowerCase"]()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 337 -> 341 call = new (...) => undefined(???*0*, 2, false, ???*1*(), null, false, false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["toLowerCase"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 343 member call = ["autoReverse", "externalResourcesRequired", "focusable", "preserveAlpha"]["forEach"]((...) => undefined)
 
 343 -> 345 call = new (...) => undefined(???*0*, 2, false, ???*1*, null, false, false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 348 member call = "allowFullScreen async autoFocus autoPlay controls default defer disabled disablePictureInPicture disableRemotePlayback formNoValidate hidden loop noModule noValidate open playsInline readOnly required reversed scoped seamless itemScope"["split"](" ")
 
@@ -2349,59 +2349,59 @@
 
 349 -> 352 member call = ???*0*["toLowerCase"]()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 349 -> 353 call = new (...) => undefined(???*0*, 3, false, ???*1*(), null, false, false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["toLowerCase"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 355 member call = ["checked", "multiple", "muted", "selected"]["forEach"]((...) => undefined)
 
 355 -> 357 call = new (...) => undefined(???*0*, 3, true, ???*1*, null, false, false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 359 member call = ["capture", "download"]["forEach"]((...) => undefined)
 
 359 -> 361 call = new (...) => undefined(???*0*, 4, false, ???*1*, null, false, false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 363 member call = ["cols", "rows", "size", "span"]["forEach"]((...) => undefined)
 
 363 -> 365 call = new (...) => undefined(???*0*, 6, false, ???*1*, null, false, false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 367 member call = ["rowSpan", "start"]["forEach"]((...) => undefined)
 
 367 -> 370 member call = ???*0*["toLowerCase"]()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 367 -> 371 call = new (...) => undefined(???*0*, 5, false, ???*1*(), null, false, false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["toLowerCase"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 374 member call = ???*0*["toUpperCase"]()
 - *0* ???*1*[1]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 375 unreachable = ???*0*
 - *0* unreachable
@@ -2413,15 +2413,15 @@
 
 379 -> 381 member call = ???*0*["replace"](/[\-:]([a-z])/g, (...) => a[1]["toUpperCase"]())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 379 -> 383 call = new (...) => undefined(???*0*, 1, false, ???*2*, null, false, false)
 - *0* ???*1*["replace"](ra, sa)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 386 member call = "xlink:actuate xlink:arcrole xlink:role xlink:show xlink:title xlink:type"["split"](" ")
 
@@ -2429,43 +2429,43 @@
 
 387 -> 389 member call = ???*0*["replace"](/[\-:]([a-z])/g, (...) => a[1]["toUpperCase"]())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 387 -> 391 call = new (...) => undefined(???*0*, 1, false, ???*2*, "http://www.w3.org/1999/xlink", false, false)
 - *0* ???*1*["replace"](ra, sa)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 393 member call = ["xml:base", "xml:lang", "xml:space"]["forEach"]((...) => undefined)
 
 393 -> 395 member call = ???*0*["replace"](/[\-:]([a-z])/g, (...) => a[1]["toUpperCase"]())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 393 -> 397 call = new (...) => undefined(???*0*, 1, false, ???*2*, "http://www.w3.org/XML/1998/namespace", false, false)
 - *0* ???*1*["replace"](ra, sa)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 399 member call = ["tabIndex", "crossOrigin"]["forEach"]((...) => undefined)
 
 399 -> 402 member call = ???*0*["toLowerCase"]()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 399 -> 403 call = new (...) => undefined(???*0*, 1, false, ???*1*(), null, false, false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["toLowerCase"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 405 call = new (...) => undefined("xlinkHref", 1, false, "xlink:href", "http://www.w3.org/1999/xlink", true, false)
 
@@ -2473,21 +2473,21 @@
 
 407 -> 410 member call = ???*0*["toLowerCase"]()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 407 -> 411 call = new (...) => undefined(???*0*, 1, false, ???*1*(), null, true, true)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["toLowerCase"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 413 member call = {}["hasOwnProperty"](
     (???*0* | (???*1* ? ???*4* : null)["attributeName"] | ???*6*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined | ???*2*)(???*3*)
   ⚠️  non-function callee
 - *2* unknown mutation
@@ -2515,7 +2515,7 @@
 - *1* unknown mutation
   ⚠️  This value might have side effects
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (undefined | ???*4*)(???*5*)
   ⚠️  non-function callee
 - *4* unknown mutation
@@ -2542,7 +2542,7 @@
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["attributeName"]
   ⚠️  unknown object
 - *5* e
@@ -2551,7 +2551,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["type"]
   ⚠️  unknown object
 - *9* e
@@ -2567,7 +2567,7 @@
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["attributeName"]
   ⚠️  unknown object
 - *6* e
@@ -2576,7 +2576,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["type"]
   ⚠️  unknown object
 - *10* e
@@ -2592,16 +2592,16 @@
 - *15* unknown mutation
   ⚠️  This value might have side effects
 - *16* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???["attributeName"]
   ⚠️  unknown object
 - *18* {}[???*19*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["attributeNamespace"]
   ⚠️  unknown object
 - *22* (???*23* ? ???*28* : null)
@@ -2611,7 +2611,7 @@
 - *24* unknown mutation
   ⚠️  This value might have side effects
 - *25* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* ???*27*["attributeName"]
   ⚠️  unknown object
 - *27* e
@@ -2620,7 +2620,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *29* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* !(???*31*)
   ⚠️  nested operation
 - *31* unsupported expression
@@ -2635,7 +2635,7 @@
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (undefined | ???*3*)(???*4*)
   ⚠️  non-function callee
 - *3* unknown mutation
@@ -2654,7 +2654,7 @@
 - *9* e
   ⚠️  circular variable reference
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* (3 === (???*12* | ???*20*))
   ⚠️  nested operation
 - *12* (???*13* ? ???*18* : null)
@@ -2664,7 +2664,7 @@
 - *14* unknown mutation
   ⚠️  This value might have side effects
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["attributeName"]
   ⚠️  unknown object
 - *17* e
@@ -2673,7 +2673,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* ???*21*["type"]
   ⚠️  unknown object
 - *21* e
@@ -2685,7 +2685,7 @@
 - *24* unknown mutation
   ⚠️  This value might have side effects
 - *25* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* ???*27*["attributeName"]
   ⚠️  unknown object
 - *27* e
@@ -2694,19 +2694,19 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *29* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["type"]
   ⚠️  unknown object
 - *31* e
   ⚠️  circular variable reference
 - *32* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* (undefined | ???*34*)((???*35* | ???*36*))
   ⚠️  non-function callee
 - *34* unknown mutation
   ⚠️  This value might have side effects
 - *35* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *36* ???*37*["attributeName"]
   ⚠️  unknown object
 - *37* e
@@ -2715,7 +2715,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *39* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *40* ???*41*["attributeNamespace"]
   ⚠️  unknown object
 - *41* ???*42*["type"]
@@ -2725,13 +2725,13 @@
 
 423 -> 425 conditional = (???*0* | (???*1* ? ???*6* : null)["attributeNamespace"] | ???*8* | (null === (???*11* | ???*19*)))
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined | ???*2*)((???*3* | ???*4*))
   ⚠️  non-function callee
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["attributeName"]
   ⚠️  unknown object
 - *5* e
@@ -2740,7 +2740,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["attributeNamespace"]
   ⚠️  unknown object
 - *9* ???*10*["type"]
@@ -2754,7 +2754,7 @@
 - *13* unknown mutation
   ⚠️  This value might have side effects
 - *14* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["attributeName"]
   ⚠️  unknown object
 - *16* e
@@ -2763,7 +2763,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["type"]
   ⚠️  unknown object
 - *20* e
@@ -2773,7 +2773,7 @@
     (???*0* | (???*1* ? ???*4* : null)["attributeName"] | ???*6*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined | ???*2*)(???*3*)
   ⚠️  non-function callee
 - *2* unknown mutation
@@ -2794,7 +2794,7 @@
 
 425 -> 427 conditional = (null === (???*0* | null | ???*1*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? "" : ???*12*)
   ⚠️  nested operation
 - *2* (3 === (???*3* | ???*10*))
@@ -2806,14 +2806,14 @@
 - *5* unknown mutation
   ⚠️  This value might have side effects
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???["attributeName"]
   ⚠️  unknown object
 - *8* {}[???*9*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["type"]
   ⚠️  unknown object
 - *11* e
@@ -2825,9 +2825,9 @@
     (???*1* | (???*2* ? ???*5* : null)["attributeName"] | ???*7*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (undefined | ???*3*)(???*4*)
   ⚠️  non-function callee
 - *3* unknown mutation
@@ -2851,9 +2851,9 @@
     (???*10* | null | (???*11* ? "" : ???*22*))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (undefined | ???*3*)(???*4*)
   ⚠️  non-function callee
 - *3* unknown mutation
@@ -2872,7 +2872,7 @@
 - *9* e
   ⚠️  circular variable reference
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* (3 === (???*12* | ???*20*))
   ⚠️  nested operation
 - *12* (???*13* ? ???*18* : null)
@@ -2882,7 +2882,7 @@
 - *14* unknown mutation
   ⚠️  This value might have side effects
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["attributeName"]
   ⚠️  unknown object
 - *17* e
@@ -2891,7 +2891,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* ???*21*["type"]
   ⚠️  unknown object
 - *21* e
@@ -2905,7 +2905,7 @@
 - *1* unknown mutation
   ⚠️  This value might have side effects
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["attributeName"]
   ⚠️  unknown object
 - *4* e
@@ -2914,7 +2914,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["mustUseProperty"]
   ⚠️  unknown object
 - *8* ???*9*["type"]
@@ -2924,7 +2924,7 @@
 
 433 -> 436 conditional = (null === (???*0* | null | ???*1*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? "" : ???*12*)
   ⚠️  nested operation
 - *2* (3 === (???*3* | ???*10*))
@@ -2936,14 +2936,14 @@
 - *5* unknown mutation
   ⚠️  This value might have side effects
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???["attributeName"]
   ⚠️  unknown object
 - *8* {}[???*9*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["type"]
   ⚠️  unknown object
 - *11* e
@@ -2961,7 +2961,7 @@
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["attributeName"]
   ⚠️  unknown object
 - *6* e
@@ -2970,11 +2970,11 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 433 -> 441 conditional = (null === (???*0* | null | ???*1*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? "" : ???*12*)
   ⚠️  nested operation
 - *2* (3 === (???*3* | ???*10*))
@@ -2986,14 +2986,14 @@
 - *5* unknown mutation
   ⚠️  This value might have side effects
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???["attributeName"]
   ⚠️  unknown object
 - *8* {}[???*9*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["type"]
   ⚠️  unknown object
 - *11* e
@@ -3005,9 +3005,9 @@
     (???*1* | (???*2* ? ???*5* : null)["attributeName"] | ???*7*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (undefined | ???*3*)(???*4*)
   ⚠️  non-function callee
 - *3* unknown mutation
@@ -3034,7 +3034,7 @@
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["attributeName"]
   ⚠️  unknown object
 - *5* e
@@ -3043,7 +3043,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["type"]
   ⚠️  unknown object
 - *9* e
@@ -3055,7 +3055,7 @@
 - *12* unknown mutation
   ⚠️  This value might have side effects
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["attributeName"]
   ⚠️  unknown object
 - *15* e
@@ -3064,13 +3064,13 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *17* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["type"]
   ⚠️  unknown object
 - *19* e
   ⚠️  circular variable reference
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* (???*22* ? "" : ???*32*)
   ⚠️  nested operation
 - *22* (3 === (???*23* | ???*30*))
@@ -3082,14 +3082,14 @@
 - *25* unknown mutation
   ⚠️  This value might have side effects
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* ???["attributeName"]
   ⚠️  unknown object
 - *28* {}[???*29*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *29* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["type"]
   ⚠️  unknown object
 - *31* e
@@ -3099,13 +3099,13 @@
 
 441 -> 446 conditional = (???*0* | (???*1* ? ???*6* : null)["attributeNamespace"] | ???*8*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined | ???*2*)((???*3* | ???*4*))
   ⚠️  non-function callee
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["attributeName"]
   ⚠️  unknown object
 - *5* e
@@ -3114,7 +3114,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["attributeNamespace"]
   ⚠️  unknown object
 - *9* ???*10*["type"]
@@ -3128,15 +3128,15 @@
     (???*21* | null | (???*22* ? "" : ???*33*))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (undefined | ???*3*)((???*4* | ???*5*))
   ⚠️  non-function callee
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["attributeName"]
   ⚠️  unknown object
 - *6* e
@@ -3145,7 +3145,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["attributeNamespace"]
   ⚠️  unknown object
 - *10* ???*11*["type"]
@@ -3153,7 +3153,7 @@
 - *11* e
   ⚠️  circular variable reference
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* (undefined | ???*14*)(???*15*)
   ⚠️  non-function callee
 - *14* unknown mutation
@@ -3172,7 +3172,7 @@
 - *20* e
   ⚠️  circular variable reference
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* (3 === (???*23* | ???*31*))
   ⚠️  nested operation
 - *23* (???*24* ? ???*29* : null)
@@ -3182,7 +3182,7 @@
 - *25* unknown mutation
   ⚠️  This value might have side effects
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* ???*28*["attributeName"]
   ⚠️  unknown object
 - *28* e
@@ -3191,7 +3191,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *30* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *31* ???*32*["type"]
   ⚠️  unknown object
 - *32* e
@@ -3204,9 +3204,9 @@
     (???*10* | null | (???*11* ? "" : ???*22*))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (undefined | ???*3*)(???*4*)
   ⚠️  non-function callee
 - *3* unknown mutation
@@ -3225,7 +3225,7 @@
 - *9* e
   ⚠️  circular variable reference
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* (3 === (???*12* | ???*20*))
   ⚠️  nested operation
 - *12* (???*13* ? ???*18* : null)
@@ -3235,7 +3235,7 @@
 - *14* unknown mutation
   ⚠️  This value might have side effects
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["attributeName"]
   ⚠️  unknown object
 - *17* e
@@ -3244,7 +3244,7 @@
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* ???*21*["type"]
   ⚠️  unknown object
 - *21* e
@@ -3382,7 +3382,7 @@
 
 0 -> 508 typeof = typeof((???*0* | ???*1* | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["iterator"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -3396,7 +3396,7 @@
 
 0 -> 509 conditional = ((null === (???*0* | ???*1* | ???*3*)) | ("object" !== ???*5*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["iterator"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -3410,7 +3410,7 @@
 - *5* typeof((???*6* | ???*7* | ???*9*))
   ⚠️  nested operation
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["iterator"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -3428,7 +3428,7 @@
 
 509 -> 513 typeof = typeof((???*0* | ???*1* | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["iterator"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -3444,7 +3444,7 @@
 - *0* typeof((???*1* | ???*2* | ???*4*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["iterator"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -3513,7 +3513,7 @@
 
 0 -> 528 conditional = (!((???*0* | ???*1*)) | false | true)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? ???*3* : "")
   ⚠️  nested operation
 - *2* a
@@ -3533,7 +3533,7 @@
 
 528 -> 534 conditional = (???*0* | (...) => undefined)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 534 -> 535 free var = FreeVar(Error)
 
@@ -3556,7 +3556,7 @@
 - *1* ???*2*["prototype"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 534 -> 543 typeof = typeof(???*0*)
 - *0* FreeVar(Reflect)
@@ -3574,7 +3574,7 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 534 -> 551 free var = FreeVar(Reflect)
 
@@ -3583,7 +3583,7 @@
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* ???*4*["displayName"]
@@ -3591,15 +3591,15 @@
 - *4* a
   ⚠️  circular variable reference
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 534 -> 554 member call = (???*0* | (...) => undefined)["call"]()
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 534 -> 557 member call = (???*0* | (???*1* ? ???*2* : ""))["call"]((???*4* | (...) => undefined["prototype"]))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["displayName"]
@@ -3609,7 +3609,7 @@
 - *4* ???*5*["prototype"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 534 -> 558 free var = FreeVar(Error)
 
@@ -3620,7 +3620,7 @@
 
 534 -> 560 call = (???*0* | (???*1* ? ???*2* : ""))()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["displayName"]
@@ -3788,7 +3788,7 @@ ${(???*0* | ???*7*)}`
 - *12* ???*13*["displayName"]
   ⚠️  unknown object
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* a
   ⚠️  circular variable reference
 - *15* ???*16*["displayName"]
@@ -3804,7 +3804,7 @@ ${(???*0* | ???*7*)}`
 
 0 -> 592 conditional = (???*0* | (???*1* ? ???*2* : ""))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["displayName"]
@@ -3814,7 +3814,7 @@ ${(???*0* | ???*7*)}`
 
 0 -> 595 conditional = ((???*0* | ???*1*) ? ???*5* : "")
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? ???*3* : "")
   ⚠️  nested operation
 - *2* a
@@ -3826,12 +3826,12 @@ ${(???*0* | ???*7*)}`
 - *5* ???*6*["displayName"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 595 -> 596 call = (...) => `
 ${La}${a}`((???*0* | (???*1* ? ???*2* : "")))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["displayName"]
@@ -3930,7 +3930,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 619 conditional = (null == (???*0* | ???*1* | null["displayName"] | null["name"] | "" | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["displayName"]
   ⚠️  unknown object
 - *2* a
@@ -3952,7 +3952,7 @@ ${La}${a}`("SuspenseList")
 
 619 -> 621 typeof = typeof((???*0* | ???*1* | null["displayName"] | null["name"] | "" | (???*3* ? ???*5* : "ForwardRef")))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["displayName"]
   ⚠️  unknown object
 - *2* a
@@ -3970,7 +3970,7 @@ ${La}${a}`("SuspenseList")
 - *0* typeof((???*1* | ???*2* | null["displayName"] | null["name"] | "" | ???*4*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["displayName"]
   ⚠️  unknown object
 - *3* a
@@ -3992,7 +3992,7 @@ ${La}${a}`("SuspenseList")
 
 622 -> 626 typeof = typeof((???*0* | ???*1* | null["displayName"] | null["name"] | "" | (???*3* ? ???*5* : "ForwardRef")))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["displayName"]
   ⚠️  unknown object
 - *2* a
@@ -4010,7 +4010,7 @@ ${La}${a}`("SuspenseList")
 - *0* typeof((???*1* | ???*2* | null["displayName"] | null["name"] | "" | ???*4*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["displayName"]
   ⚠️  unknown object
 - *3* a
@@ -4056,7 +4056,7 @@ ${La}${a}`("SuspenseList")
 
 627 -> 635 typeof = typeof((???*0* | ???*1* | null["displayName"] | null["name"] | "" | (???*3* ? ???*5* : "ForwardRef")))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["displayName"]
   ⚠️  unknown object
 - *2* a
@@ -4074,7 +4074,7 @@ ${La}${a}`("SuspenseList")
 - *0* typeof((???*1* | ???*2* | null["displayName"] | null["name"] | "" | ???*4*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["displayName"]
   ⚠️  unknown object
 - *3* a
@@ -4100,7 +4100,7 @@ ${La}${a}`("SuspenseList")
 
 636 -> 647 conditional = ("" !== (???*0* | ???*1* | null["displayName"] | null["name"] | "" | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["displayName"]
   ⚠️  unknown object
 - *2* a
@@ -4124,7 +4124,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["render"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 650 -> 652 call = (...) => (
   | null
@@ -4152,7 +4152,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ("" !== ???*3*)
   ⚠️  nested operation
 - *3* a
@@ -4179,7 +4179,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["displayName"]
   ⚠️  unknown object
 - *2* a
@@ -4195,7 +4195,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["render"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ("" !== ???*10*)
   ⚠️  nested operation
 - *10* a
@@ -4239,7 +4239,7 @@ ${La}${a}`("SuspenseList")
 - *0* (???*1* | ???*2* | null["displayName"] | null["name"] | "" | (???*4* ? ???*6* : "ForwardRef"))(b)
   ⚠️  non-function callee
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["displayName"]
   ⚠️  unknown object
 - *3* a
@@ -4279,7 +4279,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 673 conditional = ("" !== (???*0* | ???*1* | ""))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["render"]
   ⚠️  unknown object
 - *2* ???*3*["type"]
@@ -4329,7 +4329,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 681 unreachable = ???*0*
 - *0* unreachable
@@ -4339,7 +4339,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["for"]("react.strict_mode")
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
@@ -4379,7 +4379,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 691 conditional = ("function" === ???*0*)
 - *0* typeof((???*1* | ""["type"]))
@@ -4387,7 +4387,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 691 -> 694 unreachable = ???*0*
 - *0* unreachable
@@ -4397,7 +4397,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 691 -> 696 conditional = ("string" === ???*0*)
 - *0* typeof((???*1* | ""["type"]))
@@ -4405,7 +4405,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 696 -> 697 unreachable = ???*0*
 - *0* unreachable
@@ -4417,7 +4417,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 699 typeof = typeof(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 700 unreachable = ???*0*
 - *0* unreachable
@@ -4433,7 +4433,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 706 member call = (???*0* | ???*1*)["toLowerCase"]()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeName"]
   ⚠️  unknown object
 - *2* a
@@ -4445,27 +4445,27 @@ ${La}${a}`("SuspenseList")
 
 0 -> 708 call = (...) => (a["nodeName"] && ("input" === a["toLowerCase"]()) && (("checkbox" === b) || ("radio" === b)))(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 709 conditional = (???*0* | ("input" === ???*2*) | ("checkbox" === ???*5*) | ("radio" === ???*7*))
 - *0* ???*1*["nodeName"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*()
   ⚠️  nested operation
 - *3* ???*4*["toLowerCase"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["type"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["type"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 711 free var = FreeVar(Object)
 
@@ -4476,11 +4476,11 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["constructor"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["nodeName"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ("input" === ???*7*)
   ⚠️  nested operation
 - *7* ???*8*()
@@ -4488,15 +4488,15 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["toLowerCase"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 717 member call = ???*0*["hasOwnProperty"](((???*1* | ???*3*) ? "checked" : "value"))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeName"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ("input" === ???*4*)
   ⚠️  nested operation
 - *4* ???*5*()
@@ -4504,7 +4504,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["toLowerCase"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 718 typeof = typeof(???*0*)
 - *0* ???*1*(???*3*, ((???*6* | ???*8*) ? "checked" : "value"))
@@ -4519,11 +4519,11 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["constructor"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["nodeName"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ("input" === ???*9*)
   ⚠️  nested operation
 - *9* ???*10*()
@@ -4531,7 +4531,7 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["toLowerCase"]
   ⚠️  unknown object
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 719 typeof = typeof(???*0*)
 - *0* ???*1*["get"]
@@ -4549,11 +4549,11 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["constructor"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["nodeName"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ("input" === ???*10*)
   ⚠️  nested operation
 - *10* ???*11*()
@@ -4577,11 +4577,11 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["constructor"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["nodeName"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ("input" === ???*10*)
   ⚠️  nested operation
 - *10* ???*11*()
@@ -4593,7 +4593,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["hasOwnProperty"](b)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* typeof(???*3*)
   ⚠️  nested operation
 - *3* ???*4*(???*6*, ((???*9* | ???*11*) ? "checked" : "value"))
@@ -4608,11 +4608,11 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["constructor"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["nodeName"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ("input" === ???*12*)
   ⚠️  nested operation
 - *12* ???*13*()
@@ -4638,7 +4638,7 @@ ${La}${a}`("SuspenseList")
 - *21* ???*22*["nodeName"]
   ⚠️  unknown object
 - *22* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* ("input" === ???*24*)
   ⚠️  nested operation
 - *24* ???()
@@ -4662,11 +4662,11 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["constructor"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["nodeName"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ("input" === ???*10*)
   ⚠️  nested operation
 - *10* ???*11*()
@@ -4696,11 +4696,11 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["constructor"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["nodeName"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ("input" === ???*10*)
   ⚠️  nested operation
 - *10* ???*11*()
@@ -4710,7 +4710,7 @@ ${La}${a}`("SuspenseList")
 - *12* unsupported expression
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 723 -> 733 member call = Object*0*["defineProperty"](
     ???*1*,
@@ -4719,11 +4719,11 @@ ${La}${a}`("SuspenseList")
 )
 - *0* Object: The global Object variable
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["nodeName"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ("input" === ???*5*)
   ⚠️  nested operation
 - *5* ???*6*()
@@ -4731,7 +4731,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["toLowerCase"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* unsupported expression
   ⚠️  This value might have side effects
 
@@ -4740,11 +4740,11 @@ ${La}${a}`("SuspenseList")
 723 -> 737 member call = Object*0*["defineProperty"](???*1*, ((???*2* | ???*4*) ? "checked" : "value"), {"enumerable": ???*8*})
 - *0* Object: The global Object variable
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["nodeName"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ("input" === ???*5*)
   ⚠️  nested operation
 - *5* ???*6*()
@@ -4752,7 +4752,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["toLowerCase"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["enumerable"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -4768,11 +4768,11 @@ ${La}${a}`("SuspenseList")
 - *13* ???*14*["constructor"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["nodeName"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ("input" === ???*18*)
   ⚠️  nested operation
 - *18* ???*19*()
@@ -4797,11 +4797,11 @@ ${La}${a}`("SuspenseList")
   | undefined
 )(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 745 conditional = !((???*0* | "" | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ((???*2* | ???*4*) ? ???*8* : ???*11*)
   ⚠️  nested operation
 - *2* ???*3*["nodeName"]
@@ -4835,7 +4835,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["_valueTracker"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 748 -> 749 unreachable = ???*0*
 - *0* unreachable
@@ -4849,7 +4849,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["_valueTracker"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["nodeName"]
   ⚠️  unknown object
 - *3* a
@@ -4877,7 +4877,7 @@ ${La}${a}`("SuspenseList")
     (???*0* | "" | ((???*1* | ???*3*) ? ???*7* : ???*10*))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeName"]
   ⚠️  unknown object
 - *2* a
@@ -4912,7 +4912,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["nodeName"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["nodeName"]
   ⚠️  unknown object
 - *3* a
@@ -4940,21 +4940,21 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["toLowerCase"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["type"]
   ⚠️  unknown object
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["type"]
   ⚠️  unknown object
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 753 -> 755 conditional = (???*0* | ""["checked"] | ((???*2* | ???*4*) ? ???*8* : ???*11*)["checked"])
 - *0* ???*1*["checked"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["nodeName"]
   ⚠️  unknown object
 - *3* a
@@ -4980,7 +4980,7 @@ ${La}${a}`("SuspenseList")
 
 748 -> 757 conditional = ((???*0* | "" | ???*1*) !== ???*13*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ((???*2* | ???*4*) ? ???*8* : ???*11*)
   ⚠️  nested operation
 - *2* ???*3*["nodeName"]
@@ -5012,7 +5012,7 @@ ${La}${a}`("SuspenseList")
 - *15* ???*16*["_valueTracker"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 757 -> 759 member call = (
   | ???*0*
@@ -5024,7 +5024,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["_valueTracker"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["nodeName"]
   ⚠️  unknown object
 - *3* a
@@ -5048,7 +5048,7 @@ ${La}${a}`("SuspenseList")
 - *12* a
   ⚠️  circular variable reference
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["nodeName"]
   ⚠️  unknown object
 - *15* a
@@ -5094,7 +5094,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 765 typeof = typeof((???*0* | ???*1* | (???*2* ? ???*5* : undefined)))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ("undefined" !== ???*3*)
@@ -5112,7 +5112,7 @@ ${La}${a}`("SuspenseList")
 - *0* typeof((???*1* | ???*2* | ???*3*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* (???*4* ? ???*7* : undefined)
@@ -5144,7 +5144,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["checked"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 777 call = Object.assign*0*(
     {},
@@ -5158,23 +5158,23 @@ ${La}${a}`("SuspenseList")
 )
 - *0* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null != ???*3*)
   ⚠️  nested operation
 - *3* ???*4*["checked"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["checked"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["initialChecked"]
   ⚠️  unknown object
 - *8* ???*9*["_wrapperState"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 778 unreachable = ???*0*
 - *0* unreachable
@@ -5184,19 +5184,19 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["defaultValue"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 783 conditional = (null != ???*0*)
 - *0* ???*1*["checked"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 787 conditional = (null != ???*0*)
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 789 call = (...) => (a | "" | undefined)((???*0* ? ???*3* : (???*5* | "" | undefined)))
 - *0* (null != ???*1*)
@@ -5204,11 +5204,11 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["value"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["value"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (???*6* ? "" : ???*9*)
   ⚠️  nested operation
 - *6* (null == ???*7*)
@@ -5216,27 +5216,27 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["defaultValue"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["defaultValue"]
   ⚠️  unknown object
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 793 conditional = (("checkbox" === ???*0*) | ("radio" === ???*2*))
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["type"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 797 call = (...) => undefined(???*0*, "checked", (???*1* | ???*2*), false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["checked"]
   ⚠️  unknown object
 - *3* b
@@ -5244,59 +5244,59 @@ ${La}${a}`("SuspenseList")
 
 0 -> 798 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 800 call = (...) => (a | "" | undefined)(???*0*)
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 802 conditional = (null != (???*0* | "" | undefined))
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 802 -> 803 conditional = ("number" === ???*0*)
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 803 -> 806 conditional = ((0 === (???*0* | "" | undefined)) | ("" === ???*2*) | (???*4* != (???*6* | "" | undefined)))
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["value"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["value"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["value"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 802 -> 810 conditional = (("submit" === ???*0*) | ("reset" === ???*2*))
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["type"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 810 -> 812 member call = ???*0*["removeAttribute"]("value")
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 810 -> 813 unreachable = ???*0*
 - *0* unreachable
@@ -5304,73 +5304,73 @@ ${La}${a}`("SuspenseList")
 
 0 -> 815 member call = ???*0*["hasOwnProperty"]("value")
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 816 conditional = ???*0*
 - *0* ???*1*["hasOwnProperty"]("value")
   ⚠️  unknown callee object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 816 -> 818 call = (...) => undefined(???*0*, ???*1*, (???*3* | "" | undefined))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["value"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 816 -> 820 member call = ???*0*["hasOwnProperty"]("defaultValue")
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 816 -> 823 call = (...) => (a | "" | undefined)(???*0*)
 - *0* ???*1*["defaultValue"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 816 -> 824 call = (...) => undefined(???*0*, ???*1*, (???*3* | "" | undefined))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["defaultValue"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 830 member call = (???*0* | ???*1*)["hasOwnProperty"]("value")
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["initialValue"]
   ⚠️  unknown object
 - *2* ???*3*["_wrapperState"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 832 member call = (???*0* | ???*1*)["hasOwnProperty"]("defaultValue")
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["initialValue"]
   ⚠️  unknown object
 - *2* ???*3*["_wrapperState"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 833 conditional = ???*0*
 - *0* ???*1*["hasOwnProperty"]("value")
   ⚠️  unknown callee object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 833 -> 837 conditional = !(???*0*)
 - *0* ("submit" !== (???*1* | undefined))
@@ -5378,7 +5378,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 837 -> 838 unreachable = ???*0*
 - *0* unreachable
@@ -5388,34 +5388,34 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["ownerDocument"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 852 conditional = (("number" !== ???*0*) | ((null | ???*1* | undefined) !== ???*4*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["activeElement"]
   ⚠️  unknown object
 - *2* ???*3*["ownerDocument"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 852 -> 853 conditional = (null == ???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 860 free var = FreeVar(Array)
 
 0 -> 862 conditional = (???*0* | {} | null | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*[(0 | undefined | ???*3* | ???*4*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* ???*5*["hasOwnProperty"](`$${a[c]["value"]}`)
@@ -5425,12 +5425,12 @@ ${La}${a}`("SuspenseList")
 
 862 -> 870 member call = (???*0* | {} | null | ???*1*)["hasOwnProperty"](`$${???*6*}`)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*[(0 | undefined | ???*3* | ???*4*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* ???*5*["hasOwnProperty"](`$${a[c]["value"]}`)
@@ -5444,9 +5444,9 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* updated with update expression
   ⚠️  This value might have side effects
 - *11* c
@@ -5454,7 +5454,7 @@ ${La}${a}`("SuspenseList")
 
 862 -> 877 call = (...) => (a | "" | undefined)((???*0* | 0 | ???*1* | ???*2* | "" | undefined))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 - *2* c
@@ -5468,14 +5468,14 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* ???*5*["hasOwnProperty"](`$${???*6*}`)
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["value"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -5502,7 +5502,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *15* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* updated with update expression
   ⚠️  This value might have side effects
 - *17* c
@@ -5516,7 +5516,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["dangerouslySetInnerHTML"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 892 -> 893 free var = FreeVar(Error)
 
@@ -5538,13 +5538,13 @@ ${La}${a}`("SuspenseList")
 )
 - *0* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["initialValue"]
   ⚠️  unknown object
 - *3* ???*4*["_wrapperState"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 899 unreachable = ???*0*
 - *0* unreachable
@@ -5554,9 +5554,9 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* c
   ⚠️  circular variable reference
 
@@ -5564,15 +5564,15 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* c
   ⚠️  circular variable reference
 
 904 -> 905 conditional = (null != (???*0* | ???*1* | ???*3* | ""))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["defaultValue"]
   ⚠️  unknown object
 - *2* b
@@ -5605,9 +5605,9 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["value"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* c
   ⚠️  circular variable reference
 
@@ -5641,9 +5641,9 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* c
   ⚠️  circular variable reference
 
@@ -5651,13 +5651,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 921 call = (...) => (a | "" | undefined)(???*0*)
 - *0* ???*1*["defaultValue"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 932 unreachable = ???*0*
 - *0* unreachable
@@ -5673,9 +5673,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 935 conditional = ((null == ???*0*) | ("http://www.w3.org/1999/xhtml" === ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 935 -> 936 call = (...) => (
   | "http://www.w3.org/2000/svg"
@@ -5684,13 +5684,13 @@ ${La}${a}`("SuspenseList")
   | undefined
 )(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 935 -> 937 conditional = (("http://www.w3.org/2000/svg" === ???*0*) | ("foreignObject" === ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 938 unreachable = ???*0*
 - *0* unreachable
@@ -5727,13 +5727,13 @@ ${La}${a}`("SuspenseList")
 
 946 -> 947 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 946 -> 948 unreachable = ???*0*
 - *0* unreachable
@@ -5747,7 +5747,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["namespaceURI"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
@@ -5760,7 +5760,7 @@ ${La}${a}`("SuspenseList")
 
 951 -> 959 member call = (???*0* | ???*1* | ???*3*)["valueOf"]()
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["firstChild"]
   ⚠️  unknown object
 - *2* mb
@@ -5779,7 +5779,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["valueOf"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["valueOf"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -5795,19 +5795,19 @@ ${La}${a}`("SuspenseList")
 
 951 -> 965 member call = ???*0*["removeChild"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["firstChild"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 951 -> 969 member call = ???*0*["appendChild"]((???*1* | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["firstChild"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["firstChild"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -5823,27 +5823,27 @@ ${La}${a}`("SuspenseList")
 
 0 -> 970 conditional = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 970 -> 974 conditional = (???*0* | undefined | ((???*2* | undefined) === ???*4*) | (3 === (???*6* | undefined["nodeType"])))
 - *0* ???*1*["firstChild"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["firstChild"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["lastChild"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["nodeType"]
   ⚠️  unknown object
 - *7* ???*8*["firstChild"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 974 -> 976 unreachable = ???*0*
 - *0* unreachable
@@ -5959,35 +5959,35 @@ ${La}${a}`("SuspenseList")
 
 984 -> 987 member call = ???*0*["charAt"](0)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 984 -> 988 member call = ???*0*["toUpperCase"]()
 - *0* ???*1*["charAt"](0)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 984 -> 990 member call = ???*0*["substring"](1)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 993 typeof = typeof(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 994 conditional = ((null == ???*0*) | ("boolean" === ???*1*) | ("" === ???*3*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* typeof(???*2*)
   ⚠️  nested operation
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 994 -> 995 typeof = typeof(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 994 -> 997 member call = {
     "animationIterationCount": true,
@@ -6035,32 +6035,32 @@ ${La}${a}`("SuspenseList")
     "strokeWidth": true
 }["hasOwnProperty"](???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 994 -> 999 conditional = (???*0* | ("number" !== ???*1*) | (0 === ???*3*) | ???*4* | true | ???*7*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* typeof(???*2*)
   ⚠️  nested operation
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (undefined | ???*5*)(???*6*)
   ⚠️  non-function callee
 - *5* unknown mutation
   ⚠️  This value might have side effects
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* {}[???*8*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 999 -> 1001 member call = ???*0*["trim"]()
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1002 unreachable = ???*0*
 - *0* unreachable
@@ -6068,14 +6068,14 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1005 member call = ???*0*["hasOwnProperty"]((???*1* | "cssFloat"))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* for-in variable currently not analyzed
 
 0 -> 1006 conditional = ???*0*
 - *0* ???*1*["hasOwnProperty"](c)
   ⚠️  unknown callee object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1006 -> 1008 member call = (???*0* | "cssFloat")["indexOf"]("--")
 - *0* for-in variable currently not analyzed
@@ -6085,7 +6085,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*[c]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["indexOf"]("--")
   ⚠️  unknown callee object
 - *4* for-in variable currently not analyzed
@@ -6101,7 +6101,7 @@ ${La}${a}`("SuspenseList")
 
 1011 -> 1013 member call = (???*0* | ???*1*)["setProperty"]((???*3* | "cssFloat"), ((???*4* ? "" : ???*7*) | undefined))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["style"]
   ⚠️  unknown object
 - *2* a
@@ -6112,7 +6112,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*[c]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ((???*8* | undefined | ???*12* | ???*15*) ? ???*16* : ???*20*)
   ⚠️  nested operation
 - *8* (0 === (???*9* | ???*11*))
@@ -6136,13 +6136,13 @@ ${La}${a}`("SuspenseList")
 - *18* ???*19*[c]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* `${???*21*}px`
   ⚠️  nested operation
 - *21* ???*22*[c]
   ⚠️  unknown object
 - *22* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1015 call = Object.assign*0*(
     {"menuitem": true},
@@ -6168,24 +6168,24 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1016 conditional = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1016 -> 1020 conditional = (true | ???*0* | (null != ???*2*))
 - *0* {}[???*1*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["children"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1020 -> 1021 free var = FreeVar(Error)
 
 1020 -> 1022 call = (...) => `Minified React error #${a}; visit ${b} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`(137, ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1020 -> 1023 call = ???*0*(
     `Minified React error #${137}; visit ${???*1*} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`
@@ -6200,13 +6200,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["dangerouslySetInnerHTML"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1025 -> 1027 conditional = (null != ???*0*)
 - *0* ???*1*["children"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1027 -> 1028 free var = FreeVar(Error)
 
@@ -6225,7 +6225,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["dangerouslySetInnerHTML"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1025 -> 1034 conditional = (("object" !== ???*0*) | !(???*3*))
 - *0* typeof(???*1*)
@@ -6233,7 +6233,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["dangerouslySetInnerHTML"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported expression
   ⚠️  This value might have side effects
 
@@ -6254,19 +6254,19 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["style"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1016 -> 1041 conditional = ((null != ???*0*) | ("object" !== ???*2*))
 - *0* ???*1*["style"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* typeof(???*3*)
   ⚠️  nested operation
 - *3* ???*4*["style"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1041 -> 1042 free var = FreeVar(Error)
 
@@ -6283,7 +6283,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1046 member call = ???*0*["indexOf"]("-")
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1047 conditional = (???*0* === ???*1*)
 - *0* unsupported expression
@@ -6291,13 +6291,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["indexOf"]("-")
   ⚠️  unknown callee object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1047 -> 1048 typeof = typeof(???*0*)
 - *0* ???*1*["is"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1047 -> 1050 unreachable = ???*0*
 - *0* unreachable
@@ -6317,7 +6317,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -6334,7 +6334,7 @@ ${La}${a}`("SuspenseList")
  || ((5 !== a["tag"]) && (6 !== a["tag"]) && (13 !== a["tag"]) && (3 !== a["tag"]))
 ) ? null : a)((???*0* | (???*1* ? null : (???*5* | ???*6*))))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* !((???*2* | ???*3*))
   ⚠️  nested operation
 - *2* a
@@ -6354,7 +6354,7 @@ ${La}${a}`("SuspenseList")
 - *0* !((???*1* | ???*2* | ???*10*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? null : (???*7* | ???*8*))
   ⚠️  nested operation
 - *3* !((???*4* | ???*5*))
@@ -6376,7 +6376,7 @@ ${La}${a}`("SuspenseList")
 - *11* a
   ⚠️  circular variable reference
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* (???*14* ? null : (???*18* | ???*19*))
   ⚠️  nested operation
 - *14* !((???*15* | ???*16*))
@@ -6423,7 +6423,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* !((???*3* | ???*4*))
   ⚠️  nested operation
 - *3* a
@@ -6452,7 +6452,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* !((???*3* | ???*4*))
   ⚠️  nested operation
 - *3* a
@@ -6470,7 +6470,7 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*["type"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* !((???*12* | ???*13*))
   ⚠️  nested operation
 - *12* a
@@ -6488,7 +6488,7 @@ ${La}${a}`("SuspenseList")
 - *18* ???*19*["stateNode"]
   ⚠️  unknown object
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* !((???*21* | ???*22*))
   ⚠️  nested operation
 - *21* a
@@ -6506,31 +6506,31 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1074 conditional = (null | ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1074 -> 1075 conditional = (null | [???*0*])
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1075 -> 1077 member call = (null | [???*0*])["push"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1078 conditional = (null | ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1078 -> 1079 call = (...) => undefined((null | ???*0* | undefined | 0 | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
 1078 -> 1080 conditional = (null | [???*0*] | undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1080 -> 1083 call = (...) => undefined(
     (
@@ -6543,31 +6543,31 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 - *2* [???*3*][null]
   ⚠️  non-num constant property on array
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* [][???*6*]
   ⚠️  unknown array prototype methods or values
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unknown mutation
   ⚠️  This value might have side effects
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* updated with update expression
   ⚠️  This value might have side effects
 
 0 -> 1084 call = ???*0*(???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1085 unreachable = ???*0*
 - *0* unreachable
@@ -6577,11 +6577,11 @@ ${La}${a}`("SuspenseList")
 
 1086 -> 1087 call = ???*0*(???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1086 -> 1088 unreachable = ???*0*
 - *0* unreachable
@@ -6589,11 +6589,11 @@ ${La}${a}`("SuspenseList")
 
 1086 -> 1089 call = ((...) => a(b) | (...) => (a(b) | undefined))(???*0*, ???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1086 -> 1090 unreachable = ???*0*
 - *0* unreachable
@@ -6601,9 +6601,9 @@ ${La}${a}`("SuspenseList")
 
 1086 -> 1091 conditional = ((null !== (null | ???*0*)) | (null !== (null | [???*1*])))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1091 -> 1092 call = ((...) => undefined | (...) => (a() | undefined))()
 
@@ -6613,9 +6613,9 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1095 -> 1096 unreachable = ???*0*
 - *0* unreachable
@@ -6634,7 +6634,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*[Pf]
   ⚠️  unknown object
 - *3* c
@@ -6646,17 +6646,17 @@ ${La}${a}`("SuspenseList")
 - *6* d
   ⚠️  circular variable reference
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["disabled"]
   ⚠️  unknown object
 - *9* d
   ⚠️  circular variable reference
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ("button" === (???*12* | ???*13* | ???*15* | false))
   ⚠️  nested operation
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["type"]
   ⚠️  unknown object
 - *14* a
@@ -6666,7 +6666,7 @@ ${La}${a}`("SuspenseList")
 - *16* d
   ⚠️  circular variable reference
 - *17* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1095 -> 1098 conditional = (null === (???*0* | false["stateNode"][???*7*] | null | ???*12*))
 - *0* ???*1*[`__reactProps$${???*3*}`]
@@ -6674,7 +6674,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["slice"](2)
   ⚠️  unknown callee object
 - *4* ???*5*(36)
@@ -6710,7 +6710,7 @@ ${La}${a}`("SuspenseList")
 
 1098 -> 1104 conditional = (???*0* | ???*1* | !((???*3* | null | ???*6*)) | false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* a
@@ -6743,7 +6743,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*[Pf]
   ⚠️  unknown object
 - *3* c
@@ -6755,17 +6755,17 @@ ${La}${a}`("SuspenseList")
 - *6* d
   ⚠️  circular variable reference
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["disabled"]
   ⚠️  unknown object
 - *9* d
   ⚠️  circular variable reference
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ("button" === (???*12* | ???*13* | ???*15* | false))
   ⚠️  nested operation
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["type"]
   ⚠️  unknown object
 - *14* a
@@ -6775,7 +6775,7 @@ ${La}${a}`("SuspenseList")
 - *16* d
   ⚠️  circular variable reference
 - *17* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1104 -> 1107 conditional = (
   | ???*0*
@@ -6789,7 +6789,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*[Pf]
   ⚠️  unknown object
 - *3* c
@@ -6801,17 +6801,17 @@ ${La}${a}`("SuspenseList")
 - *6* d
   ⚠️  circular variable reference
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["disabled"]
   ⚠️  unknown object
 - *9* d
   ⚠️  circular variable reference
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ("button" === (???*12* | ???*13* | ???*15* | false))
   ⚠️  nested operation
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["type"]
   ⚠️  unknown object
 - *14* a
@@ -6821,15 +6821,15 @@ ${La}${a}`("SuspenseList")
 - *16* d
   ⚠️  circular variable reference
 - *17* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* typeof((???*19* | false["stateNode"] | null[???*21*]))
   ⚠️  nested operation
 - *19* ???*20*["stateNode"]
   ⚠️  unknown object
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1107 -> 1108 free var = FreeVar(Error)
 
@@ -6844,7 +6844,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*[Pf]
   ⚠️  unknown object
 - *3* c
@@ -6856,17 +6856,17 @@ ${La}${a}`("SuspenseList")
 - *6* d
   ⚠️  circular variable reference
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["disabled"]
   ⚠️  unknown object
 - *9* d
   ⚠️  circular variable reference
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ("button" === (???*12* | ???*13* | ???*15* | false))
   ⚠️  nested operation
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["type"]
   ⚠️  unknown object
 - *14* a
@@ -6876,7 +6876,7 @@ ${La}${a}`("SuspenseList")
 - *16* d
   ⚠️  circular variable reference
 - *17* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1107 -> 1110 call = (...) => `Minified React error #${a}; visit ${b} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`(
     231,
@@ -6884,13 +6884,13 @@ ${La}${a}`("SuspenseList")
     typeof((???*1* | false["stateNode"] | null[???*3*]))
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1107 -> 1111 call = ???*0*(
     `Minified React error #${231}; visit ${???*1*} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`
@@ -6953,9 +6953,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1130 member call = ???*0*["apply"](???*1*, ???*2*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["call"](FreeVar(arguments), 3)
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
@@ -7012,13 +7012,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1152 conditional = (3 === ???*0*)
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1153 unreachable = ???*0*
 - *0* unreachable
@@ -7028,13 +7028,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1155 -> 1159 conditional = (null !== (???*0* | undefined))
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1159 -> 1161 unreachable = ???*0*
 - *0* unreachable
@@ -7046,7 +7046,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1163 call = (...) => ((3 === b["tag"]) ? c : null)(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1164 conditional = (???*0* !== ???*8*)
 - *0* (???*1* ? (???*4* | ???*5* | ???*6*) : null)
@@ -7056,9 +7056,9 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["tag"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* a
   ⚠️  circular variable reference
 - *6* ???*7*["return"]
@@ -7066,7 +7066,7 @@ ${La}${a}`("SuspenseList")
 - *7* b
   ⚠️  circular variable reference
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1164 -> 1165 free var = FreeVar(Error)
 
@@ -7085,7 +7085,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? (???*6* | ???*7* | ???*8*) : null)
   ⚠️  nested operation
 - *3* (3 === ???*4*)
@@ -7093,9 +7093,9 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["tag"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* a
   ⚠️  circular variable reference
 - *8* ???*9*["return"]
@@ -7105,13 +7105,13 @@ ${La}${a}`("SuspenseList")
 
 1169 -> 1170 call = (...) => ((3 === b["tag"]) ? c : null)(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1169 -> 1171 conditional = (null === (???*0* | ???*2*))
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? (???*6* | ???*7* | ???*8*) : null)
   ⚠️  nested operation
 - *3* (3 === ???*4*)
@@ -7119,9 +7119,9 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["tag"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* a
   ⚠️  circular variable reference
 - *8* ???*9*["return"]
@@ -7146,7 +7146,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? (???*6* | ???*7* | ???*8*) : null)
   ⚠️  nested operation
 - *3* (3 === ???*4*)
@@ -7154,9 +7154,9 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["tag"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* a
   ⚠️  circular variable reference
 - *8* ???*9*["return"]
@@ -7164,7 +7164,7 @@ ${La}${a}`("SuspenseList")
 - *9* b
   ⚠️  circular variable reference
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1169 -> 1176 unreachable = ???*0*
 - *0* unreachable
@@ -7176,7 +7176,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1169 -> 1183 conditional = ((???*0* | undefined["return"]["child"] | undefined["child"]) === (???*3* | undefined["alternate"]["child"] | undefined["child"] | undefined["child"]["child"]))
 - *0* ???*1*["child"]
@@ -7184,7 +7184,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["child"]
   ⚠️  unknown object
 - *4* ???*5*["alternate"]
@@ -7192,7 +7192,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["return"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1183 -> 1185 conditional = ((???*0* | undefined["alternate"] | undefined | undefined["child"]) === (
   | ???*3*
@@ -7208,13 +7208,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["alternate"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* (???*7* ? (???*10* | ???*11* | ???*12*) : null)
   ⚠️  nested operation
 - *7* (3 === ???*8*)
@@ -7222,9 +7222,9 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["tag"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* a
   ⚠️  circular variable reference
 - *12* ???*13*["return"]
@@ -7243,15 +7243,15 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["return"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (3 === ???*3*)
   ⚠️  nested operation
 - *3* ???*4*["tag"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* a
   ⚠️  circular variable reference
 - *7* ???*8*["return"]
@@ -7277,11 +7277,11 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (???*6* ? (???*9* | ???*10* | ???*11*) : null)
   ⚠️  nested operation
 - *6* (3 === ???*7*)
@@ -7289,9 +7289,9 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["tag"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* a
   ⚠️  circular variable reference
 - *11* ???*12*["return"]
@@ -7310,15 +7310,15 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["return"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (3 === ???*3*)
   ⚠️  nested operation
 - *3* ???*4*["tag"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* a
   ⚠️  circular variable reference
 - *7* ???*8*["return"]
@@ -7360,13 +7360,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["return"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["return"]
   ⚠️  unknown object
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1197 -> 1200 conditional = !((false | undefined | true))
 
@@ -7403,11 +7403,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (???*5* ? (???*8* | ???*9* | ???*10*) : null)
   ⚠️  nested operation
 - *5* (3 === ???*6*)
@@ -7415,9 +7415,9 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["tag"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* a
   ⚠️  circular variable reference
 - *10* ???*11*["return"]
@@ -7448,7 +7448,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1213 -> 1214 free var = FreeVar(Error)
 
@@ -7483,13 +7483,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["alternate"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* (???*7* ? (???*10* | ???*11* | ???*12*) : null)
   ⚠️  nested operation
 - *7* (3 === ???*8*)
@@ -7497,9 +7497,9 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["tag"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* a
   ⚠️  circular variable reference
 - *12* ???*13*["return"]
@@ -7518,7 +7518,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ((???*3* | ???*5*) !== ???*12*)
   ⚠️  nested operation
 - *3* ???*4*["alternate"]
@@ -7611,7 +7611,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1222 conditional = (null !== (???*0* | ???*1* | ???*13*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? null : ???*12*)
   ⚠️  nested operation
 - *2* ((???*3* | ???*5*) !== ???*11*)
@@ -7644,7 +7644,7 @@ ${La}${a}`("SuspenseList")
     (???*0* | (???*1* ? null : ???*12*) | ???*13* | (???*14* ? ???*28* : (???*29* | ???*31*)))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ((???*2* | ???*4*) !== ???*11*)
   ⚠️  nested operation
 - *2* ???*3*["alternate"]
@@ -7743,11 +7743,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["tag"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1227 -> 1228 unreachable = ???*0*
 - *0* unreachable
@@ -7755,7 +7755,7 @@ ${La}${a}`("SuspenseList")
 
 1227 -> 1230 call = (...) => (a | b | null)((???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* a
@@ -7763,7 +7763,7 @@ ${La}${a}`("SuspenseList")
 
 1227 -> 1231 conditional = (null !== (???*0* | ???*1* | ???*3* | null | undefined))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* a
@@ -7807,7 +7807,7 @@ ${La}${a}`("SuspenseList")
 - *1* node limit reached
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported expression
   ⚠️  This value might have side effects
 
@@ -7829,7 +7829,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1262 conditional = (0 === (???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -7841,7 +7841,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -7905,7 +7905,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["pendingLanes"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
@@ -7933,7 +7933,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["pingedLanes"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 - *4* unsupported expression
@@ -7955,7 +7955,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["pingedLanes"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 - *4* unsupported expression
@@ -7983,7 +7983,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["pingedLanes"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -8014,19 +8014,19 @@ ${La}${a}`("SuspenseList")
   | ???*13*
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["entangledLanes"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["entangledLanes"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported assign operation
   ⚠️  This value might have side effects
 - *8* unsupported expression
@@ -8034,7 +8034,7 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*["pingedLanes"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* unsupported assign operation
   ⚠️  This value might have side effects
 - *12* unsupported expression
@@ -8053,11 +8053,11 @@ ${La}${a}`("SuspenseList")
 
 1292 -> 1295 conditional = (0 !== (???*0* | ???*1* | ???*3*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["entangledLanes"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -8079,11 +8079,11 @@ ${La}${a}`("SuspenseList")
 - *5* unsupported expression
   ⚠️  This value might have side effects
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["entangledLanes"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -8131,7 +8131,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["pendingLanes"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -8143,7 +8143,7 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["expirationTimes"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1311 -> 1312 conditional = ((0 === ???*0*) | (0 !== ???*1*))
 - *0* unsupported expression
@@ -8157,11 +8157,11 @@ ${La}${a}`("SuspenseList")
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1317 conditional = (0 !== (???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
@@ -8175,7 +8175,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1321 member call = []["push"](???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1322 unreachable = ???*0*
 - *0* unreachable
@@ -8199,7 +8199,7 @@ ${La}${a}`("SuspenseList")
 - *5* unsupported expression
   ⚠️  This value might have side effects
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
@@ -8243,7 +8243,7 @@ ${La}${a}`("SuspenseList")
 - *5* unsupported expression
   ⚠️  This value might have side effects
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -8278,7 +8278,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["pointerId"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1361 member call = new ???*0*()["delete"](???*1*)
 - *0* FreeVar(Map)
@@ -8287,7 +8287,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["pointerId"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1363 conditional = (
   | (null === (
@@ -8303,9 +8303,9 @@ ${La}${a}`("SuspenseList")
   | ((???*16* | ???*18* | ???*19*) !== ???*20*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? null : (???*7* | ???*8*))
   ⚠️  nested operation
 - *3* !((???*4* | ???*5*))
@@ -8327,23 +8327,23 @@ ${La}${a}`("SuspenseList")
 - *11* a
   ⚠️  circular variable reference
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["nativeEvent"]
   ⚠️  unknown object
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* unknown mutation
   ⚠️  This value might have side effects
 - *20* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1363 -> 1364 call = (...) => ((
  || !(a)
@@ -8352,7 +8352,7 @@ ${La}${a}`("SuspenseList")
     (???*0* | (???*1* ? null : (???*5* | ???*6*)) | ???*8* | [???*10*] | ???*11*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* !((???*2* | ???*3*))
   ⚠️  nested operation
 - *2* b
@@ -8370,9 +8370,9 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["targetContainers"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* unknown mutation
   ⚠️  This value might have side effects
 
@@ -8382,7 +8382,7 @@ ${La}${a}`("SuspenseList")
 - *0* Fc
   ⚠️  pattern without value
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* !((???*3* | ???*4*))
   ⚠️  nested operation
 - *3* b
@@ -8400,9 +8400,9 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*["targetContainers"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* unknown mutation
   ⚠️  This value might have side effects
 
@@ -8412,7 +8412,7 @@ ${La}${a}`("SuspenseList")
 
 1363 -> 1370 member call = (???*0* | (???*1* ? null : (???*5* | ???*6*)) | ???*8* | [???*10*] | ???*11*)["indexOf"](???*12*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* !((???*2* | ???*3*))
   ⚠️  nested operation
 - *2* b
@@ -8430,17 +8430,17 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["targetContainers"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* unknown mutation
   ⚠️  This value might have side effects
 - *12* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1363 -> 1372 member call = (???*0* | (???*1* ? null : (???*5* | ???*6*)) | ???*8* | [???*10*] | ???*11*)["push"](???*12*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* !((???*2* | ???*3*))
   ⚠️  nested operation
 - *2* b
@@ -8458,13 +8458,13 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["targetContainers"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* unknown mutation
   ⚠️  This value might have side effects
 - *12* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1363 -> 1373 unreachable = ???*0*
 - *0* unreachable
@@ -8498,7 +8498,7 @@ ${La}${a}`("SuspenseList")
 - *2* Lc
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* !((???*5* | ???*6*))
   ⚠️  nested operation
 - *5* b
@@ -8518,23 +8518,23 @@ ${La}${a}`("SuspenseList")
 - *12* a
   ⚠️  circular variable reference
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1375 unreachable = ???*0*
 - *0* unreachable
@@ -8568,7 +8568,7 @@ ${La}${a}`("SuspenseList")
 - *2* Mc
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* !((???*5* | ???*6*))
   ⚠️  nested operation
 - *5* b
@@ -8588,23 +8588,23 @@ ${La}${a}`("SuspenseList")
 - *12* a
   ⚠️  circular variable reference
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1377 unreachable = ???*0*
 - *0* unreachable
@@ -8638,7 +8638,7 @@ ${La}${a}`("SuspenseList")
 - *2* Nc
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* !((???*5* | ???*6*))
   ⚠️  nested operation
 - *5* b
@@ -8658,23 +8658,23 @@ ${La}${a}`("SuspenseList")
 - *12* a
   ⚠️  circular variable reference
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1379 unreachable = ???*0*
 - *0* unreachable
@@ -8687,7 +8687,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["pointerId"]
   ⚠️  unknown object
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1384 call = (...) => (???*0* | a)((???*1* | null), ???*7*, ???*8*, ???*9*, ???*10*, ???*11*)
 - *0* a
@@ -8705,17 +8705,17 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["pointerId"]
   ⚠️  unknown object
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1385 member call = new ???*0*()["set"](
     ???*1*,
@@ -8738,7 +8738,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["pointerId"]
   ⚠️  unknown object
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* a
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -8754,9 +8754,9 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["pointerId"]
   ⚠️  unknown object
 - *9* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* !((???*12* | ???*13*))
   ⚠️  nested operation
 - *12* b
@@ -8776,13 +8776,13 @@ ${La}${a}`("SuspenseList")
 - *19* a
   ⚠️  circular variable reference
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1386 unreachable = ???*0*
 - *0* unreachable
@@ -8795,7 +8795,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["pointerId"]
   ⚠️  unknown object
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1391 call = (...) => (???*0* | a)((???*1* | null), ???*7*, ???*8*, ???*9*, ???*10*, ???*11*)
 - *0* a
@@ -8813,17 +8813,17 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["pointerId"]
   ⚠️  unknown object
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1392 member call = new ???*0*()["set"](
     ???*1*,
@@ -8846,7 +8846,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["pointerId"]
   ⚠️  unknown object
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* a
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
@@ -8862,9 +8862,9 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["pointerId"]
   ⚠️  unknown object
 - *9* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* !((???*12* | ???*13*))
   ⚠️  nested operation
 - *12* b
@@ -8884,13 +8884,13 @@ ${La}${a}`("SuspenseList")
 - *19* a
   ⚠️  circular variable reference
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1393 unreachable = ???*0*
 - *0* unreachable
@@ -8904,7 +8904,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["target"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1397 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
@@ -8932,7 +8932,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["priority"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1405 -> 1406 call = (???*0* | (...) => undefined)(???*1*)
 - *0* Gc
@@ -8977,7 +8977,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["blockedOn"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1421 -> 1422 unreachable = ???*0*
 - *0* unreachable
@@ -8991,11 +8991,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["domEventName"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["eventSystemFlags"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*[0]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9004,7 +9004,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["nativeEvent"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1421 -> 1430 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
@@ -9060,13 +9060,13 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1447 member call = ???*0*["delete"](???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1448 call = (...) => (!(1) | ???*0* | !(0))(
     (
@@ -9091,7 +9091,7 @@ ${La}${a}`("SuspenseList")
 - *2* Lc
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* !((???*5* | ???*6*))
   ⚠️  nested operation
 - *5* b
@@ -9111,13 +9111,13 @@ ${La}${a}`("SuspenseList")
 - *12* a
   ⚠️  circular variable reference
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1449 call = (...) => (!(1) | ???*0* | !(0))(
     (
@@ -9142,7 +9142,7 @@ ${La}${a}`("SuspenseList")
 - *2* Mc
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* !((???*5* | ???*6*))
   ⚠️  nested operation
 - *5* b
@@ -9162,13 +9162,13 @@ ${La}${a}`("SuspenseList")
 - *12* a
   ⚠️  circular variable reference
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1450 call = (...) => (!(1) | ???*0* | !(0))(
     (
@@ -9193,7 +9193,7 @@ ${La}${a}`("SuspenseList")
 - *2* Nc
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* !((???*5* | ???*6*))
   ⚠️  nested operation
 - *5* b
@@ -9213,13 +9213,13 @@ ${La}${a}`("SuspenseList")
 - *12* a
   ⚠️  circular variable reference
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1452 member call = new ???*0*()["forEach"]((...) => undefined)
 - *0* FreeVar(Map)
@@ -9237,7 +9237,7 @@ ${La}${a}`("SuspenseList")
 - *0* [][0]
   ⚠️  invalid index
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1467 call = (...) => undefined(
     (
@@ -9260,7 +9260,7 @@ ${La}${a}`("SuspenseList")
 - *1* Lc
   ⚠️  circular variable reference
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* !((???*4* | ???*5*))
   ⚠️  nested operation
 - *4* b
@@ -9280,15 +9280,15 @@ ${La}${a}`("SuspenseList")
 - *11* a
   ⚠️  circular variable reference
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1468 call = (...) => undefined(
     (
@@ -9311,7 +9311,7 @@ ${La}${a}`("SuspenseList")
 - *1* Mc
   ⚠️  circular variable reference
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* !((???*4* | ???*5*))
   ⚠️  nested operation
 - *4* b
@@ -9331,15 +9331,15 @@ ${La}${a}`("SuspenseList")
 - *11* a
   ⚠️  circular variable reference
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1469 call = (...) => undefined(
     (
@@ -9362,7 +9362,7 @@ ${La}${a}`("SuspenseList")
 - *1* Nc
   ⚠️  circular variable reference
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* !((???*4* | ???*5*))
   ⚠️  nested operation
 - *4* b
@@ -9382,15 +9382,15 @@ ${La}${a}`("SuspenseList")
 - *11* a
   ⚠️  circular variable reference
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1471 member call = new ???*0*()["forEach"]((...) => ad(b, a))
 - *0* FreeVar(Map)
@@ -9412,9 +9412,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1485 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1486 unreachable = ???*0*
 - *0* unreachable
@@ -9422,23 +9422,23 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1490 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1494 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1496 conditional = (true | false | !(???*0*))
 - *0* !((null | ???*1*))
@@ -9452,13 +9452,13 @@ ${La}${a}`("SuspenseList")
   | null
 )(???*0*, ???*1*, ???*2*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1496 -> 1498 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
@@ -9486,19 +9486,19 @@ ${La}${a}`("SuspenseList")
     ???*69*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (3 === (???*5* | ???*7*))
   ⚠️  nested operation
 - *5* ???*6*["nodeType"]
   ⚠️  unknown object
 - *6* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9508,7 +9508,7 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*["parentNode"]
   ⚠️  unknown object
 - *10* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9516,7 +9516,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *13* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["target"]
   ⚠️  unknown object
 - *15* a
@@ -9637,13 +9637,13 @@ ${La}${a}`("SuspenseList")
 - *68* b
   ⚠️  circular variable reference
 - *69* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1498 -> 1500 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1498 -> 1501 call = (...) => (???*0* | !(0) | !(1))(???*1*, ???*2*, ???*3*, ???*4*, ???*5*)
 - *0* !(0)
@@ -9652,13 +9652,13 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1498 -> 1502 conditional = (???*0* | true | false)
 - *0* !(0)
@@ -9667,17 +9667,17 @@ ${La}${a}`("SuspenseList")
 
 1502 -> 1504 member call = ???*0*["stopPropagation"]()
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1502 -> 1505 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1502 -> 1507 member call = "mousedown mouseup touchcancel touchend touchstart auxclick dblclick pointercancel pointerdown pointerup dragend dragstart drop compositionend compositionstart keydown keypress keyup input textInput copy cut paste click change contextmenu reset submit"["split"](" ")["indexOf"](???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1502 -> 1508 call = (...) => ((
  || !(a)
@@ -9698,13 +9698,13 @@ ${La}${a}`("SuspenseList")
   | null
 )(???*0*, ???*1*, ???*2*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1502 -> 1511 call = (...) => undefined(
     ???*0*,
@@ -9728,19 +9728,19 @@ ${La}${a}`("SuspenseList")
     ???*69*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (3 === (???*5* | ???*7*))
   ⚠️  nested operation
 - *5* ???*6*["nodeType"]
   ⚠️  unknown object
 - *6* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9750,7 +9750,7 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*["parentNode"]
   ⚠️  unknown object
 - *10* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9758,7 +9758,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *13* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["target"]
   ⚠️  unknown object
 - *15* a
@@ -9879,25 +9879,25 @@ ${La}${a}`("SuspenseList")
 - *68* b
   ⚠️  circular variable reference
 - *69* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1502 -> 1513 member call = ???*0*["stopPropagation"]()
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1502 -> 1514 call = (...) => undefined(???*0*, ???*1*, ???*2*, null, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1515 call = (...) => ((3 === a["nodeType"]) ? a["parentNode"] : a)(???*0*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1516 call = (...) => (b | c | null)(
     (
@@ -9917,13 +9917,13 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === (???*2* | ???*4*))
   ⚠️  nested operation
 - *2* ???*3*["nodeType"]
   ⚠️  unknown object
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9933,7 +9933,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["parentNode"]
   ⚠️  unknown object
 - *7* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9941,7 +9941,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *10* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["target"]
   ⚠️  unknown object
 - *12* a
@@ -10075,7 +10075,7 @@ ${La}${a}`("SuspenseList")
   | undefined["dehydrated"]
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? (???*7* | ???*9*) : (???*11* | ???*12* | ???*14*))
   ⚠️  nested operation
 - *2* (3 === (???*3* | ???*5*))
@@ -10083,7 +10083,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["nodeType"]
   ⚠️  unknown object
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -10093,7 +10093,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["parentNode"]
   ⚠️  unknown object
 - *8* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -10101,7 +10101,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *11* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["target"]
   ⚠️  unknown object
 - *13* a
@@ -10190,13 +10190,13 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === (???*2* | ???*4*))
   ⚠️  nested operation
 - *2* ???*3*["nodeType"]
   ⚠️  unknown object
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -10206,7 +10206,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["parentNode"]
   ⚠️  unknown object
 - *7* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -10214,7 +10214,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *10* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["target"]
   ⚠️  unknown object
 - *12* a
@@ -10356,7 +10356,7 @@ ${La}${a}`("SuspenseList")
   | undefined["dehydrated"]
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? (???*7* | ???*9*) : (???*11* | ???*12* | ???*14*))
   ⚠️  nested operation
 - *2* (3 === (???*3* | ???*5*))
@@ -10364,7 +10364,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["nodeType"]
   ⚠️  unknown object
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -10374,7 +10374,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["parentNode"]
   ⚠️  unknown object
 - *8* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -10382,7 +10382,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *11* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["target"]
   ⚠️  unknown object
 - *13* a
@@ -10571,7 +10571,7 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["nodeType"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -10581,7 +10581,7 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["parentNode"]
   ⚠️  unknown object
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -10589,7 +10589,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["target"]
   ⚠️  unknown object
 - *14* a
@@ -10606,7 +10606,7 @@ ${La}${a}`("SuspenseList")
 - *19* ???*20*["nodeType"]
   ⚠️  unknown object
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -10616,7 +10616,7 @@ ${La}${a}`("SuspenseList")
 - *23* ???*24*["parentNode"]
   ⚠️  unknown object
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -10624,7 +10624,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *27* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* ???*29*["target"]
   ⚠️  unknown object
 - *29* a
@@ -10649,7 +10649,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["charCode"]
   ⚠️  unknown object
 - *3* a
@@ -10740,32 +10740,32 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1593 member call = ???*0*["hasOwnProperty"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* for-in variable currently not analyzed
 
 0 -> 1596 conditional = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*[c]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1596 -> 1597 call = (???*0* | ???*1*)(???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*[c]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1601 conditional = (null != ???*0*)
 - *0* ???*1*["defaultPrevented"]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1604 conditional = (???*0* ? ???*3* : ???*5*)
 - *0* (null != ???*1*)
@@ -10773,17 +10773,17 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["defaultPrevented"]
   ⚠️  unknown object
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["defaultPrevented"]
   ⚠️  unknown object
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (false === ???*6*)
   ⚠️  nested operation
 - *6* ???*7*["returnValue"]
   ⚠️  unknown object
 - *7* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1606 unreachable = ???*0*
 - *0* unreachable
@@ -10842,17 +10842,17 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["relatedTarget"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1616 -> 1619 conditional = (???*0* === ???*2*)
 - *0* ???*1*["fromElement"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["srcElement"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1623 unreachable = ???*0*
 - *0* unreachable
@@ -10866,11 +10866,11 @@ ${La}${a}`("SuspenseList")
 - *0* yd
   ⚠️  pattern without value
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["type"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1632 unreachable = ???*0*
 - *0* unreachable
@@ -11153,7 +11153,7 @@ ${La}${a}`("SuspenseList")
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* {}[???*4*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
@@ -11165,7 +11165,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unknown mutation
   ⚠️  This value might have side effects
 
@@ -11184,7 +11184,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["key"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* (13 === (???*4* | ???*5* | 13))
@@ -11224,11 +11224,11 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["key"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["key"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1666 -> 1667 unreachable = ???*0*
 - *0* unreachable
@@ -11238,7 +11238,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1669 -> 1670 call = (...) => ((???*0* || (13 === a)) ? a : 0)(
     (???*1* | ((???*2* | ???*3*) ? (???*7* | ???*8* | 13) : 0))
@@ -11246,7 +11246,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* (13 === (???*4* | ???*5* | 13))
@@ -11266,7 +11266,7 @@ ${La}${a}`("SuspenseList")
 
 1669 -> 1671 conditional = (13 === (???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ((???*2* | ???*3*) ? (???*7* | ???*8* | 13) : 0)
   ⚠️  nested operation
 - *2* unsupported expression
@@ -11295,7 +11295,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* (13 === (???*4* | ???*5* | 13))
@@ -11317,11 +11317,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["type"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1680 unreachable = ???*0*
 - *0* unreachable
@@ -11331,13 +11331,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1682 -> 1683 call = (...) => ((???*0* || (13 === a)) ? a : 0)(???*1*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1684 unreachable = ???*0*
 - *0* unreachable
@@ -11347,11 +11347,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["type"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1689 unreachable = ???*0*
 - *0* unreachable
@@ -11361,23 +11361,23 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1691 -> 1692 call = (...) => ((???*0* || (13 === a)) ? a : 0)(???*1*)
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1691 -> 1695 conditional = (("keydown" === ???*0*) | ("keyup" === ???*2*))
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["type"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1697 unreachable = ???*0*
 - *0* unreachable
@@ -11631,7 +11631,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["keyCode"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1726 unreachable = ???*0*
 - *0* unreachable
@@ -11651,7 +11651,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1732 typeof = typeof((???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["detail"]
   ⚠️  unknown object
 - *2* a
@@ -11661,7 +11661,7 @@ ${La}${a}`("SuspenseList")
 - *0* typeof((???*1* | ???*2*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["detail"]
   ⚠️  unknown object
 - *3* a
@@ -11677,7 +11677,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1737 unreachable = ???*0*
 - *0* unreachable
@@ -11687,7 +11687,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["which"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1739 -> 1740 unreachable = ???*0*
 - *0* unreachable
@@ -11699,11 +11699,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1743 conditional = (((???*0* | ???*1*) === ???*3*) | false | true)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["data"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["fromCharCode"](32)
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
@@ -11725,7 +11725,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*((???*10* | 0 | ???*11*), ???*12*)
   ⚠️  unknown callee
   ⚠️  This value might have side effects
@@ -11754,7 +11754,7 @@ ${La}${a}`("SuspenseList")
 - *14* unsupported expression
   ⚠️  This value might have side effects
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1746 -> 1748 conditional = (
   | ("compositionend" === (???*0* | null | ???*1*))
@@ -11766,7 +11766,7 @@ ${La}${a}`("SuspenseList")
   | undefined
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*((???*9* | 0 | ???*10*), ???*11*)
   ⚠️  unknown callee
   ⚠️  This value might have side effects
@@ -11814,11 +11814,11 @@ ${La}${a}`("SuspenseList")
 - *22* ???*23*["keyCode"]
   ⚠️  unknown object
 - *23* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* ???*25*["keyCode"]
   ⚠️  unknown object
 - *25* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1748 -> 1749 call = (...) => (md | e["slice"](a, (???*0* ? ???*1* : undefined)))()
 - *0* unsupported expression
@@ -11838,17 +11838,17 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["ctrlKey"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["ctrlKey"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1757 -> 1761 conditional = (???*0* | ???*2*)
 - *0* ???*1*["char"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
@@ -11860,7 +11860,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["which"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1765 -> 1767 free var = FreeVar(String)
 
@@ -11871,7 +11871,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["which"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1765 -> 1770 unreachable = ???*0*
 - *0* unreachable
@@ -11911,7 +11911,7 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*["locale"]
   ⚠️  unknown object
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1746 -> 1775 unreachable = ???*0*
 - *0* unreachable
@@ -11925,15 +11925,15 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["nodeName"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1781 conditional = ("input" === (???*0* | ???*1* | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeName"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*()
   ⚠️  nested operation
 - *4* ???*5*["toLowerCase"]
@@ -11941,15 +11941,15 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["nodeName"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1781 -> 1784 conditional = ("textarea" === (???*0* | ???*1* | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeName"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*()
   ⚠️  nested operation
 - *4* ???*5*["toLowerCase"]
@@ -11957,7 +11957,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["nodeName"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1785 unreachable = ???*0*
 - *0* unreachable
@@ -11965,11 +11965,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1786 call = (...) => undefined(???*0*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1787 call = (...) => d((???*0* | []), "onChange")
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1789 call = new (...) => ???*0*(
     "onChange",
@@ -11984,15 +11984,15 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* c
   ⚠️  circular variable reference
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1791 member call = ???*0*["push"](
     {
@@ -12004,25 +12004,25 @@ ${La}${a}`("SuspenseList")
     }
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* c
   ⚠️  circular variable reference
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1792 call = (...) => undefined(???*0*, 0)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1793 call = (...) => (a["stateNode"] | undefined)(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1794 call = (...) => (!(1) | !(0) | ((a !== c) ? ???*0* : !(1)))((???*1* | undefined))
 - *0* !(0)
@@ -12031,7 +12031,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1795 conditional = (false | true | (???*0* ? ???*18* : false))
 - *0* ((???*1* | undefined | "" | ???*3*) !== ???*14*)
@@ -12039,7 +12039,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ((???*4* | ???*6*) ? ???*9* : ???*12*)
   ⚠️  nested operation
 - *4* ???*5*["nodeName"]
@@ -12080,7 +12080,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1797 conditional = ("change" === ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1797 -> 1798 unreachable = ???*0*
 - *0* unreachable
@@ -12155,23 +12155,23 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1815 member call = (null | ???*0*)["detachEvent"]("onpropertychange", (...) => undefined)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1817 call = (...) => (a | undefined)((null | ???*0*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1818 conditional = (("value" === ???*0*) | null | ???*2* | undefined)
 - *0* ???*1*["propertyName"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1818 -> 1819 call = (...) => ((3 === a["nodeType"]) ? a["parentNode"] : a)(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1818 -> 1820 call = (...) => undefined(
     ([] | undefined),
@@ -12180,15 +12180,15 @@ ${La}${a}`("SuspenseList")
     (???*2* ? (???*7* | ???*9*) : (???*11* | ???*12* | ???*14*))
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (3 === (???*3* | ???*5*))
   ⚠️  nested operation
 - *3* ???*4*["nodeType"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -12198,7 +12198,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["parentNode"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -12206,7 +12206,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["target"]
   ⚠️  unknown object
 - *13* a
@@ -12219,27 +12219,27 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1822 conditional = ("focusin" === ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1822 -> 1823 call = (...) => undefined()
 
 1822 -> 1825 member call = (null | ???*0*)["attachEvent"]("onpropertychange", (...) => undefined)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1822 -> 1826 call = (...) => undefined()
 
 0 -> 1827 conditional = (("selectionchange" === ???*0*) | ("keyup" === ???*1*) | ("keydown" === ???*2*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1827 -> 1828 call = (...) => (a | undefined)((null | ???*0*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1827 -> 1829 unreachable = ???*0*
 - *0* unreachable
@@ -12247,11 +12247,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1830 conditional = ("click" === ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1830 -> 1831 call = (...) => (a | undefined)(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1830 -> 1832 unreachable = ???*0*
 - *0* unreachable
@@ -12259,13 +12259,13 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1833 conditional = (("input" === ???*0*) | ("change" === ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1833 -> 1834 call = (...) => (a | undefined)(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1833 -> 1835 unreachable = ???*0*
 - *0* unreachable
@@ -12313,9 +12313,9 @@ ${La}${a}`("SuspenseList")
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1844 conditional = ???*0*
 - *0* ???*1*(???*11*, ???*12*)
@@ -12341,9 +12341,9 @@ ${La}${a}`("SuspenseList")
 - *10* unsupported expression
   ⚠️  This value might have side effects
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1844 -> 1845 unreachable = ???*0*
 - *0* unreachable
@@ -12351,19 +12351,19 @@ ${La}${a}`("SuspenseList")
 
 1844 -> 1846 typeof = typeof(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1844 -> 1847 typeof = typeof(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1844 -> 1848 conditional = (("object" !== ???*0*) | (null === ???*2*))
 - *0* typeof(???*1*)
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1848 -> 1849 unreachable = ???*0*
 - *0* unreachable
@@ -12374,14 +12374,14 @@ ${La}${a}`("SuspenseList")
 1848 -> 1852 member call = Object*0*["keys"](???*1*)
 - *0* Object: The global Object variable
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1848 -> 1854 free var = FreeVar(Object)
 
 1848 -> 1855 member call = Object*0*["keys"](???*1*)
 - *0* Object: The global Object variable
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1848 -> 1858 conditional = (???*0* !== (???*5* | 0["length"]))
 - *0* ???*1*["length"]
@@ -12395,7 +12395,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  This value might have side effects
 - *3* Object: The global Object variable
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["length"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -12407,7 +12407,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  This value might have side effects
 - *8* Object: The global Object variable
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1858 -> 1859 unreachable = ???*0*
 - *0* unreachable
@@ -12422,7 +12422,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  This value might have side effects
 - *2* Object: The global Object variable
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*[d]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -12434,7 +12434,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  This value might have side effects
 - *7* Object: The global Object variable
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1858 -> 1866 call = (???*0* ? ???*4* : (...) => ???*6*)(???*9*, ???*11*)
 - *0* ("function" === ???*1*)
@@ -12458,11 +12458,11 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*[e]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*[e]
   ⚠️  unknown object
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1858 -> 1867 conditional = (!(???*0*) | !(???*4*))
 - *0* ???*1*["call"](b, e)
@@ -12503,11 +12503,11 @@ ${La}${a}`("SuspenseList")
 - *15* ???*16*[e]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*[e]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1867 -> 1868 unreachable = ???*0*
 - *0* unreachable
@@ -12530,7 +12530,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* d
   ⚠️  pattern without value
 - *2* a
@@ -12546,7 +12546,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1875 -> 1878 conditional = ???*0*
 - *0* unsupported expression
@@ -12564,7 +12564,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["nextSibling"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* ???*4*["length"]
@@ -12578,7 +12578,7 @@ ${La}${a}`("SuspenseList")
     (???*0* | 0 | ???*1* | (???*2* + ???*3*) | ???*6* | undefined | ???*8*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* d
   ⚠️  pattern without value
 - *2* a
@@ -12598,29 +12598,29 @@ ${La}${a}`("SuspenseList")
 
 0 -> 1886 conditional = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1886 -> 1887 conditional = (???*0* === ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1887 -> 1889 conditional = (???*0* | (3 === ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1889 -> 1891 conditional = (???*0* | (3 === ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1891 -> 1893 call = (...) => ((a && b) ? ((a === b) ? !(0) : ((a && (3 === a["nodeType"])) ? !(1) : ((b && (3 === b["nodeType"])) ? Le(a, b["parentNode"]) : (???*0* ? a["contains"](b) : (a["compareDocumentPosition"] ? !(!(???*1*)) : !(1)))))) : !(1))(???*2*, ???*3*)
 - *0* unsupported expression
@@ -12628,29 +12628,29 @@ ${La}${a}`("SuspenseList")
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["parentNode"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1891 -> 1895 member call = ???*0*["contains"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1891 -> 1897 conditional = ???*0*
 - *0* ???*1*["compareDocumentPosition"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 1897 -> 1899 member call = ???*0*["compareDocumentPosition"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1900 unreachable = ???*0*
 - *0* unreachable
@@ -12882,7 +12882,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["nodeName"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 1923 unreachable = ???*0*
 - *0* unreachable
@@ -13284,15 +13284,15 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["window"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2017 -> 2020 conditional = (9 === ???*0*)
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2022 call = (...) => (null | (a["activeElement"] || a["body"]) | a["body"] | undefined)(???*0*)
 - *0* max number of linking steps reached
@@ -13449,15 +13449,15 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* b
   ⚠️  circular variable reference
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2042 member call = ???*0*["push"](
     {
@@ -13469,25 +13469,25 @@ ${La}${a}`("SuspenseList")
     }
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* b
   ⚠️  circular variable reference
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* max number of linking steps reached
   ⚠️  This value might have side effects
 
 0 -> 2046 member call = ???*0*["toLowerCase"]()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2048 member call = ???*0*["toLowerCase"]()
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2051 unreachable = ???*0*
 - *0* unreachable
@@ -13517,7 +13517,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2071 -> 2073 unreachable = ???*0*
 - *0* unreachable
@@ -13528,7 +13528,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2075 -> 2076 unreachable = ???*0*
 - *0* unreachable
@@ -13539,7 +13539,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* c
   ⚠️  pattern without value
 - *3* for-in variable currently not analyzed
@@ -13559,7 +13559,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* c
   ⚠️  pattern without value
 - *8* for-in variable currently not analyzed
@@ -13596,15 +13596,15 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2095 call = (...) => undefined(???*0*, [???*1*])
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2099 member call = (
   | "abort auxClick cancel canPlay canPlayThrough click close contextMenu copy cut drag dragEnd dragEnter dragExit dragLeave dragOver dragStart drop durationChange emptied encrypted ended error gotPointerCapture input invalid keyDown keyPress keyUp load loadedData loadedMetadata loadStart lostPointerCapture mouseDown mouseMove mouseOut mouseOver mouseUp paste pause play playing pointerCancel pointerDown pointerMove pointerOut pointerOver pointerUp progress rateChange reset resize seeked seeking stalled submit suspend timeUpdate touchCancel touchEnd touchStart volumeChange scroll toggle touchMove waiting wheel"["split"](" ")[(0 | ???*0*)]
@@ -13831,11 +13831,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2149 conditional = ???*0*
 - *0* labeled statement
@@ -13843,7 +13843,7 @@ ${La}${a}`("SuspenseList")
 
 2149 -> 2150 conditional = (???*0* | (0 !== ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
@@ -13862,7 +13862,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* updated with update expression
@@ -13910,7 +13910,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* updated with update expression
@@ -13930,7 +13930,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* updated with update expression
   ⚠️  This value might have side effects
 - *13* unsupported expression
@@ -13967,7 +13967,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *28* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *29* updated with update expression
   ⚠️  This value might have side effects
 - *30* unsupported expression
@@ -14012,7 +14012,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* updated with update expression
@@ -14060,7 +14060,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* updated with update expression
@@ -14080,7 +14080,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* updated with update expression
   ⚠️  This value might have side effects
 - *13* unsupported expression
@@ -14117,7 +14117,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *28* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *29* updated with update expression
   ⚠️  This value might have side effects
 - *30* unsupported expression
@@ -14158,39 +14158,39 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*[of]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* FreeVar(Set)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2173 call = (...) => undefined(???*0*, ???*1*, 2, false)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2175 member call = (???*0* | new ???*2*())["add"](`${???*3*}__bubble`)
 - *0* ???*1*[of]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* FreeVar(Set)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2176 call = (...) => undefined(???*0*, ???*1*, (0 | ???*2*), ???*3*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported assign operation
   ⚠️  This value might have side effects
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2180 free var = FreeVar(Math)
 
@@ -14225,7 +14225,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*[rf]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2185 -> 2188 member call = new ???*0*()["forEach"]((...) => undefined)
 - *0* FreeVar(Set)
@@ -14245,25 +14245,25 @@ ${La}${a}`("SuspenseList")
 - *4* "abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting"["split"](" ")
   ⚠️  nested operation
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2188 -> 2191 call = (...) => undefined(???*0*, false, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2188 -> 2192 call = (...) => undefined(???*0*, true, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2185 -> 2194 conditional = (9 === ???*0*)
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2185 -> 2198 call = (...) => undefined("selectionchange", false, ((???*0* ? ???*3* : ???*4*) | undefined))
 - *0* (9 === ???*1*)
@@ -14271,17 +14271,17 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["ownerDocument"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2199 call = (...) => (1 | 4 | 16 | 536870912 | undefined)(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2201 member call = ((...) => undefined | undefined | true)["bind"](
     null,
@@ -14295,33 +14295,33 @@ ${La}${a}`("SuspenseList")
     ???*11*
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* c
   ⚠️  circular variable reference
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* c
   ⚠️  circular variable reference
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* c
   ⚠️  circular variable reference
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2202 conditional = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2202 -> 2203 conditional = (undefined !== ((...) => undefined | undefined | true))
 
@@ -14336,29 +14336,29 @@ ${La}${a}`("SuspenseList")
     {"capture": true, "passive": ((...) => undefined | undefined | true)}
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* c
   ⚠️  circular variable reference
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* c
   ⚠️  circular variable reference
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* c
   ⚠️  circular variable reference
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2203 -> 2207 member call = ???*0*["addEventListener"](
     ???*1*,
@@ -14371,29 +14371,29 @@ ${La}${a}`("SuspenseList")
     true
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* c
   ⚠️  circular variable reference
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* c
   ⚠️  circular variable reference
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* c
   ⚠️  circular variable reference
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2202 -> 2208 conditional = (undefined !== ((...) => undefined | undefined | true))
 
@@ -14408,29 +14408,29 @@ ${La}${a}`("SuspenseList")
     {"passive": ((...) => undefined | undefined | true)}
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* c
   ⚠️  circular variable reference
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* c
   ⚠️  circular variable reference
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* c
   ⚠️  circular variable reference
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2208 -> 2212 member call = ???*0*["addEventListener"](
     ???*1*,
@@ -14443,35 +14443,35 @@ ${La}${a}`("SuspenseList")
     false
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* c
   ⚠️  circular variable reference
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* c
   ⚠️  circular variable reference
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* c
   ⚠️  circular variable reference
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2213 conditional = ((0 === ???*0*) | (null !== (???*1* | ???*2* | undefined | ???*4*)))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["tag"]
   ⚠️  unknown object
 - *3* d
@@ -14485,7 +14485,7 @@ ${La}${a}`("SuspenseList")
 
 2214 -> 2215 conditional = (null === (???*0* | ???*1* | undefined | ???*3*))
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["tag"]
   ⚠️  unknown object
 - *2* d
@@ -14501,13 +14501,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* node limit reached
   ⚠️  This value might have side effects
 - *3* ???*4*["tag"]
   ⚠️  unknown object
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* node limit reached
   ⚠️  This value might have side effects
 
@@ -14515,7 +14515,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* node limit reached
   ⚠️  This value might have side effects
 
@@ -14529,7 +14529,7 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -14541,7 +14541,7 @@ ${La}${a}`("SuspenseList")
 - *5* max number of linking steps reached
   ⚠️  This value might have side effects
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2231 -> 2232 unreachable = ???*0*
 - *0* unreachable
@@ -14567,7 +14567,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["slice"](2)
   ⚠️  unknown callee object
 - *4* ???*5*(36)
@@ -14652,7 +14652,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* node limit reached
   ⚠️  This value might have side effects
 
@@ -14664,7 +14664,7 @@ ${La}${a}`("SuspenseList")
 
 2240 -> 2241 call = (...) => ((3 === a["nodeType"]) ? a["parentNode"] : a)(???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2240 -> 2242 conditional = ???*0*
 - *0* labeled statement
@@ -14675,7 +14675,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2242 -> 2245 conditional = (undefined !== ???*0*)
 - *0* max number of linking steps reached
@@ -14685,7 +14685,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2245 -> 2248 conditional = ???*0*
 - *0* max number of linking steps reached
@@ -14738,13 +14738,13 @@ ${La}${a}`("SuspenseList")
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (3 === (???*5* | ???*7*))
   ⚠️  nested operation
 - *5* ???*6*["nodeType"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -14754,7 +14754,7 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*["parentNode"]
   ⚠️  unknown object
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -14762,7 +14762,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["target"]
   ⚠️  unknown object
 - *15* a
@@ -14773,7 +14773,7 @@ ${La}${a}`("SuspenseList")
 - *17* unsupported expression
   ⚠️  This value might have side effects
 - *18* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* e
   ⚠️  circular variable reference
 
@@ -14809,7 +14809,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["nodeType"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -14819,7 +14819,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["parentNode"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -14827,7 +14827,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["target"]
   ⚠️  unknown object
 - *13* a
@@ -14842,7 +14842,7 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["nodeType"]
   ⚠️  unknown object
 - *18* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -14852,7 +14852,7 @@ ${La}${a}`("SuspenseList")
 - *21* ???*22*["parentNode"]
   ⚠️  unknown object
 - *22* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* ???*24*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -14860,7 +14860,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *25* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* ???*27*["target"]
   ⚠️  unknown object
 - *27* a
@@ -14878,7 +14878,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -14888,7 +14888,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["parentNode"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -14896,7 +14896,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["target"]
   ⚠️  unknown object
 - *11* a
@@ -14907,7 +14907,7 @@ ${La}${a}`("SuspenseList")
 - *13* unsupported expression
   ⚠️  This value might have side effects
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* e
   ⚠️  circular variable reference
 
@@ -14970,13 +14970,13 @@ ${La}${a}`("SuspenseList")
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (3 === (???*6* | ???*8*))
   ⚠️  nested operation
 - *6* ???*7*["nodeType"]
   ⚠️  unknown object
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -14986,7 +14986,7 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["parentNode"]
   ⚠️  unknown object
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -14994,7 +14994,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["target"]
   ⚠️  unknown object
 - *16* a
@@ -15005,7 +15005,7 @@ ${La}${a}`("SuspenseList")
 - *18* unsupported expression
   ⚠️  This value might have side effects
 - *19* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* e
   ⚠️  circular variable reference
 
@@ -15020,7 +15020,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15030,7 +15030,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["parentNode"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15038,7 +15038,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["target"]
   ⚠️  unknown object
 - *11* a
@@ -15049,7 +15049,7 @@ ${La}${a}`("SuspenseList")
 - *13* unsupported expression
   ⚠️  This value might have side effects
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* e
   ⚠️  circular variable reference
 
@@ -15072,13 +15072,13 @@ ${La}${a}`("SuspenseList")
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (3 === (???*6* | ???*8*))
   ⚠️  nested operation
 - *6* ???*7*["nodeType"]
   ⚠️  unknown object
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15088,7 +15088,7 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["parentNode"]
   ⚠️  unknown object
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15096,7 +15096,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["target"]
   ⚠️  unknown object
 - *16* a
@@ -15107,7 +15107,7 @@ ${La}${a}`("SuspenseList")
 - *18* unsupported expression
   ⚠️  This value might have side effects
 - *19* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* e
   ⚠️  circular variable reference
 
@@ -15264,7 +15264,7 @@ ${La}${a}`("SuspenseList")
 - *1* na
   ⚠️  circular variable reference
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -15316,13 +15316,13 @@ ${La}${a}`("SuspenseList")
 - *1* na
   ⚠️  circular variable reference
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (3 === (???*4* | ???*6*))
   ⚠️  nested operation
 - *4* ???*5*["nodeType"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15332,7 +15332,7 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["parentNode"]
   ⚠️  unknown object
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15340,7 +15340,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["target"]
   ⚠️  unknown object
 - *14* a
@@ -15351,7 +15351,7 @@ ${La}${a}`("SuspenseList")
 - *16* unsupported expression
   ⚠️  This value might have side effects
 - *17* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* e
   ⚠️  circular variable reference
 
@@ -15359,7 +15359,7 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 - *3* max number of linking steps reached
@@ -15397,13 +15397,13 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === (???*2* | ???*4*))
   ⚠️  nested operation
 - *2* ???*3*["nodeType"]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15413,7 +15413,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["parentNode"]
   ⚠️  unknown object
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15421,7 +15421,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["target"]
   ⚠️  unknown object
 - *12* a
@@ -15432,7 +15432,7 @@ ${La}${a}`("SuspenseList")
 - *14* unsupported expression
   ⚠️  This value might have side effects
 - *15* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* e
   ⚠️  circular variable reference
 
@@ -15445,13 +15445,13 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === (???*2* | ???*4*))
   ⚠️  nested operation
 - *2* ???*3*["nodeType"]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15461,7 +15461,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["parentNode"]
   ⚠️  unknown object
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15469,7 +15469,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["target"]
   ⚠️  unknown object
 - *12* a
@@ -15480,7 +15480,7 @@ ${La}${a}`("SuspenseList")
 - *14* unsupported expression
   ⚠️  This value might have side effects
 - *15* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* e
   ⚠️  circular variable reference
 
@@ -15505,9 +15505,9 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2261 -> 2345 conditional = (
   | false
@@ -15521,9 +15521,9 @@ ${La}${a}`("SuspenseList")
 - *2* ba
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (???*6* ? (???*11* | ???*13*) : (???*15* | ???*16* | ???*18*))
   ⚠️  nested operation
 - *6* (3 === (???*7* | ???*9*))
@@ -15531,7 +15531,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["nodeType"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15541,7 +15541,7 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*["parentNode"]
   ⚠️  unknown object
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15549,7 +15549,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *15* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["target"]
   ⚠️  unknown object
 - *17* a
@@ -15581,9 +15581,9 @@ ${La}${a}`("SuspenseList")
 - *2* ba
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (???*6* ? (???*11* | ???*13*) : (???*15* | ???*16* | ???*18*))
   ⚠️  nested operation
 - *6* (3 === (???*7* | ???*9*))
@@ -15591,7 +15591,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["nodeType"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15601,7 +15601,7 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*["parentNode"]
   ⚠️  unknown object
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15609,7 +15609,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *15* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["target"]
   ⚠️  unknown object
 - *17* a
@@ -15641,9 +15641,9 @@ ${La}${a}`("SuspenseList")
 - *2* ba
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (???*6* ? (???*11* | ???*13*) : (???*15* | ???*16* | ???*18*))
   ⚠️  nested operation
 - *6* (3 === (???*7* | ???*9*))
@@ -15651,7 +15651,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["nodeType"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15661,7 +15661,7 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*["parentNode"]
   ⚠️  unknown object
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15669,7 +15669,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *15* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["target"]
   ⚠️  unknown object
 - *17* a
@@ -15678,15 +15678,15 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* (3 === (???*22* | ???*24*))
   ⚠️  nested operation
 - *22* ???*23*["nodeType"]
   ⚠️  unknown object
 - *23* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* ???*25*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15696,7 +15696,7 @@ ${La}${a}`("SuspenseList")
 - *26* ???*27*["parentNode"]
   ⚠️  unknown object
 - *27* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* ???*29*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15704,7 +15704,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *30* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *31* ???*32*["target"]
   ⚠️  unknown object
 - *32* a
@@ -15715,7 +15715,7 @@ ${La}${a}`("SuspenseList")
 - *34* unsupported expression
   ⚠️  This value might have side effects
 - *35* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *36* e
   ⚠️  circular variable reference
 
@@ -15736,9 +15736,9 @@ ${La}${a}`("SuspenseList")
 - *1* ba
   ⚠️  circular variable reference
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (???*5* ? (???*10* | ???*12*) : (???*14* | ???*15* | ???*17*))
   ⚠️  nested operation
 - *5* (3 === (???*6* | ???*8*))
@@ -15746,7 +15746,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["nodeType"]
   ⚠️  unknown object
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15756,7 +15756,7 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["parentNode"]
   ⚠️  unknown object
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15764,7 +15764,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["target"]
   ⚠️  unknown object
 - *16* a
@@ -15783,7 +15783,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2261 -> 2358 conditional = (!(???*0*) | ???*3* | !((null | ???*4*)))
 - *0* ("undefined" === ???*1*)
@@ -15804,9 +15804,9 @@ ${La}${a}`("SuspenseList")
 
 2358 -> 2359 call = (...) => (he(b) | null | ee | (((a === ee) && fe) ? null : a) | undefined)(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2358 -> 2360 call = (...) => (
   | ((("compositionend" === a) || (!(ae) && ge(a, b))) ? ???*0* : null)
@@ -15820,9 +15820,9 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2261 -> 2361 conditional = ???*0*
 - *0* max number of linking steps reached
@@ -15845,13 +15845,13 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (3 === (???*3* | ???*5*))
   ⚠️  nested operation
 - *3* ???*4*["nodeType"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15861,7 +15861,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["parentNode"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15869,7 +15869,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["target"]
   ⚠️  unknown object
 - *13* a
@@ -15880,7 +15880,7 @@ ${La}${a}`("SuspenseList")
 - *15* unsupported expression
   ⚠️  This value might have side effects
 - *16* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* e
   ⚠️  circular variable reference
 
@@ -15898,7 +15898,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15908,7 +15908,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["parentNode"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15916,7 +15916,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["target"]
   ⚠️  unknown object
 - *11* a
@@ -15927,7 +15927,7 @@ ${La}${a}`("SuspenseList")
 - *13* unsupported expression
   ⚠️  This value might have side effects
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* e
   ⚠️  circular variable reference
 - *16* max number of linking steps reached
@@ -15935,7 +15935,7 @@ ${La}${a}`("SuspenseList")
 
 2240 -> 2368 call = (...) => undefined([], ???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2369 unreachable = ???*0*
 - *0* unreachable
@@ -15943,13 +15943,13 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2372 call = (...) => (null | c)((???*0* | ???*1*), `${???*3*}Capture`)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2374 call = (...) => {"instance": a, "listener": b, "currentTarget": c}(
     (???*0* | ???*1*),
@@ -15985,7 +15985,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -15993,7 +15993,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*[Pf]
   ⚠️  unknown object
 - *6* c
@@ -16005,17 +16005,17 @@ ${La}${a}`("SuspenseList")
 - *9* d
   ⚠️  circular variable reference
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["disabled"]
   ⚠️  unknown object
 - *12* d
   ⚠️  circular variable reference
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ("button" === (???*15* | ???*16* | ???*18* | false))
   ⚠️  nested operation
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["return"]
   ⚠️  unknown object
 - *17* a
@@ -16025,7 +16025,7 @@ ${La}${a}`("SuspenseList")
 - *19* d
   ⚠️  circular variable reference
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*[Pf]
   ⚠️  unknown object
 - *22* c
@@ -16037,17 +16037,17 @@ ${La}${a}`("SuspenseList")
 - *25* d
   ⚠️  circular variable reference
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* ???*28*["disabled"]
   ⚠️  unknown object
 - *28* d
   ⚠️  circular variable reference
 - *29* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ("button" === (???*31* | ???*32* | ???*34* | false))
   ⚠️  nested operation
 - *31* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["return"]
   ⚠️  unknown object
 - *33* a
@@ -16057,9 +16057,9 @@ ${La}${a}`("SuspenseList")
 - *35* d
   ⚠️  circular variable reference
 - *36* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *38* ???*39*["return"]
   ⚠️  unknown object
 - *39* a
@@ -16075,17 +16075,17 @@ ${La}${a}`("SuspenseList")
 - *44* d
   ⚠️  circular variable reference
 - *45* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *46* ???*47*["disabled"]
   ⚠️  unknown object
 - *47* d
   ⚠️  circular variable reference
 - *48* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *49* ("button" === (???*50* | ???*51* | ???*53* | false))
   ⚠️  nested operation
 - *50* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *51* ???*52*["return"]
   ⚠️  unknown object
 - *52* a
@@ -16095,7 +16095,7 @@ ${La}${a}`("SuspenseList")
 - *54* d
   ⚠️  circular variable reference
 - *55* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *56* ???*57*[Pf]
   ⚠️  unknown object
 - *57* c
@@ -16107,17 +16107,17 @@ ${La}${a}`("SuspenseList")
 - *60* d
   ⚠️  circular variable reference
 - *61* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *62* ???*63*["disabled"]
   ⚠️  unknown object
 - *63* d
   ⚠️  circular variable reference
 - *64* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *65* ("button" === (???*66* | ???*67* | ???*69* | false))
   ⚠️  nested operation
 - *66* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *67* ???*68*["return"]
   ⚠️  unknown object
 - *68* a
@@ -16127,7 +16127,7 @@ ${La}${a}`("SuspenseList")
 - *70* d
   ⚠️  circular variable reference
 - *71* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2375 member call = []["unshift"](???*0*)
 - *0* node limit reached
@@ -16135,13 +16135,13 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2376 call = (...) => (null | c)((???*0* | ???*1*), ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2378 call = (...) => {"instance": a, "listener": b, "currentTarget": c}(
     (???*0* | ???*1*),
@@ -16177,7 +16177,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -16185,7 +16185,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*[Pf]
   ⚠️  unknown object
 - *6* c
@@ -16197,17 +16197,17 @@ ${La}${a}`("SuspenseList")
 - *9* d
   ⚠️  circular variable reference
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["disabled"]
   ⚠️  unknown object
 - *12* d
   ⚠️  circular variable reference
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ("button" === (???*15* | ???*16* | ???*18* | false))
   ⚠️  nested operation
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["return"]
   ⚠️  unknown object
 - *17* a
@@ -16217,7 +16217,7 @@ ${La}${a}`("SuspenseList")
 - *19* d
   ⚠️  circular variable reference
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*[Pf]
   ⚠️  unknown object
 - *22* c
@@ -16229,17 +16229,17 @@ ${La}${a}`("SuspenseList")
 - *25* d
   ⚠️  circular variable reference
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* ???*28*["disabled"]
   ⚠️  unknown object
 - *28* d
   ⚠️  circular variable reference
 - *29* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ("button" === (???*31* | ???*32* | ???*34* | false))
   ⚠️  nested operation
 - *31* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["return"]
   ⚠️  unknown object
 - *33* a
@@ -16249,9 +16249,9 @@ ${La}${a}`("SuspenseList")
 - *35* d
   ⚠️  circular variable reference
 - *36* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *38* ???*39*["return"]
   ⚠️  unknown object
 - *39* a
@@ -16267,17 +16267,17 @@ ${La}${a}`("SuspenseList")
 - *44* d
   ⚠️  circular variable reference
 - *45* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *46* ???*47*["disabled"]
   ⚠️  unknown object
 - *47* d
   ⚠️  circular variable reference
 - *48* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *49* ("button" === (???*50* | ???*51* | ???*53* | false))
   ⚠️  nested operation
 - *50* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *51* ???*52*["return"]
   ⚠️  unknown object
 - *52* a
@@ -16287,7 +16287,7 @@ ${La}${a}`("SuspenseList")
 - *54* d
   ⚠️  circular variable reference
 - *55* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *56* ???*57*[Pf]
   ⚠️  unknown object
 - *57* c
@@ -16299,17 +16299,17 @@ ${La}${a}`("SuspenseList")
 - *60* d
   ⚠️  circular variable reference
 - *61* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *62* ???*63*["disabled"]
   ⚠️  unknown object
 - *63* d
   ⚠️  circular variable reference
 - *64* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *65* ("button" === (???*66* | ???*67* | ???*69* | false))
   ⚠️  nested operation
 - *66* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *67* ???*68*["return"]
   ⚠️  unknown object
 - *68* a
@@ -16319,7 +16319,7 @@ ${La}${a}`("SuspenseList")
 - *70* d
   ⚠️  circular variable reference
 - *71* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2379 member call = []["push"](???*0*)
 - *0* node limit reached
@@ -16331,7 +16331,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2382 conditional = (null === (???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -16343,7 +16343,7 @@ ${La}${a}`("SuspenseList")
 
 2382 -> 2386 conditional = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -16355,11 +16355,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2392 conditional = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2392 -> 2393 call = (...) => (null | c)((???*0* | ???*1*), ???*3*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* c
@@ -16367,7 +16367,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["_reactName"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2392 -> 2395 call = (...) => {"instance": a, "listener": b, "currentTarget": c}(
     (???*0* | ???*1*),
@@ -16385,7 +16385,7 @@ ${La}${a}`("SuspenseList")
     (???*24* | ???*25* | undefined)
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* c
@@ -16393,7 +16393,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*[Pf]
   ⚠️  unknown object
 - *6* c
@@ -16407,7 +16407,7 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["_reactName"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["disabled"]
   ⚠️  unknown object
 - *13* d
@@ -16415,11 +16415,11 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["_reactName"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ("button" === (???*17* | ???*18* | ???*20* | false))
   ⚠️  nested operation
 - *17* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["return"]
   ⚠️  unknown object
 - *19* c
@@ -16431,9 +16431,9 @@ ${La}${a}`("SuspenseList")
 - *22* ???*23*["_reactName"]
   ⚠️  unknown object
 - *23* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*["return"]
   ⚠️  unknown object
 - *26* c
@@ -16457,7 +16457,7 @@ ${La}${a}`("SuspenseList")
     }
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* c
@@ -16465,7 +16465,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*[Pf]
   ⚠️  unknown object
 - *6* c
@@ -16479,7 +16479,7 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["_reactName"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["disabled"]
   ⚠️  unknown object
 - *13* d
@@ -16487,11 +16487,11 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["_reactName"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ("button" === (???*17* | ???*18* | ???*20* | false))
   ⚠️  nested operation
 - *17* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["return"]
   ⚠️  unknown object
 - *19* c
@@ -16503,9 +16503,9 @@ ${La}${a}`("SuspenseList")
 - *22* ???*23*["_reactName"]
   ⚠️  unknown object
 - *23* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*["return"]
   ⚠️  unknown object
 - *26* c
@@ -16513,7 +16513,7 @@ ${La}${a}`("SuspenseList")
 
 2392 -> 2397 call = (...) => (null | c)((???*0* | ???*1*), ???*3*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* c
@@ -16521,7 +16521,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["_reactName"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2392 -> 2399 call = (...) => {"instance": a, "listener": b, "currentTarget": c}(
     (???*0* | ???*1*),
@@ -16539,7 +16539,7 @@ ${La}${a}`("SuspenseList")
     (???*24* | ???*25* | undefined)
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* c
@@ -16547,7 +16547,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*[Pf]
   ⚠️  unknown object
 - *6* c
@@ -16561,7 +16561,7 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["_reactName"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["disabled"]
   ⚠️  unknown object
 - *13* d
@@ -16569,11 +16569,11 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["_reactName"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ("button" === (???*17* | ???*18* | ???*20* | false))
   ⚠️  nested operation
 - *17* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["return"]
   ⚠️  unknown object
 - *19* c
@@ -16585,9 +16585,9 @@ ${La}${a}`("SuspenseList")
 - *22* ???*23*["_reactName"]
   ⚠️  unknown object
 - *23* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*["return"]
   ⚠️  unknown object
 - *26* c
@@ -16611,7 +16611,7 @@ ${La}${a}`("SuspenseList")
     }
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* c
@@ -16619,7 +16619,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*[Pf]
   ⚠️  unknown object
 - *6* c
@@ -16633,7 +16633,7 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["_reactName"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["disabled"]
   ⚠️  unknown object
 - *13* d
@@ -16641,11 +16641,11 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["_reactName"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ("button" === (???*17* | ???*18* | ???*20* | false))
   ⚠️  nested operation
 - *17* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["return"]
   ⚠️  unknown object
 - *19* c
@@ -16657,9 +16657,9 @@ ${La}${a}`("SuspenseList")
 - *22* ???*23*["_reactName"]
   ⚠️  unknown object
 - *23* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*["return"]
   ⚠️  unknown object
 - *26* c
@@ -16667,19 +16667,19 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2404 member call = ???*0*["push"]({"event": ???*1*, "listeners": []})
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2407 typeof = typeof(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2408 conditional = ("string" === ???*0*)
 - *0* typeof(???*1*)
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2409 member call = (???*0* ? ???*3* : ???*4*)["replace"](/\r\n?/g, "\n")
 - *0* ("string" === ???*1*)
@@ -16687,11 +16687,11 @@ ${La}${a}`("SuspenseList")
 - *1* typeof(???*2*)
   ⚠️  nested operation
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2410 member call = ???*0*["replace"](/\u0000|\uFFFD/g, "")
 - *0* ???*1*(/\r\n?/g, "\n")
@@ -16705,9 +16705,9 @@ ${La}${a}`("SuspenseList")
 - *4* typeof(???)
   ⚠️  nested operation
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2411 unreachable = ???*0*
 - *0* unreachable
@@ -16715,7 +16715,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2412 call = (...) => (("string" === typeof(a)) ? a : `${a}`)["replace"](xf, "\n")["replace"](yf, "")((???*0* | ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["replace"](yf, "")
   ⚠️  unknown callee object
 - *2* ???*3*(/\r\n?/g, "\n")
@@ -16733,7 +16733,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2413 call = (...) => (("string" === typeof(a)) ? a : `${a}`)["replace"](xf, "\n")["replace"](yf, "")(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2414 conditional = ((???*0* !== (???*7* | ???*8*)) | ???*15*)
 - *0* ???*1*["replace"](yf, "")
@@ -16747,11 +16747,11 @@ ${La}${a}`("SuspenseList")
 - *4* ("string" === ???)
   ⚠️  nested operation
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["replace"](yf, "")
   ⚠️  unknown callee object
 - *9* ???*10*(/\r\n?/g, "\n")
@@ -16767,7 +16767,7 @@ ${La}${a}`("SuspenseList")
 - *14* b
   ⚠️  circular variable reference
 - *15* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2414 -> 2415 free var = FreeVar(Error)
 
@@ -16786,19 +16786,19 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["children"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2420 typeof = typeof(???*0*)
 - *0* ???*1*["children"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2422 typeof = typeof(???*0*)
 - *0* ???*1*["dangerouslySetInnerHTML"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2427 unreachable = ???*0*
 - *0* unreachable
@@ -16923,7 +16923,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2445 -> 2451 member call = ???*0*["catch"]((...) => undefined)
 - *0* ???*1*["then"](a)
@@ -16953,9 +16953,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2457 member call = ???*0*["removeChild"]((???*1* | ???*2* | undefined["data"] | undefined))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["data"]
   ⚠️  unknown object
 - *3* ???*4*["nextSibling"]
@@ -16967,17 +16967,17 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["nextSibling"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["nodeType"]
   ⚠️  unknown object
 - *3* ???*4*["nextSibling"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2459 -> 2461 conditional = ("/$" === (???*0* | ???*1* | undefined["data"] | undefined))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["data"]
   ⚠️  unknown object
 - *2* ???*3*["nextSibling"]
@@ -16991,15 +16991,15 @@ ${La}${a}`("SuspenseList")
 
 2462 -> 2464 member call = ???*0*["removeChild"]((???*1* | undefined))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nextSibling"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2462 -> 2465 call = (...) => undefined(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2462 -> 2466 unreachable = ???*0*
 - *0* unreachable
@@ -17007,19 +17007,19 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2467 call = (...) => undefined(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2470 conditional = (8 === (???*0* | undefined))
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2470 -> 2472 conditional = ("/$" === (???*0* | undefined))
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2472 -> 2473 unreachable = ???*0*
 - *0* unreachable
@@ -17033,7 +17033,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2477 -> 2479 conditional = (
   | ("$" === (???*0* | undefined))
@@ -17043,15 +17043,15 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["data"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["data"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["data"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2479 -> 2480 conditional = (0 === (0 | ???*0*))
 - *0* updated with update expression
@@ -17105,7 +17105,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*[`__reactFiber$${???*2*}`]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["slice"](2)
   ⚠️  unknown callee object
 - *3* ???*4*(36)
@@ -17210,7 +17210,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["parentNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["slice"](2)
   ⚠️  unknown callee object
 - *4* ???*5*(36)
@@ -17352,7 +17352,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*[`__reactFiber$${???*3*}`]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["slice"](2)
   ⚠️  unknown callee object
 - *4* ???*5*(36)
@@ -17432,7 +17432,7 @@ ${La}${a}`("SuspenseList")
 - *41* ???*42*["parentNode"]
   ⚠️  unknown object
 - *42* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *43* `__reactFiber$${???*44*}`
   ⚠️  nested operation
 - *44* ???*45*["slice"](2)
@@ -17458,7 +17458,7 @@ ${La}${a}`("SuspenseList")
 - *54* ???*55*["parentNode"]
   ⚠️  unknown object
 - *55* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *56* `__reactFiber$${???*57*}`
   ⚠️  nested operation
 - *57* ???*58*["slice"](2)
@@ -17482,7 +17482,7 @@ ${La}${a}`("SuspenseList")
 
 2501 -> 2502 call = (...) => (a | null)((???*0* | ???*1* | ???*2* | null))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["previousSibling"]
@@ -17494,7 +17494,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*[`__reactFiber$${???*2*}`]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["slice"](2)
   ⚠️  unknown callee object
 - *3* ???*4*(36)
@@ -17521,7 +17521,7 @@ ${La}${a}`("SuspenseList")
 
 2504 -> 2506 call = (...) => (a | null)((???*0* | ???*1* | ???*2* | null))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["previousSibling"]
@@ -17539,7 +17539,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2516 conditional = (!((???*0* | ???*1*)) | (5 !== ???*3*) | (6 !== ???*5*) | (13 !== ???*7*) | (3 !== ???*9*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*[Of]
   ⚠️  unknown object
 - *2* a
@@ -17547,19 +17547,19 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["tag"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["tag"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["tag"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["tag"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2517 unreachable = ???*0*
 - *0* unreachable
@@ -17569,11 +17569,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["tag"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2520 -> 2522 unreachable = ???*0*
 - *0* unreachable
@@ -17610,7 +17610,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2539 -> 2540 unreachable = ???*0*
 - *0* unreachable
@@ -17620,15 +17620,15 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["__reactInternalMemoizedUnmaskedChildContext"]
   ⚠️  unknown object
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2543 -> 2545 unreachable = ???*0*
 - *0* unreachable
@@ -17665,11 +17665,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2561 call = (...) => undefined({"current": {}}, ???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2562 call = (...) => undefined({"current": false}, ???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2565 typeof = typeof((???*0* | ???*3*()["getChildContext"]))
 - *0* ???*1*["getChildContext"]
@@ -17677,7 +17677,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["getChildContext"]
   ⚠️  unknown object
 - *4* d
@@ -17691,7 +17691,7 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2567 -> 2568 unreachable = ???*0*
 - *0* unreachable
@@ -17701,7 +17701,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["getChildContext"]
   ⚠️  unknown object
 - *3* d
@@ -17736,7 +17736,7 @@ ${La}${a}`("SuspenseList")
   | null
 )(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2571 -> 2574 call = (...) => `Minified React error #${a}; visit ${b} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`(108, ???*0*, ???*1*)
 - *0* max number of linking steps reached
@@ -17753,11 +17753,11 @@ ${La}${a}`("SuspenseList")
 2567 -> 2576 call = Object.assign*0*({}, ???*1*, (???*2* | ???*4*()))
 - *0* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["getChildContext"]
   ⚠️  unknown object
 - *5* d
@@ -17769,7 +17769,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2581 call = (...) => undefined({"current": {}}, (???*0* | ???*1* | {}))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
@@ -17787,7 +17787,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* ???*4*["stateNode"]
@@ -17811,11 +17811,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2590 conditional = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2590 -> 2591 call = (...) => (c | A({}, c, d))((???*0* | {} | ???*1* | ???*2*), ???*9*, ({} | ???*10*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unknown mutation
   ⚠️  This value might have side effects
 - *2* Object.assign*3*({}, ({} | ???*4*), (???*5* | ???*7*()))
@@ -17833,7 +17833,7 @@ ${La}${a}`("SuspenseList")
 - *8* d
   ⚠️  circular variable reference
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* unknown mutation
   ⚠️  This value might have side effects
 
@@ -17843,7 +17843,7 @@ ${La}${a}`("SuspenseList")
 
 2590 -> 2595 call = (...) => undefined({"current": {}}, (???*0* | {} | ???*1* | ???*2*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unknown mutation
   ⚠️  This value might have side effects
 - *2* Object.assign*3*({}, ({} | ???*4*), (???*5* | ???*7*()))
@@ -17865,11 +17865,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2597 call = (...) => undefined({"current": false}, ???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2598 conditional = (null === (null | [???*0*] | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["slice"]((a + 1))
   ⚠️  unknown callee object
 - *2* eg
@@ -17877,21 +17877,21 @@ ${La}${a}`("SuspenseList")
 
 2598 -> 2600 member call = (null | [???*0*] | ???*1*)["push"](???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["slice"]((a + 1))
   ⚠️  unknown callee object
 - *2* eg
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2601 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2602 conditional = (!((false | true)) | (null !== (null | [???*0*] | ???*1*)))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["slice"]((a + 1))
   ⚠️  unknown callee object
 - *2* eg
@@ -17911,13 +17911,13 @@ ${La}${a}`("SuspenseList")
 - *0* updated with update expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* [???*4*][undefined]
   ⚠️  non-num constant property on array
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* [][???*6*]
   ⚠️  unknown array prototype methods or values
 - *6* updated with update expression
@@ -17940,7 +17940,7 @@ ${La}${a}`("SuspenseList")
 
 2602 -> 2607 member call = (null | [???*0*] | ???*1*)["slice"](((0 | undefined | ???*3*) + 1))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["slice"]((a + 1))
   ⚠️  unknown callee object
 - *2* eg
@@ -17995,7 +17995,7 @@ ${La}${a}`("SuspenseList")
 - *5* unsupported expression
   ⚠️  This value might have side effects
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2618 member call = ???*0*["toString"](32)
 - *0* unsupported expression
@@ -18019,33 +18019,33 @@ ${La}${a}`("SuspenseList")
 - *5* unsupported expression
   ⚠️  This value might have side effects
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2621 call = (...) => undefined(???*0*, 1)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2622 call = (...) => undefined(???*0*, 1, 0)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2633 call = (...) => new al(a, b, c, d)(5, null, null, 0)
 
 0 -> 2638 conditional = (null === (???*0* | ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["deletions"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2638 -> 2642 member call = (???*0* | ???*1*)["push"](new (...) => undefined(5, null, null, 0))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["deletions"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2647 member call = ???*0*["toLowerCase"]()
 - *0* max number of linking steps reached
@@ -18101,7 +18101,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["pendingProps"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -18165,7 +18165,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -18179,7 +18179,7 @@ ${La}${a}`("SuspenseList")
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2680 -> 2682 conditional = ((0 !== ???*0*) | (0 === ???*1*))
 - *0* unsupported expression
@@ -18221,7 +18221,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -18241,7 +18241,7 @@ ${La}${a}`("SuspenseList")
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2678 -> 2694 conditional = ((0 !== ???*0*) | (0 === ???*1*))
 - *0* unsupported expression
@@ -18264,7 +18264,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2705 conditional = ((???*0* | ???*1* | ???*3*) !== ???*8*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* a
@@ -18290,7 +18290,7 @@ ${La}${a}`("SuspenseList")
 
 2707 -> 2708 call = (...) => undefined((???*0* | ???*1* | (???*3* ? ???*5* : null)))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* a
@@ -18325,7 +18325,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== ???*3*)
   ⚠️  nested operation
 - *3* a
@@ -18337,7 +18337,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["memoizedProps"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* (null !== ???*9*)
   ⚠️  nested operation
 - *9* a
@@ -18357,7 +18357,7 @@ ${La}${a}`("SuspenseList")
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* a
@@ -18394,7 +18394,7 @@ ${La}${a}`("SuspenseList")
 
 2716 -> 2723 call = (...) => undefined((???*0* | ???*1* | (???*3* ? ???*5* : null)), ???*7*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* a
@@ -18419,7 +18419,7 @@ ${La}${a}`("SuspenseList")
 
 2707 -> 2726 call = (...) => undefined((???*0* | ???*1* | (???*3* ? ???*5* : null)))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* a
@@ -18437,11 +18437,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2728 -> 2730 conditional = (null !== (???*0* | ???*1* | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* a
@@ -18459,7 +18459,7 @@ ${La}${a}`("SuspenseList")
 
 2728 -> 2732 conditional = !((???*0* | ???*1* | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* a
@@ -18496,13 +18496,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2739 -> 2741 conditional = ("/$" === (???*0* | undefined))
 - *0* ???*1*["data"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2741 -> 2742 conditional = (0 === ???*0*)
 - *0* max number of linking steps reached
@@ -18512,7 +18512,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["nextSibling"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== ???*3*)
   ⚠️  nested operation
 - *3* a
@@ -18537,7 +18537,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* a
@@ -18560,17 +18560,17 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2753 conditional = (null === (null | [???*0*]))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2753 -> 2755 member call = (null | [???*0*])["push"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2758 conditional = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["defaultProps"]
   ⚠️  unknown object
 - *2* a
@@ -18579,7 +18579,7 @@ ${La}${a}`("SuspenseList")
 2758 -> 2759 call = Object.assign*0*({}, (???*1* | ???*2*))
 - *0* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* Object.assign*3*({}, ???*4*)
   ⚠️  only const object assign is supported
   ⚠️  This value might have side effects
@@ -18603,14 +18603,14 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2783 conditional = (null !== (
   | ???*0*
   | {"context": ???*1*, "memoizedValue": ???*2*, "next": null}
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["_currentValue"]
@@ -18624,7 +18624,7 @@ ${La}${a}`("SuspenseList")
   | {"context": ???*1*, "memoizedValue": ???*2*, "next": null}
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["_currentValue"]
@@ -18634,7 +18634,7 @@ ${La}${a}`("SuspenseList")
 
 2784 -> 2785 conditional = (null === (null | ???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["dependencies"]
   ⚠️  unknown object
 - *2* a
@@ -18659,29 +18659,29 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2792 conditional = (null === (null | [???*0*]))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2792 -> 2794 member call = (null | [???*0*])["push"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2796 conditional = (null === ???*0*)
 - *0* ???*1*["interleaved"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2796 -> 2798 call = (...) => undefined(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2803 call = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2804 unreachable = ???*0*
 - *0* unreachable
@@ -18693,7 +18693,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2816 unreachable = ???*0*
 - *0* unreachable
@@ -18707,7 +18707,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2829 -> 2830 unreachable = ???*0*
 - *0* unreachable
@@ -18723,13 +18723,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2832 -> 2840 call = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2832 -> 2841 unreachable = ???*0*
 - *0* unreachable
@@ -18741,19 +18741,19 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2843 -> 2845 call = (...) => undefined(???*0*)
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2832 -> 2850 call = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2832 -> 2851 unreachable = ???*0*
 - *0* unreachable
@@ -18761,7 +18761,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 2854 conditional = ((null !== (???*0* | ???*1*)) | (0 !== ???*3*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* b
@@ -18771,9 +18771,9 @@ ${La}${a}`("SuspenseList")
 
 2854 -> 2858 call = (...) => undefined(???*0*, (???*1* | ???*2*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -18817,7 +18817,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* ???*4*["alternate"]
@@ -18828,13 +18828,13 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["updateQueue"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["baseState"]
   ⚠️  unknown object
 - *8* ???*9*["alternate"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["eventTime"]
   ⚠️  unknown object
 - *11* c
@@ -18856,7 +18856,7 @@ ${La}${a}`("SuspenseList")
 - *19* c
   ⚠️  circular variable reference
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["eventTime"]
   ⚠️  unknown object
 - *22* c
@@ -18878,23 +18878,23 @@ ${La}${a}`("SuspenseList")
 - *30* c
   ⚠️  circular variable reference
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["shared"]
   ⚠️  unknown object
 - *33* ???*34*["alternate"]
   ⚠️  unknown object
 - *34* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *35* ???*36*["effects"]
   ⚠️  unknown object
 - *36* ???*37*["alternate"]
   ⚠️  unknown object
 - *37* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *38* ???*39*["alternate"]
   ⚠️  unknown object
 - *39* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *40* unknown mutation
   ⚠️  This value might have side effects
 - *41* ???*42*["alternate"]
@@ -18940,13 +18940,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["baseState"]
   ⚠️  unknown object
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["eventTime"]
   ⚠️  unknown object
 - *6* c
@@ -18968,7 +18968,7 @@ ${La}${a}`("SuspenseList")
 - *14* c
   ⚠️  circular variable reference
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["eventTime"]
   ⚠️  unknown object
 - *17* c
@@ -18990,19 +18990,19 @@ ${La}${a}`("SuspenseList")
 - *25* c
   ⚠️  circular variable reference
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* ???*28*["shared"]
   ⚠️  unknown object
 - *28* ???*29*["alternate"]
   ⚠️  unknown object
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["effects"]
   ⚠️  unknown object
 - *31* ???*32*["alternate"]
   ⚠️  unknown object
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2864 -> 2870 conditional = (null === (
   | null
@@ -19022,7 +19022,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* ???*5*["lane"]
@@ -19030,7 +19030,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["updateQueue"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unknown mutation
   ⚠️  This value might have side effects
 - *8* ???*9*["tag"]
@@ -19038,7 +19038,7 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*["updateQueue"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* unknown mutation
   ⚠️  This value might have side effects
 - *12* ???*13*["payload"]
@@ -19046,7 +19046,7 @@ ${La}${a}`("SuspenseList")
 - *13* ???*14*["updateQueue"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unknown mutation
   ⚠️  This value might have side effects
 - *16* ???*17*["callback"]
@@ -19054,11 +19054,11 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["updateQueue"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* unknown mutation
   ⚠️  This value might have side effects
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2864 -> 2873 conditional = (null === (
   | null
@@ -19078,7 +19078,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* ???*5*["lane"]
@@ -19086,7 +19086,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["updateQueue"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unknown mutation
   ⚠️  This value might have side effects
 - *8* ???*9*["tag"]
@@ -19094,7 +19094,7 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*["updateQueue"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* unknown mutation
   ⚠️  This value might have side effects
 - *12* ???*13*["payload"]
@@ -19102,7 +19102,7 @@ ${La}${a}`("SuspenseList")
 - *13* ???*14*["updateQueue"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unknown mutation
   ⚠️  This value might have side effects
 - *16* ???*17*["callback"]
@@ -19110,11 +19110,11 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["updateQueue"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* unknown mutation
   ⚠️  This value might have side effects
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2862 -> 2879 unreachable = ???*0*
 - *0* unreachable
@@ -19136,7 +19136,7 @@ ${La}${a}`("SuspenseList")
   | ???*14*
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["lastBaseUpdate"]
   ⚠️  unknown object
 - *2* ???*3*["updateQueue"]
@@ -19207,7 +19207,7 @@ ${La}${a}`("SuspenseList")
   | (???*9* ? ???*12* : ???*14*)["next"]["payload"]
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["payload"]
   ⚠️  unknown object
 - *2* ???*3*["pending"]
@@ -19217,7 +19217,7 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["updateQueue"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["payload"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -19254,7 +19254,7 @@ ${La}${a}`("SuspenseList")
     ))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["payload"]
   ⚠️  unknown object
 - *3* ???*4*["pending"]
@@ -19286,7 +19286,7 @@ ${La}${a}`("SuspenseList")
   | (???*9* ? ???*12* : ???*14*)["next"]["payload"]
 )["call"](???*15*, ???*16*, ???*17*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["payload"]
   ⚠️  unknown object
 - *2* ???*3*["pending"]
@@ -19296,7 +19296,7 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["updateQueue"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["payload"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -19338,7 +19338,7 @@ ${La}${a}`("SuspenseList")
   | (???*9* ? ???*12* : ???*14*)["next"]["payload"]
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["payload"]
   ⚠️  unknown object
 - *2* ???*3*["pending"]
@@ -19348,7 +19348,7 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["updateQueue"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["payload"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -19385,7 +19385,7 @@ ${La}${a}`("SuspenseList")
     ))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["payload"]
   ⚠️  unknown object
 - *3* ???*4*["pending"]
@@ -19417,7 +19417,7 @@ ${La}${a}`("SuspenseList")
   | (???*9* ? ???*12* : ???*14*)["next"]["payload"]
 )["call"](???*15*, ???*16*, ???*17*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["payload"]
   ⚠️  unknown object
 - *2* ???*3*["pending"]
@@ -19427,7 +19427,7 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["updateQueue"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["payload"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -19485,7 +19485,7 @@ ${La}${a}`("SuspenseList")
 
 2904 -> 2956 conditional = (null !== (???*0* | ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["interleaved"]
   ⚠️  unknown object
 - *2* ???*3*["shared"]
@@ -19493,15 +19493,15 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["updateQueue"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2965 conditional = (null !== (???*0* | ???*1* | 0["effects"] | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["effects"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["effects"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -19522,19 +19522,19 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* updated with update expression
   ⚠️  This value might have side effects
 - *7* ???*8*["callback"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2969 -> 2971 typeof = typeof((
   | ???*0*
@@ -19550,19 +19550,19 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* updated with update expression
   ⚠️  This value might have side effects
 - *7* ???*8*["callback"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2969 -> 2972 conditional = ("function" !== ???*0*)
 - *0* typeof((
@@ -19580,19 +19580,19 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* updated with update expression
   ⚠️  This value might have side effects
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* updated with update expression
   ⚠️  This value might have side effects
 - *8* ???*9*["callback"]
   ⚠️  unknown object
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2972 -> 2973 free var = FreeVar(Error)
 
@@ -19613,19 +19613,19 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* updated with update expression
   ⚠️  This value might have side effects
 - *7* ???*8*["callback"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2972 -> 2975 call = ???*0*(
     `Minified React error #${191}; visit ${???*1*} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`
@@ -19652,40 +19652,40 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* updated with update expression
   ⚠️  This value might have side effects
 - *7* ???*8*["callback"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*[(???*11* | 0 | ???*12*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* updated with update expression
   ⚠️  This value might have side effects
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* updated with update expression
   ⚠️  This value might have side effects
 - *15* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2980 member call = module<react, {}>["Component"]()
 
 0 -> 2982 call = (???*0* | ???*1* | (???*3* ? (???*5* | ???*6*) : ???*8*))(???*14*, (???*15* | ???*16*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*(d, b)
   ⚠️  unknown callee
 - *2* c
@@ -19695,35 +19695,35 @@ ${La}${a}`("SuspenseList")
 - *4* c
   ⚠️  circular variable reference
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["memoizedState"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* Object.assign*9*({}, (???*10* | ???*11*), ???*13*)
   ⚠️  only const object assign is supported
   ⚠️  This value might have side effects
 - *9* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["memoizedState"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* c
   ⚠️  circular variable reference
 - *14* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["memoizedState"]
   ⚠️  unknown object
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 2983 conditional = ((null === (???*0* | ???*1* | ???*3*)) | (undefined === (???*15* | ???*16* | ???*18*)))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*(d, b)
   ⚠️  unknown callee
 - *2* c
@@ -19735,25 +19735,25 @@ ${La}${a}`("SuspenseList")
 - *5* c
   ⚠️  circular variable reference
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["memoizedState"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* Object.assign*10*({}, (???*11* | ???*12*), ???*14*)
   ⚠️  only const object assign is supported
   ⚠️  This value might have side effects
 - *10* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["memoizedState"]
   ⚠️  unknown object
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* c
   ⚠️  circular variable reference
 - *15* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*(d, b)
   ⚠️  unknown callee
 - *17* c
@@ -19765,21 +19765,21 @@ ${La}${a}`("SuspenseList")
 - *20* c
   ⚠️  circular variable reference
 - *21* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* ???*23*["memoizedState"]
   ⚠️  unknown object
 - *23* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* Object.assign*25*({}, (???*26* | ???*27*), ???*29*)
   ⚠️  only const object assign is supported
   ⚠️  This value might have side effects
 - *25* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* ???*28*["memoizedState"]
   ⚠️  unknown object
 - *28* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *29* c
   ⚠️  circular variable reference
 
@@ -19790,13 +19790,13 @@ ${La}${a}`("SuspenseList")
 )
 - *0* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*(d, b)
   ⚠️  unknown callee
 - *6* c
@@ -19806,21 +19806,21 @@ ${La}${a}`("SuspenseList")
 - *8* c
   ⚠️  circular variable reference
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["memoizedState"]
   ⚠️  unknown object
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* Object.assign*13*({}, (???*14* | ???*15*), ???*17*)
   ⚠️  only const object assign is supported
   ⚠️  This value might have side effects
 - *13* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 - *14* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["memoizedState"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* c
   ⚠️  circular variable reference
 
@@ -19828,11 +19828,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["_reactInternals"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 2990 -> 2991 call = (...) => ((3 === b["tag"]) ? c : null)((???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* a
@@ -19855,7 +19855,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["_reactInternals"]
   ⚠️  unknown object
 - *4* a
@@ -19907,7 +19907,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["_reactInternals"]
   ⚠️  unknown object
 - *15* a
@@ -19939,11 +19939,11 @@ ${La}${a}`("SuspenseList")
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -19996,7 +19996,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* a
@@ -20029,7 +20029,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["_reactInternals"]
   ⚠️  unknown object
 - *18* a
@@ -20061,11 +20061,11 @@ ${La}${a}`("SuspenseList")
 - *31* unsupported expression
   ⚠️  This value might have side effects
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* ???*34*["value"]
   ⚠️  unknown object
 - *34* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *35* ???*36*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20082,7 +20082,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *41* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *42* ???*43*["_reactInternals"]
   ⚠️  unknown object
 - *43* a
@@ -20114,11 +20114,11 @@ ${La}${a}`("SuspenseList")
 - *56* unsupported expression
   ⚠️  This value might have side effects
 - *57* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *58* ???*59*["value"]
   ⚠️  unknown object
 - *59* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *60* ???*61*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20151,7 +20151,7 @@ ${La}${a}`("SuspenseList")
     (???*36* ? ???*38* : ???*39*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -20159,15 +20159,15 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["_reactInternals"]
   ⚠️  unknown object
 - *10* a
@@ -20178,7 +20178,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["_reactInternals"]
   ⚠️  unknown object
 - *15* a
@@ -20210,11 +20210,11 @@ ${La}${a}`("SuspenseList")
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20268,7 +20268,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -20276,15 +20276,15 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["_reactInternals"]
   ⚠️  unknown object
 - *10* a
@@ -20295,7 +20295,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["_reactInternals"]
   ⚠️  unknown object
 - *15* a
@@ -20327,11 +20327,11 @@ ${La}${a}`("SuspenseList")
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20356,7 +20356,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["_reactInternals"]
   ⚠️  unknown object
 - *4* a
@@ -20408,7 +20408,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["_reactInternals"]
   ⚠️  unknown object
 - *15* a
@@ -20440,11 +20440,11 @@ ${La}${a}`("SuspenseList")
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20497,7 +20497,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* a
@@ -20530,7 +20530,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["_reactInternals"]
   ⚠️  unknown object
 - *18* a
@@ -20562,11 +20562,11 @@ ${La}${a}`("SuspenseList")
 - *31* unsupported expression
   ⚠️  This value might have side effects
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* ???*34*["value"]
   ⚠️  unknown object
 - *34* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *35* ???*36*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20583,7 +20583,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *41* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *42* ???*43*["_reactInternals"]
   ⚠️  unknown object
 - *43* a
@@ -20615,11 +20615,11 @@ ${La}${a}`("SuspenseList")
 - *56* unsupported expression
   ⚠️  This value might have side effects
 - *57* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *58* ???*59*["value"]
   ⚠️  unknown object
 - *59* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *60* ???*61*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20652,7 +20652,7 @@ ${La}${a}`("SuspenseList")
     (???*36* ? ???*38* : ???*39*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -20660,15 +20660,15 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["_reactInternals"]
   ⚠️  unknown object
 - *10* a
@@ -20679,7 +20679,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["_reactInternals"]
   ⚠️  unknown object
 - *15* a
@@ -20711,11 +20711,11 @@ ${La}${a}`("SuspenseList")
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20769,7 +20769,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -20777,15 +20777,15 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["_reactInternals"]
   ⚠️  unknown object
 - *10* a
@@ -20796,7 +20796,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["_reactInternals"]
   ⚠️  unknown object
 - *15* a
@@ -20828,11 +20828,11 @@ ${La}${a}`("SuspenseList")
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20857,7 +20857,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["_reactInternals"]
   ⚠️  unknown object
 - *4* a
@@ -20909,7 +20909,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["_reactInternals"]
   ⚠️  unknown object
 - *15* a
@@ -20941,11 +20941,11 @@ ${La}${a}`("SuspenseList")
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20998,7 +20998,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* a
@@ -21031,7 +21031,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["_reactInternals"]
   ⚠️  unknown object
 - *18* a
@@ -21063,11 +21063,11 @@ ${La}${a}`("SuspenseList")
 - *31* unsupported expression
   ⚠️  This value might have side effects
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* ???*34*["value"]
   ⚠️  unknown object
 - *34* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *35* ???*36*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -21084,7 +21084,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *41* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *42* ???*43*["_reactInternals"]
   ⚠️  unknown object
 - *43* a
@@ -21116,11 +21116,11 @@ ${La}${a}`("SuspenseList")
 - *56* unsupported expression
   ⚠️  This value might have side effects
 - *57* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *58* ???*59*["value"]
   ⚠️  unknown object
 - *59* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *60* ???*61*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -21153,7 +21153,7 @@ ${La}${a}`("SuspenseList")
     (???*36* ? ???*38* : ???*39*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -21161,15 +21161,15 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["_reactInternals"]
   ⚠️  unknown object
 - *10* a
@@ -21180,7 +21180,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["_reactInternals"]
   ⚠️  unknown object
 - *15* a
@@ -21212,11 +21212,11 @@ ${La}${a}`("SuspenseList")
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -21270,7 +21270,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -21278,15 +21278,15 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["_reactInternals"]
   ⚠️  unknown object
 - *10* a
@@ -21297,7 +21297,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["_reactInternals"]
   ⚠️  unknown object
 - *15* a
@@ -21329,11 +21329,11 @@ ${La}${a}`("SuspenseList")
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -21349,7 +21349,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["shouldComponentUpdate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3024 conditional = ("function" === ???*0*)
 - *0* typeof(???*1*)
@@ -21357,39 +21357,39 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["shouldComponentUpdate"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3024 -> 3026 member call = (???*0* | ???*1*)["shouldComponentUpdate"](???*3*, ???*4*, ???*5*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3024 -> 3030 conditional = ???*0*
 - *0* ???*1*["prototype"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3030 -> 3031 call = (...) => (!(0) | !(1))(???*0*, ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3030 -> 3032 call = (...) => (!(0) | !(1))(???*0*, ???*1*)
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3033 unreachable = ???*0*
 - *0* unreachable
@@ -21405,11 +21405,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["contextType"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* b
   ⚠️  circular variable reference
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* f
   ⚠️  circular variable reference
 - *5* unknown mutation
@@ -21419,7 +21419,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["contextTypes"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* (null !== ???*10*)
   ⚠️  nested operation
 - *10* d
@@ -21429,7 +21429,7 @@ ${La}${a}`("SuspenseList")
 - *12* ???*13*["stateNode"]
   ⚠️  unknown object
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3036 conditional = (
   | ("object" === ???*0*)
@@ -21440,7 +21440,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["contextType"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* (???*5* ? ({} | ???*10*) : {})
@@ -21450,7 +21450,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["contextTypes"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* (null !== ???*9*)
   ⚠️  nested operation
 - *9* d
@@ -21460,11 +21460,11 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*["stateNode"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["contextType"]
   ⚠️  unknown object
 - *14* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unknown mutation
   ⚠️  This value might have side effects
 - *16* (???*17* ? ({} | ???*22*) : {})
@@ -21474,7 +21474,7 @@ ${La}${a}`("SuspenseList")
 - *18* ???*19*["contextTypes"]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* (null !== ???*21*)
   ⚠️  nested operation
 - *21* d
@@ -21484,7 +21484,7 @@ ${La}${a}`("SuspenseList")
 - *23* ???*24*["stateNode"]
   ⚠️  unknown object
 - *24* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3036 -> 3037 call = (...) => b(
     (
@@ -21498,11 +21498,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["contextType"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* b
   ⚠️  circular variable reference
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* f
   ⚠️  circular variable reference
 - *5* unknown mutation
@@ -21512,7 +21512,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["contextTypes"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* (null !== ???*10*)
   ⚠️  nested operation
 - *10* d
@@ -21522,7 +21522,7 @@ ${La}${a}`("SuspenseList")
 - *12* ???*13*["stateNode"]
   ⚠️  unknown object
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3036 -> 3038 call = (...) => ((null !== a) && (undefined !== a))(
     (
@@ -21531,11 +21531,11 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["contextType"]
   ⚠️  unknown object
 - *4* b
@@ -21559,17 +21559,17 @@ ${La}${a}`("SuspenseList")
 - *13* ???*14*["stateNode"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3036 -> 3039 conditional = ((null !== (???*0* | ???*1* | ???*16*)) | (undefined !== (???*18* | ???*19* | ???*34*)))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* new ???*2*(???*3*, (???*4* | undefined | ???*6* | ???*7*))
   ⚠️  nested operation
 - *2* b
   ⚠️  circular variable reference
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["contextType"]
   ⚠️  unknown object
 - *5* b
@@ -21593,19 +21593,19 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["stateNode"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["childContextTypes"]
   ⚠️  unknown object
 - *17* a
   ⚠️  circular variable reference
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* new ???*20*(???*21*, (???*22* | undefined | ???*24* | ???*25*))
   ⚠️  nested operation
 - *20* b
   ⚠️  circular variable reference
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* ???*23*["contextType"]
   ⚠️  unknown object
 - *23* b
@@ -21629,7 +21629,7 @@ ${La}${a}`("SuspenseList")
 - *32* ???*33*["stateNode"]
   ⚠️  unknown object
 - *33* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *34* ???*35*["childContextTypes"]
   ⚠️  unknown object
 - *35* a
@@ -21639,7 +21639,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["contextTypes"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== ???*3*)
   ⚠️  nested operation
 - *3* d
@@ -21647,7 +21647,7 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["contextTypes"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* (null !== ???*7*)
   ⚠️  nested operation
 - *7* d
@@ -21655,7 +21655,7 @@ ${La}${a}`("SuspenseList")
 
 3042 -> 3043 call = (...) => (Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)((???*0* | ???*1*), ({} | (???*3* ? ({} | ???*19*) : ({} | ???*20*))))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
@@ -21663,13 +21663,13 @@ ${La}${a}`("SuspenseList")
 - *3* (null !== (???*4* | ???*5* | ???*17*))
   ⚠️  nested operation
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* new ???*6*(???*7*, (???*8* | undefined | ???*10* | ???*11*))
   ⚠️  nested operation
 - *6* b
   ⚠️  circular variable reference
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["contextType"]
   ⚠️  unknown object
 - *9* b
@@ -21711,11 +21711,11 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["contextType"]
   ⚠️  unknown object
 - *4* b
@@ -21739,17 +21739,17 @@ ${La}${a}`("SuspenseList")
 - *13* ???*14*["stateNode"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["contextType"]
   ⚠️  unknown object
 - *17* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* b
   ⚠️  circular variable reference
 - *19* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* f
   ⚠️  circular variable reference
 - *21* unknown mutation
@@ -21759,7 +21759,7 @@ ${La}${a}`("SuspenseList")
 - *23* ???*24*["contextTypes"]
   ⚠️  unknown object
 - *24* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* (null !== ???*26*)
   ⚠️  nested operation
 - *26* d
@@ -21769,17 +21769,17 @@ ${La}${a}`("SuspenseList")
 - *28* ???*29*["stateNode"]
   ⚠️  unknown object
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3048 conditional = ((null !== ???*0*) | (undefined !== ???*2*))
 - *0* ???*1*["state"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["state"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3056 unreachable = ???*0*
 - *0* unreachable
@@ -21789,29 +21789,29 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["componentWillReceiveProps"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3061 member call = ???*0*["componentWillReceiveProps"](???*1*, ???*2*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3062 typeof = typeof(???*0*)
 - *0* ???*1*["UNSAFE_componentWillReceiveProps"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3065 member call = ???*0*["UNSAFE_componentWillReceiveProps"](???*1*, ???*2*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3069 member call = {
     "isMounted": (...) => (a["_reactInternals"] ? (Vb(a) === a) : !(1)),
@@ -21820,31 +21820,31 @@ ${La}${a}`("SuspenseList")
     "enqueueForceUpdate": (...) => undefined
 }["enqueueReplaceState"](???*0*, ???*1*, null)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["state"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3075 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3077 typeof = typeof((???*0* | (???*2* ? ({} | ???*7*) : ({} | ???*8*))))
 - *0* ???*1*["contextType"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== (???*3* | ???*4*))
   ⚠️  nested operation
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["state"]
   ⚠️  unknown object
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unknown mutation
   ⚠️  This value might have side effects
 - *8* unknown mutation
@@ -21856,13 +21856,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["contextType"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (???*4* ? ({} | ???*8*) : ({} | ???*9*))
   ⚠️  nested operation
 - *4* (null !== (???*5* | ???*6*))
   ⚠️  nested operation
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["state"]
   ⚠️  unknown object
 - *7* ???["stateNode"]
@@ -21874,19 +21874,19 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["contextType"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* (???*13* ? ({} | ???*18*) : ({} | ???*19*))
   ⚠️  nested operation
 - *13* (null !== (???*14* | ???*15*))
   ⚠️  nested operation
 - *14* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["state"]
   ⚠️  unknown object
 - *16* ???*17*["stateNode"]
   ⚠️  unknown object
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* unknown mutation
   ⚠️  This value might have side effects
 - *19* unknown mutation
@@ -21898,17 +21898,17 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["contextType"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== (???*3* | ???*4*))
   ⚠️  nested operation
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["state"]
   ⚠️  unknown object
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unknown mutation
   ⚠️  This value might have side effects
 - *8* unknown mutation
@@ -21916,52 +21916,52 @@ ${La}${a}`("SuspenseList")
 
 3078 -> 3081 call = (...) => ((null !== a) && (undefined !== a))((???*0* | ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["state"]
   ⚠️  unknown object
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3078 -> 3082 conditional = ((null !== (???*0* | ???*1*)) | (undefined !== (???*4* | ???*5*)))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["state"]
   ⚠️  unknown object
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["state"]
   ⚠️  unknown object
 - *6* ???*7*["stateNode"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3078 -> 3085 call = (...) => (Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)(
     ???*0*,
     (???*1* | (???*3* ? ({} | ???*8*) : ({} | ???*9*)))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["contextType"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (null !== (???*4* | ???*5*))
   ⚠️  nested operation
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["state"]
   ⚠️  unknown object
 - *6* ???*7*["stateNode"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* unknown mutation
   ⚠️  This value might have side effects
 - *9* unknown mutation
@@ -21971,17 +21971,17 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["contextType"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== (???*3* | ???*4*))
   ⚠️  nested operation
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["state"]
   ⚠️  unknown object
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unknown mutation
   ⚠️  This value might have side effects
 - *8* unknown mutation
@@ -21994,41 +21994,41 @@ ${La}${a}`("SuspenseList")
     ???*14*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["state"]
   ⚠️  unknown object
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["contextType"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (null !== (???*8* | ???*9*))
   ⚠️  nested operation
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["state"]
   ⚠️  unknown object
 - *10* ???*11*["stateNode"]
   ⚠️  unknown object
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* unknown mutation
   ⚠️  This value might have side effects
 - *13* unknown mutation
   ⚠️  This value might have side effects
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3093 typeof = typeof(???*0*)
 - *0* ???*1*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3095 typeof = typeof(???*0*)
 - *0* ???*1*["getSnapshotBeforeUpdate"]
@@ -22036,7 +22036,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3097 typeof = typeof(???*0*)
 - *0* ???*1*["UNSAFE_componentWillMount"]
@@ -22044,7 +22044,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3099 typeof = typeof(???*0*)
 - *0* ???*1*["componentWillMount"]
@@ -22052,7 +22052,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3102 typeof = typeof(???*0*)
 - *0* ???*1*["componentWillMount"]
@@ -22060,13 +22060,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3105 member call = ???*0*["componentWillMount"]()
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3106 typeof = typeof(???*0*)
 - *0* ???*1*["UNSAFE_componentWillMount"]
@@ -22074,13 +22074,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3109 member call = ???*0*["UNSAFE_componentWillMount"]()
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3113 member call = {
     "isMounted": (...) => (a["_reactInternals"] ? (Vb(a) === a) : !(1)),
@@ -22091,25 +22091,25 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["state"]
   ⚠️  unknown object
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3114 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*4*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3117 typeof = typeof(???*0*)
 - *0* ???*1*["componentDidMount"]
@@ -22117,57 +22117,57 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3121 typeof = typeof((???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["ref"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3122 typeof = typeof((???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["ref"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3123 conditional = ((null !== (???*0* | ???*1*)) | ("function" !== ???*3*) | ("object" !== ???*7*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["ref"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* typeof((???*4* | ???*5*))
   ⚠️  nested operation
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["ref"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* typeof((???*8* | ???*9*))
   ⚠️  nested operation
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["ref"]
   ⚠️  unknown object
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3123 -> 3125 conditional = ???*0*
 - *0* ???*1*["_owner"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3125 -> 3127 conditional = (???*0* | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_owner"]
   ⚠️  unknown object
 - *2* c
@@ -22177,7 +22177,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3129 -> 3130 free var = FreeVar(Error)
 
@@ -22196,17 +22196,17 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3134 -> 3135 free var = FreeVar(Error)
 
 3134 -> 3136 call = (...) => `Minified React error #${a}; visit ${b} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`(147, (???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["ref"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3134 -> 3137 call = ???*0*(
     `Minified React error #${147}; visit ${???*1*} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`
@@ -22221,7 +22221,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["ref"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3125 -> 3143 conditional = (
   | (null !== (???*0* | (...) => undefined))
@@ -22230,29 +22230,29 @@ ${La}${a}`("SuspenseList")
   | ((???*6* | (...) => undefined["ref"]["_stringRef"]) === (???*9* | ???*10* | undefined))
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["ref"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* typeof((???*4* | (...) => undefined["ref"]))
   ⚠️  nested operation
 - *4* ???*5*["ref"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["_stringRef"]
   ⚠️  unknown object
 - *7* ???*8*["ref"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["ref"]
   ⚠️  unknown object
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3143 -> 3145 unreachable = ???*0*
 - *0* unreachable
@@ -22260,7 +22260,7 @@ ${La}${a}`("SuspenseList")
 
 3143 -> 3148 conditional = (null === ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3143 -> 3152 unreachable = ???*0*
 - *0* unreachable
@@ -22268,21 +22268,21 @@ ${La}${a}`("SuspenseList")
 
 3125 -> 3153 typeof = typeof((???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["ref"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3125 -> 3154 conditional = ("string" !== ???*0*)
 - *0* typeof((???*1* | ???*2*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["ref"]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3154 -> 3155 free var = FreeVar(Error)
 
@@ -22301,17 +22301,17 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["_owner"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3159 -> 3160 free var = FreeVar(Error)
 
 3159 -> 3161 call = (...) => `Minified React error #${a}; visit ${b} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`(290, (???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["ref"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3159 -> 3162 call = ???*0*(
     `Minified React error #${290}; visit ${???*1*} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`
@@ -22337,13 +22337,13 @@ ${La}${a}`("SuspenseList")
   ⚠️  This value might have side effects
 - *2* Object: The global Object variable
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3169 free var = FreeVar(Error)
 
 0 -> 3170 conditional = ("[object Object]" === (???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["call"](b)
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
@@ -22360,7 +22360,7 @@ ${La}${a}`("SuspenseList")
 3170 -> 3174 member call = Object*0*["keys"](???*1*)
 - *0* Object: The global Object variable
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3170 -> 3175 member call = ???*0*["join"](", ")
 - *0* ???*1*(???*3*)
@@ -22371,13 +22371,13 @@ ${La}${a}`("SuspenseList")
   ⚠️  This value might have side effects
 - *2* Object: The global Object variable
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3176 call = (...) => `Minified React error #${a}; visit ${b} for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`(31, (???*0* ? ???*6* : (???*12* | ???*13*)))
 - *0* ("[object Object]" === (???*1* | ???*2*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["call"](b)
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
@@ -22401,9 +22401,9 @@ ${La}${a}`("SuspenseList")
   ⚠️  This value might have side effects
 - *10* Object: The global Object variable
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["call"](b)
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
@@ -22428,11 +22428,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["_init"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["_payload"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3181 unreachable = ???*0*
 - *0* unreachable
@@ -22444,25 +22444,25 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3183 conditional = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3183 -> 3185 conditional = (null === (???*0* | undefined))
 - *0* ???*1*["deletions"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3185 -> 3189 member call = (???*0* | undefined)["push"](???*2*)
 - *0* ???*1*["deletions"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3190 conditional = !(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3190 -> 3191 unreachable = ???*0*
 - *0* unreachable
@@ -22470,9 +22470,9 @@ ${La}${a}`("SuspenseList")
 
 3190 -> 3192 call = (...) => undefined(???*0*, (???*1* | ???*2*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["sibling"]
   ⚠️  unknown object
 - *3* d
@@ -22493,20 +22493,20 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["key"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3198 -> 3201 member call = (???*0* | new ???*1*())["set"](???*2*, (???*4* | ???*5*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* FreeVar(Map)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *2* ???*3*["key"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["sibling"]
   ⚠️  unknown object
 - *6* b
@@ -22514,16 +22514,16 @@ ${La}${a}`("SuspenseList")
 
 3198 -> 3204 member call = (???*0* | new ???*1*())["set"](???*2*, (???*4* | ???*5*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* FreeVar(Map)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *2* ???*3*["index"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["sibling"]
   ⚠️  unknown object
 - *6* b
@@ -22542,7 +22542,7 @@ ${La}${a}`("SuspenseList")
     ???*12*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* a
@@ -22552,7 +22552,7 @@ ${La}${a}`("SuspenseList")
 - *4* a
   ⚠️  circular variable reference
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["dependencies"]
   ⚠️  unknown object
 - *7* a
@@ -22566,7 +22566,7 @@ ${La}${a}`("SuspenseList")
 - *11* a
   ⚠️  circular variable reference
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3210 unreachable = ???*0*
 - *0* unreachable
@@ -22574,7 +22574,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3212 conditional = !(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3212 -> 3214 unreachable = ???*0*
 - *0* unreachable
@@ -22582,11 +22582,11 @@ ${La}${a}`("SuspenseList")
 
 3212 -> 3216 conditional = (null !== (???*0* | ???*1*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3216 -> 3219 unreachable = ???*0*
 - *0* unreachable
@@ -22602,7 +22602,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3226 conditional = ((null === (???*0* | ???*1* | ???*5* | ???*6*)) | (6 !== ???*8*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* new (...) => undefined(6, ???*2*, null, ???*3*)
   ⚠️  nested operation
 - *2* a
@@ -22610,7 +22610,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* b
   ⚠️  circular variable reference
 - *6* ???*7*["alternate"]
@@ -22620,17 +22620,17 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["tag"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3226 -> 3228 call = (...) => a(???*0*, ???*1*, ???*3*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["mode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3226 -> 3230 unreachable = ???*0*
 - *0* unreachable
@@ -22647,13 +22647,13 @@ ${La}${a}`("SuspenseList")
     ???*16*
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["mode"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* b
   ⚠️  circular variable reference
 - *5* ???*6*["alternate"]
@@ -22665,7 +22665,7 @@ ${La}${a}`("SuspenseList")
 - *8* a
   ⚠️  circular variable reference
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["dependencies"]
   ⚠️  unknown object
 - *11* a
@@ -22679,7 +22679,7 @@ ${La}${a}`("SuspenseList")
 - *15* a
   ⚠️  circular variable reference
 - *16* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3226 -> 3233 unreachable = ???*0*
 - *0* unreachable
@@ -22689,7 +22689,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["for"]("react.fragment")
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
@@ -22716,17 +22716,17 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["children"]
   ⚠️  unknown object
 - *4* ???*5*["props"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["alternate"]
   ⚠️  unknown object
 - *8* a
@@ -22738,7 +22738,7 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*["props"]
   ⚠️  unknown object
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["key"]
   ⚠️  unknown object
 - *14* a
@@ -22752,25 +22752,25 @@ ${La}${a}`("SuspenseList")
 - *18* ???*19*["key"]
   ⚠️  unknown object
 - *19* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*21*, ???*23*, (???*24* | ???*26*))
   ⚠️  nested operation
 - *21* ???*22*["props"]
   ⚠️  unknown object
 - *22* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* b
   ⚠️  circular variable reference
 - *24* ???*25*["mode"]
   ⚠️  unknown object
 - *25* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* unsupported assign operation
   ⚠️  This value might have side effects
 - *27* ???*28*["mode"]
   ⚠️  unknown object
 - *28* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *29* unsupported assign operation
   ⚠️  This value might have side effects
 - *30* a
@@ -22781,43 +22781,43 @@ ${La}${a}`("SuspenseList")
 - *32* ???*33*["key"]
   ⚠️  unknown object
 - *33* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *34* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*35*, ???*37*, (???*38* | ???*40*))
   ⚠️  nested operation
 - *35* ???*36*["props"]
   ⚠️  unknown object
 - *36* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* b
   ⚠️  circular variable reference
 - *38* ???*39*["mode"]
   ⚠️  unknown object
 - *39* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *40* unsupported assign operation
   ⚠️  This value might have side effects
 - *41* ???*42*["mode"]
   ⚠️  unknown object
 - *42* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *43* unsupported assign operation
   ⚠️  This value might have side effects
 - *44* ???*45*["props"]
   ⚠️  unknown object
 - *45* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *46* b
   ⚠️  circular variable reference
 - *47* ???*48*["mode"]
   ⚠️  unknown object
 - *48* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *49* unsupported assign operation
   ⚠️  This value might have side effects
 - *50* ???*51*["key"]
   ⚠️  unknown object
 - *51* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3235 -> 3240 unreachable = ???*0*
 - *0* unreachable
@@ -22827,13 +22827,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3235 -> 3244 call = (...) => b(a["_payload"])(???*0*)
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3235 -> 3246 conditional = (
   | (null !== ???*0*)
@@ -22844,31 +22844,31 @@ ${La}${a}`("SuspenseList")
   | (???*15* === ???*19*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["elementType"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["type"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* typeof(???*6*)
   ⚠️  nested operation
 - *6* ???*7*["type"]
   ⚠️  unknown object
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["type"]
   ⚠️  unknown object
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["$$typeof"]
   ⚠️  unknown object
 - *11* ???*12*["type"]
   ⚠️  unknown object
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["for"]("react.lazy")
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
@@ -22882,27 +22882,27 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["type"]
   ⚠️  unknown object
 - *18* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["type"]
   ⚠️  unknown object
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3246 -> 3248 call = (...) => a(???*0*, ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["props"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3246 -> 3250 call = (...) => (b["ref"] | b | a)(???*0*, ???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3246 -> 3252 unreachable = ???*0*
 - *0* unreachable
@@ -22930,21 +22930,21 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["key"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["props"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["mode"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["alternate"]
   ⚠️  unknown object
 - *11* a
@@ -22956,7 +22956,7 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["props"]
   ⚠️  unknown object
 - *15* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["key"]
   ⚠️  unknown object
 - *17* a
@@ -22970,25 +22970,25 @@ ${La}${a}`("SuspenseList")
 - *21* ???*22*["key"]
   ⚠️  unknown object
 - *22* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*24*, ???*26*, (???*27* | ???*29*))
   ⚠️  nested operation
 - *24* ???*25*["props"]
   ⚠️  unknown object
 - *25* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* b
   ⚠️  circular variable reference
 - *27* ???*28*["mode"]
   ⚠️  unknown object
 - *28* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *29* unsupported assign operation
   ⚠️  This value might have side effects
 - *30* ???*31*["mode"]
   ⚠️  unknown object
 - *31* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* unsupported assign operation
   ⚠️  This value might have side effects
 - *33* a
@@ -22999,47 +22999,47 @@ ${La}${a}`("SuspenseList")
 - *35* ???*36*["key"]
   ⚠️  unknown object
 - *36* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*38*, ???*40*, (???*41* | ???*43*))
   ⚠️  nested operation
 - *38* ???*39*["props"]
   ⚠️  unknown object
 - *39* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *40* b
   ⚠️  circular variable reference
 - *41* ???*42*["mode"]
   ⚠️  unknown object
 - *42* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *43* unsupported assign operation
   ⚠️  This value might have side effects
 - *44* ???*45*["mode"]
   ⚠️  unknown object
 - *45* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *46* unsupported assign operation
   ⚠️  This value might have side effects
 - *47* ???*48*["props"]
   ⚠️  unknown object
 - *48* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *49* b
   ⚠️  circular variable reference
 - *50* ???*51*["mode"]
   ⚠️  unknown object
 - *51* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *52* unsupported assign operation
   ⚠️  This value might have side effects
 
 3246 -> 3259 call = (...) => (b["ref"] | b | a)(???*0*, ???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3246 -> 3261 unreachable = ???*0*
 - *0* unreachable
@@ -23047,11 +23047,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3269 conditional = ((null === (???*0* | ???*1* | ???*3* | ???*13*)) | (4 !== ???*14*) | (???*16* !== ???*19*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["mode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* new (...) => undefined(4, ???*4*, ???*10*, ???*12*)
   ⚠️  nested operation
 - *4* (???*5* ? ???*8* : [])
@@ -23061,15 +23061,15 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["children"]
   ⚠️  unknown object
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["children"]
   ⚠️  unknown object
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["key"]
   ⚠️  unknown object
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* b
   ⚠️  circular variable reference
 - *13* b
@@ -23077,27 +23077,27 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["tag"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["containerInfo"]
   ⚠️  unknown object
 - *17* ???*18*["stateNode"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["containerInfo"]
   ⚠️  unknown object
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3269 -> 3271 call = (...) => b(???*0*, ???*1*, ???*3*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["mode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3269 -> 3273 unreachable = ???*0*
 - *0* unreachable
@@ -23114,11 +23114,11 @@ ${La}${a}`("SuspenseList")
     (???*21* | []){truthy}
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["mode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (???*4* ? ???*7* : [])
   ⚠️  nested operation
 - *4* (null !== ???*5*)
@@ -23126,15 +23126,15 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["children"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["children"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["key"]
   ⚠️  unknown object
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* b
   ⚠️  circular variable reference
 - *12* b
@@ -23146,7 +23146,7 @@ ${La}${a}`("SuspenseList")
 - *15* ???*16*["children"]
   ⚠️  unknown object
 - *16* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["key"]
   ⚠️  unknown object
 - *18* a
@@ -23158,7 +23158,7 @@ ${La}${a}`("SuspenseList")
 - *21* ???*22*["children"]
   ⚠️  unknown object
 - *22* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3269 -> 3277 unreachable = ???*0*
 - *0* unreachable
@@ -23166,17 +23166,17 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3279 conditional = ((null === (???*0* | ???*1* | ???*6* | ???*7*)) | (7 !== ???*9*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* new (...) => undefined(7, ???*2*, ???*3*, ???*4*)
   ⚠️  nested operation
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["mode"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* b
   ⚠️  circular variable reference
 - *7* ???*8*["alternate"]
@@ -23186,19 +23186,19 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*["tag"]
   ⚠️  unknown object
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3279 -> 3281 call = (...) => a(???*0*, ???*1*, ???*3*, ???*4*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["mode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3279 -> 3283 unreachable = ???*0*
 - *0* unreachable
@@ -23215,15 +23215,15 @@ ${La}${a}`("SuspenseList")
     ???*17*
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* b
   ⚠️  circular variable reference
 - *6* ???*7*["alternate"]
@@ -23235,7 +23235,7 @@ ${La}${a}`("SuspenseList")
 - *9* a
   ⚠️  circular variable reference
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["dependencies"]
   ⚠️  unknown object
 - *12* a
@@ -23249,7 +23249,7 @@ ${La}${a}`("SuspenseList")
 - *16* a
   ⚠️  circular variable reference
 - *17* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3279 -> 3286 unreachable = ???*0*
 - *0* unreachable
@@ -23264,7 +23264,7 @@ ${La}${a}`("SuspenseList")
   | new (...) => undefined(7, ???*16*, null, ???*17*)
 ))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* a
@@ -23272,11 +23272,11 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["mode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (???*8* ? ???*11* : [])
   ⚠️  nested operation
 - *8* (null !== ???*9*)
@@ -23300,7 +23300,7 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["mode"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3288 typeof = typeof((
   | ???*0*
@@ -23311,7 +23311,7 @@ ${La}${a}`("SuspenseList")
   | new (...) => undefined(7, ???*16*, null, ???*17*)
 ))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* a
@@ -23319,11 +23319,11 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["mode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (???*8* ? ???*11* : [])
   ⚠️  nested operation
 - *8* (null !== ???*9*)
@@ -23347,13 +23347,13 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["mode"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3289 conditional = (("string" === ???*0*) | ("" !== (???*9* | ???*10* | ???*11* | ???*15*)) | ("number" === ???*17*))
 - *0* typeof((???*1* | ???*2* | ???*3* | ???*7*))
   ⚠️  nested operation
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* b
   ⚠️  circular variable reference
 - *3* new (...) => undefined(6, ???*4*, null, ???*5*)
@@ -23363,13 +23363,13 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["mode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["mode"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* b
   ⚠️  circular variable reference
 - *11* new (...) => undefined(6, ???*12*, null, ???*13*)
@@ -23379,15 +23379,15 @@ ${La}${a}`("SuspenseList")
 - *13* ???*14*["mode"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["mode"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* typeof((???*18* | ???*19* | ???*20* | ???*24*))
   ⚠️  nested operation
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* b
   ⚠️  circular variable reference
 - *20* new (...) => undefined(6, ???*21*, null, ???*22*)
@@ -23397,11 +23397,11 @@ ${La}${a}`("SuspenseList")
 - *22* ???*23*["mode"]
   ⚠️  unknown object
 - *23* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* ???*25*["mode"]
   ⚠️  unknown object
 - *25* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3289 -> 3291 call = (...) => a(
     (
@@ -23416,7 +23416,7 @@ ${La}${a}`("SuspenseList")
     (???*21* | ???*22*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* a
@@ -23424,11 +23424,11 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["mode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (???*8* ? ???*11* : [])
   ⚠️  nested operation
 - *8* (null !== ???*9*)
@@ -23452,13 +23452,13 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["mode"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["mode"]
   ⚠️  unknown object
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* node limit reached
   ⚠️  This value might have side effects
 
@@ -23475,7 +23475,7 @@ ${La}${a}`("SuspenseList")
   | new (...) => undefined(7, ???*16*, null, ???*17*)
 ))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* a
@@ -23483,11 +23483,11 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["mode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (???*8* ? ???*11* : [])
   ⚠️  nested operation
 - *8* (null !== ???*9*)
@@ -23511,13 +23511,13 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["mode"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3289 -> 3295 conditional = (("object" === ???*0*) | (null !== (???*9* | ???*10* | ???*11* | ???*15*)))
 - *0* typeof((???*1* | ???*2* | ???*3* | ???*7*))
   ⚠️  nested operation
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* b
   ⚠️  circular variable reference
 - *3* new (...) => undefined(6, ???*4*, null, ???*5*)
@@ -23527,13 +23527,13 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["mode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["mode"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* b
   ⚠️  circular variable reference
 - *11* new (...) => undefined(6, ???*12*, null, ???*13*)
@@ -23543,11 +23543,11 @@ ${La}${a}`("SuspenseList")
 - *13* ???*14*["mode"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["mode"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3295 -> 3301 call = (...) => (Ah(c["children"], e, f, b) | ???*0* | qj(c, e, f, b) | b)(
     (
@@ -23578,13 +23578,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* a
   ⚠️  circular variable reference
 - *4* ???*5*["mode"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* (???*7* ? ???*10* : [])
   ⚠️  nested operation
 - *7* (null !== ???*8*)
@@ -23608,17 +23608,17 @@ ${La}${a}`("SuspenseList")
 - *16* ???*17*["mode"]
   ⚠️  unknown object
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["key"]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* a
   ⚠️  circular variable reference
 - *21* ???*22*["mode"]
   ⚠️  unknown object
 - *22* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* (???*24* ? ???*27* : [])
   ⚠️  nested operation
 - *24* (null !== ???*25*)
@@ -23642,17 +23642,17 @@ ${La}${a}`("SuspenseList")
 - *33* ???*34*["mode"]
   ⚠️  unknown object
 - *34* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *35* ???*36*["props"]
   ⚠️  unknown object
 - *36* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* a
   ⚠️  circular variable reference
 - *38* ???*39*["mode"]
   ⚠️  unknown object
 - *39* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *40* (???*41* ? ???*44* : [])
   ⚠️  nested operation
 - *41* (null !== ???*42*)
@@ -23676,13 +23676,13 @@ ${La}${a}`("SuspenseList")
 - *50* ???*51*["mode"]
   ⚠️  unknown object
 - *51* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *52* ???*53*["mode"]
   ⚠️  unknown object
 - *53* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *54* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *55* node limit reached
   ⚠️  This value might have side effects
 
@@ -23699,9 +23699,9 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* b
   ⚠️  circular variable reference
 - *3* a
@@ -23709,11 +23709,11 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["mode"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["mode"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* (???*9* ? ???*12* : [])
   ⚠️  nested operation
 - *9* (null !== ???*10*)
@@ -23737,7 +23737,7 @@ ${La}${a}`("SuspenseList")
 - *18* ???*19*["mode"]
   ⚠️  unknown object
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3295 -> 3305 unreachable = ???*0*
 - *0* unreachable
@@ -23756,7 +23756,7 @@ ${La}${a}`("SuspenseList")
     (???*21* | ???*22*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* a
@@ -23764,11 +23764,11 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["mode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (???*8* ? ???*11* : [])
   ⚠️  nested operation
 - *8* (null !== ???*9*)
@@ -23792,13 +23792,13 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["mode"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["mode"]
   ⚠️  unknown object
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* node limit reached
   ⚠️  This value might have side effects
 
@@ -23823,13 +23823,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["_init"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (???*6* ? ???*9* : [])
   ⚠️  nested operation
 - *6* (null !== ???*7*)
@@ -23853,17 +23853,17 @@ ${La}${a}`("SuspenseList")
 - *15* ???*16*["mode"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["_payload"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* a
   ⚠️  circular variable reference
 - *20* ???*21*["mode"]
   ⚠️  unknown object
 - *21* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* (???*23* ? ???*26* : [])
   ⚠️  nested operation
 - *23* (null !== ???*24*)
@@ -23887,14 +23887,14 @@ ${La}${a}`("SuspenseList")
 - *32* ???*33*["mode"]
   ⚠️  unknown object
 - *33* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3295 -> 3313 call = (...) => (???*0* | q(a, d(b["_payload"]), c) | null)(???*1*, ???*2*, (???*20* | ???*21*))
 - *0* b
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (
       | ???*3*
       | new (...) => undefined(6, ???*5*, null, ???*6*)["_init"]
@@ -23906,13 +23906,13 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["_init"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* a
   ⚠️  circular variable reference
 - *6* ???*7*["mode"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* (???*9* ? ???*12* : [])
   ⚠️  nested operation
 - *9* (null !== ???*10*)
@@ -23936,9 +23936,9 @@ ${La}${a}`("SuspenseList")
 - *18* ???*19*["mode"]
   ⚠️  unknown object
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* node limit reached
   ⚠️  This value might have side effects
 
@@ -23963,7 +23963,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* b
   ⚠️  circular variable reference
 - *4* a
@@ -23971,11 +23971,11 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["mode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["mode"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* (???*10* ? ???*13* : [])
   ⚠️  nested operation
 - *10* (null !== ???*11*)
@@ -23999,7 +23999,7 @@ ${La}${a}`("SuspenseList")
 - *19* ???*20*["mode"]
   ⚠️  unknown object
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3295 -> 3316 call = (...) => (null | (("function" === typeof(a)) ? a : null))(
     (
@@ -24012,7 +24012,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* a
@@ -24020,11 +24020,11 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["mode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (???*8* ? ???*11* : [])
   ⚠️  nested operation
 - *8* (null !== ???*9*)
@@ -24048,7 +24048,7 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["mode"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3295 -> 3317 conditional = (
   | ???*0*
@@ -24069,7 +24069,7 @@ ${La}${a}`("SuspenseList")
 - *4* typeof((???*5* | ???*6* | ???*7* | ???*11* | ???*13*))
   ⚠️  nested operation
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* b
   ⚠️  circular variable reference
 - *7* new (...) => undefined(6, ???*8*, null, ???*9*)
@@ -24079,11 +24079,11 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*["mode"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["mode"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["iterator"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -24091,7 +24091,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* b
   ⚠️  circular variable reference
 - *17* new (...) => undefined(6, ???*18*, null, ???*19*)
@@ -24101,11 +24101,11 @@ ${La}${a}`("SuspenseList")
 - *19* ???*20*["mode"]
   ⚠️  unknown object
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["mode"]
   ⚠️  unknown object
 - *22* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* ???*24*["iterator"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -24127,7 +24127,7 @@ ${La}${a}`("SuspenseList")
     null
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* a
@@ -24135,11 +24135,11 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["mode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (???*8* ? ???*11* : [])
   ⚠️  nested operation
 - *8* (null !== ???*9*)
@@ -24163,13 +24163,13 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["mode"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["mode"]
   ⚠️  unknown object
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* node limit reached
   ⚠️  This value might have side effects
 
@@ -24189,9 +24189,9 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* b
   ⚠️  circular variable reference
 - *3* a
@@ -24199,11 +24199,11 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["mode"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["mode"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* (???*9* ? ???*12* : [])
   ⚠️  nested operation
 - *9* (null !== ???*10*)
@@ -24227,7 +24227,7 @@ ${La}${a}`("SuspenseList")
 - *18* ???*19*["mode"]
   ⚠️  unknown object
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3289 -> 3323 unreachable = ???*0*
 - *0* unreachable
@@ -24235,27 +24235,27 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3324 conditional = (null !== ???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3326 typeof = typeof(???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3327 typeof = typeof(???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3328 conditional = (("string" === ???*0*) | ("" !== ???*2*) | ("number" === ???*3*))
 - *0* typeof(???*1*)
   ⚠️  nested operation
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* typeof(???*4*)
   ⚠️  nested operation
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3328 -> 3329 conditional = (null !== (???*0* | ???*5*))
 - *0* (???*1* ? ???*3* : null)
@@ -24263,28 +24263,28 @@ ${La}${a}`("SuspenseList")
 - *1* (null !== ???*2*)
   ⚠️  nested operation
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["key"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["_init"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3329 -> 3330 call = (...) => (???*0* | b)(???*1*, ???*2*, ???*3*, ???*4*)
 - *0* b
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3328 -> 3331 unreachable = ???*0*
 - *0* unreachable
@@ -24292,48 +24292,48 @@ ${La}${a}`("SuspenseList")
 
 3328 -> 3332 typeof = typeof(???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3328 -> 3333 conditional = (("object" === ???*0*) | (null !== ???*2*))
 - *0* typeof(???*1*)
   ⚠️  nested operation
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3333 -> 3336 conditional = (???*0* === (???*2* | ???*7*))
 - *0* ???*1*["key"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? ???*5* : null)
   ⚠️  nested operation
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["key"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["_init"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3336 -> 3337 call = (...) => (m(a, b, c["props"]["children"], d, c["key"]) | ???*0* | d)(???*1*, ???*2*, ???*3*, ???*4*)
 - *0* d
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3333 -> 3338 unreachable = ???*0*
 - *0* unreachable
@@ -24343,34 +24343,34 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["key"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? ???*5* : null)
   ⚠️  nested operation
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["key"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["_init"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3340 -> 3341 call = (...) => (???*0* | b)(???*1*, ???*2*, ???*3*, ???*4*)
 - *0* b
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3333 -> 3342 unreachable = ???*0*
 - *0* unreachable
@@ -24380,19 +24380,19 @@ ${La}${a}`("SuspenseList")
 - *0* (null !== ???*1*)
   ⚠️  nested operation
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["key"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["_init"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["_payload"]
   ⚠️  unknown object
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3333 -> 3346 call = (...) => (
   | ((null !== e) ? null : h(a, b, `${c}`, d))
@@ -24403,25 +24403,25 @@ ${La}${a}`("SuspenseList")
   | null
 )(???*0*, ???*1*, ???*2*, ???*9*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ((???*3* ? ???*5* : null) | ???*7*)(c["_payload"])
   ⚠️  non-function callee
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["key"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["_init"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3333 -> 3347 unreachable = ???*0*
 - *0* unreachable
@@ -24435,11 +24435,11 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3333 -> 3349 call = (...) => (null | (("function" === typeof(a)) ? a : null))(???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3333 -> 3350 conditional = (???*0* | null | (???*3* ? (???*10* | ???*11* | ???*13*) : null))
 - *0* ???*1*(c)
@@ -24456,7 +24456,7 @@ ${La}${a}`("SuspenseList")
 - *4* typeof((???*5* | ???*6* | ???*8*))
   ⚠️  nested operation
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["iterator"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -24468,7 +24468,7 @@ ${La}${a}`("SuspenseList")
 - *9* a
   ⚠️  circular variable reference
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["iterator"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -24486,28 +24486,28 @@ ${La}${a}`("SuspenseList")
 - *1* (null !== ???*2*)
   ⚠️  nested operation
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["key"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["_init"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3351 -> 3352 call = (...) => (???*0* | b)(???*1*, ???*2*, ???*3*, ???*4*, null)
 - *0* b
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3350 -> 3353 unreachable = ???*0*
 - *0* unreachable
@@ -24515,9 +24515,9 @@ ${La}${a}`("SuspenseList")
 
 3350 -> 3354 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3328 -> 3355 unreachable = ???*0*
 - *0* unreachable
@@ -24525,50 +24525,50 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3356 typeof = typeof(???*0*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3357 typeof = typeof(???*0*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3358 conditional = (("string" === ???*0*) | ("" !== ???*2*) | ("number" === ???*3*))
 - *0* typeof(???*1*)
   ⚠️  nested operation
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* typeof(???*4*)
   ⚠️  nested operation
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3358 -> 3360 member call = (???*0* | ???*1* | null)["get"](???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["get"](c)
   ⚠️  unknown callee object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3358 -> 3361 call = (...) => (???*0* | b)(???*1*, (???*2* | ???*3* | null), ???*5*, ???*6*)
 - *0* b
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["get"](c)
   ⚠️  unknown callee object
 - *4* a
   ⚠️  circular variable reference
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3358 -> 3362 unreachable = ???*0*
 - *0* unreachable
@@ -24576,25 +24576,25 @@ ${La}${a}`("SuspenseList")
 
 3358 -> 3363 typeof = typeof(???*0*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3358 -> 3364 conditional = (("object" === ???*0*) | (null !== ???*2*))
 - *0* typeof(???*1*)
   ⚠️  nested operation
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3364 -> 3368 conditional = (null === ???*0*)
 - *0* ???*1*["key"]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3364 -> 3370 member call = (???*0* | ???*1* | null)["get"]((???*3* ? ???*6* : ???*7*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["get"](c)
   ⚠️  unknown callee object
 - *2* a
@@ -24604,30 +24604,30 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["key"]
   ⚠️  unknown object
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["key"]
   ⚠️  unknown object
 - *8* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3364 -> 3371 call = (...) => (m(a, b, c["props"]["children"], d, c["key"]) | ???*0* | d)(???*1*, (???*2* | ???*3* | null), ???*5*, ???*6*)
 - *0* d
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["get"](c)
   ⚠️  unknown callee object
 - *4* a
   ⚠️  circular variable reference
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3364 -> 3372 unreachable = ???*0*
 - *0* unreachable
@@ -24637,11 +24637,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["key"]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3364 -> 3377 member call = (???*0* | ???*1* | null)["get"]((???*3* ? ???*6* : ???*7*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["get"](c)
   ⚠️  unknown callee object
 - *2* a
@@ -24651,30 +24651,30 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["key"]
   ⚠️  unknown object
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["key"]
   ⚠️  unknown object
 - *8* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3364 -> 3378 call = (...) => (???*0* | b)(???*1*, (???*2* | ???*3* | null), ???*5*, ???*6*)
 - *0* b
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["get"](c)
   ⚠️  unknown callee object
 - *4* a
   ⚠️  circular variable reference
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3364 -> 3379 unreachable = ???*0*
 - *0* unreachable
@@ -24684,34 +24684,34 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["_init"]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["_payload"]
   ⚠️  unknown object
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3364 -> 3383 call = (...) => (???*0* | y(a, b, c, f(d["_payload"]), e) | null)((???*1* | ???*2* | null), ???*4*, ???*5*, ???*6*, ???*9*)
 - *0* h(b, a, ("" + d), e)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["get"](c)
   ⚠️  unknown callee object
 - *3* a
   ⚠️  circular variable reference
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* (???*7* | undefined)(d["_payload"])
   ⚠️  non-function callee
 - *7* ???*8*["_init"]
   ⚠️  unknown object
 - *8* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3364 -> 3384 unreachable = ???*0*
 - *0* unreachable
@@ -24725,11 +24725,11 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3364 -> 3386 call = (...) => (null | (("function" === typeof(a)) ? a : null))(???*0*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3364 -> 3387 conditional = (???*0* | null | (???*3* ? (???*10* | ???*11* | ???*13*) : null))
 - *0* ???*1*(d)
@@ -24746,7 +24746,7 @@ ${La}${a}`("SuspenseList")
 - *4* typeof((???*5* | ???*6* | ???*8*))
   ⚠️  nested operation
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["iterator"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -24758,7 +24758,7 @@ ${La}${a}`("SuspenseList")
 - *9* a
   ⚠️  circular variable reference
 - *10* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["iterator"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -24772,30 +24772,30 @@ ${La}${a}`("SuspenseList")
 
 3387 -> 3389 member call = (???*0* | ???*1* | null)["get"](???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["get"](c)
   ⚠️  unknown callee object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3387 -> 3390 call = (...) => (???*0* | b)(???*1*, (???*2* | ???*3* | null), ???*5*, ???*6*, null)
 - *0* b
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["get"](c)
   ⚠️  unknown callee object
 - *4* a
   ⚠️  circular variable reference
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3387 -> 3391 unreachable = ???*0*
 - *0* unreachable
@@ -24803,9 +24803,9 @@ ${La}${a}`("SuspenseList")
 
 3387 -> 3392 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3358 -> 3393 unreachable = ???*0*
 - *0* unreachable
@@ -24820,19 +24820,19 @@ ${La}${a}`("SuspenseList")
   | null
 )(???*0*, ???*1*, ???*2*, ???*4*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* ???*3*[w]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3400 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -24856,17 +24856,17 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["length"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3405 -> 3406 call = (...) => null(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3405 -> 3407 call = (...) => undefined(???*0*, (0 | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
@@ -24883,13 +24883,13 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*[w]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3409 -> 3413 call = (...) => (c | (???*0* ? c : d))(???*1*, ???*2*, (0 | ???*3*))
 - *0* unsupported expression
@@ -24907,7 +24907,7 @@ ${La}${a}`("SuspenseList")
 
 3409 -> 3416 call = (...) => undefined(???*0*, (0 | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
@@ -24917,7 +24917,7 @@ ${La}${a}`("SuspenseList")
 
 3409 -> 3418 call = (...) => a(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -24928,15 +24928,15 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* ???*5*[w]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3409 -> 3425 conditional = (null === ???*0*)
 - *0* ???*1*["key"]
@@ -24983,9 +24983,9 @@ ${La}${a}`("SuspenseList")
 
 3432 -> 3433 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3432 -> 3434 unreachable = ???*0*
 - *0* unreachable
@@ -24993,7 +24993,7 @@ ${La}${a}`("SuspenseList")
 
 3409 -> 3435 call = (...) => undefined(???*0*, (0 | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
@@ -25068,7 +25068,7 @@ ${La}${a}`("SuspenseList")
   | null
 )(???*0*, ???*1*, ???*2*, ???*4*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* ???*3*["value"]
@@ -25077,11 +25077,11 @@ ${La}${a}`("SuspenseList")
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3459 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -25108,13 +25108,13 @@ ${La}${a}`("SuspenseList")
 
 3464 -> 3465 call = (...) => null(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 3464 -> 3466 call = (...) => undefined(???*0*, (0 | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
@@ -25135,14 +25135,14 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["value"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3468 -> 3474 call = (...) => (c | (???*0* ? c : d))(???*1*, ???*2*, (0 | ???*3*))
 - *0* unsupported expression
@@ -25160,7 +25160,7 @@ ${La}${a}`("SuspenseList")
 
 3468 -> 3477 call = (...) => undefined(???*0*, (0 | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
@@ -25170,7 +25170,7 @@ ${La}${a}`("SuspenseList")
 
 3468 -> 3479 call = (...) => a(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -25185,7 +25185,7 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* ???*5*["value"]
@@ -25194,7 +25194,7 @@ ${La}${a}`("SuspenseList")
 - *5* max number of linking steps reached
   ⚠️  This value might have side effects
 - *6* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3468 -> 3488 conditional = (null === ???*0*)
 - *0* ???*1*["key"]
@@ -25241,9 +25241,9 @@ ${La}${a}`("SuspenseList")
 
 3495 -> 3496 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3495 -> 3497 unreachable = ???*0*
 - *0* unreachable
@@ -25251,7 +25251,7 @@ ${La}${a}`("SuspenseList")
 
 3468 -> 3498 call = (...) => undefined(???*0*, (0 | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
@@ -25261,7 +25261,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3500 typeof = typeof((???*0* | ???*1* | ???*4*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* ???*3*["props"]
@@ -25273,7 +25273,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3505 typeof = typeof((???*0* | ???*1* | ???*4*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* ???*3*["props"]
@@ -25287,7 +25287,7 @@ ${La}${a}`("SuspenseList")
 - *0* typeof((???*1* | ???*2* | ???*5*))
   ⚠️  nested operation
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["children"]
   ⚠️  unknown object
 - *3* ???*4*["props"]
@@ -25297,7 +25297,7 @@ ${La}${a}`("SuspenseList")
 - *5* f
   ⚠️  circular variable reference
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["children"]
   ⚠️  unknown object
 - *8* ???*9*["props"]
@@ -25320,13 +25320,13 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["key"]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3511 -> 3513 conditional = ((???*0* | undefined) === ???*2*)
 - *0* ???*1*["key"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["for"]("react.fragment")
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
@@ -25358,19 +25358,19 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["props"]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3513 -> 3523 typeof = typeof((???*0* | undefined))
 - *0* ???*1*["key"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3513 -> 3525 call = (...) => b(a["_payload"])((???*0* | undefined))
 - *0* ???*1*["key"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3513 -> 3527 conditional = (
   | (???*0* === (???*2* | undefined))
@@ -25387,23 +25387,23 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["key"]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* typeof((???*5* | undefined))
   ⚠️  nested operation
 - *5* ???*6*["key"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["key"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["$$typeof"]
   ⚠️  unknown object
 - *10* ???*11*["key"]
   ⚠️  unknown object
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["for"]("react.lazy")
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
@@ -25417,7 +25417,7 @@ ${La}${a}`("SuspenseList")
 - *16* ???*17*["key"]
   ⚠️  unknown object
 - *17* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["type"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -25439,7 +25439,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["props"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3527 -> 3533 call = (...) => (b["ref"] | b | a)(???*0*, ???*1*, (???*2* | ???*3* | ???*6*))
 - *0* max number of linking steps reached
@@ -25447,7 +25447,7 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["children"]
   ⚠️  unknown object
 - *4* ???*5*["props"]
@@ -25473,7 +25473,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["for"]("react.fragment")
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
@@ -25487,7 +25487,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["props"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["mode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -25498,7 +25498,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["key"]
   ⚠️  unknown object
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3539 -> 3550 call = (...) => (Ah(c["children"], e, f, b) | ???*0* | qj(c, e, f, b) | b)(???*1*, ???*3*, ???*5*, null, ???*7*, ???*9*)
 - *0* a
@@ -25507,15 +25507,15 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["key"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["props"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["mode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -25530,7 +25530,7 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["children"]
   ⚠️  unknown object
 - *4* ???*5*["props"]
@@ -25578,7 +25578,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["containerInfo"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3567 -> 3569 call = (...) => null(???*0*, ???*1*)
 - *0* max number of linking steps reached
@@ -25595,7 +25595,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3567 -> 3573 call = (...) => null(???*0*, ???*1*)
 - *0* max number of linking steps reached
@@ -25611,7 +25611,7 @@ ${La}${a}`("SuspenseList")
 
 3556 -> 3577 call = (...) => b((???*0* | ???*1* | ???*4*), ???*5*, ???*7*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* ???*3*["props"]
@@ -25642,7 +25642,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["_payload"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3506 -> 3584 call = (...) => (
   | g(a)
@@ -25678,7 +25678,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["children"]
   ⚠️  unknown object
 - *4* ???*5*["props"]
@@ -25708,7 +25708,7 @@ ${La}${a}`("SuspenseList")
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["children"]
   ⚠️  unknown object
 - *5* ???*6*["props"]
@@ -25726,7 +25726,7 @@ ${La}${a}`("SuspenseList")
 
 3587 -> 3590 call = (...) => (null | (("function" === typeof(a)) ? a : null))((???*0* | ???*1* | ???*4*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* ???*3*["props"]
@@ -25745,7 +25745,7 @@ ${La}${a}`("SuspenseList")
 - *1* typeof((???*2* | ???*3* | ???*6* | ???*7*))
   ⚠️  nested operation
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["children"]
   ⚠️  unknown object
 - *4* ???*5*["props"]
@@ -25761,7 +25761,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["children"]
   ⚠️  unknown object
 - *11* ???*12*["props"]
@@ -25786,7 +25786,7 @@ ${La}${a}`("SuspenseList")
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["children"]
   ⚠️  unknown object
 - *5* ???*6*["props"]
@@ -25806,7 +25806,7 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["children"]
   ⚠️  unknown object
 - *3* ???*4*["props"]
@@ -25818,7 +25818,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3595 typeof = typeof((???*0* | ???*1* | ???*4*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* ???*3*["props"]
@@ -25830,7 +25830,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3596 typeof = typeof((???*0* | ???*1* | ???*4*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* ???*3*["props"]
@@ -25844,7 +25844,7 @@ ${La}${a}`("SuspenseList")
 - *0* typeof((???*1* | ???*2* | ???*5*))
   ⚠️  nested operation
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["children"]
   ⚠️  unknown object
 - *3* ???*4*["props"]
@@ -25854,7 +25854,7 @@ ${La}${a}`("SuspenseList")
 - *5* f
   ⚠️  circular variable reference
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["children"]
   ⚠️  unknown object
 - *8* ???*9*["props"]
@@ -25866,7 +25866,7 @@ ${La}${a}`("SuspenseList")
 - *11* typeof((???*12* | ???*13* | ???*16*))
   ⚠️  nested operation
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["children"]
   ⚠️  unknown object
 - *14* ???*15*["props"]
@@ -25898,7 +25898,7 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["children"]
   ⚠️  unknown object
 - *3* ???*4*["props"]
@@ -25916,7 +25916,7 @@ ${La}${a}`("SuspenseList")
 
 3599 -> 3606 call = (...) => a((???*0* | ???*1* | ???*4*), ???*5*, ???*7*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* ???*3*["props"]
@@ -25959,7 +25959,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3616 conditional = (???*0* === {})
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3616 -> 3617 free var = FreeVar(Error)
 
@@ -25995,7 +25995,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["documentElement"]
   ⚠️  unknown object
 - *2* b
@@ -26057,11 +26057,11 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["documentElement"]
   ⚠️  unknown object
 - *4* b
@@ -26098,9 +26098,9 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["parentNode"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* (???*21* ? ???*23* : ???*25*)
   ⚠️  nested operation
 - *21* ???*22*["documentElement"]
@@ -26142,7 +26142,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["documentElement"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["documentElement"]
   ⚠️  unknown object
 - *3* b
@@ -26187,11 +26187,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3629 conditional = (8 === (???*0* | ???*1* | null["nodeType"] | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (???*4* ? (???*6* | null["parentNode"]) : (???*8* | ???*9* | ???*16* | null))
   ⚠️  nested operation
 - *4* (8 === ???*5*)
@@ -26201,9 +26201,9 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["parentNode"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* (???*10* ? ???*12* : ???*14*)
   ⚠️  nested operation
 - *10* ???*11*["documentElement"]
@@ -26257,7 +26257,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["documentElement"]
   ⚠️  unknown object
 - *2* b
@@ -26302,11 +26302,11 @@ ${La}${a}`("SuspenseList")
 - *19* b
   ⚠️  circular variable reference
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["nodeType"]
   ⚠️  unknown object
 - *22* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* ???*24*["documentElement"]
   ⚠️  unknown object
 - *24* b
@@ -26343,9 +26343,9 @@ ${La}${a}`("SuspenseList")
 - *37* ???*38*["parentNode"]
   ⚠️  unknown object
 - *38* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *39* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *40* (???*41* ? ???*43* : ???*45*)
   ⚠️  nested operation
 - *41* ???*42*["documentElement"]
@@ -26389,7 +26389,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["documentElement"]
   ⚠️  unknown object
 - *2* b
@@ -26454,11 +26454,11 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3645 call = (...) => undefined({"current": {}}, ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3646 call = (...) => undefined(
     {"current": {}},
@@ -26492,7 +26492,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3652 -> 3657 conditional = (
   | (null !== (???*0* | undefined))
@@ -26503,23 +26503,23 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["data"]
   ⚠️  unknown object
 - *5* ???*6*["memoizedState"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["data"]
   ⚠️  unknown object
 - *8* ???*9*["memoizedState"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3657 -> 3658 unreachable = ???*0*
 - *0* unreachable
@@ -26529,13 +26529,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["revealOrder"]
   ⚠️  unknown object
 - *3* ???*4*["memoizedProps"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3662 -> 3664 conditional = (0 !== ???*0*)
 - *0* unsupported expression
@@ -26549,19 +26549,19 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["child"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3674 conditional = ((null === ???*0*) | (???*2* === ???*4*))
 - *0* ???*1*["return"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["return"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3674 -> 3675 unreachable = ???*0*
 - *0* unreachable
@@ -26586,7 +26586,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3691 conditional = (null === ???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3691 -> 3692 unreachable = ???*0*
 - *0* unreachable
@@ -26614,11 +26614,11 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*[c]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*[c]
   ⚠️  unknown object
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3691 -> 3698 conditional = !(???*0*)
 - *0* ???*1*(???*11*, ???*13*)
@@ -26646,11 +26646,11 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*[c]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*[c]
   ⚠️  unknown object
 - *14* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3698 -> 3699 unreachable = ???*0*
 - *0* unreachable
@@ -26662,23 +26662,23 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3706 conditional = ((null === (???*0* | ???*1*)) | (null === ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*(d, e)
   ⚠️  unknown callee
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3707 call = ???*0*(???*1*, ???*2*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3708 conditional = (false | true)
 
@@ -26697,11 +26697,11 @@ ${La}${a}`("SuspenseList")
 
 3708 -> 3714 call = ???*0*(???*1*, ???*2*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3717 conditional = (
   | ???*0*
@@ -26722,7 +26722,7 @@ ${La}${a}`("SuspenseList")
   | (null !== (null["next"] | null["alternate"]["next"] | ???*16* | undefined["next"] | null | ???*19*))
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* b
@@ -26808,7 +26808,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["next"]
   ⚠️  unknown object
 - *6* P
@@ -26816,7 +26816,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["alternate"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["memoizedState"]
   ⚠️  unknown object
 - *10* a
@@ -26849,7 +26849,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? ???*5* : null)
   ⚠️  nested operation
 - *3* (null !== ???*4*)
@@ -26894,7 +26894,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? ???*5* : null)
   ⚠️  nested operation
 - *3* (null !== ???*4*)
@@ -26947,7 +26947,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["next"]
   ⚠️  unknown object
 - *6* P
@@ -26955,7 +26955,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["alternate"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["memoizedState"]
   ⚠️  unknown object
 - *10* a
@@ -26994,7 +26994,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? ???*5* : null)
   ⚠️  nested operation
 - *3* (null !== ???*4*)
@@ -27060,7 +27060,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["next"]
   ⚠️  unknown object
 - *6* P
@@ -27068,7 +27068,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["alternate"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["memoizedState"]
   ⚠️  unknown object
 - *10* a
@@ -27092,19 +27092,19 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3748 typeof = typeof(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3749 conditional = ("function" === ???*0*)
 - *0* typeof(???*1*)
   ⚠️  nested operation
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3749 -> 3750 call = ???*0*(???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3751 unreachable = ???*0*
 - *0* unreachable
@@ -27134,7 +27134,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["memoizedState"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["next"]
   ⚠️  unknown object
 - *8* P
@@ -27193,7 +27193,7 @@ ${La}${a}`("SuspenseList")
   | null["next"]["queue"]["interleaved"]
 )(???*20*, ???*21*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["interleaved"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -27206,7 +27206,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["memoizedState"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["next"]
   ⚠️  unknown object
 - *8* P
@@ -27218,7 +27218,7 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*["alternate"]
   ⚠️  unknown object
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* a
   ⚠️  circular variable reference
 - *14* ???*15*["next"]
@@ -27294,7 +27294,7 @@ ${La}${a}`("SuspenseList")
 - *13* ???*14*["memoizedState"]
   ⚠️  unknown object
 - *14* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["next"]
   ⚠️  unknown object
 - *16* P
@@ -27304,7 +27304,7 @@ ${La}${a}`("SuspenseList")
 - *18* ???*19*["alternate"]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* a
   ⚠️  circular variable reference
 - *21* ???*22*["next"]
@@ -27331,7 +27331,7 @@ ${La}${a}`("SuspenseList")
   | null["next"]["queue"]["interleaved"]
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["interleaved"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -27350,7 +27350,7 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["memoizedState"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["next"]
   ⚠️  unknown object
 - *11* P
@@ -27384,7 +27384,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["memoizedState"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["next"]
   ⚠️  unknown object
 - *8* P
@@ -27430,7 +27430,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["memoizedState"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["next"]
   ⚠️  unknown object
 - *10* P
@@ -27454,7 +27454,7 @@ ${La}${a}`("SuspenseList")
     ???*20*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unknown mutation
   ⚠️  This value might have side effects
 - *2* (null === ???*3*)
@@ -27464,7 +27464,7 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["memoizedState"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["next"]
   ⚠️  unknown object
 - *7* P
@@ -27474,7 +27474,7 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*["alternate"]
   ⚠️  unknown object
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* a
   ⚠️  circular variable reference
 - *12* ???*13*["next"]
@@ -27492,7 +27492,7 @@ ${La}${a}`("SuspenseList")
 - *18* ???*19*(f, g["action"])
   ⚠️  unknown callee
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* node limit reached
   ⚠️  This value might have side effects
 
@@ -27552,7 +27552,7 @@ ${La}${a}`("SuspenseList")
 - *12* ???*13*["memoizedState"]
   ⚠️  unknown object
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["next"]
   ⚠️  unknown object
 - *15* P
@@ -27562,7 +27562,7 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["alternate"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* a
   ⚠️  circular variable reference
 - *20* ???*21*["next"]
@@ -27580,7 +27580,7 @@ ${La}${a}`("SuspenseList")
 - *26* ???*27*(f, g["action"])
   ⚠️  unknown callee
 - *27* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* unknown mutation
   ⚠️  This value might have side effects
 - *29* (null === ???*30*)
@@ -27590,7 +27590,7 @@ ${La}${a}`("SuspenseList")
 - *31* ???*32*["memoizedState"]
   ⚠️  unknown object
 - *32* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* ???*34*["next"]
   ⚠️  unknown object
 - *34* P
@@ -27600,7 +27600,7 @@ ${La}${a}`("SuspenseList")
 - *36* ???*37*["alternate"]
   ⚠️  unknown object
 - *37* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *38* a
   ⚠️  circular variable reference
 - *39* ???*40*["next"]
@@ -27624,7 +27624,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3831 call = ???*0*()
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3833 call = (???*0* ? ???*4* : (...) => ???*6*)(
     (
@@ -27669,7 +27669,7 @@ ${La}${a}`("SuspenseList")
 - *12* ???*13*["memoizedState"]
   ⚠️  unknown object
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["next"]
   ⚠️  unknown object
 - *15* P
@@ -27679,7 +27679,7 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["alternate"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* a
   ⚠️  circular variable reference
 - *20* ???*21*["next"]
@@ -27695,7 +27695,7 @@ ${La}${a}`("SuspenseList")
 - *25* a
   ⚠️  circular variable reference
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3837 member call = (...) => c(*anonymous function 67764*)["bind"](
     null,
@@ -27739,7 +27739,7 @@ ${La}${a}`("SuspenseList")
     ???*43*
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* N
@@ -27785,7 +27785,7 @@ ${La}${a}`("SuspenseList")
 - *22* ???*23*["memoizedState"]
   ⚠️  unknown object
 - *23* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* ???*25*["next"]
   ⚠️  unknown object
 - *25* P
@@ -27793,7 +27793,7 @@ ${La}${a}`("SuspenseList")
 - *26* ???*27*["alternate"]
   ⚠️  unknown object
 - *27* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* a
   ⚠️  circular variable reference
 - *29* ???*30*["next"]
@@ -27825,13 +27825,13 @@ ${La}${a}`("SuspenseList")
 - *42* a
   ⚠️  circular variable reference
 - *43* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3838 call = (...) => ui(2048, 8, a, b)(???*0*, [???*1*])
 - *0* node limit reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3842 conditional = (
   | ((
@@ -27875,13 +27875,13 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["memoizedState"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["next"]
   ⚠️  unknown object
 - *8* P
   ⚠️  circular variable reference
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*(
         (
           | null["memoizedState"]
@@ -27934,7 +27934,7 @@ ${La}${a}`("SuspenseList")
 - *25* ???*26*["memoizedState"]
   ⚠️  unknown object
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* ???*28*["next"]
   ⚠️  unknown object
 - *28* P
@@ -27944,7 +27944,7 @@ ${La}${a}`("SuspenseList")
 - *30* ???*31*["alternate"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* (null !== (null | ???*33*))
   ⚠️  nested operation
 - *33* a
@@ -27968,7 +27968,7 @@ ${La}${a}`("SuspenseList")
 - *42* ???*43*()
   ⚠️  nested operation
 - *43* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *44* (???*45* ? (null["memoizedState"] | ???*47*) : ???*49*)
   ⚠️  nested operation
 - *45* (null === ???*46*)
@@ -27978,7 +27978,7 @@ ${La}${a}`("SuspenseList")
 - *47* ???*48*["memoizedState"]
   ⚠️  unknown object
 - *48* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *49* ???*50*["next"]
   ⚠️  unknown object
 - *50* P
@@ -27986,7 +27986,7 @@ ${La}${a}`("SuspenseList")
 - *51* ???*52*["alternate"]
   ⚠️  unknown object
 - *52* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *53* ???*54*["memoizedState"]
   ⚠️  unknown object
 - *54* a
@@ -28049,7 +28049,7 @@ ${La}${a}`("SuspenseList")
     ???*44*
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* N
@@ -28095,7 +28095,7 @@ ${La}${a}`("SuspenseList")
 - *22* ???*23*["memoizedState"]
   ⚠️  unknown object
 - *23* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* ???*25*["next"]
   ⚠️  unknown object
 - *25* P
@@ -28103,7 +28103,7 @@ ${La}${a}`("SuspenseList")
 - *26* ???*27*["alternate"]
   ⚠️  unknown object
 - *27* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* a
   ⚠️  circular variable reference
 - *29* ???*30*["next"]
@@ -28135,9 +28135,9 @@ ${La}${a}`("SuspenseList")
 - *42* a
   ⚠️  circular variable reference
 - *43* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *44* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3842 -> 3846 call = (...) => a(9, ???*0*, undefined, null)
 - *0* node limit reached
@@ -28145,7 +28145,7 @@ ${La}${a}`("SuspenseList")
 
 3842 -> 3847 conditional = (null === (null | ???*0* | ???*1* | ???*4*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* ???*3*["current"]
@@ -28215,7 +28215,7 @@ ${La}${a}`("SuspenseList")
     ???*21*()
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* N
@@ -28255,9 +28255,9 @@ ${La}${a}`("SuspenseList")
 - *19* unknown mutation
   ⚠️  This value might have side effects
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3852 unreachable = ???*0*
 - *0* unreachable
@@ -28265,19 +28265,19 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3855 conditional = (null === (???*0* | null["updateQueue"] | ???*1* | {"lastEffect": null, "stores": null}))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3855 -> 3859 conditional = (null === (???*0* | ???*1* | null["updateQueue"]["stores"] | null | ???*3*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stores"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unknown mutation
   ⚠️  This value might have side effects
 
@@ -28350,11 +28350,11 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stores"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* N
@@ -28396,13 +28396,13 @@ ${La}${a}`("SuspenseList")
 - *22* unknown mutation
   ⚠️  This value might have side effects
 - *23* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*["updateQueue"]
   ⚠️  unknown object
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* ???*28*["alternate"]
   ⚠️  unknown object
 - *28* N
@@ -28442,11 +28442,11 @@ ${La}${a}`("SuspenseList")
 - *45* unknown mutation
   ⚠️  This value might have side effects
 - *46* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *47* ???*48*["stores"]
   ⚠️  unknown object
 - *48* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *49* ???*50*["alternate"]
   ⚠️  unknown object
 - *50* N
@@ -28490,23 +28490,23 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3865 call = (...) => (!(He(a, c)) | !(0) | undefined)(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3866 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3867 call = ???*0*((...) => undefined)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3867 -> 3868 call = (...) => (!(He(a, c)) | !(0) | undefined)(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3867 -> 3869 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3870 unreachable = ???*0*
 - *0* unreachable
@@ -28516,7 +28516,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["getSnapshot"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3874 call = (???*0* ? ???*4* : (...) => ???*6*)((???*9* | ???*10*), (???*12*() | undefined))
 - *0* ("function" === ???*1*)
@@ -28538,7 +28538,7 @@ ${La}${a}`("SuspenseList")
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["value"]
   ⚠️  unknown object
 - *11* a
@@ -28546,7 +28546,7 @@ ${La}${a}`("SuspenseList")
 - *12* ???*13*["getSnapshot"]
   ⚠️  unknown object
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3875 unreachable = ???*0*
 - *0* unreachable
@@ -28558,7 +28558,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3877 call = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)(???*0*, 1)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3878 call = (...) => undefined((???*0* ? ???*4* : null), ???*7*, 1, ???*8*)
 - *0* (3 === ???*1*)
@@ -28568,15 +28568,15 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["stateNode"]
   ⚠️  unknown object
 - *5* ???*6*["alternate"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* unsupported expression
   ⚠️  This value might have side effects
 
@@ -28596,13 +28596,13 @@ ${La}${a}`("SuspenseList")
   | (...) => undefined["bind"](null, (null | ???*3* | ???*4*), ???*20*)
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (null !== (
       | null
       | ???*5*
@@ -28664,13 +28664,13 @@ ${La}${a}`("SuspenseList")
   | (...) => undefined["bind"](null, (null | ???*3* | ???*4*), ???*20*)
 )()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (null !== (
       | null
       | ???*5*
@@ -28753,7 +28753,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* N
@@ -28793,13 +28793,13 @@ ${La}${a}`("SuspenseList")
 - *19* unknown mutation
   ⚠️  This value might have side effects
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* a
   ⚠️  circular variable reference
 - *22* a
   ⚠️  circular variable reference
 - *23* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* (null !== (
       | null
       | ???*25*
@@ -28853,19 +28853,19 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3891 conditional = (null === (???*0* | null["updateQueue"] | ???*1* | {"lastEffect": null, "stores": null}))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3891 -> 3896 conditional = (null === (???*0* | ???*1* | null["updateQueue"]["lastEffect"] | null | ???*3*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["lastEffect"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unknown mutation
   ⚠️  This value might have side effects
 
@@ -28883,25 +28883,25 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3910 conditional = (undefined === ???*0*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3911 call = (...) => a(???*0*, ???*1*, undefined, (???*2* ? null : ???*4*))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (undefined === ???*3*)
   ⚠️  nested operation
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3912 call = (...) => P()
 
 0 -> 3913 conditional = (undefined === (???*0* | ???*1*))
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? null : ???*4*)
   ⚠️  nested operation
 - *2* (undefined === ???*3*)
@@ -28922,7 +28922,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? ???*5* : null)
   ⚠️  nested operation
 - *3* (null !== ???*4*)
@@ -28965,7 +28965,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined === ???*2*)
   ⚠️  nested operation
 - *2* d
@@ -28979,7 +28979,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* O
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -29002,7 +29002,7 @@ ${La}${a}`("SuspenseList")
 
 3914 -> 3919 conditional = ((null !== (???*0* | ???*1*)) | false | true)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? null : ???*4*)
   ⚠️  nested operation
 - *2* (undefined === ???*3*)
@@ -29030,9 +29030,9 @@ ${La}${a}`("SuspenseList")
     (???*15* | (???*16* ? null : ???*18*))
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["destroy"]
   ⚠️  unknown object
 - *3* ???*4*["memoizedState"]
@@ -29040,7 +29040,7 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["alternate"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* O
   ⚠️  circular variable reference
 - *7* ???*8*["next"]
@@ -29061,7 +29061,7 @@ ${La}${a}`("SuspenseList")
 - *14* unknown mutation
   ⚠️  This value might have side effects
 - *15* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* (undefined === ???*17*)
   ⚠️  nested operation
 - *17* d
@@ -29093,7 +29093,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["destroy"]
   ⚠️  unknown object
 - *3* ???*4*["memoizedState"]
@@ -29101,7 +29101,7 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["alternate"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* O
   ⚠️  circular variable reference
 - *7* ???*8*["next"]
@@ -29122,7 +29122,7 @@ ${La}${a}`("SuspenseList")
 - *14* unknown mutation
   ⚠️  This value might have side effects
 - *15* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* (undefined === ???*17*)
   ⚠️  nested operation
 - *17* d
@@ -29132,9 +29132,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3926 call = (...) => undefined(8390656, 8, ???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3927 unreachable = ???*0*
 - *0* unreachable
@@ -29142,9 +29142,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3928 call = (...) => undefined(2048, 8, ???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3929 unreachable = ???*0*
 - *0* unreachable
@@ -29152,9 +29152,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3930 call = (...) => undefined(4, 2, ???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3931 unreachable = ???*0*
 - *0* unreachable
@@ -29162,9 +29162,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3932 call = (...) => undefined(4, 4, ???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3933 unreachable = ???*0*
 - *0* unreachable
@@ -29172,31 +29172,31 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3934 typeof = typeof(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3935 conditional = ("function" === ???*0*)
 - *0* typeof(???*1*)
   ⚠️  nested operation
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3935 -> 3936 call = (???*0* | ???*1*())()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 
 3935 -> 3937 call = ???*0*((???*1* | ???*2*()))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 
 3935 -> 3938 call = ???*0*(null)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3935 -> 3939 unreachable = ???*0*
 - *0* unreachable
@@ -29204,13 +29204,13 @@ ${La}${a}`("SuspenseList")
 
 3935 -> 3940 conditional = ((null !== ???*0*) | (undefined !== ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3940 -> 3941 call = (???*0* | ???*1*())()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 
@@ -29220,7 +29220,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3945 conditional = ((null !== (???*0* | ???*1*)) | (undefined !== (???*6* | ???*7*)))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? ???*4* : null)
   ⚠️  nested operation
 - *2* (null !== ???*3*)
@@ -29232,7 +29232,7 @@ ${La}${a}`("SuspenseList")
 - *5* c
   ⚠️  circular variable reference
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (???*8* ? ???*10* : null)
   ⚠️  nested operation
 - *8* (null !== ???*9*)
@@ -29246,7 +29246,7 @@ ${La}${a}`("SuspenseList")
 
 3945 -> 3947 member call = (???*0* | (???*1* ? ???*3* : null))["concat"]([???*5*])
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (null !== ???*2*)
   ⚠️  nested operation
 - *2* c
@@ -29256,16 +29256,16 @@ ${La}${a}`("SuspenseList")
 - *4* c
   ⚠️  circular variable reference
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3949 member call = (...) => (???*0* | undefined)["bind"](null, ???*1*, ???*2*)
 - *0* *anonymous function 69020*
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3950 call = (...) => undefined(
     4,
@@ -29277,11 +29277,11 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (null !== ???*5*)
   ⚠️  nested operation
 - *5* c
@@ -29299,7 +29299,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3953 conditional = (undefined === (???*0* | ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? null : ???*4*)
   ⚠️  nested operation
 - *2* (undefined === ???*3*)
@@ -29326,7 +29326,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined === ???*2*)
   ⚠️  nested operation
 - *2* b
@@ -29345,7 +29345,7 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["memoizedState"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["next"]
   ⚠️  unknown object
 - *11* P
@@ -29357,7 +29357,7 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["alternate"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* a
   ⚠️  circular variable reference
 - *17* ???*18*["next"]
@@ -29400,13 +29400,13 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["memoizedState"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["next"]
   ⚠️  unknown object
 - *8* P
   ⚠️  circular variable reference
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* (???*11* ? null : ???*13*)
   ⚠️  nested operation
 - *11* (undefined === ???*12*)
@@ -29428,7 +29428,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 3963 conditional = (undefined === (???*0* | ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? null : ???*4*)
   ⚠️  nested operation
 - *2* (undefined === ???*3*)
@@ -29455,7 +29455,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined === ???*2*)
   ⚠️  nested operation
 - *2* b
@@ -29474,7 +29474,7 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["memoizedState"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["next"]
   ⚠️  unknown object
 - *11* P
@@ -29486,7 +29486,7 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["alternate"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* a
   ⚠️  circular variable reference
 - *17* ???*18*["next"]
@@ -29529,13 +29529,13 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["memoizedState"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["next"]
   ⚠️  unknown object
 - *8* P
   ⚠️  circular variable reference
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* (???*11* ? null : ???*13*)
   ⚠️  nested operation
 - *11* (undefined === ???*12*)
@@ -29551,7 +29551,7 @@ ${La}${a}`("SuspenseList")
 
 3967 -> 3970 call = (???*0* | ???*1*())()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 
@@ -29587,11 +29587,11 @@ ${La}${a}`("SuspenseList")
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* unsupported assign operation
   ⚠️  This value might have side effects
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3973 -> 3979 call = (...) => a()
 
@@ -29616,21 +29616,21 @@ ${La}${a}`("SuspenseList")
 - *5* c
   ⚠️  circular variable reference
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 
 0 -> 3984 call = ???*0*(true)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3987 call = ???*0*(false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3988 call = ???*0*()
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3991 call = (...) => P()
 
@@ -29645,11 +29645,11 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3994 call = (...) => ((a === N) || ((null !== b) && (b === N)))(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 3995 conditional = (
   | (???*0* === (null | ???*1* | ???*2*))
@@ -29657,9 +29657,9 @@ ${La}${a}`("SuspenseList")
   | (???*20* === (null | ???*22* | ???*23*))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== (
       | null
       | ???*3*
@@ -29707,13 +29707,13 @@ ${La}${a}`("SuspenseList")
 - *18* ???*19*["alternate"]
   ⚠️  unknown object
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* ???*21*["alternate"]
   ⚠️  unknown object
 - *21* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* (null !== (
       | null
       | ???*24*
@@ -29787,16 +29787,16 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* C
   ⚠️  circular variable reference
 - *6* (0 !== ???*7*)
@@ -29824,11 +29824,11 @@ ${La}${a}`("SuspenseList")
 - *17* unsupported expression
   ⚠️  This value might have side effects
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["value"]
   ⚠️  unknown object
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -29848,13 +29848,13 @@ ${La}${a}`("SuspenseList")
 - *28* ???*29*["alternate"]
   ⚠️  unknown object
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["stateNode"]
   ⚠️  unknown object
 - *31* ???*32*["alternate"]
   ⚠️  unknown object
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 3995 -> 3997 call = (...) => Zg(a, d)(
     ???*0*,
@@ -29899,18 +29899,18 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported expression
   ⚠️  This value might have side effects
 - *4* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* C
   ⚠️  circular variable reference
 - *7* (0 !== ???*8*)
@@ -29938,11 +29938,11 @@ ${La}${a}`("SuspenseList")
 - *18* unsupported expression
   ⚠️  This value might have side effects
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* ???*21*["value"]
   ⚠️  unknown object
 - *21* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* ???*23*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -29962,20 +29962,20 @@ ${La}${a}`("SuspenseList")
 - *29* ???*30*["alternate"]
   ⚠️  unknown object
 - *30* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *31* ???*32*["stateNode"]
   ⚠️  unknown object
 - *32* ???*33*["alternate"]
   ⚠️  unknown object
 - *33* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *34* unsupported expression
   ⚠️  This value might have side effects
 - *35* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *36* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* C
   ⚠️  circular variable reference
 - *38* (0 !== ???*39*)
@@ -30003,11 +30003,11 @@ ${La}${a}`("SuspenseList")
 - *49* unsupported expression
   ⚠️  This value might have side effects
 - *50* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *51* ???*52*["value"]
   ⚠️  unknown object
 - *52* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *53* ???*54*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -30068,14 +30068,14 @@ ${La}${a}`("SuspenseList")
     ((???*56* ? ???*58* : ???*59*) | undefined)
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* C
   ⚠️  circular variable reference
 - *5* (0 !== ???*6*)
@@ -30103,11 +30103,11 @@ ${La}${a}`("SuspenseList")
 - *16* unsupported expression
   ⚠️  This value might have side effects
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["value"]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* ???*21*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -30127,22 +30127,22 @@ ${La}${a}`("SuspenseList")
 - *27* ???*28*["alternate"]
   ⚠️  unknown object
 - *28* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *29* ???*30*["stateNode"]
   ⚠️  unknown object
 - *30* ???*31*["alternate"]
   ⚠️  unknown object
 - *31* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* unsupported expression
   ⚠️  This value might have side effects
 - *34* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *35* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *36* C
   ⚠️  circular variable reference
 - *37* (0 !== ???*38*)
@@ -30170,11 +30170,11 @@ ${La}${a}`("SuspenseList")
 - *48* unsupported expression
   ⚠️  This value might have side effects
 - *49* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *50* ???*51*["value"]
   ⚠️  unknown object
 - *51* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *52* ???*53*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -30250,14 +30250,14 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* C
   ⚠️  circular variable reference
 - *5* (0 !== ???*6*)
@@ -30285,11 +30285,11 @@ ${La}${a}`("SuspenseList")
 - *16* unsupported expression
   ⚠️  This value might have side effects
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["value"]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* ???*21*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -30309,22 +30309,22 @@ ${La}${a}`("SuspenseList")
 - *27* ???*28*["alternate"]
   ⚠️  unknown object
 - *28* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *29* ???*30*["stateNode"]
   ⚠️  unknown object
 - *30* ???*31*["alternate"]
   ⚠️  unknown object
 - *31* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* unsupported expression
   ⚠️  This value might have side effects
 - *34* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *35* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *36* C
   ⚠️  circular variable reference
 - *37* (0 !== ???*38*)
@@ -30352,11 +30352,11 @@ ${La}${a}`("SuspenseList")
 - *48* unsupported expression
   ⚠️  This value might have side effects
 - *49* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *50* ???*51*["value"]
   ⚠️  unknown object
 - *51* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *52* ???*53*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -30375,11 +30375,11 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4002 call = (...) => ((a === N) || ((null !== b) && (b === N)))(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4003 conditional = (
   | (???*0* === (null | ???*1* | ???*2*))
@@ -30387,9 +30387,9 @@ ${La}${a}`("SuspenseList")
   | (???*20* === (null | ???*22* | ???*23*))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== (
       | null
       | ???*3*
@@ -30437,13 +30437,13 @@ ${La}${a}`("SuspenseList")
 - *18* ???*19*["alternate"]
   ⚠️  unknown object
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* ???*21*["alternate"]
   ⚠️  unknown object
 - *21* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* (null !== (
       | null
       | ???*24*
@@ -30516,14 +30516,14 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* C
   ⚠️  circular variable reference
 - *5* (0 !== ???*6*)
@@ -30551,11 +30551,11 @@ ${La}${a}`("SuspenseList")
 - *16* unsupported expression
   ⚠️  This value might have side effects
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["value"]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* ???*21*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -30567,7 +30567,7 @@ ${La}${a}`("SuspenseList")
 - *23* a
   ⚠️  circular variable reference
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* (3 === ???*26*)
   ⚠️  nested operation
 - *26* ???*27*["tag"]
@@ -30575,13 +30575,13 @@ ${La}${a}`("SuspenseList")
 - *27* ???*28*["alternate"]
   ⚠️  unknown object
 - *28* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *29* ???*30*["stateNode"]
   ⚠️  unknown object
 - *30* ???*31*["alternate"]
   ⚠️  unknown object
 - *31* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* (0 !== ???*33*)
   ⚠️  nested operation
 - *33* unsupported expression
@@ -30614,33 +30614,33 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["lanes"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["lanes"]
   ⚠️  unknown object
 - *5* ???*6*["alternate"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["alternate"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4009 -> 4011 call = (???*0* | undefined)((???*2* | undefined), (???*4* | (???*5* ? ???*9* : null)))
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["lastRenderedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (3 === ???*6*)
   ⚠️  nested operation
 - *6* ???*7*["tag"]
@@ -30648,13 +30648,13 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["alternate"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["stateNode"]
   ⚠️  unknown object
 - *10* ???*11*["alternate"]
   ⚠️  unknown object
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4009 -> 4014 call = (???*0* ? ???*4* : (...) => ???*6*)((???*9* | undefined), (???*12* | undefined))
 - *0* ("function" === ???*1*)
@@ -30680,11 +30680,11 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["alternate"]
   ⚠️  unknown object
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["lastRenderedState"]
   ⚠️  unknown object
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4009 -> 4015 conditional = ???*0*
 - *0* ???*1*((???*11* | undefined), (???*14* | undefined))
@@ -30714,21 +30714,21 @@ ${La}${a}`("SuspenseList")
 - *12* ???*13*["alternate"]
   ⚠️  unknown object
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["lastRenderedState"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4015 -> 4017 conditional = (null === (???*0* | undefined))
 - *0* ???*1*["interleaved"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4017 -> 4019 call = (...) => undefined(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4015 -> 4024 unreachable = ???*0*
 - *0* unreachable
@@ -30776,16 +30776,16 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* C
   ⚠️  circular variable reference
 - *6* (0 !== ???*7*)
@@ -30813,11 +30813,11 @@ ${La}${a}`("SuspenseList")
 - *17* unsupported expression
   ⚠️  This value might have side effects
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["value"]
   ⚠️  unknown object
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -30829,7 +30829,7 @@ ${La}${a}`("SuspenseList")
 - *24* a
   ⚠️  circular variable reference
 - *25* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* (3 === ???*27*)
   ⚠️  nested operation
 - *27* ???*28*["tag"]
@@ -30837,13 +30837,13 @@ ${La}${a}`("SuspenseList")
 - *28* ???*29*["alternate"]
   ⚠️  unknown object
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["stateNode"]
   ⚠️  unknown object
 - *31* ???*32*["alternate"]
   ⚠️  unknown object
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* (0 !== ???*34*)
   ⚠️  nested operation
 - *34* unsupported expression
@@ -30872,7 +30872,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *46* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *47* C
   ⚠️  circular variable reference
 - *48* (0 !== ???*49*)
@@ -30900,11 +30900,11 @@ ${La}${a}`("SuspenseList")
 - *59* unsupported expression
   ⚠️  This value might have side effects
 - *60* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *61* ???*62*["value"]
   ⚠️  unknown object
 - *62* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *63* ???*64*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -30964,7 +30964,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -30972,22 +30972,22 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported expression
   ⚠️  This value might have side effects
 - *10* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* C
   ⚠️  circular variable reference
 - *13* (0 !== ???*14*)
@@ -31015,11 +31015,11 @@ ${La}${a}`("SuspenseList")
 - *24* unsupported expression
   ⚠️  This value might have side effects
 - *25* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* ???*27*["value"]
   ⚠️  unknown object
 - *27* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* ???*29*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -31036,7 +31036,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *34* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *35* C
   ⚠️  circular variable reference
 - *36* (0 !== ???*37*)
@@ -31064,11 +31064,11 @@ ${La}${a}`("SuspenseList")
 - *47* unsupported expression
   ⚠️  This value might have side effects
 - *48* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *49* ???*50*["value"]
   ⚠️  unknown object
 - *50* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *51* ???*52*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -31080,7 +31080,7 @@ ${La}${a}`("SuspenseList")
 - *54* a
   ⚠️  circular variable reference
 - *55* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *56* (3 === ???*57*)
   ⚠️  nested operation
 - *57* ???*58*["tag"]
@@ -31088,13 +31088,13 @@ ${La}${a}`("SuspenseList")
 - *58* ???*59*["alternate"]
   ⚠️  unknown object
 - *59* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *60* ???*61*["stateNode"]
   ⚠️  unknown object
 - *61* ???*62*["alternate"]
   ⚠️  unknown object
 - *62* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *63* (0 !== ???*64*)
   ⚠️  nested operation
 - *64* unsupported expression
@@ -31137,7 +31137,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -31145,22 +31145,22 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported expression
   ⚠️  This value might have side effects
 - *10* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* C
   ⚠️  circular variable reference
 - *13* (0 !== ???*14*)
@@ -31188,11 +31188,11 @@ ${La}${a}`("SuspenseList")
 - *24* unsupported expression
   ⚠️  This value might have side effects
 - *25* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* ???*27*["value"]
   ⚠️  unknown object
 - *27* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* ???*29*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -31212,7 +31212,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["pending"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4038 conditional = (0 !== ???*0*)
 - *0* unsupported expression
@@ -31220,9 +31220,9 @@ ${La}${a}`("SuspenseList")
 
 4038 -> 4042 call = (...) => undefined(???*0*, (???*1* | ???*2*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -31230,7 +31230,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4045 conditional = (undefined === ???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4046 unreachable = ???*0*
 - *0* unreachable
@@ -31238,7 +31238,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4047 conditional = ((null !== (???*0* | ???*1*)) | (undefined !== (???*6* | ???*7*)))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? ???*4* : null)
   ⚠️  nested operation
 - *2* (null !== ???*3*)
@@ -31250,7 +31250,7 @@ ${La}${a}`("SuspenseList")
 - *5* c
   ⚠️  circular variable reference
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (???*8* ? ???*10* : null)
   ⚠️  nested operation
 - *8* (null !== ???*9*)
@@ -31264,7 +31264,7 @@ ${La}${a}`("SuspenseList")
 
 4047 -> 4049 member call = (???*0* | (???*1* ? ???*3* : null))["concat"]([???*5*])
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (null !== ???*2*)
   ⚠️  nested operation
 - *2* c
@@ -31274,16 +31274,16 @@ ${La}${a}`("SuspenseList")
 - *4* c
   ⚠️  circular variable reference
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4051 member call = (...) => (???*0* | undefined)["bind"](null, ???*1*, ???*2*)
 - *0* *anonymous function 69020*
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4052 call = (...) => undefined(
     4194308,
@@ -31295,11 +31295,11 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (null !== ???*5*)
   ⚠️  nested operation
 - *5* c
@@ -31315,9 +31315,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4054 call = (...) => undefined(4194308, 4, ???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4055 unreachable = ???*0*
 - *0* unreachable
@@ -31325,9 +31325,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4056 call = (...) => undefined(4, 2, ???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4057 unreachable = ???*0*
 - *0* unreachable
@@ -31337,7 +31337,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4059 conditional = (undefined === (???*0* | ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? null : ???*4*)
   ⚠️  nested operation
 - *2* (undefined === ???*3*)
@@ -31349,7 +31349,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4060 call = (???*0* | ???*1*())()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 
@@ -31361,21 +31361,21 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4064 conditional = (undefined !== ???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4064 -> 4065 call = ???*0*((???*1* | (???*2* ? ???*4* : ???*6*)))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (undefined !== ???*3*)
   ⚠️  nested operation
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*(b)
   ⚠️  unknown callee
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* b
   ⚠️  circular variable reference
 
@@ -31413,7 +31413,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* N
@@ -31453,23 +31453,23 @@ ${La}${a}`("SuspenseList")
 - *19* unknown mutation
   ⚠️  This value might have side effects
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* a
   ⚠️  circular variable reference
 - *22* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* (undefined !== ???*24*)
   ⚠️  nested operation
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*(b)
   ⚠️  unknown callee
 - *26* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* b
   ⚠️  circular variable reference
 - *28* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *29* (null !== (
       | null
       | ???*30*
@@ -31554,7 +31554,7 @@ ${La}${a}`("SuspenseList")
 
 4089 -> 4090 conditional = (undefined === (???*0* | ???*1*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*()
   ⚠️  nested operation
 - *2* c
@@ -31575,19 +31575,19 @@ ${La}${a}`("SuspenseList")
 
 4089 -> 4094 call = (???*0* | ???*1*() | ???*2*())()
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* c
   ⚠️  circular variable reference
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4089 -> 4095 call = ???*0*()
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4089 -> 4096 conditional = (null === (null | ???*0* | ???*1* | ???*4*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* ???*3*["current"]
@@ -31657,7 +31657,7 @@ ${La}${a}`("SuspenseList")
     (???*21* | ???*22*() | ???*23*())
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* N
@@ -31697,13 +31697,13 @@ ${La}${a}`("SuspenseList")
 - *19* unknown mutation
   ⚠️  This value might have side effects
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* c
   ⚠️  circular variable reference
 - *23* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4104 member call = (...) => c(*anonymous function 67764*)["bind"](
     null,
@@ -31729,7 +31729,7 @@ ${La}${a}`("SuspenseList")
     ???*24*
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* N
@@ -31769,15 +31769,15 @@ ${La}${a}`("SuspenseList")
 - *19* unknown mutation
   ⚠️  This value might have side effects
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* c
   ⚠️  circular variable reference
 - *22* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4105 call = (...) => ti(8390656, 8, a, b)(
     (...) => ???*0*["bind"](
@@ -31791,7 +31791,7 @@ ${La}${a}`("SuspenseList")
 - *0* c(*anonymous function 67764*)
   ⚠️  nested operation
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== (
       | null
       | ???*3*
@@ -31837,17 +31837,17 @@ ${La}${a}`("SuspenseList")
 - *17* O
   ⚠️  circular variable reference
 - *18* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*()
   ⚠️  nested operation
 - *20* c
   ⚠️  circular variable reference
 - *21* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4108 member call = (...) => undefined["bind"](
     null,
@@ -31874,7 +31874,7 @@ ${La}${a}`("SuspenseList")
     ???*27*
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* N
@@ -31914,21 +31914,21 @@ ${La}${a}`("SuspenseList")
 - *19* unknown mutation
   ⚠️  This value might have side effects
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* c
   ⚠️  circular variable reference
 - *22* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* c
   ⚠️  circular variable reference
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4109 call = (...) => a(
     9,
@@ -31943,7 +31943,7 @@ ${La}${a}`("SuspenseList")
     null
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (null !== (
       | null
       | ???*2*
@@ -31989,21 +31989,21 @@ ${La}${a}`("SuspenseList")
 - *16* O
   ⚠️  circular variable reference
 - *17* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*()
   ⚠️  nested operation
 - *19* c
   ⚠️  circular variable reference
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* ???*23*()
   ⚠️  nested operation
 - *23* c
   ⚠️  circular variable reference
 - *24* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4110 unreachable = ???*0*
 - *0* unreachable
@@ -32096,7 +32096,7 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -32104,7 +32104,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -32140,7 +32140,7 @@ ${La}${a}`("SuspenseList")
 - *24* ???*25*["alternate"]
   ⚠️  unknown object
 - *25* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* O
   ⚠️  circular variable reference
 - *27* ???*28*["next"]
@@ -32158,7 +32158,7 @@ ${La}${a}`("SuspenseList")
 - *33* unknown mutation
   ⚠️  This value might have side effects
 - *34* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4128 unreachable = ???*0*
 - *0* unreachable
@@ -32191,7 +32191,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? ???*5* : null)
   ⚠️  nested operation
 - *3* (null !== ???*4*)
@@ -32258,7 +32258,7 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -32266,7 +32266,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -32302,7 +32302,7 @@ ${La}${a}`("SuspenseList")
 - *24* ???*25*["alternate"]
   ⚠️  unknown object
 - *25* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* O
   ⚠️  circular variable reference
 - *27* ???*28*["next"]
@@ -32320,7 +32320,7 @@ ${La}${a}`("SuspenseList")
 - *33* unknown mutation
   ⚠️  This value might have side effects
 - *34* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4141 unreachable = ???*0*
 - *0* unreachable
@@ -32339,7 +32339,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["return"]
   ⚠️  unknown object
 - *3* d
@@ -32351,11 +32351,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4152 conditional = (null != ???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4153 conditional = (null != ???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4154 unreachable = ???*0*
 - *0* unreachable
@@ -32370,7 +32370,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["value"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4159 free var = FreeVar(setTimeout)
 
@@ -32407,7 +32407,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* c
@@ -32415,9 +32415,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4171 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4172 unreachable = ???*0*
 - *0* unreachable
@@ -32433,7 +32433,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* c
@@ -32445,7 +32445,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4178 conditional = ("function" === ???*0*)
 - *0* typeof(???*1*)
@@ -32455,7 +32455,7 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["type"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4178 -> 4181 call = ???*0*((???*3* | undefined))
 - *0* ???*1*["getDerivedStateFromError"]
@@ -32463,11 +32463,11 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["value"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4178 -> 4182 unreachable = ???*0*
 - *0* unreachable
@@ -32475,9 +32475,9 @@ ${La}${a}`("SuspenseList")
 
 4178 -> 4184 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4186 typeof = typeof(???*0*)
 - *0* ???*1*["componentDidCatch"]
@@ -32485,13 +32485,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4189 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4190 typeof = typeof(???*0*)
 - *0* ???*1*["getDerivedStateFromError"]
@@ -32499,7 +32499,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4191 conditional = (null === (???*0* | null))
 - *0* new ???*1*([???*2*])
@@ -32532,7 +32532,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stack"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4200 member call = ???*0*["componentDidCatch"](???*1*, {"componentStack": (???*3* ? ???*6* : "")})
 - *0* unsupported expression
@@ -32540,17 +32540,17 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["value"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* ???*5*["stack"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["stack"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4201 unreachable = ???*0*
 - *0* unreachable
@@ -32560,7 +32560,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["pingCache"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* new ???*3*()
   ⚠️  nested operation
 - *3* (???*4* ? ???*7* : ???*8*)
@@ -32609,13 +32609,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["pingCache"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (???*6* ? ???*9* : ???*10*)
   ⚠️  nested operation
 - *6* ("function" === ???*7*)
@@ -32632,7 +32632,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* FreeVar(Set)
   ⚠️  unknown global
   ⚠️  This value might have side effects
@@ -32641,9 +32641,9 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["pingCache"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*(???*24*)
   ⚠️  unknown callee
 - *18* ???*19*["get"]
@@ -32655,11 +32655,11 @@ ${La}${a}`("SuspenseList")
 - *21* a
   ⚠️  circular variable reference
 - *22* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4203 -> 4211 member call = (
   | ???*0*
@@ -32669,13 +32669,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["pingCache"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (???*6* ? ???*9* : ???*10*)
   ⚠️  nested operation
 - *6* ("function" === ???*7*)
@@ -32692,7 +32692,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4203 -> 4212 free var = FreeVar(Set)
 
@@ -32709,13 +32709,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["pingCache"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (???*6* ? ???*9* : ???*10*)
   ⚠️  nested operation
 - *6* ("function" === ???*7*)
@@ -32732,7 +32732,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* FreeVar(Set)
   ⚠️  unknown global
   ⚠️  This value might have side effects
@@ -32741,9 +32741,9 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["pingCache"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*(???*24*)
   ⚠️  unknown callee
 - *18* ???*19*["get"]
@@ -32755,11 +32755,11 @@ ${La}${a}`("SuspenseList")
 - *21* a
   ⚠️  circular variable reference
 - *22* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4217 member call = (new ???*0*() | undefined | ???*1* | ???*5*)["has"](???*13*)
 - *0* FreeVar(Set)
@@ -32770,9 +32770,9 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["pingCache"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*(???*12*)
   ⚠️  unknown callee
 - *6* ???*7*["get"]
@@ -32784,13 +32784,13 @@ ${La}${a}`("SuspenseList")
 - *9* a
   ⚠️  circular variable reference
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4219 member call = (new ???*0*() | undefined | ???*1* | ???*5*)["add"](???*13*)
 - *0* FreeVar(Set)
@@ -32801,9 +32801,9 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["pingCache"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*(???*12*)
   ⚠️  unknown callee
 - *6* ???*7*["get"]
@@ -32815,13 +32815,13 @@ ${La}${a}`("SuspenseList")
 - *9* a
   ⚠️  circular variable reference
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4221 member call = (...) => undefined["bind"](
     null,
@@ -32833,17 +32833,17 @@ ${La}${a}`("SuspenseList")
     ???*5*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4223 member call = ???*0*["then"](
     (
@@ -32856,29 +32856,29 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* a
   ⚠️  circular variable reference
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4225 conditional = (13 === ???*0*)
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4225 -> 4227 conditional = (null !== (???*0* | ???*1* | ???*4*))
 - *0* b
@@ -32888,11 +32888,11 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["tag"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["memoizedState"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4227 -> 4229 conditional = (null !== ???*0*)
 - *0* ???*1*["dehydrated"]
@@ -32906,11 +32906,11 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["tag"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (null !== ???*6*)
   ⚠️  nested operation
 - *6* b
@@ -32941,9 +32941,9 @@ ${La}${a}`("SuspenseList")
   | {"eventTime": ???*2*, "lane": 1, "tag": 0, "payload": null, "callback": null, "next": null}
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
@@ -32951,7 +32951,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4243 -> 4245 call = (...) => {"eventTime": a, "lane": b, "tag": 0, "payload": null, "callback": null, "next": null}(???*0*, 1)
 - *0* unsupported expression
@@ -32966,9 +32966,9 @@ ${La}${a}`("SuspenseList")
     1
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
@@ -32982,7 +32982,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4255 conditional = (null === ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4255 -> 4256 call = (...) => (
   | g(a)
@@ -32995,11 +32995,11 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4255 -> 4258 call = (...) => (
   | g(a)
@@ -33012,29 +33012,29 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["child"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4261 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4262 call = (...) => a(???*0*, ???*1*, (???*2* | ???*3* | (0 !== (0 | ???*5*))), (???*6* | ???*7*), ???*12*, ???*14*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["render"]
   ⚠️  unknown object
 - *4* c
@@ -33042,11 +33042,11 @@ ${La}${a}`("SuspenseList")
 - *5* updated with update expression
   ⚠️  This value might have side effects
 - *6* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (???*8* | ???*9* | (0 !== (0 | ???*11*)))(d, e)
   ⚠️  non-function callee
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["render"]
   ⚠️  unknown object
 - *10* c
@@ -33056,15 +33056,15 @@ ${La}${a}`("SuspenseList")
 - *12* ???*13*["ref"]
   ⚠️  unknown object
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4263 call = (...) => a()
 
 0 -> 4264 conditional = ((null !== ???*0*) | !((true | false | ???*1*)))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? true : false)
   ⚠️  nested operation
 - *2* (0 !== ???*3*)
@@ -33074,11 +33074,11 @@ ${La}${a}`("SuspenseList")
 
 4264 -> 4269 call = (...) => (null | b["child"])(???*0*, ???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4264 -> 4270 unreachable = ???*0*
 - *0* unreachable
@@ -33086,19 +33086,19 @@ ${La}${a}`("SuspenseList")
 
 4264 -> 4271 call = (...) => undefined(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4264 -> 4273 call = (...) => undefined(???*0*, ???*1*, (???*2* | ???*3*), ???*8*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (???*4* | ???*5* | (0 !== (0 | ???*7*)))(d, e)
   ⚠️  non-function callee
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["render"]
   ⚠️  unknown object
 - *6* c
@@ -33106,7 +33106,7 @@ ${La}${a}`("SuspenseList")
 - *7* updated with update expression
   ⚠️  This value might have side effects
 - *8* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4264 -> 4275 unreachable = ???*0*
 - *0* unreachable
@@ -33114,11 +33114,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4276 conditional = (null === (???*0* | ???*1* | ???*3* | ???*14* | null | undefined["alternate"]))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* new (...) => undefined(7, ???*4*, (null | ???*5*), (???*11* | ???*13*))
   ⚠️  nested operation
 - *4* a
@@ -33126,19 +33126,19 @@ ${La}${a}`("SuspenseList")
 - *5* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*6*, ???*7*, (???*8* | ???*10*))
   ⚠️  nested operation
 - *6* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* b
   ⚠️  circular variable reference
 - *8* ???*9*["mode"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* unsupported assign operation
   ⚠️  This value might have side effects
 - *11* ???*12*["mode"]
   ⚠️  unknown object
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* unsupported assign operation
   ⚠️  This value might have side effects
 - *14* a
@@ -33159,7 +33159,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== ???*3*)
   ⚠️  nested operation
 - *3* c
@@ -33175,19 +33175,19 @@ ${La}${a}`("SuspenseList")
 - *8* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*9*, ???*10*, (???*11* | ???*13*))
   ⚠️  nested operation
 - *9* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* b
   ⚠️  circular variable reference
 - *11* ???*12*["mode"]
   ⚠️  unknown object
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* unsupported assign operation
   ⚠️  This value might have side effects
 - *14* ???*15*["mode"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* unsupported assign operation
   ⚠️  This value might have side effects
 - *17* ???*18*["child"]
@@ -33201,29 +33201,29 @@ ${La}${a}`("SuspenseList")
 - *20* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*21*, ???*22*, (???*23* | ???*25*))
   ⚠️  nested operation
 - *21* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* b
   ⚠️  circular variable reference
 - *23* ???*24*["mode"]
   ⚠️  unknown object
 - *24* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* unsupported assign operation
   ⚠️  This value might have side effects
 - *26* ???*27*["mode"]
   ⚠️  unknown object
 - *27* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* unsupported assign operation
   ⚠️  This value might have side effects
 - *29* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* b
   ⚠️  circular variable reference
 - *31* ???*32*["mode"]
   ⚠️  unknown object
 - *32* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* unsupported assign operation
   ⚠️  This value might have side effects
 - *34* ???*35*["tag"]
@@ -33231,7 +33231,7 @@ ${La}${a}`("SuspenseList")
 - *35* f
   ⚠️  circular variable reference
 - *36* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* ???*38*["dependencies"]
   ⚠️  unknown object
 - *38* f
@@ -33261,7 +33261,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== ???*3*)
   ⚠️  nested operation
 - *3* c
@@ -33277,19 +33277,19 @@ ${La}${a}`("SuspenseList")
 - *8* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*9*, ???*10*, (???*11* | ???*13*))
   ⚠️  nested operation
 - *9* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* b
   ⚠️  circular variable reference
 - *11* ???*12*["mode"]
   ⚠️  unknown object
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* unsupported assign operation
   ⚠️  This value might have side effects
 - *14* ???*15*["mode"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* unsupported assign operation
   ⚠️  This value might have side effects
 - *17* ???*18*["child"]
@@ -33303,29 +33303,29 @@ ${La}${a}`("SuspenseList")
 - *20* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*21*, ???*22*, (???*23* | ???*25*))
   ⚠️  nested operation
 - *21* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* b
   ⚠️  circular variable reference
 - *23* ???*24*["mode"]
   ⚠️  unknown object
 - *24* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* unsupported assign operation
   ⚠️  This value might have side effects
 - *26* ???*27*["mode"]
   ⚠️  unknown object
 - *27* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* unsupported assign operation
   ⚠️  This value might have side effects
 - *29* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* b
   ⚠️  circular variable reference
 - *31* ???*32*["mode"]
   ⚠️  unknown object
 - *32* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* unsupported assign operation
   ⚠️  This value might have side effects
 - *34* ???*35*["tag"]
@@ -33333,7 +33333,7 @@ ${La}${a}`("SuspenseList")
 - *35* f
   ⚠️  circular variable reference
 - *36* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* ???*38*["dependencies"]
   ⚠️  unknown object
 - *38* f
@@ -33359,7 +33359,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["child"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -33373,7 +33373,7 @@ ${La}${a}`("SuspenseList")
 - *7* ???*8*["type"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["child"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -33385,7 +33385,7 @@ ${La}${a}`("SuspenseList")
 - *12* ???*13*["type"]
   ⚠️  unknown object
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["defaultProps"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -33398,11 +33398,11 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["compare"]
   ⚠️  unknown object
 - *18* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["defaultProps"]
   ⚠️  unknown object
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4283 -> 4286 call = (...) => ($i(a, b, e) | dj(a, b, c, d, e))(
     (
@@ -33438,29 +33438,29 @@ ${La}${a}`("SuspenseList")
     ???*92*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* a
   ⚠️  circular variable reference
 - *4* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*5*, ???*6*, (???*7* | ???*9*))
   ⚠️  nested operation
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* b
   ⚠️  circular variable reference
 - *7* ???*8*["mode"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported assign operation
   ⚠️  This value might have side effects
 - *10* ???*11*["mode"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* unsupported assign operation
   ⚠️  This value might have side effects
 - *13* a
@@ -33471,29 +33471,29 @@ ${La}${a}`("SuspenseList")
 - *15* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*16*, ???*17*, (???*18* | ???*20*))
   ⚠️  nested operation
 - *16* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* b
   ⚠️  circular variable reference
 - *18* ???*19*["mode"]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* unsupported assign operation
   ⚠️  This value might have side effects
 - *21* ???*22*["mode"]
   ⚠️  unknown object
 - *22* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* unsupported assign operation
   ⚠️  This value might have side effects
 - *24* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* b
   ⚠️  circular variable reference
 - *26* ???*27*["mode"]
   ⚠️  unknown object
 - *27* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* unsupported assign operation
   ⚠️  This value might have side effects
 - *29* (null !== ???*30*)
@@ -33511,33 +33511,33 @@ ${La}${a}`("SuspenseList")
 - *35* ???*36*["type"]
   ⚠️  unknown object
 - *36* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *38* ???*39*["dependencies"]
   ⚠️  unknown object
 - *39* ???*40*["type"]
   ⚠️  unknown object
 - *40* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *41* ???*42*["key"]
   ⚠️  unknown object
 - *42* ???*43*["type"]
   ⚠️  unknown object
 - *43* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *44* ???*45*["mode"]
   ⚠️  unknown object
 - *45* ???*46*["type"]
   ⚠️  unknown object
 - *46* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *47* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *48* ???*49*["type"]
   ⚠️  unknown object
 - *49* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *50* (null !== ???*51*)
   ⚠️  nested operation
 - *51* c
@@ -33553,19 +33553,19 @@ ${La}${a}`("SuspenseList")
 - *56* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*57*, ???*58*, (???*59* | ???*61*))
   ⚠️  nested operation
 - *57* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *58* b
   ⚠️  circular variable reference
 - *59* ???*60*["mode"]
   ⚠️  unknown object
 - *60* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *61* unsupported assign operation
   ⚠️  This value might have side effects
 - *62* ???*63*["mode"]
   ⚠️  unknown object
 - *63* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *64* unsupported assign operation
   ⚠️  This value might have side effects
 - *65* ???*66*["child"]
@@ -33579,29 +33579,29 @@ ${La}${a}`("SuspenseList")
 - *68* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*69*, ???*70*, (???*71* | ???*73*))
   ⚠️  nested operation
 - *69* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *70* b
   ⚠️  circular variable reference
 - *71* ???*72*["mode"]
   ⚠️  unknown object
 - *72* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *73* unsupported assign operation
   ⚠️  This value might have side effects
 - *74* ???*75*["mode"]
   ⚠️  unknown object
 - *75* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *76* unsupported assign operation
   ⚠️  This value might have side effects
 - *77* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *78* b
   ⚠️  circular variable reference
 - *79* ???*80*["mode"]
   ⚠️  unknown object
 - *80* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *81* unsupported assign operation
   ⚠️  This value might have side effects
 - *82* ???*83*["tag"]
@@ -33609,7 +33609,7 @@ ${La}${a}`("SuspenseList")
 - *83* f
   ⚠️  circular variable reference
 - *84* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *85* ???*86*["dependencies"]
   ⚠️  unknown object
 - *86* f
@@ -33623,9 +33623,9 @@ ${La}${a}`("SuspenseList")
 - *90* f
   ⚠️  circular variable reference
 - *91* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *92* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4283 -> 4287 unreachable = ???*0*
 - *0* unreachable
@@ -33648,7 +33648,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* c
@@ -33660,15 +33660,15 @@ ${La}${a}`("SuspenseList")
 - *7* !(1)
   ⚠️  nested operation
 - *8* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["mode"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4283 -> 4295 unreachable = ???*0*
 - *0* unreachable
@@ -33680,7 +33680,7 @@ ${La}${a}`("SuspenseList")
 
 4298 -> 4301 conditional = (null !== (???*0* | ???*1* | ???*3*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["compare"]
   ⚠️  unknown object
 - *2* c
@@ -33714,7 +33714,7 @@ ${La}${a}`("SuspenseList")
     ???*53*
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["compare"]
   ⚠️  unknown object
 - *2* c
@@ -33734,7 +33734,7 @@ ${La}${a}`("SuspenseList")
 - *9* ???*10*["type"]
   ⚠️  unknown object
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* (null !== ???*12*)
   ⚠️  nested operation
 - *12* c
@@ -33750,19 +33750,19 @@ ${La}${a}`("SuspenseList")
 - *17* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*18*, ???*19*, (???*20* | ???*22*))
   ⚠️  nested operation
 - *18* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* b
   ⚠️  circular variable reference
 - *20* ???*21*["mode"]
   ⚠️  unknown object
 - *21* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* unsupported assign operation
   ⚠️  This value might have side effects
 - *23* ???*24*["mode"]
   ⚠️  unknown object
 - *24* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* unsupported assign operation
   ⚠️  This value might have side effects
 - *26* ???*27*["memoizedProps"]
@@ -33779,29 +33779,29 @@ ${La}${a}`("SuspenseList")
 - *30* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*31*, ???*32*, (???*33* | ???*35*))
   ⚠️  nested operation
 - *31* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* b
   ⚠️  circular variable reference
 - *33* ???*34*["mode"]
   ⚠️  unknown object
 - *34* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *35* unsupported assign operation
   ⚠️  This value might have side effects
 - *36* ???*37*["mode"]
   ⚠️  unknown object
 - *37* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *38* unsupported assign operation
   ⚠️  This value might have side effects
 - *39* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *40* b
   ⚠️  circular variable reference
 - *41* ???*42*["mode"]
   ⚠️  unknown object
 - *42* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *43* unsupported assign operation
   ⚠️  This value might have side effects
 - *44* ???*45*["tag"]
@@ -33809,7 +33809,7 @@ ${La}${a}`("SuspenseList")
 - *45* f
   ⚠️  circular variable reference
 - *46* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *47* ???*48*["dependencies"]
   ⚠️  unknown object
 - *48* f
@@ -33823,13 +33823,13 @@ ${La}${a}`("SuspenseList")
 - *52* f
   ⚠️  circular variable reference
 - *53* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4298 -> 4305 conditional = (???*0* | (???*9* === ???*10*))
 - *0* (???*1* | ???*2* | (???*4* ? ???*6* : (...) => (???*7* | ???*8*)))(g, d)
   ⚠️  non-function callee
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["compare"]
   ⚠️  unknown object
 - *3* c
@@ -33849,7 +33849,7 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["ref"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4305 -> 4306 call = (...) => (null | b["child"])(
     (
@@ -33873,29 +33873,29 @@ ${La}${a}`("SuspenseList")
     ???*48*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* a
   ⚠️  circular variable reference
 - *4* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*5*, ???*6*, (???*7* | ???*9*))
   ⚠️  nested operation
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* b
   ⚠️  circular variable reference
 - *7* ???*8*["mode"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported assign operation
   ⚠️  This value might have side effects
 - *10* ???*11*["mode"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* unsupported assign operation
   ⚠️  This value might have side effects
 - *13* a
@@ -33906,29 +33906,29 @@ ${La}${a}`("SuspenseList")
 - *15* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*16*, ???*17*, (???*18* | ???*20*))
   ⚠️  nested operation
 - *16* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* b
   ⚠️  circular variable reference
 - *18* ???*19*["mode"]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* unsupported assign operation
   ⚠️  This value might have side effects
 - *21* ???*22*["mode"]
   ⚠️  unknown object
 - *22* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* unsupported assign operation
   ⚠️  This value might have side effects
 - *24* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* b
   ⚠️  circular variable reference
 - *26* ???*27*["mode"]
   ⚠️  unknown object
 - *27* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* unsupported assign operation
   ⚠️  This value might have side effects
 - *29* (null !== ???*30*)
@@ -33946,31 +33946,31 @@ ${La}${a}`("SuspenseList")
 - *35* ???*36*["type"]
   ⚠️  unknown object
 - *36* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *38* ???*39*["dependencies"]
   ⚠️  unknown object
 - *39* ???*40*["type"]
   ⚠️  unknown object
 - *40* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *41* ???*42*["key"]
   ⚠️  unknown object
 - *42* ???*43*["type"]
   ⚠️  unknown object
 - *43* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *44* ???*45*["mode"]
   ⚠️  unknown object
 - *45* ???*46*["type"]
   ⚠️  unknown object
 - *46* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *47* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *48* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4305 -> 4307 unreachable = ???*0*
 - *0* unreachable
@@ -33993,7 +33993,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== ???*3*)
   ⚠️  nested operation
 - *3* c
@@ -34009,19 +34009,19 @@ ${La}${a}`("SuspenseList")
 - *8* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*9*, ???*10*, (???*11* | ???*13*))
   ⚠️  nested operation
 - *9* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* b
   ⚠️  circular variable reference
 - *11* ???*12*["mode"]
   ⚠️  unknown object
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* unsupported assign operation
   ⚠️  This value might have side effects
 - *14* ???*15*["mode"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* unsupported assign operation
   ⚠️  This value might have side effects
 - *17* ???*18*["child"]
@@ -34035,29 +34035,29 @@ ${La}${a}`("SuspenseList")
 - *20* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*21*, ???*22*, (???*23* | ???*25*))
   ⚠️  nested operation
 - *21* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* b
   ⚠️  circular variable reference
 - *23* ???*24*["mode"]
   ⚠️  unknown object
 - *24* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* unsupported assign operation
   ⚠️  This value might have side effects
 - *26* ???*27*["mode"]
   ⚠️  unknown object
 - *27* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* unsupported assign operation
   ⚠️  This value might have side effects
 - *29* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* b
   ⚠️  circular variable reference
 - *31* ???*32*["mode"]
   ⚠️  unknown object
 - *32* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* unsupported assign operation
   ⚠️  This value might have side effects
 - *34* ???*35*["tag"]
@@ -34065,7 +34065,7 @@ ${La}${a}`("SuspenseList")
 - *35* f
   ⚠️  circular variable reference
 - *36* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* ???*38*["dependencies"]
   ⚠️  unknown object
 - *38* f
@@ -34079,7 +34079,7 @@ ${La}${a}`("SuspenseList")
 - *42* f
   ⚠️  circular variable reference
 - *43* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4276 -> 4314 unreachable = ???*0*
 - *0* unreachable
@@ -34087,29 +34087,29 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4315 conditional = (null !== ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4315 -> 4317 call = (...) => (!(0) | !(1))((???*0* | undefined), (???*2* | ???*3* | undefined))
 - *0* ???*1*["memoizedProps"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["memoizedProps"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4315 -> 4320 conditional = (true | false | (???*0* === ???*2*))
 - *0* ???*1*["ref"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["ref"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4320 -> 4323 conditional = (0 !== ???*0*)
 - *0* unsupported expression
@@ -34117,11 +34117,11 @@ ${La}${a}`("SuspenseList")
 
 4323 -> 4326 call = (...) => (null | b["child"])(???*0*, ???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4323 -> 4327 unreachable = ???*0*
 - *0* unreachable
@@ -34132,19 +34132,19 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["memoizedProps"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4330 unreachable = ???*0*
 - *0* unreachable
@@ -34152,7 +34152,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4333 conditional = (null !== (???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? ???*8* : ???*9*)
   ⚠️  nested operation
 - *2* (null !== ???*3*)
@@ -34170,7 +34170,7 @@ ${La}${a}`("SuspenseList")
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4336 conditional = ("hidden" === (???*0* | ???*3*))
 - *0* ???*1*["mode"]
@@ -34178,7 +34178,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["pendingProps"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["mode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -34195,7 +34195,7 @@ ${La}${a}`("SuspenseList")
 - *1* unknown mutation
   ⚠️  This value might have side effects
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 
@@ -34209,7 +34209,7 @@ ${La}${a}`("SuspenseList")
 - *1* (null !== (???*2* | ???*3*))
   ⚠️  nested operation
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (???*4* ? ???*6* : ???*7*)
   ⚠️  nested operation
 - *4* (null !== ???*5*)
@@ -34219,11 +34219,11 @@ ${La}${a}`("SuspenseList")
 - *6* unsupported expression
   ⚠️  This value might have side effects
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["memoizedState"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4341 -> 4348 call = (...) => undefined({"current": 0}, (???*0* | 0 | ???*1* | ???*2* | ???*3*))
 - *0* unsupported assign operation
@@ -34231,7 +34231,7 @@ ${La}${a}`("SuspenseList")
 - *1* unknown mutation
   ⚠️  This value might have side effects
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 
@@ -34245,7 +34245,7 @@ ${La}${a}`("SuspenseList")
 - *1* (null !== (???*2* | ???*3*))
   ⚠️  nested operation
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (???*4* ? ???*6* : ???*7*)
   ⚠️  nested operation
 - *4* (null !== ???*5*)
@@ -34255,11 +34255,11 @@ ${La}${a}`("SuspenseList")
 - *6* unsupported expression
   ⚠️  This value might have side effects
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["memoizedState"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4341 -> 4353 call = (...) => undefined({"current": 0}, (???*0* | 0 | ???*1* | ???*2* | ???*3*))
 - *0* unsupported assign operation
@@ -34267,7 +34267,7 @@ ${La}${a}`("SuspenseList")
 - *1* unknown mutation
   ⚠️  This value might have side effects
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 
@@ -34277,7 +34277,7 @@ ${La}${a}`("SuspenseList")
 - *1* (null !== (???*2* | ???*3*))
   ⚠️  nested operation
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (???*4* ? ???*6* : ???*7*)
   ⚠️  nested operation
 - *4* (null !== ???*5*)
@@ -34287,11 +34287,11 @@ ${La}${a}`("SuspenseList")
 - *6* unsupported expression
   ⚠️  This value might have side effects
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["memoizedState"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4336 -> 4357 call = (...) => undefined({"current": 0}, (???*0* | 0 | ???*1* | ???*2* | ???*3*))
 - *0* unsupported assign operation
@@ -34299,7 +34299,7 @@ ${La}${a}`("SuspenseList")
 - *1* unknown mutation
   ⚠️  This value might have side effects
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 
@@ -34310,7 +34310,7 @@ ${La}${a}`("SuspenseList")
     ???*36*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (null !== ???*2*)
   ⚠️  nested operation
 - *2* (???*3* ? ???*5* : null)
@@ -34326,15 +34326,15 @@ ${La}${a}`("SuspenseList")
 - *7* unsupported expression
   ⚠️  This value might have side effects
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["children"]
   ⚠️  unknown object
 - *11* ???*12*["pendingProps"]
   ⚠️  unknown object
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* (null !== ???*14*)
   ⚠️  nested operation
 - *14* (???*15* ? ???*21* : null)
@@ -34342,7 +34342,7 @@ ${La}${a}`("SuspenseList")
 - *15* (null !== (???*16* | ???*17*))
   ⚠️  nested operation
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* (???*18* ? ???*19* : ???*20*)
   ⚠️  nested operation
 - *18* (null !== ???)
@@ -34350,11 +34350,11 @@ ${La}${a}`("SuspenseList")
 - *19* unsupported expression
   ⚠️  This value might have side effects
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["memoizedState"]
   ⚠️  unknown object
 - *22* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* ???*24*["baseLanes"]
   ⚠️  unknown object
 - *24* (???*25* ? ???*31* : null)
@@ -34362,7 +34362,7 @@ ${La}${a}`("SuspenseList")
 - *25* (null !== (???*26* | ???*27*))
   ⚠️  nested operation
 - *26* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* (???*28* ? ???*29* : ???*30*)
   ⚠️  nested operation
 - *28* (null !== ???)
@@ -34370,20 +34370,20 @@ ${La}${a}`("SuspenseList")
 - *29* unsupported expression
   ⚠️  This value might have side effects
 - *30* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *31* ???*32*["memoizedState"]
   ⚠️  unknown object
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *34* ???*35*["children"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *35* unsupported expression
   ⚠️  This value might have side effects
 - *36* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4360 unreachable = ???*0*
 - *0* unreachable
@@ -34391,25 +34391,25 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4363 conditional = ((null === ???*0*) | (null !== ???*1*) | (null !== ???*3*) | (???*4* !== ???*6*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["ref"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["ref"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["ref"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4366 call = (...) => ((null !== a) && (undefined !== a))((???*0* | ???*1*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*(d, e)
   ⚠️  unknown callee
 - *2* c
@@ -34417,7 +34417,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4367 conditional = ((null !== (???*0* | ???*1* | ???*3*)) | (undefined !== (???*5* | ???*6* | ???*8*)))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*(d, e)
   ⚠️  unknown callee
 - *2* c
@@ -34427,7 +34427,7 @@ ${La}${a}`("SuspenseList")
 - *4* a
   ⚠️  circular variable reference
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*(d, e)
   ⚠️  unknown callee
 - *7* c
@@ -34442,11 +34442,11 @@ ${La}${a}`("SuspenseList")
     ((???*1* ? ({} | ???*7*) : ({} | ???*8*)) | {} | ???*9*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (null !== (???*2* | ???*3* | ???*5*))
   ⚠️  nested operation
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*(d, e)
   ⚠️  unknown callee
 - *4* c
@@ -34464,13 +34464,13 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["stateNode"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4370 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4371 call = (...) => a(
     ???*0*,
@@ -34481,23 +34481,23 @@ ${La}${a}`("SuspenseList")
     ???*18*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*(d, e)
   ⚠️  unknown callee
 - *4* c
   ⚠️  circular variable reference
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* updated with update expression
   ⚠️  This value might have side effects
 - *7* (null !== (???*8* | ???*9* | ???*11*))
   ⚠️  nested operation
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*(d, e)
   ⚠️  unknown callee
 - *10* c
@@ -34515,15 +34515,15 @@ ${La}${a}`("SuspenseList")
 - *16* ???*17*["stateNode"]
   ⚠️  unknown object
 - *17* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4372 call = (...) => a()
 
 0 -> 4373 conditional = ((null !== ???*0*) | !((true | false | ???*1*)))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? true : false)
   ⚠️  nested operation
 - *2* (0 !== ???*3*)
@@ -34533,11 +34533,11 @@ ${La}${a}`("SuspenseList")
 
 4373 -> 4378 call = (...) => (null | b["child"])(???*0*, ???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4373 -> 4379 unreachable = ???*0*
 - *0* unreachable
@@ -34545,21 +34545,21 @@ ${La}${a}`("SuspenseList")
 
 4373 -> 4380 call = (...) => undefined(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4373 -> 4382 call = (...) => undefined(???*0*, ???*1*, (???*2* | ???*3*), ???*5*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*(d, e)
   ⚠️  unknown callee
 - *4* c
   ⚠️  circular variable reference
 - *5* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4373 -> 4384 unreachable = ???*0*
 - *0* unreachable
@@ -34567,17 +34567,17 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4385 call = (...) => ((null !== a) && (undefined !== a))(???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4386 conditional = ((null !== (???*0* | ???*1*)) | (undefined !== (???*3* | ???*4*)))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["childContextTypes"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["childContextTypes"]
   ⚠️  unknown object
 - *5* a
@@ -34585,47 +34585,47 @@ ${La}${a}`("SuspenseList")
 
 4386 -> 4387 call = (...) => !(0)(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4388 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4390 conditional = (null === ???*0*)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4390 -> 4391 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4390 -> 4392 call = (...) => b(???*0*, ???*1*, ???*2*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
 4390 -> 4393 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*3*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 - *3* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4390 -> 4394 conditional = (null === ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4394 -> 4400 typeof = typeof(???*0*)
 - *0* max number of linking steps reached
@@ -34645,17 +34645,17 @@ ${La}${a}`("SuspenseList")
 
 4401 -> 4403 call = (...) => ((null !== a) && (undefined !== a))(???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4401 -> 4404 conditional = ((null !== (???*0* | ???*1*)) | (undefined !== (???*3* | ???*4*)))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["childContextTypes"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["childContextTypes"]
   ⚠️  unknown object
 - *5* a
@@ -34663,7 +34663,7 @@ ${La}${a}`("SuspenseList")
 
 4401 -> 4406 call = (...) => (Vf | d["__reactInternalMemoizedMaskedChildContext"] | e)(???*0*, ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -34671,13 +34671,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* typeof((???*3* | undefined))
   ⚠️  nested operation
 - *3* ???*4*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4394 -> 4409 typeof = typeof((???*0* | undefined["getSnapshotBeforeUpdate"]))
 - *0* ???*1*["getSnapshotBeforeUpdate"]
@@ -34685,7 +34685,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4394 -> 4411 typeof = typeof((???*0* | undefined["UNSAFE_componentWillReceiveProps"]))
 - *0* ???*1*["UNSAFE_componentWillReceiveProps"]
@@ -34693,7 +34693,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4394 -> 4413 typeof = typeof((???*0* | undefined["componentWillReceiveProps"]))
 - *0* ???*1*["componentWillReceiveProps"]
@@ -34701,15 +34701,15 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4394 -> 4415 call = (...) => undefined(???*0*, (???*1* | undefined), ???*3*, ???*4*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* max number of linking steps reached
@@ -34717,15 +34717,15 @@ ${La}${a}`("SuspenseList")
 
 4394 -> 4418 call = (...) => undefined(???*0*, ???*1*, (???*2* | undefined), ???*4*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4394 -> 4421 conditional = (
   | (???*0* !== ???*1*)
@@ -34741,13 +34741,13 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["context"]
   ⚠️  unknown object
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unknown mutation
   ⚠️  This value might have side effects
 - *8* (???*9* ? ({} | ???*13*) : ({} | ???*14*))
@@ -34755,7 +34755,7 @@ ${La}${a}`("SuspenseList")
 - *9* (null !== (???*10* | ???*11*))
   ⚠️  nested operation
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["childContextTypes"]
   ⚠️  unknown object
 - *12* a
@@ -34771,29 +34771,29 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* typeof((???*3* | undefined))
   ⚠️  nested operation
 - *3* ???*4*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4421 -> 4423 call = (...) => undefined(???*0*, ???*1*, (???*2* | undefined | ("function" === ???*4*)), ???*7*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* typeof((???*5* | undefined))
   ⚠️  nested operation
 - *5* ???*6*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -34814,9 +34814,9 @@ ${La}${a}`("SuspenseList")
     ???*16*
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 - *3* max number of linking steps reached
@@ -34824,19 +34824,19 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["memoizedState"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["context"]
   ⚠️  unknown object
 - *7* ???*8*["stateNode"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unknown mutation
   ⚠️  This value might have side effects
 - *10* (null !== (???*11* | ???*12*))
   ⚠️  nested operation
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["childContextTypes"]
   ⚠️  unknown object
 - *13* a
@@ -34856,7 +34856,7 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["shouldComponentUpdate"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["shouldComponentUpdate"](
         ???*6*,
         (
@@ -34872,7 +34872,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* max number of linking steps reached
   ⚠️  This value might have side effects
 - *7* ???*8*["context"]
@@ -34880,13 +34880,13 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["stateNode"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* unknown mutation
   ⚠️  This value might have side effects
 - *11* (null !== (???*12* | ???*13*))
   ⚠️  nested operation
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["childContextTypes"]
   ⚠️  unknown object
 - *14* a
@@ -34902,7 +34902,7 @@ ${La}${a}`("SuspenseList")
 - *19* ???*20*["prototype"]
   ⚠️  unknown object
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* !((true | false))
   ⚠️  nested operation
 
@@ -34912,7 +34912,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4426 -> 4429 typeof = typeof((???*0* | undefined["componentWillMount"]))
 - *0* ???*1*["componentWillMount"]
@@ -34920,7 +34920,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4426 -> 4431 typeof = typeof((???*0* | undefined["componentWillMount"]))
 - *0* ???*1*["componentWillMount"]
@@ -34928,13 +34928,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4426 -> 4434 member call = (???*0* | undefined)["componentWillMount"]()
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4426 -> 4435 typeof = typeof((???*0* | undefined["UNSAFE_componentWillMount"]))
 - *0* ???*1*["UNSAFE_componentWillMount"]
@@ -34942,13 +34942,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4426 -> 4438 member call = (???*0* | undefined)["UNSAFE_componentWillMount"]()
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4426 -> 4439 typeof = typeof((???*0* | undefined["componentDidMount"]))
 - *0* ???*1*["componentDidMount"]
@@ -34956,7 +34956,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4426 -> 4442 typeof = typeof((???*0* | undefined["componentDidMount"]))
 - *0* ???*1*["componentDidMount"]
@@ -34964,7 +34964,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4421 -> 4450 typeof = typeof((???*0* | undefined["componentDidMount"]))
 - *0* ???*1*["componentDidMount"]
@@ -34972,29 +34972,29 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4394 -> 4454 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4394 -> 4458 conditional = (???*0* === ???*2*)
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["elementType"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4458 -> 4460 call = (...) => b(???*0*, ???*2*)
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -35011,13 +35011,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* (null !== (???*5* | ???*6*))
   ⚠️  nested operation
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["childContextTypes"]
   ⚠️  unknown object
 - *7* a
@@ -35038,7 +35038,7 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* unknown mutation
   ⚠️  This value might have side effects
 - *5* (???*6* ? ({} | ???*10*) : ({} | ???*11*))
@@ -35046,7 +35046,7 @@ ${La}${a}`("SuspenseList")
 - *6* (null !== (???*7* | ???*8*))
   ⚠️  nested operation
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["childContextTypes"]
   ⚠️  unknown object
 - *9* a
@@ -35060,7 +35060,7 @@ ${La}${a}`("SuspenseList")
 - *13* ???*14*["stateNode"]
   ⚠️  unknown object
 - *14* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unknown mutation
   ⚠️  This value might have side effects
 - *16* (???*17* ? ({} | ???*21*) : ({} | ???*22*))
@@ -35068,7 +35068,7 @@ ${La}${a}`("SuspenseList")
 - *17* (null !== (???*18* | ???*19*))
   ⚠️  nested operation
 - *18* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["childContextTypes"]
   ⚠️  unknown object
 - *20* a
@@ -35093,13 +35093,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* (null !== (???*5* | ???*6*))
   ⚠️  nested operation
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["childContextTypes"]
   ⚠️  unknown object
 - *7* a
@@ -35111,17 +35111,17 @@ ${La}${a}`("SuspenseList")
 
 4466 -> 4468 call = (...) => ((null !== a) && (undefined !== a))(???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4466 -> 4469 conditional = ((null !== (???*0* | ???*1*)) | (undefined !== (???*3* | ???*4*)))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["childContextTypes"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["childContextTypes"]
   ⚠️  unknown object
 - *5* a
@@ -35139,19 +35139,19 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["context"]
   ⚠️  unknown object
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* unknown mutation
   ⚠️  This value might have side effects
 - *5* (null !== (???*6* | ???*7*))
   ⚠️  nested operation
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["childContextTypes"]
   ⚠️  unknown object
 - *8* a
@@ -35165,7 +35165,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4394 -> 4474 typeof = typeof((???*0* | undefined["getSnapshotBeforeUpdate"]))
 - *0* ???*1*["getSnapshotBeforeUpdate"]
@@ -35173,7 +35173,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4394 -> 4476 typeof = typeof((???*0* | undefined["UNSAFE_componentWillReceiveProps"]))
 - *0* ???*1*["UNSAFE_componentWillReceiveProps"]
@@ -35181,7 +35181,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4394 -> 4478 typeof = typeof((???*0* | undefined["componentWillReceiveProps"]))
 - *0* ???*1*["componentWillReceiveProps"]
@@ -35189,7 +35189,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4394 -> 4480 call = (...) => undefined(
     ???*0*,
@@ -35205,11 +35205,11 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* ???*5*["context"]
@@ -35217,13 +35217,13 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unknown mutation
   ⚠️  This value might have side effects
 - *8* (null !== (???*9* | ???*10*))
   ⚠️  nested operation
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["childContextTypes"]
   ⚠️  unknown object
 - *11* a
@@ -35235,15 +35235,15 @@ ${La}${a}`("SuspenseList")
 
 4394 -> 4483 call = (...) => undefined(???*0*, ???*1*, (???*2* | undefined), ???*4*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4394 -> 4486 conditional = (
   | (???*0* !== (???*1* | undefined | ???*8*))
@@ -35261,7 +35261,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ("function" === ???*6*)
   ⚠️  nested operation
 - *6* typeof((???*7* | undefined))
@@ -35271,15 +35271,15 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["pendingProps"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["memoizedState"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["memoizedState"]
   ⚠️  unknown object
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* unknown mutation
   ⚠️  This value might have side effects
 
@@ -35287,17 +35287,17 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4486 -> 4488 call = (...) => undefined(???*0*, ???*1*, (???*2* | undefined), ???*4*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -35318,9 +35318,9 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 - *3* max number of linking steps reached
@@ -35328,23 +35328,23 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["memoizedState"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["memoizedState"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["context"]
   ⚠️  unknown object
 - *9* ???*10*["stateNode"]
   ⚠️  unknown object
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* unknown mutation
   ⚠️  This value might have side effects
 - *12* (null !== (???*13* | ???*14*))
   ⚠️  nested operation
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["childContextTypes"]
   ⚠️  unknown object
 - *15* a
@@ -35362,7 +35362,7 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["shouldComponentUpdate"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["shouldComponentUpdate"](
         ???*6*,
         (???*7* | undefined),
@@ -35378,25 +35378,25 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* max number of linking steps reached
   ⚠️  This value might have side effects
 - *7* ???*8*["memoizedState"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["context"]
   ⚠️  unknown object
 - *10* ???*11*["stateNode"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* unknown mutation
   ⚠️  This value might have side effects
 - *13* (null !== (???*14* | ???*15*))
   ⚠️  nested operation
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["childContextTypes"]
   ⚠️  unknown object
 - *16* a
@@ -35410,7 +35410,7 @@ ${La}${a}`("SuspenseList")
 - *20* ???*21*["prototype"]
   ⚠️  unknown object
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* !((true | false))
   ⚠️  nested operation
 
@@ -35420,7 +35420,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4491 -> 4494 typeof = typeof((???*0* | undefined["componentWillUpdate"]))
 - *0* ???*1*["componentWillUpdate"]
@@ -35428,7 +35428,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4491 -> 4496 typeof = typeof((???*0* | undefined["componentWillUpdate"]))
 - *0* ???*1*["componentWillUpdate"]
@@ -35436,7 +35436,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4491 -> 4499 member call = (???*0* | undefined)["componentWillUpdate"](
     ???*2*,
@@ -35453,25 +35453,25 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["context"]
   ⚠️  unknown object
 - *6* ???*7*["stateNode"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* unknown mutation
   ⚠️  This value might have side effects
 - *9* (null !== (???*10* | ???*11*))
   ⚠️  nested operation
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["childContextTypes"]
   ⚠️  unknown object
 - *12* a
@@ -35487,7 +35487,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4491 -> 4503 member call = (???*0* | undefined)["UNSAFE_componentWillUpdate"](
     ???*2*,
@@ -35504,25 +35504,25 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["context"]
   ⚠️  unknown object
 - *6* ???*7*["stateNode"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* unknown mutation
   ⚠️  This value might have side effects
 - *9* (null !== (???*10* | ???*11*))
   ⚠️  nested operation
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["childContextTypes"]
   ⚠️  unknown object
 - *12* a
@@ -35538,7 +35538,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4491 -> 4507 typeof = typeof((???*0* | undefined["getSnapshotBeforeUpdate"]))
 - *0* ???*1*["getSnapshotBeforeUpdate"]
@@ -35546,7 +35546,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4491 -> 4510 typeof = typeof((???*0* | undefined["componentDidUpdate"]))
 - *0* ???*1*["componentDidUpdate"]
@@ -35554,7 +35554,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4491 -> 4515 typeof = typeof((???*0* | undefined["getSnapshotBeforeUpdate"]))
 - *0* ???*1*["getSnapshotBeforeUpdate"]
@@ -35562,7 +35562,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4486 -> 4525 typeof = typeof((???*0* | undefined["componentDidUpdate"]))
 - *0* ???*1*["componentDidUpdate"]
@@ -35570,7 +35570,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4486 -> 4530 typeof = typeof((???*0* | undefined["getSnapshotBeforeUpdate"]))
 - *0* ???*1*["getSnapshotBeforeUpdate"]
@@ -35578,22 +35578,22 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4535 call = (...) => (???*0* | b["child"])(???*1*, ???*2*, ???*3*, ???*4*, (true | undefined | false), ???*5*)
 - *0* $i(a, b, f)
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* max number of linking steps reached
   ⚠️  This value might have side effects
 - *5* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4536 unreachable = ???*0*
 - *0* unreachable
@@ -35601,17 +35601,17 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4537 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4539 conditional = (!((???*0* | ???*1*)) | !(???*3*))
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (0 !== ???*4*)
   ⚠️  nested operation
 - *4* unsupported expression
@@ -35619,17 +35619,17 @@ ${La}${a}`("SuspenseList")
 
 4539 -> 4540 call = (...) => undefined(???*0*, ???*1*, false)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4539 -> 4541 call = (...) => (null | b["child"])(???*0*, ???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4539 -> 4542 unreachable = ???*0*
 - *0* unreachable
@@ -35639,7 +35639,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["getDerivedStateFromError"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4539 -> 4547 conditional = ((0 !== ???*0*) | ("function" !== ???*1*))
 - *0* unsupported expression
@@ -35649,19 +35649,19 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["getDerivedStateFromError"]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4547 -> 4549 member call = (???*0* | ???*1*)["render"]()
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4539 -> 4551 conditional = ((null !== ???*0*) | (0 !== ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
@@ -35676,13 +35676,13 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["child"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4551 -> 4556 call = (...) => (
   | g(a)
@@ -35695,7 +35695,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (0 !== ???*3*)
   ⚠️  nested operation
 - *3* unsupported expression
@@ -35705,15 +35705,15 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["render"]
   ⚠️  unknown object
 - *6* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4551 -> 4557 call = (...) => undefined(???*0*, ???*1*, (???*2* ? null : ???*4*), ???*7*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (0 !== ???*3*)
   ⚠️  nested operation
 - *3* unsupported expression
@@ -35723,15 +35723,15 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["render"]
   ⚠️  unknown object
 - *6* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4539 -> 4560 call = (...) => undefined(???*0*, ???*1*, true)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4539 -> 4562 unreachable = ???*0*
 - *0* unreachable
@@ -35743,65 +35743,65 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4565 -> 4569 call = (...) => undefined(???*0*, ???*1*, (???*4* !== ???*7*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["pendingContext"]
   ⚠️  unknown object
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["pendingContext"]
   ⚠️  unknown object
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["context"]
   ⚠️  unknown object
 - *8* ???*9*["stateNode"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4565 -> 4572 call = (...) => undefined(???*0*, ???*1*, false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["context"]
   ⚠️  unknown object
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4574 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["containerInfo"]
   ⚠️  unknown object
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4575 call = (...) => undefined()
 
 0 -> 4576 call = (...) => undefined(???*0*)
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4578 call = (...) => undefined(???*0*, ???*1*, ???*2*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4580 unreachable = ???*0*
 - *0* unreachable
@@ -35834,7 +35834,7 @@ ${La}${a}`("SuspenseList")
 
 4591 -> 4592 call = (...) => undefined(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4591 -> 4595 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
@@ -35877,23 +35877,23 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["deletions"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4606 -> 4620 call = (...) => {"baseLanes": a, "cachePool": null, "transitions": null}((???*0* | ???*1*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["deletions"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4606 -> 4622 call = (...) => b(???*0*, ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -35912,7 +35912,7 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* max number of linking steps reached
@@ -35922,11 +35922,11 @@ ${La}${a}`("SuspenseList")
 - *6* max number of linking steps reached
   ⚠️  This value might have side effects
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["deletions"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4626 -> 4628 unreachable = ???*0*
 - *0* unreachable
@@ -35942,7 +35942,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -35968,11 +35968,11 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["deletions"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4629 -> 4655 conditional = (null === ???*0*)
 - *0* max number of linking steps reached
@@ -35980,11 +35980,11 @@ ${La}${a}`("SuspenseList")
 
 4655 -> 4656 call = (...) => {"baseLanes": a, "cachePool": null, "transitions": null}((???*0* | ???*1*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["deletions"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4629 -> 4663 unreachable = ???*0*
 - *0* unreachable
@@ -36001,19 +36001,19 @@ ${La}${a}`("SuspenseList")
 
 4629 -> 4673 conditional = (null === (???*0* | ???*1*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["deletions"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4673 -> 4677 member call = (???*0* | ???*1*)["push"](???*3*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["deletions"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -36035,7 +36035,7 @@ ${La}${a}`("SuspenseList")
     null
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* a
@@ -36043,11 +36043,11 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["mode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4685 unreachable = ???*0*
 - *0* unreachable
@@ -36055,7 +36055,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4686 call = (...) => undefined(???*0*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4688 call = (...) => (
   | g(a)
@@ -36078,11 +36078,11 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["child"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* unknown mutation
   ⚠️  This value might have side effects
 - *5* a
@@ -36090,19 +36090,19 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["mode"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4691 call = (...) => b(???*0*, ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* ???*3*["pendingProps"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4694 unreachable = ???*0*
 - *0* unreachable
@@ -36110,7 +36110,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4695 conditional = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4695 -> 4698 free var = FreeVar(Error)
 
@@ -36139,7 +36139,7 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -36173,7 +36173,7 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4705 -> 4722 call = (...) => (
   | g(a)
@@ -36193,11 +36193,11 @@ ${La}${a}`("SuspenseList")
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 - *4* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4705 -> 4725 call = (...) => {"baseLanes": a, "cachePool": null, "transitions": null}(???*0*)
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4705 -> 4727 unreachable = ???*0*
 - *0* unreachable
@@ -36213,7 +36213,7 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4729 -> 4731 unreachable = ???*0*
 - *0* unreachable
@@ -36255,7 +36255,7 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -36324,7 +36324,7 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -36371,17 +36371,17 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["return"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4788 conditional = (null === ???*0*)
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4800 call = (...) => undefined(
     (
@@ -36400,11 +36400,11 @@ ${La}${a}`("SuspenseList")
     (???*12* | ???*13* | 0["revealOrder"] | ???*15* | null | ???*17*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36414,24 +36414,24 @@ ${La}${a}`("SuspenseList")
 - *5* unknown mutation
   ⚠️  This value might have side effects
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["children"]
   ⚠️  unknown object
 - *8* ???*9*["pendingProps"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["children"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *11* unknown mutation
   ⚠️  This value might have side effects
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["child"]
   ⚠️  unknown object
 - *14* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["revealOrder"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36459,11 +36459,11 @@ ${La}${a}`("SuspenseList")
   | (0 !== ???*6*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36492,7 +36492,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["tag"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36521,11 +36521,11 @@ ${La}${a}`("SuspenseList")
     ???*12*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36535,11 +36535,11 @@ ${La}${a}`("SuspenseList")
 - *5* unknown mutation
   ⚠️  This value might have side effects
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["child"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["revealOrder"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36548,7 +36548,7 @@ ${La}${a}`("SuspenseList")
 - *11* c
   ⚠️  circular variable reference
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4809 -> 4813 conditional = (19 === (
   | ???*0*
@@ -36563,7 +36563,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["tag"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36592,11 +36592,11 @@ ${La}${a}`("SuspenseList")
     ???*12*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36606,11 +36606,11 @@ ${La}${a}`("SuspenseList")
 - *5* unknown mutation
   ⚠️  This value might have side effects
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["child"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["revealOrder"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36619,7 +36619,7 @@ ${La}${a}`("SuspenseList")
 - *11* c
   ⚠️  circular variable reference
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4813 -> 4816 conditional = (null !== (
   | ???*0*
@@ -36634,7 +36634,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["child"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["child"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36651,7 +36651,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["pendingProps"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* unsupported expression
@@ -36677,11 +36677,11 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36693,11 +36693,11 @@ ${La}${a}`("SuspenseList")
 
 4830 -> 4836 conditional = (null === (???*0* | ???*1* | 0["revealOrder"] | ???*3* | null | ???*5*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["revealOrder"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36714,28 +36714,28 @@ ${La}${a}`("SuspenseList")
     (???*14* | 0["tail"] | ???*17*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["revealOrder"]
   ⚠️  unknown object
 - *2* ???*3*["pendingProps"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["revealOrder"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *5* unknown mutation
   ⚠️  This value might have side effects
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* e
   ⚠️  circular variable reference
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["child"]
   ⚠️  unknown object
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["revealOrder"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36748,7 +36748,7 @@ ${La}${a}`("SuspenseList")
 - *15* ???*16*["pendingProps"]
   ⚠️  unknown object
 - *16* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["tail"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36769,11 +36769,11 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36809,11 +36809,11 @@ ${La}${a}`("SuspenseList")
     ))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36823,11 +36823,11 @@ ${La}${a}`("SuspenseList")
 - *5* unknown mutation
   ⚠️  This value might have side effects
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["child"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["alternate"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36845,13 +36845,13 @@ ${La}${a}`("SuspenseList")
     (???*7* | 0["tail"] | ???*10*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["child"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["revealOrder"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36864,7 +36864,7 @@ ${La}${a}`("SuspenseList")
 - *8* ???*9*["pendingProps"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["tail"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -36873,7 +36873,7 @@ ${La}${a}`("SuspenseList")
 
 4830 -> 4851 call = (...) => undefined(???*0*, false, null, null, undefined)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4854 unreachable = ???*0*
 - *0* unreachable
@@ -36889,19 +36889,19 @@ ${La}${a}`("SuspenseList")
 
 4863 -> 4867 conditional = ((null !== (???*0* | ???*1*)) | (???*3* !== ???*5*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["child"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["child"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4867 -> 4868 free var = FreeVar(Error)
 
@@ -36920,31 +36920,31 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["child"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4872 -> 4875 call = (...) => c((???*0* | ???*1*), ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["pendingProps"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4872 -> 4882 call = (...) => c((???*0* | ???*1*), ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["pendingProps"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4863 -> 4886 unreachable = ???*0*
 - *0* unreachable
@@ -36952,33 +36952,33 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4888 call = (...) => undefined(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4889 call = (...) => undefined()
 
 0 -> 4890 call = (...) => undefined(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4892 call = (...) => ((null !== a) && (undefined !== a))(???*0*)
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4893 call = (...) => !(0)(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4896 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["containerInfo"]
   ⚠️  unknown object
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4902 call = (...) => undefined({"current": null}, (???*0* | (0 !== ???*4*)["_currentValue"]))
 - *0* ???*1*["_currentValue"]
@@ -36988,7 +36988,7 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["type"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* unsupported expression
   ⚠️  This value might have side effects
 
@@ -36998,7 +36998,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (0 !== ???*4*)
   ⚠️  nested operation
 - *4* unsupported expression
@@ -37012,7 +37012,7 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["type"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4907 -> 4909 call = (...) => undefined({"current": 0}, ???*0*)
 - *0* unsupported expression
@@ -37034,15 +37034,15 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["child"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4914 -> 4916 unreachable = ???*0*
 - *0* unreachable
@@ -37054,23 +37054,23 @@ ${La}${a}`("SuspenseList")
 
 4914 -> 4919 call = (...) => (null | b["child"])((???*0* | null | ???*1*), ???*3*, ???*4*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4914 -> 4920 conditional = (null !== (???*0* | null | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4914 -> 4922 unreachable = ???*0*
 - *0* unreachable
@@ -37090,21 +37090,21 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported expression
   ⚠️  This value might have side effects
 
 4928 -> 4929 call = (...) => b["child"]((???*0* | null | ???*1*), ???*3*, ???*4*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4928 -> 4930 unreachable = ???*0*
 - *0* unreachable
@@ -37120,7 +37120,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported expression
   ⚠️  This value might have side effects
 
@@ -37133,15 +37133,15 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["child"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4942 unreachable = ???*0*
 - *0* unreachable
@@ -37149,15 +37149,15 @@ ${La}${a}`("SuspenseList")
 
 0 -> 4943 call = (...) => (null | b["child"])((???*0* | null | ???*1*), ???*3*, ???*4*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4944 unreachable = ???*0*
 - *0* unreachable
@@ -37169,23 +37169,23 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["tag"]
   ⚠️  unknown object
 - *4* ???*5*["child"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4948 -> 4951 member call = ???*0*["appendChild"](???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* ???*3*["child"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4948 -> 4954 conditional = ((4 !== ???*0*) | (null !== ???*3*))
 - *0* ???*1*["tag"]
@@ -37193,13 +37193,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["child"]
   ⚠️  unknown object
 - *4* ???*5*["child"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 4961 conditional = ((null === ???*0*) | (???*3* === ???*6*))
 - *0* ???*1*["return"]
@@ -37207,15 +37207,15 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["return"]
   ⚠️  unknown object
 - *4* ???*5*["child"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4961 -> 4962 unreachable = ???*0*
 - *0* unreachable
@@ -37225,7 +37225,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["memoizedProps"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* Object.assign*3*(
         {},
         ???*4*,
@@ -37256,9 +37256,9 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*["_wrapperState"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* Object.assign*15*(
         {},
         ???*16*,
@@ -37289,7 +37289,7 @@ ${La}${a}`("SuspenseList")
 - *23* ???*24*["_wrapperState"]
   ⚠️  unknown object
 - *24* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4969 -> 4972 call = (...) => a(({} | ???*0*))
 - *0* unknown mutation
@@ -37306,15 +37306,15 @@ ${La}${a}`("SuspenseList")
     }
 )((???*0* | ???*1*), (???*3* | ???*5*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["memoizedProps"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* Object.assign*6*(
         {},
         ???*7*,
@@ -37345,7 +37345,7 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["_wrapperState"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4969 -> 4974 call = (...) => A(
     {},
@@ -37358,13 +37358,13 @@ ${La}${a}`("SuspenseList")
     }
 )((???*0* | ???*1*), (???*3* | ???*4*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* Object.assign*5*(
         {},
         ???*6*,
@@ -37395,14 +37395,14 @@ ${La}${a}`("SuspenseList")
 - *13* ???*14*["_wrapperState"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4969 -> 4975 call = Object.assign*0*({}, (???*1* | ???*3*), {"value": undefined})
 - *0* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 - *1* ???*2*["memoizedProps"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* Object.assign*4*(
         {},
         ???*5*,
@@ -37433,12 +37433,12 @@ ${La}${a}`("SuspenseList")
 - *12* ???*13*["_wrapperState"]
   ⚠️  unknown object
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4969 -> 4976 call = Object.assign*0*({}, (???*1* | ???*2*), {"value": undefined})
 - *0* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* Object.assign*3*(
         {},
         ???*4*,
@@ -37469,7 +37469,7 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*["_wrapperState"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4969 -> 4977 call = (...) => A(
     {},
@@ -37481,15 +37481,15 @@ ${La}${a}`("SuspenseList")
     }
 )((???*0* | ???*1*), (???*3* | ???*5*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["memoizedProps"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* Object.assign*6*(
         {},
         ???*7*,
@@ -37520,7 +37520,7 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["_wrapperState"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4969 -> 4978 call = (...) => A(
     {},
@@ -37532,13 +37532,13 @@ ${La}${a}`("SuspenseList")
     }
 )((???*0* | ???*1*), (???*3* | ???*4*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* Object.assign*5*(
         {},
         ???*6*,
@@ -37569,7 +37569,7 @@ ${La}${a}`("SuspenseList")
 - *13* ???*14*["_wrapperState"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4969 -> 4979 typeof = typeof((???*0* | ???*3*))
 - *0* ???*1*["onClick"]
@@ -37577,7 +37577,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["memoizedProps"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["onClick"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -37611,13 +37611,13 @@ ${La}${a}`("SuspenseList")
 - *13* ???*14*["_wrapperState"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4969 -> 4981 typeof = typeof((???*0* | ???*2*))
 - *0* ???*1*["onClick"]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["onClick"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -37651,18 +37651,18 @@ ${La}${a}`("SuspenseList")
 - *12* ???*13*["_wrapperState"]
   ⚠️  unknown object
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4969 -> 4984 call = (...) => undefined(
     (???*0* | null | {} | ???*1* | ???*5* | undefined | (???*19* ? ???*20* : undefined)),
     (???*22* | ???*23*)
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*[(???*3* | null | undefined | [] | ???*4*)]
   ⚠️  unknown object
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
@@ -37699,7 +37699,7 @@ ${La}${a}`("SuspenseList")
 - *15* ???*16*["_wrapperState"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* for-in variable currently not analyzed
 - *18* f
   ⚠️  circular variable reference
@@ -37710,7 +37710,7 @@ ${La}${a}`("SuspenseList")
 - *21* k
   ⚠️  circular variable reference
 - *22* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* Object.assign*24*(
         {},
         ???*25*,
@@ -37741,11 +37741,11 @@ ${La}${a}`("SuspenseList")
 - *32* ???*33*["_wrapperState"]
   ⚠️  unknown object
 - *33* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4969 -> 4986 member call = (???*0* | ???*1*)["hasOwnProperty"]((???*12* | null | undefined | [] | ???*13*))
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* Object.assign*2*(
         {},
         ???*3*,
@@ -37776,7 +37776,7 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["_wrapperState"]
   ⚠️  unknown object
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* for-in variable currently not analyzed
 - *13* f
   ⚠️  circular variable reference
@@ -37785,7 +37785,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["memoizedProps"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* Object.assign*3*(
         {},
         ???*4*,
@@ -37816,7 +37816,7 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*["_wrapperState"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* for-in variable currently not analyzed
 - *14* f
   ⚠️  circular variable reference
@@ -37825,7 +37825,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["hasOwnProperty"]((???*2* | null | undefined | [] | ???*3*))
   ⚠️  unknown callee object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
@@ -37862,7 +37862,7 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["_wrapperState"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* for-in variable currently not analyzed
 - *17* f
   ⚠️  circular variable reference
@@ -37871,7 +37871,7 @@ ${La}${a}`("SuspenseList")
 - *19* ???*20*["memoizedProps"]
   ⚠️  unknown object
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* for-in variable currently not analyzed
 - *22* f
   ⚠️  circular variable reference
@@ -37908,7 +37908,7 @@ ${La}${a}`("SuspenseList")
 - *33* ???*34*["_wrapperState"]
   ⚠️  unknown object
 - *34* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *35* for-in variable currently not analyzed
 - *36* f
   ⚠️  circular variable reference
@@ -37917,7 +37917,7 @@ ${La}${a}`("SuspenseList")
 - *38* ???*39*["memoizedProps"]
   ⚠️  unknown object
 - *39* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *40* for-in variable currently not analyzed
 - *41* f
   ⚠️  circular variable reference
@@ -37954,7 +37954,7 @@ ${La}${a}`("SuspenseList")
 - *52* ???*53*["_wrapperState"]
   ⚠️  unknown object
 - *53* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *54* for-in variable currently not analyzed
 - *55* f
   ⚠️  circular variable reference
@@ -37976,7 +37976,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["memoizedProps"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
@@ -38013,7 +38013,7 @@ ${La}${a}`("SuspenseList")
 - *15* ???*16*["_wrapperState"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* for-in variable currently not analyzed
 - *18* f
   ⚠️  circular variable reference
@@ -38022,7 +38022,7 @@ ${La}${a}`("SuspenseList")
 - *20* ???*21*["memoizedProps"]
   ⚠️  unknown object
 - *21* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* Object.assign*23*(
         {},
         ???*24*,
@@ -38053,13 +38053,13 @@ ${La}${a}`("SuspenseList")
 - *31* ???*32*["_wrapperState"]
   ⚠️  unknown object
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* ???*34*[(???*36* | null | undefined | [] | ???*37*)]
   ⚠️  unknown object
 - *34* ???*35*["memoizedProps"]
   ⚠️  unknown object
 - *35* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *36* for-in variable currently not analyzed
 - *37* f
   ⚠️  circular variable reference
@@ -38096,7 +38096,7 @@ ${La}${a}`("SuspenseList")
 - *48* ???*49*["_wrapperState"]
   ⚠️  unknown object
 - *49* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *50* for-in variable currently not analyzed
 - *51* f
   ⚠️  circular variable reference
@@ -38135,7 +38135,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["memoizedProps"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* Object.assign*3*(
         {},
         ???*4*,
@@ -38166,11 +38166,11 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*["_wrapperState"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 4969 -> 5005 member call = (???*0* | ???*1*)["hasOwnProperty"]((???*12* | null | undefined | [] | ???*13*))
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* Object.assign*2*(
         {},
         ???*3*,
@@ -38201,7 +38201,7 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["_wrapperState"]
   ⚠️  unknown object
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* for-in variable currently not analyzed
 - *13* f
   ⚠️  circular variable reference
@@ -38215,7 +38215,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["hasOwnProperty"]((???*2* | null | undefined | [] | ???*3*))
   ⚠️  unknown callee object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
@@ -38252,14 +38252,14 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["_wrapperState"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* for-in variable currently not analyzed
 - *17* f
   ⚠️  circular variable reference
 - *18* ???*19*[(???*20* | null | undefined | [] | ???*21*)]
   ⚠️  unknown object
 - *19* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* for-in variable currently not analyzed
 - *21* f
   ⚠️  circular variable reference
@@ -38296,7 +38296,7 @@ ${La}${a}`("SuspenseList")
 - *32* ???*33*["_wrapperState"]
   ⚠️  unknown object
 - *33* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *34* for-in variable currently not analyzed
 - *35* f
   ⚠️  circular variable reference
@@ -38313,7 +38313,7 @@ ${La}${a}`("SuspenseList")
 - *41* ???*42*["memoizedProps"]
   ⚠️  unknown object
 - *42* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *43* for-in variable currently not analyzed
 - *44* f
   ⚠️  circular variable reference
@@ -38350,7 +38350,7 @@ ${La}${a}`("SuspenseList")
 - *55* ???*56*["_wrapperState"]
   ⚠️  unknown object
 - *56* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *57* for-in variable currently not analyzed
 - *58* f
   ⚠️  circular variable reference
@@ -38361,7 +38361,7 @@ ${La}${a}`("SuspenseList")
 - *61* ???*62*["memoizedProps"]
   ⚠️  unknown object
 - *62* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *63* Object.assign*64*(
         {},
         ???*65*,
@@ -38394,7 +38394,7 @@ ${La}${a}`("SuspenseList")
 - *73* ???*74*["memoizedProps"]
   ⚠️  unknown object
 - *74* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *75* for-in variable currently not analyzed
 - *76* f
   ⚠️  circular variable reference
@@ -38434,7 +38434,7 @@ ${La}${a}`("SuspenseList")
 - *89* ???*90*[(???*91* | null | undefined | [] | ???*92*)]
   ⚠️  unknown object
 - *90* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *91* for-in variable currently not analyzed
 - *92* f
   ⚠️  circular variable reference
@@ -38471,7 +38471,7 @@ ${La}${a}`("SuspenseList")
 - *103* ???*104*["_wrapperState"]
   ⚠️  unknown object
 - *104* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *105* for-in variable currently not analyzed
 - *106* f
   ⚠️  circular variable reference
@@ -38501,7 +38501,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["memoizedProps"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
@@ -38538,7 +38538,7 @@ ${La}${a}`("SuspenseList")
 - *15* ???*16*["_wrapperState"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* for-in variable currently not analyzed
 - *18* f
   ⚠️  circular variable reference
@@ -38547,7 +38547,7 @@ ${La}${a}`("SuspenseList")
 - *20* ???*21*["memoizedProps"]
   ⚠️  unknown object
 - *21* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* Object.assign*23*(
         {},
         ???*24*,
@@ -38578,13 +38578,13 @@ ${La}${a}`("SuspenseList")
 - *31* ???*32*["_wrapperState"]
   ⚠️  unknown object
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* ???*34*[(???*36* | null | undefined | [] | ???*37*)]
   ⚠️  unknown object
 - *34* ???*35*["memoizedProps"]
   ⚠️  unknown object
 - *35* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *36* for-in variable currently not analyzed
 - *37* f
   ⚠️  circular variable reference
@@ -38621,7 +38621,7 @@ ${La}${a}`("SuspenseList")
 - *48* ???*49*["_wrapperState"]
   ⚠️  unknown object
 - *49* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *50* for-in variable currently not analyzed
 - *51* f
   ⚠️  circular variable reference
@@ -38644,7 +38644,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["memoizedProps"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
@@ -38681,7 +38681,7 @@ ${La}${a}`("SuspenseList")
 - *15* ???*16*["_wrapperState"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* for-in variable currently not analyzed
 - *18* f
   ⚠️  circular variable reference
@@ -38690,7 +38690,7 @@ ${La}${a}`("SuspenseList")
 - *20* ???*21*["memoizedProps"]
   ⚠️  unknown object
 - *21* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* Object.assign*23*(
         {},
         ???*24*,
@@ -38721,13 +38721,13 @@ ${La}${a}`("SuspenseList")
 - *31* ???*32*["_wrapperState"]
   ⚠️  unknown object
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* ???*34*[(???*36* | null | undefined | [] | ???*37*)]
   ⚠️  unknown object
 - *34* ???*35*["memoizedProps"]
   ⚠️  unknown object
 - *35* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *36* for-in variable currently not analyzed
 - *37* f
   ⚠️  circular variable reference
@@ -38764,7 +38764,7 @@ ${La}${a}`("SuspenseList")
 - *48* ???*49*["_wrapperState"]
   ⚠️  unknown object
 - *49* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *50* for-in variable currently not analyzed
 - *51* f
   ⚠️  circular variable reference
@@ -38782,7 +38782,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*[(???*2* | null | undefined | [] | ???*3*)]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
@@ -38819,7 +38819,7 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["_wrapperState"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* for-in variable currently not analyzed
 - *17* f
   ⚠️  circular variable reference
@@ -38837,7 +38837,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*[(???*2* | null | undefined | [] | ???*3*)]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
@@ -38874,7 +38874,7 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["_wrapperState"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* for-in variable currently not analyzed
 - *17* f
   ⚠️  circular variable reference
@@ -38898,11 +38898,11 @@ ${La}${a}`("SuspenseList")
 - *2* f
   ⚠️  circular variable reference
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*[(???*6* | null | undefined | [] | ???*7*)]
   ⚠️  unknown object
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* for-in variable currently not analyzed
 - *7* f
   ⚠️  circular variable reference
@@ -38939,7 +38939,7 @@ ${La}${a}`("SuspenseList")
 - *18* ???*19*["_wrapperState"]
   ⚠️  unknown object
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* for-in variable currently not analyzed
 - *21* f
   ⚠️  circular variable reference
@@ -38959,7 +38959,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*[(???*2* | null | undefined | [] | ???*3*)]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
@@ -38996,7 +38996,7 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["_wrapperState"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* for-in variable currently not analyzed
 - *17* f
   ⚠️  circular variable reference
@@ -39019,7 +39019,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["memoizedProps"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
@@ -39056,7 +39056,7 @@ ${La}${a}`("SuspenseList")
 - *15* ???*16*["_wrapperState"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* for-in variable currently not analyzed
 - *18* f
   ⚠️  circular variable reference
@@ -39065,7 +39065,7 @@ ${La}${a}`("SuspenseList")
 - *20* ???*21*["memoizedProps"]
   ⚠️  unknown object
 - *21* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* Object.assign*23*(
         {},
         ???*24*,
@@ -39096,13 +39096,13 @@ ${La}${a}`("SuspenseList")
 - *31* ???*32*["_wrapperState"]
   ⚠️  unknown object
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* ???*34*[(???*36* | null | undefined | [] | ???*37*)]
   ⚠️  unknown object
 - *34* ???*35*["memoizedProps"]
   ⚠️  unknown object
 - *35* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *36* for-in variable currently not analyzed
 - *37* f
   ⚠️  circular variable reference
@@ -39139,7 +39139,7 @@ ${La}${a}`("SuspenseList")
 - *48* ???*49*["_wrapperState"]
   ⚠️  unknown object
 - *49* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *50* for-in variable currently not analyzed
 - *51* f
   ⚠️  circular variable reference
@@ -39162,7 +39162,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*[(???*5* | null | undefined | [] | ???*6*)]
   ⚠️  unknown object
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* for-in variable currently not analyzed
 - *6* f
   ⚠️  circular variable reference
@@ -39199,7 +39199,7 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["_wrapperState"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* for-in variable currently not analyzed
 - *20* f
   ⚠️  circular variable reference
@@ -39219,7 +39219,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*[(???*2* | null | undefined | [] | ???*3*)]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
@@ -39256,7 +39256,7 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["_wrapperState"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* for-in variable currently not analyzed
 - *17* f
   ⚠️  circular variable reference
@@ -39271,7 +39271,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*[(???*2* | null | undefined | [] | ???*3*)]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
@@ -39308,7 +39308,7 @@ ${La}${a}`("SuspenseList")
 - *14* ???*15*["_wrapperState"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* for-in variable currently not analyzed
 - *17* f
   ⚠️  circular variable reference
@@ -39331,7 +39331,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*[(???*5* | null | undefined | [] | ???*6*)]
   ⚠️  unknown object
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* for-in variable currently not analyzed
 - *6* f
   ⚠️  circular variable reference
@@ -39368,7 +39368,7 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["_wrapperState"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* for-in variable currently not analyzed
 - *20* f
   ⚠️  circular variable reference
@@ -39395,11 +39395,11 @@ ${La}${a}`("SuspenseList")
 
 5036 -> 5037 call = (...) => undefined("scroll", (???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5036 -> 5039 member call = (null | undefined | [] | ???*0*){truthy}["push"](
     (???*1* | null | undefined | [] | ???*2*),
@@ -39413,7 +39413,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*[(???*5* | null | undefined | [] | ???*6*)]
   ⚠️  unknown object
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* for-in variable currently not analyzed
 - *6* f
   ⚠️  circular variable reference
@@ -39450,7 +39450,7 @@ ${La}${a}`("SuspenseList")
 - *17* ???*18*["_wrapperState"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* for-in variable currently not analyzed
 - *20* f
   ⚠️  circular variable reference
@@ -39468,11 +39468,11 @@ ${La}${a}`("SuspenseList")
 - *0* f
   ⚠️  circular variable reference
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*[(???*4* | null | undefined | [] | ???*5*)]
   ⚠️  unknown object
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* for-in variable currently not analyzed
 - *5* f
   ⚠️  circular variable reference
@@ -39509,7 +39509,7 @@ ${La}${a}`("SuspenseList")
 - *16* ???*17*["_wrapperState"]
   ⚠️  unknown object
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* for-in variable currently not analyzed
 - *19* f
   ⚠️  circular variable reference
@@ -39529,47 +39529,47 @@ ${La}${a}`("SuspenseList")
 
 5046 -> 5051 conditional = (null === (null | ???*0* | ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["tail"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5046 -> 5057 conditional = (null === (null | ???*0* | ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["tail"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5057 -> 5059 conditional = (???*0* | ???*1* | (null === ???*3*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["tail"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["tail"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5068 conditional = ((null !== ???*0*) | (???*2* === ???*5*))
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["child"]
   ⚠️  unknown object
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["child"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5085 unreachable = ???*0*
 - *0* unreachable
@@ -39635,7 +39635,7 @@ ${La}${a}`("SuspenseList")
 
 5108 -> 5114 call = (...) => undefined((null | [???*0*]))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5115 call = (???*0* | (...) => undefined)(???*1*, ???*2*)
 - *0* Bj
@@ -40124,7 +40124,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*(*anonymous function 13608*)
   ⚠️  unknown callee
 - *1* *anonymous function 13449*
-  ⚠️  no value of this variable analysed
+  ⚠️  no value of this variable analyzed
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 - *3* max number of linking steps reached
@@ -40489,7 +40489,7 @@ ${La}${a}`("SuspenseList")
 
 5347 -> 5371 call = (...) => undefined((null | [???*0*]))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5344 -> 5372 conditional = !(???*0*)
 - *0* max number of linking steps reached
@@ -40770,13 +40770,13 @@ ${La}${a}`("SuspenseList")
 
 0 -> 5532 call = (...) => undefined(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5535 call = (...) => ((null !== a) && (undefined !== a))(???*0*)
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5536 call = (...) => undefined()
 
@@ -40804,7 +40804,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 5548 call = (...) => undefined(???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5549 unreachable = ???*0*
 - *0* unreachable
@@ -40814,21 +40814,21 @@ ${La}${a}`("SuspenseList")
 
 0 -> 5553 conditional = ((null !== (???*0* | ???*1*)) | (null !== ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["flags"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["dehydrated"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5553 -> 5555 conditional = (null === ???*0*)
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5555 -> 5556 free var = FreeVar(Error)
 
@@ -40867,7 +40867,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5570 unreachable = ???*0*
 - *0* unreachable
@@ -40909,13 +40909,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["ref"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5581 -> 5582 typeof = typeof(???*0*)
 - *0* ???*1*["ref"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5581 -> 5583 conditional = ("function" === ???*0*)
 - *0* typeof(???*1*)
@@ -40923,31 +40923,31 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["ref"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5583 -> 5584 call = ???*0*(null)
 - *0* ???*1*["ref"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5583 -> 5585 call = (...) => undefined(???*0*, ???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* d
   ⚠️  pattern without value
 
 0 -> 5587 call = ???*0*()
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5588 call = (...) => undefined(???*0*, ???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* d
   ⚠️  pattern without value
 
@@ -41210,7 +41210,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? ???*5* : null)
   ⚠️  nested operation
 - *3* (null !== ???*4*)
@@ -41226,7 +41226,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? ???*5* : null)
   ⚠️  nested operation
 - *3* (null !== ???*4*)
@@ -41242,7 +41242,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5666 -> 5669 call = (...) => undefined(
     ???*0*,
@@ -41250,9 +41250,9 @@ ${La}${a}`("SuspenseList")
     (???*2* | (???*6* ? ???*8* : null)["next"]["destroy"] | undefined["destroy"] | undefined)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["destroy"]
   ⚠️  unknown object
 - *3* ???*4*["next"]
@@ -41260,7 +41260,7 @@ ${La}${a}`("SuspenseList")
 - *4* ???*5*["updateQueue"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* (null !== ???*7*)
   ⚠️  nested operation
 - *7* d
@@ -41272,7 +41272,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 5672 conditional = (null !== (???*0* | ???*1* | ???*3*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* b
@@ -41290,7 +41290,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 5674 conditional = (null !== (???*0* | ???*1* | ???*3*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* b
@@ -41310,7 +41310,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5677 -> 5680 call = (???*0* | (???*3* ? ???*5* : null)["next"]["create"] | undefined["create"] | undefined)()
 - *0* ???*1*["create"]
@@ -41318,7 +41318,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["next"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* b
@@ -41332,13 +41332,13 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["ref"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5683 -> 5686 typeof = typeof((???*0* | undefined["ref"]))
 - *0* ???*1*["ref"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5683 -> 5687 conditional = ("function" === ???*0*)
 - *0* typeof((???*1* | undefined["ref"]))
@@ -41346,15 +41346,15 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["ref"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5687 -> 5688 call = (???*0* | undefined["ref"])((???*2* | ???*3* | undefined))
 - *0* ???*1*["ref"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* a
@@ -41364,7 +41364,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5714 unreachable = ???*0*
 - *0* unreachable
@@ -41378,31 +41378,31 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["return"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5715 -> 5720 conditional = ((null === ???*0*) | (5 === ???*2*) | (3 === ???*5*) | (4 === ???*8*))
 - *0* ???*1*["return"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["tag"]
   ⚠️  unknown object
 - *3* ???*4*["return"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["tag"]
   ⚠️  unknown object
 - *6* ???*7*["return"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["tag"]
   ⚠️  unknown object
 - *9* ???*10*["return"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5720 -> 5721 unreachable = ???*0*
 - *0* unreachable
@@ -41412,11 +41412,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["child"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["tag"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5715 -> 5738 conditional = !(???*0*)
 - *0* unsupported expression
@@ -41430,85 +41430,85 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["tag"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5742 -> 5744 conditional = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["parentNode"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5744 -> 5746 conditional = (8 === ???*0*)
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5746 -> 5749 member call = ???*0*["insertBefore"]((???*2* | ???*3*), (???*5* | ???*6*))
 - *0* ???*1*["parentNode"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* a
   ⚠️  circular variable reference
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["parentNode"]
   ⚠️  unknown object
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5746 -> 5751 member call = (???*0* | ???*1*)["insertBefore"]((???*3* | ???*4*), (???*6* | ???*7*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactRootContainer"]
   ⚠️  unknown object
 - *2* c
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["stateNode"]
   ⚠️  unknown object
 - *5* a
   ⚠️  circular variable reference
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["parentNode"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5744 -> 5753 conditional = (8 === ???*0*)
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5753 -> 5756 member call = (???*0* | ???*1*)["insertBefore"]((???*3* | ???*4*), (???*6* | ???*7*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["parentNode"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["stateNode"]
   ⚠️  unknown object
 - *5* a
   ⚠️  circular variable reference
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["_reactRootContainer"]
   ⚠️  unknown object
 - *8* c
@@ -41516,13 +41516,13 @@ ${La}${a}`("SuspenseList")
 
 5753 -> 5758 member call = (???*0* | ???*1*)["appendChild"]((???*3* | ???*4*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["parentNode"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["stateNode"]
   ⚠️  unknown object
 - *5* a
@@ -41532,9 +41532,9 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* a
@@ -41542,19 +41542,19 @@ ${La}${a}`("SuspenseList")
 
 5763 -> 5764 call = (...) => undefined((???*0* | ???*1*), (???*3* | ???*4*), (???*6* | ???*7*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["parentNode"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["_reactRootContainer"]
   ⚠️  unknown object
 - *8* c
@@ -41562,19 +41562,19 @@ ${La}${a}`("SuspenseList")
 
 5763 -> 5766 call = (...) => undefined((???*0* | ???*1*), (???*3* | ???*4*), (???*6* | ???*7*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["parentNode"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["_reactRootContainer"]
   ⚠️  unknown object
 - *8* c
@@ -41584,33 +41584,33 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["tag"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5769 -> 5771 conditional = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5771 -> 5773 member call = ???*0*["insertBefore"]((???*1* | ???*2*), ???*4*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* a
   ⚠️  circular variable reference
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5771 -> 5775 member call = ???*0*["appendChild"]((???*1* | ???*2*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* a
@@ -41620,9 +41620,9 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* a
@@ -41630,35 +41630,35 @@ ${La}${a}`("SuspenseList")
 
 5777 -> 5778 call = (...) => undefined((???*0* | ???*1*), ???*3*, ???*4*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5777 -> 5780 call = (...) => undefined((???*0* | ???*1*), ???*3*, ???*4*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5783 call = (...) => undefined(???*0*, ???*1*, (???*2* | ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["child"]
   ⚠️  unknown object
 - *4* c
@@ -41692,7 +41692,7 @@ ${La}${a}`("SuspenseList")
 - *1* node limit reached
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* c
@@ -41700,21 +41700,21 @@ ${La}${a}`("SuspenseList")
 
 0 -> 5791 call = (...) => undefined((???*0* | ???*1*), ???*3*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* c
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5792 call = (...) => undefined(???*0*, ???*1*, (???*2* | ???*3*))
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* c
@@ -41738,7 +41738,7 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* c
@@ -41748,7 +41748,7 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* c
@@ -41760,7 +41760,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5805 conditional = ???*0*
 - *0* max number of linking steps reached
@@ -41780,7 +41780,7 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* c
@@ -41790,7 +41790,7 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* c
@@ -41806,15 +41806,15 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5818 call = (...) => undefined(???*0*, ???*1*, (???*2* | ???*3*))
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* c
@@ -41832,25 +41832,25 @@ ${La}${a}`("SuspenseList")
 
 5825 -> 5826 call = (...) => undefined((???*0* | ???*1*), ???*3*, ???*4*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* c
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
 5825 -> 5827 call = (...) => undefined((???*0* | ???*1*), ???*3*, ???*4*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* c
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -41858,9 +41858,9 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* c
@@ -41868,13 +41868,13 @@ ${La}${a}`("SuspenseList")
 
 0 -> 5830 call = (...) => undefined((???*0* | ???*1*), ???*3*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* c
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5832 typeof = typeof(???*0*)
 - *0* ???*1*["componentWillUnmount"]
@@ -41896,13 +41896,13 @@ ${La}${a}`("SuspenseList")
 
 5834 -> 5841 call = (...) => undefined((???*0* | ???*1*), ???*3*, ???*4*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* c
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* h
   ⚠️  pattern without value
 
@@ -41910,9 +41910,9 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* c
@@ -41922,9 +41922,9 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* c
@@ -41934,9 +41934,9 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* c
@@ -41946,9 +41946,9 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* c
@@ -41958,9 +41958,9 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* c
@@ -41970,7 +41970,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5850 -> 5854 call = new (???*0* ? ???*3* : ???*4*)()
 - *0* ("function" === ???*1*)
@@ -41991,19 +41991,19 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5856 -> 5858 member call = (...) => undefined["bind"](null, ???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5856 -> 5860 member call = (???*0* | undefined | new ???*2*())["has"](???*8*)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? ???*6* : ???*7*)
   ⚠️  nested operation
 - *3* ("function" === ???*4*)
@@ -42020,13 +42020,13 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5856 -> 5862 member call = (???*0* | undefined | new ???*2*())["add"](???*8*)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? ???*6* : ???*7*)
   ⚠️  nested operation
 - *3* ("function" === ???*4*)
@@ -42043,25 +42043,25 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5856 -> 5864 member call = ???*0*["then"]((...) => undefined["bind"](null, ???*1*, ???*2*), (...) => undefined["bind"](null, ???*3*, ???*4*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5866 conditional = (null !== ???*0*)
 - *0* ???*1*["deletions"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5866 -> 5869 conditional = ???*0*
 - *0* labeled statement
@@ -42086,9 +42086,9 @@ ${La}${a}`("SuspenseList")
 
 5866 -> 5881 call = (...) => undefined((???*0* | undefined), (???*1* | ???*2* | undefined), (???*4* | undefined))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["child"]
   ⚠️  unknown object
 - *3* b
@@ -42098,7 +42098,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["deletions"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5866 -> 5885 call = (...) => undefined((???*0* | undefined), (???*3* | ???*4*), ???*6*)
 - *0* ???*1*[d]
@@ -42106,9 +42106,9 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["deletions"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["child"]
   ⚠️  unknown object
 - *5* b
@@ -42118,61 +42118,61 @@ ${La}${a}`("SuspenseList")
 
 0 -> 5888 call = (...) => undefined((???*0* | ???*1*), ???*3*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* b
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5893 call = (...) => undefined(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5894 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5896 call = (...) => undefined(3, ???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5897 call = (...) => undefined(3, ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5899 call = (...) => undefined(???*0*, ???*1*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* t
   ⚠️  pattern without value
 
 0 -> 5901 call = (...) => undefined(5, ???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5903 call = (...) => undefined(???*0*, ???*1*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* t
   ⚠️  pattern without value
 
@@ -42180,11 +42180,11 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5905 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5907 call = (...) => undefined(???*0*, ???*1*)
 - *0* max number of linking steps reached
@@ -42199,11 +42199,11 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5909 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5911 call = (...) => undefined(???*0*, ???*1*)
 - *0* max number of linking steps reached
@@ -42220,11 +42220,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 5916 call = (...) => undefined(???*0*, ???*1*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* t
   ⚠️  pattern without value
 
@@ -42278,7 +42278,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*(*anonymous function 13608*)
   ⚠️  unknown callee
 - *1* *anonymous function 13449*
-  ⚠️  no value of this variable analysed
+  ⚠️  no value of this variable analyzed
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 - *3* max number of linking steps reached
@@ -42381,11 +42381,11 @@ ${La}${a}`("SuspenseList")
 
 5925 -> 5964 call = (...) => undefined(???*0*, ???*1*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* t
   ⚠️  pattern without value
 
@@ -42393,17 +42393,17 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5966 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5968 conditional = (null === ???*0*)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 5968 -> 5969 free var = FreeVar(Error)
 
@@ -42420,11 +42420,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 5976 call = (...) => undefined(???*0*, ???*1*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* t
   ⚠️  pattern without value
 
@@ -42432,11 +42432,11 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5978 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5981 conditional = (???*0* | (null !== ???*1*) | ???*2*)
 - *0* unsupported expression
@@ -42461,11 +42461,11 @@ ${La}${a}`("SuspenseList")
 
 5981 -> 5985 call = (...) => undefined(???*0*, ???*1*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* t
   ⚠️  pattern without value
 
@@ -42473,43 +42473,43 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5987 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5988 call = (...) => undefined(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5989 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 5998 call = module<scheduler, {}>["unstable_now"]()
 
 0 -> 5999 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6002 call = (...) => undefined(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6003 call = (...) => undefined(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6004 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6009 conditional = (???*0* | !(???*1*) | (0 !== ???*2*))
 - *0* max number of linking steps reached
@@ -42653,11 +42653,11 @@ ${La}${a}`("SuspenseList")
 
 6041 -> 6062 call = (...) => undefined(???*0*, ???*1*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* t
   ⚠️  pattern without value
 
@@ -42678,11 +42678,11 @@ ${La}${a}`("SuspenseList")
 
 6065 -> 6071 call = (...) => undefined(???*0*, ???*1*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* t
   ⚠️  pattern without value
 
@@ -42705,7 +42705,7 @@ ${La}${a}`("SuspenseList")
 - *6* max number of linking steps reached
   ⚠️  This value might have side effects
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["child"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -42716,25 +42716,25 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6089 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6090 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6091 call = (...) => undefined(???*0*, ???*1*)
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6092 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6094 conditional = ???*0*
 - *0* labeled statement
@@ -42744,7 +42744,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["return"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6094 -> 6098 free var = FreeVar(Error)
 
@@ -42765,29 +42765,29 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6106 call = (...) => (null | a["stateNode"] | undefined)(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6107 call = (...) => undefined(???*0*, (null | ???*1* | undefined), (???*3* | undefined["stateNode"] | undefined))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
 - *4* ???*5*["return"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6110 call = (...) => (null | a["stateNode"] | undefined)(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6111 call = (...) => undefined(
     ???*0*,
@@ -42795,11 +42795,11 @@ ${La}${a}`("SuspenseList")
     (???*3* | undefined["stateNode"]["containerInfo"] | undefined)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["containerInfo"]
   ⚠️  unknown object
 - *4* ???*5*["stateNode"]
@@ -42807,7 +42807,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["return"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6112 free var = FreeVar(Error)
 
@@ -42824,21 +42824,21 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6116 call = (...) => undefined(???*0*, ???*1*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* k
   ⚠️  pattern without value
 
 0 -> 6119 call = (...) => undefined(???*0*, ???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6123 conditional = ((22 === ???*0*) | (0 !== ???*2*))
 - *0* ???*1*["tag"]
@@ -42887,17 +42887,17 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6123 -> 6139 call = (...) => undefined(???*0*, ???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6123 -> 6141 conditional = ((0 !== ???*0*) | (null !== ???*1*))
 - *0* unsupported expression
@@ -42907,11 +42907,11 @@ ${La}${a}`("SuspenseList")
 
 6141 -> 6143 call = (...) => undefined(???*0*, ???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6145 conditional = (0 !== ???*0*)
 - *0* unsupported expression
@@ -43186,7 +43186,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* updated with update expression
   ⚠️  This value might have side effects
 
@@ -43204,7 +43204,7 @@ ${La}${a}`("SuspenseList")
 
 6259 -> 6262 conditional = (0 !== (???*0* | 0 | 1 | ???*1* | 4 | undefined | ???*2* | ???*7*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* C
   ⚠️  circular variable reference
 - *2* ((???*3* | ???*5*) ? ???*6* : 4)
@@ -43232,7 +43232,7 @@ ${La}${a}`("SuspenseList")
 
 6262 -> 6266 conditional = (undefined === (???*0* | 0 | 1 | ???*1* | 4 | undefined | ???*2* | ???*7*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* C
   ⚠️  circular variable reference
 - *2* ((???*3* | ???*5*) ? ???*6* : 4)
@@ -43268,7 +43268,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (0 !== ???*3*)
   ⚠️  nested operation
 - *3* C
@@ -43294,11 +43294,11 @@ ${La}${a}`("SuspenseList")
 - *13* unsupported expression
   ⚠️  This value might have side effects
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["value"]
   ⚠️  unknown object
 - *16* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["type"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -43332,19 +43332,19 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6273 call = (...) => undefined(???*0*, ???*1*, ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6274 conditional = ((0 === ???*0*) | (???*1* !== (null | ???*2* | ???*3* | ???*6*)))
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* ???*5*["current"]
@@ -43380,17 +43380,17 @@ ${La}${a}`("SuspenseList")
 
 6274 -> 6275 call = (...) => undefined(???*0*, (0 | ???*1* | ???*2*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* updated with update expression
   ⚠️  This value might have side effects
 
 6274 -> 6276 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6274 -> 6278 call = module<scheduler, {}>["unstable_now"]()
 
@@ -43398,17 +43398,17 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6281 call = (...) => undefined(???*0*, (???*1* | ???*2*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
 0 -> 6282 conditional = (???*0* === (null | ???*1* | ???*2* | ???*5*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* ???*4*["current"]
@@ -43444,13 +43444,13 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6283 call = (...) => (0 | b | d)(???*0*, (???*1* ? (0 | ???*20* | ???*21*) : 0))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* === (null | ???*3* | ???*4* | ???*7*))
   ⚠️  nested operation
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["alternate"]
   ⚠️  unknown object
 - *5* ???*6*["current"]
@@ -43484,7 +43484,7 @@ ${La}${a}`("SuspenseList")
 - *19* a
   ⚠️  circular variable reference
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* updated with update expression
   ⚠️  This value might have side effects
 
@@ -43511,9 +43511,9 @@ ${La}${a}`("SuspenseList")
 - *1* (???*2* === (null | ???*3* | ???*4* | ???*7*))
   ⚠️  nested operation
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["alternate"]
   ⚠️  unknown object
 - *5* ???*6*["current"]
@@ -43539,13 +43539,13 @@ ${La}${a}`("SuspenseList")
 - *15* ???["current"]
   ⚠️  unknown object
 - *16* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* updated with update expression
   ⚠️  This value might have side effects
 - *18* ???*19*["entangledLanes"]
   ⚠️  unknown object
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* unsupported assign operation
   ⚠️  This value might have side effects
 - *21* unsupported expression
@@ -43565,7 +43565,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["callbackNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* c
   ⚠️  circular variable reference
 - *3* (...) => (null | ???*4*)["bind"](null, ???*5*)
@@ -43573,7 +43573,7 @@ ${La}${a}`("SuspenseList")
 - *4* ((a["callbackNode"] === c) ? Hk["bind"](null, a) : null)
   ⚠️  nested operation
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6284 -> 6289 call = module<scheduler, {}>["unstable_cancelCallback"](
     (
@@ -43589,7 +43589,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["callbackNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* c
   ⚠️  circular variable reference
 - *3* (...) => (null | ???*4*)["bind"](null, ???*5*)
@@ -43597,11 +43597,11 @@ ${La}${a}`("SuspenseList")
 - *4* ((a["callbackNode"] === c) ? Hk["bind"](null, a) : null)
   ⚠️  nested operation
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6284 -> 6290 conditional = (1 === (???*0* | ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
@@ -43609,35 +43609,35 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6292 -> 6294 member call = (...) => (???*0* | null)["bind"](null, ???*1*)
 - *0* null
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6292 -> 6295 call = (...) => undefined((...) => (???*0* | null)["bind"](null, ???*1*))
 - *0* null
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6292 -> 6297 member call = (...) => (???*0* | null)["bind"](null, ???*1*)
 - *0* null
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6292 -> 6298 call = (...) => undefined((...) => (???*0* | null)["bind"](null, ???*1*))
 - *0* null
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6290 -> 6299 call = (???*0* ? ???*3* : ???*4*)((...) => undefined)
 - *0* ("function" === ???*1*)
@@ -43709,9 +43709,9 @@ ${La}${a}`("SuspenseList")
 - *3* (???*4* === (null | ???*5* | ???*6* | ???*9*))
   ⚠️  nested operation
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* ???*8*["current"]
@@ -43745,13 +43745,13 @@ ${La}${a}`("SuspenseList")
 - *21* a
   ⚠️  circular variable reference
 - *22* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* updated with update expression
   ⚠️  This value might have side effects
 - *24* ???*25*["entangledLanes"]
   ⚠️  unknown object
 - *25* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* unsupported assign operation
   ⚠️  This value might have side effects
 - *27* unsupported expression
@@ -43762,7 +43762,7 @@ ${La}${a}`("SuspenseList")
   | ((a["callbackNode"] === c) ? Hk["bind"](null, a) : null)
 )["bind"](null, ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6290 -> 6304 call = (...) => ac(a, b)(
     (
@@ -43779,7 +43779,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["callbackNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* c
   ⚠️  circular variable reference
 - *3* (...) => (null | ???*4*)["bind"](null, ???*5*)
@@ -43787,11 +43787,11 @@ ${La}${a}`("SuspenseList")
 - *4* ((a["callbackNode"] === c) ? Hk["bind"](null, a) : null)
   ⚠️  nested operation
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ((a["callbackNode"] === c) ? Hk["bind"](null, a) : null)
   ⚠️  nested operation
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6307 conditional = (0 !== ???*0*)
 - *0* unsupported expression
@@ -43816,7 +43816,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["callbackNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -43826,9 +43826,9 @@ ${La}${a}`("SuspenseList")
 
 6314 -> 6316 conditional = (???*0* === (null | ???*1* | ???*2* | ???*5*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* ???*4*["current"]
@@ -43864,13 +43864,13 @@ ${La}${a}`("SuspenseList")
 
 6314 -> 6317 call = (...) => (0 | b | d)(???*0*, (???*1* ? (0 | ???*20* | ???*21*) : 0))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* === (null | ???*3* | ???*4* | ???*7*))
   ⚠️  nested operation
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["alternate"]
   ⚠️  unknown object
 - *5* ???*6*["current"]
@@ -43904,7 +43904,7 @@ ${La}${a}`("SuspenseList")
 - *19* a
   ⚠️  circular variable reference
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* updated with update expression
   ⚠️  This value might have side effects
 
@@ -43924,7 +43924,7 @@ ${La}${a}`("SuspenseList")
 
 6321 -> 6322 call = (...) => T(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -43932,7 +43932,7 @@ ${La}${a}`("SuspenseList")
 
 6321 -> 6324 conditional = (((null | ???*0* | ???*1* | ???*4*) !== ???*17*) | ((0 | ???*18* | ???*19*) !== ???*20*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* ???*3*["current"]
@@ -43966,9 +43966,9 @@ ${La}${a}`("SuspenseList")
 - *16* a
   ⚠️  circular variable reference
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* updated with update expression
   ⚠️  This value might have side effects
 - *20* max number of linking steps reached
@@ -43978,7 +43978,7 @@ ${La}${a}`("SuspenseList")
 
 6324 -> 6326 call = (...) => a(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -43986,7 +43986,7 @@ ${La}${a}`("SuspenseList")
 
 6321 -> 6328 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* h
   ⚠️  pattern without value
 
@@ -44004,11 +44004,11 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6332 -> 6334 call = (...) => a(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -44018,11 +44018,11 @@ ${La}${a}`("SuspenseList")
 
 6335 -> 6336 call = (...) => a(???*0*, 0)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6335 -> 6337 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -44030,7 +44030,7 @@ ${La}${a}`("SuspenseList")
 
 6335 -> 6339 call = (...) => undefined(???*0*, module<scheduler, {}>["unstable_now"]())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6332 -> 6340 conditional = (6 === ???*0*)
 - *0* max number of linking steps reached
@@ -44038,7 +44038,7 @@ ${La}${a}`("SuspenseList")
 
 6340 -> 6341 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -44048,7 +44048,7 @@ ${La}${a}`("SuspenseList")
 
 6340 -> 6345 call = (...) => T(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -44056,7 +44056,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6340 -> 6347 call = (...) => a(
     ???*0*,
@@ -44087,17 +44087,17 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (null === module<react, {}>["__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"]["ReactCurrentDispatcher"]["current"])
   ⚠️  nested operation
 - *2* (0 !== (???*3* | ???*4*))
   ⚠️  nested operation
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* unsupported expression
   ⚠️  This value might have side effects
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* unsupported expression
   ⚠️  This value might have side effects
 - *7* (???*8* ? 1073741824 : 0)
@@ -44116,11 +44116,11 @@ ${La}${a}`("SuspenseList")
 
 6348 -> 6349 call = (...) => a(???*0*, 0)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6348 -> 6350 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -44128,7 +44128,7 @@ ${La}${a}`("SuspenseList")
 
 6348 -> 6352 call = (...) => undefined(???*0*, module<scheduler, {}>["unstable_now"]())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6340 -> 6355 free var = FreeVar(Error)
 
@@ -44145,13 +44145,13 @@ ${La}${a}`("SuspenseList")
 
 6340 -> 6358 call = (...) => null(???*0*, ???*1*, null)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6340 -> 6359 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -44170,7 +44170,7 @@ ${La}${a}`("SuspenseList")
 
 6361 -> 6362 call = (...) => (0 | b | d)(???*0*, 0)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6361 -> 6364 conditional = (???*0* !== ???*1*)
 - *0* unsupported expression
@@ -44186,7 +44186,7 @@ ${La}${a}`("SuspenseList")
 
 6361 -> 6370 member call = (...) => null["bind"](null, ???*0*, ???*1*, null)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -44202,7 +44202,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* max number of linking steps reached
   ⚠️  This value might have side effects
 - *6* max number of linking steps reached
@@ -44210,13 +44210,13 @@ ${La}${a}`("SuspenseList")
 
 6340 -> 6372 call = (...) => null(???*0*, ???*1*, null)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6340 -> 6373 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -44254,7 +44254,7 @@ ${La}${a}`("SuspenseList")
 
 6340 -> 6381 member call = (...) => null["bind"](null, ???*0*, ???*1*, null)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -44270,7 +44270,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* max number of linking steps reached
   ⚠️  This value might have side effects
 - *6* max number of linking steps reached
@@ -44278,13 +44278,13 @@ ${La}${a}`("SuspenseList")
 
 6340 -> 6383 call = (...) => null(???*0*, ???*1*, null)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
 6340 -> 6384 call = (...) => null(???*0*, ???*1*, null)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -44305,13 +44305,13 @@ ${La}${a}`("SuspenseList")
 
 6318 -> 6389 call = (...) => undefined(???*0*, module<scheduler, {}>["unstable_now"]())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6318 -> 6391 conditional = (???*0* === ???*2*)
 - *0* ???*1*["callbackNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -44320,7 +44320,7 @@ ${La}${a}`("SuspenseList")
   | ((a["callbackNode"] === c) ? Hk["bind"](null, a) : null)
 )["bind"](null, ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6318 -> 6394 unreachable = ???*0*
 - *0* unreachable
@@ -44359,13 +44359,13 @@ ${La}${a}`("SuspenseList")
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6410 conditional = (null !== (???*0* | undefined))
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6410 -> 6415 call = (
   | ???*0*
@@ -44383,7 +44383,7 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["updateQueue"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 - *5* updated with update expression
@@ -44432,7 +44432,7 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*["updateQueue"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* updated with update expression
   ⚠️  This value might have side effects
 - *14* updated with update expression
@@ -44449,7 +44449,7 @@ ${La}${a}`("SuspenseList")
 - *19* ???*20*["updateQueue"]
   ⚠️  unknown object
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* updated with update expression
   ⚠️  This value might have side effects
 - *22* updated with update expression
@@ -44520,7 +44520,7 @@ ${La}${a}`("SuspenseList")
 - *25* ???*26*["updateQueue"]
   ⚠️  unknown object
 - *26* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* updated with update expression
   ⚠️  This value might have side effects
 - *28* updated with update expression
@@ -44544,19 +44544,19 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6422 -> 6427 conditional = ((null === (???*0* | undefined["return"])) | ((???*2* | undefined["return"]) === ???*4*))
 - *0* ???*1*["return"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["return"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6427 -> 6428 unreachable = ???*0*
 - *0* unreachable
@@ -44584,7 +44584,7 @@ ${La}${a}`("SuspenseList")
 - *5* unsupported expression
   ⚠️  This value might have side effects
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -44609,7 +44609,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6445 call = (...) => (0 | b | d)(???*0*, 0)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6446 conditional = (0 === ???*0*)
 - *0* unsupported expression
@@ -44619,7 +44619,7 @@ ${La}${a}`("SuspenseList")
 
 6446 -> 6448 call = (...) => undefined(???*0*, module<scheduler, {}>["unstable_now"]())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6446 -> 6449 unreachable = ???*0*
 - *0* unreachable
@@ -44647,11 +44647,11 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["entangledLanes"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 - *4* unsupported expression
@@ -44659,11 +44659,11 @@ ${La}${a}`("SuspenseList")
 - *5* (0 !== (???*6* | ???*7*))
   ⚠️  nested operation
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported expression
   ⚠️  This value might have side effects
 - *10* (???*11* ? 1073741824 : 0)
@@ -44675,7 +44675,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -44683,22 +44683,22 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6452 -> 6454 call = (...) => a(
     ???*0*,
     ((???*1* ? (???*4* | ???*5*) : ???*6*) | undefined)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (0 !== (???*2* | ???*3*))
   ⚠️  nested operation
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported expression
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* unsupported expression
   ⚠️  This value might have side effects
 - *6* (???*7* ? 1073741824 : 0)
@@ -44712,7 +44712,7 @@ ${La}${a}`("SuspenseList")
 
 6455 -> 6456 call = (...) => a(???*0*, 0)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6455 -> 6457 call = (...) => undefined(
     ???*0*,
@@ -44736,11 +44736,11 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["entangledLanes"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 - *4* unsupported expression
@@ -44748,11 +44748,11 @@ ${La}${a}`("SuspenseList")
 - *5* (0 !== (???*6* | ???*7*))
   ⚠️  nested operation
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported expression
   ⚠️  This value might have side effects
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported expression
   ⚠️  This value might have side effects
 - *10* (???*11* ? 1073741824 : 0)
@@ -44764,7 +44764,7 @@ ${La}${a}`("SuspenseList")
 
 6455 -> 6459 call = (...) => undefined(???*0*, module<scheduler, {}>["unstable_now"]())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6446 -> 6460 conditional = (6 === ???*0*)
 - *0* max number of linking steps reached
@@ -44785,7 +44785,7 @@ ${La}${a}`("SuspenseList")
 
 6446 -> 6468 call = (...) => null(???*0*, ???*1*, null)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -44793,7 +44793,7 @@ ${La}${a}`("SuspenseList")
 
 6446 -> 6470 call = (...) => undefined(???*0*, module<scheduler, {}>["unstable_now"]())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6446 -> 6471 unreachable = ???*0*
 - *0* unreachable
@@ -44801,9 +44801,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6472 call = ???*0*(???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6473 unreachable = ???*0*
 - *0* unreachable
@@ -44817,11 +44817,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6480 conditional = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6480 -> 6481 call = ???*0*()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6480 -> 6482 unreachable = ???*0*
 - *0* unreachable
@@ -44895,7 +44895,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["current"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["tag"]
   ⚠️  unknown object
 - *3* ???*4*["current"]
@@ -44923,7 +44923,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6514 conditional = (null !== (null | [???*0*]))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6514 -> 6518 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
@@ -45235,7 +45235,7 @@ ${La}${a}`("SuspenseList")
     (0 | ???*16* | ???*17*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* ???*3*["current"]
@@ -45267,7 +45267,7 @@ ${La}${a}`("SuspenseList")
 - *15* a
   ⚠️  circular variable reference
 - *16* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* updated with update expression
   ⚠️  This value might have side effects
 
@@ -45275,7 +45275,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6619 conditional = (((null | ???*0* | ???*1* | ???*4*) !== ???*17*) | ((0 | ???*18* | ???*19*) !== ???*20*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* ???*3*["current"]
@@ -45309,25 +45309,25 @@ ${La}${a}`("SuspenseList")
 - *16* a
   ⚠️  circular variable reference
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* updated with update expression
   ⚠️  This value might have side effects
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6619 -> 6620 call = (...) => a(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6621 call = (...) => undefined()
 
 0 -> 6622 call = (...) => undefined(???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* e
   ⚠️  pattern without value
 
@@ -45385,15 +45385,15 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* unsupported assign operation
   ⚠️  This value might have side effects
 - *6* unknown mutation
   ⚠️  This value might have side effects
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* updated with update expression
   ⚠️  This value might have side effects
 
@@ -45420,7 +45420,7 @@ ${La}${a}`("SuspenseList")
 
 6637 -> 6638 call = (...) => undefined(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6643 conditional = (0 === ???*0*)
 - *0* unsupported expression
@@ -45435,7 +45435,7 @@ ${La}${a}`("SuspenseList")
 - *2* max number of linking steps reached
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["return"]
   ⚠️  unknown object
 - *5* b
@@ -45445,7 +45445,7 @@ ${La}${a}`("SuspenseList")
 - *7* unknown mutation
   ⚠️  This value might have side effects
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* updated with update expression
   ⚠️  This value might have side effects
 
@@ -45470,7 +45470,7 @@ ${La}${a}`("SuspenseList")
 - *5* max number of linking steps reached
   ⚠️  This value might have side effects
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["return"]
   ⚠️  unknown object
 - *8* b
@@ -45486,7 +45486,7 @@ ${La}${a}`("SuspenseList")
 
 6647 -> 6650 conditional = (null !== (???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -45498,7 +45498,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6656 conditional = (null !== (???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* b
@@ -45524,11 +45524,11 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* C
   ⚠️  circular variable reference
 - *4* (0 !== ???*5*)
@@ -45556,13 +45556,13 @@ ${La}${a}`("SuspenseList")
 - *15* unsupported expression
   ⚠️  This value might have side effects
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["value"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6662 unreachable = ???*0*
 - *0* unreachable
@@ -45589,11 +45589,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6670 conditional = (null === (???*0* | ???*1* | null["finishedWork"] | 0 | ???*3*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["finishedWork"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 
@@ -45603,17 +45603,17 @@ ${La}${a}`("SuspenseList")
 
 6670 -> 6675 conditional = ((???*0* | ???*1* | null["finishedWork"] | 0 | ???*3*) === (???*4* | null["current"]))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["finishedWork"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* ???*5*["current"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6675 -> 6676 free var = FreeVar(Error)
 
@@ -45639,11 +45639,11 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["value"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported expression
   ⚠️  This value might have side effects
 - *4* unsupported expression
@@ -45651,7 +45651,7 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["pendingLanes"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6670 -> 6686 call = (...) => ac(a, b)(module<scheduler, {}>["unstable_NormalPriority"], (...) => null)
 
@@ -45675,24 +45675,24 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["pendingLanes"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6691 -> 6695 call = (...) => n(
     (???*0* | ???*1* | null),
     (???*3* | ???*4* | null["finishedWork"] | 0 | ???*6*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["value"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["finishedWork"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* updated with update expression
   ⚠️  This value might have side effects
 
@@ -45701,19 +45701,19 @@ ${La}${a}`("SuspenseList")
     (???*4* | ???*5* | null)
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["finishedWork"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["value"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6691 -> 6697 call = (...) => undefined(???*0*)
 - *0* max number of linking steps reached
@@ -45725,23 +45725,23 @@ ${La}${a}`("SuspenseList")
     (???*7* | null["finishedLanes"])
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["finishedWork"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["value"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["finishedLanes"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6691 -> 6700 call = module<scheduler, {}>["unstable_requestPaint"]()
 
@@ -45752,32 +45752,32 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["onRecoverableError"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6670 -> 6706 call = module<scheduler, {}>["unstable_now"]()
 
 6670 -> 6707 call = (...) => undefined((???*0* | ???*1* | null), module<scheduler, {}>["unstable_now"]())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["value"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6670 -> 6708 conditional = (null !== ???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6708 -> 6715 call = (???*0* | ???*1* | null["onRecoverableError"])(
     (???*3* | null["finishedLanes"]["value"]),
@@ -45787,29 +45787,29 @@ ${La}${a}`("SuspenseList")
     }
 )
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["onRecoverableError"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["value"]
   ⚠️  unknown object
 - *4* ???*5*["finishedLanes"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["stack"]
   ⚠️  unknown object
 - *7* ???*8*["finishedLanes"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["digest"]
   ⚠️  unknown object
 - *10* ???*11*["finishedLanes"]
   ⚠️  unknown object
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6670 -> 6717 call = (...) => (d | !(1))()
 
@@ -45819,17 +45819,17 @@ ${La}${a}`("SuspenseList")
 
 6719 -> 6720 conditional = ((???*0* | ???*1* | null) === (null | ???*3* | ???*4*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["value"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["value"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6670 -> 6721 call = (...) => null()
 
@@ -45839,11 +45839,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6723 conditional = (null !== (null | ???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["value"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6723 -> 6724 call = (...) => (???*0* ? (???*1* ? ((0 !== ???*2*) ? 16 : 536870912) : 4) : 1)((0 | ???*3* | null["finishedLanes"]))
 - *0* unsupported expression
@@ -45855,15 +45855,15 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["finishedLanes"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6723 -> 6727 conditional = (null === (null | ???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["value"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6727 -> 6728 conditional = (0 !== ???*0*)
 - *0* unsupported expression
@@ -46021,11 +46021,11 @@ ${La}${a}`("SuspenseList")
 - *7* unsupported expression
   ⚠️  This value might have side effects
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["value"]
   ⚠️  unknown object
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6723 -> 6794 unreachable = ???*0*
 - *0* unreachable
@@ -46037,7 +46037,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6797 call = (...) => {"value": a, "source": b, "stack": e, "digest": null}(???*0*, ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -46084,7 +46084,7 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6804 -> 6807 conditional = (3 === ???*0*)
 - *0* ???*1*["tag"]
@@ -46099,7 +46099,7 @@ ${La}${a}`("SuspenseList")
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 6807 -> 6810 conditional = (1 === ???*0*)
 - *0* ???*1*["tag"]
@@ -46173,7 +46173,7 @@ ${La}${a}`("SuspenseList")
 
 6819 -> 6820 call = (...) => {"value": a, "source": b, "stack": e, "digest": null}(???*0*, ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* max number of linking steps reached
   ⚠️  This value might have side effects
 
@@ -46211,9 +46211,9 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["pingCache"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (0 !== ???*4*)
   ⚠️  nested operation
 - *4* unsupported expression
@@ -46254,7 +46254,7 @@ ${La}${a}`("SuspenseList")
 - *0* unsupported expression
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* updated with update expression
   ⚠️  This value might have side effects
 - *3* unsupported expression
@@ -46262,13 +46262,13 @@ ${La}${a}`("SuspenseList")
 
 6834 -> 6835 call = (...) => a(???*0*, 0)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6836 call = (...) => undefined(???*0*, (???*1* | (???*2* ? ???*4* : ???*5*)))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (0 !== ???*3*)
   ⚠️  nested operation
 - *3* unsupported expression
@@ -46304,7 +46304,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6840 call = (...) => ((3 === c["tag"]) ? c["stateNode"] : null)((???*0* | (???*1* ? ???*5* : null)), (???*8* | 1 | 4194304 | ???*9*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -46320,7 +46320,7 @@ ${La}${a}`("SuspenseList")
 - *7* a
   ⚠️  circular variable reference
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -46330,7 +46330,7 @@ ${La}${a}`("SuspenseList")
     (???*10* ? ???*12* : ???*13*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -46346,7 +46346,7 @@ ${La}${a}`("SuspenseList")
 - *7* a
   ⚠️  circular variable reference
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported assign operation
   ⚠️  This value might have side effects
 - *10* (0 !== ???*11*)
@@ -46374,7 +46374,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6842 call = (...) => undefined((???*0* | (???*1* ? ???*5* : null)), (???*8* ? ???*10* : ???*11*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -46414,13 +46414,13 @@ ${La}${a}`("SuspenseList")
 
 0 -> 6845 call = (...) => undefined(???*0*, (0 | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["retryLane"]
   ⚠️  unknown object
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6851 free var = FreeVar(Error)
 
@@ -46439,19 +46439,19 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6856 call = (...) => undefined(???*0*, (0 | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["retryLane"]
   ⚠️  unknown object
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 6857 conditional = (null !== ???*0*)
 - *0* max number of linking steps reached
@@ -46506,7 +46506,7 @@ ${La}${a}`("SuspenseList")
 - *0* max number of linking steps reached
   ⚠️  This value might have side effects
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* [][???*3*]
   ⚠️  unknown array prototype methods or values
 - *3* unsupported expression
@@ -47723,9 +47723,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 7164 call = module<scheduler, {}>["unstable_scheduleCallback"](???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7165 unreachable = ???*0*
 - *0* unreachable
@@ -47733,13 +47733,13 @@ ${La}${a}`("SuspenseList")
 
 0 -> 7188 call = new (...) => undefined(???*0*, ???*1*, ???*2*, ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7189 unreachable = ???*0*
 - *0* unreachable
@@ -47751,7 +47751,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 7193 typeof = typeof((???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["$$typeof"]
   ⚠️  unknown object
 - *2* a
@@ -47761,7 +47761,7 @@ ${La}${a}`("SuspenseList")
 - *0* typeof((???*1* | ???*2*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["$$typeof"]
   ⚠️  unknown object
 - *3* a
@@ -47769,7 +47769,7 @@ ${La}${a}`("SuspenseList")
 
 7194 -> 7195 call = (...) => !((!(a) || !(a["isReactComponent"])))((???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["$$typeof"]
   ⚠️  unknown object
 - *2* a
@@ -47779,7 +47779,7 @@ ${La}${a}`("SuspenseList")
 - *0* !((???*1* | ???*2*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["$$typeof"]
   ⚠️  unknown object
 - *3* a
@@ -47791,13 +47791,13 @@ ${La}${a}`("SuspenseList")
 
 7194 -> 7198 conditional = ((undefined !== (???*0* | ???*1*)) | (null !== (???*3* | ???*4*)))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["$$typeof"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["$$typeof"]
   ⚠️  unknown object
 - *5* a
@@ -47805,7 +47805,7 @@ ${La}${a}`("SuspenseList")
 
 7198 -> 7200 conditional = ((???*0* | ???*1*) === ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["$$typeof"]
   ⚠️  unknown object
 - *2* a
@@ -47823,7 +47823,7 @@ ${La}${a}`("SuspenseList")
 
 7200 -> 7202 conditional = ((???*0* | ???*1*) === ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["$$typeof"]
   ⚠️  unknown object
 - *2* a
@@ -47847,55 +47847,55 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* new (...) => undefined(???*3*, (???*5* | ???*6*), ???*8*, ???*10*)
   ⚠️  nested operation
 - *3* ???*4*["tag"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["dependencies"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["key"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["mode"]
   ⚠️  unknown object
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7206 -> 7210 call = (...) => new al(a, b, c, d)(???*0*, (???*2* | ???*3*), ???*5*, ???*7*)
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["dependencies"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["key"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["mode"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7241 conditional = (null === (???*0* | ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["dependencies"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7250 unreachable = ???*0*
 - *0* unreachable
@@ -47908,57 +47908,57 @@ ${La}${a}`("SuspenseList")
   | new (...) => undefined(19, ???*18*, (???*19* | ???*20*), (???*25* | ???*26*))
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*4*, ???*5*, (???*6* | ???*7*))
   ⚠️  nested operation
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* b
   ⚠️  circular variable reference
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported assign operation
   ⚠️  This value might have side effects
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*12*, ???*13*, (???*14* | ???*15*))
   ⚠️  nested operation
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* b
   ⚠️  circular variable reference
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unsupported assign operation
   ⚠️  This value might have side effects
 - *16* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* unsupported assign operation
   ⚠️  This value might have side effects
 - *18* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*21*, ???*22*, (???*23* | ???*24*))
   ⚠️  nested operation
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* b
   ⚠️  circular variable reference
 - *23* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* unsupported assign operation
   ⚠️  This value might have side effects
 - *25* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -47966,21 +47966,21 @@ ${La}${a}`("SuspenseList")
 - *0* typeof((???*1* | ???*2*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* new (...) => undefined(12, ???*3*, (???*4* | ???*5*), ???*10*)
   ⚠️  nested operation
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*6*, ???*7*, (???*8* | ???*9*))
   ⚠️  nested operation
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* b
   ⚠️  circular variable reference
 - *8* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported assign operation
   ⚠️  This value might have side effects
 - *10* unsupported expression
@@ -47995,57 +47995,57 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*4*, ???*5*, (???*6* | ???*7*))
   ⚠️  nested operation
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* b
   ⚠️  circular variable reference
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported assign operation
   ⚠️  This value might have side effects
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*12*, ???*13*, (???*14* | ???*15*))
   ⚠️  nested operation
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* b
   ⚠️  circular variable reference
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unsupported assign operation
   ⚠️  This value might have side effects
 - *16* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* unsupported assign operation
   ⚠️  This value might have side effects
 - *18* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*21*, ???*22*, (???*23* | ???*24*))
   ⚠️  nested operation
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* b
   ⚠️  circular variable reference
 - *23* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* unsupported assign operation
   ⚠️  This value might have side effects
 - *25* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -48056,57 +48056,57 @@ ${La}${a}`("SuspenseList")
   | new (...) => undefined(19, ???*18*, (???*19* | ???*20*), (???*25* | ???*26*))
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*4*, ???*5*, (???*6* | ???*7*))
   ⚠️  nested operation
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* b
   ⚠️  circular variable reference
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported assign operation
   ⚠️  This value might have side effects
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*12*, ???*13*, (???*14* | ???*15*))
   ⚠️  nested operation
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* b
   ⚠️  circular variable reference
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unsupported assign operation
   ⚠️  This value might have side effects
 - *16* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* unsupported assign operation
   ⚠️  This value might have side effects
 - *18* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*21*, ???*22*, (???*23* | ???*24*))
   ⚠️  nested operation
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* b
   ⚠️  circular variable reference
 - *23* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* unsupported assign operation
   ⚠️  This value might have side effects
 - *25* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -48114,21 +48114,21 @@ ${La}${a}`("SuspenseList")
 - *0* typeof((???*1* | ???*2*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* new (...) => undefined(12, ???*3*, (???*4* | ???*5*), ???*10*)
   ⚠️  nested operation
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*6*, ???*7*, (???*8* | ???*9*))
   ⚠️  nested operation
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* b
   ⚠️  circular variable reference
 - *8* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported assign operation
   ⚠️  This value might have side effects
 - *10* unsupported expression
@@ -48150,21 +48150,21 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["children"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 - *4* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* b
   ⚠️  circular variable reference
 - *8* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -48182,15 +48182,15 @@ ${La}${a}`("SuspenseList")
     ???*6*
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* b
   ⚠️  circular variable reference
 - *4* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* unsupported assign operation
   ⚠️  This value might have side effects
 - *6* unsupported expression
@@ -48210,19 +48210,19 @@ ${La}${a}`("SuspenseList")
     (???*6* | ???*7*)
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* b
   ⚠️  circular variable reference
 - *4* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* unsupported assign operation
   ⚠️  This value might have side effects
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -48240,19 +48240,19 @@ ${La}${a}`("SuspenseList")
     (???*6* | ???*7*)
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* b
   ⚠️  circular variable reference
 - *4* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* unsupported assign operation
   ⚠️  This value might have side effects
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -48270,21 +48270,21 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported assign operation
   ⚠️  This value might have side effects
 - *3* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* b
   ⚠️  circular variable reference
 - *7* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -48299,57 +48299,57 @@ ${La}${a}`("SuspenseList")
   | new (...) => undefined(19, ???*18*, (???*19* | ???*20*), (???*25* | ???*26*))
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*4*, ???*5*, (???*6* | ???*7*))
   ⚠️  nested operation
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* b
   ⚠️  circular variable reference
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported assign operation
   ⚠️  This value might have side effects
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*12*, ???*13*, (???*14* | ???*15*))
   ⚠️  nested operation
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* b
   ⚠️  circular variable reference
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unsupported assign operation
   ⚠️  This value might have side effects
 - *16* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* unsupported assign operation
   ⚠️  This value might have side effects
 - *18* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*21*, ???*22*, (???*23* | ???*24*))
   ⚠️  nested operation
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* b
   ⚠️  circular variable reference
 - *23* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* unsupported assign operation
   ⚠️  This value might have side effects
 - *25* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -48357,41 +48357,41 @@ ${La}${a}`("SuspenseList")
 - *0* typeof((???*1* | ???*2*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* new (...) => undefined(12, ???*3*, (???*4* | ???*5*), ???*10*)
   ⚠️  nested operation
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*6*, ???*7*, (???*8* | ???*9*))
   ⚠️  nested operation
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* b
   ⚠️  circular variable reference
 - *8* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported assign operation
   ⚠️  This value might have side effects
 - *10* unsupported expression
   ⚠️  This value might have side effects
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* new (...) => undefined(12, ???*13*, (???*14* | ???*15*), ???*20*)
   ⚠️  nested operation
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*16*, ???*17*, (???*18* | ???*19*))
   ⚠️  nested operation
 - *16* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* b
   ⚠️  circular variable reference
 - *18* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* unsupported assign operation
   ⚠️  This value might have side effects
 - *20* unsupported expression
@@ -48401,21 +48401,21 @@ ${La}${a}`("SuspenseList")
 
 7256 -> 7278 conditional = (null == (???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* new (...) => undefined(12, ???*2*, (???*3* | ???*4*), ???*9*)
   ⚠️  nested operation
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*5*, ???*6*, (???*7* | ???*8*))
   ⚠️  nested operation
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* b
   ⚠️  circular variable reference
 - *7* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* unsupported assign operation
   ⚠️  This value might have side effects
 - *9* unsupported expression
@@ -48428,57 +48428,57 @@ ${La}${a}`("SuspenseList")
   | new (...) => undefined(19, ???*18*, (???*19* | ???*20*), (???*25* | ???*26*))
 ))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*4*, ???*5*, (???*6* | ???*7*))
   ⚠️  nested operation
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* b
   ⚠️  circular variable reference
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported assign operation
   ⚠️  This value might have side effects
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*12*, ???*13*, (???*14* | ???*15*))
   ⚠️  nested operation
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* b
   ⚠️  circular variable reference
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unsupported assign operation
   ⚠️  This value might have side effects
 - *16* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* unsupported assign operation
   ⚠️  This value might have side effects
 - *18* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*21*, ???*22*, (???*23* | ???*24*))
   ⚠️  nested operation
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* b
   ⚠️  circular variable reference
 - *23* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* unsupported assign operation
   ⚠️  This value might have side effects
 - *25* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -48486,41 +48486,41 @@ ${La}${a}`("SuspenseList")
 - *0* (null == (???*1* | ???*2*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* new (...) => undefined(12, ???*3*, (???*4* | ???*5*), ???*10*)
   ⚠️  nested operation
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*6*, ???*7*, (???*8* | ???*9*))
   ⚠️  nested operation
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* b
   ⚠️  circular variable reference
 - *8* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported assign operation
   ⚠️  This value might have side effects
 - *10* unsupported expression
   ⚠️  This value might have side effects
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* new (...) => undefined(12, ???*13*, (???*14* | ???*15*), ???*20*)
   ⚠️  nested operation
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*16*, ???*17*, (???*18* | ???*19*))
   ⚠️  nested operation
 - *16* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* b
   ⚠️  circular variable reference
 - *18* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* unsupported assign operation
   ⚠️  This value might have side effects
 - *20* unsupported expression
@@ -48528,21 +48528,21 @@ ${La}${a}`("SuspenseList")
 - *21* typeof((???*22* | ???*23*))
   ⚠️  nested operation
 - *22* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* new (...) => undefined(12, ???*24*, (???*25* | ???*26*), ???*31*)
   ⚠️  nested operation
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*27*, ???*28*, (???*29* | ???*30*))
   ⚠️  nested operation
 - *27* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* b
   ⚠️  circular variable reference
 - *29* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* unsupported assign operation
   ⚠️  This value might have side effects
 - *31* unsupported expression
@@ -48567,19 +48567,19 @@ ${La}${a}`("SuspenseList")
     (???*6* | ???*7*)
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* b
   ⚠️  circular variable reference
 - *4* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* unsupported assign operation
   ⚠️  This value might have side effects
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -48594,17 +48594,17 @@ ${La}${a}`("SuspenseList")
     ???*5*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7289 unreachable = ???*0*
 - *0* unreachable
@@ -48617,17 +48617,17 @@ ${La}${a}`("SuspenseList")
     ???*5*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7294 unreachable = ???*0*
 - *0* unreachable
@@ -48640,13 +48640,13 @@ ${La}${a}`("SuspenseList")
     ???*3*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7297 unreachable = ???*0*
 - *0* unreachable
@@ -48656,7 +48656,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["children"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7302 call = (...) => new al(a, b, c, d)(
     4,
@@ -48672,17 +48672,17 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["children"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["key"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* (???*9* ? ???*12* : [])
   ⚠️  nested operation
 - *9* (null !== ???*10*)
@@ -48690,15 +48690,15 @@ ${La}${a}`("SuspenseList")
 - *10* ???*11*["children"]
   ⚠️  unknown object
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["children"]
   ⚠️  unknown object
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["key"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* b
   ⚠️  circular variable reference
 
@@ -48725,39 +48725,39 @@ ${La}${a}`("SuspenseList")
     ???*11*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* unsupported assign operation
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7336 conditional = (1 === (???*0* | 1 | ???*1* | 0))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
 0 -> 7337 call = (...) => new al(a, b, c, d)(3, null, null, (???*0* | 1 | ???*1* | 0))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -48768,9 +48768,9 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -48820,7 +48820,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 7352 conditional = !((???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* a
@@ -48836,7 +48836,7 @@ ${La}${a}`("SuspenseList")
 
 7355 -> 7356 call = (...) => ((3 === b["tag"]) ? c : null)((???*0* | ???*1*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* a
@@ -48850,9 +48850,9 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["tag"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["_reactInternals"]
   ⚠️  unknown object
 - *6* a
@@ -48860,7 +48860,7 @@ ${La}${a}`("SuspenseList")
 - *7* a
   ⚠️  circular variable reference
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["_reactInternals"]
   ⚠️  unknown object
 - *10* a
@@ -48868,7 +48868,7 @@ ${La}${a}`("SuspenseList")
 - *11* ???*12*["tag"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7358 -> 7359 free var = FreeVar(Error)
 
@@ -48887,17 +48887,17 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7355 -> 7367 conditional = ((null !== (???*0* | undefined["type"])) | (undefined !== (???*2* | undefined["type"])))
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["type"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7355 -> 7371 free var = FreeVar(Error)
 
@@ -48916,27 +48916,27 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7375 -> 7377 call = (...) => ((null !== a) && (undefined !== a))((???*0* | undefined))
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7375 -> 7378 conditional = ((null !== (???*0* | undefined)) | (undefined !== (???*2* | undefined)))
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["type"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7378 -> 7379 call = (...) => (c | A({}, c, d))((???*0* | ???*1*), (???*3* | undefined), (???*5* | ???*6* | undefined))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* a
@@ -48944,9 +48944,9 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["type"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["_reactInternals"]
   ⚠️  unknown object
 - *7* a
@@ -49012,18 +49012,18 @@ ${La}${a}`("SuspenseList")
     ???*116*
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["current"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["current"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *4* node limit reached
   ⚠️  This value might have side effects
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* (0 !== ???*7*)
   ⚠️  nested operation
 - *7* unsupported expression
@@ -49047,11 +49047,11 @@ ${La}${a}`("SuspenseList")
 - *16* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* node limit reached
   ⚠️  This value might have side effects
 - *19* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* unsupported expression
   ⚠️  This value might have side effects
 - *21* Ck
@@ -49060,11 +49060,11 @@ ${La}${a}`("SuspenseList")
 - *22* ???*23*["current"]
   ⚠️  unknown object
 - *23* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* a
   ⚠️  circular variable reference
 - *25* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* (???*27* ? ???*29* : ???*30*)
   ⚠️  nested operation
 - *27* (0 !== ???*28*)
@@ -49092,9 +49092,9 @@ ${La}${a}`("SuspenseList")
 - *38* unsupported assign operation
   ⚠️  This value might have side effects
 - *39* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *40* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *41* C
   ⚠️  circular variable reference
 - *42* (0 !== ???*43*)
@@ -49122,11 +49122,11 @@ ${La}${a}`("SuspenseList")
 - *53* unsupported expression
   ⚠️  This value might have side effects
 - *54* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *55* ???*56*["value"]
   ⚠️  unknown object
 - *56* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *57* ???*58*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -49138,9 +49138,9 @@ ${La}${a}`("SuspenseList")
 - *60* a
   ⚠️  circular variable reference
 - *61* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *62* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *63* (0 !== ???*64*)
   ⚠️  nested operation
 - *64* unsupported expression
@@ -49164,7 +49164,7 @@ ${La}${a}`("SuspenseList")
 - *73* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
 - *74* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *75* unsupported expression
   ⚠️  This value might have side effects
 - *76* Ck
@@ -49173,11 +49173,11 @@ ${La}${a}`("SuspenseList")
 - *77* ???*78*["current"]
   ⚠️  unknown object
 - *78* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *79* a
   ⚠️  circular variable reference
 - *80* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *81* (???*82* ? ???*84* : ???*85*)
   ⚠️  nested operation
 - *82* (0 !== ???*83*)
@@ -49201,9 +49201,9 @@ ${La}${a}`("SuspenseList")
 - *91* unsupported assign operation
   ⚠️  This value might have side effects
 - *92* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *93* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *94* C
   ⚠️  circular variable reference
 - *95* (0 !== ???*96*)
@@ -49231,11 +49231,11 @@ ${La}${a}`("SuspenseList")
 - *106* unsupported expression
   ⚠️  This value might have side effects
 - *107* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *108* ???*109*["value"]
   ⚠️  unknown object
 - *109* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *110* ???*111*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -49247,11 +49247,11 @@ ${La}${a}`("SuspenseList")
 - *113* a
   ⚠️  circular variable reference
 - *114* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *115* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *116* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7384 call = (...) => (Vf | bg(a, c, b) | b)(null)
 
@@ -49268,11 +49268,11 @@ ${La}${a}`("SuspenseList")
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["current"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["current"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -49299,7 +49299,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (0 !== ???*2*)
   ⚠️  nested operation
 - *2* unsupported expression
@@ -49323,7 +49323,7 @@ ${La}${a}`("SuspenseList")
 - *11* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
 - *12* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* unsupported expression
   ⚠️  This value might have side effects
 - *14* Ck
@@ -49332,11 +49332,11 @@ ${La}${a}`("SuspenseList")
 - *15* ???*16*["current"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* a
   ⚠️  circular variable reference
 - *18* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* (???*20* ? ???*22* : ???*23*)
   ⚠️  nested operation
 - *20* (0 !== ???*21*)
@@ -49364,9 +49364,9 @@ ${La}${a}`("SuspenseList")
 - *31* unsupported assign operation
   ⚠️  This value might have side effects
 - *32* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *34* C
   ⚠️  circular variable reference
 - *35* (0 !== ???*36*)
@@ -49394,11 +49394,11 @@ ${La}${a}`("SuspenseList")
 - *46* unsupported expression
   ⚠️  This value might have side effects
 - *47* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *48* ???*49*["value"]
   ⚠️  unknown object
 - *49* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *50* ???*51*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -49412,9 +49412,9 @@ ${La}${a}`("SuspenseList")
 
 0 -> 7390 conditional = ((undefined !== ???*0*) | (null !== ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7391 call = (...) => (null | Zg(a, c))(
     (???*0* | ???*1* | ???*3*),
@@ -49462,20 +49462,20 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["current"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["current"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *4* node limit reached
   ⚠️  This value might have side effects
 - *5* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (0 !== ???*8*)
   ⚠️  nested operation
 - *8* unsupported expression
@@ -49499,7 +49499,7 @@ ${La}${a}`("SuspenseList")
 - *17* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
 - *18* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* unsupported expression
   ⚠️  This value might have side effects
 - *20* Ck
@@ -49508,11 +49508,11 @@ ${La}${a}`("SuspenseList")
 - *21* ???*22*["current"]
   ⚠️  unknown object
 - *22* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* a
   ⚠️  circular variable reference
 - *24* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* (???*26* ? ???*28* : ???*29*)
   ⚠️  nested operation
 - *26* (0 !== ???*27*)
@@ -49536,9 +49536,9 @@ ${La}${a}`("SuspenseList")
 - *35* unsupported assign operation
   ⚠️  This value might have side effects
 - *36* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *38* C
   ⚠️  circular variable reference
 - *39* (0 !== ???*40*)
@@ -49566,11 +49566,11 @@ ${La}${a}`("SuspenseList")
 - *50* unsupported expression
   ⚠️  This value might have side effects
 - *51* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *52* ???*53*["value"]
   ⚠️  unknown object
 - *53* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *54* ???*55*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -49582,7 +49582,7 @@ ${La}${a}`("SuspenseList")
 - *57* a
   ⚠️  circular variable reference
 - *58* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *59* unsupported expression
   ⚠️  This value might have side effects
 - *60* Ck
@@ -49591,11 +49591,11 @@ ${La}${a}`("SuspenseList")
 - *61* ???*62*["current"]
   ⚠️  unknown object
 - *62* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *63* a
   ⚠️  circular variable reference
 - *64* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *65* (???*66* ? ???*68* : ???*69*)
   ⚠️  nested operation
 - *66* (0 !== ???*67*)
@@ -49623,9 +49623,9 @@ ${La}${a}`("SuspenseList")
 - *77* unsupported assign operation
   ⚠️  This value might have side effects
 - *78* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *79* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *80* C
   ⚠️  circular variable reference
 - *81* (0 !== ???*82*)
@@ -49653,11 +49653,11 @@ ${La}${a}`("SuspenseList")
 - *92* unsupported expression
   ⚠️  This value might have side effects
 - *93* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *94* ???*95*["value"]
   ⚠️  unknown object
 - *95* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *96* ???*97*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -49690,11 +49690,11 @@ ${La}${a}`("SuspenseList")
     (???*44* | (???*45* ? ???*47* : ???*48*))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* node limit reached
   ⚠️  This value might have side effects
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported expression
   ⚠️  This value might have side effects
 - *4* Ck
@@ -49703,11 +49703,11 @@ ${La}${a}`("SuspenseList")
 - *5* ???*6*["current"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* a
   ⚠️  circular variable reference
 - *8* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* (???*10* ? ???*12* : ???*13*)
   ⚠️  nested operation
 - *10* (0 !== ???*11*)
@@ -49735,9 +49735,9 @@ ${La}${a}`("SuspenseList")
 - *21* unsupported assign operation
   ⚠️  This value might have side effects
 - *22* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* C
   ⚠️  circular variable reference
 - *25* (0 !== ???*26*)
@@ -49765,11 +49765,11 @@ ${La}${a}`("SuspenseList")
 - *36* unsupported expression
   ⚠️  This value might have side effects
 - *37* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *38* ???*39*["value"]
   ⚠️  unknown object
 - *39* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *40* ???*41*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -49781,7 +49781,7 @@ ${La}${a}`("SuspenseList")
 - *43* a
   ⚠️  circular variable reference
 - *44* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *45* (0 !== ???*46*)
   ⚠️  nested operation
 - *46* unsupported expression
@@ -49807,11 +49807,11 @@ ${La}${a}`("SuspenseList")
 
 0 -> 7395 call = (...) => undefined((???*0* | ???*1*), (???*2* | (???*3* ? ???*5* : ???*6*)))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* node limit reached
   ⚠️  This value might have side effects
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (0 !== ???*4*)
   ⚠️  nested operation
 - *4* unsupported expression
@@ -49854,7 +49854,7 @@ ${La}${a}`("SuspenseList")
 - *2* ???*3*["current"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* unknown mutation
   ⚠️  This value might have side effects
 
@@ -49862,7 +49862,7 @@ ${La}${a}`("SuspenseList")
     (???*0* | {} | ???*1* | ???*2* | undefined | ???*4*)
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* c
   ⚠️  circular variable reference
 - *2* ???*3*["_reactInternals"]
@@ -49892,7 +49892,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["context"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unknown mutation
   ⚠️  This value might have side effects
 
@@ -49945,7 +49945,7 @@ ${La}${a}`("SuspenseList")
 - *13* ???*14*["current"]
   ⚠️  unknown object
 - *14* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unknown mutation
   ⚠️  This value might have side effects
 - *16* C
@@ -49975,13 +49975,13 @@ ${La}${a}`("SuspenseList")
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* ???*34*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -49995,7 +49995,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 7407 conditional = (undefined === (???*0* | ???*1*))
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? null : ???*4*)
   ⚠️  nested operation
 - *2* (undefined === ???*3*)
@@ -50052,11 +50052,11 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["current"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (0 !== ???*5*)
   ⚠️  nested operation
 - *5* unsupported expression
@@ -50115,13 +50115,13 @@ ${La}${a}`("SuspenseList")
 - *31* unsupported expression
   ⚠️  This value might have side effects
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* ???*34*["value"]
   ⚠️  unknown object
 - *34* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *35* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *36* ???*37*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -50140,7 +50140,7 @@ ${La}${a}`("SuspenseList")
 - *42* ???*43*["current"]
   ⚠️  unknown object
 - *43* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *44* unknown mutation
   ⚠️  This value might have side effects
 - *45* C
@@ -50170,13 +50170,13 @@ ${La}${a}`("SuspenseList")
 - *57* unsupported expression
   ⚠️  This value might have side effects
 - *58* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *59* ???*60*["value"]
   ⚠️  unknown object
 - *60* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *61* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *62* ???*63*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -50214,7 +50214,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["current"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* unsupported expression
@@ -50225,7 +50225,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["current"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* unknown mutation
   ⚠️  This value might have side effects
 - *9* C
@@ -50255,13 +50255,13 @@ ${La}${a}`("SuspenseList")
 - *21* unsupported expression
   ⚠️  This value might have side effects
 - *22* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* ???*24*["value"]
   ⚠️  unknown object
 - *24* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* ???*27*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -50320,7 +50320,7 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["current"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* unsupported expression
@@ -50331,7 +50331,7 @@ ${La}${a}`("SuspenseList")
 - *6* ???*7*["current"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* unknown mutation
   ⚠️  This value might have side effects
 - *9* C
@@ -50361,13 +50361,13 @@ ${La}${a}`("SuspenseList")
 - *21* unsupported expression
   ⚠️  This value might have side effects
 - *22* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* ???*24*["value"]
   ⚠️  unknown object
 - *24* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* ???*27*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -50387,7 +50387,7 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["child"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7415 -> 7416 unreachable = ???*0*
 - *0* unreachable
@@ -50403,7 +50403,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 7427 conditional = ((null !== (???*0* | ???*1*)) | (null !== ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* a
@@ -50411,35 +50411,35 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["dehydrated"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7427 -> 7430 conditional = ((0 !== (???*0* | undefined)) | ???*2*)
 - *0* ???*1*["retryLane"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
 0 -> 7431 call = (...) => undefined((???*0* | ???*1*), ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7433 call = (...) => undefined((???*0* | ???*1*), ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7434 unreachable = ???*0*
 - *0* unreachable
@@ -50468,7 +50468,7 @@ ${La}${a}`("SuspenseList")
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7448 conditional = (null === ???*0*)
 - *0* ???*1*["_internalRoot"]
@@ -50492,7 +50492,7 @@ ${La}${a}`("SuspenseList")
 
 0 -> 7452 call = (...) => g(???*0*, ???*1*, null, null)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_internalRoot"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -50534,7 +50534,7 @@ ${La}${a}`("SuspenseList")
     }
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* Hc
@@ -50566,13 +50566,13 @@ ${La}${a}`("SuspenseList")
 - *15* unsupported expression
   ⚠️  This value might have side effects
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["value"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7467 -> 7468 call = (???*0* | (...) => C)()
 - *0* Hc
@@ -50603,7 +50603,7 @@ ${La}${a}`("SuspenseList")
 - *0* updated with update expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* Hc
@@ -50635,13 +50635,13 @@ ${La}${a}`("SuspenseList")
 - *16* unsupported expression
   ⚠️  This value might have side effects
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["value"]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7467 -> 7474 call = (...) => undefined(
     (
@@ -50664,7 +50664,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* Hc
@@ -50696,13 +50696,13 @@ ${La}${a}`("SuspenseList")
 - *15* unsupported expression
   ⚠️  This value might have side effects
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["value"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7478 unreachable = ???*0*
 - *0* unreachable
@@ -50714,25 +50714,25 @@ ${La}${a}`("SuspenseList")
 
 0 -> 7485 conditional = (???*0* | ???*1*)
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["lastChild"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7485 -> 7486 typeof = typeof((???*0* | (...) => undefined))
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7485 -> 7487 conditional = ("function" === ???*0*)
 - *0* typeof((???*1* | (...) => undefined))
   ⚠️  nested operation
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7487 -> 7488 call = (...) => (null | a["child"]["stateNode"] | undefined)((???*0* | ???*1* | undefined))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* node limit reached
   ⚠️  This value might have side effects
 
@@ -50740,13 +50740,13 @@ ${La}${a}`("SuspenseList")
     (null | ???*1* | ???*4* | undefined["child"]["stateNode"] | undefined)
 )
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* ???*3*["child"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["stateNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -50758,17 +50758,17 @@ ${La}${a}`("SuspenseList")
 
 7485 -> 7491 call = (...) => a(???*0*, (???*1* | (...) => undefined), ???*2*, 0, null, false, false, "", (...) => undefined)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7485 -> 7496 conditional = (8 === ???*0*)
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7485 -> 7498 call = (...) => undefined((???*0* ? ???*3* : ???*5*))
 - *0* (8 === ???*1*)
@@ -50776,13 +50776,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["parentNode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7485 -> 7499 call = (...) => (a() | undefined)()
 
@@ -50792,23 +50792,23 @@ ${La}${a}`("SuspenseList")
 
 7485 -> 7503 member call = ???*0*["removeChild"]((???*1* | ???*2*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["lastChild"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7485 -> 7504 typeof = typeof((???*0* | (...) => undefined))
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7485 -> 7505 conditional = ("function" === ???*0*)
 - *0* typeof((???*1* | (...) => undefined))
   ⚠️  nested operation
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7505 -> 7506 call = (...) => (null | a["child"]["stateNode"] | undefined)(
     (
@@ -50817,7 +50817,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* unsupported assign operation
@@ -50832,13 +50832,13 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* ???*3*["child"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* a
   ⚠️  circular variable reference
 - *5* unsupported assign operation
@@ -50846,13 +50846,13 @@ ${La}${a}`("SuspenseList")
 
 7485 -> 7509 call = (...) => a(???*0*, 0, false, null, null, false, false, "", (...) => undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7485 -> 7514 conditional = (8 === ???*0*)
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7485 -> 7516 call = (...) => undefined((???*0* ? ???*3* : ???*5*))
 - *0* (8 === ???*1*)
@@ -50860,13 +50860,13 @@ ${La}${a}`("SuspenseList")
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["parentNode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7485 -> 7517 call = (...) => (a() | undefined)((...) => undefined)
 
@@ -50880,17 +50880,17 @@ ${La}${a}`("SuspenseList")
     (???*5* | (...) => undefined)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7485 -> 7519 unreachable = ???*0*
 - *0* unreachable
@@ -50900,17 +50900,17 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["_reactRootContainer"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7521 -> 7522 typeof = typeof((???*0* | (...) => undefined))
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7521 -> 7523 conditional = ("function" === ???*0*)
 - *0* typeof((???*1* | (...) => undefined))
   ⚠️  nested operation
 - *1* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7523 -> 7524 call = (...) => (null | a["child"]["stateNode"] | undefined)(
     (
@@ -50924,9 +50924,9 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["_reactRootContainer"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* node limit reached
   ⚠️  This value might have side effects
 - *4* a
@@ -50945,7 +50945,7 @@ ${La}${a}`("SuspenseList")
     )
 )
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* ???*3*["child"]
@@ -50953,7 +50953,7 @@ ${La}${a}`("SuspenseList")
 - *3* ???*4*["_reactRootContainer"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -50980,13 +50980,13 @@ ${La}${a}`("SuspenseList")
     (???*8* | (...) => undefined)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactRootContainer"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* node limit reached
   ⚠️  This value might have side effects
 - *5* a
@@ -50994,21 +50994,21 @@ ${La}${a}`("SuspenseList")
 - *6* unsupported assign operation
   ⚠️  This value might have side effects
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 7521 -> 7528 call = (...) => (g | k)(???*0*, ???*1*, ???*2*, (???*3* | (...) => undefined), ???*4*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7529 call = (...) => (null | a["child"]["stateNode"] | undefined)(
     (
@@ -51022,9 +51022,9 @@ ${La}${a}`("SuspenseList")
 - *0* ???*1*["_reactRootContainer"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* node limit reached
   ⚠️  This value might have side effects
 - *4* a

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/react-dom-production/resolved-explained.snapshot
@@ -325,7 +325,7 @@ Aa = ???*0*
 
 Ab = (null | [???*0*])
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 Ac = (...) => undefined
 
@@ -374,11 +374,11 @@ Aj = (???*0* | (...) => undefined)
 
 Ak = (null | ???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["value"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 B = module<scheduler, {}>["unstable_now"]
 
@@ -462,13 +462,13 @@ C = (
 - *12* unsupported expression
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["value"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 Ca = ???*0*
 - *0* ???*1*["for"]("react.context")
@@ -1089,7 +1089,7 @@ Lc = (
 - *1* Lc
   ⚠️  circular variable reference
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* !((???*4* | ???*5*))
   ⚠️  nested operation
 - *4* b
@@ -1109,13 +1109,13 @@ Lc = (
 - *11* a
   ⚠️  circular variable reference
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 Ld = (...) => ???*0*
 - *0* unsupported expression
@@ -1177,7 +1177,7 @@ Mc = (
 - *1* Mc
   ⚠️  circular variable reference
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* !((???*4* | ???*5*))
   ⚠️  nested operation
 - *4* b
@@ -1197,13 +1197,13 @@ Mc = (
 - *11* a
   ⚠️  circular variable reference
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 Md = {
     "Esc": "Escape",
@@ -1253,7 +1253,7 @@ N = (
   | (null !== (null["next"] | ???*16* | undefined["next"] | null | ???*19*))
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* N
@@ -1315,7 +1315,7 @@ Nc = (
 - *1* Nc
   ⚠️  circular variable reference
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* !((???*4* | ???*5*))
   ⚠️  nested operation
 - *4* b
@@ -1335,13 +1335,13 @@ Nc = (
 - *11* a
   ⚠️  circular variable reference
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 Nd = {
     8: "Backspace",
@@ -1415,7 +1415,7 @@ Nf = ???*0*
 
 Ng = (null | ???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["dependencies"]
   ⚠️  unknown object
 - *2* a
@@ -1461,7 +1461,7 @@ O = (
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* O
   ⚠️  circular variable reference
 - *3* ???*4*["next"]
@@ -1529,7 +1529,7 @@ Og = (
   | {"context": ???*1*, "memoizedValue": ???*2*, "next": null}
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["_currentValue"]
@@ -1571,7 +1571,7 @@ P = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -1579,7 +1579,7 @@ P = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -1618,7 +1618,7 @@ Pa = (...) => (Ma(a["type"]) | Ma("Lazy") | Ma("Suspense") | Ma("SuspenseList") 
 
 Pb = (null | ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 Pc = new ???*0*()
 - *0* FreeVar(Map)
@@ -1729,7 +1729,7 @@ Qi = (???*0* | null)
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 Qj = (...) => undefined
 
@@ -1742,7 +1742,7 @@ R = (
   | new (...) => undefined(???*4*, (null | ???*7*), ???*10*, ???*13*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* ???*3*["current"]
@@ -1799,7 +1799,7 @@ Ra = (...) => (
 
 Rb = (null | ???*0* | undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 Rc = "mousedown mouseup touchcancel touchend touchstart auxclick dblclick pointercancel pointerdown pointerup dragend dragstart drop compositionend compositionstart keydown keypress keyup input textInput copy cut paste click change contextmenu reset submit"["split"](" ")
 
@@ -1828,7 +1828,7 @@ Rg = (...) => undefined
 
 Rh = (0 | ???*0* | (???*1* + 1))
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* f
   ⚠️  circular variable reference
 
@@ -2022,7 +2022,7 @@ Wf = {"current": false}
 
 Wg = (null | [???*0*])
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 Wh = (...) => (!(1) | !(0))
 
@@ -2161,7 +2161,7 @@ Yk = (...) => undefined
 
 Z = (0 | ???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
@@ -2196,15 +2196,15 @@ Zk = (...) => undefined
 
 a#10 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#1001 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#1004 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#1008 = ???*0*
 - *0* max number of linking steps reached
@@ -2212,7 +2212,7 @@ a#1008 = ???*0*
 
 a#101 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#1011 = ???*0*
 - *0* a
@@ -2220,11 +2220,11 @@ a#1011 = ???*0*
 
 a#1012 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#1013 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#1014 = ???*0*
 - *0* max number of linking steps reached
@@ -2232,25 +2232,25 @@ a#1014 = ???*0*
 
 a#1016 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#1017 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#1018 = (???*0* | 0 | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
 a#1019 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#102 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["style"]
   ⚠️  unknown object
 - *2* a
@@ -2258,23 +2258,23 @@ a#102 = (???*0* | ???*1*)
 
 a#1020 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#1023 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#104 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#107 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#108 = (???*0* | ???*1* | ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["target"]
   ⚠️  unknown object
 - *2* a
@@ -2285,7 +2285,7 @@ a#108 = (???*0* | ???*1* | ???*3*)
 
 a#109 = (???*0* | (???*1* ? null : (???*5* | ???*6*)))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* !((???*2* | ???*3*))
   ⚠️  nested operation
 - *2* a
@@ -2303,29 +2303,29 @@ a#109 = (???*0* | (???*1* ? null : (???*5* | ???*6*)))
 
 a#11 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#111 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#112 = (null | ???*0* | undefined | 0 | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
 a#114 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#116 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#119 = (???*0* | ???*1* | !((???*3* | null | ???*6*)) | false)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* a
@@ -2345,7 +2345,7 @@ a#119 = (???*0* | ???*1* | !((???*3* | null | ???*6*)) | false)
 
 a#12 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#122 = ???*0*
 - *0* a
@@ -2353,27 +2353,27 @@ a#122 = ???*0*
 
 a#123 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#126 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#127 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#128 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#13 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#131 = (???*0* | ???*1* | ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["return"]
@@ -2383,7 +2383,7 @@ a#131 = (???*0* | ???*1* | ???*2*)
 
 a#133 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* a
@@ -2391,23 +2391,23 @@ a#133 = (???*0* | ???*1*)
 
 a#135 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#136 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#14 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#15 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#151 = (???*0* | (???*1* ? null : ???*12*) | ???*13* | (???*14* ? ???*28* : (???*29* | ???*31*)))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ((???*2* | ???*4*) !== ???*11*)
   ⚠️  nested operation
 - *2* ???*3*["alternate"]
@@ -2500,7 +2500,7 @@ a#151 = (???*0* | (???*1* ? null : ???*12*) | ???*13* | (???*14* ? ???*28* : (??
 
 a#152 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* a
@@ -2508,21 +2508,21 @@ a#152 = (???*0* | ???*1*)
 
 a#154 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#157 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
 a#158 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#159 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["entanglements"]
   ⚠️  unknown object
 - *2* a
@@ -2530,19 +2530,19 @@ a#159 = (???*0* | ???*1*)
 
 a#16 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#161 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#162 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#165 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
@@ -2552,11 +2552,11 @@ a#166 = (64 | ???*0*)
 
 a#167 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#168 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["eventTimes"]
   ⚠️  unknown object
 - *2* a
@@ -2564,7 +2564,7 @@ a#168 = (???*0* | ???*1*)
 
 a#169 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["expirationTimes"]
   ⚠️  unknown object
 - *2* a
@@ -2572,11 +2572,11 @@ a#169 = (???*0* | ???*1*)
 
 a#17 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#171 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["entanglements"]
   ⚠️  unknown object
 - *2* a
@@ -2584,13 +2584,13 @@ a#171 = (???*0* | ???*1*)
 
 a#173 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
 a#174 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#175 = (
   | ???*0*
@@ -2603,9 +2603,9 @@ a#175 = (
     }
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* !((???*3* | ???*4*))
   ⚠️  nested operation
 - *3* b
@@ -2625,61 +2625,61 @@ a#175 = (
 - *10* a
   ⚠️  circular variable reference
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#176 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#177 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#18 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#183 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#186 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#188 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#189 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#19 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#193 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#196 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#199 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#20 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#203 = (
   | ???*0*
@@ -2697,13 +2697,13 @@ a#203 = (
   | undefined["dehydrated"]
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === (???*2* | ???*4*))
   ⚠️  nested operation
 - *2* ???*3*["nodeType"]
   ⚠️  unknown object
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -2713,7 +2713,7 @@ a#203 = (
 - *6* ???*7*["parentNode"]
   ⚠️  unknown object
 - *7* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -2721,7 +2721,7 @@ a#203 = (
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *10* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["target"]
   ⚠️  unknown object
 - *12* a
@@ -2844,7 +2844,7 @@ a#203 = (
 
 a#206 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#207 = (???*0* | 0 | ???*1*)
 - *0* a
@@ -2854,7 +2854,7 @@ a#207 = (???*0* | 0 | ???*1*)
 
 a#208 = (???*0* | ???*1* | 13)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["charCode"]
   ⚠️  unknown object
 - *2* a
@@ -2862,11 +2862,11 @@ a#208 = (???*0* | ???*1* | 13)
 
 a#21 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#211 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#213 = ???*0*
 - *0* ???*1*["nativeEvent"]
@@ -2884,31 +2884,31 @@ a#214 = ???*0*
 
 a#216 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#217 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#218 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#219 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#22 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#220 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#221 = (???*0* | "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* {}[???*2*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
@@ -2917,7 +2917,7 @@ a#221 = (???*0* | "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | ???*1*)
 
 a#223 = (???*0* | ((???*1* | ???*2*) ? (???*6* | ???*7* | 13) : 0))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* (13 === (???*3* | ???*4* | 13))
@@ -2937,35 +2937,35 @@ a#223 = (???*0* | ((???*1* | ???*2*) ? (???*6* | ???*7* | 13) : 0))
 
 a#225 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#226 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#227 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#228 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#229 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#23 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#230 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#231 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["detail"]
   ⚠️  unknown object
 - *2* a
@@ -2973,15 +2973,15 @@ a#231 = (???*0* | ???*1*)
 
 a#232 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["data"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#233 = (???*0* | null | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*((???*9* | 0 | ???*10*), ???*11*)
   ⚠️  unknown callee
   ⚠️  This value might have side effects
@@ -3012,63 +3012,63 @@ a#233 = (???*0* | null | ???*1*)
 
 a#235 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#236 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#237 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#238 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#239 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#24 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#244 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#246 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#247 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#248 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#249 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#25 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#250 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#251 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#253 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["firstChild"]
   ⚠️  unknown object
 - *2* a
@@ -3081,7 +3081,7 @@ a#254 = (
   | (???*2* + (???*3* | undefined["textContent"]["length"]))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* d
   ⚠️  pattern without value
 - *2* a
@@ -3095,7 +3095,7 @@ a#254 = (
 
 a#26 = (???*0* | ???*1* | ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["iterator"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -3109,7 +3109,7 @@ a#26 = (???*0* | ???*1* | ???*3*)
 
 a#260 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#261 = (
   | ???*0*
@@ -3194,7 +3194,7 @@ a#261 = (
 
 a#265 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#266 = ???*0*
 - *0* max number of linking steps reached
@@ -3202,59 +3202,59 @@ a#266 = ???*0*
 
 a#269 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#27 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#270 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#271 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#272 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#274 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#275 = (???*0* | null | undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#280 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#281 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#282 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#285 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#286 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#3 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#30 = (???*0* | (???*1* ? ???*2* : ""))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["displayName"]
@@ -3264,11 +3264,11 @@ a#30 = (???*0* | (???*1* ? ???*2* : ""))
 
 a#307 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#308 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -3276,7 +3276,7 @@ a#308 = (???*0* | ???*1*)
 
 a#310 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -3284,35 +3284,35 @@ a#310 = (???*0* | ???*1*)
 
 a#311 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#313 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#314 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#316 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#317 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#318 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#320 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#324 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nextSibling"]
   ⚠️  unknown object
 - *2* a
@@ -3320,7 +3320,7 @@ a#324 = (???*0* | ???*1*)
 
 a#327 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["previousSibling"]
   ⚠️  unknown object
 - *2* a
@@ -3328,7 +3328,7 @@ a#327 = (???*0* | ???*1*)
 
 a#331 = (???*0* | ???*1* | ???*2* | null)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["previousSibling"]
@@ -3338,7 +3338,7 @@ a#331 = (???*0* | ???*1* | ???*2* | null)
 
 a#335 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*[Of]
   ⚠️  unknown object
 - *2* a
@@ -3346,27 +3346,27 @@ a#335 = (???*0* | ???*1*)
 
 a#336 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#337 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#338 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#339 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#340 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#341 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
@@ -3374,7 +3374,7 @@ a#341 = (???*0* | ???*1*)
 
 a#342 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["childContextTypes"]
   ⚠️  unknown object
 - *2* a
@@ -3382,15 +3382,15 @@ a#342 = (???*0* | ???*1*)
 
 a#344 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#345 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#346 = (???*0* | ???*1* | {})
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
@@ -3398,7 +3398,7 @@ a#346 = (???*0* | ???*1* | {})
 
 a#347 = (???*0* | {} | ???*1* | ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unknown mutation
   ⚠️  This value might have side effects
 - *2* Object.assign*3*({}, ({} | ???*4*), (???*5* | ???*7*()))
@@ -3418,11 +3418,11 @@ a#347 = (???*0* | {} | ???*1* | ???*2*)
 
 a#348 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#349 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#350 = (0 | undefined | ???*0*)
 - *0* updated with update expression
@@ -3430,7 +3430,7 @@ a#350 = (0 | undefined | ???*0*)
 
 a#356 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#357 = ???*0*
 - *0* max number of linking steps reached
@@ -3438,31 +3438,31 @@ a#357 = ???*0*
 
 a#359 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#360 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#361 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#362 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#363 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#364 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#369 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -3470,7 +3470,7 @@ a#369 = (???*0* | ???*1*)
 
 a#370 = (???*0* | ???*1* | (???*3* ? ???*5* : null))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* a
@@ -3490,11 +3490,11 @@ a#378 = ???*0*
 
 a#380 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#381 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["defaultProps"]
   ⚠️  unknown object
 - *2* a
@@ -3502,11 +3502,11 @@ a#381 = (???*0* | ???*1*)
 
 a#384 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#385 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -3514,7 +3514,7 @@ a#385 = (???*0* | ???*1*)
 
 a#387 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["dependencies"]
   ⚠️  unknown object
 - *2* a
@@ -3525,7 +3525,7 @@ a#388 = (
   | {"context": ???*1*, "memoizedValue": ???*2*, "next": null}
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["_currentValue"]
@@ -3535,15 +3535,15 @@ a#388 = (
 
 a#390 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#391 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#392 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -3551,11 +3551,11 @@ a#392 = (???*0* | ???*1*)
 
 a#393 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#394 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* a
@@ -3563,19 +3563,19 @@ a#394 = (???*0* | ???*1*)
 
 a#395 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#396 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#398 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#4 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#400 = (
   | ???*0*
@@ -3593,7 +3593,7 @@ a#400 = (
   | ???*14*
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["lastBaseUpdate"]
   ⚠️  unknown object
 - *2* ???*3*["updateQueue"]
@@ -3625,15 +3625,15 @@ a#400 = (
 
 a#404 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#412 = (???*0* | ???*1* | 0["effects"] | ???*3*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["effects"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["effects"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -3642,11 +3642,11 @@ a#412 = (???*0* | ???*1* | 0["effects"] | ???*3*)
 
 a#415 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#416 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* a
@@ -3654,7 +3654,7 @@ a#416 = (???*0* | ???*1*)
 
 a#417 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* a
@@ -3662,7 +3662,7 @@ a#417 = (???*0* | ???*1*)
 
 a#418 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* a
@@ -3670,7 +3670,7 @@ a#418 = (???*0* | ???*1*)
 
 a#419 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* a
@@ -3678,7 +3678,7 @@ a#419 = (???*0* | ???*1*)
 
 a#420 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
@@ -3686,7 +3686,7 @@ a#420 = (???*0* | ???*1*)
 
 a#421 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
@@ -3694,31 +3694,31 @@ a#421 = (???*0* | ???*1*)
 
 a#422 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["state"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#423 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#424 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["ref"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#428 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#429 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["call"](b)
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
@@ -3732,15 +3732,15 @@ a#429 = (???*0* | ???*1*)
 
 a#430 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#431 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#435 = (???*0* | new ???*1*())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* FreeVar(Map)
   ⚠️  unknown global
   ⚠️  This value might have side effects
@@ -3751,7 +3751,7 @@ a#436 = (
   | new (...) => undefined(???*3*, (???*5* | ???*6*), ???*8*, ???*10*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* a
@@ -3761,7 +3761,7 @@ a#436 = (
 - *4* a
   ⚠️  circular variable reference
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["dependencies"]
   ⚠️  unknown object
 - *7* a
@@ -3777,31 +3777,31 @@ a#436 = (
 
 a#439 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#440 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#441 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#442 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#443 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#445 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#447 = (???*0* | ???*1* | null)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["get"](c)
   ⚠️  unknown callee object
 - *2* a
@@ -3809,11 +3809,11 @@ a#447 = (???*0* | ???*1* | null)
 
 a#453 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#458 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#459 = ???*0*
 - *0* max number of linking steps reached
@@ -3821,7 +3821,7 @@ a#459 = ???*0*
 
 a#471 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#472 = (
   | ???*0*
@@ -3837,11 +3837,11 @@ a#472 = (
   | (???*15* ? (???*17* | null["parentNode"]) : (???*19* | ???*20* | ???*27* | null))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["documentElement"]
   ⚠️  unknown object
 - *4* b
@@ -3878,9 +3878,9 @@ a#472 = (
 - *17* ???*18*["parentNode"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* (???*21* ? ???*23* : ???*25*)
   ⚠️  nested operation
 - *21* ???*22*["documentElement"]
@@ -3907,15 +3907,15 @@ a#472 = (
 
 a#474 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#475 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#476 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#482 = (0 | ???*0*)
 - *0* updated with update expression
@@ -3923,15 +3923,15 @@ a#482 = (0 | ???*0*)
 
 a#484 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#485 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*(d, e)
   ⚠️  unknown callee
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#488 = (0 !== (0 | ???*0*))
 - *0* updated with update expression
@@ -3962,7 +3962,7 @@ a#490 = (
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* ???*4*["next"]
@@ -3996,7 +3996,7 @@ a#490 = (
 
 a#493 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#494 = (
   | ???*0*
@@ -4013,7 +4013,7 @@ a#494 = (
   | null["next"]["queue"]["interleaved"]
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["interleaved"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -4026,7 +4026,7 @@ a#494 = (
 - *5* ???*6*["memoizedState"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["next"]
   ⚠️  unknown object
 - *8* P
@@ -4038,7 +4038,7 @@ a#494 = (
 - *11* ???*12*["alternate"]
   ⚠️  unknown object
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* a
   ⚠️  circular variable reference
 - *14* ???*15*["next"]
@@ -4056,13 +4056,13 @@ a#494 = (
 
 a#5 = (???*0* | 0 | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
 a#50 = (???*0* | ???*1* | null["displayName"] | null["name"] | "" | (???*3* ? ???*5* : "ForwardRef"))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["displayName"]
   ⚠️  unknown object
 - *2* a
@@ -4078,11 +4078,11 @@ a#50 = (???*0* | ???*1* | null["displayName"] | null["name"] | "" | (???*3* ? ??
 
 a#501 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#504 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#506 = (
   | ???*0*
@@ -4131,13 +4131,13 @@ a#506 = (
     }
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["updateQueue"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["alternate"]
   ⚠️  unknown object
 - *5* N
@@ -4177,11 +4177,11 @@ a#506 = (
 - *22* unknown mutation
   ⚠️  This value might have side effects
 - *23* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* ???*25*["stores"]
   ⚠️  unknown object
 - *25* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* ???*27*["alternate"]
   ⚠️  unknown object
 - *27* N
@@ -4225,15 +4225,15 @@ a#506 = (
 
 a#507 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#508 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#510 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["value"]
   ⚠️  unknown object
 - *2* a
@@ -4241,7 +4241,7 @@ a#510 = (???*0* | ???*1*)
 
 a#513 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#514 = (
   | ???*0*
@@ -4257,13 +4257,13 @@ a#514 = (
   | (...) => undefined["bind"](null, (null | ???*3* | ???*4*), ???*20*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (null !== (
       | null
       | ???*5*
@@ -4317,41 +4317,41 @@ a#515 = ???*0*
 
 a#517 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#518 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#521 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#522 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#523 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#524 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#525 = (???*0* | ???*1*())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 
 a#528 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#53 = (???*0* | ???*1* | "")
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["render"]
   ⚠️  unknown object
 - *2* ???*3*["type"]
@@ -4361,53 +4361,53 @@ a#53 = (???*0* | ???*1* | "")
 
 a#530 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#531 = (???*0* | ???*1*())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 
 a#532 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#533 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#537 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#539 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#54 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#545 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#546 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#547 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#549 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#55 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeName"]
   ⚠️  unknown object
 - *2* a
@@ -4415,19 +4415,19 @@ a#55 = (???*0* | ???*1*)
 
 a#550 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#551 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#552 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#553 = (???*0* | ???*1*())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 
@@ -4444,23 +4444,23 @@ a#554 = (
   | (...) => undefined["bind"](null, (null | ???*8* | ???*9*), ???*25*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (undefined !== ???*4*)
   ⚠️  nested operation
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*(b)
   ⚠️  unknown callee
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* b
   ⚠️  circular variable reference
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* (null !== (
       | null
       | ???*10*
@@ -4510,13 +4510,13 @@ a#554 = (
 
 a#555 = (???*0* | {"current": ???*1*})
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 
 a#556 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#557 = ???*0*
 - *0* node limit reached
@@ -4524,11 +4524,11 @@ a#557 = ???*0*
 
 a#559 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#56 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#562 = (
   | null
@@ -4556,7 +4556,7 @@ a#562 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -4564,7 +4564,7 @@ a#562 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -4598,7 +4598,7 @@ a#562 = (
 
 a#565 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#566 = ???*0*
 - *0* max number of linking steps reached
@@ -4606,7 +4606,7 @@ a#566 = ???*0*
 
 a#568 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#569 = ???*0*
 - *0* max number of linking steps reached
@@ -4614,40 +4614,40 @@ a#569 = ???*0*
 
 a#570 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#573 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#574 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#578 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#580 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#585 = (
   | ???*0*
   | (...) => undefined["bind"](null, ???*1*, ???*2*, ???*3*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#587 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -4655,19 +4655,19 @@ a#587 = (???*0* | ???*1*)
 
 a#589 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#59 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#590 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#591 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#592 = (
   | ???*0*
@@ -4687,29 +4687,29 @@ a#592 = (
     )
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* a
   ⚠️  circular variable reference
 - *4* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*5*, ???*6*, (???*7* | ???*9*))
   ⚠️  nested operation
 - *5* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* b
   ⚠️  circular variable reference
 - *7* ???*8*["mode"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* unsupported assign operation
   ⚠️  This value might have side effects
 - *10* ???*11*["mode"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* unsupported assign operation
   ⚠️  This value might have side effects
 - *13* a
@@ -4720,29 +4720,29 @@ a#592 = (
 - *15* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*16*, ???*17*, (???*18* | ???*20*))
   ⚠️  nested operation
 - *16* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* b
   ⚠️  circular variable reference
 - *18* ???*19*["mode"]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* unsupported assign operation
   ⚠️  This value might have side effects
 - *21* ???*22*["mode"]
   ⚠️  unknown object
 - *22* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* unsupported assign operation
   ⚠️  This value might have side effects
 - *24* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* b
   ⚠️  circular variable reference
 - *26* ???*27*["mode"]
   ⚠️  unknown object
 - *27* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* unsupported assign operation
   ⚠️  This value might have side effects
 - *29* (null !== ???*30*)
@@ -4760,35 +4760,35 @@ a#592 = (
 - *35* ???*36*["type"]
   ⚠️  unknown object
 - *36* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *38* ???*39*["dependencies"]
   ⚠️  unknown object
 - *39* ???*40*["type"]
   ⚠️  unknown object
 - *40* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *41* ???*42*["key"]
   ⚠️  unknown object
 - *42* ???*43*["type"]
   ⚠️  unknown object
 - *43* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *44* ???*45*["mode"]
   ⚠️  unknown object
 - *45* ???*46*["type"]
   ⚠️  unknown object
 - *46* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#595 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#597 = (???*0* | (???*1* ? ???*7* : ???*8*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (null !== ???*2*)
   ⚠️  nested operation
 - *2* (???*3* ? ???*5* : null)
@@ -4804,39 +4804,39 @@ a#597 = (???*0* | (???*1* ? ???*7* : ???*8*))
 - *7* unsupported expression
   ⚠️  This value might have side effects
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#599 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#6 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#600 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#601 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#605 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#606 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#607 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#608 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#609 = ???*0*
 - *0* max number of linking steps reached
@@ -4844,11 +4844,11 @@ a#609 = ???*0*
 
 a#61 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#612 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#613 = (
   | ???*0*
@@ -4857,13 +4857,13 @@ a#613 = (
   | new (...) => undefined(22, ???*5*, null, ???*6*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* ???*3*["pendingProps"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* b
   ⚠️  circular variable reference
 - *5* a
@@ -4871,7 +4871,7 @@ a#613 = (
 - *6* ???*7*["mode"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#614 = ???*0*
 - *0* max number of linking steps reached
@@ -4879,11 +4879,11 @@ a#614 = ???*0*
 
 a#619 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#620 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#621 = (
   | ???*0*
@@ -4897,11 +4897,11 @@ a#621 = (
   | null["sibling"]["sibling"]
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -4913,43 +4913,43 @@ a#621 = (
 
 a#628 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#629 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#63 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#631 = (???*0* | null | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#634 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#639 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#64 = (???*0* | "" | ((???*1* | ???*3*) ? ???*7* : ???*10*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeName"]
   ⚠️  unknown object
 - *2* a
@@ -4975,15 +4975,15 @@ a#64 = (???*0* | "" | ((???*1* | ???*3*) ? ???*7* : ???*10*))
 
 a#644 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#645 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#646 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#647 = ???*0*
 - *0* max number of linking steps reached
@@ -4991,7 +4991,7 @@ a#647 = ???*0*
 
 a#65 = (???*0* | ???*1* | (???*2* ? ???*5* : undefined))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ("undefined" !== ???*3*)
@@ -5007,19 +5007,19 @@ a#65 = (???*0* | ???*1* | (???*2* ? ???*5* : undefined))
 
 a#665 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["flags"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#667 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#670 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#673 = ???*0*
 - *0* max number of linking steps reached
@@ -5027,23 +5027,23 @@ a#673 = ???*0*
 
 a#68 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#687 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#69 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#691 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#695 = (???*0* | ???*1* | undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
@@ -5051,15 +5051,15 @@ a#695 = (???*0* | ???*1* | undefined)
 
 a#697 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#698 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#699 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -5067,7 +5067,7 @@ a#699 = (???*0* | ???*1*)
 
 a#7 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*(0, 5)
   ⚠️  unknown callee
 - *2* ???*3*["slice"]
@@ -5081,11 +5081,11 @@ a#7 = (???*0* | ???*1*)
 
 a#70 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#703 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
@@ -5093,7 +5093,7 @@ a#703 = (???*0* | ???*1*)
 
 a#704 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* a
@@ -5101,7 +5101,7 @@ a#704 = (???*0* | ???*1*)
 
 a#705 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#706 = ???*0*
 - *0* max number of linking steps reached
@@ -5109,47 +5109,47 @@ a#706 = ???*0*
 
 a#71 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#713 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#716 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#721 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#74 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#756 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#76 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#763 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#764 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#768 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#77 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["options"]
   ⚠️  unknown object
 - *2* a
@@ -5157,15 +5157,15 @@ a#77 = (???*0* | ???*1*)
 
 a#781 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#785 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#8 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#801 = (
   | ???*0*
@@ -5180,7 +5180,7 @@ a#801 = (
   | (???*19* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* C
   ⚠️  circular variable reference
 - *2* (0 !== ???*3*)
@@ -5208,11 +5208,11 @@ a#801 = (
 - *13* unsupported expression
   ⚠️  This value might have side effects
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["value"]
   ⚠️  unknown object
 - *16* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -5226,15 +5226,15 @@ a#801 = (
 
 a#802 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#803 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#807 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#817 = ???*0*
 - *0* max number of linking steps reached
@@ -5242,19 +5242,19 @@ a#817 = ???*0*
 
 a#818 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#819 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#82 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#827 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["expirationTimes"]
   ⚠️  unknown object
 - *2* a
@@ -5262,19 +5262,19 @@ a#827 = (???*0* | ???*1*)
 
 a#829 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#83 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#831 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#834 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#838 = (
   | ???*0*
@@ -5282,7 +5282,7 @@ a#838 = (
   | new (...) => undefined(???*4*, (null | ???*7*), ???*10*, ???*13*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* ???*3*["current"]
@@ -5316,21 +5316,21 @@ a#838 = (
 
 a#843 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#861 = module<react, {}>["__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"]["ReactCurrentDispatcher"]["current"]
 
 a#863 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#868 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#869 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -5338,23 +5338,23 @@ a#869 = (???*0* | ???*1*)
 
 a#87 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#877 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#88 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#880 = (???*0* | ???*1* | null)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["value"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#883 = ((???*0* ? ???*1* : 1) | undefined | null | ???*6* | ???*7*)
 - *0* unsupported expression
@@ -5370,23 +5370,23 @@ a#883 = ((???*0* ? ???*1* : 1) | undefined | null | ???*6* | ???*7*)
 - *5* unsupported expression
   ⚠️  This value might have side effects
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["value"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#89 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#9 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#90 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#909 = ???*0*
 - *0* max number of linking steps reached
@@ -5400,11 +5400,11 @@ a#910 = ???*0*
 
 a#915 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#916 = (???*0* | (???*1* ? ???*5* : null))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -5422,11 +5422,11 @@ a#916 = (???*0* | (???*1* ? ???*5* : null))
 
 a#917 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#918 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#919 = ???*0*
 - *0* max number of linking steps reached
@@ -5434,23 +5434,23 @@ a#919 = ???*0*
 
 a#94 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#940 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#941 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#942 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#943 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["prototype"]
   ⚠️  unknown object
 - *2* a
@@ -5458,7 +5458,7 @@ a#943 = (???*0* | ???*1*)
 
 a#944 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["$$typeof"]
   ⚠️  unknown object
 - *2* a
@@ -5466,7 +5466,7 @@ a#944 = (???*0* | ???*1*)
 
 a#946 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#947 = (
   | ???*0*
@@ -5475,122 +5475,122 @@ a#947 = (
   | new (...) => undefined(19, ???*18*, (???*19* | ???*20*), (???*25* | ???*26*))
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*4*, ???*5*, (???*6* | ???*7*))
   ⚠️  nested operation
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* b
   ⚠️  circular variable reference
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported assign operation
   ⚠️  This value might have side effects
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*12*, ???*13*, (???*14* | ???*15*))
   ⚠️  nested operation
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* b
   ⚠️  circular variable reference
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unsupported assign operation
   ⚠️  This value might have side effects
 - *16* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* unsupported assign operation
   ⚠️  This value might have side effects
 - *18* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*21*, ???*22*, (???*23* | ???*24*))
   ⚠️  nested operation
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* b
   ⚠️  circular variable reference
 - *23* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* unsupported assign operation
   ⚠️  This value might have side effects
 - *25* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* unsupported assign operation
   ⚠️  This value might have side effects
 
 a#948 = (???*0* | new (...) => undefined(7, ???*1*, ???*2*, ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#949 = (???*0* | new (...) => undefined(22, ???*1*, ???*2*, ???*3*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#950 = (???*0* | new (...) => undefined(6, ???*1*, null, ???*2*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#951 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#952 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#953 = (
   | ???*0*
   | new (...) => undefined(???*1*, (???*2* | 1 | ???*3* | 0), ???*4*, ???*5*, ???*6*)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#954 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#955 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* a
@@ -5598,11 +5598,11 @@ a#955 = (???*0* | ???*1*)
 
 a#96 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#960 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* node limit reached
   ⚠️  This value might have side effects
 
@@ -5612,7 +5612,7 @@ a#961 = ???*0*
 
 a#962 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["current"]
   ⚠️  unknown object
 - *2* a
@@ -5620,7 +5620,7 @@ a#962 = (???*0* | ???*1*)
 
 a#963 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* a
@@ -5628,7 +5628,7 @@ a#963 = (???*0* | ???*1*)
 
 a#965 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* a
@@ -5636,15 +5636,15 @@ a#965 = (???*0* | ???*1*)
 
 a#967 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#968 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#969 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#970 = ???*0*
 - *0* ???*1*["_internalRoot"]
@@ -5655,7 +5655,7 @@ a#970 = ???*0*
 
 a#973 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#974 = (
   | ???*0*
@@ -5676,7 +5676,7 @@ a#974 = (
     }
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* Hc
@@ -5708,25 +5708,25 @@ a#974 = (
 - *15* unsupported expression
   ⚠️  This value might have side effects
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["value"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#976 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#977 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#979 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#982 = (null | ???*0* | ???*3* | undefined["child"]["stateNode"] | undefined)
 - *0* ???*1*["stateNode"]
@@ -5734,7 +5734,7 @@ a#982 = (null | ???*0* | ???*3* | undefined["child"]["stateNode"] | undefined)
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["stateNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -5755,7 +5755,7 @@ a#984 = (
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* a
   ⚠️  circular variable reference
 - *4* unsupported assign operation
@@ -5763,7 +5763,7 @@ a#984 = (
 
 a#986 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#989 = (
   | null
@@ -5780,7 +5780,7 @@ a#989 = (
 - *2* ???*3*["_reactRootContainer"]
   ⚠️  unknown object
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["stateNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -5796,19 +5796,19 @@ a#989 = (
 
 a#99 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#990 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#994 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 a#997 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 aa = module<react, {}>
 
@@ -5879,7 +5879,7 @@ al = (...) => undefined
 
 b#100 = (???*0* | (???*1* + ???*2* + ???*6*))
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* ???*3*()
@@ -5889,23 +5889,23 @@ b#100 = (???*0* | (???*1* + ???*2* + ???*6*))
 - *4* ???*5*["charAt"](0)
   ⚠️  unknown callee object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["substring"](1)
   ⚠️  unknown callee object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#1001 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#1004 = (???*0* | ???*1* | ???*3* | 0 | ???*6*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["name"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["name"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -5921,18 +5921,18 @@ b#1004 = (???*0* | ???*1* | ???*3* | 0 | ???*6*)
 
 b#101 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#1012 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#1013 = (
   | ???*0*
   | new (...) => undefined(???*1*, (1 | ???*2* | 0), false, ("" | ???*3*), (???*5* | ???*10*))
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* unsupported assign operation
@@ -5964,7 +5964,7 @@ b#1014 = ???*0*
 
 b#1017 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#1018 = ???*0*
 - *0* max number of linking steps reached
@@ -5972,29 +5972,29 @@ b#1018 = ???*0*
 
 b#1019 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#102 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#1023 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#104 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#107 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#109 = (???*0* | (???*2* ? null : (???*6* | ???*7*))["stateNode"] | undefined | null)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* !((???*3* | ???*4*))
   ⚠️  nested operation
 - *3* a
@@ -6014,39 +6014,39 @@ b#11 = ???*0*
 - *0* ???*1*[0]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#112 = (null | [???*0*] | undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#114 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#116 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#119 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#123 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#127 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#128 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#131 = (???*0* | ???*1* | ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* ???*3*["return"]
@@ -6058,21 +6058,21 @@ b#133 = (???*0* | undefined)
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#136 = (???*0* | (???*2* ? (???*5* | ???*6* | ???*7*) : null))
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (3 === ???*3*)
   ⚠️  nested operation
 - *3* ???*4*["tag"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* a
   ⚠️  circular variable reference
 - *7* ???*8*["return"]
@@ -6082,7 +6082,7 @@ b#136 = (???*0* | (???*2* ? (???*5* | ???*6* | ???*7*) : null))
 
 b#152 = (???*0* | ???*1* | ???*3* | null | undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* a
@@ -6096,49 +6096,49 @@ b#156 = ???*0*
 
 b#159 = (???*0* | ???*1* | ???*3*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["entangledLanes"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 
 b#161 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#162 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#167 = []
 
 b#168 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
 b#169 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["entanglements"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#171 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#174 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#175 = (???*0* | (???*1* ? null : (???*5* | ???*6*)) | ???*8* | [???*10*] | ???*11*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* !((???*2* | ???*3*))
   ⚠️  nested operation
 - *2* b
@@ -6156,15 +6156,15 @@ b#175 = (???*0* | (???*1* ? null : (???*5* | ???*6*)) | ???*8* | [???*10*] | ???
 - *8* ???*9*["targetContainers"]
   ⚠️  unknown object
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* unknown mutation
   ⚠️  This value might have side effects
 
 b#176 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#177 = ???*0*
 - *0* max number of linking steps reached
@@ -6176,35 +6176,35 @@ b#183 = ???*0*
 
 b#186 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#188 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#189 = (...) => ad(b, a)
 
 b#190 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#193 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#196 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#199 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#20 = ???*0*
 - *0* ???*1*["replace"](ra, sa)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#203 = ???*0*
 - *0* max number of linking steps reached
@@ -6225,7 +6225,7 @@ b#207 = (
 - *4* ???*5*["nodeType"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -6235,7 +6235,7 @@ b#207 = (
 - *8* ???*9*["parentNode"]
   ⚠️  unknown object
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -6243,7 +6243,7 @@ b#207 = (
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["target"]
   ⚠️  unknown object
 - *14* a
@@ -6260,7 +6260,7 @@ b#207 = (
 - *19* ???*20*["nodeType"]
   ⚠️  unknown object
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -6270,7 +6270,7 @@ b#207 = (
 - *23* ???*24*["parentNode"]
   ⚠️  unknown object
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -6278,7 +6278,7 @@ b#207 = (
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *27* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* ???*29*["target"]
   ⚠️  unknown object
 - *29* a
@@ -6291,13 +6291,13 @@ b#208 = (???*0* | 13["keyCode"])
 - *0* ???*1*["keyCode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#21 = ???*0*
 - *0* ???*1*["replace"](ra, sa)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#211 = (...) => ???*0*
 - *0* unsupported expression
@@ -6305,17 +6305,17 @@ b#211 = (...) => ???*0*
 
 b#212 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*[c]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#22 = ???*0*
 - *0* ???*1*["replace"](ra, sa)
   ⚠️  unknown callee object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#221 = ???*0*
 - *0* ???*1*["nativeEvent"]
@@ -6347,11 +6347,11 @@ b#223 = (
 - *1* ???*2*["key"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["key"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* unsupported expression
   ⚠️  This value might have side effects
 - *6* (13 === (???*7* | ???*8* | 13))
@@ -6371,61 +6371,61 @@ b#223 = (
 
 b#230 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#232 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#233 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#235 = (???*0* | ???*1* | ???*3*())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeName"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["toLowerCase"]
   ⚠️  unknown object
 - *4* ???*5*["nodeName"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#236 = (???*0* | [])
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#238 = (???*0* | undefined)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#239 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#244 = ([] | undefined)
 
 b#246 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#248 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#249 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#25 = (???*0* | (???*1* ? ???*4* : null)["attributeName"] | ???*6*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined | ???*2*)(???*3*)
   ⚠️  non-function callee
 - *2* unknown mutation
@@ -6446,19 +6446,19 @@ b#25 = (???*0* | (???*1* ? ???*4* : null)["attributeName"] | ???*6*)
 
 b#250 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#251 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#254 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#260 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#261 = (
   | null
@@ -6547,17 +6547,17 @@ b#261 = (
 
 b#265 = (???*0* | ???*1* | ???*3*())
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["nodeName"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["toLowerCase"]
   ⚠️  unknown object
 - *4* ???*5*["nodeName"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#266 = ???*0*
 - *0* max number of linking steps reached
@@ -6568,13 +6568,13 @@ b#269 = (
   | new (...) => ???*1*("onSelect", "select", null, ???*2*, ???*3*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* b
   ⚠️  circular variable reference
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#27 = (???*0* | undefined)
 - *0* ???*1*(/\n( *(at )?)/)
@@ -6590,36 +6590,36 @@ b#27 = (???*0* | undefined)
 
 b#270 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#271 = ({} | ???*0*)
 - *0* {}[???*1*]
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#272 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#274 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#275 = (???*0* | (0 !== ???*1*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
 b#280 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#281 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#282 = ((???*0* ? ???*3* : ???*4*) | undefined)
 - *0* (9 === ???*1*)
@@ -6627,32 +6627,32 @@ b#282 = ((???*0* ? ???*3* : ???*4*) | undefined)
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["ownerDocument"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#284 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#285 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#286 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#3 = (
   | `https://reactjs.org/docs/error-decoder.html?invariant=${???*0*}`
   | `${???*1*}&args[]=${???*2*}`
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* ???*3*(FreeVar(arguments)[c])
@@ -6664,23 +6664,23 @@ b#3 = (
 
 b#30 = (???*0* | (...) => undefined)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#307 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#308 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#311 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#314 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["replace"](yf, "")
   ⚠️  unknown callee object
 - *2* ???*3*(/\r\n?/g, "\n")
@@ -6698,17 +6698,17 @@ b#314 = (???*0* | ???*1*)
 
 b#316 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#320 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#324 = (???*0* | undefined)
 - *0* ???*1*["nodeType"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#327 = (0 | ???*0*)
 - *0* updated with update expression
@@ -6725,7 +6725,7 @@ b#331 = (
 - *0* ???*1*[`__reactFiber$${???*2*}`]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["slice"](2)
   ⚠️  unknown callee object
 - *3* ???*4*(36)
@@ -6814,19 +6814,19 @@ b#331 = (
 
 b#340 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#341 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#344 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#345 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["childContextTypes"]
   ⚠️  unknown object
 - *2* b
@@ -6834,7 +6834,7 @@ b#345 = (???*0* | ???*1*)
 
 b#347 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#350 = (
   | 0
@@ -6873,29 +6873,29 @@ b#350 = (
 - *12* unsupported expression
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["value"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#356 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#357 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#361 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["deletions"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#362 = ???*0*
 - *0* max number of linking steps reached
@@ -6911,7 +6911,7 @@ b#370 = ???*0*
 
 b#381 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* Object.assign*2*({}, ???*3*)
   ⚠️  only const object assign is supported
   ⚠️  This value might have side effects
@@ -6925,43 +6925,43 @@ b#384 = (null | ???*0*)
 
 b#385 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#387 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#388 = (???*0* | undefined | ???*2*)
 - *0* ???*1*["_currentValue"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unknown mutation
   ⚠️  This value might have side effects
 
 b#391 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#392 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#394 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#395 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#396 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#398 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* b
@@ -6969,15 +6969,15 @@ b#398 = (???*0* | ???*1*)
 
 b#4 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#400 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#404 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["interleaved"]
   ⚠️  unknown object
 - *2* ???*3*["shared"]
@@ -6985,25 +6985,25 @@ b#404 = (???*0* | ???*1*)
 - *3* ???*4*["updateQueue"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#412 = (???*0* | 0 | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
 b#415 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#417 = (???*0* | null | (???*1* ? ???*5* : null))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -7011,17 +7011,17 @@ b#417 = (???*0* | null | (???*1* ? ???*5* : null))
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#418 = (???*0* | null | (???*1* ? ???*5* : null))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -7029,17 +7029,17 @@ b#418 = (???*0* | null | (???*1* ? ???*5* : null))
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#419 = (???*0* | null | (???*1* ? ???*5* : null))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -7047,28 +7047,28 @@ b#419 = (???*0* | null | (???*1* ? ???*5* : null))
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#420 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#421 = (
   | ???*0*
   | new ???*1*(???*2*, (???*3* | undefined | ???*5* | ???*6*))
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["contextType"]
   ⚠️  unknown object
 - *4* b
@@ -7092,25 +7092,25 @@ b#421 = (
 - *13* ???*14*["stateNode"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#422 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#423 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["state"]
   ⚠️  unknown object
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#424 = (???*0* | (...) => undefined)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#428 = (???*0* | undefined["refs"] | {})
 - *0* ???*1*["refs"]
@@ -7118,27 +7118,27 @@ b#428 = (???*0* | undefined["refs"] | {})
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#429 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#430 = ???*0*
 - *0* ???*1*["_init"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#431 = (...) => undefined
 
 b#432 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#435 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["sibling"]
   ⚠️  unknown object
 - *2* b
@@ -7146,15 +7146,15 @@ b#435 = (???*0* | ???*1*)
 
 b#436 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#437 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#438 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#439 = (
   | ???*0*
@@ -7164,13 +7164,13 @@ b#439 = (
   | new (...) => undefined(???*7*, (???*9* | ???*10*), ???*12*, ???*14*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["mode"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* b
   ⚠️  circular variable reference
 - *5* ???*6*["alternate"]
@@ -7182,7 +7182,7 @@ b#439 = (
 - *8* a
   ⚠️  circular variable reference
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["dependencies"]
   ⚠️  unknown object
 - *11* a
@@ -7198,7 +7198,7 @@ b#439 = (
 
 b#440 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#441 = (
   | ???*0*
@@ -7208,11 +7208,11 @@ b#441 = (
   | new (...) => undefined(???*13*, (???*15* | []), ???*17*, ???*19*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["mode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (???*4* ? ???*7* : [])
   ⚠️  nested operation
 - *4* (null !== ???*5*)
@@ -7220,15 +7220,15 @@ b#441 = (
 - *5* ???*6*["children"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["children"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["key"]
   ⚠️  unknown object
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* b
   ⚠️  circular variable reference
 - *12* b
@@ -7240,7 +7240,7 @@ b#441 = (
 - *15* ???*16*["children"]
   ⚠️  unknown object
 - *16* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["key"]
   ⚠️  unknown object
 - *18* a
@@ -7258,15 +7258,15 @@ b#442 = (
   | new (...) => undefined(???*8*, (???*10* | ???*11*), ???*13*, ???*15*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* b
   ⚠️  circular variable reference
 - *6* ???*7*["alternate"]
@@ -7278,7 +7278,7 @@ b#442 = (
 - *9* a
   ⚠️  circular variable reference
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["dependencies"]
   ⚠️  unknown object
 - *12* a
@@ -7301,7 +7301,7 @@ b#443 = (
   | new (...) => undefined(7, ???*16*, null, ???*17*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* a
@@ -7309,11 +7309,11 @@ b#443 = (
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["mode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (???*8* ? ???*11* : [])
   ⚠️  nested operation
 - *8* (null !== ???*9*)
@@ -7337,15 +7337,15 @@ b#443 = (
 - *17* ???*18*["mode"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#445 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#447 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#472 = (
   | ???*0*
@@ -7361,7 +7361,7 @@ b#472 = (
     ) : ???*16*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["documentElement"]
   ⚠️  unknown object
 - *2* b
@@ -7412,7 +7412,7 @@ b#474 = ({} | ???*0*)
 
 b#476 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* b
@@ -7420,7 +7420,7 @@ b#476 = (???*0* | ???*1*)
 
 b#484 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#485 = (
   | ???*0*
@@ -7441,7 +7441,7 @@ b#485 = (
   | (null !== (null["next"] | null["alternate"]["next"] | ???*16* | undefined["next"] | null | ???*19*))
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* b
@@ -7487,7 +7487,7 @@ b#490 = ???*0*
 
 b#493 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#494 = (
   | null
@@ -7515,7 +7515,7 @@ b#494 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -7523,7 +7523,7 @@ b#494 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -7557,7 +7557,7 @@ b#494 = (
 
 b#5 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#50 = (
   | ???*0*
@@ -7572,7 +7572,7 @@ b#50 = (
 - *0* ???*1*["render"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ("" !== ???*3*)
   ⚠️  nested operation
 - *3* a
@@ -7624,7 +7624,7 @@ b#501 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -7632,7 +7632,7 @@ b#501 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -7666,7 +7666,7 @@ b#501 = (
 
 b#504 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#506 = (
   | ???*0*
@@ -7689,11 +7689,11 @@ b#506 = (
   | {"lastEffect": null, "stores": null}
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* N
@@ -7735,17 +7735,17 @@ b#506 = (
 
 b#507 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#508 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#510 = ???*0*
 - *0* ???*1*["getSnapshot"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#513 = (???*0* ? ???*4* : null)
 - *0* (3 === ???*1*)
@@ -7755,13 +7755,13 @@ b#513 = (???*0* ? ???*4* : null)
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["stateNode"]
   ⚠️  unknown object
 - *5* ???*6*["alternate"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#514 = (
   | null
@@ -7789,7 +7789,7 @@ b#514 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -7797,7 +7797,7 @@ b#514 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -7850,11 +7850,11 @@ b#515 = (
   | {"lastEffect": null, "stores": null}
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* N
@@ -7896,45 +7896,45 @@ b#515 = (
 
 b#517 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#518 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#521 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#522 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#523 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#524 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#525 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#528 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#53 = (???*0* | ""["type"])
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#530 = (???*0* | (???*1* ? null : ???*3*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined === ???*2*)
   ⚠️  nested operation
 - *2* b
@@ -7944,7 +7944,7 @@ b#530 = (???*0* | (???*1* ? null : ???*3*))
 
 b#531 = (???*0* | (???*1* ? null : ???*3*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined === ???*2*)
   ⚠️  nested operation
 - *2* b
@@ -7954,59 +7954,59 @@ b#531 = (???*0* | (???*1* ? null : ???*3*))
 
 b#532 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#533 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#537 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#539 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#545 = ???*0*
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#546 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#547 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#549 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#55 = ???*0*
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#550 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#551 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#552 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#553 = (???*0* | (???*1* ? null : ???*3*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined === ???*2*)
   ⚠️  nested operation
 - *2* b
@@ -8016,15 +8016,15 @@ b#553 = (???*0* | (???*1* ? null : ???*3*))
 
 b#554 = (???*0* | (???*1* ? ???*3* : ???*5*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined !== ???*2*)
   ⚠️  nested operation
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*(b)
   ⚠️  unknown callee
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* b
   ⚠️  circular variable reference
 
@@ -8054,7 +8054,7 @@ b#555 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -8062,7 +8062,7 @@ b#555 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -8103,13 +8103,13 @@ b#557 = ???*0*
 
 b#559 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#56 = ((???*0* | ???*2*) ? "checked" : "value")
 - *0* ???*1*["nodeName"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ("input" === ???*3*)
   ⚠️  nested operation
 - *3* ???*4*()
@@ -8117,7 +8117,7 @@ b#56 = ((???*0* | ???*2*) ? "checked" : "value")
 - *4* ???*5*["toLowerCase"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#562 = ???*0*
 - *0* max number of linking steps reached
@@ -8149,7 +8149,7 @@ b#565 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -8157,7 +8157,7 @@ b#565 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -8211,7 +8211,7 @@ b#566 = (
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["next"]
   ⚠️  unknown object
 - *6* P
@@ -8221,7 +8221,7 @@ b#566 = (
 - *8* ???*9*["alternate"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* a
   ⚠️  circular variable reference
 - *11* ???*12*["next"]
@@ -8263,7 +8263,7 @@ b#568 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -8271,7 +8271,7 @@ b#568 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -8325,7 +8325,7 @@ b#569 = (
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["next"]
   ⚠️  unknown object
 - *6* P
@@ -8335,7 +8335,7 @@ b#569 = (
 - *8* ???*9*["alternate"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* a
   ⚠️  circular variable reference
 - *11* ???*12*["next"]
@@ -8353,27 +8353,27 @@ b#569 = (
 
 b#570 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#573 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#574 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#578 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#580 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#585 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#587 = (???*0* | (13 === ???*1*) | ???*3* | (???*5* ? ???*7* : true))
 - *0* b
@@ -8381,11 +8381,11 @@ b#587 = (???*0* | (13 === ???*1*) | ???*3* | (???*5* ? ???*7* : true))
 - *1* ???*2*["tag"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (null !== ???*6*)
   ⚠️  nested operation
 - *6* b
@@ -8404,59 +8404,59 @@ b#589 = (
   | {"eventTime": ???*1*, "lane": 1, "tag": 0, "payload": null, "callback": null, "next": null}
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
 b#590 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#591 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#592 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#595 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#597 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#599 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#600 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#601 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#605 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#606 = ???*0*
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#607 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#609 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#612 = (
   | ???*0*
@@ -8464,7 +8464,7 @@ b#612 = (
   | new (...) => undefined(22, ???*2*, null, ???*3*)
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* b
   ⚠️  circular variable reference
 - *2* a
@@ -8472,11 +8472,11 @@ b#612 = (
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#613 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#614 = ???*0*
 - *0* max number of linking steps reached
@@ -8484,35 +8484,35 @@ b#614 = ???*0*
 
 b#619 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#620 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#621 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#628 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#629 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#631 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#634 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#639 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#64 = (
   | ???*0*
@@ -8522,7 +8522,7 @@ b#64 = (
 - *0* ???*1*["_valueTracker"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["nodeName"]
   ⚠️  unknown object
 - *3* a
@@ -8548,31 +8548,31 @@ b#64 = (
 
 b#644 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#645 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["tail"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#646 = ((null !== ???*0*) | (???*2* === ???*5*))
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["child"]
   ⚠️  unknown object
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["child"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#647 = ???*0*
 - *0* max number of linking steps reached
@@ -8580,11 +8580,11 @@ b#647 = ???*0*
 
 b#665 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#667 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#67 = ???*0*
 - *0* b
@@ -8592,7 +8592,7 @@ b#67 = ???*0*
 
 b#670 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#673 = ???*0*
 - *0* max number of linking steps reached
@@ -8600,19 +8600,19 @@ b#673 = ???*0*
 
 b#68 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#687 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#69 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#691 = (???*0* | ???*1* | (???*3* ? ???*5* : null))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* b
@@ -8630,21 +8630,21 @@ b#695 = (???*0* | undefined["ref"])
 - *0* ???*1*["ref"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#697 = ???*0*
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#7 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#70 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["checked"]
   ⚠️  unknown object
 - *2* b
@@ -8652,41 +8652,41 @@ b#70 = (???*0* | ???*1*)
 
 b#703 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["parentNode"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#704 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#705 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#706 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#71 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#713 = ???*0*
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#715 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#716 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* b
@@ -8698,31 +8698,31 @@ b#721 = ???*0*
 
 b#74 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["initialValue"]
   ⚠️  unknown object
 - *2* ???*3*["_wrapperState"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#756 = ???*0*
 - *0* ???*1*["flags"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#76 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#763 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#764 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#768 = ???*0*
 - *0* max number of linking steps reached
@@ -8730,12 +8730,12 @@ b#768 = ???*0*
 
 b#77 = (???*0* | {} | null | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*[(0 | undefined | ???*3* | ???*4*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* ???*5*["hasOwnProperty"](`$${a[c]["value"]}`)
@@ -8753,15 +8753,15 @@ b#785 = ???*0*
 
 b#8 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#802 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#803 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 
@@ -8775,7 +8775,7 @@ b#817 = ???*0*
 
 b#819 = (???*0* | ???*1* | undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* b
@@ -8783,11 +8783,11 @@ b#819 = (???*0* | ???*1* | undefined)
 
 b#82 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#827 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -8812,7 +8812,7 @@ b#829 = (
 - *0* ???*1*["entangledLanes"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported assign operation
   ⚠️  This value might have side effects
 - *3* unsupported expression
@@ -8820,11 +8820,11 @@ b#829 = (
 - *4* (0 !== (???*5* | ???*6*))
   ⚠️  nested operation
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* unsupported expression
   ⚠️  This value might have side effects
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* (???*10* ? 1073741824 : 0)
@@ -8834,7 +8834,7 @@ b#829 = (
 
 b#83 = (???*0* | ???*1* | ???*3* | "")
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["defaultValue"]
   ⚠️  unknown object
 - *2* b
@@ -8844,7 +8844,7 @@ b#83 = (???*0* | ???*1* | ???*3* | "")
 
 b#831 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#834 = ???*0*
 - *0* max number of linking steps reached
@@ -8852,7 +8852,7 @@ b#834 = ???*0*
 
 b#838 = (???*0* | 0 | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
@@ -8862,7 +8862,7 @@ b#843 = ???*0*
 
 b#863 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#868 = ???*0*
 - *0* (
@@ -8887,7 +8887,7 @@ b#868 = ???*0*
 
 b#869 = (???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* b
@@ -8895,21 +8895,21 @@ b#869 = (???*0* | ???*1*)
 
 b#87 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#877 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#88 = ???*0*
 - *0* ???*1*["textContent"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#880 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#883 = (
   | module<react, {}>["__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"]["ReactCurrentBatchConfig"]["transition"]
@@ -8918,11 +8918,11 @@ b#883 = (
 
 b#9 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#90 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#909 = ???*0*
 - *0* max number of linking steps reached
@@ -8934,7 +8934,7 @@ b#910 = ???*0*
 
 b#915 = (???*0* | (???*1* ? ???*3* : ???*4*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (0 !== ???*2*)
   ⚠️  nested operation
 - *2* unsupported expression
@@ -8960,7 +8960,7 @@ b#915 = (???*0* | (???*1* ? ???*3* : ???*4*))
 
 b#916 = (???*0* | 1 | 4194304 | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -8968,11 +8968,11 @@ b#917 = ???*0*
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#918 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#919 = ???*0*
 - *0* max number of linking steps reached
@@ -8980,11 +8980,11 @@ b#919 = ???*0*
 
 b#92 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#94 = (???*0* | ???*1* | ???*3*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["firstChild"]
   ⚠️  unknown object
 - *2* mb
@@ -9001,54 +9001,54 @@ b#94 = (???*0* | ???*1* | ???*3*)
 
 b#940 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#941 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#942 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#946 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["dependencies"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#947 = (
   | ???*0*
   | new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*1*, ???*2*, (???*3* | ???*4*))
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* b
   ⚠️  circular variable reference
 - *3* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* unsupported assign operation
   ⚠️  This value might have side effects
 
 b#948 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#949 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#950 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#951 = (???*0* | new (...) => undefined(4, ???*1*, ???*7*, ???*9*))
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* ? ???*5* : [])
   ⚠️  nested operation
 - *2* (null !== ???*3*)
@@ -9056,35 +9056,35 @@ b#951 = (???*0* | new (...) => undefined(4, ???*1*, ???*7*, ???*9*))
 - *3* ???*4*["children"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["children"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["key"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* b
   ⚠️  circular variable reference
 
 b#952 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#953 = (???*0* | 1 | ???*1* | 0)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
 b#954 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#955 = (???*0* | ???*1* | undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactInternals"]
   ⚠️  unknown object
 - *2* a
@@ -9092,11 +9092,11 @@ b#955 = (???*0* | ???*1* | undefined)
 
 b#96 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#960 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#961 = (
   | ???*0*
@@ -9124,7 +9124,7 @@ b#961 = (
     }
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (0 !== ???*2*)
   ⚠️  nested operation
 - *2* unsupported expression
@@ -9183,13 +9183,13 @@ b#961 = (
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* ???*34*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9203,11 +9203,11 @@ b#961 = (
 
 b#963 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#965 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#969 = ???*0*
 - *0* ???*1*["_internalRoot"]
@@ -9266,27 +9266,27 @@ b#974 = (
 - *13* unsupported expression
   ⚠️  This value might have side effects
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["value"]
   ⚠️  unknown object
 - *16* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#979 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#986 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#990 = ???*0*
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#992 = (???*0* ? ???*4* : null)
 - *0* (3 === ???*1*)
@@ -9296,13 +9296,13 @@ b#992 = (???*0* ? ???*4* : null)
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["stateNode"]
   ⚠️  unknown object
 - *5* ???*6*["alternate"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#994 = ((???*0* ? ???*4* : null) | undefined)
 - *0* (3 === ???*1*)
@@ -9312,13 +9312,13 @@ b#994 = ((???*0* ? ???*4* : null) | undefined)
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["stateNode"]
   ⚠️  unknown object
 - *5* ???*6*["alternate"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 b#997 = (
   | 1
@@ -9340,7 +9340,7 @@ b#997 = (
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* C
   ⚠️  circular variable reference
 - *4* (0 !== ???*5*)
@@ -9368,11 +9368,11 @@ b#997 = (
 - *15* unsupported expression
   ⚠️  This value might have side effects
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["value"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9396,9 +9396,9 @@ ba = (
 - *1* ba
   ⚠️  circular variable reference
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (???*5* ? (???*10* | ???*12*) : (???*14* | ???*15* | ???*17*))
   ⚠️  nested operation
 - *5* (3 === (???*6* | ???*8*))
@@ -9406,7 +9406,7 @@ ba = (
 - *6* ???*7*["nodeType"]
   ⚠️  unknown object
 - *7* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9416,7 +9416,7 @@ ba = (
 - *10* ???*11*["parentNode"]
   ⚠️  unknown object
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9424,7 +9424,7 @@ ba = (
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["target"]
   ⚠️  unknown object
 - *16* a
@@ -9513,17 +9513,17 @@ c#1001 = (
 - *12* unsupported expression
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["value"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#1004 = (???*0* | ???*1* | ???*3*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["parentNode"]
   ⚠️  unknown object
 - *2* c
@@ -9538,7 +9538,7 @@ c#1004 = (???*0* | ???*1* | ???*3*)
 
 c#101 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#1012 = ((???*0* | ???*1*) ? ???*4* : null)
 - *0* unsupported expression
@@ -9562,15 +9562,15 @@ c#1013 = (false | true)
 
 c#1017 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#1018 = (???*0* | (null != ???*1*)[(???*2* | 0 | ???*3*)] | ???*4* | null[(???*9* | 0 | ???*10*)])
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* c
   ⚠️  circular variable reference
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* ???*5*[(???*7* | 0 | ???*8*)]
@@ -9581,28 +9581,28 @@ c#1018 = (???*0* | (null != ???*1*)[(???*2* | 0 | ???*3*)] | ???*4* | null[(???*
 - *6* c
   ⚠️  circular variable reference
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* updated with update expression
   ⚠️  This value might have side effects
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* updated with update expression
   ⚠️  This value might have side effects
 
 c#1019 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#102 = (???*0* | "cssFloat")
 - *0* for-in variable currently not analyzed
 
 c#1023 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#116 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#119 = (
   | ???*0*
@@ -9615,7 +9615,7 @@ c#119 = (
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*[Pf]
   ⚠️  unknown object
 - *3* c
@@ -9627,17 +9627,17 @@ c#119 = (
 - *6* d
   ⚠️  circular variable reference
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["disabled"]
   ⚠️  unknown object
 - *9* d
   ⚠️  circular variable reference
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ("button" === (???*12* | ???*13* | ???*15* | false))
   ⚠️  nested operation
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["type"]
   ⚠️  unknown object
 - *14* a
@@ -9647,23 +9647,23 @@ c#119 = (
 - *16* d
   ⚠️  circular variable reference
 - *17* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#123 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#127 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#128 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#131 = (???*0* | ???*1* | ???*2*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* ???*3*["return"]
@@ -9681,19 +9681,19 @@ c#136 = (
   | undefined["child"]
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (3 === ???*4*)
   ⚠️  nested operation
 - *4* ???*5*["tag"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* a
   ⚠️  circular variable reference
 - *8* ???*9*["return"]
@@ -9705,7 +9705,7 @@ c#159 = (???*0* | ???*2*)
 - *0* ???*1*["pendingLanes"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
@@ -9713,7 +9713,7 @@ c#162 = ???*0*
 - *0* ???*1*["suspendedLanes"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#167 = (0 | ???*0*)
 - *0* updated with update expression
@@ -9721,7 +9721,7 @@ c#167 = (0 | ???*0*)
 
 c#168 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#169 = (???*0* | ???*1*)
 - *0* unsupported expression
@@ -9731,17 +9731,17 @@ c#169 = (???*0* | ???*1*)
 
 c#171 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
 c#175 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#176 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#177 = ???*0*
 - *0* max number of linking steps reached
@@ -9753,7 +9753,7 @@ c#183 = ???*0*
 
 c#186 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#189 = (1 | undefined | ???*0* | 0 | ???*1*)
 - *0* updated with update expression
@@ -9763,15 +9763,15 @@ c#189 = (1 | undefined | ???*0* | 0 | ???*1*)
 
 c#193 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#196 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#199 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#203 = ???*0*
 - *0* max number of linking steps reached
@@ -9792,7 +9792,7 @@ c#207 = (
 - *4* ???*5*["nodeType"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9802,7 +9802,7 @@ c#207 = (
 - *8* ???*9*["parentNode"]
   ⚠️  unknown object
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9810,7 +9810,7 @@ c#207 = (
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["target"]
   ⚠️  unknown object
 - *14* a
@@ -9827,7 +9827,7 @@ c#207 = (
 - *19* ???*20*["nodeType"]
   ⚠️  unknown object
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9837,7 +9837,7 @@ c#207 = (
 - *23* ???*24*["parentNode"]
   ⚠️  unknown object
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -9845,7 +9845,7 @@ c#207 = (
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *27* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* ???*29*["target"]
   ⚠️  unknown object
 - *29* a
@@ -9862,21 +9862,21 @@ c#236 = (
   | new (...) => ???*1*("onChange", "change", null, ???*2*, ???*3*)
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* c
   ⚠️  circular variable reference
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#246 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#25 = (???*0* | null | (???*1* ? "" : ???*12*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === (???*2* | ???*10*))
   ⚠️  nested operation
 - *2* (???*3* ? ???*8* : null)
@@ -9886,7 +9886,7 @@ c#25 = (???*0* | null | (???*1* ? "" : ???*12*))
 - *4* unknown mutation
   ⚠️  This value might have side effects
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["attributeName"]
   ⚠️  unknown object
 - *7* e
@@ -9895,7 +9895,7 @@ c#25 = (???*0* | null | (???*1* ? "" : ???*12*))
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["type"]
   ⚠️  unknown object
 - *11* e
@@ -9912,11 +9912,11 @@ c#251 = ???*0*
   ⚠️  This value might have side effects
 - *2* Object: The global Object variable
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#254 = (???*0* | 0 | ???*1* | (???*2* + ???*3*) | ???*6* | undefined | ???*8*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* d
   ⚠️  pattern without value
 - *2* a
@@ -9969,7 +9969,7 @@ c#266 = ???*0*
 
 c#269 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#270 = {}
 
@@ -9980,7 +9980,7 @@ c#271 = (???*0* | ???*1*)
 
 c#274 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#275 = (0 | ???*0*)
 - *0* updated with update expression
@@ -9990,14 +9990,14 @@ c#280 = (???*0* | new ???*2*())
 - *0* ???*1*[of]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* FreeVar(Set)
   ⚠️  unknown global
   ⚠️  This value might have side effects
 
 c#281 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#285 = (
   | ???*0*
@@ -10006,29 +10006,29 @@ c#285 = (
   | true["bind"](null, ???*7*, ???*8*, ???*9*)
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* c
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* c
   ⚠️  circular variable reference
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* c
   ⚠️  circular variable reference
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#286 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#29 = ???*0*
 - *0* c
@@ -10048,15 +10048,15 @@ c#30 = ???*0*
 
 c#307 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#308 = `${???*0*}Capture`
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#311 = (???*0* | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* c
@@ -10064,11 +10064,11 @@ c#311 = (???*0* | ???*1*)
 
 c#314 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#320 = (???*0* | ???*1* | undefined["data"] | undefined)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["data"]
   ⚠️  unknown object
 - *2* ???*3*["nextSibling"]
@@ -10080,7 +10080,7 @@ c#327 = (???*0* | undefined)
 - *0* ???*1*["data"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#331 = (
   | ???*0*
@@ -10091,7 +10091,7 @@ c#331 = (
 - *0* ???*1*["parentNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["slice"](2)
   ⚠️  unknown callee object
 - *3* ???*4*(36)
@@ -10121,23 +10121,23 @@ c#341 = ???*0*
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#344 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#345 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#347 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#350 = (null | [???*0*] | ???*1* | undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["slice"]((a + 1))
   ⚠️  unknown callee object
 - *2* eg
@@ -10145,7 +10145,7 @@ c#350 = (null | [???*0*] | ???*1* | undefined)
 
 c#357 = (???*0* | (???*1* + 1))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* c
   ⚠️  circular variable reference
 
@@ -10163,7 +10163,7 @@ c#370 = (???*0* | (???*2* ? ???*4* : null)["data"] | undefined)
 - *0* ???*1*["data"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== ???*3*)
   ⚠️  nested operation
 - *3* a
@@ -10178,27 +10178,27 @@ c#381 = ???*0*
 
 c#385 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#391 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#392 = (???*0* | ???*2*)
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#396 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#398 = (???*0* | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -10239,13 +10239,13 @@ c#400 = (
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["baseState"]
   ⚠️  unknown object
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["eventTime"]
   ⚠️  unknown object
 - *6* c
@@ -10267,7 +10267,7 @@ c#400 = (
 - *14* c
   ⚠️  circular variable reference
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* ???*17*["eventTime"]
   ⚠️  unknown object
 - *17* c
@@ -10289,31 +10289,31 @@ c#400 = (
 - *25* c
   ⚠️  circular variable reference
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* ???*28*["shared"]
   ⚠️  unknown object
 - *28* ???*29*["alternate"]
   ⚠️  unknown object
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["effects"]
   ⚠️  unknown object
 - *31* ???*32*["alternate"]
   ⚠️  unknown object
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#404 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#412 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#415 = (???*0* | ???*1* | (???*3* ? (???*5* | ???*6*) : ???*8*))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*(d, b)
   ⚠️  unknown callee
 - *2* c
@@ -10323,31 +10323,31 @@ c#415 = (???*0* | ???*1* | (???*3* ? (???*5* | ???*6*) : ???*8*))
 - *4* c
   ⚠️  circular variable reference
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["memoizedState"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* Object.assign*9*({}, (???*10* | ???*11*), ???*13*)
   ⚠️  only const object assign is supported
   ⚠️  This value might have side effects
 - *9* Object.assign: Object.assign method: https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["memoizedState"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* c
   ⚠️  circular variable reference
 
 c#417 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#418 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#419 = (???*0* ? ???*2* : ???*3*)
 - *0* (0 !== ???*1*)
@@ -10375,23 +10375,23 @@ c#419 = (???*0* ? ???*2* : ???*3*)
 
 c#420 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#421 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#422 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#423 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#424 = (???*0* | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_owner"]
   ⚠️  unknown object
 - *2* c
@@ -10401,45 +10401,45 @@ c#431 = (...) => null
 
 c#432 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#434 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#437 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#439 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#440 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#441 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#442 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#443 = (???*0* | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* node limit reached
   ⚠️  This value might have side effects
 
 c#445 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#447 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#474 = (???*0* ? (
   | "http://www.w3.org/2000/svg"
@@ -10464,7 +10464,7 @@ c#476 = (???*0* | undefined)
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#484 = (0 | ???*0*)
 - *0* updated with update expression
@@ -10472,7 +10472,7 @@ c#484 = (0 | ???*0*)
 
 c#485 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#494 = (
   | null["queue"]
@@ -10496,7 +10496,7 @@ c#494 = (
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["next"]
   ⚠️  unknown object
 - *6* P
@@ -10506,7 +10506,7 @@ c#494 = (
 - *8* ???*9*["alternate"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* a
   ⚠️  circular variable reference
 - *11* ???*12*["next"]
@@ -10544,7 +10544,7 @@ c#501 = (
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["next"]
   ⚠️  unknown object
 - *6* P
@@ -10554,7 +10554,7 @@ c#501 = (
 - *8* ???*9*["alternate"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* a
   ⚠️  circular variable reference
 - *11* ???*12*["next"]
@@ -10589,7 +10589,7 @@ c#504 = (
   | (null !== (null["next"] | ???*16* | undefined["next"] | null | ???*19*))
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* N
@@ -10651,11 +10651,11 @@ c#506 = (
   | ???*22*
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stores"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* N
@@ -10699,17 +10699,17 @@ c#506 = (
 
 c#507 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#508 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#510 = (???*0*() | undefined)
 - *0* ???*1*["getSnapshot"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#515 = (
   | ???*0*
@@ -10733,11 +10733,11 @@ c#515 = (
   | ???*22*
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["lastEffect"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* N
@@ -10781,11 +10781,11 @@ c#515 = (
 
 c#517 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#518 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#52 = ???*0*
 - *0* c
@@ -10793,7 +10793,7 @@ c#52 = ???*0*
 
 c#528 = (???*0* | (???*1* ? ???*3* : null))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (null !== ???*2*)
   ⚠️  nested operation
 - *2* c
@@ -10829,7 +10829,7 @@ c#530 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -10837,7 +10837,7 @@ c#530 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -10895,7 +10895,7 @@ c#531 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -10903,7 +10903,7 @@ c#531 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -10937,7 +10937,7 @@ c#531 = (
 
 c#532 = (???*0* | 64 | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -10978,13 +10978,13 @@ c#533 = (
 - *12* unsupported expression
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["value"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#537 = (
   | ???*0*
@@ -11011,14 +11011,14 @@ c#537 = (
   | (???*25* ? ???*29* : null)
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* Ck
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* C
   ⚠️  circular variable reference
 - *5* (0 !== ???*6*)
@@ -11046,11 +11046,11 @@ c#537 = (
 - *16* unsupported expression
   ⚠️  This value might have side effects
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*["value"]
   ⚠️  unknown object
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* ???*21*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -11070,17 +11070,17 @@ c#537 = (
 - *27* ???*28*["alternate"]
   ⚠️  unknown object
 - *28* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *29* ???*30*["stateNode"]
   ⚠️  unknown object
 - *30* ???*31*["alternate"]
   ⚠️  unknown object
 - *31* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#539 = (???*0* | (???*1* ? ???*5* : null))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === ???*2*)
   ⚠️  nested operation
 - *2* ???*3*["tag"]
@@ -11088,29 +11088,29 @@ c#539 = (???*0* | (???*1* ? ???*5* : null))
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#546 = ???*0*
 - *0* ???*1*["pending"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#547 = (???*0* | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
 c#550 = (???*0* | (???*1* ? ???*3* : null))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (null !== ???*2*)
   ⚠️  nested operation
 - *2* c
@@ -11146,7 +11146,7 @@ c#553 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -11154,7 +11154,7 @@ c#553 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -11188,15 +11188,15 @@ c#553 = (
 
 c#554 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#559 = (???*0* | ???*1*() | ???*2*())
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* c
   ⚠️  circular variable reference
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#56 = ???*0*
 - *0* ???*1*(???*3*, ((???*6* | ???*8*) ? "checked" : "value"))
@@ -11211,11 +11211,11 @@ c#56 = ???*0*
 - *4* ???*5*["constructor"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["nodeName"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ("input" === ???*9*)
   ⚠️  nested operation
 - *9* ???*10*()
@@ -11223,7 +11223,7 @@ c#56 = ???*0*
 - *10* ???*11*["toLowerCase"]
   ⚠️  unknown object
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#562 = ???*0*
 - *0* max number of linking steps reached
@@ -11235,7 +11235,7 @@ c#570 = ???*0*
 
 c#573 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#576 = ???*0*
 - *0* c
@@ -11246,7 +11246,7 @@ c#578 = (
   | {"eventTime": ???*1*, "lane": ???*2*, "tag": 0, "payload": null, "callback": null, "next": null}
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* c
@@ -11257,7 +11257,7 @@ c#580 = (
   | {"eventTime": ???*1*, "lane": ???*2*, "tag": 0, "payload": null, "callback": null, "next": null}
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* c
@@ -11267,23 +11267,23 @@ c#584 = ???*0*
 - *0* ???*1*["stack"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#585 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#589 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#590 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#591 = (???*0* | ???*1* | (0 !== (0 | ???*3*)))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["render"]
   ⚠️  unknown object
 - *2* c
@@ -11293,7 +11293,7 @@ c#591 = (???*0* | ???*1* | (0 !== (0 | ???*3*)))
 
 c#592 = (???*0* | ???*1* | (???*3* ? ???*5* : (...) => (???*6* | ???*7*)))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["compare"]
   ⚠️  unknown object
 - *2* c
@@ -11311,21 +11311,21 @@ c#592 = (???*0* | ???*1* | (???*3* ? ???*5* : (...) => (???*6* | ???*7*)))
 
 c#595 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#597 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#599 = ???*0*
 - *0* ???*1*["ref"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#600 = (???*0* | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*(d, e)
   ⚠️  unknown callee
 - *2* c
@@ -11333,47 +11333,47 @@ c#600 = (???*0* | ???*1*)
 
 c#601 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#605 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#607 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#609 = (???*0* | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["deletions"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#613 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#614 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#619 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#620 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#621 = (???*0* | ???*1* | 0["revealOrder"] | ???*3* | null | ???*5*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["revealOrder"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -11388,45 +11388,45 @@ c#629 = (
   | new (...) => undefined(???*3*, ???*5*, ???*7*, ???*9*)
 )
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["tag"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["pendingProps"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["key"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["mode"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#631 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#634 = ???*0*
 - *0* ???*1*["child"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#639 = (???*0* | null | {} | ???*1* | ???*5* | undefined | (???*19* ? ???*20* : undefined))
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*[(???*3* | null | undefined | [] | ???*4*)]
   ⚠️  unknown object
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
@@ -11463,7 +11463,7 @@ c#639 = (???*0* | null | {} | ???*1* | ???*5* | undefined | (???*19* ? ???*20* :
 - *15* ???*16*["_wrapperState"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* for-in variable currently not analyzed
 - *18* f
   ⚠️  circular variable reference
@@ -11480,19 +11480,19 @@ c#64 = (???*0*() | ""["_valueTracker"]["getValue"]())
 - *1* ???*2*["_valueTracker"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#644 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#645 = (null | ???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["tail"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#646 = (0 | ???*0*)
 - *0* unsupported assign operation
@@ -11506,11 +11506,11 @@ c#667 = ???*0*
 - *0* ???*1*["ref"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#670 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#673 = ???*0*
 - *0* max number of linking steps reached
@@ -11520,11 +11520,11 @@ c#68 = ???*0*
 - *0* ???*1*["checked"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#687 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#69 = ((???*0* ? "" : ???*3*) | (???*5* ? ???*8* : ???*10*) | "" | undefined)
 - *0* (null == ???*1*)
@@ -11532,21 +11532,21 @@ c#69 = ((???*0* ? "" : ???*3*) | (???*5* ? ???*8* : ???*10*) | "" | undefined)
 - *1* ???*2*["defaultValue"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["defaultValue"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (null != ???*6*)
   ⚠️  nested operation
 - *6* ???*7*["value"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["value"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* c
   ⚠️  circular variable reference
 
@@ -11554,7 +11554,7 @@ c#691 = (???*0* | (???*2* ? ???*4* : null)["next"] | undefined)
 - *0* ???*1*["next"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== ???*3*)
   ⚠️  nested operation
 - *3* b
@@ -11568,15 +11568,15 @@ c#695 = (???*0* | undefined)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#7 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#703 = (???*0* | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["_reactRootContainer"]
   ⚠️  unknown object
 - *2* c
@@ -11584,11 +11584,11 @@ c#703 = (???*0* | ???*1*)
 
 c#704 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#705 = (???*0* | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* c
@@ -11596,7 +11596,7 @@ c#705 = (???*0* | ???*1*)
 
 c#706 = (???*0* | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* c
@@ -11606,13 +11606,13 @@ c#71 = (???*0* | "" | undefined)
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#713 = (???*0* | undefined | new ???*2*())
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? ???*6* : ???*7*)
   ⚠️  nested operation
 - *3* ("function" === ???*4*)
@@ -11633,7 +11633,7 @@ c#716 = ???*0*
 - *0* ???*1*["deletions"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#721 = ???*0*
 - *0* max number of linking steps reached
@@ -11641,29 +11641,29 @@ c#721 = ???*0*
 
 c#74 = (???*0* | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["name"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#756 = (???*0* | undefined)
 - *0* ???*1*["return"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#76 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#763 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#764 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#768 = ???*0*
 - *0* max number of linking steps reached
@@ -11671,7 +11671,7 @@ c#768 = ???*0*
 
 c#77 = (???*0* | 0 | ???*1* | ???*2* | "" | undefined)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 - *2* c
@@ -11687,11 +11687,11 @@ c#785 = ???*0*
 
 c#8 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#802 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#803 = (
   | ???*0*
@@ -11705,7 +11705,7 @@ c#803 = (
 - *0* ???*1*["callbackNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* c
   ⚠️  circular variable reference
 - *3* (...) => (null | ???*4*)["bind"](null, ???*5*)
@@ -11713,7 +11713,7 @@ c#803 = (
 - *4* ((a["callbackNode"] === c) ? Hk["bind"](null, a) : null)
   ⚠️  nested operation
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#807 = ???*0*
 - *0* max number of linking steps reached
@@ -11727,7 +11727,7 @@ c#819 = (???*0* | undefined)
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#827 = (???*0* | undefined)
 - *0* unsupported expression
@@ -11741,9 +11741,9 @@ c#83 = (???*0* | ""["value"] | ""["children"] | ???*2* | ???*3* | "")
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* c
   ⚠️  circular variable reference
 
@@ -11773,21 +11773,21 @@ c#87 = (???*0* | "" | undefined | ???*2*)
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* c
   ⚠️  circular variable reference
 
 c#877 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#880 = (???*0* | ???*1* | null["finishedWork"] | 0 | ???*3*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["finishedWork"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 
@@ -11828,29 +11828,29 @@ c#883 = (
 - *12* unsupported expression
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["value"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#9 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#909 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#910 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#915 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#916 = (???*0* ? ???*2* : ???*3*)
 - *0* (0 !== ???*1*)
@@ -11882,7 +11882,7 @@ c#917 = (0 | ???*0*)
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#918 = (0 | ???*0*)
 - *0* ???*1*["retryLane"]
@@ -11890,7 +11890,7 @@ c#918 = (0 | ???*0*)
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#919 = ???*0*
 - *0* max number of linking steps reached
@@ -11898,15 +11898,15 @@ c#919 = ???*0*
 
 c#92 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#941 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#942 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#946 = (
   | ???*0*
@@ -11915,77 +11915,77 @@ c#946 = (
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["tag"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["dependencies"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["key"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["mode"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#947 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#948 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#949 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#950 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#951 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#952 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#953 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#954 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#955 = (???*0* | undefined)
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#96 = (???*0* | undefined)
 - *0* ???*1*["firstChild"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#960 = (???*0* | ???*1* | ???*3*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["current"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["current"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -11994,7 +11994,7 @@ c#960 = (???*0* | ???*1* | ???*3*)
 
 c#961 = (???*0* | {} | ???*1* | ???*2* | undefined | ???*4*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* c
   ⚠️  circular variable reference
 - *2* ???*3*["_reactInternals"]
@@ -12024,7 +12024,7 @@ c#963 = (???*0* | undefined)
 - *0* ???*1*["retryLane"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#974 = (0 | undefined | ???*0*)
 - *0* updated with update expression
@@ -12032,11 +12032,11 @@ c#974 = (0 | undefined | ???*0*)
 
 c#979 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#986 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#990 = (
   | 1
@@ -12060,7 +12060,7 @@ c#990 = (
 - *2* ???*3*["stateNode"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 c#992 = ((???*0* ? ???*2* : ???*3*) | undefined)
 - *0* (0 !== ???*1*)
@@ -12118,13 +12118,13 @@ c#997 = ((???*0* ? ???*4* : null) | undefined)
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["stateNode"]
   ⚠️  unknown object
 - *5* ???*6*["alternate"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 ca = module<scheduler, {}>
 
@@ -12185,13 +12185,13 @@ d#1004 = (???*0* | undefined)
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["name"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["name"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -12213,7 +12213,7 @@ d#1013 = (
 - *0* ???*1*["identifierPrefix"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* unsupported assign operation
@@ -12239,7 +12239,7 @@ d#1013 = (
 
 d#1018 = ((null != (???*0* | ???*1*)) | ???*3* | null)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*[a]
   ⚠️  unknown object
 - *2* d
@@ -12247,7 +12247,7 @@ d#1018 = ((null != (???*0* | ???*1*)) | ???*3* | null)
 - *3* ???*4*["hydratedSources"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#102 = ((0 === (???*0* | ???*2*)) | undefined)
 - *0* ???*1*["indexOf"]("--")
@@ -12258,7 +12258,7 @@ d#102 = ((0 === (???*0* | ???*2*)) | undefined)
 
 d#1023 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#119 = (
   | ???*0*
@@ -12273,7 +12273,7 @@ d#119 = (
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["slice"](2)
   ⚠️  unknown callee object
 - *4* ???*5*(36)
@@ -12313,7 +12313,7 @@ d#119 = (
 - *20* ("button" === (???*21* | ???*22* | ???*24* | false))
   ⚠️  nested operation
 - *21* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* ???*23*["type"]
   ⚠️  unknown object
 - *23* a
@@ -12325,15 +12325,15 @@ d#119 = (
 
 d#123 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#127 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#128 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#136 = (
   | ???*0*
@@ -12347,15 +12347,15 @@ d#136 = (
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (3 === ???*3*)
   ⚠️  nested operation
 - *3* ???*4*["tag"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* a
   ⚠️  circular variable reference
 - *7* ???*8*["return"]
@@ -12385,7 +12385,7 @@ d#159 = (
 - *1* ???*2*["pingedLanes"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -12393,13 +12393,13 @@ d#162 = ???*0*
 - *0* ???*1*["pingedLanes"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#169 = ???*0*
 - *0* ???*1*["eventTimes"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#171 = (???*0* | undefined)
 - *0* unsupported expression
@@ -12407,11 +12407,11 @@ d#171 = (???*0* | undefined)
 
 d#175 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#176 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#183 = ???*0*
 - *0* max number of linking steps reached
@@ -12429,19 +12429,19 @@ d#189 = (???*0* | ???*1* | ???*2* | undefined)
 
 d#193 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#196 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#199 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#203 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#207 = (???*0* | 1 | ???*1*)
 - *0* d
@@ -12451,21 +12451,21 @@ d#207 = (???*0* | 1 | ???*1*)
 
 d#212 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#236 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#25 = (???*0* | (???*1* ? ???*6* : null)["attributeNamespace"] | ???*8*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined | ???*2*)((???*3* | ???*4*))
   ⚠️  non-function callee
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["attributeName"]
   ⚠️  unknown object
 - *5* e
@@ -12474,7 +12474,7 @@ d#25 = (???*0* | (???*1* ? ???*6* : null)["attributeNamespace"] | ???*8*)
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["attributeNamespace"]
   ⚠️  unknown object
 - *9* ???*10*["type"]
@@ -12491,7 +12491,7 @@ d#251 = (???*0* | 0 | ???*4*)
   ⚠️  This value might have side effects
 - *2* Object: The global Object variable
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 
@@ -12505,7 +12505,7 @@ d#254 = (
 - *0* d
   ⚠️  pattern without value
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* d
   ⚠️  circular variable reference
 - *3* ???*4*["length"]
@@ -12513,7 +12513,7 @@ d#254 = (
 - *4* ???*5*["textContent"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#264 = ???*0*
 - *0* d
@@ -12531,14 +12531,14 @@ d#274 = (???*0* | "unknown-event"){truthy}
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#275 = (???*0* | null[(0 | ???*3*)] | undefined[(0 | ???*4*)] | undefined | ???*5*)
 - *0* ???*1*[(0 | ???*2*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* updated with update expression
   ⚠️  This value might have side effects
 - *3* updated with update expression
@@ -12552,7 +12552,7 @@ d#275 = (???*0* | null[(0 | ???*3*)] | undefined[(0 | ???*4*)] | undefined | ???
 
 d#280 = `${???*0*}__bubble`
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#281 = (0 | ???*0*)
 - *0* unsupported assign operation
@@ -12560,11 +12560,11 @@ d#281 = (0 | ???*0*)
 
 d#285 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#286 = (???*0* | ???*1* | undefined | ???*3*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["tag"]
   ⚠️  unknown object
 - *2* d
@@ -12584,7 +12584,7 @@ d#308 = []
 
 d#311 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#320 = (0 | ???*0*)
 - *0* updated with update expression
@@ -12594,13 +12594,13 @@ d#341 = ???*0*
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#345 = (???*0* | ???*2*())
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["getChildContext"]
   ⚠️  unknown object
 - *3* d
@@ -12610,7 +12610,7 @@ d#347 = (???*0* | undefined | ???*2* | ???*3*)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* ???*4*["stateNode"]
@@ -12633,13 +12633,13 @@ d#350 = (
 - *0* updated with update expression
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* [???*4*][undefined]
   ⚠️  non-num constant property on array
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* [][???*6*]
   ⚠️  unknown array prototype methods or values
 - *6* updated with update expression
@@ -12672,23 +12672,23 @@ d#385 = (???*0* | undefined)
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#391 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#396 = ???*0*
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#398 = (???*0* | undefined | ???*2*)
 - *0* ???*1*["lanes"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -12696,7 +12696,7 @@ d#400 = (???*0* | null["alternate"] | undefined["alternate"] | undefined | ???*2
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* ???*4*["alternate"]
@@ -12707,28 +12707,28 @@ d#400 = (???*0* | null["alternate"] | undefined["alternate"] | undefined | ???*2
 
 d#404 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#412 = (???*0* | 0["effects"][(???*4* | 0 | ???*5*)] | undefined | ???*6*)
 - *0* ???*1*[(???*2* | 0 | ???*3*)]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* updated with update expression
   ⚠️  This value might have side effects
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#415 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#417 = (???*0* ? ???*2* : ???*3*)
 - *0* (0 !== ???*1*)
@@ -12799,7 +12799,7 @@ d#419 = (
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["_reactInternals"]
   ⚠️  unknown object
 - *4* a
@@ -12831,11 +12831,11 @@ d#419 = (
 - *17* unsupported expression
   ⚠️  This value might have side effects
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["value"]
   ⚠️  unknown object
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -12849,7 +12849,7 @@ d#419 = (
 
 d#420 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#421 = (
   | false
@@ -12861,11 +12861,11 @@ d#421 = (
 - *0* ???*1*["contextTypes"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* b
   ⚠️  circular variable reference
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["contextType"]
   ⚠️  unknown object
 - *5* b
@@ -12883,7 +12883,7 @@ d#421 = (
 - *11* ???*12*["stateNode"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* d
   ⚠️  circular variable reference
 - *14* d
@@ -12891,17 +12891,17 @@ d#421 = (
 
 d#422 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#423 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#424 = (???*0* | undefined)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#431 = (...) => a
 
@@ -12909,11 +12909,11 @@ d#432 = (???*0* | undefined)
 - *0* ???*1*["deletions"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#434 = (???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["sibling"]
   ⚠️  unknown object
 - *2* d
@@ -12921,15 +12921,15 @@ d#434 = (???*0* | ???*1*)
 
 d#437 = (???*0* | ???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#439 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#440 = (
   | ???*0*
@@ -12941,7 +12941,7 @@ d#440 = (
   | new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*38*, ???*40*, (???*41* | ???*43*))
 )
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* a
@@ -12953,7 +12953,7 @@ d#440 = (
 - *5* ???*6*["props"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["key"]
   ⚠️  unknown object
 - *8* a
@@ -12967,25 +12967,25 @@ d#440 = (
 - *12* ???*13*["key"]
   ⚠️  unknown object
 - *13* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*15*, ???*17*, (???*18* | ???*20*))
   ⚠️  nested operation
 - *15* ???*16*["props"]
   ⚠️  unknown object
 - *16* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* b
   ⚠️  circular variable reference
 - *18* ???*19*["mode"]
   ⚠️  unknown object
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* unsupported assign operation
   ⚠️  This value might have side effects
 - *21* ???*22*["mode"]
   ⚠️  unknown object
 - *22* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* unsupported assign operation
   ⚠️  This value might have side effects
 - *24* a
@@ -12996,47 +12996,47 @@ d#440 = (
 - *26* ???*27*["key"]
   ⚠️  unknown object
 - *27* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*29*, ???*31*, (???*32* | ???*34*))
   ⚠️  nested operation
 - *29* ???*30*["props"]
   ⚠️  unknown object
 - *30* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *31* b
   ⚠️  circular variable reference
 - *32* ???*33*["mode"]
   ⚠️  unknown object
 - *33* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *34* unsupported assign operation
   ⚠️  This value might have side effects
 - *35* ???*36*["mode"]
   ⚠️  unknown object
 - *36* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* unsupported assign operation
   ⚠️  This value might have side effects
 - *38* ???*39*["props"]
   ⚠️  unknown object
 - *39* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *40* b
   ⚠️  circular variable reference
 - *41* ???*42*["mode"]
   ⚠️  unknown object
 - *42* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *43* unsupported assign operation
   ⚠️  This value might have side effects
 
 d#441 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#442 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#443 = (
   | ???*0*
@@ -13048,13 +13048,13 @@ d#443 = (
 - *0* ???*1*["_init"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* ???*4*["mode"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (???*6* ? ???*9* : [])
   ⚠️  nested operation
 - *6* (null !== ???*7*)
@@ -13078,15 +13078,15 @@ d#443 = (
 - *15* ???*16*["mode"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#445 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#447 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#459 = ???*0*
 - *0* max number of linking steps reached
@@ -13094,7 +13094,7 @@ d#459 = ???*0*
 
 d#485 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#494 = ???*0*
 - *0* max number of linking steps reached
@@ -13125,7 +13125,7 @@ d#501 = (
 - *4* ???*5*["memoizedState"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["next"]
   ⚠️  unknown object
 - *7* P
@@ -13137,7 +13137,7 @@ d#501 = (
 - *10* ???*11*["alternate"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* a
   ⚠️  circular variable reference
 - *13* ???*14*["next"]
@@ -13179,7 +13179,7 @@ d#504 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -13187,7 +13187,7 @@ d#504 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -13221,7 +13221,7 @@ d#504 = (
 
 d#507 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#512 = ???*0*
 - *0* d
@@ -13249,11 +13249,11 @@ d#515 = (
   | ???*22*
 )
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["next"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* N
@@ -13300,11 +13300,11 @@ d#515 = (
 
 d#517 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#518 = (???*0* | (???*1* ? null : ???*3*))
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined === ???*2*)
   ⚠️  nested operation
 - *2* d
@@ -13334,7 +13334,7 @@ d#530 = (
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["next"]
   ⚠️  unknown object
 - *6* P
@@ -13344,7 +13344,7 @@ d#530 = (
 - *8* ???*9*["alternate"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* a
   ⚠️  circular variable reference
 - *11* ???*12*["next"]
@@ -13382,7 +13382,7 @@ d#531 = (
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["next"]
   ⚠️  unknown object
 - *6* P
@@ -13392,7 +13392,7 @@ d#531 = (
 - *8* ???*9*["alternate"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* a
   ⚠️  circular variable reference
 - *11* ???*12*["next"]
@@ -13430,7 +13430,7 @@ d#537 = (
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* C
   ⚠️  circular variable reference
 - *4* (0 !== ???*5*)
@@ -13458,11 +13458,11 @@ d#537 = (
 - *15* unsupported expression
   ⚠️  This value might have side effects
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["value"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -13494,7 +13494,7 @@ d#539 = (
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* C
   ⚠️  circular variable reference
 - *4* (0 !== ???*5*)
@@ -13522,11 +13522,11 @@ d#539 = (
 - *15* unsupported expression
   ⚠️  This value might have side effects
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["value"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -13542,7 +13542,7 @@ d#547 = (???*0* | undefined | ???*2*)
 - *0* ???*1*["lanes"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -13572,7 +13572,7 @@ d#554 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -13580,7 +13580,7 @@ d#554 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -13631,7 +13631,7 @@ d#559 = (
   | (null !== (null["next"] | ???*16* | undefined["next"] | null | ???*19*))
 )
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* N
@@ -13675,9 +13675,9 @@ d#56 = (???*0* | ???*2*)
 - *0* ???*1*[b]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#562 = ???*0*
 - *0* max number of linking steps reached
@@ -13685,7 +13685,7 @@ d#562 = ???*0*
 
 d#570 = (???*0* | undefined | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* d
@@ -13695,7 +13695,7 @@ d#578 = ???*0*
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#580 = ???*0*
 - *0* ???*1*["getDerivedStateFromError"]
@@ -13703,7 +13703,7 @@ d#580 = ???*0*
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#585 = (
   | ???*0*
@@ -13713,13 +13713,13 @@ d#585 = (
 - *0* ???*1*["pingCache"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* a
   ⚠️  circular variable reference
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* (???*6* ? ???*9* : ???*10*)
   ⚠️  nested operation
 - *6* ("function" === ???*7*)
@@ -13738,19 +13738,19 @@ d#585 = (
 
 d#589 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#590 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#591 = (???*0* | ???*1*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (???*2* | ???*3* | (0 !== (0 | ???*5*)))(d, e)
   ⚠️  non-function callee
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["render"]
   ⚠️  unknown object
 - *4* c
@@ -13760,21 +13760,21 @@ d#591 = (???*0* | ???*1*)
 
 d#592 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#595 = (???*0* | ???*1* | undefined)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["memoizedProps"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#597 = (???*0* | (???*2* ? ???*12* : ???*22*) | ???*23* | ???*24*)
 - *0* ???*1*["pendingProps"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== ???*3*)
   ⚠️  nested operation
 - *3* (???*4* ? ???*10* : null)
@@ -13782,7 +13782,7 @@ d#597 = (???*0* | (???*2* ? ???*12* : ???*22*) | ???*23* | ???*24*)
 - *4* (null !== (???*5* | ???*6*))
   ⚠️  nested operation
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* (???*7* ? ???*8* : ???*9*)
   ⚠️  nested operation
 - *7* (null !== ???)
@@ -13790,11 +13790,11 @@ d#597 = (???*0* | (???*2* ? ???*12* : ???*22*) | ???*23* | ???*24*)
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["memoizedState"]
   ⚠️  unknown object
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ???*13*["baseLanes"]
   ⚠️  unknown object
 - *13* (???*14* ? ???*20* : null)
@@ -13802,7 +13802,7 @@ d#597 = (???*0* | (???*2* ? ???*12* : ???*22*) | ???*23* | ???*24*)
 - *14* (null !== (???*15* | ???*16*))
   ⚠️  nested operation
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* (???*17* ? ???*18* : ???*19*)
   ⚠️  nested operation
 - *17* (null !== ???)
@@ -13810,21 +13810,21 @@ d#597 = (???*0* | (???*2* ? ???*12* : ???*22*) | ???*23* | ???*24*)
 - *18* unsupported expression
   ⚠️  This value might have side effects
 - *19* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* ???*21*["memoizedState"]
   ⚠️  unknown object
 - *21* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* unsupported expression
   ⚠️  This value might have side effects
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#600 = (???*0* | (0 !== (0 | ???*1*)))
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* updated with update expression
   ⚠️  This value might have side effects
 
@@ -13834,15 +13834,15 @@ d#601 = ???*0*
 
 d#605 = (???*0* | ???*1*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#607 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#609 = ???*0*
 - *0* max number of linking steps reached
@@ -13850,7 +13850,7 @@ d#609 = ???*0*
 
 d#613 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#614 = ???*0*
 - *0* max number of linking steps reached
@@ -13860,17 +13860,17 @@ d#619 = ???*0*
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#620 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#621 = (???*0* | 0 | ???*2* | ???*3* | ???*4*)
 - *0* ???*1*["pendingProps"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unknown mutation
   ⚠️  This value might have side effects
 - *3* unsupported expression
@@ -13884,13 +13884,13 @@ d#631 = (???*0* | (0 !== ???*3*))
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported expression
   ⚠️  This value might have side effects
 
 d#639 = (???*0* | ???*1*)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* Object.assign*2*(
         {},
         ???*3*,
@@ -13921,13 +13921,13 @@ d#639 = (???*0* | ???*1*)
 - *10* ???*11*["_wrapperState"]
   ⚠️  unknown object
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#64 = ("" | ((???*0* | ???*2*) ? ???*6* : ???*9*))
 - *0* ???*1*["nodeName"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ("input" === ???*3*)
   ⚠️  nested operation
 - *3* ???*4*()
@@ -13935,29 +13935,29 @@ d#64 = ("" | ((???*0* | ???*2*) ? ???*6* : ???*9*))
 - *4* ???*5*["toLowerCase"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* (???*7* ? "true" : "false")
   ⚠️  nested operation
 - *7* ???*8*["checked"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["value"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#644 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#645 = (null | ???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["tail"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#646 = (0 | ???*0*)
 - *0* unsupported assign operation
@@ -13983,7 +13983,7 @@ d#687 = (???*0* | (???*2* ? ???*4* : null))
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== ???*3*)
   ⚠️  nested operation
 - *3* d
@@ -13999,15 +13999,15 @@ d#69 = (???*0* ? ???*3* : ???*5*)
 - *1* ???*2*["checked"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["checked"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["defaultChecked"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#691 = (???*0* | (???*3* ? ???*5* : null)["next"]["create"] | undefined["create"] | undefined)
 - *0* ???*1*["create"]
@@ -14015,7 +14015,7 @@ d#691 = (???*0* | (???*3* ? ???*5* : null)["next"]["create"] | undefined["create
 - *1* ???*2*["next"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* b
@@ -14027,19 +14027,19 @@ d#691 = (???*0* | (???*3* ? ???*5* : null)["next"]["create"] | undefined["create
 
 d#7 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#703 = ???*0*
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#704 = ???*0*
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#706 = ???*0*
 - *0* max number of linking steps reached
@@ -14049,13 +14049,13 @@ d#71 = ???*0*
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#715 = (...) => undefined["bind"](null, ???*0*, ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#716 = (0 | ???*0*)
 - *0* updated with update expression
@@ -14069,13 +14069,13 @@ d#74 = (???*0* | undefined)
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#756 = (???*0* | undefined)
 - *0* ???*1*["return"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#764 = (0 !== ???*0*)
 - *0* unsupported expression
@@ -14087,7 +14087,7 @@ d#768 = ???*0*
 
 d#77 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#785 = ???*0*
 - *0* max number of linking steps reached
@@ -14095,11 +14095,11 @@ d#785 = ???*0*
 
 d#8 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#802 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#803 = (
   | 0
@@ -14122,9 +14122,9 @@ d#803 = (
 - *0* (???*1* === (null | ???*2* | ???*3* | ???*6*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* ???*5*["current"]
@@ -14158,13 +14158,13 @@ d#803 = (
 - *18* a
   ⚠️  circular variable reference
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* updated with update expression
   ⚠️  This value might have side effects
 - *21* ???*22*["entangledLanes"]
   ⚠️  unknown object
 - *22* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* unsupported assign operation
   ⚠️  This value might have side effects
 - *24* unsupported expression
@@ -14186,11 +14186,11 @@ d#829 = ((???*0* ? (???*3* | ???*4*) : ???*5*) | undefined)
 - *0* (0 !== (???*1* | ???*2*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* unsupported expression
   ⚠️  This value might have side effects
 - *5* (???*6* ? 1073741824 : 0)
@@ -14235,13 +14235,13 @@ d#834 = (
 - *12* unsupported expression
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["value"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#838 = ???*0*
 - *0* max number of linking steps reached
@@ -14269,7 +14269,7 @@ d#843 = (
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* N
@@ -14336,7 +14336,7 @@ d#87 = (???*0* | "" | undefined)
 - *0* ???*1*["defaultValue"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#877 = (
   | 0
@@ -14375,27 +14375,27 @@ d#877 = (
 - *12* unsupported expression
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["value"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#880 = (???*0* | ???*1* | null["onRecoverableError"])
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["onRecoverableError"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#883 = (false | undefined | true)
 
 d#9 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#910 = ???*0*
 - *0* max number of linking steps reached
@@ -14405,13 +14405,13 @@ d#915 = ???*0*
 - *0* ???*1*["pingCache"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#918 = ???*0*
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#919 = ???*0*
 - *0* max number of linking steps reached
@@ -14419,15 +14419,15 @@ d#919 = ???*0*
 
 d#92 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#941 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#942 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#947 = (
   | ???*0*
@@ -14437,75 +14437,75 @@ d#947 = (
   | null
 )
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*4*, ???*5*, (???*6* | ???*7*))
   ⚠️  nested operation
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* b
   ⚠️  circular variable reference
 - *6* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unsupported assign operation
   ⚠️  This value might have side effects
 - *8* unsupported expression
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*12*, ???*13*, (???*14* | ???*15*))
   ⚠️  nested operation
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* b
   ⚠️  circular variable reference
 - *14* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unsupported assign operation
   ⚠️  This value might have side effects
 - *16* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* unsupported assign operation
   ⚠️  This value might have side effects
 - *18* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*21*, ???*22*, (???*23* | ???*24*))
   ⚠️  nested operation
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* b
   ⚠️  circular variable reference
 - *23* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* unsupported assign operation
   ⚠️  This value might have side effects
 - *25* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *26* unsupported assign operation
   ⚠️  This value might have side effects
 
 d#948 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#949 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#952 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#953 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#954 = ((???*0* | ???*1*) ? ???*4* : null)
 - *0* unsupported expression
@@ -14527,7 +14527,7 @@ d#954 = ((???*0* | ???*1*) ? ???*4* : null)
 
 d#960 = (???*0* | (???*1* ? ???*3* : ???*4*))
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (0 !== ???*2*)
   ⚠️  nested operation
 - *2* unsupported expression
@@ -14553,7 +14553,7 @@ d#960 = (???*0* | (???*1* ? ???*3* : ???*4*))
 
 d#961 = (???*0* | (???*1* ? null : ???*3*))
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (undefined === ???*2*)
   ⚠️  nested operation
 - *2* d
@@ -14563,11 +14563,11 @@ d#961 = (???*0* | (???*1* ? null : ???*3*))
 
 d#979 = (???*0* | (...) => undefined)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#986 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 d#997 = ((???*0* ? ???*2* : ???*3*) | undefined)
 - *0* (0 !== ???*1*)
@@ -14670,13 +14670,13 @@ e#1004 = (???*0* | undefined[`__reactProps$${???*14*}`] | null | undefined)
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["name"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["name"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -14727,7 +14727,7 @@ e#1013 = (
 - *4* ???*5*["onRecoverableError"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* a
   ⚠️  circular variable reference
 - *7* unsupported assign operation
@@ -14751,11 +14751,11 @@ e#1018 = (
 - *0* ???*1*["_getVersion"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* c
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 - *5* ???*6*["_getVersion"]
@@ -14769,11 +14769,11 @@ e#1018 = (
 - *8* c
   ⚠️  circular variable reference
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* updated with update expression
   ⚠️  This value might have side effects
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* updated with update expression
   ⚠️  This value might have side effects
 - *13* ???*14*(c["_source"])
@@ -14787,7 +14787,7 @@ e#102 = ((???*0* ? "" : ???*3*) | undefined)
 - *1* ???*2*[c]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ((???*4* | undefined | ???*8* | ???*11*) ? ???*12* : ???*16*)
   ⚠️  nested operation
 - *4* (0 === (???*5* | ???*7*))
@@ -14811,25 +14811,25 @@ e#102 = ((???*0* ? "" : ???*3*) | undefined)
 - *14* ???*15*[c]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* `${???*17*}px`
   ⚠️  nested operation
 - *17* ???*18*[c]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#123 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#127 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#128 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#136 = (
   | ???*0*
@@ -14840,15 +14840,15 @@ e#136 = (
 - *0* ???*1*["return"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (3 === ???*3*)
   ⚠️  nested operation
 - *3* ???*4*["tag"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* a
   ⚠️  circular variable reference
 - *7* ???*8*["return"]
@@ -14860,7 +14860,7 @@ e#159 = (???*0* | ???*2*)
 - *0* ???*1*["suspendedLanes"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported expression
   ⚠️  This value might have side effects
 
@@ -14868,7 +14868,7 @@ e#162 = ???*0*
 - *0* ???*1*["expirationTimes"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#169 = (???*0* | undefined)
 - *0* unsupported expression
@@ -14880,11 +14880,11 @@ e#171 = (???*0* | undefined)
 
 e#175 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#176 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#193 = (
   | 0
@@ -14923,13 +14923,13 @@ e#193 = (
 - *12* unsupported expression
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["value"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#196 = (
   | 0
@@ -14968,13 +14968,13 @@ e#196 = (
 - *12* unsupported expression
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["value"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#199 = ???*0*
 - *0* max number of linking steps reached
@@ -14992,7 +14992,7 @@ e#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))
 - *4* ???*5*["nodeType"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15002,7 +15002,7 @@ e#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))
 - *8* ???*9*["parentNode"]
   ⚠️  unknown object
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15010,7 +15010,7 @@ e#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["target"]
   ⚠️  unknown object
 - *14* a
@@ -15027,7 +15027,7 @@ e#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))
 - *19* ???*20*["nodeType"]
   ⚠️  unknown object
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15037,7 +15037,7 @@ e#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))
 - *23* ???*24*["parentNode"]
   ⚠️  unknown object
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15045,7 +15045,7 @@ e#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *27* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* ???*29*["target"]
   ⚠️  unknown object
 - *29* a
@@ -15056,7 +15056,7 @@ e#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))
 
 e#212 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#25 = ((???*0* ? ???*5* : null) | ???*7*)
 - *0* (undefined | ???*1*)((???*2* | ???*3*))
@@ -15064,7 +15064,7 @@ e#25 = ((???*0* ? ???*5* : null) | ???*7*)
 - *1* unknown mutation
   ⚠️  This value might have side effects
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["attributeName"]
   ⚠️  unknown object
 - *4* e
@@ -15073,7 +15073,7 @@ e#25 = ((???*0* ? ???*5* : null) | ???*7*)
   ⚠️  unknown object prototype methods or values
   ⚠️  This value might have side effects
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["type"]
   ⚠️  unknown object
 - *8* e
@@ -15091,7 +15091,7 @@ e#251 = (???*0* | undefined)
   ⚠️  This value might have side effects
 - *3* Object: The global Object variable
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#266 = ???*0*
 - *0* max number of linking steps reached
@@ -15112,7 +15112,7 @@ e#275 = (
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* updated with update expression
@@ -15130,7 +15130,7 @@ e#285 = ((...) => undefined | undefined | true)
 
 e#286 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#292 = (
   | (???*0* ? (???*5* | ???*7*) : (???*9* | ???*10* | ???*12*))
@@ -15141,7 +15141,7 @@ e#292 = (
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15151,7 +15151,7 @@ e#292 = (
 - *5* ???*6*["parentNode"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15159,7 +15159,7 @@ e#292 = (
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["target"]
   ⚠️  unknown object
 - *11* a
@@ -15170,7 +15170,7 @@ e#292 = (
 - *13* unsupported expression
   ⚠️  This value might have side effects
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* e
   ⚠️  circular variable reference
 
@@ -15198,7 +15198,7 @@ e#308 = (
   | !(???*28*)[???*34*]
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* a
@@ -15214,17 +15214,17 @@ e#308 = (
 - *7* d
   ⚠️  circular variable reference
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["disabled"]
   ⚠️  unknown object
 - *10* d
   ⚠️  circular variable reference
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* ("button" === (???*13* | ???*14* | ???*16* | false))
   ⚠️  nested operation
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["return"]
   ⚠️  unknown object
 - *15* a
@@ -15234,7 +15234,7 @@ e#308 = (
 - *17* d
   ⚠️  circular variable reference
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*[Pf]
   ⚠️  unknown object
 - *20* c
@@ -15246,17 +15246,17 @@ e#308 = (
 - *23* d
   ⚠️  circular variable reference
 - *24* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*["disabled"]
   ⚠️  unknown object
 - *26* d
   ⚠️  circular variable reference
 - *27* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* ("button" === (???*29* | ???*30* | ???*32* | false))
   ⚠️  nested operation
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["return"]
   ⚠️  unknown object
 - *31* a
@@ -15266,17 +15266,17 @@ e#308 = (
 - *33* d
   ⚠️  circular variable reference
 - *34* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#311 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#320 = (???*0* | undefined)
 - *0* ???*1*["nextSibling"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#341 = {}
 
@@ -15297,7 +15297,7 @@ e#391 = ???*0*
 - *0* ???*1*["interleaved"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#396 = (???*0* | undefined)
 - *0* ???*1*["pending"]
@@ -15305,7 +15305,7 @@ e#396 = (???*0* | undefined)
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#400 = (
   | null
@@ -15325,7 +15325,7 @@ e#400 = (
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* ???*5*["lane"]
@@ -15333,7 +15333,7 @@ e#400 = (
 - *5* ???*6*["updateQueue"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unknown mutation
   ⚠️  This value might have side effects
 - *8* ???*9*["tag"]
@@ -15341,7 +15341,7 @@ e#400 = (
 - *9* ???*10*["updateQueue"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* unknown mutation
   ⚠️  This value might have side effects
 - *12* ???*13*["payload"]
@@ -15349,7 +15349,7 @@ e#400 = (
 - *13* ???*14*["updateQueue"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unknown mutation
   ⚠️  This value might have side effects
 - *16* ???*17*["callback"]
@@ -15357,19 +15357,19 @@ e#400 = (
 - *17* ???*18*["updateQueue"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* unknown mutation
   ⚠️  This value might have side effects
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#404 = (???*0* | ???*2*)
 - *0* ???*1*["updateQueue"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#412 = (
   | ???*0*
@@ -15385,19 +15385,19 @@ e#412 = (
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* updated with update expression
   ⚠️  This value might have side effects
 - *7* ???*8*["callback"]
   ⚠️  unknown object
 - *8* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#417 = (
   | 1
@@ -15420,7 +15420,7 @@ e#417 = (
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["_reactInternals"]
   ⚠️  unknown object
 - *4* a
@@ -15452,11 +15452,11 @@ e#417 = (
 - *17* unsupported expression
   ⚠️  This value might have side effects
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["value"]
   ⚠️  unknown object
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15489,7 +15489,7 @@ e#418 = (
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["_reactInternals"]
   ⚠️  unknown object
 - *4* a
@@ -15521,11 +15521,11 @@ e#418 = (
 - *17* unsupported expression
   ⚠️  This value might have side effects
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["value"]
   ⚠️  unknown object
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15587,7 +15587,7 @@ e#419 = {
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["_reactInternals"]
   ⚠️  unknown object
 - *15* a
@@ -15619,11 +15619,11 @@ e#419 = {
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -15637,19 +15637,19 @@ e#419 = {
 
 e#420 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#421 = ({} | (???*0* ? ({} | ???*16*) : ({} | ???*17*)))
 - *0* (null !== (???*1* | ???*2* | ???*14*))
   ⚠️  nested operation
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* new ???*3*(???*4*, (???*5* | undefined | ???*7* | ???*8*))
   ⚠️  nested operation
 - *3* b
   ⚠️  circular variable reference
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["contextType"]
   ⚠️  unknown object
 - *6* b
@@ -15681,13 +15681,13 @@ e#423 = ???*0*
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#424 = (???*0* | undefined)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#431 = (...) => a
 
@@ -15695,31 +15695,31 @@ e#445 = ((???*0* ? ???*2* : null) | ???*4*)
 - *0* (null !== ???*1*)
   ⚠️  nested operation
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*["key"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["_init"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#447 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#449 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#454 = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#485 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#494 = ???*0*
 - *0* max number of linking steps reached
@@ -15750,7 +15750,7 @@ e#501 = (
 - *4* ???*5*["memoizedState"]
   ⚠️  unknown object
 - *5* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["next"]
   ⚠️  unknown object
 - *7* P
@@ -15762,7 +15762,7 @@ e#501 = (
 - *10* ???*11*["alternate"]
   ⚠️  unknown object
 - *11* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* a
   ⚠️  circular variable reference
 - *13* ???*14*["next"]
@@ -15780,7 +15780,7 @@ e#501 = (
 
 e#504 = ???*0*()
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#517 = (
   | null
@@ -15808,7 +15808,7 @@ e#517 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -15816,7 +15816,7 @@ e#517 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -15874,7 +15874,7 @@ e#518 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -15882,7 +15882,7 @@ e#518 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -15967,7 +15967,7 @@ e#539 = (
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* C
   ⚠️  circular variable reference
 - *4* (0 !== ???*5*)
@@ -15995,11 +15995,11 @@ e#539 = (
 - *15* unsupported expression
   ⚠️  This value might have side effects
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["value"]
   ⚠️  unknown object
 - *18* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -16011,7 +16011,7 @@ e#539 = (
 - *22* a
   ⚠️  circular variable reference
 - *23* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* (3 === ???*25*)
   ⚠️  nested operation
 - *25* ???*26*["tag"]
@@ -16019,13 +16019,13 @@ e#539 = (
 - *26* ???*27*["alternate"]
   ⚠️  unknown object
 - *27* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* ???*29*["stateNode"]
   ⚠️  unknown object
 - *29* ???*30*["alternate"]
   ⚠️  unknown object
 - *30* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *31* (0 !== ???*32*)
   ⚠️  nested operation
 - *32* unsupported expression
@@ -16075,7 +16075,7 @@ e#559 = (
 - *2* ???*3*["memoizedState"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["next"]
   ⚠️  unknown object
 - *5* P
@@ -16083,7 +16083,7 @@ e#559 = (
 - *6* ???*7*["alternate"]
   ⚠️  unknown object
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* a
   ⚠️  circular variable reference
 - *9* ???*10*["next"]
@@ -16131,11 +16131,11 @@ e#56 = (???*0* | undefined)
 - *5* ???*6*["constructor"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["nodeName"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ("input" === ???*10*)
   ⚠️  nested operation
 - *10* ???*11*()
@@ -16151,7 +16151,7 @@ e#580 = (???*0* | undefined)
 - *0* ???*1*["value"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#585 = (new ???*0*() | undefined | ???*1* | ???*5*)
 - *0* FreeVar(Set)
@@ -16162,9 +16162,9 @@ e#585 = (new ???*0*() | undefined | ???*1* | ???*5*)
 - *2* ???*3*["pingCache"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*(???*12*)
   ⚠️  unknown callee
 - *6* ???*7*["get"]
@@ -16176,27 +16176,27 @@ e#585 = (new ???*0*() | undefined | ???*1* | ???*5*)
 - *9* a
   ⚠️  circular variable reference
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#589 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#591 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#592 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#595 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#597 = (???*0* | (???*3* ? ???*13* : ???*23*)["children"] | ???*24*)
 - *0* ???*1*["children"]
@@ -16204,7 +16204,7 @@ e#597 = (???*0* | (???*3* ? ???*13* : ???*23*)["children"] | ???*24*)
 - *1* ???*2*["pendingProps"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* (???*5* ? ???*11* : null)
@@ -16212,7 +16212,7 @@ e#597 = (???*0* | (???*3* ? ???*13* : ???*23*)["children"] | ???*24*)
 - *5* (null !== (???*6* | ???*7*))
   ⚠️  nested operation
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (???*8* ? ???*9* : ???*10*)
   ⚠️  nested operation
 - *8* (null !== ???)
@@ -16220,11 +16220,11 @@ e#597 = (???*0* | (???*3* ? ???*13* : ???*23*)["children"] | ???*24*)
 - *9* unsupported expression
   ⚠️  This value might have side effects
 - *10* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["memoizedState"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["baseLanes"]
   ⚠️  unknown object
 - *14* (???*15* ? ???*21* : null)
@@ -16232,7 +16232,7 @@ e#597 = (???*0* | (???*3* ? ???*13* : ???*23*)["children"] | ???*24*)
 - *15* (null !== (???*16* | ???*17*))
   ⚠️  nested operation
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* (???*18* ? ???*19* : ???*20*)
   ⚠️  nested operation
 - *18* (null !== ???)
@@ -16240,13 +16240,13 @@ e#597 = (???*0* | (???*3* ? ???*13* : ???*23*)["children"] | ???*24*)
 - *19* unsupported expression
   ⚠️  This value might have side effects
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["memoizedState"]
   ⚠️  unknown object
 - *22* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *23* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* ???*25*["children"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -16255,19 +16255,19 @@ e#597 = (???*0* | (???*3* ? ???*13* : ???*23*)["children"] | ???*24*)
 
 e#600 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#601 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#605 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#607 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#609 = ???*0*
 - *0* max number of linking steps reached
@@ -16279,7 +16279,7 @@ e#614 = ???*0*
 
 e#620 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#621 = (???*0* | 0["revealOrder"] | ???*3* | null | ???*5* | ???*6* | null["sibling"] | null["alternate"])
 - *0* ???*1*["revealOrder"]
@@ -16287,14 +16287,14 @@ e#621 = (???*0* | 0["revealOrder"] | ???*3* | null | ???*5* | ???*6* | null["sib
 - *1* ???*2*["pendingProps"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["revealOrder"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *4* unknown mutation
   ⚠️  This value might have side effects
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* e
   ⚠️  circular variable reference
 
@@ -16304,13 +16304,13 @@ e#631 = ???*0*
 - *1* ???*2*["memoizedProps"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#639 = (???*0* | ???*2*)
 - *0* ???*1*["memoizedProps"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* Object.assign*3*(
         {},
         ???*4*,
@@ -16341,13 +16341,13 @@ e#639 = (???*0* | ???*2*)
 - *11* ???*12*["_wrapperState"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#646 = ???*0*
 - *0* ???*1*["child"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#647 = ???*0*
 - *0* max number of linking steps reached
@@ -16363,7 +16363,7 @@ e#687 = (???*0* | (???*3* ? ???*5* : null)["next"] | undefined)
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* d
@@ -16383,7 +16383,7 @@ e#716 = (???*0* | undefined)
 - *1* ???*2*["deletions"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#721 = ???*0*
 - *0* max number of linking steps reached
@@ -16395,7 +16395,7 @@ e#756 = (???*0* | undefined["stateNode"] | undefined)
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#764 = ???*0*
 - *0* max number of linking steps reached
@@ -16412,7 +16412,7 @@ e#77 = (0 | undefined | ???*0* | ???*1* | ???*9* | null["hasOwnProperty"](???*17
   ⚠️  unknown callee object
   ⚠️  This value might have side effects
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["value"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -16420,9 +16420,9 @@ e#77 = (0 | undefined | ???*0* | ???*1* | ???*9* | null["hasOwnProperty"](???*17
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* updated with update expression
   ⚠️  This value might have side effects
 - *8* c
@@ -16439,9 +16439,9 @@ e#77 = (0 | undefined | ???*0* | ???*1* | ???*9* | null["hasOwnProperty"](???*17
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* updated with update expression
   ⚠️  This value might have side effects
 - *16* c
@@ -16455,9 +16455,9 @@ e#77 = (0 | undefined | ???*0* | ???*1* | ???*9* | null["hasOwnProperty"](???*17
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* updated with update expression
   ⚠️  This value might have side effects
 - *23* c
@@ -16478,7 +16478,7 @@ e#819 = (???*0* | undefined[(0 | undefined | ???*4*)] | undefined | ???*5*)
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* updated with update expression
@@ -16517,7 +16517,7 @@ e#843 = (
 - *1* ???*2*["memoizedState"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["alternate"]
   ⚠️  unknown object
 - *4* N
@@ -16567,7 +16567,7 @@ e#880 = (???*0* | null["finishedLanes"])
 - *0* ???*1*["finishedLanes"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#883 = ???*0*
 - *0* max number of linking steps reached
@@ -16575,13 +16575,13 @@ e#883 = ???*0*
 
 e#9 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#918 = ???*0*
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#919 = ???*0*
 - *0* max number of linking steps reached
@@ -16589,21 +16589,21 @@ e#919 = ???*0*
 
 e#92 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#947 = (???*0* | ???*1*)
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported assign operation
   ⚠️  This value might have side effects
 
 e#952 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#953 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#960 = (
   | ???*0*
@@ -16622,7 +16622,7 @@ e#960 = (
   | (???*40* ? 16 : (1 | 4 | 16 | 536870912 | undefined))
 )
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* unsupported expression
   ⚠️  This value might have side effects
 - *2* Ck
@@ -16631,11 +16631,11 @@ e#960 = (
 - *3* ???*4*["current"]
   ⚠️  unknown object
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* a
   ⚠️  circular variable reference
 - *6* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* (???*8* ? ???*10* : ???*11*)
   ⚠️  nested operation
 - *8* (0 !== ???*9*)
@@ -16663,9 +16663,9 @@ e#960 = (
 - *19* unsupported assign operation
   ⚠️  This value might have side effects
 - *20* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* C
   ⚠️  circular variable reference
 - *23* (0 !== ???*24*)
@@ -16693,11 +16693,11 @@ e#960 = (
 - *34* unsupported expression
   ⚠️  This value might have side effects
 - *35* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *36* ???*37*["value"]
   ⚠️  unknown object
 - *37* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *38* ???*39*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -16713,21 +16713,21 @@ e#961 = (???*0* | undefined | ???*2*)
 - *0* ???*1*["current"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unknown mutation
   ⚠️  This value might have side effects
 
 e#979 = (???*0* | ???*1*)
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["lastChild"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 e#986 = (???*0* | (...) => undefined)
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 ea = {}
 
@@ -16755,7 +16755,7 @@ ef = "abort auxClick cancel canPlay canPlayThrough click close contextMenu copy 
 
 eg = (null | [???*0*] | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["slice"]((a + 1))
   ⚠️  unknown callee object
 - *2* eg
@@ -16784,11 +16784,11 @@ f#1018 = (
 - *0* ???*1*["identifierPrefix"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* c
   ⚠️  circular variable reference
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 - *5* ???*6*["identifierPrefix"]
@@ -16802,25 +16802,25 @@ f#1018 = (
 - *8* c
   ⚠️  circular variable reference
 - *9* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* updated with update expression
   ⚠️  This value might have side effects
 - *11* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *12* updated with update expression
   ⚠️  This value might have side effects
 
 f#123 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#127 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#128 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#136 = (
   | ???*0*
@@ -16835,15 +16835,15 @@ f#136 = (
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (3 === ???*4*)
   ⚠️  nested operation
 - *4* ???*5*["tag"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* a
   ⚠️  circular variable reference
 - *8* ???*9*["return"]
@@ -16855,9 +16855,9 @@ f#136 = (
 - *11* ???*12*["tag"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* a
   ⚠️  circular variable reference
 - *15* ???*16*["return"]
@@ -16869,7 +16869,7 @@ f#159 = (???*0* | ???*2* | ???*3*)
 - *0* ???*1*["pingedLanes"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported assign operation
   ⚠️  This value might have side effects
 - *3* unsupported expression
@@ -16879,7 +16879,7 @@ f#162 = (???*0* | ???*2*)
 - *0* ???*1*["pendingLanes"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -16889,13 +16889,13 @@ f#169 = (???*0* | undefined)
 
 f#175 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#176 = ???*0*
 - *0* ???*1*["pointerId"]
   ⚠️  unknown object
 - *1* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#193 = module<react, {}>["__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED"]["ReactCurrentBatchConfig"]["transition"]
 
@@ -16917,7 +16917,7 @@ f#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))["l
 - *4* ???*5*["nodeType"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -16927,7 +16927,7 @@ f#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))["l
 - *8* ???*9*["parentNode"]
   ⚠️  unknown object
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -16935,7 +16935,7 @@ f#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))["l
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["target"]
   ⚠️  unknown object
 - *14* a
@@ -16952,7 +16952,7 @@ f#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))["l
 - *19* ???*20*["nodeType"]
   ⚠️  unknown object
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -16962,7 +16962,7 @@ f#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))["l
 - *23* ???*24*["parentNode"]
   ⚠️  unknown object
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -16970,7 +16970,7 @@ f#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))["l
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *27* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* ???*29*["target"]
   ⚠️  unknown object
 - *29* a
@@ -16981,7 +16981,7 @@ f#207 = (???*0* ? (null["value"] | ???*1*) : (null["textContent"] | ???*16*))["l
 
 f#212 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#266 = ???*0*
 - *0* max number of linking steps reached
@@ -17006,7 +17006,7 @@ f#275 = (
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 - *5* unsupported expression
@@ -17066,7 +17066,7 @@ f#308 = (
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*[Pf]
   ⚠️  unknown object
 - *3* c
@@ -17078,17 +17078,17 @@ f#308 = (
 - *6* d
   ⚠️  circular variable reference
 - *7* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["disabled"]
   ⚠️  unknown object
 - *9* d
   ⚠️  circular variable reference
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ("button" === (???*12* | ???*13* | ???*15* | false))
   ⚠️  nested operation
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["return"]
   ⚠️  unknown object
 - *14* a
@@ -17098,7 +17098,7 @@ f#308 = (
 - *16* d
   ⚠️  circular variable reference
 - *17* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* ???*19*[Pf]
   ⚠️  unknown object
 - *19* c
@@ -17110,17 +17110,17 @@ f#308 = (
 - *22* d
   ⚠️  circular variable reference
 - *23* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* ???*25*["disabled"]
   ⚠️  unknown object
 - *25* d
   ⚠️  circular variable reference
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* ("button" === (???*28* | ???*29* | ???*31* | false))
   ⚠️  nested operation
 - *28* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *29* ???*30*["return"]
   ⚠️  unknown object
 - *30* a
@@ -17130,13 +17130,13 @@ f#308 = (
 - *32* d
   ⚠️  circular variable reference
 - *33* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#311 = ???*0*
 - *0* ???*1*["_reactName"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#341 = (???*0* | ???*1*)
 - *0* f
@@ -17174,7 +17174,7 @@ f#400 = (
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* ???*5*["lane"]
@@ -17182,7 +17182,7 @@ f#400 = (
 - *5* ???*6*["updateQueue"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unknown mutation
   ⚠️  This value might have side effects
 - *8* ???*9*["tag"]
@@ -17190,7 +17190,7 @@ f#400 = (
 - *9* ???*10*["updateQueue"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* unknown mutation
   ⚠️  This value might have side effects
 - *12* ???*13*["payload"]
@@ -17198,7 +17198,7 @@ f#400 = (
 - *13* ???*14*["updateQueue"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unknown mutation
   ⚠️  This value might have side effects
 - *16* ???*17*["callback"]
@@ -17206,11 +17206,11 @@ f#400 = (
 - *17* ???*18*["updateQueue"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* unknown mutation
   ⚠️  This value might have side effects
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#404 = ???*0*
 - *0* max number of linking steps reached
@@ -17266,7 +17266,7 @@ f#417 = {
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["_reactInternals"]
   ⚠️  unknown object
 - *15* a
@@ -17298,11 +17298,11 @@ f#417 = {
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -17364,7 +17364,7 @@ f#418 = {
   ⚠️  sequence with side effects
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["_reactInternals"]
   ⚠️  unknown object
 - *15* a
@@ -17396,11 +17396,11 @@ f#418 = {
 - *28* unsupported expression
   ⚠️  This value might have side effects
 - *29* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* ???*31*["value"]
   ⚠️  unknown object
 - *31* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* ???*33*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -17414,7 +17414,7 @@ f#418 = {
 
 f#420 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#421 = (
   | ???*0*
@@ -17426,11 +17426,11 @@ f#421 = (
 - *0* ???*1*["contextType"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* b
   ⚠️  circular variable reference
 - *3* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* f
   ⚠️  circular variable reference
 - *5* unknown mutation
@@ -17440,7 +17440,7 @@ f#421 = (
 - *7* ???*8*["contextTypes"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* (null !== ???*10*)
   ⚠️  nested operation
 - *10* d
@@ -17450,23 +17450,23 @@ f#421 = (
 - *12* ???*13*["stateNode"]
   ⚠️  unknown object
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#423 = (???*0* | (???*2* ? ({} | ???*7*) : ({} | ???*8*)))
 - *0* ???*1*["contextType"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== (???*3* | ???*4*))
   ⚠️  nested operation
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["state"]
   ⚠️  unknown object
 - *5* ???*6*["stateNode"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unknown mutation
   ⚠️  This value might have side effects
 - *8* unknown mutation
@@ -17474,11 +17474,11 @@ f#423 = (???*0* | (???*2* ? ({} | ???*7*) : ({} | ???*8*)))
 
 f#424 = (???*0* | ???*1* | undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["ref"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#431 = (...) => (c | (???*0* ? c : d))
 - *0* unsupported expression
@@ -17488,21 +17488,21 @@ f#440 = ???*0*
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#442 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#447 = (???*0* | undefined)
 - *0* ???*1*["_init"]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#459 = (???*0* | ???*1* | ???*4*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["children"]
   ⚠️  unknown object
 - *2* ???*3*["props"]
@@ -17514,7 +17514,7 @@ f#459 = (???*0* | ???*1* | ???*4*)
 
 f#485 = (???*0* | 0 | (???*1* + 1))
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* f
   ⚠️  circular variable reference
 
@@ -17545,7 +17545,7 @@ f#501 = (
 - *3* ???*4*["memoizedState"]
   ⚠️  unknown object
 - *4* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* ???*6*["next"]
   ⚠️  unknown object
 - *6* P
@@ -17555,7 +17555,7 @@ f#501 = (
 - *8* ???*9*["alternate"]
   ⚠️  unknown object
 - *9* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* a
   ⚠️  circular variable reference
 - *11* ???*12*["next"]
@@ -17573,7 +17573,7 @@ f#501 = (
 - *17* ???*18*(f, g["action"])
   ⚠️  unknown callee
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#504 = !(???*0*)
 - *0* ???*1*(
@@ -17625,7 +17625,7 @@ f#504 = !(???*0*)
 - *15* ???*16*["memoizedState"]
   ⚠️  unknown object
 - *16* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* ???*18*["next"]
   ⚠️  unknown object
 - *18* P
@@ -17635,7 +17635,7 @@ f#504 = !(???*0*)
 - *20* ???*21*["alternate"]
   ⚠️  unknown object
 - *21* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* (null !== (null | ???*23*))
   ⚠️  nested operation
 - *23* a
@@ -17659,7 +17659,7 @@ f#504 = !(???*0*)
 - *32* ???*33*()
   ⚠️  nested operation
 - *33* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#518 = (
   | undefined
@@ -17680,7 +17680,7 @@ f#518 = (
 - *2* ???*3*["alternate"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* O
   ⚠️  circular variable reference
 - *5* ???*6*["next"]
@@ -17705,17 +17705,17 @@ f#539 = (???*0* | undefined)
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#559 = {"value": (???*0* | ???*1*() | ???*2*()), "getSnapshot": ???*3*}
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* c
   ⚠️  circular variable reference
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#56 = (???*0* | undefined)
 - *0* ???*1*["set"]
@@ -17733,11 +17733,11 @@ f#56 = (???*0* | undefined)
 - *5* ???*6*["constructor"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["nodeName"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ("input" === ???*10*)
   ⚠️  nested operation
 - *10* ???*11*()
@@ -17753,13 +17753,13 @@ f#580 = ???*0*
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#591 = ???*0*
 - *0* ???*1*["ref"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#592 = (
   | ???*0*
@@ -17775,7 +17775,7 @@ f#592 = (
 - *0* ???*1*["type"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (null !== ???*3*)
   ⚠️  nested operation
 - *3* c
@@ -17791,19 +17791,19 @@ f#592 = (
 - *8* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*9*, ???*10*, (???*11* | ???*13*))
   ⚠️  nested operation
 - *9* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* b
   ⚠️  circular variable reference
 - *11* ???*12*["mode"]
   ⚠️  unknown object
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* unsupported assign operation
   ⚠️  This value might have side effects
 - *14* ???*15*["mode"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* unsupported assign operation
   ⚠️  This value might have side effects
 - *17* ???*18*["child"]
@@ -17817,29 +17817,29 @@ f#592 = (
 - *20* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*21*, ???*22*, (???*23* | ???*25*))
   ⚠️  nested operation
 - *21* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* b
   ⚠️  circular variable reference
 - *23* ???*24*["mode"]
   ⚠️  unknown object
 - *24* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* unsupported assign operation
   ⚠️  This value might have side effects
 - *26* ???*27*["mode"]
   ⚠️  unknown object
 - *27* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* unsupported assign operation
   ⚠️  This value might have side effects
 - *29* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* b
   ⚠️  circular variable reference
 - *31* ???*32*["mode"]
   ⚠️  unknown object
 - *32* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* unsupported assign operation
   ⚠️  This value might have side effects
 - *34* ???*35*["tag"]
@@ -17847,7 +17847,7 @@ f#592 = (
 - *35* f
   ⚠️  circular variable reference
 - *36* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *37* ???*38*["dependencies"]
   ⚠️  unknown object
 - *38* f
@@ -17865,13 +17865,13 @@ f#595 = (???*0* | undefined)
 - *0* ???*1*["memoizedProps"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#597 = (???*0* ? ???*7* : null)
 - *0* (null !== (???*1* | ???*2*))
   ⚠️  nested operation
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (???*3* ? ???*5* : ???*6*)
   ⚠️  nested operation
 - *3* (null !== ???*4*)
@@ -17881,17 +17881,17 @@ f#597 = (???*0* ? ???*7* : null)
 - *5* unsupported expression
   ⚠️  This value might have side effects
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["memoizedState"]
   ⚠️  unknown object
 - *8* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#600 = ((???*0* ? ({} | ???*6*) : ({} | ???*7*)) | {} | ???*8*)
 - *0* (null !== (???*1* | ???*2* | ???*4*))
   ⚠️  nested operation
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*(d, e)
   ⚠️  unknown callee
 - *3* c
@@ -17909,13 +17909,13 @@ f#600 = ((???*0* ? ({} | ???*6*) : ({} | ???*7*)) | {} | ???*8*)
 - *9* ???*10*["stateNode"]
   ⚠️  unknown object
 - *10* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#601 = (true | undefined | false)
 
 f#605 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#609 = ???*0*
 - *0* max number of linking steps reached
@@ -17929,7 +17929,7 @@ f#620 = ???*0*
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#621 = (???*0* | 0["tail"] | ???*3*)
 - *0* ???*1*["tail"]
@@ -17937,7 +17937,7 @@ f#621 = (???*0* | 0["tail"] | ???*3*)
 - *1* ???*2*["pendingProps"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["tail"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -17964,7 +17964,7 @@ f#687 = (???*0* | (???*4* ? ???*6* : null)["next"]["destroy"] | undefined["destr
 - *2* ???*3*["updateQueue"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* (null !== ???*5*)
   ⚠️  nested operation
 - *5* d
@@ -17980,7 +17980,7 @@ f#706 = ???*0*
 
 f#716 = (???*0* | undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#721 = ???*0*
 - *0* max number of linking steps reached
@@ -17990,7 +17990,7 @@ f#756 = (null | ???*0* | undefined)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#764 = ???*0*
 - *0* max number of linking steps reached
@@ -18034,11 +18034,11 @@ f#807 = (
 - *1* (0 !== (???*2* | ???*3*))
   ⚠️  nested operation
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unsupported expression
   ⚠️  This value might have side effects
 - *4* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *5* unsupported expression
   ⚠️  This value might have side effects
 - *6* (???*7* ? 1073741824 : 0)
@@ -18064,7 +18064,7 @@ f#819 = (
 - *2* ???*3*["updateQueue"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 - *5* updated with update expression
@@ -18098,7 +18098,7 @@ f#880 = (
 - *2* ???*3*["pendingLanes"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#883 = ???*0*
 - *0* max number of linking steps reached
@@ -18106,7 +18106,7 @@ f#883 = ???*0*
 
 f#9 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#919 = ???*0*
 - *0* max number of linking steps reached
@@ -18114,16 +18114,16 @@ f#919 = ???*0*
 
 f#947 = ???*0*
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#953 = (
   | ???*0*
   | new (...) => undefined(3, null, null, (???*1* | 1 | ???*2* | 0))
 )
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* unsupported assign operation
   ⚠️  This value might have side effects
 
@@ -18154,9 +18154,9 @@ f#960 = (
     }
 )
 - *0* arguments[5]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* (0 !== ???*3*)
   ⚠️  nested operation
 - *3* unsupported expression
@@ -18180,7 +18180,7 @@ f#960 = (
 - *12* module<scheduler, {}>["unstable_now"]()
   ⚠️  nested operation
 - *13* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* unsupported expression
   ⚠️  This value might have side effects
 - *15* Ck
@@ -18189,11 +18189,11 @@ f#960 = (
 - *16* ???*17*["current"]
   ⚠️  unknown object
 - *17* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *18* a
   ⚠️  circular variable reference
 - *19* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* (???*21* ? ???*23* : ???*24*)
   ⚠️  nested operation
 - *21* (0 !== ???*22*)
@@ -18221,9 +18221,9 @@ f#960 = (
 - *32* unsupported assign operation
   ⚠️  This value might have side effects
 - *33* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *34* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *35* C
   ⚠️  circular variable reference
 - *36* (0 !== ???*37*)
@@ -18251,11 +18251,11 @@ f#960 = (
 - *47* unsupported expression
   ⚠️  This value might have side effects
 - *48* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *49* ???*50*["value"]
   ⚠️  unknown object
 - *50* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *51* ???*52*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -18293,13 +18293,13 @@ f#961 = (???*0* ? ???*2* : ???*3*)
 
 f#979 = (???*0* | (...) => undefined | undefined)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 f#986 = ???*0*
 - *0* ???*1*["_reactRootContainer"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 fa = (...) => undefined
 
@@ -18345,11 +18345,11 @@ g#1018 = (
 - *4* ???*5*["onRecoverableError"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* c
   ⚠️  circular variable reference
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* updated with update expression
   ⚠️  This value might have side effects
 - *9* ???*10*["onRecoverableError"]
@@ -18363,25 +18363,25 @@ g#1018 = (
 - *12* c
   ⚠️  circular variable reference
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* updated with update expression
   ⚠️  This value might have side effects
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* updated with update expression
   ⚠️  This value might have side effects
 
 g#123 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 g#127 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 g#128 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 g#136 = (false | undefined | true)
 
@@ -18399,7 +18399,7 @@ g#207 = ???*0*
 
 g#212 = ???*0*
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 g#266 = ???*0*
 - *0* max number of linking steps reached
@@ -18415,7 +18415,7 @@ g#286 = (???*0* | undefined | ???*2*)
 - *0* ???*1*["tag"]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* node limit reached
   ⚠️  This value might have side effects
 
@@ -18449,7 +18449,7 @@ g#400 = (
 - *1* ???*2*["updateQueue"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* ???*5*["lane"]
@@ -18457,7 +18457,7 @@ g#400 = (
 - *5* ???*6*["updateQueue"]
   ⚠️  unknown object
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* unknown mutation
   ⚠️  This value might have side effects
 - *8* ???*9*["tag"]
@@ -18465,7 +18465,7 @@ g#400 = (
 - *9* ???*10*["updateQueue"]
   ⚠️  unknown object
 - *10* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* unknown mutation
   ⚠️  This value might have side effects
 - *12* ???*13*["payload"]
@@ -18473,7 +18473,7 @@ g#400 = (
 - *13* ???*14*["updateQueue"]
   ⚠️  unknown object
 - *14* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* unknown mutation
   ⚠️  This value might have side effects
 - *16* ???*17*["callback"]
@@ -18481,7 +18481,7 @@ g#400 = (
 - *17* ???*18*["updateQueue"]
   ⚠️  unknown object
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* unknown mutation
   ⚠️  This value might have side effects
 
@@ -18491,7 +18491,7 @@ g#404 = ???*0*
 
 g#420 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 g#431 = (...) => b
 
@@ -18536,7 +18536,7 @@ g#501 = (
 - *5* ???*6*["memoizedState"]
   ⚠️  unknown object
 - *6* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["next"]
   ⚠️  unknown object
 - *8* P
@@ -18550,7 +18550,7 @@ g#501 = (
 - *12* ???*13*["alternate"]
   ⚠️  unknown object
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* a
   ⚠️  circular variable reference
 - *15* ???*16*["next"]
@@ -18582,7 +18582,7 @@ g#518 = (
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* O
   ⚠️  circular variable reference
 - *4* ???*5*["next"]
@@ -18604,7 +18604,7 @@ g#539 = (???*0* | undefined)
 - *0* ???*1*["lastRenderedState"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 g#592 = (
   | ???*0*
@@ -18623,7 +18623,7 @@ g#592 = (
 - *1* ???*2*["type"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (null !== ???*4*)
   ⚠️  nested operation
 - *4* c
@@ -18639,19 +18639,19 @@ g#592 = (
 - *9* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*10*, ???*11*, (???*12* | ???*14*))
   ⚠️  nested operation
 - *10* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* b
   ⚠️  circular variable reference
 - *12* ???*13*["mode"]
   ⚠️  unknown object
 - *13* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* unsupported assign operation
   ⚠️  This value might have side effects
 - *15* ???*16*["mode"]
   ⚠️  unknown object
 - *16* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* unsupported assign operation
   ⚠️  This value might have side effects
 - *18* ???*19*["memoizedProps"]
@@ -18668,29 +18668,29 @@ g#592 = (
 - *22* new (...) => undefined((2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16), ???*23*, ???*24*, (???*25* | ???*27*))
   ⚠️  nested operation
 - *23* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *24* b
   ⚠️  circular variable reference
 - *25* ???*26*["mode"]
   ⚠️  unknown object
 - *26* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *27* unsupported assign operation
   ⚠️  This value might have side effects
 - *28* ???*29*["mode"]
   ⚠️  unknown object
 - *29* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *30* unsupported assign operation
   ⚠️  This value might have side effects
 - *31* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *32* b
   ⚠️  circular variable reference
 - *33* ???*34*["mode"]
   ⚠️  unknown object
 - *34* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *35* unsupported assign operation
   ⚠️  This value might have side effects
 - *36* ???*37*["tag"]
@@ -18698,7 +18698,7 @@ g#592 = (
 - *37* f
   ⚠️  circular variable reference
 - *38* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *39* ???*40*["dependencies"]
   ⚠️  unknown object
 - *40* f
@@ -18716,7 +18716,7 @@ g#601 = (???*0* | undefined)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 g#605 = (0 !== ???*0*)
 - *0* unsupported expression
@@ -18728,7 +18728,7 @@ g#609 = ???*0*
 
 g#614 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 g#639 = (???*0* | ???*1*)
 - *0* g
@@ -18749,7 +18749,7 @@ g#706 = ???*0*
 
 g#716 = (???*0* | ???*1* | undefined)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* b
@@ -18767,7 +18767,7 @@ g#756 = (???*0* | undefined["stateNode"]["containerInfo"] | undefined)
 - *2* ???*3*["return"]
   ⚠️  unknown object
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 g#764 = ???*0*
 - *0* max number of linking steps reached
@@ -18834,13 +18834,13 @@ g#880 = (
 - *12* unsupported expression
   ⚠️  This value might have side effects
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* ???*15*["value"]
   ⚠️  unknown object
 - *15* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 g#883 = ???*0*
 - *0* max number of linking steps reached
@@ -18848,7 +18848,7 @@ g#883 = ???*0*
 
 g#9 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 g#919 = ???*0*
 - *0* max number of linking steps reached
@@ -18858,11 +18858,11 @@ g#947 = (2 | 1 | 5 | 8 | 10 | 9 | 11 | 14 | 16)
 
 g#953 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 g#960 = ???*0*
 - *0* arguments[6]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 g#961 = (
   | 1
@@ -18888,7 +18888,7 @@ g#961 = (
 - *2* ???*3*["current"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* unknown mutation
   ⚠️  This value might have side effects
 - *5* C
@@ -18918,13 +18918,13 @@ g#961 = (
 - *17* unsupported expression
   ⚠️  This value might have side effects
 - *18* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *19* ???*20*["value"]
   ⚠️  unknown object
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* ???*23*["event"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -18938,7 +18938,7 @@ g#961 = (
 
 g#979 = (???*0* | ???*1* | undefined)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* node limit reached
   ⚠️  This value might have side effects
 
@@ -18952,9 +18952,9 @@ g#986 = (
 - *0* ???*1*["_reactRootContainer"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* node limit reached
   ⚠️  This value might have side effects
 - *4* a
@@ -18996,7 +18996,7 @@ gj = (???*0* | 0 | ???*1* | ???*2* | ???*3*)
 - *1* unknown mutation
   ⚠️  This value might have side effects
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 
@@ -19006,15 +19006,15 @@ gl = (...) => g
 
 h#123 = ???*0*
 - *0* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 h#127 = ???*0*
 - *0* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 h#128 = ???*0*
 - *0* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 h#136 = (
   | ???*0*
@@ -19032,15 +19032,15 @@ h#136 = (
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* (3 === ???*4*)
   ⚠️  nested operation
 - *4* ???*5*["tag"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* a
   ⚠️  circular variable reference
 - *8* ???*9*["return"]
@@ -19052,9 +19052,9 @@ h#136 = (
 - *11* ???*12*["tag"]
   ⚠️  unknown object
 - *12* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *14* a
   ⚠️  circular variable reference
 - *15* ???*16*["return"]
@@ -19066,9 +19066,9 @@ h#136 = (
 - *18* ???*19*["tag"]
   ⚠️  unknown object
 - *19* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *20* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* a
   ⚠️  circular variable reference
 - *22* ???*23*["return"]
@@ -19099,7 +19099,7 @@ h#275 = (
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* updated with update expression
   ⚠️  This value might have side effects
 - *4* unsupported expression
@@ -19145,7 +19145,7 @@ h#286 = (
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["slice"](2)
   ⚠️  unknown callee object
 - *4* ???*5*(36)
@@ -19247,7 +19247,7 @@ h#30 = (???*0* | undefined | ???*1*)
 
 h#311 = (???*0* | ???*1* | undefined)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["return"]
   ⚠️  unknown object
 - *2* c
@@ -19264,7 +19264,7 @@ h#431 = (...) => (???*0* | b)
 
 h#449 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 h#454 = ???*0*
 - *0* max number of linking steps reached
@@ -19284,7 +19284,7 @@ h#539 = (???*0* | undefined)
 - *1* ???*2*["alternate"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 h#601 = ???*0*
 - *0* max number of linking steps reached
@@ -19300,7 +19300,7 @@ h#605 = (???*0* ? null : ???*2*)
 - *3* ???*4*["render"]
   ⚠️  unknown object
 - *4* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 h#609 = ???*0*
 - *0* max number of linking steps reached
@@ -19322,7 +19322,7 @@ h#639 = (
 - *1* ???*2*["memoizedProps"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* for-in variable currently not analyzed
 - *4* f
   ⚠️  circular variable reference
@@ -19359,7 +19359,7 @@ h#639 = (
 - *15* ???*16*["_wrapperState"]
   ⚠️  unknown object
 - *16* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *17* for-in variable currently not analyzed
 - *18* f
   ⚠️  circular variable reference
@@ -19368,7 +19368,7 @@ h#639 = (
 - *20* ???*21*["memoizedProps"]
   ⚠️  unknown object
 - *21* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *22* Object.assign*23*(
         {},
         ???*24*,
@@ -19399,13 +19399,13 @@ h#639 = (
 - *31* ???*32*["_wrapperState"]
   ⚠️  unknown object
 - *32* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *33* ???*34*[(???*36* | null | undefined | [] | ???*37*)]
   ⚠️  unknown object
 - *34* ???*35*["memoizedProps"]
   ⚠️  unknown object
 - *35* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *36* for-in variable currently not analyzed
 - *37* f
   ⚠️  circular variable reference
@@ -19442,7 +19442,7 @@ h#639 = (
 - *48* ???*49*["_wrapperState"]
   ⚠️  unknown object
 - *49* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *50* for-in variable currently not analyzed
 - *51* f
   ⚠️  circular variable reference
@@ -19471,7 +19471,7 @@ h#712 = ???*0*
 
 h#716 = (???*0* | ???*1* | undefined)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["child"]
   ⚠️  unknown object
 - *2* b
@@ -19485,7 +19485,7 @@ h#756 = (null | ???*0* | undefined)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 h#764 = ???*0*
 - *0* max number of linking steps reached
@@ -19521,19 +19521,19 @@ h#919 = ???*0*
 
 h#953 = ???*0*
 - *0* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 h#960 = ???*0*
 - *0* arguments[7]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 h#979 = (???*0* | (...) => undefined | undefined)
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 h#986 = (???*0* | (...) => undefined | undefined)
 - *0* arguments[4]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 ha = (...) => undefined
 
@@ -19597,13 +19597,13 @@ id = (
   | undefined["dehydrated"]
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* (3 === (???*2* | ???*4*))
   ⚠️  nested operation
 - *2* ???*3*["nodeType"]
   ⚠️  unknown object
 - *3* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* ???*5*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -19613,7 +19613,7 @@ id = (
 - *6* ???*7*["parentNode"]
   ⚠️  unknown object
 - *7* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *8* ???*9*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -19621,7 +19621,7 @@ id = (
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *10* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *11* ???*12*["target"]
   ⚠️  unknown object
 - *12* a
@@ -19799,15 +19799,15 @@ jl = (...) => undefined
 
 k#123 = ???*0*
 - *0* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 k#127 = ???*0*
 - *0* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 k#128 = ???*0*
 - *0* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 k#162 = (???*0* | undefined)
 - *0* ???*1*[g]
@@ -19815,7 +19815,7 @@ k#162 = (???*0* | undefined)
 - *1* ???*2*["expirationTimes"]
   ⚠️  unknown object
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 k#275 = (
   | ???*0*
@@ -19836,7 +19836,7 @@ k#275 = (
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 - *5* unsupported expression
@@ -19921,7 +19921,7 @@ k#311 = (
 - *0* ???*1*["alternate"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* ???*3*[Pf]
   ⚠️  unknown object
 - *3* c
@@ -19935,7 +19935,7 @@ k#311 = (
 - *7* ???*8*["_reactName"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *9* ???*10*["disabled"]
   ⚠️  unknown object
 - *10* d
@@ -19943,11 +19943,11 @@ k#311 = (
 - *11* ???*12*["_reactName"]
   ⚠️  unknown object
 - *12* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ("button" === (???*14* | ???*15* | ???*17* | false))
   ⚠️  nested operation
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* ???*16*["return"]
   ⚠️  unknown object
 - *16* c
@@ -19959,7 +19959,7 @@ k#311 = (
 - *19* ???*20*["_reactName"]
   ⚠️  unknown object
 - *20* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 k#404 = ???*0*
 - *0* max number of linking steps reached
@@ -19972,17 +19972,17 @@ k#431 = (...) => (m(a, b, c["props"]["children"], d, c["key"]) | ???*0* | d)
 
 k#449 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 k#454 = ???*0*
 - *0* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 k#459 = (???*0* | undefined)
 - *0* ???*1*["key"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 k#494 = ???*0*
 - *0* max number of linking steps reached
@@ -19992,7 +19992,7 @@ k#539 = (???*0* | undefined)
 - *0* ???*1*["interleaved"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 k#601 = (
   | ???*0*
@@ -20007,13 +20007,13 @@ k#601 = (
 - *1* ???*2*["stateNode"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* unknown mutation
   ⚠️  This value might have side effects
 - *4* (null !== (???*5* | ???*6*))
   ⚠️  nested operation
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["childContextTypes"]
   ⚠️  unknown object
 - *7* a
@@ -20031,7 +20031,7 @@ k#639 = (???*0* | ???*4* | undefined | (???*18* ? ???*19* : undefined))
 - *0* ???*1*[(???*2* | null | undefined | [] | ???*3*)]
   ⚠️  unknown object
 - *1* arguments[3]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* for-in variable currently not analyzed
 - *3* f
   ⚠️  circular variable reference
@@ -20068,7 +20068,7 @@ k#639 = (???*0* | ???*4* | undefined | (???*18* ? ???*19* : undefined))
 - *14* ???*15*["_wrapperState"]
   ⚠️  unknown object
 - *15* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *16* for-in variable currently not analyzed
 - *17* f
   ⚠️  circular variable reference
@@ -20095,7 +20095,7 @@ k#716 = (???*0* | undefined["alternate"] | undefined)
 - *2* ???*3*["deletions"]
   ⚠️  unknown object
 - *3* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 k#721 = ???*0*
 - *0* max number of linking steps reached
@@ -20147,18 +20147,18 @@ k#919 = ???*0*
 
 k#953 = ???*0*
 - *0* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 k#960 = ???*0*
 - *0* arguments[8]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 k#979 = (
   | ???*0*
   | new (...) => undefined(???*1*, (0 | 1 | ???*2*), false, "", (...) => undefined)
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* a
   ⚠️  circular variable reference
 - *2* unsupported assign operation
@@ -20187,7 +20187,7 @@ kd = (
 - *1* ???*2*["nodeType"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ???*4*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20197,7 +20197,7 @@ kd = (
 - *5* ???*6*["parentNode"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20205,7 +20205,7 @@ kd = (
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["target"]
   ⚠️  unknown object
 - *11* a
@@ -20216,7 +20216,7 @@ kd = (
 - *13* unsupported expression
   ⚠️  This value might have side effects
 - *14* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *15* e
   ⚠️  circular variable reference
 
@@ -20295,7 +20295,7 @@ l#123 = ???*0*
 
 l#128 = (null | ???*0* | undefined)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 l#275 = (
   | ???*0*
@@ -20316,7 +20316,7 @@ l#275 = (
   ⚠️  unknown object
   ⚠️  This value might have side effects
 - *3* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *4* updated with update expression
   ⚠️  This value might have side effects
 - *5* unsupported expression
@@ -20350,7 +20350,7 @@ l#311 = (???*0* | undefined["stateNode"] | undefined)
 - *0* ???*1*["stateNode"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 l#36 = ???*0*
 - *0* l
@@ -20462,7 +20462,7 @@ ld = (
 - *4* ???*5*["nodeType"]
   ⚠️  unknown object
 - *5* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20472,7 +20472,7 @@ ld = (
 - *8* ???*9*["parentNode"]
   ⚠️  unknown object
 - *9* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *10* ???*11*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20480,7 +20480,7 @@ ld = (
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *12* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *13* ???*14*["target"]
   ⚠️  unknown object
 - *14* a
@@ -20497,7 +20497,7 @@ ld = (
 - *19* ???*20*["nodeType"]
   ⚠️  unknown object
 - *20* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *21* ???*22*["nodeType"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20507,7 +20507,7 @@ ld = (
 - *23* ???*24*["parentNode"]
   ⚠️  unknown object
 - *24* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *25* ???*26*["parentNode"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20515,7 +20515,7 @@ ld = (
   ⚠️  unknown global
   ⚠️  This value might have side effects
 - *27* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *28* ???*29*["target"]
   ⚠️  unknown object
 - *29* a
@@ -20602,13 +20602,13 @@ m#601 = (???*0* | undefined | ("function" === ???*2*))
 - *0* ???*1*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* typeof((???*3* | undefined))
   ⚠️  nested operation
 - *3* ???*4*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *4* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 m#673 = (0 | undefined | ???*0*)
 - *0* updated with update expression
@@ -20696,7 +20696,7 @@ mf = new ???*0*(???*1*)
 
 mg = (null | ???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* [][???*2*]
   ⚠️  unknown array prototype methods or values
 - *2* unsupported expression
@@ -20737,7 +20737,7 @@ n#404 = (
   | (???*9* ? ???*12* : ???*14*)["next"]["payload"]
 )
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["payload"]
   ⚠️  unknown object
 - *2* ???*3*["pending"]
@@ -20747,7 +20747,7 @@ n#404 = (
 - *4* ???*5*["updateQueue"]
   ⚠️  unknown object
 - *5* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *6* ???*7*["payload"]
   ⚠️  unknown object
   ⚠️  This value might have side effects
@@ -20785,7 +20785,7 @@ n#601 = (???*0* | undefined)
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 n#673 = ???*0*
 - *0* max number of linking steps reached
@@ -20832,7 +20832,7 @@ nb = ???*0*
 - *0* ???*1*(*anonymous function 13608*)
   ⚠️  unknown callee
 - *1* *anonymous function 13449*
-  ⚠️  no value of this variable analysed
+  ⚠️  no value of this variable analyzed
 
 nc = (...) => ((0 === a) ? 32 : ???*0*)
 - *0* unsupported expression
@@ -20850,7 +20850,7 @@ nf = (...) => undefined
 
 ng = (0 | ???*0* | ???*1*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* [][???*2*]
   ⚠️  unknown array prototype methods or values
 - *2* unsupported expression
@@ -20989,7 +20989,7 @@ pd = (...) => !(0)
 
 pe = (null | ???*0*)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 pf = (...) => undefined
 
@@ -21043,7 +21043,7 @@ q#601 = (("function" === ???*0*) | undefined | ???*7*)
 - *1* ???*2*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *2* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *3* ("function" === ???*4*)
   ⚠️  nested operation
 - *4* typeof((???*5* | undefined))
@@ -21051,11 +21051,11 @@ q#601 = (("function" === ???*0*) | undefined | ???*7*)
 - *5* ???*6*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *6* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *7* ???*8*["pendingProps"]
   ⚠️  unknown object
 - *8* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 q#673 = ???*0*
 - *0* max number of linking steps reached
@@ -21095,7 +21095,7 @@ qd = (...) => !(1)
 
 qe = (null | ???*0*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 qf = (...) => undefined
 
@@ -21132,7 +21132,7 @@ r#601 = (???*0* | undefined | undefined["context"])
 - *0* ???*1*["memoizedState"]
   ⚠️  unknown object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 r#673 = ???*0*
 - *0* max number of linking steps reached
@@ -21541,7 +21541,7 @@ w#883 = ((???*0* ? ???*1* : 1)["current"] | undefined["current"] | null["current
 - *6* ???*7*["current"]
   ⚠️  unknown object
 - *7* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 wa = ???*0*
 - *0* ???*1*["for"]("react.portal")
@@ -21674,11 +21674,11 @@ xj = (...) => undefined
 
 xk = (null | ???*0* | ???*1*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* ???*2*["value"]
   ⚠️  unknown object
 - *2* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 y#404 = ???*0*
 - *0* max number of linking steps reached
@@ -21693,7 +21693,7 @@ y#601 = (???*0* | undefined)
 - *0* ???*1*["getDerivedStateFromProps"]
   ⚠️  unknown object
 - *1* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 y#673 = ???*0*
 - *0* max number of linking steps reached
@@ -21727,7 +21727,7 @@ yd = (???*0* | ???*1*)
 - *0* yd
   ⚠️  pattern without value
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 ye = (???*0* | undefined | ("function" === ???*1*))
 - *0* unsupported expression
@@ -21766,7 +21766,7 @@ yk = (0 | ???*0* | null["finishedLanes"])
 - *0* ???*1*["finishedLanes"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 z = {}
 
@@ -21780,7 +21780,7 @@ za = ???*0*
 
 zb = (null | ???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 zc = (...) => b
 
@@ -21798,7 +21798,7 @@ zf = (...) => (("string" === typeof(a)) ? a : `${a}`)["replace"](xf, "\n")["repl
 
 zg = (null | [???*0*])
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 zh = (...) => b
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/require-context/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/require-context/resolved-effects.snapshot
@@ -11,15 +11,15 @@
 
 0 -> 9 member call = ???*0*["keys"]()
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 10 member call = ???*0*()["map"](???*2*)
 - *0* ???*1*["keys"]
   ⚠️  unknown object
 - *1* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 11 unreachable = ???*0*
 - *0* unreachable

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/require-context/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/require-context/resolved-explained.snapshot
@@ -9,4 +9,4 @@ items = [module<[context: ./test]/a, {}>, module<[context: ./test]/b, {}>, modul
 
 r = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/resolved-explained.snapshot
@@ -6,4 +6,4 @@ C = (...) => undefined
 
 v = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/resolved-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/resolved-effects.snapshot
@@ -1,14 +1,14 @@
 0 -> 5 member call = ???*0*["r"](???*1*)
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 7 member call = ???*0*["d"](???*1*, {"default": (...) => handler})
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 8 free var = FreeVar(require)
 
@@ -20,7 +20,7 @@
 
 0 -> 14 member call = ???*0*["status"](200)
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 15 member call = ???*0*["json"](
     {"users": [{"id": 1}, {"id": 2}, {"id": 3}], "hello": ???*2*}
@@ -28,7 +28,7 @@
 - *0* ???*1*["status"](200)
   ⚠️  unknown callee object
 - *1* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 - *2* fs.readFile*3*("./hello.txt", "utf-8")
   ⚠️  unsupported function
   ⚠️  This value might have side effects
@@ -43,7 +43,7 @@
 
 0 -> 21 call = (module<../../webpack-api-runtime.js, {}> | undefined)(???*0*)
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 0 -> 22 call = ((...) => __webpack_require__(moduleId) | undefined)(5166)
 

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/resolved-explained.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/resolved-explained.snapshot
@@ -6,7 +6,7 @@
 
 __unused_webpack_module = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 __webpack_exec__ = ((...) => __webpack_require__(moduleId) | undefined)
 
@@ -16,17 +16,17 @@ __webpack_exports__#3 = (???*0* | undefined)
 
 __webpack_exports__#4 = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 __webpack_require__#3 = (module<../../webpack-api-runtime.js, {}> | undefined)
 
 __webpack_require__#4 = ???*0*
 - *0* arguments[2]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 _req = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 exports = ({} | undefined)
 
@@ -40,13 +40,13 @@ hello = ???*0*
 
 moduleId = ???*0*
 - *0* arguments[0]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 promises_namespaceObject = fs*0*
 - *0* fs: The Node.js fs module: https://nodejs.org/api/fs.html
 
 res = ???*0*
 - *0* arguments[1]
-  ⚠️  function calls are not analysed yet
+  ⚠️  function calls are not analyzed yet
 
 users = [{"id": 1}, {"id": 2}, {"id": 3}]


### PR DESCRIPTION
Standardize the spelling of 'analyze'

Clearly I'm bringing my American perspective here, but the thing that really irked me was the inconsistency.

Closes PACK-5541