### PR TITLE
Development: Only load webpack when used

### DIFF
--- a/packages/next/src/bundles/webpack/packages/webpack.js
+++ b/packages/next/src/bundles/webpack/packages/webpack.js
@@ -2,43 +2,40 @@ exports.__esModule = true
 
 exports.default = undefined
 
-exports.init = function () {
-  if (process.env.NEXT_RSPACK) {
-    // eslint-disable-next-line
-    Object.assign(exports, getRspackCore())
-    Object.assign(exports, {
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      StringXor: require('./bundle5')().StringXor,
-    })
-  } else if (process.env.NEXT_PRIVATE_LOCAL_WEBPACK) {
-    Object.assign(exports, {
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      BasicEvaluatedExpression: require('webpack/lib/javascript/BasicEvaluatedExpression'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      ConcatenatedModule: require('webpack/lib/optimize/ConcatenatedModule'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      makePathsAbsolute: require('webpack/lib/util/identifier')
-        .makePathsAbsolute,
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      ModuleFilenameHelpers: require('webpack/lib/ModuleFilenameHelpers'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      NodeTargetPlugin: require('webpack/lib/node/NodeTargetPlugin'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      RuntimeGlobals: require('webpack/lib/RuntimeGlobals'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      SourceMapDevToolModuleOptionsPlugin: require('webpack/lib/SourceMapDevToolModuleOptionsPlugin'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      StringXor: require('webpack/lib/util/StringXor'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      NormalModule: require('webpack/lib/NormalModule'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      sources: require('webpack').sources,
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      webpack: require('webpack'),
-    })
-  } else {
-    Object.assign(exports, require('./bundle5')())
-  }
+if (process.env.NEXT_RSPACK) {
+  // eslint-disable-next-line
+  Object.assign(exports, getRspackCore())
+  Object.assign(exports, {
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    StringXor: require('./bundle5')().StringXor,
+  })
+} else if (process.env.NEXT_PRIVATE_LOCAL_WEBPACK) {
+  Object.assign(exports, {
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    BasicEvaluatedExpression: require('webpack/lib/javascript/BasicEvaluatedExpression'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    ConcatenatedModule: require('webpack/lib/optimize/ConcatenatedModule'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    makePathsAbsolute: require('webpack/lib/util/identifier').makePathsAbsolute,
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    ModuleFilenameHelpers: require('webpack/lib/ModuleFilenameHelpers'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    NodeTargetPlugin: require('webpack/lib/node/NodeTargetPlugin'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    RuntimeGlobals: require('webpack/lib/RuntimeGlobals'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    SourceMapDevToolModuleOptionsPlugin: require('webpack/lib/SourceMapDevToolModuleOptionsPlugin'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    StringXor: require('webpack/lib/util/StringXor'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    NormalModule: require('webpack/lib/NormalModule'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    sources: require('webpack').sources,
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    webpack: require('webpack'),
+  })
+} else {
+  Object.assign(exports, require('./bundle5')())
 }
 
 function getRspackCore() {

--- a/packages/next/src/compiled/webpack/webpack.js
+++ b/packages/next/src/compiled/webpack/webpack.js
@@ -2,43 +2,40 @@ exports.__esModule = true
 
 exports.default = undefined
 
-exports.init = function () {
-  if (process.env.NEXT_RSPACK) {
-    // eslint-disable-next-line
-    Object.assign(exports, getRspackCore())
-    Object.assign(exports, {
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      StringXor: require('./bundle5')().StringXor,
-    })
-  } else if (process.env.NEXT_PRIVATE_LOCAL_WEBPACK) {
-    Object.assign(exports, {
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      BasicEvaluatedExpression: require('webpack/lib/javascript/BasicEvaluatedExpression'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      ConcatenatedModule: require('webpack/lib/optimize/ConcatenatedModule'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      makePathsAbsolute: require('webpack/lib/util/identifier')
-        .makePathsAbsolute,
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      ModuleFilenameHelpers: require('webpack/lib/ModuleFilenameHelpers'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      NodeTargetPlugin: require('webpack/lib/node/NodeTargetPlugin'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      RuntimeGlobals: require('webpack/lib/RuntimeGlobals'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      SourceMapDevToolModuleOptionsPlugin: require('webpack/lib/SourceMapDevToolModuleOptionsPlugin'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      StringXor: require('webpack/lib/util/StringXor'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      NormalModule: require('webpack/lib/NormalModule'),
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      sources: require('webpack').sources,
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      webpack: require('webpack'),
-    })
-  } else {
-    Object.assign(exports, require('./bundle5')())
-  }
+if (process.env.NEXT_RSPACK) {
+  // eslint-disable-next-line
+  Object.assign(exports, getRspackCore())
+  Object.assign(exports, {
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    StringXor: require('./bundle5')().StringXor,
+  })
+} else if (process.env.NEXT_PRIVATE_LOCAL_WEBPACK) {
+  Object.assign(exports, {
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    BasicEvaluatedExpression: require('webpack/lib/javascript/BasicEvaluatedExpression'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    ConcatenatedModule: require('webpack/lib/optimize/ConcatenatedModule'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    makePathsAbsolute: require('webpack/lib/util/identifier').makePathsAbsolute,
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    ModuleFilenameHelpers: require('webpack/lib/ModuleFilenameHelpers'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    NodeTargetPlugin: require('webpack/lib/node/NodeTargetPlugin'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    RuntimeGlobals: require('webpack/lib/RuntimeGlobals'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    SourceMapDevToolModuleOptionsPlugin: require('webpack/lib/SourceMapDevToolModuleOptionsPlugin'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    StringXor: require('webpack/lib/util/StringXor'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    NormalModule: require('webpack/lib/NormalModule'),
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    sources: require('webpack').sources,
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    webpack: require('webpack'),
+  })
+} else {
+  Object.assign(exports, require('./bundle5')())
 }
 
 function getRspackCore() {

--- a/packages/next/src/server/config-utils.ts
+++ b/packages/next/src/server/config-utils.ts
@@ -1,13 +1,10 @@
 let installed: boolean = false
 
 export function loadWebpackHook() {
-  const { init: initWebpack } =
-    require('next/dist/compiled/webpack/webpack') as typeof import('next/dist/compiled/webpack/webpack')
   if (installed) {
     return
   }
   installed = true
-  initWebpack()
 
   // hook the Node.js require so that webpack requires are
   // routed to the bundled and now initialized webpack version


### PR DESCRIPTION
## What?

Avoid requiring webpack when using Turbopack. 

This makes "ready in" roughly 50ms faster.

Closes PACK-5544