### PR TITLE
docs: Add deprecation note to `middleware` convention and recommend `proxy`

### DIFF
--- a/docs/01-app/01-getting-started/15-route-handlers-and-middleware.mdx
+++ b/docs/01-app/01-getting-started/15-route-handlers-and-middleware.mdx
@@ -147,6 +147,8 @@ export async function GET(_req: NextRequest, ctx: RouteContext<'/users/[id]'>) {
 
 Middleware allows you to run code before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
 
+> **Note**: The `middleware` file convention is deprecated and has been renamed to `proxy`. Please use `proxy.js|ts` instead of `middleware.js|ts`. The `middleware` convention will be removed by default in Next.js 17.
+
 ### Use cases
 
 Some common scenarios where Middleware is effective include:

--- a/docs/01-app/01-getting-started/15-route-handlers-and-middleware.mdx
+++ b/docs/01-app/01-getting-started/15-route-handlers-and-middleware.mdx
@@ -147,7 +147,7 @@ export async function GET(_req: NextRequest, ctx: RouteContext<'/users/[id]'>) {
 
 Middleware allows you to run code before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
 
-> **Note**: The `middleware` file convention is deprecated and has been renamed to `proxy`. Please use `proxy.js|ts` instead of `middleware.js|ts`. The `middleware` convention will be removed by default in Next.js 17.
+> **Note**: The `middleware` file convention is deprecated and has been renamed to [`proxy`](/docs/app/api-reference/file-conventions/proxy). Please use `proxy.js|ts` instead of `middleware.js|ts`. The `middleware` convention will be removed in the future versions of Next.js.
 
 ### Use cases
 

--- a/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
@@ -10,6 +10,8 @@ related:
 
 The `middleware.js|ts` file is used to write [Middleware](/docs/app/getting-started/route-handlers-and-middleware#middleware) and run code on the server before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
 
+> **Note**: The `middleware` file convention is deprecated and has been renamed to `proxy`. Please use `proxy.js|ts` instead of `middleware.js|ts`. The `middleware` convention will be removed by default in Next.js 17.
+
 Middleware executes before routes are rendered. It's particularly useful for implementing custom server-side logic like authentication, logging, or handling redirects.
 
 > **Good to know**:

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -1,34 +1,34 @@
 ---
-title: middleware.js
-description: API reference for the middleware.js file.
+title: proxy.js
+description: API reference for the proxy.js file.
 related:
-  title: Learn more about Middleware
+  title: Learn more about Proxy
   links:
     - app/api-reference/functions/next-request
     - app/api-reference/functions/next-response
 ---
 
-The `middleware.js|ts` file is used to write [Middleware](/docs/app/getting-started/route-handlers-and-middleware#middleware) and run code on the server before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
+The `proxy.js|ts` file is used to write [Proxy](/docs/app/getting-started/route-handlers-and-middleware#middleware) and run code on the server before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
 
-> **Note**: The `middleware` file convention is deprecated and has been renamed to [`proxy`](/docs/app/api-reference/file-conventions/proxy). Please use `proxy.js|ts` instead of `middleware.js|ts`. The `middleware` convention will be removed in the future versions of Next.js.
+> **Note**: The `proxy` file convention is a rename of `middleware` file convention which is deprecated and will be removed in the future versions of Next.js.
 
-Middleware executes before routes are rendered. It's particularly useful for implementing custom server-side logic like authentication, logging, or handling redirects.
+Proxy executes before routes are rendered. It's particularly useful for implementing custom server-side logic like authentication, logging, or handling redirects.
 
 > **Good to know**:
 >
-> Middleware is meant to be invoked separately of your render code and in optimized cases deployed to your CDN for fast redirect/rewrite handling, you should not attempt relying on shared modules or globals.
+> Proxy is meant to be invoked separately of your render code and in optimized cases deployed to your CDN for fast redirect/rewrite handling, you should not attempt relying on shared modules or globals.
 >
-> To pass information from Middleware to your application, use [headers](#setting-headers), [cookies](#using-cookies), [rewrites](/docs/app/api-reference/functions/next-response#rewrite), [redirects](/docs/app/api-reference/functions/next-response#redirect), or the URL.
+> To pass information from Proxy to your application, use [headers](#setting-headers), [cookies](#using-cookies), [rewrites](/docs/app/api-reference/functions/next-response#rewrite), [redirects](/docs/app/api-reference/functions/next-response#redirect), or the URL.
 
-Create a `middleware.ts` (or `.js`) file in the project root, or inside `src` if applicable, so that it is located at the same level as `pages` or `app`.
+Create a `proxy.ts` (or `.js`) file in the project root, or inside `src` if applicable, so that it is located at the same level as `pages` or `app`.
 
-If you’ve customized [`pageExtensions`](/docs/app/api-reference/config/next-config-js/pageExtensions), for example to `.page.ts` or `.page.js`, name your file `middleware.page.ts` or `middleware.page.js` accordingly.
+If you've customized [`pageExtensions`](/docs/app/api-reference/config/next-config-js/pageExtensions), for example to `.page.ts` or `.page.js`, name your file `proxy.page.ts` or `proxy.page.js` accordingly.
 
-```tsx filename="middleware.ts" switcher
+```tsx filename="proxy.ts" switcher
 import { NextResponse, NextRequest } from 'next/server'
 
 // This function can be marked `async` if using `await` inside
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   return NextResponse.redirect(new URL('/home', request.url))
 }
 
@@ -37,11 +37,11 @@ export const config = {
 }
 ```
 
-```js filename="middleware.js" switcher
+```js filename="proxy.js" switcher
 import { NextResponse } from 'next/server'
 
 // This function can be marked `async` if using `await` inside
-export function middleware(request) {
+export function proxy(request) {
   return NextResponse.redirect(new URL('/home', request.url))
 }
 
@@ -52,29 +52,29 @@ export const config = {
 
 ## Exports
 
-### Middleware function
+### Proxy function
 
-The file must export a single function, either as a default export or named `middleware`. Note that multiple middleware from the same file are not supported.
+The file must export a single function, either as a default export or named `proxy`. Note that multiple proxy from the same file are not supported.
 
-```js filename="middleware.js"
+```js filename="proxy.js"
 // Example of default export
-export default function middleware(request) {
-  // Middleware logic
+export default function proxy(request) {
+  // Proxy logic
 }
 ```
 
 ### Config object (optional)
 
-Optionally, a config object can be exported alongside the Middleware function. This object includes the [matcher](#matcher) to specify paths where the Middleware applies.
+Optionally, a config object can be exported alongside the Proxy function. This object includes the [matcher](#matcher) to specify paths where the Proxy applies.
 
 ### Matcher
 
-The `matcher` option allows you to target specific paths for the Middleware to run on. You can specify these paths in several ways:
+The `matcher` option allows you to target specific paths for the Proxy to run on. You can specify these paths in several ways:
 
 - For a single path: Directly use a string to define the path, like `'/about'`.
-- For multiple paths: Use an array to list multiple paths, such as `matcher: ['/about', '/contact']`, which applies the Middleware to both `/about` and `/contact`.
+- For multiple paths: Use an array to list multiple paths, such as `matcher: ['/about', '/contact']`, which applies the Proxy to both `/about` and `/contact`.
 
-```js filename="middleware.js"
+```js filename="proxy.js"
 export const config = {
   matcher: ['/about/:path*', '/dashboard/:path*'],
 }
@@ -90,7 +90,7 @@ The `matcher` option accepts an array of objects with the following keys:
 - `has` (optional): Specifies conditions based on the presence of specific request elements such as headers, query parameters, or cookies.
 - `missing` (optional): Focuses on conditions where certain request elements are absent, like missing headers or cookies.
 
-```js filename="middleware.js"
+```js filename="proxy.js"
 export const config = {
   matcher: [
     {
@@ -125,25 +125,25 @@ Read more details on [path-to-regexp](https://github.com/pillarjs/path-to-regexp
 
 ### `request`
 
-When defining Middleware, the default export function accepts a single parameter, `request`. This parameter is an instance of `NextRequest`, which represents the incoming HTTP request.
+When defining Proxy, the default export function accepts a single parameter, `request`. This parameter is an instance of `NextRequest`, which represents the incoming HTTP request.
 
-```tsx filename="middleware.ts" switcher
+```tsx filename="proxy.ts" switcher
 import type { NextRequest } from 'next/server'
 
-export function middleware(request: NextRequest) {
-  // Middleware logic goes here
+export function proxy(request: NextRequest) {
+  // Proxy logic goes here
 }
 ```
 
-```js filename="middleware.js" switcher
-export function middleware(request) {
-  // Middleware logic goes here
+```js filename="proxy.js" switcher
+export function proxy(request) {
+  // Proxy logic goes here
 }
 ```
 
 > **Good to know**:
 >
-> - `NextRequest` is a type that represents incoming HTTP requests in Next.js Middleware, whereas [`NextResponse`](#nextresponse) is a class used to manipulate and send back HTTP responses.
+> - `NextRequest` is a type that represents incoming HTTP requests in Next.js Proxy, whereas [`NextResponse`](#nextresponse) is a class used to manipulate and send back HTTP responses.
 
 ## NextResponse
 
@@ -157,7 +157,7 @@ The `NextResponse` API allows you to:
 
 <AppOnly>
 
-To produce a response from Middleware, you can:
+To produce a response from Proxy, you can:
 
 1. `rewrite` to a route ([Page](/docs/app/api-reference/file-conventions/page) or [Route Handler](/docs/app/api-reference/file-conventions/route)) that produces a response
 2. return a `NextResponse` directly. See [Producing a Response](#producing-a-response)
@@ -168,7 +168,7 @@ To produce a response from Middleware, you can:
 
 <PagesOnly>
 
-To produce a response from Middleware, you can:
+To produce a response from Proxy, you can:
 
 1. `rewrite` to a route ([Page](/docs/pages/building-your-application/routing/pages-and-layouts) or [Edge API Route](/docs/pages/building-your-application/routing/api-routes)) that produces a response
 2. return a `NextResponse` directly. See [Producing a Response](#producing-a-response)
@@ -177,11 +177,11 @@ To produce a response from Middleware, you can:
 
 ## Execution order
 
-Middleware will be invoked for **every route in your project**. Given this, it's crucial to use [matchers](#matcher) to precisely target or exclude specific routes. The following is the execution order:
+Proxy will be invoked for **every route in your project**. Given this, it's crucial to use [matchers](#matcher) to precisely target or exclude specific routes. The following is the execution order:
 
 1. `headers` from `next.config.js`
 2. `redirects` from `next.config.js`
-3. Middleware (`rewrites`, `redirects`, etc.)
+3. Proxy (`rewrites`, `redirects`, etc.)
 4. `beforeFiles` (`rewrites`) from `next.config.js`
 5. Filesystem routes (`public/`, `_next/static/`, `pages/`, `app/`, etc.)
 6. `afterFiles` (`rewrites`) from `next.config.js`
@@ -190,25 +190,25 @@ Middleware will be invoked for **every route in your project**. Given this, it's
 
 ## Runtime
 
-Middleware defaults to using the Edge runtime. As of v15.5, we have support for using the Node.js runtime. To enable, in your middleware file, set the runtime to `nodejs` in the `config` object:
+Proxy defaults to using the Edge runtime. As of v15.5, we have support for using the Node.js runtime. To enable, in your proxy file, set the runtime to `nodejs` in the `config` object:
 
-```js highlight={2} filename="middleware.js" switcher
+```js highlight={2} filename="proxy.js" switcher
 export const config = {
   runtime: 'nodejs',
 }
 ```
 
-```ts highlight={2} filename="middleware.ts" switcher
+```ts highlight={2} filename="proxy.ts" switcher
 export const config = {
   runtime: 'nodejs',
 }
 ```
 
-## Advanced Middleware flags
+## Advanced Proxy flags
 
-In `v13.1` of Next.js two additional flags were introduced for middleware, `skipMiddlewareUrlNormalize` and `skipTrailingSlashRedirect` to handle advanced use cases.
+In `v13.1` of Next.js two additional flags were introduced for proxy, `skipMiddlewareUrlNormalize` and `skipTrailingSlashRedirect` to handle advanced use cases.
 
-`skipTrailingSlashRedirect` disables Next.js redirects for adding or removing trailing slashes. This allows custom handling inside middleware to maintain the trailing slash for some paths but not others, which can make incremental migrations easier.
+`skipTrailingSlashRedirect` disables Next.js redirects for adding or removing trailing slashes. This allows custom handling inside proxy to maintain the trailing slash for some paths but not others, which can make incremental migrations easier.
 
 ```js filename="next.config.js"
 module.exports = {
@@ -216,10 +216,10 @@ module.exports = {
 }
 ```
 
-```js filename="middleware.js"
+```js filename="proxy.js"
 const legacyPrefixes = ['/docs', '/blog']
 
-export default async function middleware(req) {
+export default async function proxy(req) {
   const { pathname } = req.nextUrl
 
   if (legacyPrefixes.some((prefix) => pathname.startsWith(prefix))) {
@@ -246,8 +246,8 @@ module.exports = {
 }
 ```
 
-```js filename="middleware.js"
-export default async function middleware(req) {
+```js filename="proxy.js"
+export default async function proxy(req) {
   const { pathname } = req.nextUrl
 
   // GET /_next/data/build-id/hello.json
@@ -262,11 +262,11 @@ export default async function middleware(req) {
 
 ### Conditional Statements
 
-```ts filename="middleware.ts" switcher
+```ts filename="proxy.ts" switcher
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   if (request.nextUrl.pathname.startsWith('/about')) {
     return NextResponse.rewrite(new URL('/about-2', request.url))
   }
@@ -277,10 +277,10 @@ export function middleware(request: NextRequest) {
 }
 ```
 
-```js filename="middleware.js" switcher
+```js filename="proxy.js" switcher
 import { NextResponse } from 'next/server'
 
-export function middleware(request) {
+export function proxy(request) {
   if (request.nextUrl.pathname.startsWith('/about')) {
     return NextResponse.rewrite(new URL('/about-2', request.url))
   }
@@ -298,11 +298,11 @@ Cookies are regular headers. On a `Request`, they are stored in the `Cookie` hea
 1. For incoming requests, `cookies` comes with the following methods: `get`, `getAll`, `set`, and `delete` cookies. You can check for the existence of a cookie with `has` or remove all cookies with `clear`.
 2. For outgoing responses, `cookies` have the following methods `get`, `getAll`, `set`, and `delete`.
 
-```ts filename="middleware.ts" switcher
+```ts filename="proxy.ts" switcher
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   // Assume a "Cookie:nextjs=fast" header to be present on the incoming request
   // Getting cookies from the request using the `RequestCookies` API
   let cookie = request.cookies.get('nextjs')
@@ -330,10 +330,10 @@ export function middleware(request: NextRequest) {
 }
 ```
 
-```js filename="middleware.js" switcher
+```js filename="proxy.js" switcher
 import { NextResponse } from 'next/server'
 
-export function middleware(request) {
+export function proxy(request) {
   // Assume a "Cookie:nextjs=fast" header to be present on the incoming request
   // Getting cookies from the request using the `RequestCookies` API
   let cookie = request.cookies.get('nextjs')
@@ -365,14 +365,14 @@ export function middleware(request) {
 
 You can set request and response headers using the `NextResponse` API (setting _request_ headers is available since Next.js v13.0.0).
 
-```ts filename="middleware.ts" switcher
+```ts filename="proxy.ts" switcher
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-export function middleware(request: NextRequest) {
-  // Clone the request headers and set a new header `x-hello-from-middleware1`
+export function proxy(request: NextRequest) {
+  // Clone the request headers and set a new header `x-hello-from-proxy1`
   const requestHeaders = new Headers(request.headers)
-  requestHeaders.set('x-hello-from-middleware1', 'hello')
+  requestHeaders.set('x-hello-from-proxy1', 'hello')
 
   // You can also set request headers in NextResponse.next
   const response = NextResponse.next({
@@ -382,19 +382,19 @@ export function middleware(request: NextRequest) {
     },
   })
 
-  // Set a new response header `x-hello-from-middleware2`
-  response.headers.set('x-hello-from-middleware2', 'hello')
+  // Set a new response header `x-hello-from-proxy2`
+  response.headers.set('x-hello-from-proxy2', 'hello')
   return response
 }
 ```
 
-```js filename="middleware.js" switcher
+```js filename="proxy.js" switcher
 import { NextResponse } from 'next/server'
 
-export function middleware(request) {
-  // Clone the request headers and set a new header `x-hello-from-middleware1`
+export function proxy(request) {
+  // Clone the request headers and set a new header `x-hello-from-proxy1`
   const requestHeaders = new Headers(request.headers)
-  requestHeaders.set('x-hello-from-middleware1', 'hello')
+  requestHeaders.set('x-hello-from-proxy1', 'hello')
 
   // You can also set request headers in NextResponse.next
   const response = NextResponse.next({
@@ -404,8 +404,8 @@ export function middleware(request) {
     },
   })
 
-  // Set a new response header `x-hello-from-middleware2`
-  response.headers.set('x-hello-from-middleware2', 'hello')
+  // Set a new response header `x-hello-from-proxy2`
+  response.headers.set('x-hello-from-proxy2', 'hello')
   return response
 }
 ```
@@ -415,15 +415,15 @@ Note that the snippet uses:
 - `NextResponse.next({ request: { headers: requestHeaders } })` to make `requestHeaders` available upstream
 - **NOT** `NextResponse.next({ headers: requestHeaders })` which makes `requestHeaders` available to clients
 
-Learn more in [NextResponse headers in Middleware](/docs/app/api-reference/functions/next-response#next).
+Learn more in [NextResponse headers in Proxy](/docs/app/api-reference/functions/next-response#next).
 
 > **Good to know**: Avoid setting large headers as it might cause [431 Request Header Fields Too Large](https://developer.mozilla.org/docs/Web/HTTP/Status/431) error depending on your backend web server configuration.
 
 ### CORS
 
-You can set CORS headers in Middleware to allow cross-origin requests, including [simple](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests) and [preflighted](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests) requests.
+You can set CORS headers in Proxy to allow cross-origin requests, including [simple](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests) and [preflighted](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests) requests.
 
-```tsx filename="middleware.ts" switcher
+```tsx filename="proxy.ts" switcher
 import { NextRequest, NextResponse } from 'next/server'
 
 const allowedOrigins = ['https://acme.com', 'https://my-app.org']
@@ -433,7 +433,7 @@ const corsOptions = {
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
 }
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   // Check the origin from the request
   const origin = request.headers.get('origin') ?? ''
   const isAllowedOrigin = allowedOrigins.includes(origin)
@@ -468,7 +468,7 @@ export const config = {
 }
 ```
 
-```jsx filename="middleware.js" switcher
+```jsx filename="proxy.js" switcher
 import { NextResponse } from 'next/server'
 
 const allowedOrigins = ['https://acme.com', 'https://my-app.org']
@@ -478,7 +478,7 @@ const corsOptions = {
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
 }
 
-export function middleware(request) {
+export function proxy(request) {
   // Check the origin from the request
   const origin = request.headers.get('origin') ?? ''
   const isAllowedOrigin = allowedOrigins.includes(origin)
@@ -521,18 +521,18 @@ export const config = {
 
 ### Producing a response
 
-You can respond from Middleware directly by returning a `Response` or `NextResponse` instance. (This is available since [Next.js v13.1.0](https://nextjs.org/blog/next-13-1#nextjs-advanced-middleware))
+You can respond from Proxy directly by returning a `Response` or `NextResponse` instance. (This is available since [Next.js v13.1.0](https://nextjs.org/blog/next-13-1#nextjs-advanced-middleware))
 
-```ts filename="middleware.ts" switcher
+```ts filename="proxy.ts" switcher
 import type { NextRequest } from 'next/server'
 import { isAuthenticated } from '@lib/auth'
 
-// Limit the middleware to paths starting with `/api/`
+// Limit the proxy to paths starting with `/api/`
 export const config = {
   matcher: '/api/:function*',
 }
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   // Call our authentication function to check the request
   if (!isAuthenticated(request)) {
     // Respond with JSON indicating an error message
@@ -544,15 +544,15 @@ export function middleware(request: NextRequest) {
 }
 ```
 
-```js filename="middleware.js" switcher
+```js filename="proxy.js" switcher
 import { isAuthenticated } from '@lib/auth'
 
-// Limit the middleware to paths starting with `/api/`
+// Limit the proxy to paths starting with `/api/`
 export const config = {
   matcher: '/api/:function*',
 }
 
-export function middleware(request) {
+export function proxy(request) {
   // Call our authentication function to check the request
   if (!isAuthenticated(request)) {
     // Respond with JSON indicating an error message
@@ -568,7 +568,7 @@ export function middleware(request) {
 
 The `matcher` config allows full regex so matching like negative lookaheads or character matching is supported. An example of a negative lookahead to match all except specific paths can be seen here:
 
-```js filename="middleware.js"
+```js filename="proxy.js"
 export const config = {
   matcher: [
     /*
@@ -583,9 +583,9 @@ export const config = {
 }
 ```
 
-You can also bypass Middleware for certain requests by using the `missing` or `has` arrays, or a combination of both:
+You can also bypass Proxy for certain requests by using the `missing` or `has` arrays, or a combination of both:
 
-```js filename="middleware.js"
+```js filename="proxy.js"
 export const config = {
   matcher: [
     /*
@@ -627,13 +627,13 @@ export const config = {
 
 The `NextFetchEvent` object extends the native [`FetchEvent`](https://developer.mozilla.org/docs/Web/API/FetchEvent) object, and includes the [`waitUntil()`](https://developer.mozilla.org/docs/Web/API/ExtendableEvent/waitUntil) method.
 
-The `waitUntil()` method takes a promise as an argument, and extends the lifetime of the Middleware until the promise settles. This is useful for performing work in the background.
+  The `waitUntil()` method takes a promise as an argument, and extends the lifetime of the Proxy until the promise settles. This is useful for performing work in the background.
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import { NextResponse } from 'next/server'
 import type { NextFetchEvent, NextRequest } from 'next/server'
 
-export function middleware(req: NextRequest, event: NextFetchEvent) {
+export function proxy(req: NextRequest, event: NextFetchEvent) {
   event.waitUntil(
     fetch('https://my-analytics-platform.com', {
       method: 'POST',
@@ -647,9 +647,9 @@ export function middleware(req: NextRequest, event: NextFetchEvent) {
 
 ### Unit testing (experimental)
 
-Starting in Next.js 15.1, the `next/experimental/testing/server` package contains utilities to help unit test middleware files. Unit testing middleware can help ensure that it's only run on desired paths and that custom routing logic works as intended before code reaches production.
+Starting in Next.js 15.1, the `next/experimental/testing/server` package contains utilities to help unit test proxy files. Unit testing proxy can help ensure that it's only run on desired paths and that custom routing logic works as intended before code reaches production.
 
-The `unstable_doesMiddlewareMatch` function can be used to assert whether middleware will run for the provided URL, headers, and cookies.
+The `unstable_doesMiddlewareMatch` function can be used to assert whether proxy will run for the provided URL, headers, and cookies.
 
 ```js
 import { unstable_doesMiddlewareMatch } from 'next/experimental/testing/server'
@@ -663,13 +663,13 @@ expect(
 ).toEqual(false)
 ```
 
-The entire middleware function can also be tested.
+The entire proxy function can also be tested.
 
 ```js
 import { isRewrite, getRewrittenUrl } from 'next/experimental/testing/server'
 
 const request = new NextRequest('https://nextjs.org/docs')
-const response = await middleware(request)
+const response = await proxy(request)
 expect(isRewrite(response)).toEqual(true)
 expect(getRewrittenUrl(response)).toEqual('https://other-domain.com/docs')
 // getRedirectUrl could also be used if the response were a redirect
@@ -684,7 +684,7 @@ expect(getRewrittenUrl(response)).toEqual('https://other-domain.com/docs')
 | [Static export](/docs/app/getting-started/deploying#static-export)  | No                |
 | [Adapters](/docs/app/getting-started/deploying#adapters)            | Platform-specific |
 
-Learn how to [configure Middleware](/docs/app/guides/self-hosting#middleware) when self-hosting Next.js.
+Learn how to [configure Proxy](/docs/app/guides/self-hosting#middleware) when self-hosting Next.js.
 
 ## Version history
 


### PR DESCRIPTION
Stacked to https://github.com/vercel/next.js/pull/84119

Add deprecation for `middleware` convention and its renaming to `proxy`.