### PR TITLE
Add codemod for `middleware` to `proxy`

### DIFF
--- a/packages/next-codemod/lib/utils.ts
+++ b/packages/next-codemod/lib/utils.ts
@@ -126,4 +126,9 @@ export const TRANSFORMER_INQUIRER_CHOICES = [
     value: 'next-lint-to-eslint-cli',
     version: '16.0.0',
   },
+  {
+    title: 'Migrate from deprecated `middleware` convention to `proxy`',
+    value: 'middleware-to-proxy',
+    version: '16.0.0',
+  },
 ]

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/async-function.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/async-function.input.ts
@@ -1,0 +1,10 @@
+import { NextResponse, NextRequest } from 'next/server'
+
+export async function middleware(request: NextRequest) {
+  const response = await fetch('/api/auth')
+  return NextResponse.redirect(new URL('/home', request.url))
+}
+
+export const config = {
+  matcher: '/about/:path*',
+}

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/async-function.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/async-function.output.ts
@@ -1,0 +1,10 @@
+import { NextResponse, NextRequest } from 'next/server'
+
+export async function proxy(request: NextRequest) {
+  const response = await fetch('/api/auth')
+  return NextResponse.redirect(new URL('/home', request.url))
+}
+
+export const config = {
+  matcher: '/about/:path*',
+}

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/const-export.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/const-export.input.ts
@@ -1,0 +1,11 @@
+import { NextResponse, NextRequest } from 'next/server'
+
+const middleware = (request: NextRequest) => {
+  return NextResponse.redirect(new URL('/home', request.url))
+}
+
+export { middleware }
+
+export const config = {
+  matcher: '/about/:path*',
+}

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/const-export.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/const-export.output.ts
@@ -1,0 +1,11 @@
+import { NextResponse, NextRequest } from 'next/server'
+
+const proxy = (request: NextRequest) => {
+  return NextResponse.redirect(new URL('/home', request.url))
+}
+
+export { proxy }
+
+export const config = {
+  matcher: '/about/:path*',
+}

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/default-export.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/default-export.input.ts
@@ -1,0 +1,10 @@
+import { NextResponse, NextRequest } from 'next/server'
+
+// default export name doesn't matter
+export default function middleware(request: NextRequest) {
+  return NextResponse.redirect(new URL('/home', request.url))
+}
+
+export const config = {
+  matcher: '/about/:path*',
+}

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/default-export.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/default-export.input.ts
@@ -1,6 +1,5 @@
 import { NextResponse, NextRequest } from 'next/server'
 
-// default export name doesn't matter
 export default function middleware(request: NextRequest) {
   return NextResponse.redirect(new URL('/home', request.url))
 }

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/default-export.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/default-export.output.ts
@@ -1,0 +1,10 @@
+import { NextResponse, NextRequest } from 'next/server'
+
+// default export name doesn't matter
+export default function middleware(request: NextRequest) {
+  return NextResponse.redirect(new URL('/home', request.url))
+}
+
+export const config = {
+  matcher: '/about/:path*',
+}

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/default-export.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/default-export.output.ts
@@ -1,7 +1,6 @@
 import { NextResponse, NextRequest } from 'next/server'
 
-// default export name doesn't matter
-export default function middleware(request: NextRequest) {
+export default function proxy(request: NextRequest) {
   return NextResponse.redirect(new URL('/home', request.url))
 }
 

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/export-as-alias.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/export-as-alias.input.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+
+const proxy = 'existing proxy variable'
+
+function middleware() {
+  return NextResponse.next()
+}
+
+export { middleware as randomName }

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/export-as-alias.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/export-as-alias.output.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+
+const proxy = 'existing proxy variable'
+
+function _proxy1() {
+  return NextResponse.next()
+}
+
+export { _proxy1 as randomName }

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/export-specifier.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/export-specifier.input.ts
@@ -1,0 +1,11 @@
+import { NextResponse, NextRequest } from 'next/server'
+
+function middleware(request: NextRequest) {
+  return NextResponse.redirect(new URL('/home', request.url))
+}
+
+const config = {
+  matcher: '/about/:path*',
+}
+
+export { middleware, config }

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/export-specifier.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/export-specifier.output.ts
@@ -1,0 +1,11 @@
+import { NextResponse, NextRequest } from 'next/server'
+
+function proxy(request: NextRequest) {
+  return NextResponse.redirect(new URL('/home', request.url))
+}
+
+const config = {
+  matcher: '/about/:path*',
+}
+
+export { proxy, config }

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/import-conflict.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/import-conflict.input.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+// @ts-expect-error: test fixture
+import { proxy } from 'some-library'
+
+export function middleware() {
+  return NextResponse.next()
+}

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/import-conflict.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/import-conflict.output.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+// @ts-expect-error: test fixture
+import { proxy } from 'some-library'
+
+export function _proxy1() {
+  return NextResponse.next()
+}
+export { _proxy1 as proxy };

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/multiple-references.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/multiple-references.input.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from 'next/server'
+
+const proxy = 'existing proxy variable'
+
+export function middleware(request: NextRequest) {
+  return middleware(request) // self-reference
+}
+
+const handler = middleware
+export { handler }

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/multiple-references.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/multiple-references.output.ts
@@ -1,0 +1,11 @@
+import { NextRequest } from 'next/server'
+
+const proxy = 'existing proxy variable'
+
+export function _proxy1(request: NextRequest) {
+  return _proxy1(request); // self-reference
+}
+
+const handler = _proxy1
+export { handler }
+export { _proxy1 as proxy };

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/named-export.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/named-export.input.ts
@@ -1,0 +1,9 @@
+import { NextResponse, NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  return NextResponse.redirect(new URL('/home', request.url))
+}
+
+export const config = {
+  matcher: '/about/:path*',
+}

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/named-export.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/named-export.output.ts
@@ -1,0 +1,9 @@
+import { NextResponse, NextRequest } from 'next/server'
+
+export function proxy(request: NextRequest) {
+  return NextResponse.redirect(new URL('/home', request.url))
+}
+
+export const config = {
+  matcher: '/about/:path*',
+}

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/scope-conflict.input.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/scope-conflict.input.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+
+const proxy = 'existing proxy variable'
+
+export function middleware() {
+  return NextResponse.next()
+}

--- a/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/scope-conflict.output.ts
+++ b/packages/next-codemod/transforms/__testfixtures__/middleware-to-proxy/scope-conflict.output.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+
+const proxy = 'existing proxy variable'
+
+export function _proxy1() {
+  return NextResponse.next()
+}
+export { _proxy1 as proxy };

--- a/packages/next-codemod/transforms/__tests__/middleware-to-proxy.test.js
+++ b/packages/next-codemod/transforms/__tests__/middleware-to-proxy.test.js
@@ -1,0 +1,16 @@
+/* global jest */
+jest.autoMockOff()
+const defineTest = require('jscodeshift/dist/testUtils').defineTest
+const { readdirSync } = require('fs')
+const { join } = require('path')
+
+const fixtureDir = 'middleware-to-proxy'
+const fixtureDirPath = join(__dirname, '..', '__testfixtures__', fixtureDir)
+const fixtures = readdirSync(fixtureDirPath)
+  .filter(file => file.endsWith('.input.ts'))
+  .map(file => file.replace('.input.ts', ''))
+
+for (const fixture of fixtures) {
+  const prefix = `${fixtureDir}/${fixture}`
+  defineTest(__dirname, fixtureDir, null, prefix, { parser: 'ts' })
+}

--- a/packages/next-codemod/transforms/middleware-to-proxy.ts
+++ b/packages/next-codemod/transforms/middleware-to-proxy.ts
@@ -21,7 +21,7 @@ export default function transformer(file: FileInfo) {
 
   let hasChanges = false
 
-  // Handle export declarations in a single traversal
+  // Handle named export declarations
   root.find(j.ExportNamedDeclaration).forEach((nodePath) => {
     const declaration = nodePath.node.declaration
 
@@ -56,19 +56,27 @@ export default function transformer(file: FileInfo) {
     }
   })
 
+  // Handle default export declarations
+  root.find(j.ExportDefaultDeclaration).forEach((nodePath) => {
+    const declaration = nodePath.node.declaration
+
+    // Handle: export default function middleware() {} or export default async function middleware() {}
+    if (
+      j.FunctionDeclaration.check(declaration) &&
+      declaration.id?.name === 'middleware'
+    ) {
+      declaration.id.name = 'proxy'
+      hasChanges = true
+    }
+  })
+
   // Handle function declarations that are later exported
   // Find: function middleware() {} followed by export { middleware }
-  // But exclude default exports
   root
     .find(j.FunctionDeclaration, {
       id: { name: 'middleware' },
     })
     .forEach((nodePath) => {
-      // Skip if this function is part of a default export
-      if (nodePath.parent?.node?.type === 'ExportDefaultDeclaration') {
-        return
-      }
-
       if (nodePath.node.id) {
         nodePath.node.id.name = 'proxy'
         hasChanges = true
@@ -76,25 +84,16 @@ export default function transformer(file: FileInfo) {
     })
 
   // Handle variable declarations: const middleware = ...
-  // But exclude those that are part of default exports
   root
     .find(j.VariableDeclarator, {
       id: { name: 'middleware' },
     })
     .forEach((nodePath) => {
-      // Skip if this variable is part of a default export
-      if (nodePath.parent?.parent?.node?.type === 'ExportDefaultDeclaration') {
-        return
-      }
-
       if (j.Identifier.check(nodePath.node.id)) {
         nodePath.node.id.name = 'proxy'
         hasChanges = true
       }
     })
-
-  // Skip default exports - they don't need to be renamed
-  // export default function middleware() {} works as-is with proxy files
 
   if (!hasChanges) {
     return file.source

--- a/packages/next-codemod/transforms/middleware-to-proxy.ts
+++ b/packages/next-codemod/transforms/middleware-to-proxy.ts
@@ -1,7 +1,7 @@
-import type { FileInfo } from 'jscodeshift'
-import { createParserFromPath } from '../lib/parser'
+import type { API, ASTPath, Collection, FileInfo } from 'jscodeshift'
 import path from 'path'
 import fs from 'fs'
+import { createParserFromPath } from '../lib/parser'
 
 export default function transformer(file: FileInfo) {
   if (
@@ -19,7 +19,12 @@ export default function transformer(file: FileInfo) {
     return file.source
   }
 
+  const proxyIdentifier = generateUniqueIdentifier(root, j, 'proxy')
+  const needsAlias = proxyIdentifier !== 'proxy'
+
   let hasChanges = false
+  // Track if we exported something as 'proxy'
+  let exportedAsProxy = false
 
   // Handle named export declarations
   root.find(j.ExportNamedDeclaration).forEach((nodePath) => {
@@ -30,7 +35,8 @@ export default function transformer(file: FileInfo) {
       j.FunctionDeclaration.check(declaration) &&
       declaration.id?.name === 'middleware'
     ) {
-      declaration.id.name = 'proxy'
+      declaration.id.name = proxyIdentifier
+      exportedAsProxy = true // Exported function declarations become proxy
       hasChanges = true
     }
 
@@ -39,18 +45,36 @@ export default function transformer(file: FileInfo) {
       nodePath.node.specifiers.forEach((specifier) => {
         if (
           j.ExportSpecifier.check(specifier) &&
-          j.Identifier.check(specifier.exported) &&
-          specifier.exported.name === 'middleware'
+          j.Identifier.check(specifier.local) &&
+          specifier.local.name === 'middleware'
         ) {
-          specifier.exported.name = 'proxy'
-          // Also rename the local identifier if it matches
+          // Check if this is exporting middleware as 'middleware' (which should become 'proxy')
           if (
-            j.Identifier.check(specifier.local) &&
-            specifier.local.name === 'middleware'
+            j.Identifier.check(specifier.exported) &&
+            specifier.exported.name === 'middleware'
           ) {
-            specifier.local.name = 'proxy'
+            if (needsAlias) {
+              // Create export alias: export { _proxy1 as proxy }
+              const newSpecifier = j.exportSpecifier.from({
+                local: j.identifier(proxyIdentifier),
+                exported: j.identifier('proxy'),
+              })
+              // Replace in the specifiers array
+              const specifierIndex = nodePath.node.specifiers.indexOf(specifier)
+              nodePath.node.specifiers[specifierIndex] = newSpecifier
+            } else {
+              // Simple rename: export { proxy }
+              specifier.exported = j.identifier('proxy')
+              specifier.local = j.identifier('proxy')
+            }
+            exportedAsProxy = true
+            hasChanges = true
+          } else {
+            // This is exporting middleware as something else (e.g., export { middleware as randomName })
+            // Just update the local reference to the new identifier
+            specifier.local = j.identifier(proxyIdentifier)
+            hasChanges = true
           }
-          hasChanges = true
         }
       })
     }
@@ -65,20 +89,19 @@ export default function transformer(file: FileInfo) {
       j.FunctionDeclaration.check(declaration) &&
       declaration.id?.name === 'middleware'
     ) {
-      declaration.id.name = 'proxy'
+      declaration.id.name = proxyIdentifier
       hasChanges = true
     }
   })
 
   // Handle function declarations that are later exported
-  // Find: function middleware() {} followed by export { middleware }
   root
     .find(j.FunctionDeclaration, {
       id: { name: 'middleware' },
     })
     .forEach((nodePath) => {
       if (nodePath.node.id) {
-        nodePath.node.id.name = 'proxy'
+        nodePath.node.id.name = proxyIdentifier
         hasChanges = true
       }
     })
@@ -90,13 +113,81 @@ export default function transformer(file: FileInfo) {
     })
     .forEach((nodePath) => {
       if (j.Identifier.check(nodePath.node.id)) {
-        nodePath.node.id.name = 'proxy'
+        nodePath.node.id.name = proxyIdentifier
         hasChanges = true
       }
     })
 
+  // Update all references to middleware in the scope
+  if (hasChanges && needsAlias) {
+    root
+      .find(j.Identifier, { name: 'middleware' })
+      .filter((astPath: ASTPath<any>) => {
+        // Don't rename if it's part of an export specifier we already handled
+        const parent = astPath.parent
+        if (j.ExportSpecifier.check(parent.node)) {
+          return false
+        }
+
+        // Don't rename if it's a function/variable declaration we already handled
+        if (
+          (j.FunctionDeclaration.check(parent.node) &&
+            parent.node.id === astPath.node) ||
+          (j.VariableDeclarator.check(parent.node) &&
+            parent.node.id === astPath.node)
+        ) {
+          return false
+        }
+
+        return true
+      })
+      .forEach((astPath: ASTPath<any>) => {
+        astPath.node.name = proxyIdentifier
+      })
+  }
+
   if (!hasChanges) {
     return file.source
+  }
+
+  // If we used a unique identifier AND we exported `as proxy`, add an export alias
+  // This handles cases where the export was part of the declaration itself:
+  //   export function middleware() {} -> export function _proxy1() {} (needs alias)
+  // vs cases where export was separate:
+  //   export { middleware } -> export { _proxy1 as proxy } (already handled)
+  if (needsAlias && hasChanges && exportedAsProxy) {
+    // Check if we already created a proxy export (from export specifiers like `export { middleware }`)
+    const hasExportSpecifier =
+      root.find(j.ExportNamedDeclaration).filter((astPath: ASTPath<any>) => {
+        return (
+          astPath.node.specifiers &&
+          astPath.node.specifiers.some(
+            (spec) =>
+              j.ExportSpecifier.check(spec) &&
+              j.Identifier.check(spec.exported) &&
+              spec.exported.name === 'proxy'
+          )
+        )
+      }).length > 0
+
+    // If no proxy export exists yet, create one to maintain the 'proxy' API
+    // Example: export function _proxy1() {} + export { _proxy1 as proxy }
+    if (!hasExportSpecifier) {
+      const exportSpecifier = j.exportSpecifier.from({
+        local: j.identifier(proxyIdentifier),
+        exported: j.identifier('proxy'),
+      })
+
+      const exportDeclaration = j.exportNamedDeclaration(null, [
+        exportSpecifier,
+      ])
+
+      // Add the export at the end of the file
+      const program = root.find(j.Program)
+      if (program.length > 0) {
+        program.get('body').value.push(exportDeclaration)
+      }
+    }
   }
 
   const source = root.toSource()
@@ -119,4 +210,61 @@ export default function transformer(file: FileInfo) {
     )
     return file.source
   }
+}
+
+function generateUniqueIdentifier(
+  root: Collection<any>,
+  j: API['j'],
+  baseName: string
+): string {
+  // First check if baseName itself is available
+  if (!hasIdentifierInScope(root, j, baseName)) {
+    return baseName
+  }
+
+  // Generate _proxy1, _proxy2, etc.
+  let counter = 1
+  while (true) {
+    const candidate = `_${baseName}${counter}`
+    if (!hasIdentifierInScope(root, j, candidate)) {
+      return candidate
+    }
+    counter++
+  }
+}
+
+function hasIdentifierInScope(
+  root: Collection<any>,
+  j: API['j'],
+  name: string
+): boolean {
+  // Check for variable declarations
+  const hasVariableDeclaration =
+    root
+      .find(j.VariableDeclarator)
+      .filter(
+        (astPath: ASTPath<any>) =>
+          j.Identifier.check(astPath.value.id) && astPath.value.id.name === name
+      ).length > 0
+
+  // Check for function declarations
+  const hasFunctionDeclaration =
+    root
+      .find(j.FunctionDeclaration)
+      .filter(
+        (astPath: ASTPath<any>) =>
+          astPath.value.id && astPath.value.id.name === name
+      ).length > 0
+
+  // Check for import specifiers
+  const hasImportSpecifier =
+    root
+      .find(j.ImportSpecifier)
+      .filter(
+        (astPath: ASTPath<any>) =>
+          j.Identifier.check(astPath.value.local) &&
+          astPath.value.local.name === name
+      ).length > 0
+
+  return hasVariableDeclaration || hasFunctionDeclaration || hasImportSpecifier
 }

--- a/packages/next-codemod/transforms/middleware-to-proxy.ts
+++ b/packages/next-codemod/transforms/middleware-to-proxy.ts
@@ -4,33 +4,22 @@ import path from 'path'
 import fs from 'fs'
 
 export default function transformer(file: FileInfo) {
-  const j = createParserFromPath(file.path)
-  let hasChanges = false
-
-  // Handle file renaming first
-  const fileName = path.basename(file.path)
-  const fileNameWithoutExt = path.basename(file.path, path.extname(file.path))
-  const isMiddlewareFile = fileNameWithoutExt === 'middleware'
-
-  if (isMiddlewareFile) {
-    const newFileName = fileName.replace(/^middleware\./, 'proxy.')
-    const newFilePath = path.join(path.dirname(file.path), newFileName)
-
-    try {
-      fs.renameSync(file.path, newFilePath)
-    } catch (cause) {
-      console.error(
-        `Failed to rename "${file.path}" to "${newFilePath}".\n${JSON.stringify({ cause })}`
-      )
-      return file.source
-    }
+  if (
+    !/(^|[/\\])middleware\.|[/\\]src[/\\]middleware\./.test(file.path) &&
+    // fixtures have unique basenames in test
+    process.env.NODE_ENV !== 'test'
+  ) {
+    return file.source
   }
 
+  const j = createParserFromPath(file.path)
   const root = j(file.source)
 
   if (!root.length) {
     return file.source
   }
+
+  let hasChanges = false
 
   // Handle export declarations in a single traversal
   root.find(j.ExportNamedDeclaration).forEach((nodePath) => {
@@ -107,9 +96,28 @@ export default function transformer(file: FileInfo) {
   // Skip default exports - they don't need to be renamed
   // export default function middleware() {} works as-is with proxy files
 
-  if (hasChanges) {
-    return root.toSource()
+  if (!hasChanges) {
+    return file.source
   }
 
-  return file.source
+  const source = root.toSource()
+
+  // We will not modify the original file in real world,
+  // so return the source here for testing.
+  if (process.env.NODE_ENV === 'test') {
+    return source
+  }
+
+  const { dir, ext } = path.parse(file.path)
+  const newFilePath = path.join(dir, 'proxy' + ext)
+
+  try {
+    fs.writeFileSync(newFilePath, source)
+    fs.unlinkSync(file.path)
+  } catch (cause) {
+    console.error(
+      `Failed to write "${newFilePath}" and delete "${file.path}".\n${JSON.stringify({ cause })}`
+    )
+    return file.source
+  }
 }

--- a/packages/next-codemod/transforms/middleware-to-proxy.ts
+++ b/packages/next-codemod/transforms/middleware-to-proxy.ts
@@ -1,0 +1,111 @@
+import type { FileInfo } from 'jscodeshift'
+import { createParserFromPath } from '../lib/parser'
+import path from 'path'
+import fs from 'fs'
+
+export default function transformer(file: FileInfo) {
+  const j = createParserFromPath(file.path)
+  let hasChanges = false
+
+  // Handle file renaming first
+  const fileName = path.basename(file.path)
+  const fileNameWithoutExt = path.basename(file.path, path.extname(file.path))
+  const isMiddlewareFile = fileNameWithoutExt === 'middleware'
+
+  if (isMiddlewareFile) {
+    const newFileName = fileName.replace(/^middleware\./, 'proxy.')
+    const newFilePath = path.join(path.dirname(file.path), newFileName)
+
+    // Rename the file
+    try {
+      fs.renameSync(file.path, newFilePath)
+      console.log(`Renamed ${file.path} -> ${newFilePath}`)
+    } catch (error) {
+      console.warn(`Failed to rename ${file.path}: ${error}`)
+    }
+  }
+
+  // Parse and transform the AST
+  const source = j(file.source)
+
+  // Handle export declarations in a single traversal
+  source.find(j.ExportNamedDeclaration).forEach((nodePath) => {
+    const declaration = nodePath.node.declaration
+
+    // Handle: export function middleware() {} or export async function middleware() {}
+    if (
+      j.FunctionDeclaration.check(declaration) &&
+      declaration.id?.name === 'middleware'
+    ) {
+      declaration.id.name = 'proxy'
+      hasChanges = true
+    }
+
+    // Handle: export { middleware }
+    if (nodePath.node.specifiers) {
+      nodePath.node.specifiers.forEach((specifier) => {
+        if (
+          j.ExportSpecifier.check(specifier) &&
+          j.Identifier.check(specifier.exported) &&
+          specifier.exported.name === 'middleware'
+        ) {
+          specifier.exported.name = 'proxy'
+          // Also rename the local identifier if it matches
+          if (
+            j.Identifier.check(specifier.local) &&
+            specifier.local.name === 'middleware'
+          ) {
+            specifier.local.name = 'proxy'
+          }
+          hasChanges = true
+        }
+      })
+    }
+  })
+
+  // Handle function declarations that are later exported
+  // Find: function middleware() {} followed by export { middleware }
+  // But exclude default exports
+  source
+    .find(j.FunctionDeclaration, {
+      id: { name: 'middleware' },
+    })
+    .forEach((nodePath) => {
+      // Skip if this function is part of a default export
+      if (nodePath.parent?.node?.type === 'ExportDefaultDeclaration') {
+        return
+      }
+
+      if (nodePath.node.id) {
+        nodePath.node.id.name = 'proxy'
+        hasChanges = true
+      }
+    })
+
+  // Handle variable declarations: const middleware = ...
+  // But exclude those that are part of default exports
+  source
+    .find(j.VariableDeclarator, {
+      id: { name: 'middleware' },
+    })
+    .forEach((nodePath) => {
+      // Skip if this variable is part of a default export
+      if (nodePath.parent?.parent?.node?.type === 'ExportDefaultDeclaration') {
+        return
+      }
+
+      if (j.Identifier.check(nodePath.node.id)) {
+        nodePath.node.id.name = 'proxy'
+        hasChanges = true
+      }
+    })
+
+  // Skip default exports - they don't need to be renamed
+  // export default function middleware() {} works as-is with proxy files
+
+  if (hasChanges) {
+    return source.toSource()
+  }
+
+  return file.source
+}

--- a/packages/next-codemod/transforms/middleware-to-proxy.ts
+++ b/packages/next-codemod/transforms/middleware-to-proxy.ts
@@ -16,20 +16,24 @@ export default function transformer(file: FileInfo) {
     const newFileName = fileName.replace(/^middleware\./, 'proxy.')
     const newFilePath = path.join(path.dirname(file.path), newFileName)
 
-    // Rename the file
     try {
       fs.renameSync(file.path, newFilePath)
-      console.log(`Renamed ${file.path} -> ${newFilePath}`)
-    } catch (error) {
-      console.warn(`Failed to rename ${file.path}: ${error}`)
+    } catch (cause) {
+      console.error(
+        `Failed to rename "${file.path}" to "${newFilePath}".\n${JSON.stringify({ cause })}`
+      )
+      return file.source
     }
   }
 
-  // Parse and transform the AST
-  const source = j(file.source)
+  const root = j(file.source)
+
+  if (!root.length) {
+    return file.source
+  }
 
   // Handle export declarations in a single traversal
-  source.find(j.ExportNamedDeclaration).forEach((nodePath) => {
+  root.find(j.ExportNamedDeclaration).forEach((nodePath) => {
     const declaration = nodePath.node.declaration
 
     // Handle: export function middleware() {} or export async function middleware() {}
@@ -66,7 +70,7 @@ export default function transformer(file: FileInfo) {
   // Handle function declarations that are later exported
   // Find: function middleware() {} followed by export { middleware }
   // But exclude default exports
-  source
+  root
     .find(j.FunctionDeclaration, {
       id: { name: 'middleware' },
     })
@@ -84,7 +88,7 @@ export default function transformer(file: FileInfo) {
 
   // Handle variable declarations: const middleware = ...
   // But exclude those that are part of default exports
-  source
+  root
     .find(j.VariableDeclarator, {
       id: { name: 'middleware' },
     })
@@ -104,7 +108,7 @@ export default function transformer(file: FileInfo) {
   // export default function middleware() {} works as-is with proxy files
 
   if (hasChanges) {
-    return source.toSource()
+    return root.toSource()
   }
 
   return file.source


### PR DESCRIPTION
Stacked to https://github.com/vercel/next.js/pull/84119

This PR adds a codemod for renaming `middleware` to `proxy`. Below are the behaviors:

- Rename `middleware.*`, `src/middleware.*` to `proxy.*`, `src/proxy.*`
- Rename function/variable exports from `middleware` to `proxy`. Default exports are skipped.