### PR TITLE
Fix double comma in build manifest

### DIFF
--- a/packages/next/src/build/webpack/plugins/build-manifest-plugin-utils.ts
+++ b/packages/next/src/build/webpack/plugins/build-manifest-plugin-utils.ts
@@ -72,9 +72,9 @@ export function createEdgeRuntimeManifest(
     `globalThis.__BUILD_MANIFEST.lowPriorityFiles = [\n` +
     manifestFilenames
       .map((filename) => {
-        return `"/static/" + process.env.__NEXT_BUILD_ID + "/${filename}",\n`
+        return `"/static/" + process.env.__NEXT_BUILD_ID + "/${filename}"`
       })
-      .join(',') +
+      .join(',\n') +
     `\n];`
 
   return manifestDefCode + lowPriorityFilesCode


### PR DESCRIPTION
## What?

Fixes a bug highlighted by Vercel Agent while moving code in #84125. 

Specific comment: https://github.com/vercel/next.js/pull/84125/files#r2371621679



Closes PACK-5557