### PR TITLE
docs: Missing upgrade guide for pages router @ 15

### DIFF
--- a/docs/01-app/02-guides/upgrading/version-15.mdx
+++ b/docs/01-app/02-guides/upgrading/version-15.mdx
@@ -24,6 +24,8 @@ npm i next@latest react@latest react-dom@latest eslint-config-next@latest
 >
 > - If you see a peer dependencies warning, you may need to update `react` and `react-dom` to the suggested versions, or use the `--force` or `--legacy-peer-deps` flag to ignore the warning. This won't be necessary once both Next.js 15 and React 19 are stable.
 
+<AppOnly>
+
 ## React 19
 
 - The minimum versions of `react` and `react-dom` is now 19.
@@ -517,6 +519,18 @@ module.exports = nextConfig
 ```
 
 [Layouts](/docs/app/api-reference/file-conventions/layout) and [loading states](/docs/app/api-reference/file-conventions/loading) are still cached and reused on navigation.
+
+</AppOnly>
+
+<PagesOnly>
+
+## Pages Router on React 18
+
+Next.js 15 maintains backward compatibility for the Pages Router with React 18, allowing users to continue using React 18 while benefiting from improvements in Next.js 15.
+
+Since the first Release Candidate (RC1), we've shifted our focus to include support for React 18 based on community feedback. This flexibility enables you to adopt Next.js 15 while using the Pages Router with React 18, giving you greater control over your upgrade path.
+
+</PagesOnly>
 
 ## `next/font`
 

--- a/docs/02-pages/02-guides/upgrading/version-15.mdx
+++ b/docs/02-pages/02-guides/upgrading/version-15.mdx
@@ -1,0 +1,8 @@
+---
+title: How to upgrade to version 15
+nav_title: Version 15
+description: Upgrade your Next.js Application from Version 14 to 15.
+source: app/guides/upgrading/version-15
+---
+
+{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}


### PR DESCRIPTION
We did not publish an entry for Pages Router Upgrading to 15, even though there wasn't much to upgrade. Pages Router is supported in v15 too.

Closes: https://linear.app/vercel/issue/DOC-4082/update-left-nav-bar-to-include-link-to-version-15