### PR TITLE
Turbopack: fix run_once when returning error

### DIFF
--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -526,13 +526,13 @@ impl<B: Backend + 'static> TurboTasks<B> {
     ) -> Result<T> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.spawn_once_task(async move {
-            let result = future.await?;
+            let result = future.await;
             tx.send(result)
                 .map_err(|_| anyhow!("unable to send result"))?;
             Ok(Completion::new())
         });
 
-        Ok(rx.await?)
+        rx.await?
     }
 
     pub async fn run<T: TraceRawVcs + Send + 'static>(


### PR DESCRIPTION
Errors returned from the callback are never read.
Instead, send errors returned from the `future` over the channel.


Closes PACK-5552