### PR TITLE
feat: add hiddenSourceMaps option to prevent sourcemap exposure

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2312,6 +2312,7 @@ export default async function getBaseWebpackConfig(
         ? undefined
         : config.devIndicators.position,
     productionBrowserSourceMaps: !!config.productionBrowserSourceMaps,
+    hiddenSourceMaps: !!config.hiddenSourceMaps,
     reactStrictMode: config.reactStrictMode,
     optimizeCss: config.experimental.optimizeCss,
     nextScriptWorkers: config.experimental.nextScriptWorkers,
@@ -2459,6 +2460,7 @@ export default async function getBaseWebpackConfig(
     assetPrefix: config.assetPrefix || '',
     sassOptions: config.sassOptions,
     productionBrowserSourceMaps: config.productionBrowserSourceMaps,
+    hiddenSourceMaps: config.hiddenSourceMaps,
     future: (config as any).future,
     experimental: config.experimental,
     disableStaticImages: config.images.disableStaticImages,

--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -48,7 +48,7 @@ export const base = curry(function base(
       (ctx.productionBrowserSourceMaps && ctx.isClient)
     ) {
       // Use hidden-source-map if hiddenSourceMaps is enabled for client builds
-      config.devtool = ctx.isClient && ctx.hiddenSourceMaps 
+      config.devtool = ctx.isClient && ctx.productionBrowserSourceMaps && ctx.hiddenSourceMaps 
         ? 'hidden-source-map' 
         : 'source-map'
     } else {

--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -61,7 +61,7 @@ export const base = curry(function base(
   }
 
   config.plugins ??= []
-  if (config.devtool === 'source-map' && !process.env.NEXT_RSPACK) {
+  if ((config.devtool === 'source-map' || config.devtool === 'hidden-source-map') && !process.env.NEXT_RSPACK) {
     config.plugins.push(
       new DevToolsIgnorePlugin({
         shouldIgnorePath,

--- a/packages/next/src/build/webpack/config/blocks/base.ts
+++ b/packages/next/src/build/webpack/config/blocks/base.ts
@@ -47,7 +47,10 @@ export const base = curry(function base(
       // Enable browser sourcemaps:
       (ctx.productionBrowserSourceMaps && ctx.isClient)
     ) {
-      config.devtool = 'source-map'
+      // Use hidden-source-map if hiddenSourceMaps is enabled for client builds
+      config.devtool = ctx.isClient && ctx.hiddenSourceMaps 
+        ? 'hidden-source-map' 
+        : 'source-map'
     } else {
       config.devtool = false
     }

--- a/packages/next/src/build/webpack/config/index.ts
+++ b/packages/next/src/build/webpack/config/index.ts
@@ -21,6 +21,7 @@ export async function buildConfiguration(
     assetPrefix,
     sassOptions,
     productionBrowserSourceMaps,
+    hiddenSourceMaps,
     future,
     transpilePackages,
     experimental,
@@ -38,6 +39,7 @@ export async function buildConfiguration(
     assetPrefix: string
     sassOptions: any
     productionBrowserSourceMaps: boolean
+    hiddenSourceMaps: boolean
     transpilePackages: NextConfigComplete['transpilePackages']
     // @ts-expect-error TODO: remove any
     future: NextConfigComplete['future']
@@ -64,6 +66,7 @@ export async function buildConfiguration(
       : '',
     sassOptions,
     productionBrowserSourceMaps,
+    hiddenSourceMaps,
     transpilePackages,
     future,
     experimental,

--- a/packages/next/src/build/webpack/config/utils.ts
+++ b/packages/next/src/build/webpack/config/utils.ts
@@ -22,6 +22,7 @@ export type ConfigurationContext = {
 
   sassOptions: any
   productionBrowserSourceMaps: boolean
+  hiddenSourceMaps: boolean
   serverSourceMaps: boolean
 
   transpilePackages: NextConfigComplete['transpilePackages']

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -653,6 +653,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
     pageExtensions: z.array(z.string()).min(1).optional(),
     poweredByHeader: z.boolean().optional(),
     productionBrowserSourceMaps: z.boolean().optional(),
+    hiddenSourceMaps: z.boolean().optional(),
     reactProductionProfiling: z.boolean().optional(),
     reactStrictMode: z.boolean().nullable().optional(),
     reactMaxHeadersLength: z.number().nonnegative().int().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1095,6 +1095,13 @@ export interface NextConfig {
   productionBrowserSourceMaps?: boolean
 
   /**
+   * Generate hidden source maps for production browser builds.
+   * When enabled, source maps are generated without sourceMappingURL comments.
+   * Only takes effect when productionBrowserSourceMaps is true.
+   */
+  hiddenSourceMaps?: boolean
+
+  /**
    * Enable react profiling in production
    *
    */
@@ -1352,6 +1359,7 @@ export const defaultConfig = Object.freeze({
   trailingSlash: false,
   i18n: null,
   productionBrowserSourceMaps: false,
+  hiddenSourceMaps: false,
   excludeDefaultMomentLocales: true,
   reactProductionProfiling: false,
   reactStrictMode: null,


### PR DESCRIPTION
- Add hiddenSourceMaps boolean option to Next.js config
- When enabled with productionBrowserSourceMaps, generates 'hidden-source-map' instead of 'source-map'
- Prevents # sourceMappingURL comments in generated JS bundles
- Allows error tracking services to use source maps while hiding them from end users
- Fixes S3/CDN 404 errors when source maps aren't uploaded publicly

Closes #[84095]

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

## What?

Adds a `hiddenSourceMaps` config option that generates source maps without exposing them to users in production.

## Why?

When you enable `productionBrowserSourceMaps`, Next.js includes `# sourceMappingURL` comments in your JS bundles. This means:
- Users can access your source code through browser dev tools
- Your CDN gets 404 requests for source map files you don't want to upload publicly
- Error tracking works fine, but you're sharing more than you intended

## How?

The new option works alongside `productionBrowserSourceMaps`:

```js
// next.config.js
module.exports = {
  productionBrowserSourceMaps: true,
  hiddenSourceMaps: true, // no more sourceMappingURL comments
}

Closes #84095

-->
