### PR TITLE
docs: update Security section to direct disclosures 

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -42,9 +42,8 @@ Contributions to Next.js are welcome and highly appreciated. However, before you
 We have a list of **[good first issues](https://github.com/vercel/next.js/labels/%22good%20first%20issue%22)** that contain bugs that have a relatively limited scope. This is a great place for newcomers and beginners alike to get started, gain experience, and get familiar with our contribution process.
 
 ---
-
 ## Security
 
-If you believe you have found a security vulnerability in Next.js, we encourage you to **_responsibly disclose this and NOT open a public issue_**. We will investigate all legitimate reports.
+If you believe you have found a security vulnerability in Next.js, we encourage you to **_responsibly disclose this and NOT open a public issue_**.
 
-Our preference is that you make use of GitHub's private vulnerability reporting feature to disclose potential security vulnerabilities in our Open Source Software. To do this, please visit [https://github.com/vercel/next.js/security](https://github.com/vercel/next.js/security) and click the "Report a vulnerability" button.
+To participate in our Open Source Software Bug Bounty program, please email [responsible.disclosure@vercel.com](mailto:responsible.disclosure@vercel.com). We will add you to the program and provide further instructions for submitting your report.


### PR DESCRIPTION
This PR updates the README.md Security section:

- Removes reference to GitHub’s private vulnerability reporting feature.
- Directs researchers to email responsible.disclosure@vercel.com.
- Clarifies that researchers will be added to our Open Source Software Bug Bounty program upon contacting us.

This change aligns our security disclosure process with Vercel’s current bug bounty program enrollment flow.