### PR TITLE
add Statsig Node Core package to Server External Packages

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverExternalPackages.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverExternalPackages.mdx
@@ -35,7 +35,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@sentry/profiling-node`
 - `@sparticuz/chromium`
 - `@sparticuz/chromium-min`
-- `@statsig/statsig-node-core`,
+- `@statsig/statsig-node-core`
 - `@swc/core`
 - `@xenova/transformers`
 - `argon2`

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverExternalPackages.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverExternalPackages.mdx
@@ -35,6 +35,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@sentry/profiling-node`
 - `@sparticuz/chromium`
 - `@sparticuz/chromium-min`
+- `@statsig/statsig-node-core`,
 - `@swc/core`
 - `@xenova/transformers`
 - `argon2`

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
@@ -35,7 +35,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@sentry/profiling-node`
 - `@sparticuz/chromium`
 - `@sparticuz/chromium-min`
-- `@statsig/statsig-node-core`,
+- `@statsig/statsig-node-core`
 - `@swc/core`
 - `@xenova/transformers`
 - `argon2`

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
@@ -35,6 +35,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@sentry/profiling-node`
 - `@sparticuz/chromium`
 - `@sparticuz/chromium-min`
+- `@statsig/statsig-node-core`,
 - `@swc/core`
 - `@xenova/transformers`
 - `argon2`

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -16,6 +16,7 @@
   "@sentry/profiling-node",
   "@sparticuz/chromium",
   "@sparticuz/chromium-min",
+  "@statsig/statsig-node-core",
   "@swc/core",
   "@xenova/transformers",
   "argon2",


### PR DESCRIPTION
### What?
Statsig is a popular AB Testing/ Feature Flagging solution to use in concert with Next.js. Today, their newest Server SDK doesn't play nicely with Next as its build around a Rust library, which doesn't play nice with webpack and causes build issues.

### Why?
This'll remove a step for Statsig/Next developers having to troubleshoot and add @statsig/statsig-node-core to serverExternalPackages themselves.

### How?
Added to the list published here: https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages