### PR TITLE
fix(server): fix pages router resume router matching

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -818,5 +818,6 @@
   "817": "`cacheLifeProfiles` should always be provided.",
   "818": "`cacheLife()` can only be called inside a \"use cache\" function.",
   "819": "`cacheTag()` can only be called inside a \"use cache\" function.",
-  "820": "`cacheLife()` can only be called during App Router rendering at the moment."
+  "820": "`cacheLife()` can only be called during App Router rendering at the moment.",
+  "821": "Unprocessable request"
 }

--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -141,6 +141,25 @@ export async function collectBuildTraces({
         )
       }
 
+      // Under standalone mode, we need to ensure that the cache entry debug
+      // handler is traced so it can be copied. This is only used for testing,
+      // and is not used in production.
+      if (
+        process.env.__NEXT_TEST_MODE &&
+        process.env.NEXT_PRIVATE_DEBUG_CACHE_ENTRY_HANDLERS
+      ) {
+        sharedEntriesSet.push(
+          require.resolve(
+            path.isAbsolute(process.env.NEXT_PRIVATE_DEBUG_CACHE_ENTRY_HANDLERS)
+              ? process.env.NEXT_PRIVATE_DEBUG_CACHE_ENTRY_HANDLERS
+              : path.join(
+                  dir,
+                  process.env.NEXT_PRIVATE_DEBUG_CACHE_ENTRY_HANDLERS
+                )
+          )
+        )
+      }
+
       if (cacheHandlers) {
         for (const handlerPath of Object.values(cacheHandlers)) {
           if (handlerPath) {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2704,6 +2704,28 @@ export default async function build(
         )
       }
 
+      // Under standalone mode, we need to ensure that the cache entry debug
+      // handler is copied so that it can be used in the test. This is required
+      // for the turbopack test to run as it's more strict about the build
+      // directories. This is only used for testing and is not used in
+      // production.
+      if (
+        process.env.__NEXT_TEST_MODE &&
+        process.env.NEXT_PRIVATE_DEBUG_CACHE_ENTRY_HANDLERS
+      ) {
+        requiredServerFilesManifest.files.push(
+          path.relative(
+            dir,
+            path.isAbsolute(process.env.NEXT_PRIVATE_DEBUG_CACHE_ENTRY_HANDLERS)
+              ? process.env.NEXT_PRIVATE_DEBUG_CACHE_ENTRY_HANDLERS
+              : path.join(
+                  dir,
+                  process.env.NEXT_PRIVATE_DEBUG_CACHE_ENTRY_HANDLERS
+                )
+          )
+        )
+      }
+
       const features: EventBuildFeatureUsage[] = [
         {
           featureName: 'experimental/cacheComponents',

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -30,6 +30,7 @@ enum LoadComponentsSpan {
 
 enum NextServerSpan {
   getRequestHandler = 'NextServer.getRequestHandler',
+  getRequestHandlerWithMetadata = 'NextServer.getRequestHandlerWithMetadata',
   getServer = 'NextServer.getServer',
   getServerRequestHandler = 'NextServer.getServerRequestHandler',
   createServer = 'createServer.createServer',

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -13,7 +13,11 @@ import type RenderResult from './render-result'
 import type { FetchEventResult } from './web/types'
 import type { PrerenderManifest, RoutesManifest } from '../build'
 import type { PagesManifest } from '../build/webpack/plugins/pages-manifest-plugin'
-import type { NextParsedUrlQuery, NextUrlWithParsedQuery } from './request-meta'
+import type {
+  NextParsedUrlQuery,
+  NextUrlWithParsedQuery,
+  RequestMeta,
+} from './request-meta'
 import type { Params } from './request/params'
 import type { MiddlewareRouteMatch } from '../shared/lib/router/utils/middleware-route-matcher'
 import type { RouteMatch } from './route-matches/route-match'
@@ -27,7 +31,7 @@ import type { WaitUntil } from './after/builtin-request-context'
 import fs from 'fs'
 import { join, relative } from 'path'
 import { getRouteMatcher } from '../shared/lib/router/utils/route-matcher'
-import { addRequestMeta, getRequestMeta } from './request-meta'
+import { addRequestMeta, getRequestMeta, setRequestMeta } from './request-meta'
 import {
   PAGES_MANIFEST,
   BUILD_ID_FILE,
@@ -1271,6 +1275,17 @@ export default class NextNodeServer extends BaseServer<
       return wrapRequestHandlerNode(handler)
     }
     return handler
+  }
+
+  /**
+   * @internal - this method is internal to Next.js and should not be used directly by end-users
+   */
+  public getRequestHandlerWithMetadata(meta: RequestMeta): NodeRequestHandler {
+    const handler = this.makeRequestHandler()
+    return (req, res, parsedUrl) => {
+      setRequestMeta(req, meta)
+      return handler(req, res, parsedUrl)
+    }
   }
 
   private makeRequestHandler(): NodeRequestHandler {

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -6,7 +6,7 @@ import type {
 import type { UrlWithParsedQuery } from 'url'
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { Duplex } from 'stream'
-import type { NextUrlWithParsedQuery } from './request-meta'
+import type { NextUrlWithParsedQuery, RequestMeta } from './request-meta'
 
 import './require-hook'
 import './node-polyfill-crypto'
@@ -145,6 +145,27 @@ export class NextServer implements NextWrapperServer {
         const requestHandler = await this.getServerRequestHandler()
         return requestHandler(req, res, parsedUrl)
       })
+    }
+  }
+
+  /**
+   * @internal - this method is internal to Next.js and should not be used
+   * directly by end-users, only used in testing
+   */
+  getRequestHandlerWithMetadata(meta: RequestMeta): RequestHandler {
+    return async (
+      req: IncomingMessage,
+      res: ServerResponse,
+      parsedUrl?: UrlWithParsedQuery
+    ) => {
+      return getTracer().trace(
+        NextServerSpan.getRequestHandlerWithMetadata,
+        async () => {
+          const server = await this.getServer()
+          const handler = server.getRequestHandlerWithMetadata(meta)
+          return handler(req, res, parsedUrl)
+        }
+      )
     }
   }
 

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -21,6 +21,28 @@ export type NextIncomingMessage = (BaseNextRequest | IncomingMessage) & {
   [NEXT_REQUEST_META]?: RequestMeta
 }
 
+/**
+ * The callback function to call when a response cache entry was generated or
+ * looked up in the cache. When it returns true, the server assumes that the
+ * handler has already responded to the request and will not do so itself.
+ */
+export type OnCacheEntryHandler = (
+  /**
+   * The response cache entry that was generated or looked up in the cache.
+   */
+  cacheEntry: ResponseCacheEntry,
+
+  /**
+   * The request metadata.
+   */
+  requestMeta: {
+    /**
+     * The URL that was used to make the request.
+     */
+    url: string | undefined
+  }
+) => Promise<boolean | void> | boolean | void
+
 export interface RequestMeta {
   /**
    * The query that was used to make the request.
@@ -126,23 +148,13 @@ export interface RequestMeta {
    *
    * @deprecated Use `onCacheEntryV2` instead.
    */
-  onCacheEntry?: (
-    cacheEntry: ResponseCacheEntry,
-    requestMeta: {
-      url: string | undefined
-    }
-  ) => Promise<boolean | void> | boolean | void
+  onCacheEntry?: OnCacheEntryHandler
 
   /**
    * If provided, this will be called when a response cache entry was generated
    * or looked up in the cache.
    */
-  onCacheEntryV2?: (
-    cacheEntry: ResponseCacheEntry,
-    requestMeta: {
-      url: string | undefined
-    }
-  ) => Promise<boolean | void> | boolean | void
+  onCacheEntryV2?: OnCacheEntryHandler
 
   /**
    * The previous revalidate before rendering 404 page for notFound: true

--- a/test/production/standalone-mode/required-server-files/app/@slot/[...catchAll]/loading.js
+++ b/test/production/standalone-mode/required-server-files/app/@slot/[...catchAll]/loading.js
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="slot-loading">/[...catchAll]</p>
+}

--- a/test/production/standalone-mode/required-server-files/app/@slot/[...catchAll]/page.js
+++ b/test/production/standalone-mode/required-server-files/app/@slot/[...catchAll]/page.js
@@ -1,0 +1,8 @@
+export default async function Page({ params }) {
+  return (
+    <>
+      <p id="slot-page">/@slot/[[...catchAll]]/page.js</p>
+      <p id="slot-params">{JSON.stringify(await params)}</p>
+    </>
+  )
+}

--- a/test/production/standalone-mode/required-server-files/app/@slot/default.js
+++ b/test/production/standalone-mode/required-server-files/app/@slot/default.js
@@ -1,0 +1,3 @@
+export default function Default() {
+  return '/@slot/default.js'
+}

--- a/test/production/standalone-mode/required-server-files/app/default.js
+++ b/test/production/standalone-mode/required-server-files/app/default.js
@@ -1,0 +1,3 @@
+export default function Default() {
+  return '/default.js'
+}

--- a/test/production/standalone-mode/required-server-files/app/layout.js
+++ b/test/production/standalone-mode/required-server-files/app/layout.js
@@ -1,8 +1,15 @@
-export default function Layout({ children }) {
+import { Suspense } from 'react'
+
+export default function Layout({ children, slot }) {
   return (
     <html lang="en">
       <head />
-      <body>{children}</body>
+      <body>
+        <Suspense>
+          <div id="children-slot">{children}</div>
+          <div id="slot-slot">{slot}</div>
+        </Suspense>
+      </body>
     </html>
   )
 }

--- a/test/production/standalone-mode/required-server-files/app/postpone/isr/[slug]/page.js
+++ b/test/production/standalone-mode/required-server-files/app/postpone/isr/[slug]/page.js
@@ -2,7 +2,7 @@ export default async function Page({ params }) {
   return (
     <>
       <p id="page">/postpone/isr/[slug]</p>
-      <p id="params">{JSON.stringify(params)}</p>
+      <p id="params">{JSON.stringify(await params)}</p>
       <p id="now">{Date.now()}</p>
     </>
   )

--- a/test/production/standalone-mode/required-server-files/cache-entry-handlers.js
+++ b/test/production/standalone-mode/required-server-files/cache-entry-handlers.js
@@ -1,0 +1,66 @@
+// @ts-check
+
+/**
+ * @param {import('http').ServerResponse} res
+ * @returns {{
+ *   onCacheEntry: import('next/dist/server/request-meta').OnCacheEntryHandler,
+ *   onCacheEntryV2: import('next/dist/server/request-meta').OnCacheEntryHandler
+ * }}
+ */
+module.exports = (res) => ({
+  onCacheEntry: (cacheEntry, meta) => {
+    // If this isn't a static app page response from the response cache, then
+    // mark it as a miss.
+    if (
+      !cacheEntry.value ||
+      cacheEntry.value.kind !== 'APP_PAGE' ||
+      !cacheEntry.value.html ||
+      typeof cacheEntry.value.html.toUnchunkedString !== 'function' ||
+      !cacheEntry.value.postponed ||
+      !meta.url ||
+      typeof meta.url !== 'string'
+    ) {
+      res.setHeader('x-nextjs-cache-entry-handler', 'MISS_1')
+      return false
+    }
+
+    // If this is for a RSC request, then mark it as a miss.
+    if (meta.url.endsWith('.rsc')) {
+      res.setHeader('x-nextjs-cache-entry-handler', 'MISS_1')
+      return false
+    }
+
+    // Mark this as a hit against the cache entry handler.
+    res.setHeader('x-nextjs-cache-entry-handler', 'HIT_1')
+    return false
+  },
+  onCacheEntryV2: (cacheEntry, meta) => {
+    // If this isn't a static app page response from the response cache, then
+    // mark it as a miss.
+    if (
+      !cacheEntry.value ||
+      cacheEntry.value.kind !== 'APP_PAGE' ||
+      !cacheEntry.value.html ||
+      typeof cacheEntry.value.html.toUnchunkedString !== 'function' ||
+      !cacheEntry.value.postponed ||
+      !meta.url ||
+      typeof meta.url !== 'string'
+    ) {
+      res.setHeader('x-nextjs-cache-entry-handler', 'MISS_2')
+      return false
+    }
+
+    // If this is for a prefetch or segment request, then mark it as a miss.
+    if (
+      meta.url.endsWith('.prefetch.rsc') ||
+      meta.url.endsWith('.segment.rsc')
+    ) {
+      res.setHeader('x-nextjs-cache-entry-handler', 'MISS_2')
+      return false
+    }
+
+    // Mark this as a hit against the cache entry handler.
+    res.setHeader('x-nextjs-cache-entry-handler', 'HIT_2')
+    return false
+  },
+})

--- a/test/production/standalone-mode/required-server-files/ppr/app/not-found.js
+++ b/test/production/standalone-mode/required-server-files/ppr/app/not-found.js
@@ -1,0 +1,11 @@
+import { connection } from 'next/server'
+
+export default async function NotFound() {
+  await connection()
+
+  return (
+    <>
+      <p id="not-found">/not-found</p>
+    </>
+  )
+}


### PR DESCRIPTION
### What?

Prevents PPR resume requests on Pages Router data routes by rejecting them with a 422 status code and adds debug cache entry handlers for testing PPR cache behavior in standalone mode.

### Why?

PPR (Partial Pre-Rendering) is an App Router-specific feature that should not be used with Pages Router routes. When a request includes both:
1. PPR resume headers (`next-resume: 1`)
2. A Pages Router data route URL (`/_next/data/...`)

This represents an invalid request combination that could cause unexpected behavior. The server should explicitly reject these unprocessable requests rather than attempting to handle them.

Additionally, testing PPR cache behavior in standalone mode requires debug cache entry handlers that can track cache hits/misses during PPR rendering scenarios.

### How?

**Main Fix (packages/next/src/server/base-server.ts:1102-1117):**
- Added validation after parsing PPR resume headers to check if the request is also a next data request
- If both conditions are true, immediately return HTTP 422 (Unprocessable Entity) with empty response
- This prevents the request from proceeding to the render pipeline where it could cause issues

**Debug Infrastructure:**
- Added support for `NEXT_PRIVATE_DEBUG_CACHE_ENTRY_HANDLERS` environment variable in test mode
- Enhanced build tracing and required server files manifest to include debug handlers
- Modified render server to use debug cache entry handlers when available for testing PPR cache behavior

NAR-416