### PR TITLE
[turbopack] Use `strongly_consistent_catch_collectables` on the `project_write_all_entrypoints_to_disk` operation

### DIFF
--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -290,6 +290,10 @@ impl NapiDiagnostic {
     }
 }
 
+/// A result from a turbo-tasks computation that can be passed back and forth to JS across the
+/// [`napi`][mod@napi] boundary via [`External`].
+///
+/// The `result` field is flattened into the object when passing across the boundary.
 pub struct TurbopackResult<T: ToNapiValue> {
     pub result: T,
     pub issues: Vec<NapiIssue>,

--- a/crates/next-api/src/operation.rs
+++ b/crates/next-api/src/operation.rs
@@ -45,6 +45,19 @@ async fn entrypoints_without_collectibles_operation(
 
 #[turbo_tasks::value_impl]
 impl EntrypointsOperation {
+    /// an empty set of entrypoints for when there are critical errors
+    #[turbo_tasks::function]
+    pub fn empty() -> Vc<Self> {
+        Self {
+            routes: FxIndexMap::default(),
+            middleware: None,
+            instrumentation: None,
+            pages_document_endpoint: none_endpoint_operation(),
+            pages_app_endpoint: none_endpoint_operation(),
+            pages_error_endpoint: none_endpoint_operation(),
+        }
+        .cell()
+    }
     #[turbo_tasks::function(operation)]
     pub async fn new(entrypoints: OperationVc<Entrypoints>) -> Result<Vc<Self>> {
         let e = entrypoints.connect().await?;
@@ -138,6 +151,11 @@ enum EndpointSelector {
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionEndpoint(Option<ResolvedVc<Box<dyn Endpoint>>>);
+
+#[turbo_tasks::function(operation)]
+pub fn none_endpoint_operation() -> Vc<OptionEndpoint> {
+    OptionEndpoint(None).cell()
+}
 
 /// Given a selector and the `Entrypoints` operation that it comes from, connect the operation and
 /// return an `OperationVc` containing the selected value. The returned operation will keep the

--- a/turbopack/crates/turbopack-core/src/context.rs
+++ b/turbopack/crates/turbopack-core/src/context.rs
@@ -29,13 +29,14 @@ pub enum ProcessResult {
 #[turbo_tasks::value_impl]
 impl ProcessResult {
     #[turbo_tasks::function]
-    pub fn module(&self) -> Result<Vc<Box<dyn Module>>> {
+    pub async fn module(&self) -> Result<Vc<Box<dyn Module>>> {
         match *self {
             ProcessResult::Module(m) => Ok(*m),
             ProcessResult::Ignore => {
                 bail!("Expected process result to be a module, but it was ignored")
             }
-            ProcessResult::Unknown(_) => {
+            ProcessResult::Unknown(source) => {
+                emit_unknown_module_type_error(*source).await?;
                 bail!("Expected process result to be a module, but it could not be processed")
             }
         }

--- a/turbopack/crates/turbopack-core/src/issue/module.rs
+++ b/turbopack/crates/turbopack-core/src/issue/module.rs
@@ -70,11 +70,11 @@ pub async fn emit_unknown_module_type_error(source: Vc<Box<dyn Source>>) -> Resu
     ModuleIssue {
         ident: source.ident().to_resolved().await?,
         title: StyledString::Text(rcstr!("Unknown module type")).resolved_cell(),
-        description: StyledString::Text(
+        description: StyledString::Text(rcstr!(
             r"This module doesn't have an associated type. Use a known file extension, or register a loader for it.
 
-Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders".into(),
-        )
+Read more: https://nextjs.org/docs/app/api-reference/next-config-js/turbo#webpack-loaders"
+        ))
         .resolved_cell(),
         source: Some(IssueSource::from_source_only(source.to_resolved().await?)),
     }


### PR DESCRIPTION
A user misconfigured a webpack loader which lead to an 'unknown module type' error, however this happened early enough that even the entrypoints were affected. Which resulted in a crash,
```
> Build error occurred
Error [TurbopackInternalError]: Failed to write page endpoint /_error

Caused by:
- Expected process result to be a module, but it could not be processed

Debug info:
- Execution of get_all_written_entrypoints_with_issues_operation failed
- Execution of EntrypointsOperation::new failed
- Execution of all_entrypoints_write_to_disk_operation failed
- Execution of Project::emit_all_output_assets failed
- Execution of *emit_assets failed
- Execution of all_assets_from_entries_operation failed
- Execution of *all_assets_from_entries failed
- Execution of output_assets_operation failed
- Execution of <PageEndpoint as Endpoint>::output failed
- Failed to write page endpoint /_error
- Execution of PageEndpoint::output failed
- Execution of PageEndpoint::client_chunk_group failed
- Execution of *ChunkingContext::evaluated_chunk_group failed
- Execution of Project::client_chunking_context failed
- Execution of *get_client_chunking_context failed
- Execution of Project::module_ids failed
- Execution of Project::whole_app_module_graphs failed
- Execution of whole_app_module_graph_operation failed
- Execution of *ModuleGraph::from_single_graph failed
- Execution of *SingleModuleGraph::new_with_entries failed
- Execution of Project::get_all_entries failed
- Execution of <AppEndpoint as Endpoint>::entries failed
- Execution of get_app_page_entry failed
- Execution of ProcessResult::module failed
- Expected process result to be a module, but it could not be processed
    at <unknown> (TurbopackInternalError: Failed to write page endpoint /_error) {
  type: 'TurbopackInternalError'
}
```

Instead use `strongly_consistent_catch_collectables` to ensure Issues are reported.
