### PR TITLE
Add deprecation warning to Runtime config

### DIFF
--- a/packages/next/config.js
+++ b/packages/next/config.js
@@ -1,1 +1,12 @@
-module.exports = require('./dist/shared/lib/runtime-config.external')
+let hasWarned = false
+
+module.exports = (() => {
+  if (!hasWarned) {
+    console.warn(
+      // ANSI code aligns with Next.js warning style from picocolors.
+      ' \x1b[33m\x1b[1m⚠\x1b[22m\x1b[39m Runtime config is deprecated and will be removed in Next.js 16. Please remove the usage of "next/config" from your project.'
+    )
+    hasWarned = true
+  }
+  return require('./dist/shared/lib/runtime-config.external')
+})()

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1118,7 +1118,7 @@ export interface NextConfig {
   /**
    * Add public (in browser) runtime configuration to your app
    *
-   * @see [Runtime configuration](https://nextjs.org/docs/pages/api-reference/config/next-config-js/runtime-configuration
+   * @see [Runtime configuration](https://nextjs.org/docs/pages/api-reference/config/next-config-js/runtime-configuration)
    * @deprecated Runtime config is deprecated and will be removed in Next.js 16.
    */
   publicRuntimeConfig?: { [key: string]: any }
@@ -1126,7 +1126,7 @@ export interface NextConfig {
   /**
    * Add server runtime configuration to your app
    *
-   * @see [Runtime configuration](https://nextjs.org/docs/pages/api-reference/config/next-config-js/runtime-configuration
+   * @see [Runtime configuration](https://nextjs.org/docs/pages/api-reference/config/next-config-js/runtime-configuration)
    * @deprecated Runtime config is deprecated and will be removed in Next.js 16.
    */
   serverRuntimeConfig?: { [key: string]: any }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1119,6 +1119,7 @@ export interface NextConfig {
    * Add public (in browser) runtime configuration to your app
    *
    * @see [Runtime configuration](https://nextjs.org/docs/pages/api-reference/config/next-config-js/runtime-configuration
+   * @deprecated Runtime config is deprecated and will be removed in Next.js 16.
    */
   publicRuntimeConfig?: { [key: string]: any }
 
@@ -1126,6 +1127,7 @@ export interface NextConfig {
    * Add server runtime configuration to your app
    *
    * @see [Runtime configuration](https://nextjs.org/docs/pages/api-reference/config/next-config-js/runtime-configuration
+   * @deprecated Runtime config is deprecated and will be removed in Next.js 16.
    */
   serverRuntimeConfig?: { [key: string]: any }
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -109,6 +109,19 @@ function checkDeprecations(
   silent: boolean,
   dir: string
 ) {
+  warnOptionHasBeenDeprecated(
+    userConfig,
+    'publicRuntimeConfig',
+    `Runtime config is deprecated and the \`publicRuntimeConfig\` configuration option will be removed in Next.js 16.`,
+    silent
+  )
+  warnOptionHasBeenDeprecated(
+    userConfig,
+    'serverRuntimeConfig',
+    `Runtime config is deprecated and the \`serverRuntimeConfig\` configuration option will be removed in Next.js 16.`,
+    silent
+  )
+
   if (userConfig.experimental?.dynamicIO !== undefined) {
     warnOptionHasBeenDeprecated(
       userConfig,

--- a/packages/next/src/shared/lib/runtime-config.external.ts
+++ b/packages/next/src/shared/lib/runtime-config.external.ts
@@ -1,9 +1,15 @@
 let runtimeConfig: any
 
+/**
+ * @deprecated Runtime config is deprecated and will be removed in Next.js 16.
+ */
 export default () => {
   return runtimeConfig
 }
 
+/**
+ * @deprecated Runtime config is deprecated and will be removed in Next.js 16.
+ */
 export function setConfig(configValue: any): void {
   runtimeConfig = configValue
 }

--- a/test/e2e/app-dir/deprecation-warning-runtime-config/app/layout.tsx
+++ b/test/e2e/app-dir/deprecation-warning-runtime-config/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/deprecation-warning-runtime-config/app/page.tsx
+++ b/test/e2e/app-dir/deprecation-warning-runtime-config/app/page.tsx
@@ -1,0 +1,6 @@
+import getConfig from 'next/config'
+
+export default function Page() {
+  getConfig()
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/deprecation-warning-runtime-config/deprecation-warning-runtime-config.test.ts
+++ b/test/e2e/app-dir/deprecation-warning-runtime-config/deprecation-warning-runtime-config.test.ts
@@ -1,0 +1,16 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('deprecation-warning-runtime-config', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should warn when imported "next/config" module', async () => {
+    // Navigate to "/" for dev server to execute the code
+    await next.browser('/')
+
+    expect(next.cliOutput).toContain(
+      'Runtime config is deprecated and will be removed in Next.js 16. Please remove the usage of "next/config" from your project.'
+    )
+  })
+})

--- a/test/e2e/app-dir/deprecation-warning-runtime-config/next.config.js
+++ b/test/e2e/app-dir/deprecation-warning-runtime-config/next.config.js
@@ -1,0 +1,13 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  publicRuntimeConfig: {
+    foo: 'bar',
+  },
+  serverRuntimeConfig: {
+    foo: 'bar',
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/deprecation-warnings/deprecation-warnings.test.ts
+++ b/test/e2e/deprecation-warnings/deprecation-warnings.test.ts
@@ -32,6 +32,14 @@ describe('deprecation-warnings', () => {
       // Should warn about experimental.instrumentationHook
       expect(logs).toContain('experimental.instrumentationHook')
       expect(logs).toContain('no longer needed')
+
+      // Should warn about publicRuntimeConfig
+      expect(logs).toContain('publicRuntimeConfig')
+      expect(logs).toContain('will be removed in Next.js 16')
+
+      // Should warn about serverRuntimeConfig
+      expect(logs).toContain('serverRuntimeConfig')
+      expect(logs).toContain('will be removed in Next.js 16')
     })
   })
 })

--- a/test/e2e/deprecation-warnings/fixtures/with-deprecated-config/next.config.js
+++ b/test/e2e/deprecation-warnings/fixtures/with-deprecated-config/next.config.js
@@ -1,6 +1,13 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
   // Explicitly configure deprecated options
   experimental: {
     instrumentationHook: true,
+  },
+  publicRuntimeConfig: {
+    foo: 'bar',
+  },
+  serverRuntimeConfig: {
+    foo: 'bar',
   },
 }


### PR DESCRIPTION
Following up on https://github.com/vercel/next.js/pull/84167, adding a deprecation warning for the Runtime config. This PR will be backported to v15.