### PR TITLE
Add internal environment variable for enabling React Compiler

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1806,6 +1806,24 @@ function enforceExperimentalFeatures(
   }
 
   if (
+    process.env.__NEXT_ENABLE_REACT_COMPILER === 'true' &&
+    // We do respect an explicit value in the user config.
+    (config.experimental.reactCompiler === undefined ||
+      (isDefaultConfig && !config.experimental.reactCompiler))
+  ) {
+    config.experimental.reactCompiler = true
+
+    if (configuredExperimentalFeatures) {
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        'reactCompiler',
+        true,
+        'enabled by `__NEXT_ENABLE_REACT_COMPILER`'
+      )
+    }
+  }
+
+  if (
     config.experimental.enablePrerenderSourceMaps === undefined &&
     config.experimental.cacheComponents === true
   ) {

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -225,6 +225,14 @@ export class NextInstance {
           ...this.packageJson?.dependencies,
         }
 
+        if (
+          process.env.__NEXT_ENABLE_REACT_COMPILER === 'true' &&
+          !finalDependencies['babel-plugin-react-compiler']
+        ) {
+          finalDependencies['babel-plugin-react-compiler'] =
+            '0.0.0-experimental-3fde738-20250918'
+        }
+
         if (skipInstall || skipIsolatedNext) {
           const pkgScripts = (this.packageJson['scripts'] as {}) || {}
           await fs.mkdir(this.testDir, { recursive: true })


### PR DESCRIPTION
We'll use this in CI to enable it on certain shards or just temporarily.
Also allows quickly testing the Compiler in our tests.
It's not just about enabling the config flag but also declaring the dependency so an easy way to switch makes sense.