### PR TITLE
Turbopack: support more dynamic request with import map

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/index.js
@@ -1,4 +1,4 @@
-import { loadSub, /* loadSubNested, */ loadSubFallback } from './src/foo'
+import { loadSub, loadSubNested, loadSubFallback } from './src/foo'
 
 it('should support dynamic requests with tsconfig.paths', () => {
   expect(loadSub('file2.js').default).toBe('file2')
@@ -8,9 +8,9 @@ it('should support dynamic requests with tsconfig.paths and without extension', 
   expect(loadSub('file2').default).toBe('file2')
 })
 
-// it('should support dynamic requests with tsconfig.paths and multiple dynamic parts', () => {
-//   expect(loadSubNested('file2').default).toBe('file2')
-// })
+it('should support dynamic requests with tsconfig.paths and multiple dynamic parts', () => {
+  expect(loadSubNested('file2').default).toBe('file2')
+})
 
 it('should support dynamic requests with tsconfig.paths fallbacks', () => {
   expect(loadSubFallback('file1').default).toBe('file1')

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/src/foo.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/src/foo.ts
@@ -2,10 +2,9 @@ export function loadSub(v: string) {
   return require(`@/sub/${v}`)
 }
 
-// TODO not supported
-// export function loadSubNested(v: string) {
-//   return require(`@/sub-nested/${v}/${v}.js`)
-// }
+export function loadSubNested(v: string) {
+  return require(`@/sub-nested/${v}/${v}.js`)
+}
 
 export function loadSubFallback(v: string) {
   return require(`@sub/${v}`)


### PR DESCRIPTION
Add support to resolve arbitrarily dynamic requests into a `'@/*": "./@"` import mapping, such as

```js
import(`@/styles/themes/theme-${themeName}/theme-${themeName}`)
```

Closes [#83785](https://github.com/vercel/next.js/issues/83785)
Closes PACK-5451

This was basically a regression from #82757