### PR TITLE
Turbopack: only generate field if spans are enabled

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1835,7 +1835,7 @@ impl AppEndpoint {
                     {
                         let span = tracing::trace_span!(
                             "layout segment",
-                            name = server_component.ident().to_string().await?.as_str()
+                            name = display(server_component.ident().to_string().await?)
                         );
                         async {
                             let ChunkGroupResult {

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1585,16 +1585,16 @@ impl Endpoint for PageEndpoint {
         let span = {
             match &this.ty {
                 PageEndpointType::Html => {
-                    tracing::info_span!("page endpoint HTML", name = original_name.to_string())
+                    tracing::info_span!("page endpoint HTML", name = display(original_name))
                 }
                 PageEndpointType::Data => {
-                    tracing::info_span!("page endpoint data", name = original_name.to_string())
+                    tracing::info_span!("page endpoint data", name = display(original_name))
                 }
                 PageEndpointType::Api => {
-                    tracing::info_span!("page endpoint API", name = original_name.to_string())
+                    tracing::info_span!("page endpoint API", name = display(original_name))
                 }
                 PageEndpointType::SsrOnly => {
-                    tracing::info_span!("page endpoint SSR", name = original_name.to_string())
+                    tracing::info_span!("page endpoint SSR", name = display(original_name))
                 }
             }
         };

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -269,10 +269,10 @@ async fn get_directory_tree(
     dir: FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<DirectoryTree>> {
-    let span = {
-        let dir = dir.value_to_string().await?.to_string();
-        tracing::info_span!("read app directory tree", name = dir)
-    };
+    let span = tracing::info_span!(
+        "read app directory tree",
+        name = display(dir.value_to_string().await?)
+    );
     get_directory_tree_internal(dir, page_extensions)
         .instrument(span)
         .await

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -328,10 +328,10 @@ async fn get_pages_structure_for_directory(
     position: u32,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<PagesDirectoryStructure>> {
-    let span = {
-        let path = project_path.value_to_string().await?.to_string();
-        tracing::info_span!("analyze pages structure", name = path)
-    };
+    let span = tracing::info_span!(
+        "analyze pages structure",
+        name = display(project_path.value_to_string().await?)
+    );
     async move {
         let page_extensions_raw = &*page_extensions.await?;
 

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -639,8 +639,8 @@ impl ChunkingContext for BrowserChunkingContext {
     ) -> Result<Vc<ChunkGroupResult>> {
         let span = tracing::info_span!(
             "chunking",
+            name = display(ident.to_string().await?),
             chunking_type = "evaluated",
-            ident = display(ident.to_string().await?)
         );
         async move {
             let this = self.await?;

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -570,7 +570,7 @@ impl ChunkingContext for BrowserChunkingContext {
         module_graph: Vc<ModuleGraph>,
         availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
-        let span = tracing::info_span!("chunking", name = ident.to_string().await?.to_string());
+        let span = tracing::info_span!("chunking", name = display(ident.to_string().await?));
         async move {
             let this = self.await?;
             let entries = chunk_group.entries();
@@ -637,10 +637,11 @@ impl ChunkingContext for BrowserChunkingContext {
         module_graph: Vc<ModuleGraph>,
         input_availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
-        let span = {
-            let ident = ident.to_string().await?.to_string();
-            tracing::info_span!("chunking", chunking_type = "evaluated", ident = ident)
-        };
+        let span = tracing::info_span!(
+            "chunking",
+            chunking_type = "evaluated",
+            ident = display(ident.to_string().await?)
+        );
         async move {
             let this = self.await?;
             let entries = chunk_group.entries();

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
@@ -321,7 +321,7 @@ pub async fn make_chunks(
     let mut chunks = Vec::new();
     for (ty, (chunk_items, batch_groups)) in map {
         let ty_name = ty.to_string().await?;
-        let span = tracing::trace_span!("make chunks for type", name = display(ty_name));
+        let span = tracing::trace_span!("make chunks for type", name = display(&ty_name));
         async {
             let mut split_context = SplitContext {
                 ty,

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
@@ -321,7 +321,7 @@ pub async fn make_chunks(
     let mut chunks = Vec::new();
     for (ty, (chunk_items, batch_groups)) in map {
         let ty_name = ty.to_string().await?;
-        let span = tracing::trace_span!("make chunks for type", name = ty_name.as_str());
+        let span = tracing::trace_span!("make chunks for type", name = display(ty_name));
         async {
             let mut split_context = SplitContext {
                 ty,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1531,16 +1531,17 @@ pub async fn resolve_inline(
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
-    let span = {
-        let lookup_path = lookup_path.value_to_string().await?.to_string();
-        let request = request.to_string().await?.to_string();
-        tracing::info_span!(
-            "resolving",
-            lookup_path = lookup_path,
-            name = request,
-            reference_type = display(&reference_type),
-        )
-    };
+    let span = tracing::info_span!(
+        "resolving",
+        lookup_path = display(lookup_path.value_to_string().await?),
+        name = tracing::field::Empty,
+        reference_type = display(&reference_type),
+    );
+    if !span.is_disabled() {
+        // You can't await multiple times in the span macro call parameters.
+        span.record("name", request.to_string().await?.as_str());
+    }
+
     async {
         let before_plugins_result = handle_before_resolve_plugins(
             lookup_path.clone(),
@@ -1740,15 +1741,16 @@ async fn resolve_internal_inline(
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
-    let span = {
-        let lookup_path = lookup_path.value_to_string().await?.to_string();
-        let request = request.to_string().await?.to_string();
-        tracing::info_span!(
-            "internal resolving",
-            lookup_path = lookup_path,
-            name = request
-        )
-    };
+    let span = tracing::info_span!(
+        "internal resolving",
+        lookup_path = display(lookup_path.value_to_string().await?),
+        name = tracing::field::Empty
+    );
+    if !span.is_disabled() {
+        // You can't await multiple times in the span macro call parameters.
+        span.record("name", request.to_string().await?.as_str());
+    }
+
     async move {
         let options_value: &ResolveOptions = &*options.await?;
 

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -363,10 +363,10 @@ pub async fn parse_css(
     ty: CssModuleAssetType,
     environment: Option<ResolvedVc<Environment>>,
 ) -> Result<Vc<ParseCssResult>> {
-    let span = {
-        let name = source.ident().to_string().await?.to_string();
-        tracing::info_span!("parse css", name = name)
-    };
+    let span = tracing::info_span!(
+        "parse css",
+        name = display(source.ident().to_string().await?)
+    );
     async move {
         let content = source.content();
         let ident_str = &*source.ident().to_string().await?;

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -174,8 +174,11 @@ pub async fn parse(
     ty: EcmascriptModuleAssetType,
     transforms: ResolvedVc<EcmascriptInputTransforms>,
 ) -> Result<Vc<ParseResult>> {
-    let name = source.ident().to_string().await?.to_string();
-    let span = tracing::info_span!("parse ecmascript", name = name, ty = display(&ty));
+    let span = tracing::info_span!(
+        "parse ecmascript",
+        name = name,
+        ty = display(&source.ident().to_string().await?)
+    );
 
     match parse_internal(source, ty, transforms)
         .instrument(span)

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -176,8 +176,8 @@ pub async fn parse(
 ) -> Result<Vc<ParseResult>> {
     let span = tracing::info_span!(
         "parse ecmascript",
-        name = name,
-        ty = display(&source.ident().to_string().await?)
+        name = display(source.ident().to_string().await?),
+        ty = display(&ty)
     );
 
     match parse_internal(source, ty, transforms)

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -484,10 +484,10 @@ pub(crate) async fn analyze_ecmascript_module(
     module: ResolvedVc<EcmascriptModuleAsset>,
     part: Option<ModulePart>,
 ) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
-    let span = {
-        let module = module.ident().to_string().await?.to_string();
-        tracing::info_span!("analyze ecmascript module", name = module)
-    };
+    let span = tracing::info_span!(
+        "analyze ecmascript module",
+        name = display(module.ident().to_string().await?)
+    );
     let result = analyze_ecmascript_module_internal(module, part)
         .instrument(span)
         .await;

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -383,7 +383,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         module_graph: Vc<ModuleGraph>,
         availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
-        let span = tracing::info_span!("chunking", name = ident.to_string().await?.to_string());
+        let span = tracing::info_span!("chunking", name = display(ident.to_string().await?));
         async move {
             let modules = chunk_group.entries();
             let MakeChunkGroupResult {

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -425,56 +425,66 @@ impl ChunkingContext for NodeJsChunkingContext {
         extra_referenced_assets: Vc<OutputAssets>,
         availability_info: AvailabilityInfo,
     ) -> Result<Vc<EntryChunkGroupResult>> {
-        let evaluatable_assets_ref = evaluatable_assets.await?;
-        let entries = evaluatable_assets_ref
-            .iter()
-            .map(|&asset| ResolvedVc::upcast::<Box<dyn Module>>(asset));
-
-        let MakeChunkGroupResult {
-            chunks,
-            mut referenced_output_assets,
-            availability_info,
-        } = make_chunk_group(
-            entries,
-            module_graph,
-            ResolvedVc::upcast(self),
-            availability_info,
-        )
-        .await?;
-
-        let extra_chunks = extra_chunks.await?;
-        let mut other_chunks = chunks
-            .iter()
-            .map(|chunk| self.generate_chunk(**chunk).to_resolved())
-            .try_join()
-            .await?;
-        other_chunks.extend(extra_chunks.iter().copied());
-
-        referenced_output_assets.extend(extra_referenced_assets.await?.iter().copied());
-
-        let Some(module) = ResolvedVc::try_sidecast(*evaluatable_assets_ref.last().unwrap()) else {
-            bail!("module must be placeable in an ecmascript chunk");
-        };
-
-        let asset = ResolvedVc::upcast(
-            EcmascriptBuildNodeEntryChunk::new(
-                path,
-                Vc::cell(other_chunks),
-                evaluatable_assets,
-                *module,
-                Vc::cell(referenced_output_assets),
-                module_graph,
-                *self,
-            )
-            .to_resolved()
-            .await?,
+        let span = tracing::info_span!(
+            "chunking",
+            name = display(path.value_to_string().await?),
+            chunking_type = "entry",
         );
+        async move {
+            let evaluatable_assets_ref = evaluatable_assets.await?;
+            let entries = evaluatable_assets_ref
+                .iter()
+                .map(|&asset| ResolvedVc::upcast::<Box<dyn Module>>(asset));
 
-        Ok(EntryChunkGroupResult {
-            asset,
-            availability_info,
+            let MakeChunkGroupResult {
+                chunks,
+                mut referenced_output_assets,
+                availability_info,
+            } = make_chunk_group(
+                entries,
+                module_graph,
+                ResolvedVc::upcast(self),
+                availability_info,
+            )
+            .await?;
+
+            let extra_chunks = extra_chunks.await?;
+            let mut other_chunks = chunks
+                .iter()
+                .map(|chunk| self.generate_chunk(**chunk).to_resolved())
+                .try_join()
+                .await?;
+            other_chunks.extend(extra_chunks.iter().copied());
+
+            referenced_output_assets.extend(extra_referenced_assets.await?.iter().copied());
+
+            let Some(module) = ResolvedVc::try_sidecast(*evaluatable_assets_ref.last().unwrap())
+            else {
+                bail!("module must be placeable in an ecmascript chunk");
+            };
+
+            let asset = ResolvedVc::upcast(
+                EcmascriptBuildNodeEntryChunk::new(
+                    path,
+                    Vc::cell(other_chunks),
+                    evaluatable_assets,
+                    *module,
+                    Vc::cell(referenced_output_assets),
+                    module_graph,
+                    *self,
+                )
+                .to_resolved()
+                .await?,
+            );
+
+            Ok(EntryChunkGroupResult {
+                asset,
+                availability_info,
+            }
+            .cell())
         }
-        .cell())
+        .instrument(span)
+        .await
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -477,10 +477,10 @@ async fn process_default(
         reference_type = display(&reference_type)
     );
     if !span.is_disabled() {
-        // Need to use record, otherwise future is not Send for some reason.
-        let module_asset_context_ref = module_asset_context.await?;
-        span.record("layer", module_asset_context_ref.layer.name().as_str());
+        // You can't await multiple times in the span macro call parameters.
+        span.record("layer", module_asset_context.await?.layer.name().as_str());
     }
+
     process_default_internal(
         module_asset_context,
         source,


### PR DESCRIPTION
The rust compiler probably can't eliminate the async calls otherwise.

Closes PACK-5561