### PR TITLE
Turbopack: drop ASTs when only tracing

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -575,7 +575,12 @@ async fn analyze_ecmascript_module_internal(
         .await?;
     }
 
-    let parsed = parsed.await?;
+    let parsed = if !analyze_mode.is_code_gen() {
+        // We are never code-gening the module, so we can drop the AST after the analysis.
+        parsed.final_read_hint().await?
+    } else {
+        parsed.await?
+    };
 
     let ParseResult::Ok {
         program,

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -401,6 +401,10 @@ impl AnalyzeEcmascriptModuleResultBuilder {
 
         let references: Vec<_> = self.references.into_iter().collect();
 
+        if !self.analyze_mode.is_code_gen() {
+            debug_assert!(self.code_gens.is_empty());
+        }
+
         self.code_gens.shrink_to_fit();
         Ok(AnalyzeEcmascriptModuleResult::cell(
             AnalyzeEcmascriptModuleResult {


### PR DESCRIPTION
These modules are never codgen-ed, so we can drop the AST after the analysis.

```
before:
analyze ecmascript module [project]/packages/next/dist/compiled/babel-packages/packages-bundle.js [externals-tracing] (ecmascript)
Allocated memory: 274.32MB, Deallocated memory: 250.51MB

after:
analyze ecmascript module [project]/packages/next/dist/compiled/babel-packages/packages-bundle.js [externals-tracing] (ecmascript)
Allocated memory: 273.46MB, Deallocated memory: 271.77MB
```

Closes PACK-5572