### PR TITLE
[turbopack] defer a `value_to_string` operation until we need it

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1464,7 +1464,6 @@ pub async fn resolve_raw(
 
     let mut results = Vec::new();
 
-    let lookup_dir_str = lookup_dir.value_to_string().await?;
     let pat = path.await?;
     if let Some(pat) = pat
         .filter_could_match("/ROOT/")
@@ -1483,7 +1482,7 @@ pub async fn resolve_raw(
             println!(
                 "WARN: resolving abs pattern {} in {} leads to {} results",
                 path_str,
-                lookup_dir_str,
+                lookup_dir.value_to_string().await?,
                 matches.len()
             );
         } else {
@@ -1496,12 +1495,13 @@ pub async fn resolve_raw(
     }
 
     {
-        let matches = read_matches(lookup_dir, rcstr!(""), force_in_lookup_dir, path).await?;
+        let matches =
+            read_matches(lookup_dir.clone(), rcstr!(""), force_in_lookup_dir, path).await?;
         if matches.len() > 10000 {
             println!(
                 "WARN: resolving pattern {} in {} leads to {} results",
                 pat.describe_as_string(),
-                lookup_dir_str,
+                lookup_dir.value_to_string().await?,
                 matches.len()
             );
         }

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -48,7 +48,7 @@ impl ModuleReference for FileSourceReference {
                 context_dir,
                 *self.path,
                 self.collect_affecting_sources,
-                false,
+                /* force_in_lookup_dir */ false,
             )
             .as_raw_module_result()
             .resolve()


### PR DESCRIPTION
Don't stringify the lookup_dir unless we actually need to print it, which should be very rare.



Closes PACK-5562