### PR TITLE
[Cache Components] default to filtering unhandledRejection after abort

### DIFF
--- a/packages/next/src/server/node-environment-extensions/unhandled-rejection.test.ts
+++ b/packages/next/src/server/node-environment-extensions/unhandled-rejection.test.ts
@@ -146,7 +146,7 @@ export function runWorkerCode(fn: Function): Promise<WorkerResult> {
 
 describe('unhandled-rejection filter', () => {
   describe('environment variable configuration', () => {
-    it('should not install filter by default', async () => {
+    it('should install filter by default', async () => {
       async function testForWorker() {
         require('next/dist/server/node-environment-extensions/unhandled-rejection')
 
@@ -160,7 +160,7 @@ describe('unhandled-rejection filter', () => {
 
       expect(exitCode).toBe(0)
       expect(messages).toEqual(
-        expect.arrayContaining([expect.objectContaining({ count: 0 })])
+        expect.arrayContaining([expect.objectContaining({ count: 1 })])
       )
     })
 

--- a/packages/next/src/server/node-environment-extensions/unhandled-rejection.tsx
+++ b/packages/next/src/server/node-environment-extensions/unhandled-rejection.tsx
@@ -32,23 +32,23 @@ const MODE:
   | string
   | undefined = process.env.NEXT_USE_UNHANDLED_REJECTION_FILTER
 
-let ENABLE_UHR_FILTER = false
+let ENABLE_UHR_FILTER = true
 let DEBUG_UHR_FILTER = false
 
 switch (MODE) {
   case 'debug':
     DEBUG_UHR_FILTER = true
-  // fallthrough
-  case 'enabled':
-  case 'true':
-  case '1':
-    ENABLE_UHR_FILTER = true
     break
   case 'false':
   case 'disabled':
   case '0':
+    ENABLE_UHR_FILTER = false
+    break
   case '':
   case undefined:
+  case 'enabled':
+  case 'true':
+  case '1':
     break
   default:
     if (typeof MODE === 'string') {


### PR DESCRIPTION
defaulting this filtering to enabled but can still be disabled by environment variable.