### PR TITLE
[turbopack] Remove some bitmap clones

### DIFF
--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -751,8 +751,7 @@ pub async fn compute_module_batches(
         // Create the batch groups by grouping batches with the same chunk groups
         let mut batch_groups: FxHashMap<_, Vec<_>> = FxHashMap::default();
         for (i, pre_batch) in pre_batches.batches.iter().enumerate() {
-            let key =
-                BuildHasherDefault::<FxHasher>::default().prehash(pre_batch.chunk_groups.clone());
+            let key = BuildHasherDefault::<FxHasher>::default().prehash(&pre_batch.chunk_groups);
             let batch = batches[i];
             batch_groups.entry(key).or_default().push(batch);
         }
@@ -761,7 +760,7 @@ pub async fn compute_module_batches(
                 .module_chunk_groups
                 .get(&module)
                 .context("all modules need to have chunk group info")?;
-            let key = BuildHasherDefault::<FxHasher>::default().prehash(chunk_groups.clone());
+            let key = BuildHasherDefault::<FxHasher>::default().prehash(chunk_groups);
             batch_groups
                 .entry(key)
                 .or_default()


### PR DESCRIPTION
The lifetimes are well scoped so we can just use references.


Closes PACK-5566