### PR TITLE
[turbopack] Conditionally create pages router data endpoints.

### DIFF
--- a/crates/next-api/src/operation.rs
+++ b/crates/next-api/src/operation.rs
@@ -166,7 +166,7 @@ async fn pick_endpoint(
         }
         EndpointSelector::RoutePageData(name) => {
             if let Some(Route::Page { data_endpoint, .. }) = endpoints.routes.get(&name) {
-                Some(*data_endpoint)
+                *data_endpoint
             } else {
                 None
             }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -863,7 +863,7 @@ impl Project {
             match route {
                 Route::Page {
                     html_endpoint,
-                    data_endpoint: _,
+                    data_endpoint,
                 } => {
                     if !app_dir_only {
                         endpoints.push(*html_endpoint);
@@ -872,6 +872,10 @@ impl Project {
                             endpoints.push(entrypoints.pages_app_endpoint);
                             endpoints.push(entrypoints.pages_document_endpoint);
                             is_pages_entries_added = true;
+                        }
+                        // This only exists in development mode for HMR
+                        if let Some(data_endpoint) = data_endpoint {
+                            endpoints.push(*data_endpoint);
                         }
                     }
                 }

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -34,7 +34,7 @@ pub struct AppPageRoute {
 pub enum Route {
     Page {
         html_endpoint: ResolvedVc<Box<dyn Endpoint>>,
-        data_endpoint: ResolvedVc<Box<dyn Endpoint>>,
+        data_endpoint: Option<ResolvedVc<Box<dyn Endpoint>>>,
     },
     PageApi {
         endpoint: ResolvedVc<Box<dyn Endpoint>>,


### PR DESCRIPTION
Pages router data endpoints are only needed or used in `dev` but we would unconditionally create them even in `build` scenarios`.

This clarifies the API and modifies `endpoint` collection to also collect these when they exist.  This will unblock enabling the `whole_app_module_graph`

Closes PACK-5578