### PR TITLE
[turbopack] Simplify take_issues and peek issues

### DIFF
--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -102,8 +102,7 @@ pub fn root_task_dispose(
 }
 
 pub async fn get_issues<T: Send>(source: OperationVc<T>) -> Result<Arc<Vec<ReadRef<PlainIssue>>>> {
-    let issues = source.peek_issues().await?;
-    Ok(Arc::new(issues.get_plain_issues().await?))
+    Ok(Arc::new(source.peek_issues().get_plain_issues().await?))
 }
 
 /// Reads the [turbopack_core::diagnostics::Diagnostic] held

--- a/crates/next-api/src/operation.rs
+++ b/crates/next-api/src/operation.rs
@@ -38,7 +38,7 @@ async fn entrypoints_without_collectibles_operation(
 ) -> Result<Vc<Entrypoints>> {
     let _ = entrypoints.resolve_strongly_consistent().await?;
     let _ = entrypoints.take_collectibles::<Box<dyn Diagnostic>>();
-    let _ = entrypoints.take_issues().await?;
+    let _ = entrypoints.take_issues();
     let _ = get_effects(entrypoints).await?;
     Ok(entrypoints.connect())
 }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -977,7 +977,7 @@ impl Project {
         async move {
             let module_graphs_op = whole_app_module_graph_operation(self);
             let module_graphs_vc = module_graphs_op.resolve_strongly_consistent().await?;
-            let _ = module_graphs_op.take_issues().await?;
+            let _ = module_graphs_op.take_issues();
 
             // At this point all modules have been computed and we can get rid of the node.js
             // process pools

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
@@ -840,6 +840,15 @@ where
 {
 }
 
+impl<K: Eq + Hash, V: Eq + Hash, MH: BuildHasher, const I: usize> Hash for AutoMap<K, V, MH, I> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for (k, v) in self.iter() {
+            k.hash(state);
+            v.hash(state);
+        }
+    }
+}
+
 impl<K, V, H, const I: usize> FromIterator<(K, V)> for AutoMap<K, V, H, I>
 where
     K: Eq + Hash,

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
@@ -844,25 +844,24 @@ impl<K: Eq + Hash, V: Eq + Hash, MH: BuildHasher, const I: usize> Hash for AutoM
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         // Hash the length first to distinguish maps of different sizes
         self.len().hash(state);
-        
+
         // Use a commutative approach to ensure equal maps have equal hashes
         // regardless of iteration order
         let mut combined_hash = 0u64;
-        
+
         for (k, v) in self.iter() {
-            use std::collections::hash_map::DefaultHasher;
-            use std::hash::Hasher;
-            
+            use std::{collections::hash_map::DefaultHasher, hash::Hasher};
+
             // Hash each key-value pair independently
             let mut entry_hasher = DefaultHasher::new();
             k.hash(&mut entry_hasher);
             v.hash(&mut entry_hasher);
             let entry_hash = entry_hasher.finish();
-            
+
             // Combine using XOR to make it order-independent
             combined_hash ^= entry_hash;
         }
-        
+
         // Hash the combined result
         combined_hash.hash(state);
     }

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/map.rs
@@ -842,10 +842,29 @@ where
 
 impl<K: Eq + Hash, V: Eq + Hash, MH: BuildHasher, const I: usize> Hash for AutoMap<K, V, MH, I> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Hash the length first to distinguish maps of different sizes
+        self.len().hash(state);
+        
+        // Use a commutative approach to ensure equal maps have equal hashes
+        // regardless of iteration order
+        let mut combined_hash = 0u64;
+        
         for (k, v) in self.iter() {
-            k.hash(state);
-            v.hash(state);
+            use std::collections::hash_map::DefaultHasher;
+            use std::hash::Hasher;
+            
+            // Hash each key-value pair independently
+            let mut entry_hasher = DefaultHasher::new();
+            k.hash(&mut entry_hasher);
+            v.hash(&mut entry_hasher);
+            let entry_hash = entry_hasher.finish();
+            
+            // Combine using XOR to make it order-independent
+            combined_hash ^= entry_hash;
         }
+        
+        // Hash the combined result
+        combined_hash.hash(state);
     }
 }
 

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/set.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/set.rs
@@ -219,6 +219,12 @@ impl<K: Eq + Hash, H: BuildHasher, const I: usize> PartialEq for AutoSet<K, H, I
 
 impl<K: Eq + Hash, H: BuildHasher, const I: usize> Eq for AutoSet<K, H, I> {}
 
+impl<K: Eq + Hash, SH: BuildHasher, const I: usize> Hash for AutoSet<K, SH, I> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.map.hash(state);
+    }
+}
+
 impl<K, H, const I: usize> FromIterator<K> for AutoSet<K, H, I>
 where
     K: Hash + Eq,

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -332,6 +332,19 @@ where
     }
 }
 
+impl<T> TaskInput for auto_hash_map::AutoSet<T>
+where
+    T: TaskInput,
+{
+    fn is_resolved(&self) -> bool {
+        self.iter().all(TaskInput::is_resolved)
+    }
+
+    fn is_transient(&self) -> bool {
+        self.iter().any(TaskInput::is_transient)
+    }
+}
+
 macro_rules! tuple_impls {
     ( $( $name:ident )+ ) => {
         impl<$($name: TaskInput),+> TaskInput for ($($name,)+)

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -88,7 +88,7 @@ impl GetContentFn {
 }
 
 async fn peek_issues<T: Send>(source: OperationVc<T>) -> Result<Vec<ReadRef<PlainIssue>>> {
-    let captured = source.peek_issues().await?;
+    let captured = source.peek_issues();
 
     captured.get_plain_issues().await
 }

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -563,9 +563,7 @@ async fn snapshot_issues(
     let PreparedTest { path, .. } = &*prepared_test.await?;
     let _ = run_result_op.resolve_strongly_consistent().await;
 
-    let captured_issues = run_result_op.peek_issues().await?;
-
-    let plain_issues = captured_issues.get_plain_issues().await?;
+    let plain_issues = run_result_op.peek_issues().get_plain_issues().await?;
 
     turbopack_test_utils::snapshot::snapshot_issues(plain_issues, path.join("issues")?, &REPO_ROOT)
         .await

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -219,9 +219,8 @@ async fn run(resource: PathBuf) -> Result<()> {
 async fn run_inner_operation(resource: RcStr) -> Result<()> {
     let out_op = run_test_operation(resource);
     let out_vc = out_op.resolve_strongly_consistent().await?.owned().await?;
-    let captured_issues = out_op.peek_issues().await?;
 
-    let plain_issues = captured_issues.get_plain_issues().await?;
+    let plain_issues = out_op.peek_issues().get_plain_issues().await?;
 
     snapshot_issues(plain_issues, out_vc.join("issues")?, &REPO_ROOT)
         .await


### PR DESCRIPTION
* don't construct a `cell` just use an `Arc`
   * this will make it possible to call `peek_issues` in a top level transient task
   * This required making `AutoSet` `TaskInput` compatible.  The downside is that a few tasks get a more complicated hash/eq implementation for their inputs but the `DelegatingInputTracer` value is generally very small so this should be fine.
* these functions are no longer async or failable, so simplify the signature




Closes PACK-5585