### PR TITLE
[devtools] Disable React's default Transition indicator

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay.browser.tsx
+++ b/packages/next/src/next-devtools/dev-overlay.browser.tsx
@@ -301,6 +301,9 @@ export function renderAppDevOverlay(
 
     const root = createRoot(container, {
       identifierPrefix: 'ndt-',
+      // We don't have design for a default Transition indicator for the NDT frontend.
+      // So we disable React's built-in one to not conflict with the one for the actual Next.js app.
+      onDefaultTransitionIndicator: () => () => {},
     })
 
     const shadowRoot = container.attachShadow({ mode: 'open' })


### PR DESCRIPTION
Next.js DevTools should be fully separate from the actual Next.js app. In fact, it should be able to live in an iframe or extension. Right now it's still its own React root so we need to make sure it's isolated as much as possible from the actual React app.

React's default Transition indicator could've made the page display a loading indicator even though no Transition in the actual app is triggered. I don't think this can actually happen at the moment but good to make sure adding more Transitions to NDT doesn't just randomly make the page loading indicator show. Especially because we have React's default Transition indicator disabled for the actual Next.js app due to Chrome bugs.