### PR TITLE
Turbopack: Use `RawValue` for `mappings` inside `SourceMapJson`

### DIFF
--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -30,7 +30,7 @@ rustc-hash = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_bytes = { workspace = true }
-serde_json = { workspace = true, features = ["preserve_order"] }
+serde_json = { workspace = true, features = ["preserve_order", "raw_value"] }
 smallvec = { workspace = true }
 swc_sourcemap = { workspace = true }
 swc_core = { workspace = true, features = ["ecma_preset_env", "common"] }

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -60,7 +60,10 @@ struct SourceMapJson {
     sources_content: Option<Vec<Option<String>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     names: Option<Vec<String>>,
-    mappings: String,
+    // We just need to hold onto `mappings` for serialization/deserialization, so there's no point
+    // in decoding/encoding the string. Store it as a `RawValue`. Ideally this would be a reference
+    // to the RawValue, but we deserialize using `from_reader`, which does not support that.
+    mappings: Box<serde_json::value::RawValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
     ignore_list: Option<Vec<u32>>,
 


### PR DESCRIPTION
Normally `serde_json` has to handle JSON string escaping, which has some overhead. With `Box<RawValue>` it can just memcpy the raw string instead. More ideally we'd use `&RawValue`, but we'd need a `str` instead of a `Rope` to do that.

https://docs.rs/serde_json/latest/serde_json/value/struct.RawValue.html

This works because we don't care about the value of `mappings` here, we just want to make sure it's passed through when the struct is re-serialized.

We use `RawValue` a lot in the `swc-sourcemap` crate: https://github.com/swc-project/swc-sourcemap/blob/main/src/lazy/mod.rs

Closes PACK-5569