### PR TITLE
Feat: `get_page_metadata` MCP endpoint

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -822,5 +822,6 @@
   "821": "Unprocessable request",
   "822": "Stack frame resolver not initialized. This is a bug in Next.js.",
   "823": "Timeout waiting for error state from frontend. The browser may not be responding to HMR messages.",
-  "824": "URL is required in MCP error state response. This is a bug in Next.js."
+  "824": "URL is required in MCP browser response. This is a bug in Next.js.",
+  "825": "Timeout waiting for response from frontend. The browser may not be responding to HMR messages."
 }

--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -11,6 +11,7 @@ import {
 import {
   dispatcher,
   getSerializedOverlayState,
+  getSegmentTrieData,
 } from 'next/dist/compiled/next-devtools'
 import { ReplaySsrOnlyErrors } from '../../../../next-devtools/userspace/app/errors/replay-ssr-only-errors'
 import { AppDevOverlayErrorBoundary } from '../../../../next-devtools/userspace/app/app-dev-overlay-error-boundary'
@@ -26,6 +27,7 @@ import type {
   TurbopackMessageSentToBrowser,
 } from '../../../../server/dev/hot-reloader-types'
 import type { McpErrorStateResponse } from '../../../../shared/lib/mcp-error-types'
+import type { McpPageMetadataResponse } from '../../../../shared/lib/mcp-page-metadata-types'
 import { useUntrackedPathname } from '../../../components/navigation-untracked'
 import reportHmrLatency from '../../report-hmr-latency'
 import { TurbopackHmr } from '../turbopack-hot-reloader-common'
@@ -482,6 +484,17 @@ export function processMessage(
         event: HMR_MESSAGE_SENT_TO_SERVER.MCP_ERROR_STATE_RESPONSE,
         requestId: message.requestId,
         errorState,
+        url: window.location.href,
+      }
+      sendMessage(JSON.stringify(response))
+      return
+    }
+    case HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_PAGE_METADATA: {
+      const segmentTrieData = getSegmentTrieData()
+      const response: McpPageMetadataResponse = {
+        event: HMR_MESSAGE_SENT_TO_SERVER.MCP_PAGE_METADATA_RESPONSE,
+        requestId: message.requestId,
+        segmentTrieData,
         url: window.location.href,
       }
       sendMessage(JSON.stringify(response))

--- a/packages/next/src/client/dev/hot-reloader/pages/hot-reloader-pages.ts
+++ b/packages/next/src/client/dev/hot-reloader/pages/hot-reloader-pages.ts
@@ -35,11 +35,13 @@
 import {
   dispatcher,
   getSerializedOverlayState,
+  getSegmentTrieData,
 } from 'next/dist/compiled/next-devtools'
 import { register } from '../../../../next-devtools/userspace/pages/pages-dev-overlay-setup'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { addMessageListener, sendMessage } from './websocket'
 import formatWebpackMessages from '../../../../shared/lib/format-webpack-messages'
+import type { McpPageMetadataResponse } from '../../../../shared/lib/mcp-page-metadata-types'
 import {
   HMR_MESSAGE_SENT_TO_BROWSER,
   HMR_MESSAGE_SENT_TO_SERVER,
@@ -409,6 +411,17 @@ function processMessage(message: HmrMessageSentToBrowser) {
       }
       sendMessage(JSON.stringify(response))
       break
+    }
+    case HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_PAGE_METADATA: {
+      const segmentTrieData = getSegmentTrieData()
+      const response: McpPageMetadataResponse = {
+        event: HMR_MESSAGE_SENT_TO_SERVER.MCP_PAGE_METADATA_RESPONSE,
+        requestId: message.requestId,
+        segmentTrieData,
+        url: window.location.href,
+      }
+      sendMessage(JSON.stringify(response))
+      return
     }
     default:
       message satisfies never

--- a/packages/next/src/client/page-bootstrap.ts
+++ b/packages/next/src/client/page-bootstrap.ts
@@ -122,6 +122,7 @@ export function pageBootstrap(assetPrefix: string) {
         case HMR_MESSAGE_SENT_TO_BROWSER.DEVTOOLS_CONFIG:
         case HMR_MESSAGE_SENT_TO_BROWSER.REACT_DEBUG_CHUNK:
         case HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_CURRENT_ERROR_STATE:
+        case HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_PAGE_METADATA:
           // Most of these action types are handled in
           // src/client/dev/hot-reloader/pages/hot-reloader-pages.ts and
           // src/client/dev/hot-reloader/app/hot-reloader-app.tsx

--- a/packages/next/src/next-devtools/dev-overlay.browser.tsx
+++ b/packages/next/src/next-devtools/dev-overlay.browser.tsx
@@ -42,9 +42,11 @@ import type { VersionInfo } from '../server/dev/parse-version-info'
 import {
   insertSegmentNode,
   removeSegmentNode,
+  getSegmentTrieRoot,
 } from './dev-overlay/segment-explorer-trie'
 import type { SegmentNodeState } from './userspace/app/segment-explorer-node'
 import type { DevToolsConfig } from './dev-overlay/shared'
+import type { SegmentTrieData } from '../shared/lib/mcp-page-metadata-types'
 
 export interface Dispatcher {
   onBuildOk(): void
@@ -79,10 +81,6 @@ type OverlayStateWithRouter = OverlayState & { routerType: 'pages' | 'app' }
 
 let currentOverlayState: OverlayStateWithRouter | null = null
 
-export function getCurrentOverlayState(): OverlayStateWithRouter | null {
-  return currentOverlayState
-}
-
 export function getSerializedOverlayState(): OverlayStateWithRouter | null {
   // Serialize error objects properly since Error properties are non-enumerable
   // This is used when sending state via HMR/JSON.stringify
@@ -100,6 +98,17 @@ export function getSerializedOverlayState(): OverlayStateWithRouter | null {
           }
         : null,
     })),
+  }
+}
+
+export function getSegmentTrieData(): SegmentTrieData | null {
+  if (!currentOverlayState) {
+    return null
+  }
+  const trieRoot = getSegmentTrieRoot()
+  return {
+    segmentTrie: trieRoot,
+    routerType: currentOverlayState.routerType,
   }
 }
 

--- a/packages/next/src/next-devtools/dev-overlay/segment-explorer-trie.ts
+++ b/packages/next/src/next-devtools/dev-overlay/segment-explorer-trie.ts
@@ -148,6 +148,7 @@ const trie: SegmentTrie = createTrie({
 })
 export const insertSegmentNode = trie.insert
 export const removeSegmentNode = trie.remove
+export const getSegmentTrieRoot = trie.getRoot
 
 export function useSegmentTree(): SegmentTrieNode {
   const state = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -114,6 +114,7 @@ import {
 } from './hot-reloader-shared-utils'
 import { getMcpMiddleware } from '../mcp/get-mcp-middleware'
 import { handleErrorStateResponse } from '../mcp/tools/get-errors'
+import { handlePageMetadataResponse } from '../mcp/tools/get-page-metadata'
 import { setStackFrameResolver } from '../mcp/tools/utils/format-errors'
 
 const wsServer = new ws.Server({ noServer: true })
@@ -943,6 +944,15 @@ export async function createHotReloaderTurbopack(
               handleErrorStateResponse(
                 parsedData.requestId,
                 parsedData.errorState,
+                parsedData.url
+              )
+              break
+            }
+
+            case 'mcp-page-metadata-response': {
+              handlePageMetadataResponse(
+                parsedData.requestId,
+                parsedData.segmentTrieData,
                 parsedData.url
               )
               break

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -31,6 +31,7 @@ export const enum HMR_MESSAGE_SENT_TO_BROWSER {
   DEV_INDICATOR = 'devIndicator',
   DEVTOOLS_CONFIG = 'devtoolsConfig',
   REQUEST_CURRENT_ERROR_STATE = 'requestCurrentErrorState',
+  REQUEST_PAGE_METADATA = 'requestPageMetadata',
 
   // Binary messages:
   REACT_DEBUG_CHUNK = 0,
@@ -39,6 +40,7 @@ export const enum HMR_MESSAGE_SENT_TO_BROWSER {
 export const enum HMR_MESSAGE_SENT_TO_SERVER {
   // JSON messages:
   MCP_ERROR_STATE_RESPONSE = 'mcp-error-state-response',
+  MCP_PAGE_METADATA_RESPONSE = 'mcp-page-metadata-response',
   PING = 'ping',
 }
 
@@ -155,6 +157,11 @@ export interface RequestCurrentErrorStateMessage {
   requestId: string
 }
 
+export interface RequestPageMetadataMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_PAGE_METADATA
+  requestId: string
+}
+
 export type HmrMessageSentToBrowser =
   | TurbopackMessage
   | TurbopackConnectedMessage
@@ -174,6 +181,7 @@ export type HmrMessageSentToBrowser =
   | DevToolsConfigMessage
   | ReactDebugChunkMessage
   | RequestCurrentErrorStateMessage
+  | RequestPageMetadataMessage
 
 export type BinaryHmrMessageSentToBrowser = Extract<
   HmrMessageSentToBrowser,

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -47,6 +47,7 @@ import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { PAGE_TYPES } from '../../lib/page-types'
 import { getNextFlightSegmentPath } from '../../client/flight-data-helpers'
 import { handleErrorStateResponse } from '../mcp/tools/get-errors'
+import { handlePageMetadataResponse } from '../mcp/tools/get-page-metadata'
 
 const debug = createDebug('next:on-demand-entry-handler')
 
@@ -1009,6 +1010,15 @@ export function onDemandEntryHandler({
             handleErrorStateResponse(
               parsedData.requestId,
               parsedData.errorState,
+              parsedData.url
+            )
+          } else if (
+            parsedData.event ===
+            HMR_MESSAGE_SENT_TO_SERVER.MCP_PAGE_METADATA_RESPONSE
+          ) {
+            handlePageMetadataResponse(
+              parsedData.requestId,
+              parsedData.segmentTrieData,
               parsedData.url
             )
           }

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
 import { registerGetProjectPathTool } from './tools/get-project-path'
 import { registerGetErrorsTool } from './tools/get-errors'
+import { registerGetPageMetadataTool } from './tools/get-page-metadata'
 import type { HmrMessageSentToBrowser } from '../dev/hot-reloader-types'
 
 let mcpServer: McpServer | undefined
@@ -21,6 +22,11 @@ export const getOrCreateMcpServer = (
 
   registerGetProjectPathTool(mcpServer, projectPath)
   registerGetErrorsTool(mcpServer, sendHmrMessage, getActiveConnectionCount)
+  registerGetPageMetadataTool(
+    mcpServer,
+    sendHmrMessage,
+    getActiveConnectionCount
+  )
 
   return mcpServer
 }

--- a/packages/next/src/server/mcp/tools/get-page-metadata.ts
+++ b/packages/next/src/server/mcp/tools/get-page-metadata.ts
@@ -1,0 +1,212 @@
+import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
+import {
+  HMR_MESSAGE_SENT_TO_BROWSER,
+  type HmrMessageSentToBrowser,
+} from '../../dev/hot-reloader-types'
+import {
+  createBrowserRequest,
+  handleBrowserPageResponse,
+  DEFAULT_BROWSER_REQUEST_TIMEOUT_MS,
+} from './utils/browser-communication'
+import type {
+  PageMetadata,
+  PageSegment,
+  SegmentTrieData,
+} from '../../../shared/lib/mcp-page-metadata-types'
+import type { SegmentTrieNode } from '../../../next-devtools/dev-overlay/segment-explorer-trie'
+
+export function registerGetPageMetadataTool(
+  server: McpServer,
+  sendHmrMessage: (message: HmrMessageSentToBrowser) => void,
+  getActiveConnectionCount: () => number
+) {
+  server.registerTool(
+    'get_page_metadata',
+    {
+      description:
+        'Get runtime metadata about what contributes to the current page render from active browser sessions.',
+      inputSchema: {},
+    },
+    async (_request) => {
+      try {
+        const connectionCount = getActiveConnectionCount()
+        if (connectionCount === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'No browser sessions connected. Please open your application in a browser to retrieve page metadata.',
+              },
+            ],
+          }
+        }
+
+        const responses = await createBrowserRequest<SegmentTrieData>(
+          HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_PAGE_METADATA,
+          sendHmrMessage,
+          getActiveConnectionCount,
+          DEFAULT_BROWSER_REQUEST_TIMEOUT_MS
+        )
+
+        if (responses.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'No browser sessions responded.',
+              },
+            ],
+          }
+        }
+
+        const metadataByUrl = new Map<string, PageMetadata>()
+        for (const response of responses) {
+          if (response.data) {
+            // TODO: Add other metadata for the current page render here. Currently, we only have segment trie data.
+            const pageMetadata = convertSegmentTrieToPageMetadata(response.data)
+            metadataByUrl.set(response.url, pageMetadata)
+          }
+        }
+
+        if (metadataByUrl.size === 0) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `No page metadata available from ${responses.length} browser session(s).`,
+              },
+            ],
+          }
+        }
+
+        const output = formatPageMetadata(metadataByUrl)
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: output,
+            },
+          ],
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        }
+      }
+    }
+  )
+}
+
+export function handlePageMetadataResponse(
+  requestId: string,
+  segmentTrieData: SegmentTrieData | null,
+  url: string | undefined
+) {
+  handleBrowserPageResponse<SegmentTrieData | null>(
+    requestId,
+    segmentTrieData,
+    url || ''
+  )
+}
+
+function convertSegmentTrieToPageMetadata(data: SegmentTrieData): PageMetadata {
+  const segments: PageSegment[] = []
+
+  if (data.segmentTrie) {
+    // Traverse the trie and collect all segments
+    function traverseTrie(node: SegmentTrieNode): void {
+      if (node.value) {
+        segments.push({
+          type: node.value.type,
+          pagePath: node.value.pagePath,
+          boundaryType: node.value.boundaryType,
+        })
+      }
+
+      for (const childNode of Object.values(node.children)) {
+        if (childNode) {
+          traverseTrie(childNode)
+        }
+      }
+    }
+
+    traverseTrie(data.segmentTrie)
+  }
+
+  return {
+    segments,
+    routerType: data.routerType,
+  }
+}
+
+function formatPageMetadata(metadataByUrl: Map<string, PageMetadata>): string {
+  let output = `# Page metadata from ${metadataByUrl.size} browser session(s)\n\n`
+
+  for (const [url, metadata] of metadataByUrl) {
+    let displayUrl = url
+    try {
+      const urlObj = new URL(url)
+      displayUrl = urlObj.pathname + urlObj.search + urlObj.hash
+    } catch {
+      // If URL parsing fails, use the original URL
+    }
+
+    output += `## Session: ${displayUrl}\n\n`
+    output += `**Router type:** ${metadata.routerType}\n\n`
+
+    if (metadata.segments.length === 0) {
+      output += '*No segments found*\n\n'
+    } else {
+      output += '### Files powering this page:\n\n'
+
+      // Ensure consistent output to avoid flaky tests
+      const sortedSegments = [...metadata.segments].sort((a, b) => {
+        const typeOrder = (segment: PageSegment): number => {
+          const type = segment.boundaryType || segment.type
+          if (type === 'layout') return 0
+          if (type.startsWith('boundary:')) return 1
+          if (type === 'page') return 2
+          return 3
+        }
+        const aOrder = typeOrder(a)
+        const bOrder = typeOrder(b)
+        if (aOrder !== bOrder) return aOrder - bOrder
+        return a.pagePath.localeCompare(b.pagePath)
+      })
+
+      for (const segment of sortedSegments) {
+        const path = segment.pagePath
+        const isBuiltin = path.startsWith('__next_builtin__')
+        const type = segment.boundaryType || segment.type
+        const isBoundary = type.startsWith('boundary:')
+
+        let displayPath = path
+          .replace(/@boundary$/, '')
+          .replace(/^__next_builtin__/, '')
+
+        if (!isBuiltin && !displayPath.startsWith('app/')) {
+          displayPath = `app/${displayPath}`
+        }
+
+        const descriptors: string[] = []
+        if (isBoundary) descriptors.push('boundary')
+        if (isBuiltin) descriptors.push('builtin')
+
+        const descriptor =
+          descriptors.length > 0 ? ` (${descriptors.join(', ')})` : ''
+        output += `- ${displayPath}${descriptor}\n`
+      }
+      output += '\n'
+    }
+
+    output += '---\n\n'
+  }
+
+  return output.trim()
+}

--- a/packages/next/src/server/mcp/tools/utils/browser-communication.ts
+++ b/packages/next/src/server/mcp/tools/utils/browser-communication.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared utilities for MCP tools that communicate with the browser.
+ * This module provides a common infrastructure for request-response
+ * communication between MCP endpoints and browser sessions via HMR.
+ */
+
+import { nanoid } from 'next/dist/compiled/nanoid'
+import type {
+  HMR_MESSAGE_SENT_TO_BROWSER,
+  HmrMessageSentToBrowser,
+} from '../../../dev/hot-reloader-types'
+
+export const DEFAULT_BROWSER_REQUEST_TIMEOUT_MS = 5000
+
+export type BrowserResponse<T> = {
+  url: string
+  data: T
+}
+
+type PendingRequest<T> = {
+  responses: BrowserResponse<T>[]
+  expectedCount: number
+  resolve: (value: BrowserResponse<T>[]) => void
+  reject: (reason?: unknown) => void
+  timeout: NodeJS.Timeout
+}
+
+const pendingRequests = new Map<string, PendingRequest<unknown>>()
+
+export function createBrowserRequest<T>(
+  messageType: HMR_MESSAGE_SENT_TO_BROWSER,
+  sendHmrMessage: (message: HmrMessageSentToBrowser) => void,
+  getActiveConnectionCount: () => number,
+  timeoutMs: number
+): Promise<BrowserResponse<T>[]> {
+  const connectionCount = getActiveConnectionCount()
+  if (connectionCount === 0) {
+    return Promise.resolve([])
+  }
+
+  const requestId = `mcp-${messageType}-${nanoid()}`
+
+  const responsePromise = new Promise<BrowserResponse<T>[]>(
+    (resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = pendingRequests.get(requestId)
+        if (pending && pending.responses.length > 0) {
+          resolve(pending.responses as BrowserResponse<T>[])
+        } else {
+          reject(
+            new Error(
+              `Timeout waiting for response from frontend. The browser may not be responding to HMR messages.`
+            )
+          )
+        }
+        pendingRequests.delete(requestId)
+      }, timeoutMs)
+
+      pendingRequests.set(requestId, {
+        responses: [],
+        expectedCount: connectionCount,
+        resolve: resolve as (value: BrowserResponse<unknown>[]) => void,
+        reject,
+        timeout,
+      })
+    }
+  )
+
+  sendHmrMessage({
+    type: messageType,
+    requestId,
+  } as HmrMessageSentToBrowser)
+
+  return responsePromise
+}
+
+export function handleBrowserPageResponse<T>(
+  requestId: string,
+  data: T,
+  url: string
+): void {
+  if (!url) {
+    throw new Error(
+      'URL is required in MCP browser response. This is a bug in Next.js.'
+    )
+  }
+
+  const pending = pendingRequests.get(requestId)
+  if (pending) {
+    pending.responses.push({ url, data })
+    if (pending.responses.length >= pending.expectedCount) {
+      clearTimeout(pending.timeout)
+      pending.resolve(pending.responses)
+      pendingRequests.delete(requestId)
+    }
+  }
+}

--- a/packages/next/src/shared/lib/mcp-page-metadata-types.ts
+++ b/packages/next/src/shared/lib/mcp-page-metadata-types.ts
@@ -1,0 +1,29 @@
+import type { SegmentTrieNode } from '../../next-devtools/dev-overlay/segment-explorer-trie'
+
+export type SegmentTrieData = {
+  segmentTrie: SegmentTrieNode | null
+  routerType: 'app' | 'pages'
+}
+
+export type PageSegment = {
+  type: string
+  pagePath: string
+  boundaryType: string | null
+}
+
+export type PageMetadata = {
+  segments: PageSegment[]
+  routerType: 'app' | 'pages'
+}
+
+export type PageMetadataWithUrl = {
+  url: string
+  metadata: PageMetadata | null
+}
+
+export interface McpPageMetadataResponse {
+  event: string
+  requestId: string
+  segmentTrieData: SegmentTrieData | null
+  url: string
+}

--- a/test/development/mcp-server/fixtures/pages-router-template/next.config.js
+++ b/test/development/mcp-server/fixtures/pages-router-template/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    mcpServer: true,
+  },
+}

--- a/test/development/mcp-server/fixtures/pages-router-template/pages/_app.tsx
+++ b/test/development/mcp-server/fixtures/pages-router-template/pages/_app.tsx
@@ -1,0 +1,5 @@
+import type { AppProps } from 'next/app'
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/test/development/mcp-server/fixtures/pages-router-template/pages/about.tsx
+++ b/test/development/mcp-server/fixtures/pages-router-template/pages/about.tsx
@@ -1,0 +1,8 @@
+export default function AboutPage() {
+  return (
+    <div>
+      <h1>About Page</h1>
+      <p>This is the about page using pages router.</p>
+    </div>
+  )
+}

--- a/test/development/mcp-server/fixtures/pages-router-template/pages/index.tsx
+++ b/test/development/mcp-server/fixtures/pages-router-template/pages/index.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <div>
+      <h1>Pages Router Home</h1>
+      <p>This is a pages router page.</p>
+    </div>
+  )
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/app/error.tsx
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/app/error.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+export default function RootError({
+  error,
+  reset,
+}: {
+  error: Error
+  reset: () => void
+}) {
+  return (
+    <div>
+      <h2>Root Error: {error.message}</h2>
+      <button onClick={reset}>Try again</button>
+    </div>
+  )
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/app/layout.tsx
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/app/loading.tsx
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/app/loading.tsx
@@ -1,0 +1,3 @@
+export default function RootLoading() {
+  return <div>Root Loading...</div>
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/app/not-found.tsx
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div>
+      <h2>404 - Page Not Found</h2>
+      <p>Could not find the requested page.</p>
+    </div>
+  )
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/app/page.tsx
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/app/page.tsx
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <div>Home Page</div>
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/@content/error.tsx
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/@content/error.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+export default function ContentError({
+  error,
+  reset,
+}: {
+  error: Error
+  reset: () => void
+}) {
+  return (
+    <div>
+      <h2>Content Error: {error.message}</h2>
+      <button onClick={reset}>Try again</button>
+    </div>
+  )
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/@content/page.tsx
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/@content/page.tsx
@@ -1,0 +1,8 @@
+export default function ContentPage() {
+  return (
+    <div>
+      <h2>Main Content</h2>
+      <p>This is the main content area with parallel routing.</p>
+    </div>
+  )
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/@sidebar/loading.tsx
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/@sidebar/loading.tsx
@@ -1,0 +1,3 @@
+export default function SidebarLoading() {
+  return <div>Sidebar Loading...</div>
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/@sidebar/page.tsx
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/@sidebar/page.tsx
@@ -1,0 +1,12 @@
+export default function SidebarPage() {
+  return (
+    <div>
+      <h3>Sidebar</h3>
+      <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+      </ul>
+    </div>
+  )
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/error.tsx
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/error.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+export default function ParallelError({
+  error,
+  reset,
+}: {
+  error: Error
+  reset: () => void
+}) {
+  return (
+    <div>
+      <h2>Parallel Error: {error.message}</h2>
+      <button onClick={reset}>Try again</button>
+    </div>
+  )
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/layout.tsx
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/layout.tsx
@@ -1,0 +1,19 @@
+export default function ParallelLayout({
+  children,
+  sidebar,
+  content,
+}: {
+  children: React.ReactNode
+  sidebar: React.ReactNode
+  content: React.ReactNode
+}) {
+  return (
+    <div style={{ display: 'flex' }}>
+      <div style={{ flex: '0 0 200px', borderRight: '1px solid #ccc' }}>
+        {sidebar}
+      </div>
+      <div style={{ flex: 1 }}>{content}</div>
+      <div>{children}</div>
+    </div>
+  )
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/loading.tsx
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/loading.tsx
@@ -1,0 +1,3 @@
+export default function ParallelLoading() {
+  return <div>Parallel Page Loading...</div>
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/page.tsx
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/app/parallel/page.tsx
@@ -1,0 +1,3 @@
+export default function ParallelPage() {
+  return <div>Default parallel page (children slot)</div>
+}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/next.config.js
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    mcpServer: true,
+  },
+}

--- a/test/development/mcp-server/mcp-server-get-page-metadata.test.ts
+++ b/test/development/mcp-server/mcp-server-get-page-metadata.test.ts
@@ -1,0 +1,238 @@
+import { FileRef, nextTestSetup } from 'e2e-utils'
+import path from 'path'
+import { retry } from 'next-test-utils'
+import stripAnsi from 'strip-ansi'
+import { launchStandaloneSession } from './test-utils'
+
+describe('mcp-server get_page_metadata tool', () => {
+  async function callGetPageMetadata(url: string, id: string) {
+    const response = await fetch(`${url}/_next/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method: 'tools/call',
+        params: { name: 'get_page_metadata', arguments: {} },
+      }),
+    })
+
+    const text = await response.text()
+    const match = text.match(/data: ({.*})/s)
+    const result = JSON.parse(match![1])
+    return result.result?.content?.[0]?.text
+  }
+
+  describe('app router', () => {
+    const { next } = nextTestSetup({
+      files: new FileRef(
+        path.join(__dirname, 'fixtures', 'parallel-routes-template')
+      ),
+    })
+
+    it('should return metadata for basic page', async () => {
+      await next.browser('/')
+      const metadata = await callGetPageMetadata(next.url, 'test-basic')
+
+      expect(stripAnsi(metadata)).toMatchInlineSnapshot(`
+       "# Page metadata from 1 browser session(s)
+
+       ## Session: /
+
+       **Router type:** app
+
+       ### Files powering this page:
+
+       - app/layout.tsx
+       - global-error.js (boundary, builtin)
+       - app/error.tsx (boundary)
+       - app/loading.tsx (boundary)
+       - app/not-found.tsx (boundary)
+       - app/page.tsx
+
+       ---"
+      `)
+    })
+
+    it('should return metadata for parallel routes', async () => {
+      await next.browser('/parallel')
+
+      let metadata: string = ''
+      await retry(async () => {
+        const sessionId = 'test-parallel-' + Date.now()
+        metadata = await callGetPageMetadata(next.url, sessionId)
+        expect(metadata).toContain('Page metadata from 1 browser session')
+        expect(metadata).toContain('Files powering this page')
+        // Ensure we have the parallel route files
+        expect(metadata).toContain('app/parallel/@sidebar/page.tsx')
+        expect(metadata).toContain('app/parallel/@content/page.tsx')
+        expect(metadata).toContain('app/parallel/page.tsx')
+      })
+
+      expect(stripAnsi(metadata)).toMatchInlineSnapshot(`
+       "# Page metadata from 1 browser session(s)
+
+       ## Session: /parallel
+
+       **Router type:** app
+
+       ### Files powering this page:
+
+       - app/layout.tsx
+       - app/parallel/layout.tsx
+       - global-error.js (boundary, builtin)
+       - app/error.tsx (boundary)
+       - app/loading.tsx (boundary)
+       - app/not-found.tsx (boundary)
+       - app/parallel/@content/error.tsx (boundary)
+       - app/parallel/@sidebar/loading.tsx (boundary)
+       - app/parallel/error.tsx (boundary)
+       - app/parallel/loading.tsx (boundary)
+       - app/parallel/@content/page.tsx
+       - app/parallel/@sidebar/page.tsx
+       - app/parallel/page.tsx
+
+       ---"
+      `)
+    })
+
+    it('should handle multiple browser sessions', async () => {
+      // Open two browser tabs using standalone sessions for true concurrent tabs
+      const session1 = await launchStandaloneSession(next.url, '/')
+      const session2 = await launchStandaloneSession(next.url, '/parallel')
+
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+
+        let metadata: string = ''
+        await retry(async () => {
+          const sessionId = 'test-multi-' + Date.now()
+          metadata = await callGetPageMetadata(next.url, sessionId)
+          expect(metadata).toMatch(/Page metadata from \d+ browser session/)
+          // Ensure both our sessions are present
+          expect(metadata).toContain('Session: /')
+          expect(metadata).toContain('Session: /parallel')
+        })
+
+        const strippedMetadata = stripAnsi(metadata)
+
+        // Extract each session's content to check them independently
+        const session1Match = strippedMetadata.match(
+          /## Session: \/\n[\s\S]*?(?=(\n## Session:|\n?$))/
+        )
+        const session2Match = strippedMetadata.match(
+          /## Session: \/parallel\n[\s\S]*?(?=(\n## Session:|\n?$))/
+        )
+
+        // Trim trailing newline if present
+        if (session1Match) session1Match[0] = session1Match[0].trimEnd()
+        if (session2Match) session2Match[0] = session2Match[0].trimEnd()
+
+        expect(session1Match).toBeTruthy()
+        expect(session2Match).toBeTruthy()
+
+        expect(session1Match?.[0]).toMatchInlineSnapshot(`
+         "## Session: /
+
+         **Router type:** app
+
+         ### Files powering this page:
+
+         - app/layout.tsx
+         - global-error.js (boundary, builtin)
+         - app/error.tsx (boundary)
+         - app/loading.tsx (boundary)
+         - app/not-found.tsx (boundary)
+         - app/page.tsx
+
+         ---"
+        `)
+
+        expect(session2Match?.[0]).toMatchInlineSnapshot(`
+         "## Session: /parallel
+
+         **Router type:** app
+
+         ### Files powering this page:
+
+         - app/layout.tsx
+         - app/parallel/layout.tsx
+         - global-error.js (boundary, builtin)
+         - app/error.tsx (boundary)
+         - app/loading.tsx (boundary)
+         - app/not-found.tsx (boundary)
+         - app/parallel/@content/error.tsx (boundary)
+         - app/parallel/@sidebar/loading.tsx (boundary)
+         - app/parallel/error.tsx (boundary)
+         - app/parallel/loading.tsx (boundary)
+         - app/parallel/@content/page.tsx
+         - app/parallel/@sidebar/page.tsx
+         - app/parallel/page.tsx
+
+         ---"
+        `)
+      } finally {
+        // Clean up sessions
+        await session1.close()
+        await session2.close()
+      }
+    })
+  })
+
+  describe('pages router', () => {
+    const { next } = nextTestSetup({
+      files: new FileRef(
+        path.join(__dirname, 'fixtures', 'pages-router-template')
+      ),
+    })
+
+    it('should return metadata showing pages router type', async () => {
+      await next.browser('/')
+
+      let metadata: string = ''
+      await retry(async () => {
+        const sessionId = 'test-pages-' + Date.now()
+        metadata = await callGetPageMetadata(next.url, sessionId)
+        expect(metadata).toContain('Page metadata from 1 browser session')
+      })
+
+      expect(stripAnsi(metadata)).toMatchInlineSnapshot(`
+          "# Page metadata from 1 browser session(s)
+
+          ## Session: /
+
+          **Router type:** pages
+
+          *No segments found*
+
+          ---"
+        `)
+    })
+
+    it('should show pages router type for about page', async () => {
+      await next.browser('/about')
+
+      let metadata: string = ''
+      await retry(async () => {
+        const sessionId = 'test-pages-about-' + Date.now()
+        metadata = await callGetPageMetadata(next.url, sessionId)
+        expect(metadata).toContain('Page metadata from 1 browser session')
+      })
+
+      expect(stripAnsi(metadata)).toMatchInlineSnapshot(`
+          "# Page metadata from 1 browser session(s)
+
+          ## Session: /about
+
+          **Router type:** pages
+
+          *No segments found*
+
+          ---"
+        `)
+    })
+  })
+})

--- a/test/development/mcp-server/test-utils.ts
+++ b/test/development/mcp-server/test-utils.ts
@@ -1,0 +1,42 @@
+import { chromium, firefox, webkit, type Browser } from 'playwright'
+
+function getFullUrl(appPortOrUrl: string | number, url: string): string {
+  const appUrl =
+    typeof appPortOrUrl === 'string'
+      ? appPortOrUrl
+      : `http://localhost:${appPortOrUrl}`
+  return url.startsWith('/') ? `${appUrl}${url}` : url
+}
+
+/**
+ * Minimal standalone browser session launcher for testing multiple concurrent browser tabs.
+ * The standard test harness (next.browser) uses a singleton browser instance which doesn't
+ * support concurrent tabs needed for testing errors across multiple browser sessions.
+ */
+export async function launchStandaloneSession(
+  appPortOrUrl: string | number,
+  url: string
+) {
+  const headless = !!process.env.HEADLESS
+  const browserName = (process.env.BROWSER_NAME || 'chrome').toLowerCase()
+  let browser: Browser
+  if (browserName === 'safari') {
+    browser = await webkit.launch({ headless })
+  } else if (browserName === 'firefox') {
+    browser = await firefox.launch({ headless })
+  } else {
+    browser = await chromium.launch({ headless })
+  }
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  const fullUrl = getFullUrl(appPortOrUrl, url)
+  await page.goto(fullUrl, { waitUntil: 'load' })
+  return {
+    page,
+    close: async () => {
+      await page.close().catch(() => {})
+      await context.close().catch(() => {})
+      await browser.close().catch(() => {})
+    },
+  }
+}


### PR DESCRIPTION
Enables AI agents to programmatically access the runtime metadata of the current page. At the moment, we only include the segment trie details, but this endpoint will be open to extension. Like `get_errors`, we support collecting information from multiple tabs.