### PR TITLE
Turbopack: add separate turbopackPersistentCachingForBuild/ForDev flags

### DIFF
--- a/bench/heavy-npm-deps/next.config.mjs
+++ b/bench/heavy-npm-deps/next.config.mjs
@@ -8,6 +8,7 @@ const nextConfig = {
   },
   experimental: {
     turbopackPersistentCaching: process.env.TURBO_CACHE === '1',
+    turbopackPersistentCachingForBuild: process.env.TURBO_CACHE === '1',
   },
 }
 

--- a/bench/heavy-npm-deps/next.config.mjs
+++ b/bench/heavy-npm-deps/next.config.mjs
@@ -7,7 +7,7 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   experimental: {
-    turbopackPersistentCaching: process.env.TURBO_CACHE === '1',
+    turbopackPersistentCachingForDev: process.env.TURBO_CACHE === '1',
     turbopackPersistentCachingForBuild: process.env.TURBO_CACHE === '1',
   },
 }

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackPersistentCaching.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackPersistentCaching.mdx
@@ -13,12 +13,17 @@ Turbopack Persistent Caching enables Turbopack to reduce work across `next dev` 
 
 > **Good to know**: Note that while `next dev` and `next build` can share cached data with each other, most cache entries are command-specific due to different configuration and environment variables.
 
+> **Note**: Persistent Caching for `next build` is enabled with a separate flag, `turbopackPersistentCachingForBuild`. Once it's stable, it will be merged into `turbopackPersistentCaching`.
+
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   experimental: {
+    // Enable persistent caching for `next dev`
     turbopackPersistentCaching: true,
+    // Enable persistent caching for `next build`
+    turbopackPersistentCachingForBuild: true,
   },
 }
 
@@ -29,7 +34,10 @@ export default nextConfig
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
+    // Enable persistent caching for `next dev`
     turbopackPersistentCaching: true,
+    // Enable persistent caching for `next build`
+    turbopackPersistentCachingForBuild: true,
   },
 }
 
@@ -40,4 +48,5 @@ module.exports = nextConfig
 
 | Version   | Changes                                     |
 | --------- | ------------------------------------------- |
+| `v16.0.0` | Separate flag for `next build` added        |
 | `v15.5.0` | Persistent caching released as experimental |

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackPersistentCaching.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackPersistentCaching.mdx
@@ -13,15 +13,13 @@ Turbopack Persistent Caching enables Turbopack to reduce work across `next dev` 
 
 > **Good to know**: Note that while `next dev` and `next build` can share cached data with each other, most cache entries are command-specific due to different configuration and environment variables.
 
-> **Note**: Persistent Caching for `next build` is enabled with a separate flag, `turbopackPersistentCachingForBuild`. Once it's stable, it will be merged into `turbopackPersistentCaching`.
-
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   experimental: {
     // Enable persistent caching for `next dev`
-    turbopackPersistentCaching: true,
+    turbopackPersistentCachingForDev: true,
     // Enable persistent caching for `next build`
     turbopackPersistentCachingForBuild: true,
   },
@@ -35,7 +33,7 @@ export default nextConfig
 const nextConfig = {
   experimental: {
     // Enable persistent caching for `next dev`
-    turbopackPersistentCaching: true,
+    turbopackPersistentCachingForDev: true,
     // Enable persistent caching for `next build`
     turbopackPersistentCachingForBuild: true,
   },
@@ -48,5 +46,5 @@ module.exports = nextConfig
 
 | Version   | Changes                                     |
 | --------- | ------------------------------------------- |
-| `v16.0.0` | Separate flag for `next build` added        |
+| `v16.0.0` | Separate flags for build and dev.           |
 | `v15.5.0` | Persistent caching released as experimental |

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -140,7 +140,7 @@ We are planning to offer an equivalent to the `innerGraph` optimization in Turbo
 
 ### Build Caching
 
-Webpack supports [disk build caching](https://webpack.js.org/configuration/cache/#cache) to speed up builds. We are planning to support an analogous feature in Turbopack but it is not ready yet. On the `next@canary` release you can experiment with our solution by enabling the [`experimental.turbopackPersistentCaching` flag](/docs/app/api-reference/config/next-config-js/turbopackPersistentCaching).
+Webpack supports [disk build caching](https://webpack.js.org/configuration/cache/#cache) to speed up builds. We are planning to support an analogous feature in Turbopack but it is not ready yet. On the `next@canary` release you can experiment with our solution by enabling the [`experimental.turbopackPersistentCachingForDev`/`experimental.turbopackPersistentCachingForBuild` flags](/docs/app/api-reference/config/next-config-js/turbopackPersistentCaching).
 
 > **Good to know:** For this reason, when comparing webpack and Turbopack performance, make sure to delete the `.next` folder between builds to see a fair comparison.
 

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -331,7 +331,8 @@ export function getDefineEnv({
     // In the worst case we'll show an option to clear the cache, but it'll be a
     // no-op that just restarts the development server.
     'process.env.__NEXT_BUNDLER_HAS_PERSISTENT_CACHE':
-      !isTurbopack || (config.experimental.turbopackPersistentCaching ?? false),
+      !isTurbopack ||
+      (config.experimental.turbopackPersistentCachingForDev ?? false),
     'process.env.__NEXT_REACT_DEBUG_CHANNEL':
       config.experimental.reactDebugChannel ?? false,
   }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -206,7 +206,7 @@ import {
 } from '../server/lib/router-utils/build-prefetch-segment-data-route'
 
 import { turbopackBuild } from './turbopack-build'
-import { isPersistentCachingEnabled } from '../shared/lib/turbopack/utils'
+import { isPersistentCachingEnabledForBuild } from '../shared/lib/turbopack/utils'
 import { inlineStaticEnv } from '../lib/inline-static-env'
 import { populateStaticEnv } from '../lib/static-env'
 import { durationToString } from './duration-to-string'
@@ -2756,7 +2756,7 @@ export default async function build(
         },
         {
           featureName: 'turbopackPersistentCaching',
-          invocationCount: isPersistentCachingEnabled(config) ? 1 : 0,
+          invocationCount: isPersistentCachingEnabledForBuild(config) ? 1 : 0,
         },
       ]
       telemetry.record(

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { validateTurboNextConfig } from '../../lib/turbopack-warning'
 import {
   formatIssue,
-  isPersistentCachingEnabled,
+  isPersistentCachingEnabledForBuild,
   isRelevantWarning,
 } from '../../shared/lib/turbopack/utils'
 import { NextBuildContext } from '../build-context'
@@ -50,7 +50,7 @@ export async function turbopackBuild(): Promise<{
 
   const supportedBrowsers = getSupportedBrowsers(dir, dev)
 
-  const persistentCaching = isPersistentCachingEnabled(config)
+  const persistentCaching = isPersistentCachingEnabledForBuild(config)
   const rootPath = config.turbopack?.root || config.outputFileTracingRoot || dir
   const project = await bindings.turbo.createProject(
     {

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -437,6 +437,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         turbopackMemoryLimit: z.number().optional(),
         turbopackMinify: z.boolean().optional(),
         turbopackPersistentCaching: z.boolean().optional(),
+        turbopackPersistentCachingForBuild: z.boolean().optional(),
         turbopackSourceMaps: z.boolean().optional(),
         turbopackTreeShaking: z.boolean().optional(),
         turbopackRemoveUnusedExports: z.boolean().optional(),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -436,7 +436,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         webpackMemoryOptimizations: z.boolean().optional(),
         turbopackMemoryLimit: z.number().optional(),
         turbopackMinify: z.boolean().optional(),
-        turbopackPersistentCaching: z.boolean().optional(),
+        turbopackPersistentCachingForDev: z.boolean().optional(),
         turbopackPersistentCachingForBuild: z.boolean().optional(),
         turbopackSourceMaps: z.boolean().optional(),
         turbopackTreeShaking: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -425,7 +425,7 @@ export interface ExperimentalConfig {
   /**
    * Enable persistent caching for the turbopack dev server.
    */
-  turbopackPersistentCaching?: boolean
+  turbopackPersistentCachingForDev?: boolean
 
   /**
    * Enable persistent caching for the turbopack build.

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -423,9 +423,14 @@ export interface ExperimentalConfig {
   turbopackScopeHoisting?: boolean
 
   /**
-   * Enable persistent caching for the turbopack dev server and build.
+   * Enable persistent caching for the turbopack dev server.
    */
   turbopackPersistentCaching?: boolean
+
+  /**
+   * Enable persistent caching for the turbopack build.
+   */
+  turbopackPersistentCachingForBuild?: boolean
 
   /**
    * Enable source maps. Defaults to true.

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -133,17 +133,17 @@ describe('loadConfig', () => {
       )
     })
 
-    it('errors when using persistentCaching if not in canary', async () => {
+    it('errors when using persistentCachingForDev if not in canary', async () => {
       await expect(
         loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
           customConfig: {
             experimental: {
-              turbopackPersistentCaching: true,
+              turbopackPersistentCachingForDev: true,
             },
           },
         })
       ).rejects.toThrow(
-        /The experimental feature "experimental.turbopackPersistentCaching" can only be enabled when using the latest canary version of Next.js./
+        /The experimental feature "experimental.turbopackPersistentCachingForDev" can only be enabled when using the latest canary version of Next.js./
       )
     })
 

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -146,6 +146,20 @@ describe('loadConfig', () => {
         /The experimental feature "experimental.turbopackPersistentCaching" can only be enabled when using the latest canary version of Next.js./
       )
     })
+
+    it('errors when using persistentCachingForBuild if not in canary', async () => {
+      await expect(
+        loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+          customConfig: {
+            experimental: {
+              turbopackPersistentCachingForBuild: true,
+            },
+          },
+        })
+      ).rejects.toThrow(
+        /The experimental feature "experimental.turbopackPersistentCachingForBuild" can only be enabled when using the latest canary version of Next.js./
+      )
+    })
   })
 
   describe('with a canary version', () => {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -358,6 +358,10 @@ function assignDefaultsAndValidate(
       throw new CanaryOnlyError({
         feature: 'experimental.turbopackPersistentCaching',
       })
+    } else if (result.experimental?.turbopackPersistentCachingForBuild) {
+      throw new CanaryOnlyError({
+        feature: 'experimental.turbopackPersistentCachingForBuild',
+      })
     }
   }
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -354,9 +354,9 @@ function assignDefaultsAndValidate(
       throw new CanaryOnlyError({ feature: 'experimental.ppr' })
     } else if (result.experimental?.cacheComponents) {
       throw new CanaryOnlyError({ feature: 'experimental.cacheComponents' })
-    } else if (result.experimental?.turbopackPersistentCaching) {
+    } else if (result.experimental?.turbopackPersistentCachingForDev) {
       throw new CanaryOnlyError({
-        feature: 'experimental.turbopackPersistentCaching',
+        feature: 'experimental.turbopackPersistentCachingForDev',
       })
     } else if (result.experimental?.turbopackPersistentCachingForBuild) {
       throw new CanaryOnlyError({

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -84,7 +84,7 @@ import { setBundlerFindSourceMapImplementation } from '../patch-error-inspect'
 import { getNextErrorFeedbackMiddleware } from '../../next-devtools/server/get-next-error-feedback-middleware'
 import {
   formatIssue,
-  isPersistentCachingEnabled,
+  isPersistentCachingEnabledForDev,
   isWellKnownError,
   processIssues,
   renderStyledStringToErrorAnsi,
@@ -273,7 +273,7 @@ export async function createHotReloaderTurbopack(
       currentNodeJsVersion,
     },
     {
-      persistentCaching: isPersistentCachingEnabled(opts.nextConfig),
+      persistentCaching: isPersistentCachingEnabledForDev(opts.nextConfig),
       memoryLimit: opts.nextConfig.experimental?.turbopackMemoryLimit,
       isShortSession: false,
     }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -69,7 +69,7 @@ import { normalizeMetadataPageToRoute } from '../../../lib/metadata/get-metadata
 import { JsConfigPathsPlugin } from '../../../build/webpack/plugins/jsconfig-paths-plugin'
 import { store as consoleStore } from '../../../build/output/store'
 import {
-  isPersistentCachingEnabled,
+  isPersistentCachingEnabledForDev,
   ModuleBuildError,
 } from '../../../shared/lib/turbopack/utils'
 import { getDefineEnv } from '../../../build/define-env'
@@ -1239,7 +1239,9 @@ export async function setupDevBundler(opts: SetupOpts) {
     eventName: EVENT_BUILD_FEATURE_USAGE,
     payload: {
       featureName: 'turbopackPersistentCaching',
-      invocationCount: isPersistentCachingEnabled(opts.nextConfig) ? 1 : 0,
+      invocationCount: isPersistentCachingEnabledForDev(opts.nextConfig)
+        ? 1
+        : 0,
     },
   })
 

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -319,3 +319,9 @@ export function isPersistentCachingEnabled(
 ): boolean {
   return config.experimental?.turbopackPersistentCaching || false
 }
+
+export function isPersistentCachingEnabledForBuild(
+  config: NextConfigComplete
+): boolean {
+  return config.experimental?.turbopackPersistentCachingForBuild || false
+}

--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -314,10 +314,10 @@ export function renderStyledStringToErrorAnsi(string: StyledString): string {
   }
 }
 
-export function isPersistentCachingEnabled(
+export function isPersistentCachingEnabledForDev(
   config: NextConfigComplete
 ): boolean {
-  return config.experimental?.turbopackPersistentCaching || false
+  return config.experimental?.turbopackPersistentCachingForDev || false
 }
 
 export function isPersistentCachingEnabledForBuild(

--- a/test/e2e/persistent-caching/next.config.js
+++ b/test/e2e/persistent-caching/next.config.js
@@ -16,7 +16,7 @@ const nextConfig = {
     },
   },
   experimental: {
-    turbopackPersistentCaching: true,
+    turbopackPersistentCachingForDev: true,
     turbopackPersistentCachingForBuild: true,
   },
   env: {

--- a/test/e2e/persistent-caching/next.config.js
+++ b/test/e2e/persistent-caching/next.config.js
@@ -17,6 +17,7 @@ const nextConfig = {
   },
   experimental: {
     turbopackPersistentCaching: true,
+    turbopackPersistentCachingForBuild: true,
   },
   env: {
     NEXT_PUBLIC_CONFIG_ENV: 'hello world',

--- a/test/integration/telemetry/next.config.persistent-cache
+++ b/test/integration/telemetry/next.config.persistent-cache
@@ -1,6 +1,6 @@
 module.exports = {
   experimental: {
-    turbopackPersistentCaching: true,
+    turbopackPersistentCachingForDev: true,
     turbopackPersistentCachingForBuild: true,
   }
 }

--- a/test/integration/telemetry/next.config.persistent-cache
+++ b/test/integration/telemetry/next.config.persistent-cache
@@ -1,5 +1,6 @@
 module.exports = {
   experimental: {
     turbopackPersistentCaching: true
+    turbopackPersistentCachingForBuild: true
   }
 }

--- a/test/integration/telemetry/next.config.persistent-cache
+++ b/test/integration/telemetry/next.config.persistent-cache
@@ -1,6 +1,6 @@
 module.exports = {
   experimental: {
-    turbopackPersistentCaching: true
-    turbopackPersistentCachingForBuild: true
+    turbopackPersistentCaching: true,
+    turbopackPersistentCachingForBuild: true,
   }
 }


### PR DESCRIPTION
### What?

Move persistent caching for `next build` into a separate config option: `turbopackPersistentCachingForBuild`.
And `next dev` to `turbopackPersistentCachingForDev`.

Closes PACK-5590