### PR TITLE
[mcp] expose logging

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -751,6 +751,7 @@ export async function createHotReloaderTurbopack(
       ? [
           getMcpMiddleware(
             projectPath,
+            distDir,
             (message) => hotReloader.send(message),
             () => clients.size
           ),

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -1647,6 +1647,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
         ? [
             getMcpMiddleware(
               this.dir,
+              this.distDir,
               (message) => this.send(message),
               () => this.webpackHotMiddleware?.getClientCount() ?? 0
             ),

--- a/packages/next/src/server/mcp/get-mcp-middleware.ts
+++ b/packages/next/src/server/mcp/get-mcp-middleware.ts
@@ -6,6 +6,7 @@ import type { HmrMessageSentToBrowser } from '../dev/hot-reloader-types'
 
 export function getMcpMiddleware(
   projectPath: string,
+  distDir: string,
   sendHmrMessage: (message: HmrMessageSentToBrowser) => void,
   getActiveConnectionCount: () => number
 ) {
@@ -20,6 +21,7 @@ export function getMcpMiddleware(
     }
     const mcpServer = getOrCreateMcpServer(
       projectPath,
+      distDir,
       sendHmrMessage,
       getActiveConnectionCount
     )

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -2,12 +2,14 @@ import { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/m
 import { registerGetProjectPathTool } from './tools/get-project-path'
 import { registerGetErrorsTool } from './tools/get-errors'
 import { registerGetPageMetadataTool } from './tools/get-page-metadata'
+import { registerGetLogsTool } from './tools/get-logs'
 import type { HmrMessageSentToBrowser } from '../dev/hot-reloader-types'
 
 let mcpServer: McpServer | undefined
 
 export const getOrCreateMcpServer = (
   projectPath: string,
+  distDir: string,
   sendHmrMessage: (message: HmrMessageSentToBrowser) => void,
   getActiveConnectionCount: () => number
 ) => {
@@ -27,6 +29,7 @@ export const getOrCreateMcpServer = (
     sendHmrMessage,
     getActiveConnectionCount
   )
+  registerGetLogsTool(mcpServer, distDir)
 
   return mcpServer
 }

--- a/packages/next/src/server/mcp/tools/get-logs.ts
+++ b/packages/next/src/server/mcp/tools/get-logs.ts
@@ -1,0 +1,56 @@
+/**
+ * MCP tool for getting the path to the Next.js development log file.
+ *
+ * This tool returns the path to the {nextConfig.distDir}/logs/next-development.log file
+ * that contains browser console logs and other development information.
+ */
+import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
+import { stat } from 'fs/promises'
+import { join } from 'path'
+
+export function registerGetLogsTool(server: McpServer, distDir: string) {
+  server.registerTool(
+    'get_logs',
+    {
+      description:
+        'Get the path to the Next.js development log file. Returns the file path so the agent can read the logs directly.',
+    },
+    async () => {
+      try {
+        const logFilePath = join(distDir, 'logs', 'next-development.log')
+
+        // Check if the log file exists
+        try {
+          await stat(logFilePath)
+        } catch (error) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Log file not found at ${logFilePath}.`,
+              },
+            ],
+          }
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Next.js log file path: ${logFilePath}`,
+            },
+          ],
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error getting log file path: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        }
+      }
+    }
+  )
+}

--- a/test/development/mcp-server/fixtures/log-file-app/.gitignore
+++ b/test/development/mcp-server/fixtures/log-file-app/.gitignore
@@ -1,0 +1,1 @@
+!tsconfig.json

--- a/test/development/mcp-server/fixtures/log-file-app/app/client/page.tsx
+++ b/test/development/mcp-server/fixtures/log-file-app/app/client/page.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function ClientPage() {
+  useEffect(() => {
+    // Logging in client component useEffect
+    // Test complex partial circular object
+    const circularObj: any = {
+      name: 'test',
+      data: {
+        nested: {
+          value: 42,
+          items: [1, 2, 3],
+        },
+      },
+      metadata: {
+        name: 'safe stringify',
+        version: '1.0.0',
+      },
+    }
+    // Create partial circular reference
+    circularObj.data.parent = circularObj
+    console.log('Client: Complex circular object:', circularObj)
+    console.error('Client: This is an error message from client component')
+    console.warn('Client: This is a warning message from client component')
+  }, [])
+
+  return <p>client page with logging</p>
+}

--- a/test/development/mcp-server/fixtures/log-file-app/app/layout.tsx
+++ b/test/development/mcp-server/fixtures/log-file-app/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/mcp-server/fixtures/log-file-app/app/server/page.tsx
+++ b/test/development/mcp-server/fixtures/log-file-app/app/server/page.tsx
@@ -1,0 +1,8 @@
+export default async function Page() {
+  // Logging in RSC render
+  console.log('RSC: This is a log message from server component')
+  console.error('RSC: This is an error message from server component')
+  console.warn('RSC: This is a warning message from server component')
+
+  return <p>hello world</p>
+}

--- a/test/development/mcp-server/fixtures/log-file-app/next.config.js
+++ b/test/development/mcp-server/fixtures/log-file-app/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    mcpServer: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/development/mcp-server/fixtures/log-file-app/pages/pages-router-page.tsx
+++ b/test/development/mcp-server/fixtures/log-file-app/pages/pages-router-page.tsx
@@ -1,0 +1,31 @@
+import { GetServerSideProps } from 'next'
+
+interface Props {
+  message: string
+}
+
+export default function Page({ message }: Props) {
+  console.log('Pages Router isomorphic: This is a log message from render')
+  return (
+    <div>
+      <h1>Pages Router Server-Side Props Test</h1>
+      <p>{message}</p>
+    </div>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async () => {
+  console.log('Pages Router SSR: This is a log message from getServerSideProps')
+  console.error(
+    'Pages Router SSR: This is an error message from getServerSideProps'
+  )
+  console.warn(
+    'Pages Router SSR: This is a warning message from getServerSideProps'
+  )
+
+  return {
+    props: {
+      message: 'Server-side props executed successfully',
+    },
+  }
+}

--- a/test/development/mcp-server/fixtures/log-file-app/tsconfig.json
+++ b/test/development/mcp-server/fixtures/log-file-app/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "**/*.mts"
+  ],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/test/development/mcp-server/mcp-server-get-logs.test.ts
+++ b/test/development/mcp-server/mcp-server-get-logs.test.ts
@@ -1,0 +1,52 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('get-logs MCP tool', () => {
+  const { next, skipped } = nextTestSetup({
+    files: path.join(__dirname, 'fixtures', 'log-file-app'),
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  async function callGetLogs(id: string): Promise<string> {
+    const response = await fetch(`${next.url}/_next/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method: 'tools/call',
+        params: { name: 'get_logs', arguments: {} },
+      }),
+    })
+
+    const text = await response.text()
+    const match = text.match(/data: ({.*})/s)
+    const result = JSON.parse(match![1])
+    return result.result?.content?.[0]?.text
+  }
+
+  it('should return log file path via MCP get_logs tool', async () => {
+    // Generate some logs by visiting pages that create log entries
+    await next.browser('/server')
+    await next.browser('/client')
+    await next.browser('/pages-router-page')
+
+    await retry(async () => {
+      const sessionId = 'test-mcp-logs-' + Date.now()
+      const response = await callGetLogs(sessionId)
+
+      // Should return the log file path
+      expect(response).toContain('Next.js log file path:')
+      expect(response).toContain('logs/next-development.log')
+      expect(response).not.toContain('Log file not found at')
+    })
+  })
+})


### PR DESCRIPTION
## MCP `get_logs` tool

### Summary

This PR implements a new Model Context Protocol (MCP) tool called `get_logs` that allows AI assistants to retrieve development logs from Next.js applications. The tool return the log path `{nextConfig.distDir}/logs/next-development.log` in the response

