### PR TITLE
Development: Skip route matching when there is an existing match

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2558,8 +2558,12 @@ export default abstract class Server<
       i18n: this.i18nProvider?.fromRequest(req, pathname),
     }
 
+    const existingMatch = getRequestMeta(ctx.req, 'match')
+
     try {
-      for await (const match of this.matchers.matchAll(pathname, options)) {
+      for await (const match of existingMatch
+        ? [existingMatch]
+        : this.matchers.matchAll(pathname, options)) {
         // when a specific invoke-output is meant to be matched
         // ensure a prior dynamic route/page doesn't take priority
         const invokeOutput = getRequestMeta(ctx.req, 'invokeOutput')

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2560,13 +2560,24 @@ export default abstract class Server<
 
     const existingMatch = getRequestMeta(ctx.req, 'match')
 
+    let fastPath = true
+    // when a specific invoke-output is meant to be matched
+    // ensure a prior dynamic route/page doesn't take priority
+    const invokeOutput = getRequestMeta(ctx.req, 'invokeOutput')
+
+    if (
+      !this.minimalMode &&
+      typeof invokeOutput === 'string' &&
+      isDynamicRoute(invokeOutput || '') &&
+      invokeOutput !== existingMatch?.definition.pathname
+    ) {
+      fastPath = false
+    }
+
     try {
-      for await (const match of existingMatch
+      for await (const match of fastPath && existingMatch
         ? [existingMatch]
         : this.matchers.matchAll(pathname, options)) {
-        // when a specific invoke-output is meant to be matched
-        // ensure a prior dynamic route/page doesn't take priority
-        const invokeOutput = getRequestMeta(ctx.req, 'invokeOutput')
         if (
           !this.minimalMode &&
           typeof invokeOutput === 'string' &&

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2566,10 +2566,11 @@ export default abstract class Server<
     const invokeOutput = getRequestMeta(ctx.req, 'invokeOutput')
 
     if (
-      !this.minimalMode &&
-      typeof invokeOutput === 'string' &&
-      isDynamicRoute(invokeOutput || '') &&
-      invokeOutput !== existingMatch?.definition.pathname
+      (!this.minimalMode &&
+        typeof invokeOutput === 'string' &&
+        isDynamicRoute(invokeOutput || '') &&
+        invokeOutput !== existingMatch?.definition.pathname) ||
+      existingMatch?.definition.page.includes('/@')
     ) {
       fastPath = false
     }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2570,6 +2570,9 @@ export default abstract class Server<
         typeof invokeOutput === 'string' &&
         isDynamicRoute(invokeOutput || '') &&
         invokeOutput !== existingMatch?.definition.pathname) ||
+      // Parallel routes are matched in `existingMatch` but since currently
+      // there can be multiple matches it's not guaranteed to be the right match
+      // therefor we need to opt-out of the fast path for parallel routes.
       existingMatch?.definition.page.includes('/@')
     ) {
       fastPath = false


### PR DESCRIPTION
## What?

Adds a fast path when there is an existing match already from matching earlier in the request lifecycle. This works for the majority of cases except for Parallel Routes as it will end up finding the wrong bundle path. That is fundamentally related to the implementation of parallel routes and where the bundles are created (under the specific parallel route name). This will need a larger refactor to fix but that doesn't have to block landing the fast path for all other cases.

Closes PACK-5606