### PR TITLE
[Cache Components] Fix caching in `generateMetadata`/`generateViewport`

### DIFF
--- a/packages/next/src/lib/client-and-server-references.ts
+++ b/packages/next/src/lib/client-and-server-references.ts
@@ -27,6 +27,19 @@ export function isUseCacheFunction<T>(
   return type === 'use-cache'
 }
 
+export function isUseCacheFunctionWithUsedArg<T>(
+  value: T & Partial<ServerReference>,
+  argIndex: number
+): value is T & ServerFunction {
+  if (!isServerReference(value)) {
+    return false
+  }
+
+  const { type, usedArgs } = extractInfoFromServerReferenceId(value.$$id)
+
+  return type === 'use-cache' && usedArgs[argIndex]
+}
+
 export function isClientReference(mod: any): boolean {
   const defaultExport = mod?.default || mod
   return defaultExport?.$$typeof === Symbol.for('react.client.reference')

--- a/packages/next/src/lib/client-and-server-references.ts
+++ b/packages/next/src/lib/client-and-server-references.ts
@@ -1,4 +1,7 @@
-import { extractInfoFromServerReferenceId } from '../shared/lib/server-reference-info'
+import {
+  extractInfoFromServerReferenceId,
+  type ServerReferenceInfo,
+} from '../shared/lib/server-reference-info'
 
 // Only contains the properties we're interested in.
 export interface ServerReference {
@@ -27,17 +30,16 @@ export function isUseCacheFunction<T>(
   return type === 'use-cache'
 }
 
-export function isUseCacheFunctionWithUsedArg<T>(
-  value: T & Partial<ServerReference>,
-  argIndex: number
-): value is T & ServerFunction {
+export function getUseCacheFunctionInfo<T>(
+  value: T & Partial<ServerReference>
+): ServerReferenceInfo | null {
   if (!isServerReference(value)) {
-    return false
+    return null
   }
 
-  const { type, usedArgs } = extractInfoFromServerReferenceId(value.$$id)
+  const info = extractInfoFromServerReferenceId(value.$$id)
 
-  return type === 'use-cache' && usedArgs[argIndex]
+  return info.type === 'use-cache' ? info : null
 }
 
 export function isClientReference(mod: any): boolean {

--- a/packages/next/src/lib/metadata/resolve-metadata.test.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.test.ts
@@ -46,9 +46,13 @@ function mapUrlsToStrings(obj: any) {
 describe('accumulateMetadata', () => {
   describe('typing', () => {
     it('should support both sync and async metadata', async () => {
+      const generateMetadata = () => Promise.resolve({ description: 'child' })
       const metadataItems: MetadataItems = [
         [{ description: 'parent' }, null],
-        [() => Promise.resolve({ description: 'child' }), null],
+        [
+          Object.assign(generateMetadata, { $$original: generateMetadata }),
+          null,
+        ],
       ]
 
       const metadata = await accumulateMetadata(metadataItems)
@@ -467,16 +471,18 @@ describe('accumulateMetadata', () => {
         },
       })
 
+      function gM2() {
+        return {
+          openGraph: {
+            images: undefined,
+          },
+          // twitter is not specified, supposed to merged with openGraph but images should not be picked up
+        }
+      }
+
       const metadataItems2: MetadataItems = [
         [
-          function gM2() {
-            return {
-              openGraph: {
-                images: undefined,
-              },
-              // twitter is not specified, supposed to merged with openGraph but images should not be picked up
-            }
-          },
+          Object.assign(gM2, { $$original: gM2 }),
           // has static metadata files
           {
             icon: undefined,

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -23,6 +23,7 @@ import type { ParsedUrlQuery } from 'querystring'
 import type { StaticMetadata } from './types/icons'
 import type { WorkStore } from '../../server/app-render/work-async-storage.external'
 import type { Params } from '../../server/request/params'
+import type { SearchParams } from '../../server/request/search-params'
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import 'server-only'
@@ -58,6 +59,11 @@ import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import * as Log from '../../build/output/log'
 import { createServerParamsForMetadata } from '../../server/request/params'
 import type { MetadataBaseURL } from './resolvers/resolve-url'
+import { isUseCacheFunction } from '../client-and-server-references'
+import type {
+  UseCacheLayoutProps,
+  UseCachePageProps,
+} from '../../server/use-cache/use-cache-wrapper'
 
 type StaticIcons = Pick<ResolvedIcons, 'icon' | 'apple'>
 
@@ -87,12 +93,16 @@ type BuildState = {
 }
 
 type LayoutProps = {
-  params: { [key: string]: any }
+  params: Promise<Params>
 }
+
 type PageProps = {
-  params: { [key: string]: any }
-  searchParams: { [key: string]: any }
+  params: Promise<Params>
+  searchParams: Promise<SearchParams>
 }
+
+type SegmentProps = LayoutProps | PageProps
+type UseCacheSegmentProps = UseCacheLayoutProps | UseCachePageProps
 
 function isFavicon(icon: IconDescriptor | undefined): boolean {
   if (!icon) {
@@ -461,11 +471,13 @@ function mergeViewport({
 
 function getDefinedViewport(
   mod: any,
-  props: any,
+  props: SegmentProps,
   tracingProps: { route: string }
 ): Viewport | ViewportResolver | null {
   if (typeof mod.generateViewport === 'function') {
     const { route } = tracingProps
+    const segmentProps = createSegmentProps(mod.generateViewport, props)
+
     return (parent: ResolvingViewport) =>
       getTracer().trace(
         ResolveMetadataSpan.generateViewport,
@@ -475,7 +487,7 @@ function getDefinedViewport(
             'next.page': route,
           },
         },
-        () => mod.generateViewport(props, parent)
+        () => mod.generateViewport(segmentProps, parent)
       )
   }
   return mod.viewport || null
@@ -483,11 +495,13 @@ function getDefinedViewport(
 
 function getDefinedMetadata(
   mod: any,
-  props: any,
+  props: SegmentProps,
   tracingProps: { route: string }
 ): Metadata | MetadataResolver | null {
   if (typeof mod.generateMetadata === 'function') {
     const { route } = tracingProps
+    const segmentProps = createSegmentProps(mod.generateMetadata, props)
+
     return (parent: ResolvingMetadata) =>
       getTracer().trace(
         ResolveMetadataSpan.generateMetadata,
@@ -497,15 +511,31 @@ function getDefinedMetadata(
             'next.page': route,
           },
         },
-        () => mod.generateMetadata(props, parent)
+        () => mod.generateMetadata(segmentProps, parent)
       )
   }
   return mod.metadata || null
 }
 
+/**
+ * If `fn` is a `'use cache'` function, we add special markers to the props,
+ * that the cache wrapper reads and removes, before passing the props to the
+ * user function.
+ */
+function createSegmentProps(
+  fn: Function,
+  props: SegmentProps
+): SegmentProps | UseCacheSegmentProps {
+  return isUseCacheFunction(fn)
+    ? 'searchParams' in props
+      ? { ...props, $$isPage: true }
+      : { ...props, $$isLayout: true }
+    : props
+}
+
 async function collectStaticImagesFiles(
   metadata: AppDirModules['metadata'],
-  props: any,
+  props: SegmentProps,
   type: keyof NonNullable<AppDirModules['metadata']>
 ) {
   if (!metadata?.[type]) return undefined
@@ -522,7 +552,7 @@ async function collectStaticImagesFiles(
 
 async function resolveStaticMetadata(
   modules: AppDirModules,
-  props: any
+  props: SegmentProps
 ): Promise<StaticMetadata> {
   const { metadata } = modules
   if (!metadata) return null
@@ -557,7 +587,7 @@ async function collectMetadata({
   tree: LoaderTree
   metadataItems: MetadataItems
   errorMetadataItem: MetadataItems[number]
-  props: any
+  props: SegmentProps
   route: string
   errorConvention?: MetadataErrorType
 }) {
@@ -608,7 +638,7 @@ async function collectViewport({
   tree: LoaderTree
   viewportItems: ViewportItems
   errorViewportItemRef: ErrorViewportItemRef
-  props: any
+  props: SegmentProps
   route: string
   errorConvention?: MetadataErrorType
 }) {
@@ -700,25 +730,14 @@ async function resolveMetadataItemsImpl(
   }
 
   const params = createServerParamsForMetadata(currentParams, workStore)
-
-  let layerProps: LayoutProps | PageProps
-  if (isPage) {
-    layerProps = {
-      params,
-      searchParams,
-    }
-  } else {
-    layerProps = {
-      params,
-    }
-  }
+  const props: SegmentProps = isPage ? { params, searchParams } : { params }
 
   await collectMetadata({
     tree,
     metadataItems,
     errorMetadataItem,
     errorConvention,
-    props: layerProps,
+    props,
     route: currentTreePrefix
       // __PAGE__ shouldn't be shown in a route
       .filter((s) => s !== PAGE_SEGMENT_KEY)

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -59,20 +59,31 @@ import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import * as Log from '../../build/output/log'
 import { createServerParamsForMetadata } from '../../server/request/params'
 import type { MetadataBaseURL } from './resolvers/resolve-url'
-import { isUseCacheFunction } from '../client-and-server-references'
+import {
+  isUseCacheFunction,
+  isUseCacheFunctionWithUsedArg,
+} from '../client-and-server-references'
 import type {
   UseCacheLayoutProps,
   UseCachePageProps,
 } from '../../server/use-cache/use-cache-wrapper'
+import { createLazyResult } from '../../server/lib/lazy-result'
 
 type StaticIcons = Pick<ResolvedIcons, 'icon' | 'apple'>
 
-type MetadataResolver = (
-  parent: ResolvingMetadata
-) => Metadata | Promise<Metadata>
-type ViewportResolver = (
-  parent: ResolvingViewport
-) => Viewport | Promise<Viewport>
+type Resolved<T> = T extends Metadata ? ResolvedMetadata : ResolvedViewport
+
+type InstrumentedResolver<TData> = ((
+  parent: Promise<Resolved<TData>>
+) => TData | Promise<TData>) & {
+  $$original: (
+    props: unknown,
+    parent: Promise<Resolved<TData>>
+  ) => TData | Promise<TData>
+}
+
+type MetadataResolver = InstrumentedResolver<Metadata>
+type ViewportResolver = InstrumentedResolver<Viewport>
 
 export type MetadataErrorType = 'not-found' | 'forbidden' | 'unauthorized'
 
@@ -478,17 +489,20 @@ function getDefinedViewport(
     const { route } = tracingProps
     const segmentProps = createSegmentProps(mod.generateViewport, props)
 
-    return (parent: ResolvingViewport) =>
-      getTracer().trace(
-        ResolveMetadataSpan.generateViewport,
-        {
-          spanName: `generateViewport ${route}`,
-          attributes: {
-            'next.page': route,
+    return Object.assign(
+      (parent: ResolvingViewport) =>
+        getTracer().trace(
+          ResolveMetadataSpan.generateViewport,
+          {
+            spanName: `generateViewport ${route}`,
+            attributes: {
+              'next.page': route,
+            },
           },
-        },
-        () => mod.generateViewport(segmentProps, parent)
-      )
+          () => mod.generateViewport(segmentProps, parent)
+        ),
+      { $$original: mod.generateViewport }
+    )
   }
   return mod.viewport || null
 }
@@ -502,17 +516,20 @@ function getDefinedMetadata(
     const { route } = tracingProps
     const segmentProps = createSegmentProps(mod.generateMetadata, props)
 
-    return (parent: ResolvingMetadata) =>
-      getTracer().trace(
-        ResolveMetadataSpan.generateMetadata,
-        {
-          spanName: `generateMetadata ${route}`,
-          attributes: {
-            'next.page': route,
+    return Object.assign(
+      (parent: ResolvingMetadata) =>
+        getTracer().trace(
+          ResolveMetadataSpan.generateMetadata,
+          {
+            spanName: `generateMetadata ${route}`,
+            attributes: {
+              'next.page': route,
+            },
           },
-        },
-        () => mod.generateMetadata(segmentProps, parent)
-      )
+          () => mod.generateMetadata(segmentProps, parent)
+        ),
+      { $$original: mod.generateMetadata }
+    )
   }
   return mod.metadata || null
 }
@@ -982,7 +999,7 @@ function prerenderMetadata(metadataItems: MetadataItems) {
   > = []
   for (let i = 0; i < metadataItems.length; i++) {
     const metadataExport = metadataItems[i][0]
-    getResult(resolversAndResults, metadataExport)
+    getResult<Metadata>(resolversAndResults, metadataExport)
   }
   return resolversAndResults
 }
@@ -996,32 +1013,49 @@ function prerenderViewport(viewportItems: ViewportItems) {
   > = []
   for (let i = 0; i < viewportItems.length; i++) {
     const viewportExport = viewportItems[i]
-    getResult(resolversAndResults, viewportExport)
+    getResult<Viewport>(resolversAndResults, viewportExport)
   }
   return resolversAndResults
 }
 
-type Resolved<T> = T extends Metadata ? ResolvedMetadata : ResolvedViewport
-
-function getResult<T extends Metadata | Viewport>(
-  resolversAndResults: Array<((value: Resolved<T>) => void) | Result<T>>,
-  exportForResult: null | T | ((parent: Promise<Resolved<T>>) => Result<T>)
+function getResult<TData extends object>(
+  resolversAndResults: Array<
+    ((value: Resolved<TData>) => void) | Result<TData>
+  >,
+  exportForResult: null | TData | InstrumentedResolver<TData>
 ) {
   if (typeof exportForResult === 'function') {
-    const result = exportForResult(
-      new Promise<Resolved<T>>((resolve) => resolversAndResults.push(resolve))
+    const promise = new Promise<Resolved<TData>>((resolve) =>
+      resolversAndResults.push(resolve)
     )
-    resolversAndResults.push(result)
-    if (result instanceof Promise) {
-      // since we eager execute generateMetadata and
-      // they can reject at anytime we need to ensure
-      // we attach the catch handler right away to
-      // prevent unhandled rejections crashing the process
-      result.catch((err) => {
-        return {
-          __nextError: err,
-        }
-      })
+
+    // If the function is a 'use cache' function that uses the parent data as
+    // the second argument, we don't want to eagerly execute it during
+    // metadata/viewport pre-rendering, as the parent data might also be
+    // computed from another 'use cache' function. To ensure that the hanging
+    // input abort signal handling works in this case (i.e. the depending
+    // function waits for the cached input to resolve while encoding its args),
+    // they must be called sequentially. This can be accomplished by wrapping
+    // the call in a lazy promise, so that the original function is only called
+    // when the result is actually awaited.
+    if (isUseCacheFunctionWithUsedArg(exportForResult.$$original, 1)) {
+      resolversAndResults.push(
+        createLazyResult(async () => exportForResult(promise))
+      )
+    } else {
+      const result = exportForResult(promise)
+      resolversAndResults.push(result)
+      if (result instanceof Promise) {
+        // since we eager execute generateMetadata and
+        // they can reject at anytime we need to ensure
+        // we attach the catch handler right away to
+        // prevent unhandled rejections crashing the process
+        result.catch((err) => {
+          return {
+            __nextError: err,
+          }
+        })
+      }
     }
   } else if (typeof exportForResult === 'object') {
     resolversAndResults.push(exportForResult)

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -60,8 +60,8 @@ import * as Log from '../../build/output/log'
 import { createServerParamsForMetadata } from '../../server/request/params'
 import type { MetadataBaseURL } from './resolvers/resolve-url'
 import {
+  getUseCacheFunctionInfo,
   isUseCacheFunction,
-  isUseCacheFunctionWithUsedArg,
 } from '../client-and-server-references'
 import type {
   UseCacheLayoutProps,
@@ -1018,6 +1018,8 @@ function prerenderViewport(viewportItems: ViewportItems) {
   return resolversAndResults
 }
 
+const noop = () => {}
+
 function getResult<TData extends object>(
   resolversAndResults: Array<
     ((value: Resolved<TData>) => void) | Result<TData>
@@ -1025,10 +1027,6 @@ function getResult<TData extends object>(
   exportForResult: null | TData | InstrumentedResolver<TData>
 ) {
   if (typeof exportForResult === 'function') {
-    const promise = new Promise<Resolved<TData>>((resolve) =>
-      resolversAndResults.push(resolve)
-    )
-
     // If the function is a 'use cache' function that uses the parent data as
     // the second argument, we don't want to eagerly execute it during
     // metadata/viewport pre-rendering, as the parent data might also be
@@ -1038,12 +1036,31 @@ function getResult<TData extends object>(
     // they must be called sequentially. This can be accomplished by wrapping
     // the call in a lazy promise, so that the original function is only called
     // when the result is actually awaited.
-    if (isUseCacheFunctionWithUsedArg(exportForResult.$$original, 1)) {
+    const useCacheFunctionInfo = getUseCacheFunctionInfo(
+      exportForResult.$$original
+    )
+    if (useCacheFunctionInfo && useCacheFunctionInfo.usedArgs[1]) {
+      const promise = new Promise<Resolved<TData>>((resolve) =>
+        resolversAndResults.push(resolve)
+      )
       resolversAndResults.push(
         createLazyResult(async () => exportForResult(promise))
       )
     } else {
-      const result = exportForResult(promise)
+      let result: TData | Promise<TData>
+      if (useCacheFunctionInfo) {
+        resolversAndResults.push(noop)
+        // @ts-expect-error We intentionally omit the parent argument, because
+        // we know from the check above that the 'use cache' function does not
+        // use it.
+        result = exportForResult()
+      } else {
+        result = exportForResult(
+          new Promise<Resolved<TData>>((resolve) =>
+            resolversAndResults.push(resolve)
+          )
+        )
+      }
       resolversAndResults.push(result)
       if (result instanceof Promise) {
         // since we eager execute generateMetadata and

--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -785,12 +785,12 @@ interface Viewport extends ViewportLayout {
   colorScheme?: null | ColorSchemeEnum | undefined
 }
 
-type ResolvingViewport = Promise<Viewport>
-
 interface ResolvedViewport extends ViewportLayout {
   themeColor: null | ThemeColorDescriptor[]
   colorScheme: null | ColorSchemeEnum
 }
+
+type ResolvingViewport = Promise<ResolvedViewport>
 
 export type {
   Metadata,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -25,8 +25,8 @@ import type { Params } from '../request/params'
 import { workUnitAsyncStorage } from './work-unit-async-storage.external'
 import { OUTLET_BOUNDARY_NAME } from '../../lib/framework/boundary-constants'
 import type {
-  UseCacheLayoutComponentProps,
-  UseCachePageComponentProps,
+  UseCacheLayoutProps,
+  UseCachePageProps,
 } from '../use-cache/use-cache-wrapper'
 import { DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
 import {
@@ -793,14 +793,14 @@ async function createComponentTreeInternal(
       let searchParams = createServerSearchParamsForServerPage(query, workStore)
 
       if (isUseCacheFunction(PageComponent)) {
-        const UseCachePageComponent: React.ComponentType<UseCachePageComponentProps> =
+        const UseCachePageComponent: React.ComponentType<UseCachePageProps> =
           PageComponent
 
         pageElement = (
           <UseCachePageComponent
             params={params}
             searchParams={searchParams}
-            $$isPageComponent
+            $$isPage
           />
         )
       } else {
@@ -951,14 +951,14 @@ async function createComponentTreeInternal(
       let serverSegment: React.ReactNode
 
       if (isUseCacheFunction(SegmentComponent)) {
-        const UseCacheLayoutComponent: React.ComponentType<UseCacheLayoutComponentProps> =
+        const UseCacheLayoutComponent: React.ComponentType<UseCacheLayoutProps> =
           SegmentComponent
 
         serverSegment = (
           <UseCacheLayoutComponent
             {...parallelRouteProps}
             params={params}
-            $$isLayoutComponent
+            $$isLayout
           />
         )
       } else {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -1010,7 +1010,10 @@ export function cache(
       if (isPageSegmentFunction(args)) {
         isPageOrLayoutSegmentFunction = true
 
-        const [{ params: outerParams, searchParams: outerSearchParams }] = args
+        const [
+          { params: outerParams, searchParams: outerSearchParams },
+          ...otherOuterArgs
+        ] = args
 
         const props: UseCachePageInnerProps = {
           params: outerParams,
@@ -1023,13 +1026,16 @@ export function cache(
           props.searchParams = outerSearchParams
         }
 
-        args = [props]
+        args = [props, ...otherOuterArgs]
 
         fn = {
-          [name]: async ({
-            params: _innerParams,
-            searchParams: innerSearchParams,
-          }: UseCachePageInnerProps) =>
+          [name]: async (
+            {
+              params: _innerParams,
+              searchParams: innerSearchParams,
+            }: UseCachePageInnerProps,
+            ...otherInnerArgs: unknown[]
+          ) =>
             originalFn.apply(null, [
               {
                 params: outerParams,
@@ -1044,25 +1050,36 @@ export function cache(
                   // need to ensure that an error is shown.
                   makeErroringSearchParamsForUseCache(workStore),
               },
+              ...otherInnerArgs,
             ]),
         }[name] as (...args: unknown[]) => Promise<unknown>
       } else if (isLayoutSegmentFunction(args)) {
         isPageOrLayoutSegmentFunction = true
 
-        const [{ params: outerParams, $$isLayout, ...outerSlots }] = args
+        const [
+          { params: outerParams, $$isLayout, ...outerSlots },
+          ...otherOuterArgs
+        ] = args
+
         // Overwrite the props to omit $$isLayout. Note that slots are only
         // passed to the layout component (if any are defined), and not to
         // generateMetadata nor generateViewport. For those functions,
         // outerSlots/innerSlots is an empty object, which is fine because we're
         // just spreading it into the props.
-        args = [{ params: outerParams, ...outerSlots }]
+        args = [{ params: outerParams, ...outerSlots }, ...otherOuterArgs]
 
         fn = {
-          [name]: async ({
-            params: _innerParams,
-            ...innerSlots
-          }: Omit<UseCacheLayoutProps, '$$isLayout'>) =>
-            originalFn.apply(null, [{ params: outerParams, ...innerSlots }]),
+          [name]: async (
+            {
+              params: _innerParams,
+              ...innerSlots
+            }: Omit<UseCacheLayoutProps, '$$isLayout'>,
+            ...otherInnerArgs: unknown[]
+          ) =>
+            originalFn.apply(null, [
+              { params: outerParams, ...innerSlots },
+              ...otherInnerArgs,
+            ]),
         }[name] as (...args: unknown[]) => Promise<unknown>
       }
 
@@ -1608,7 +1625,9 @@ export function cache(
  * Returns `true` if the `'use cache'` function is the page component itself,
  * or `generateMetadata`/`generateViewport` in a page file.
  */
-function isPageSegmentFunction(args: any[]): args is [UseCachePageProps] {
+function isPageSegmentFunction(
+  args: any[]
+): args is [UseCachePageProps, ...unknown[]] {
   const [maybeProps] = args
 
   return (
@@ -1622,7 +1641,9 @@ function isPageSegmentFunction(args: any[]): args is [UseCachePageProps] {
  * Returns `true` if the `'use cache'` function is the layout component itself,
  * or `generateMetadata`/`generateViewport` in a layout file.
  */
-function isLayoutSegmentFunction(args: any[]): args is [UseCacheLayoutProps] {
+function isLayoutSegmentFunction(
+  args: any[]
+): args is [UseCacheLayoutProps, ...unknown[]] {
   const [maybeProps] = args
 
   return (

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -91,20 +91,20 @@ type CacheKeyParts =
   | [buildId: string, id: string, args: unknown[]]
   | [buildId: string, id: string, args: unknown[], hmrRefreshHash: string]
 
-interface UseCacheInnerPageComponentProps {
+interface UseCachePageInnerProps {
   params: Promise<Params>
   searchParams?: Promise<SearchParams>
 }
 
-export interface UseCachePageComponentProps {
+export interface UseCachePageProps {
   params: Promise<Params>
   searchParams: Promise<SearchParams>
-  $$isPageComponent: true
+  $$isPage: true
 }
 
-export type UseCacheLayoutComponentProps = {
+export type UseCacheLayoutProps = {
   params: Promise<Params>
-  $$isLayoutComponent: true
+  $$isLayout: true
 } & {
   // The value type should be React.ReactNode. But such an index signature would
   // be incompatible with the other two props.
@@ -995,25 +995,26 @@ export function cache(
         }
       }
 
-      let isPageOrLayout = false
+      let isPageOrLayoutSegmentFunction = false
 
-      // For page and layout components, the cache function is overwritten,
-      // which allows us to apply special handling for params and searchParams.
-      // For pages and layouts we're using the outer params prop, and not the
-      // inner one that was serialized/deserialized. While it's not generally
-      // true for "use cache" args, in the case of `params` the inner and outer
-      // object are essentially equivalent, so this is safe to do (including
-      // fallback params that are hanging promises). It allows us to avoid
-      // waiting for the timeout, when prerendering a fallback shell of a cached
-      // page or layout that awaits params.
-      if (isPageComponent(args)) {
-        isPageOrLayout = true
+      // For page and layout segment functions (i.e. the page/layout component,
+      // or generateMetadata/generateViewport), the cache function is
+      // overwritten, which allows us to apply special handling for params and
+      // searchParams. For pages and layouts we're using the outer params prop,
+      // and not the inner one that was serialized/deserialized. While it's not
+      // generally true for "use cache" args, in the case of `params` the inner
+      // and outer object are essentially equivalent, so this is safe to do
+      // (including fallback params that are hanging promises). It allows us to
+      // avoid waiting for the timeout, when prerendering a fallback shell of a
+      // cached page or layout that awaits params.
+      if (isPageSegmentFunction(args)) {
+        isPageOrLayoutSegmentFunction = true
 
         const [{ params: outerParams, searchParams: outerSearchParams }] = args
 
-        const props: UseCacheInnerPageComponentProps = {
+        const props: UseCachePageInnerProps = {
           params: outerParams,
-          // Omit searchParams and $$isPageComponent.
+          // Omit searchParams and $$isPage.
         }
 
         if (isPrivate) {
@@ -1028,7 +1029,7 @@ export function cache(
           [name]: async ({
             params: _innerParams,
             searchParams: innerSearchParams,
-          }: UseCacheInnerPageComponentProps) =>
+          }: UseCachePageInnerProps) =>
             originalFn.apply(null, [
               {
                 params: outerParams,
@@ -1045,19 +1046,22 @@ export function cache(
               },
             ]),
         }[name] as (...args: unknown[]) => Promise<unknown>
-      } else if (isLayoutComponent(args)) {
-        isPageOrLayout = true
+      } else if (isLayoutSegmentFunction(args)) {
+        isPageOrLayoutSegmentFunction = true
 
-        const [{ params: outerParams, $$isLayoutComponent, ...outerSlots }] =
-          args
-        // Overwrite the props to omit $$isLayoutComponent.
+        const [{ params: outerParams, $$isLayout, ...outerSlots }] = args
+        // Overwrite the props to omit $$isLayout. Note that slots are only
+        // passed to the layout component (if any are defined), and not to
+        // generateMetadata nor generateViewport. For those functions,
+        // outerSlots/innerSlots is an empty object, which is fine because we're
+        // just spreading it into the props.
         args = [{ params: outerParams, ...outerSlots }]
 
         fn = {
           [name]: async ({
             params: _innerParams,
             ...innerSlots
-          }: Omit<UseCacheLayoutComponentProps, '$$isLayoutComponent'>) =>
+          }: Omit<UseCacheLayoutProps, '$$isLayout'>) =>
             originalFn.apply(null, [{ params: outerParams, ...innerSlots }]),
         }[name] as (...args: unknown[]) => Promise<unknown>
       }
@@ -1120,14 +1124,14 @@ export function cache(
         //
         // fallthrough
         case 'prerender':
-          if (!isPageOrLayout) {
-            // If the "use cache" function is not a page or a layout, we need to
-            // track dynamic access already when encoding the arguments. If
-            // params are passed explicitly into a "use cache" function (as
-            // opposed to receiving them automatically in a page or layout), we
-            // assume that the params are also accessed. This allows us to abort
-            // early, and treat the function as dynamic, instead of waiting for
-            // the timeout to be reached.
+          if (!isPageOrLayoutSegmentFunction) {
+            // If the "use cache" function is not a page or layout segment
+            // function, we need to track dynamic access already when encoding
+            // the arguments. If params are passed explicitly into a "use cache"
+            // function (as opposed to receiving them automatically in a page or
+            // layout), we assume that the params are also accessed. This allows
+            // us to abort early, and treat the function as dynamic, instead of
+            // waiting for the timeout to be reached.
             const dynamicAccessAbortController = new AbortController()
 
             encodedCacheKeyParts = await dynamicAccessAsyncStorage.run(
@@ -1600,37 +1604,31 @@ export function cache(
   return React.cache(cachedFn)
 }
 
-function isPageComponent(
-  args: any[]
-): args is [UseCachePageComponentProps, undefined] {
-  if (args.length !== 2) {
-    return false
-  }
-
-  const [props, ref] = args
+/**
+ * Returns `true` if the `'use cache'` function is the page component itself,
+ * or `generateMetadata`/`generateViewport` in a page file.
+ */
+function isPageSegmentFunction(args: any[]): args is [UseCachePageProps] {
+  const [maybeProps] = args
 
   return (
-    ref === undefined && // server components receive an undefined ref arg
-    props !== null &&
-    typeof props === 'object' &&
-    (props as UseCachePageComponentProps).$$isPageComponent
+    maybeProps !== null &&
+    typeof maybeProps === 'object' &&
+    (maybeProps as UseCachePageProps).$$isPage === true
   )
 }
 
-function isLayoutComponent(
-  args: any[]
-): args is [UseCacheLayoutComponentProps, undefined] {
-  if (args.length !== 2) {
-    return false
-  }
-
-  const [props, ref] = args
+/**
+ * Returns `true` if the `'use cache'` function is the layout component itself,
+ * or `generateMetadata`/`generateViewport` in a layout file.
+ */
+function isLayoutSegmentFunction(args: any[]): args is [UseCacheLayoutProps] {
+  const [maybeProps] = args
 
   return (
-    ref === undefined && // server components receive an undefined ref arg
-    props !== null &&
-    typeof props === 'object' &&
-    (props as UseCacheLayoutComponentProps).$$isLayoutComponent
+    maybeProps !== null &&
+    typeof maybeProps === 'object' &&
+    (maybeProps as UseCacheLayoutProps).$$isLayout === true
   )
 }
 

--- a/test/e2e/app-dir/use-cache-search-params/app/search-params-used-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/use-cache-search-params/app/search-params-used-generate-metadata/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from 'next'
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}): Promise<Metadata> {
+  'use cache'
+  const title = (await searchParams).title
+
+  return { title: String(title) }
+}
+
+export default function Page() {
+  return null
+}

--- a/test/e2e/app-dir/use-cache-search-params/app/search-params-used-generate-viewport/page.tsx
+++ b/test/e2e/app-dir/use-cache-search-params/app/search-params-used-generate-viewport/page.tsx
@@ -1,0 +1,16 @@
+import { Viewport } from 'next'
+
+export async function generateViewport({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}): Promise<Viewport> {
+  'use cache'
+  const color = (await searchParams).color
+
+  return { themeColor: String(color) }
+}
+
+export default function Page() {
+  return null
+}

--- a/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
+++ b/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
@@ -128,6 +128,46 @@ describe('use-cache-search-params', () => {
         expect(cliOutput).not.toContain(getExpectedErrorMessage(route))
       })
     })
+
+    it('should show an error when searchParams are used inside of a cached generateMetadata', async () => {
+      const browser = await next.browser(
+        '/search-params-used-generate-metadata?title=foo'
+      )
+
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Route /search-params-used-generate-metadata used \`searchParams\` inside "use cache". Accessing dynamic request data inside a cache scope is not supported. If you need some search params inside a cached function await \`searchParams\` outside of the cached function and pass only the required search params as arguments to the cached function. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/search-params-used-generate-metadata/page.tsx (9:17) @ generateMetadata
+       >  9 |   const title = (await searchParams).title
+            |                 ^",
+         "stack": [
+           "generateMetadata app/search-params-used-generate-metadata/page.tsx (9:17)",
+         ],
+       }
+      `)
+    })
+
+    it('should show an error when searchParams are used inside of a cached generateViewport', async () => {
+      const browser = await next.browser(
+        '/search-params-used-generate-viewport?color=red'
+      )
+
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Route /search-params-used-generate-viewport used \`searchParams\` inside "use cache". Accessing dynamic request data inside a cache scope is not supported. If you need some search params inside a cached function await \`searchParams\` outside of the cached function and pass only the required search params as arguments to the cached function. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/search-params-used-generate-viewport/page.tsx (9:17) @ generateViewport
+       >  9 |   const color = (await searchParams).color
+            |                 ^",
+         "stack": [
+           "generateViewport app/search-params-used-generate-viewport/page.tsx (9:17)",
+         ],
+       }
+      `)
+    })
   } else {
     afterEach(async () => {
       await next.stop()

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/generate-viewport-resume/params-used/[color]/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/generate-viewport-resume/params-used/[color]/layout.tsx
@@ -1,0 +1,23 @@
+import { Viewport } from 'next'
+
+export async function generateViewport({
+  params,
+}: {
+  params: Promise<{ color: string }>
+}): Promise<Viewport> {
+  'use cache: remote'
+
+  // We're reading params here. This makes the cache function dynamic during
+  // prerendering. It also requires suspense above body, so nothing will
+  // prerendered. The meta tag should still be cached on refreshes though.
+  const { color } = await params
+
+  return {
+    colorScheme: color === 'white' ? 'light' : 'dark',
+    maximumScale: 1 + Math.random(),
+  }
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <main>{children}</main>
+}

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/generate-viewport-resume/params-used/[color]/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/generate-viewport-resume/params-used/[color]/layout.tsx
@@ -7,6 +7,17 @@ export async function generateViewport({
 }): Promise<Viewport> {
   'use cache: remote'
 
+  // Use `eval` to side step compiler errors for using `arguments` in a 'use
+  // cache' function.
+  // eslint-disable-next-line no-eval
+  const unusedParentArg = eval('arguments')[1]
+  if (unusedParentArg !== undefined) {
+    throw new Error(
+      'Expected the unused parent argument to be omitted. Received: ' +
+        unusedParentArg
+    )
+  }
+
   // We're reading params here. This makes the cache function dynamic during
   // prerendering. It also requires suspense above body, so nothing will
   // prerendered. The meta tag should still be cached on refreshes though.

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/generate-viewport-resume/params-used/[color]/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/generate-viewport-resume/params-used/[color]/page.tsx
@@ -1,0 +1,32 @@
+import { Viewport } from 'next'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export async function generateViewport({
+  params,
+}: {
+  params: Promise<{ color: string }>
+}): Promise<Viewport> {
+  'use cache: remote'
+
+  // We're reading params here. This makes the cache function dynamic during
+  // prerendering. It also requires suspense above body, so nothing will
+  // prerendered. The meta tag should still be cached on refreshes though.
+  const { color } = await params
+
+  return { themeColor: color, initialScale: Math.random() }
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Dynamic />
+    </Suspense>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+
+  return <p>Dynamic</p>
+}

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/generate-viewport-resume/params-used/[color]/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/generate-viewport-resume/params-used/[color]/page.tsx
@@ -9,6 +9,17 @@ export async function generateViewport({
 }): Promise<Viewport> {
   'use cache: remote'
 
+  // Use `eval` to side step compiler errors for using `arguments` in a 'use
+  // cache' function.
+  // eslint-disable-next-line no-eval
+  const unusedParentArg = eval('arguments')[1]
+  if (unusedParentArg !== undefined) {
+    throw new Error(
+      'Expected the unused parent argument to be omitted. Received: ' +
+        unusedParentArg
+    )
+  }
+
   // We're reading params here. This makes the cache function dynamic during
   // prerendering. It also requires suspense above body, so nothing will
   // prerendered. The meta tag should still be cached on refreshes though.

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/canonical/[slug]/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/canonical/[slug]/layout.tsx
@@ -1,0 +1,24 @@
+import { Metadata, ResolvingMetadata } from 'next'
+
+export async function generateMetadata(
+  _: { params: Promise<{ slug: string }> },
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  'use cache'
+
+  // We're not reading params here, but we do define a canonical URL, which
+  // leads to the pathname being read under the hood. This should make the
+  // function dynamic when prerendering the fallback shell, and not lead to a
+  // timeout error.
+
+  const { metadataBase } = await parent
+
+  return {
+    // We can not return a URL instance from a `'use cache'` function.
+    metadataBase: metadataBase?.replace('/foo', '/bar'),
+  }
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/canonical/[slug]/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/canonical/[slug]/page.tsx
@@ -1,0 +1,36 @@
+import { Metadata, ResolvingMetadata } from 'next'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export async function generateMetadata(
+  _: { params: Promise<{ slug: string }> },
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  'use cache'
+
+  // We're not reading params here, but we do define a canonical URL, which
+  // leads to the pathname being read under the hood. This should make the
+  // function dynamic when prerendering the fallback shell, and not lead to a
+  // timeout error.
+
+  const { metadataBase } = await parent
+
+  return {
+    metadataBase: metadataBase?.replace('/bar', '/baz'),
+    alternates: { canonical: '/qux' },
+  }
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Dynamic />
+    </Suspense>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+
+  return <p>Dynamic</p>
+}

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/layout.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next'
 
-export async function generateMetadata(): Promise<Metadata> {
-  return { metadataBase: new URL('https://example.com/foo') }
+export const metadata: Metadata = {
+  metadataBase: new URL('https://example.com/foo'),
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/nested/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/nested/layout.tsx
@@ -1,0 +1,20 @@
+import { Metadata, ResolvingMetadata } from 'next'
+
+export async function generateMetadata(
+  _: {},
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  'use cache'
+
+  const { metadataBase } = await parent
+
+  return {
+    description: new Date().toISOString(),
+    // We can not return a URL instance from a `'use cache'` function.
+    metadataBase: metadataBase?.replace('/foo', '/bar'),
+  }
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/nested/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/nested/page.tsx
@@ -1,19 +1,24 @@
-import { Metadata } from 'next'
+import { Metadata, ResolvingMetadata } from 'next'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export async function generateMetadata({
-  searchParams,
-}: {
-  searchParams: Promise<Record<string, string | string[] | undefined>>
-}): Promise<Metadata> {
+export async function generateMetadata(
+  _: { searchParams: Promise<Record<string, string | string[] | undefined>> },
+  parent: ResolvingMetadata
+): Promise<Metadata> {
   'use cache'
 
   // Explicitly not reading search params here. The search params should be
   // omitted from the cache key, so that we ensure a cache hit when resuming the
   // partially prerendered page.
 
-  return { title: new Date().toISOString() }
+  const { metadataBase } = await parent
+
+  return {
+    title: new Date().toISOString(),
+    metadataBase: metadataBase?.replace('/bar', '/baz'),
+    alternates: { canonical: '/qux' },
+  }
 }
 
 export default function Page() {

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/page.tsx
@@ -1,0 +1,31 @@
+import { Metadata } from 'next'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}): Promise<Metadata> {
+  'use cache'
+
+  // Explicitly not reading search params here. The search params should be
+  // omitted from the cache key, so that we ensure a cache hit when resuming the
+  // partially prerendered page.
+
+  return { title: new Date().toISOString() }
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Dynamic />
+    </Suspense>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+
+  return <p>Dynamic</p>
+}

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/[slug]/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/[slug]/layout.tsx
@@ -1,10 +1,9 @@
-import { Metadata } from 'next'
+import { Metadata, ResolvingMetadata } from 'next'
 
-export async function generateMetadata({
-  params,
-}: {
-  params: Promise<{ slug: string }>
-}): Promise<Metadata> {
+export async function generateMetadata(
+  { params }: { params: Promise<{ slug: string }> },
+  parent: ResolvingMetadata
+): Promise<Metadata> {
   'use cache'
 
   // Explicitly not reading params here. The description should appear in the
@@ -12,9 +11,15 @@ export async function generateMetadata({
   // cache hit (from the RDC), but omitting unused params from cache keys (and
   // upgrading cache keys when they are used) is not yet implemented.
 
-  return { description: new Date().toISOString() }
+  const { metadataBase } = await parent
+
+  return {
+    description: new Date().toISOString(),
+    // We can not return a URL instance from a `'use cache'` function.
+    metadataBase: metadataBase?.replace('/foo', '/bar'),
+  }
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return <main>{children}</main>
+  return <>{children}</>
 }

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/[slug]/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/[slug]/layout.tsx
@@ -1,9 +1,8 @@
-import { Metadata, ResolvingMetadata } from 'next'
+import { Metadata } from 'next'
 
-export async function generateMetadata(
-  { params }: { params: Promise<{ slug: string }> },
-  parent: ResolvingMetadata
-): Promise<Metadata> {
+export async function generateMetadata(_: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
   'use cache'
 
   // Explicitly not reading params here. The description should appear in the
@@ -11,13 +10,7 @@ export async function generateMetadata(
   // cache hit (from the RDC), but omitting unused params from cache keys (and
   // upgrading cache keys when they are used) is not yet implemented.
 
-  const { metadataBase } = await parent
-
-  return {
-    description: new Date().toISOString(),
-    // We can not return a URL instance from a `'use cache'` function.
-    metadataBase: metadataBase?.replace('/foo', '/bar'),
-  }
+  return { description: new Date().toISOString() }
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/[slug]/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/[slug]/layout.tsx
@@ -1,0 +1,20 @@
+import { Metadata } from 'next'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  'use cache'
+
+  // Explicitly not reading params here. The description should appear in the
+  // partially prerendered page. TODO: When resuming the page, we should get a
+  // cache hit (from the RDC), but omitting unused params from cache keys (and
+  // upgrading cache keys when they are used) is not yet implemented.
+
+  return { description: new Date().toISOString() }
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <main>{children}</main>
+}

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/[slug]/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/[slug]/page.tsx
@@ -1,0 +1,32 @@
+import { Metadata } from 'next'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  'use cache'
+
+  // Explicitly not reading params here. The title should appear in the
+  // partially prerendered page. TODO: When resuming the page, we should get a
+  // cache hit (from the RDC), but omitting unused params from cache keys (and
+  // upgrading cache keys when they are used) is not yet implemented.
+
+  return { title: new Date().toISOString() }
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Dynamic />
+    </Suspense>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+
+  return <p>Dynamic</p>
+}

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/[slug]/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/[slug]/page.tsx
@@ -1,12 +1,11 @@
-import { Metadata } from 'next'
+import { Metadata, ResolvingMetadata } from 'next'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export async function generateMetadata({
-  params,
-}: {
-  params: Promise<{ slug: string }>
-}): Promise<Metadata> {
+export async function generateMetadata(
+  { params }: { params: Promise<{ slug: string }> },
+  parent: ResolvingMetadata
+): Promise<Metadata> {
   'use cache'
 
   // Explicitly not reading params here. The title should appear in the
@@ -14,7 +13,13 @@ export async function generateMetadata({
   // cache hit (from the RDC), but omitting unused params from cache keys (and
   // upgrading cache keys when they are used) is not yet implemented.
 
-  return { title: new Date().toISOString() }
+  const { metadataBase } = await parent
+
+  return {
+    title: new Date().toISOString(),
+    metadataBase: metadataBase?.replace('/bar', '/baz'),
+    alternates: { canonical: '/qux' },
+  }
 }
 
 export default function Page() {

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/[slug]/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/[slug]/page.tsx
@@ -1,11 +1,10 @@
-import { Metadata, ResolvingMetadata } from 'next'
+import { Metadata } from 'next'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export async function generateMetadata(
-  { params }: { params: Promise<{ slug: string }> },
-  parent: ResolvingMetadata
-): Promise<Metadata> {
+export async function generateMetadata(_: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
   'use cache'
 
   // Explicitly not reading params here. The title should appear in the
@@ -13,13 +12,7 @@ export async function generateMetadata(
   // cache hit (from the RDC), but omitting unused params from cache keys (and
   // upgrading cache keys when they are used) is not yet implemented.
 
-  const { metadataBase } = await parent
-
-  return {
-    title: new Date().toISOString(),
-    metadataBase: metadataBase?.replace('/bar', '/baz'),
-    alternates: { canonical: '/qux' },
-  }
+  return { title: new Date().toISOString() }
 }
 
 export default function Page() {

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-unused/layout.tsx
@@ -1,0 +1,9 @@
+import { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return { metadataBase: new URL('https://example.com/foo') }
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <main>{children}</main>
+}

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-used/[slug]/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-used/[slug]/layout.tsx
@@ -1,0 +1,20 @@
+import { Metadata } from 'next'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  'use cache: remote'
+
+  // We're reading params here. This makes the cache function dynamic during
+  // prerendering, and thus the description should be excluded from the
+  // partially prerendered page.
+  const { slug } = await params
+
+  return { description: new Date().toISOString(), category: slug }
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <main>{children}</main>
+}

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-used/[slug]/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-used/[slug]/layout.tsx
@@ -7,6 +7,17 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   'use cache: remote'
 
+  // Use `eval` to side step compiler errors for using `arguments` in a 'use
+  // cache' function.
+  // eslint-disable-next-line no-eval
+  const unusedParentArg = eval('arguments')[1]
+  if (unusedParentArg !== undefined) {
+    throw new Error(
+      'Expected the unused parent argument to be omitted. Received: ' +
+        unusedParentArg
+    )
+  }
+
   // We're reading params here. This makes the cache function dynamic during
   // prerendering, and thus the description should be excluded from the
   // partially prerendered page.

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-used/[slug]/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-used/[slug]/page.tsx
@@ -9,6 +9,17 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   'use cache: remote'
 
+  // Use `eval` to side step compiler errors for using `arguments` in a 'use
+  // cache' function.
+  // eslint-disable-next-line no-eval
+  const unusedParentArg = eval('arguments')[1]
+  if (unusedParentArg !== undefined) {
+    throw new Error(
+      'Expected the unused parent argument to be omitted. Received: ' +
+        unusedParentArg
+    )
+  }
+
   // We're reading params here. This makes the cache function dynamic during
   // prerendering, and thus the title should be excluded from the partially
   // prerendered page.

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-used/[slug]/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-metadata-resume/params-used/[slug]/page.tsx
@@ -1,0 +1,32 @@
+import { Metadata } from 'next'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  'use cache: remote'
+
+  // We're reading params here. This makes the cache function dynamic during
+  // prerendering, and thus the title should be excluded from the partially
+  // prerendered page.
+  const { slug } = await params
+
+  return { title: new Date().toISOString(), keywords: [slug] }
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Dynamic />
+    </Suspense>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+
+  return <p>Dynamic</p>
+}

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-viewport-resume/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-viewport-resume/page.tsx
@@ -1,0 +1,31 @@
+import { Viewport } from 'next'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export async function generateViewport({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}): Promise<Viewport> {
+  'use cache'
+
+  // Explicitly not reading search params here. The search params should be
+  // omitted from the cache key, so that we ensure a cache hit when resuming the
+  // partially prerendered page.
+
+  return { initialScale: Math.random() }
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Dynamic />
+    </Suspense>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+
+  return <p>Dynamic</p>
+}

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-viewport-resume/params-unused/[color]/layout.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-viewport-resume/params-unused/[color]/layout.tsx
@@ -1,0 +1,20 @@
+import { Viewport } from 'next'
+
+export async function generateViewport({
+  params,
+}: {
+  params: Promise<{ color: string }>
+}): Promise<Viewport> {
+  'use cache'
+
+  // Explicitly not reading params here. The meta tag should appear in the
+  // partially prerendered page. TODO: When resuming the page, we should get a
+  // cache hit (from the RDC), but omitting unused params from cache keys (and
+  // upgrading cache keys when they are used) is not yet implemented.
+
+  return { maximumScale: 1 + Math.random() }
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <main>{children}</main>
+}

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/generate-viewport-resume/params-unused/[color]/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/generate-viewport-resume/params-unused/[color]/page.tsx
@@ -1,0 +1,32 @@
+import { Viewport } from 'next'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export async function generateViewport({
+  params,
+}: {
+  params: Promise<{ color: string }>
+}): Promise<Viewport> {
+  'use cache'
+
+  // Explicitly not reading params here. The meta tag should appear in the
+  // partially prerendered page. TODO: When resuming the page, we should get a
+  // cache hit (from the RDC), but omitting unused params from cache keys (and
+  // upgrading cache keys when they are used) is not yet implemented.
+
+  return { initialScale: Math.random() }
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <Dynamic />
+    </Suspense>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+
+  return <p>Dynamic</p>
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -1102,7 +1102,7 @@ describe('use-cache', () => {
     it('can resume a cached generateMetadata function', async () => {
       // First load the page with JavaScript disabled, to ensure that the
       // generateMetadata result was included in the prerendered shell.
-      let browser = await next.browser('/generate-metadata-resume', {
+      let browser = await next.browser('/generate-metadata-resume/nested', {
         disableJavaScript: true,
       })
 
@@ -1115,7 +1115,7 @@ describe('use-cache', () => {
       await browser.close()
 
       // Load the page again, now with JavaScript enabled.
-      browser = await next.browser('/generate-metadata-resume')
+      browser = await next.browser('/generate-metadata-resume/nested')
 
       // If there was no cache hit from the RDC during the resume, we'd observe
       // a different title.
@@ -1169,9 +1169,7 @@ describe('use-cache', () => {
     })
 
     it('can serialize parent metadata as generateMetadata argument', async () => {
-      const browser = await next.browser(
-        '/generate-metadata-resume/params-unused/foo'
-      )
+      const browser = await next.browser('/generate-metadata-resume/nested')
 
       const canonicalUrl = await browser
         .elementByCss('link[rel="canonical"]')

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -1093,6 +1093,225 @@ describe('use-cache', () => {
     // the outer 'use cache'), and this expectation needs to be flipped.
     expect(description).not.toBe(initialDescription)
   })
+
+  if (withCacheComponents) {
+    it('can resume a cached generateMetadata function', async () => {
+      // First load the page with JavaScript disabled, to ensure that the
+      // generateMetadata result was included in the prerendered shell.
+      let browser = await next.browser('/generate-metadata-resume', {
+        disableJavaScript: true,
+      })
+
+      // The title must be in the head if it was prerendered.
+      const title = await browser
+        .elementByCss('head title', { state: 'attached' })
+        .text()
+      expect(title).toBeDateString()
+
+      await browser.close()
+
+      // Load the page again, now with JavaScript enabled.
+      browser = await next.browser('/generate-metadata-resume')
+
+      // If there was no cache hit from the RDC during the resume, we'd observe
+      // a different title.
+      expect(await browser.eval('document.title')).toBe(title)
+    })
+
+    it('can resume a cached generateMetadata function that does not read params', async () => {
+      // First load the page with JavaScript disabled, to ensure that the
+      // generateMetadata result was included in the prerendered shell.
+      let browser = await next.browser(
+        '/generate-metadata-resume/params-unused/foo',
+        { disableJavaScript: true }
+      )
+
+      // The metadata must be in the head if it was prerendered.
+      const title = await browser
+        .elementByCss('head title', { state: 'attached' })
+        .text()
+      expect(title).toBeDateString()
+      const description = await browser
+        .elementByCss('head meta[name="description"]', { state: 'attached' })
+        .getAttribute('content')
+      expect(description).toBeDateString()
+
+      await browser.close()
+
+      // Load the page again, now with JavaScript enabled.
+      browser = await next.browser(
+        '/generate-metadata-resume/params-unused/foo'
+      )
+
+      // If there was no cache hit from the RDC during the resume, we'd observe
+      // different metadata.
+      const title2 = await browser.eval('document.title')
+      const description2 = await browser
+        // Select the last meta element, in case another one was added during
+        // the resume due to a cache miss.
+        .elementByCss('meta[name="description"]:last-of-type')
+        .getAttribute('content')
+
+      if (isNextDev) {
+        expect(title2).toBe(title)
+        expect(description2).toBe(description)
+      } else {
+        // TODO: Omitting unused params from cache keys (and upgrading cache
+        // keys when they are used) is not yet implemented. Remove this else
+        // branch once it is.
+        expect(title2).not.toBe(title)
+        expect(description2).not.toBe(description)
+      }
+    })
+
+    it('makes a cached generateMetadata function that reads params dynamic during prerendering', async () => {
+      // First load the page with JavaScript disabled, to ensure that no
+      // generateMetadata result was included in the prerendered shell.
+      let browser = await next.browser(
+        '/generate-metadata-resume/params-used/foo',
+        { disableJavaScript: true }
+      )
+
+      // The metadata would be in the head if it was prerendered.
+      expect(
+        await browser
+          .elementByCss('head', { state: 'attached' })
+          .hasElementByCss('title')
+      ).toBe(false)
+      expect(
+        await browser
+          .elementByCss('head', { state: 'attached' })
+          .hasElementByCss('meta[name="description"]')
+      ).toBe(false)
+
+      // However, it should have been added to the body during the resume.
+      const title = await browser.eval('document.title')
+      expect(title).toBeDefined()
+      expect(title).toBeDateString()
+      const description = await browser
+        .elementByCss('meta[name="description"]')
+        .getAttribute('content')
+      expect(description).toBeDateString()
+
+      await browser.close()
+
+      // Load the page again, now with JavaScript enabled.
+      browser = await next.browser('/generate-metadata-resume/params-used/foo')
+
+      // We should see the same cached metadata again.
+      expect(await browser.eval('document.title')).toBe(title)
+      expect(
+        await browser
+          .elementByCss('meta[name="description"]')
+          .getAttribute('content')
+      ).toBe(description)
+    })
+
+    it('can resume a cached generateViewport function', async () => {
+      // First load the page with JavaScript disabled, to ensure that the
+      // generateViewport result was included in the prerendered shell.
+      let browser = await next.browser('/generate-viewport-resume', {
+        disableJavaScript: true,
+      })
+
+      // The meta tag must be in the head if it was prerendered.
+      const viewport = await browser
+        .elementByCss('head meta[name="viewport"]', { state: 'attached' })
+        .getAttribute('content')
+      const [, initialScale] = viewport.match(/initial-scale=([\d.]+)/) ?? []
+      expect(Number(initialScale)).toBeNumber()
+      await browser.close()
+
+      // Load the page again, now with JavaScript enabled.
+      browser = await next.browser('/generate-viewport-resume')
+
+      // If there was no cache hit from the RDC during the resume, we'd observe
+      // a different value.
+      const viewport2 = await browser
+        // Select the last meta element, in case another one was added during
+        // the resume due to a cache miss.
+        .elementByCss('meta[name="viewport"]:last-of-type', {
+          state: 'attached',
+        })
+        .getAttribute('content')
+      const [, initialScale2] = viewport2.match(/initial-scale=([\d.]+)/) ?? []
+      expect(initialScale2).toBe(initialScale)
+    })
+
+    it('can resume a cached generateViewport function that does not read params', async () => {
+      // First load the page with JavaScript disabled, to ensure that the
+      // generateViewport result was included in the prerendered shell.
+      let browser = await next.browser(
+        '/generate-viewport-resume/params-unused/red',
+        { disableJavaScript: true }
+      )
+
+      // The meta tag must be in the head if it was prerendered.
+      const viewport = await browser
+        .elementByCss('head meta[name="viewport"]', { state: 'attached' })
+        .getAttribute('content')
+      const [, initialScale, maximumScale] =
+        viewport.match(/initial-scale=([\d.]+), maximum-scale=([\d.]+)/) ?? []
+      expect(Number(initialScale)).toBeNumber()
+      expect(Number(maximumScale)).toBeNumber()
+
+      await browser.close()
+
+      // Load the page again, now with JavaScript enabled.
+      browser = await next.browser(
+        '/generate-viewport-resume/params-unused/red'
+      )
+
+      // If there was no cache hit from the RDC during the resume, we'd observe
+      // a different meta tag.
+      const viewport2 = await browser
+        // Select the last meta element, in case another one was added during
+        // the resume due to a cache miss.
+        .elementByCss('meta[name="viewport"]:last-of-type', {
+          state: 'attached',
+        })
+        .getAttribute('content')
+      const [, initialScale2, maximumScale2] =
+        viewport2.match(/initial-scale=([\d.]+), maximum-scale=([\d.]+)/) ?? []
+
+      if (isNextDev) {
+        expect(initialScale2).toBe(initialScale)
+        expect(maximumScale2).toBe(maximumScale)
+      } else {
+        // TODO: Omitting unused params from cache keys (and upgrading cache
+        // keys when they are used) is not yet implemented. Remove this else
+        // branch once it is.
+        expect(initialScale2).not.toBe(initialScale)
+        expect(maximumScale2).not.toBe(maximumScale)
+      }
+    })
+
+    it('makes a cached generateViewport function that reads params dynamic during prerendering', async () => {
+      // The page is fully dynamic, so we can only observe that the values are
+      // cached on subsequent requests.
+      let browser = await next.browser(
+        '/generate-viewport-resume/params-used/red'
+      )
+
+      const viewport = await browser
+        .elementByCss('meta[name="viewport"]', { state: 'attached' })
+        .getAttribute('content')
+      const [, initialScale, maximumScale] =
+        viewport.match(/initial-scale=([\d.]+), maximum-scale=([\d.]+)/) ?? []
+      expect(Number(initialScale)).toBeNumber()
+      expect(Number(maximumScale)).toBeNumber()
+
+      await browser.refresh()
+
+      const viewport2 = await browser
+        .elementByCss('meta[name="viewport"]', { state: 'attached' })
+        .getAttribute('content')
+      const [, initialScale2, maximumScale2] =
+        viewport2.match(/initial-scale=([\d.]+), maximum-scale=([\d.]+)/) ?? []
+      expect(initialScale2).toBe(initialScale)
+      expect(maximumScale2).toBe(maximumScale)
+    })
+  }
 })
 
 async function getSanitizedLogs(browser: Playwright): Promise<string[]> {

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -1,5 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
-import { assertNoConsoleErrors, retry } from 'next-test-utils'
+import {
+  assertNoConsoleErrors,
+  assertNoErrorToast,
+  retry,
+} from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 import { format } from 'util'
 import { Playwright } from 'next-webdriver'
@@ -1162,6 +1166,21 @@ describe('use-cache', () => {
         expect(title2).not.toBe(title)
         expect(description2).not.toBe(description)
       }
+    })
+
+    it('can serialize parent metadata as generateMetadata argument', async () => {
+      const browser = await next.browser(
+        '/generate-metadata-resume/params-unused/foo'
+      )
+
+      const canonicalUrl = await browser
+        .elementByCss('link[rel="canonical"]')
+        .getAttribute('href')
+
+      expect(canonicalUrl).toBe('https://example.com/baz/qux')
+
+      // There should be no timeout error.
+      await assertNoErrorToast(browser)
     })
 
     it('makes a cached generateMetadata function that reads params dynamic during prerendering', async () => {

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -1171,11 +1171,41 @@ describe('use-cache', () => {
     it('can serialize parent metadata as generateMetadata argument', async () => {
       const browser = await next.browser('/generate-metadata-resume/nested')
 
+      // The metadata must be in the head if it was prerendered.
       const canonicalUrl = await browser
-        .elementByCss('link[rel="canonical"]')
+        .elementByCss('head link[rel="canonical"]', { state: 'attached' })
         .getAttribute('href')
 
       expect(canonicalUrl).toBe('https://example.com/baz/qux')
+
+      // There should be no timeout error.
+      await assertNoErrorToast(browser)
+    })
+
+    it('makes a cached generateMetadata function that implicitly depends on params dynamic during prerendering', async () => {
+      // First load the page with JavaScript disabled, to ensure that no
+      // generateMetadata result was included in the prerendered shell.
+      let browser = await next.browser(
+        '/generate-metadata-resume/canonical/foo',
+        { disableJavaScript: true }
+      )
+
+      // The metadata would be in the head if it was prerendered.
+      expect(
+        await browser
+          .elementByCss('head', { state: 'attached' })
+          .hasElementByCss('link[rel="canonical"]')
+      ).toBe(false)
+
+      // However, it should have been added to the body during the resume.
+      expect(
+        await browser.elementByCss('link[rel="canonical"]').getAttribute('href')
+      ).toBe('https://example.com/baz/qux')
+
+      await browser.close()
+
+      // Load the page again, now with JavaScript enabled.
+      browser = await next.browser('/generate-metadata-resume/canonical/foo')
 
       // There should be no timeout error.
       await assertNoErrorToast(browser)


### PR DESCRIPTION
When using `'use cache'` in `generateMetadata` or `generateViewport`, the caching did not work correctly, because we didn't apply the same special handling for the `params` and `searchParams` props that we do for layout and page components. This caused the following issues:

- `generateMetadata`/`generateViewport` for a page without params, or with static params, yielded cache misses when resuming
- `generateMetadata` for a page/layout with unused params, became dynamic when prerendering a fallback shell
- `generateMetadata` for a page with used search params, produced a timeout error during prerendering
- `generateViewport` for a page/layout with unused params, produced a build error (unless opting into fully dynamic rendering)

Still to be done in a follow-up: Omit unused `params` from cache keys, and upgrade cache keys when they are used, to avoid unnecessary cache misses when resuming.

closes NAR-321