### PR TITLE
docs: update Dockerfile to use node:lts-alpine instead of node:18-alpine

### DIFF
--- a/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1
 
-FROM node:18-alpine
+FROM node:lts-alpine
 
 WORKDIR /app
 

--- a/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1
 
-FROM node:lts-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
Updated `examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile`  
to use `node:lts-alpine` instead of `node:18-alpine`, since Node 18 is reaching end of life and contains known vulnerabilities.

## Changes
- Updated base image in prod-without-multistage.Dockerfile from `node:18-alpine` → `node:lts-alpine`

## How I Tested
- Built Docker image locally → worked successfully.

## Notes
Part of cleanup for outdated Docker examples.
