### PR TITLE
docs: nav_title for long unbroken words

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/browserDebugInfoInTerminal.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/browserDebugInfoInTerminal.mdx
@@ -1,5 +1,6 @@
 ---
-title: browserDebugInfoInTerminal
+title: Debug Browser Info in Terminal
+nav_title: browserDebugInfoInTerminal
 description: Forward browser console logs and errors to your terminal during development.
 version: experimental
 ---

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackPersistentCaching.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackPersistentCaching.mdx
@@ -1,5 +1,6 @@
 ---
-title: turbopackPersistentCaching
+title: Turbopack Persistent Caching
+nav_title: turbopackPersistentCaching
 description: Learn how to enable Persistent Caching for Turbopack builds
 version: canary
 ---


### PR DESCRIPTION
Let's use a different title for these, otherwise we have a very long composite word.