### PR TITLE
[test] Overhaul `Undefined default export` test suite

### DIFF
--- a/test/development/acceptance-app/fixtures/undefined-default-export/app/(group)/specific-path/1/page.js
+++ b/test/development/acceptance-app/fixtures/undefined-default-export/app/(group)/specific-path/1/page.js
@@ -1,0 +1,1 @@
+export const a = 123

--- a/test/development/acceptance-app/fixtures/undefined-default-export/app/(group)/specific-path/2/layout.js
+++ b/test/development/acceptance-app/fixtures/undefined-default-export/app/(group)/specific-path/2/layout.js
@@ -1,0 +1,1 @@
+export const a = 123

--- a/test/development/acceptance-app/fixtures/undefined-default-export/app/(group)/specific-path/2/page.js
+++ b/test/development/acceptance-app/fixtures/undefined-default-export/app/(group)/specific-path/2/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Hello</div>
+}

--- a/test/development/acceptance-app/fixtures/undefined-default-export/app/layout.js
+++ b/test/development/acceptance-app/fixtures/undefined-default-export/app/layout.js
@@ -1,0 +1,7 @@
+export default function Root({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/acceptance-app/fixtures/undefined-default-export/app/will-not-found/not-found.js
+++ b/test/development/acceptance-app/fixtures/undefined-default-export/app/will-not-found/not-found.js
@@ -1,0 +1,1 @@
+export const a = 123

--- a/test/development/acceptance-app/fixtures/undefined-default-export/app/will-not-found/page.js
+++ b/test/development/acceptance-app/fixtures/undefined-default-export/app/will-not-found/page.js
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function Page() {
+  notFound()
+}

--- a/test/development/acceptance-app/undefined-default-export.test.ts
+++ b/test/development/acceptance-app/undefined-default-export.test.ts
@@ -2,51 +2,56 @@ import path from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('Undefined default export', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: new FileRef(
       path.join(__dirname, 'fixtures', 'undefined-default-export')
     ),
   })
 
-  it('should error if page component does not have default export', async () => {
-    const browser = await next.browser('/specific-path/1')
+  // TODO: This is currently always true. It's just here to already indent the
+  // code, so that git blame is preserved in the subsequent commit, when we're
+  // moving the file.
+  if (isNextDev) {
+    it('should error if page component does not have default export', async () => {
+      const browser = await next.browser('/specific-path/1')
 
-    await expect(browser).toDisplayRedbox(`
-     {
-       "description": "The default export is not a React Component in "/specific-path/1/page"",
-       "environmentLabel": null,
-       "label": "Runtime Error",
-       "source": null,
-       "stack": [],
-     }
-    `)
-  })
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "The default export is not a React Component in "/specific-path/1/page"",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": null,
+         "stack": [],
+       }
+      `)
+    })
 
-  it('should error if layout component does not have default export', async () => {
-    const browser = await next.browser('/specific-path/2')
+    it('should error if layout component does not have default export', async () => {
+      const browser = await next.browser('/specific-path/2')
 
-    await expect(browser).toDisplayRedbox(`
-     {
-       "description": "The default export is not a React Component in "/specific-path/2/layout"",
-       "environmentLabel": null,
-       "label": "Runtime Error",
-       "source": null,
-       "stack": [],
-     }
-    `)
-  })
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "The default export is not a React Component in "/specific-path/2/layout"",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": null,
+         "stack": [],
+       }
+      `)
+    })
 
-  it('should error if not-found component does not have default export when trigger not-found boundary', async () => {
-    const browser = await next.browser('/will-not-found')
+    it('should error if not-found component does not have default export when trigger not-found boundary', async () => {
+      const browser = await next.browser('/will-not-found')
 
-    await expect(browser).toDisplayRedbox(`
-     {
-       "description": "The default export is not a React Component in "/will-not-found/not-found"",
-       "environmentLabel": null,
-       "label": "Runtime Error",
-       "source": null,
-       "stack": [],
-     }
-    `)
-  })
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "The default export is not a React Component in "/will-not-found/not-found"",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": null,
+         "stack": [],
+       }
+      `)
+    })
+  }
 })

--- a/test/development/acceptance-app/undefined-default-export.test.ts
+++ b/test/development/acceptance-app/undefined-default-export.test.ts
@@ -1,26 +1,19 @@
 import path from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { createSandbox } from 'development-sandbox'
-import { retry } from 'next-test-utils'
 
 describe('Undefined default export', () => {
   const { next } = nextTestSetup({
-    files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
+    files: new FileRef(
+      path.join(__dirname, 'fixtures', 'undefined-default-export')
+    ),
   })
 
   it('should error if page component does not have default export', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        ['app/(group)/specific-path/server/page.js', 'export const a = 123'],
-      ]),
-      '/specific-path/server'
-    )
-    const { browser } = sandbox
+    const browser = await next.browser('/specific-path/1')
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "The default export is not a React Component in "/specific-path/server/page"",
+       "description": "The default export is not a React Component in "/specific-path/1/page"",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": null,
@@ -30,22 +23,11 @@ describe('Undefined default export', () => {
   })
 
   it('should error if layout component does not have default export', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        ['app/(group)/specific-path/server/layout.js', 'export const a = 123'],
-        [
-          'app/(group)/specific-path/server/page.js',
-          'export default function Page() { return <div>Hello</div> }',
-        ],
-      ]),
-      '/specific-path/server'
-    )
-    const { browser } = sandbox
+    const browser = await next.browser('/specific-path/2')
 
     await expect(browser).toDisplayRedbox(`
      {
-       "description": "The default export is not a React Component in "/specific-path/server/layout"",
+       "description": "The default export is not a React Component in "/specific-path/2/layout"",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": null,
@@ -55,75 +37,11 @@ describe('Undefined default export', () => {
   })
 
   it('should error if not-found component does not have default export when trigger not-found boundary', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/will-not-found/page.js',
-          `
-          import { notFound } from 'next/navigation'
-          export default function Page() { notFound() }
-          `,
-        ],
-        ['app/will-not-found/not-found.js', 'export const a = 123'],
-      ]),
-      '/will-not-found'
-    )
-    const { browser } = sandbox
+    const browser = await next.browser('/will-not-found')
 
     await expect(browser).toDisplayRedbox(`
      {
        "description": "The default export is not a React Component in "/will-not-found/not-found"",
-       "environmentLabel": null,
-       "label": "Runtime Error",
-       "source": null,
-       "stack": [],
-     }
-    `)
-  })
-
-  it('should error when page component export is not valid', async () => {
-    await using sandbox = await createSandbox(next, undefined, '/')
-    const { browser } = sandbox
-    const cliOutputLength = next.cliOutput.length
-
-    await next.patchFile('app/page.js', 'const a = 123')
-
-    // The page will fail build and navigate to /_error route of pages router.
-    // We wait for the error page to be compiled before asserting the redbox.
-    await retry(async () => {
-      expect(next.cliOutput.slice(cliOutputLength)).toContain(
-        '✓ Compiled /_error'
-      )
-    }, 10_000)
-
-    await expect(browser).toDisplayRedbox(`
-     {
-       "description": "The default export is not a React Component in "/page"",
-       "environmentLabel": null,
-       "label": "Runtime Error",
-       "source": null,
-       "stack": [],
-     }
-    `)
-  })
-
-  it('should error when page component export is not valid on initial load', async () => {
-    await using sandbox = await createSandbox(
-      next,
-      new Map([
-        [
-          'app/server-with-errors/page-export-initial-error/page.js',
-          'export const a = 123',
-        ],
-      ]),
-      '/server-with-errors/page-export-initial-error'
-    )
-    const { browser } = sandbox
-
-    await expect(browser).toDisplayRedbox(`
-     {
-       "description": "The default export is not a React Component in "/server-with-errors/page-export-initial-error/page"",
        "environmentLabel": null,
        "label": "Runtime Error",
        "source": null,


### PR DESCRIPTION
The test suite is now using fixture files instead of sandboxes, same principle as in #83398. I also removed two test cases that didn't test anything novel, compared to the other tests. They were originally moved from another test suite into this one in #66916.

This is done in preparation for adding build-time assertions.

> [!TIP]
> Best reviewed with hidden whitespace changes. 