### PR TITLE
Turbopack: count turbo_tasks::run as foreground tasks to avoid being idle

### DIFF
--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -539,12 +539,13 @@ impl<B: Backend + 'static> TurboTasks<B> {
         &self,
         future: impl Future<Output = Result<T>> + Send + 'static,
     ) -> Result<T, TurboTasksExecutionError> {
+        self.begin_foreground_job();
         // it's okay for execution ids to overflow and wrap, they're just used for an assert
         let execution_id = self.execution_id_factory.wrapping_get();
         let current_task_state =
             Arc::new(RwLock::new(CurrentTaskState::new_temporary(execution_id)));
 
-        TURBO_TASKS
+        let result = TURBO_TASKS
             .scope(
                 self.pin(),
                 CURRENT_TASK_STATE.scope(current_task_state, async {
@@ -563,7 +564,9 @@ impl<B: Backend + 'static> TurboTasks<B> {
                     }
                 }),
             )
-            .await
+            .await;
+        self.finish_foreground_job();
+        result
     }
 
     pub fn start_once_process(&self, future: impl Future<Output = ()> + Send + 'static) {


### PR DESCRIPTION
### What?

We need to count `turbo_tasks::run` as foreground task otherwise persistent caching thinks we are idle and starts persisting too early.

Closes PACK-5580