### PR TITLE
docs: Type helpers don't need to be imported

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/layout.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/layout.mdx
@@ -105,6 +105,7 @@ export default function Layout(props: LayoutProps<'/dashboard'>) {
 > **Good to know**:
 >
 > - Types are generated during `next dev`, `next build` or `next typegen`.
+> - After type generation, the `LayoutProps` helper is globally available. It doesn't need to be imported.
 
 ### Root Layout
 

--- a/docs/01-app/03-api-reference/03-file-conventions/page.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/page.mdx
@@ -135,6 +135,7 @@ export default async function Page(props: PageProps<'/blog/[slug]'>) {
 > - Using a literal route (e.g. `'/blog/[slug]'`) enables autocomplete and strict keys for `params`.
 > - Static routes resolve `params` to `{}`.
 > - Types are generated during `next dev`, `next build`, or with `next typegen`.
+> - After type generation, the `PageProps` helper is globally available. It doesn't need to be imported.
 
 ## Examples
 

--- a/docs/01-app/03-api-reference/03-file-conventions/route.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/route.mdx
@@ -118,6 +118,7 @@ export async function GET(_req: NextRequest, ctx: RouteContext<'/users/[id]'>) {
 > **Good to know**
 >
 > - Types are generated during `next dev`, `next build` or `next typegen`.
+> - After type generation, the `RouteContext` helper is globally available. It doesn't need to be imported.
 
 ## Examples
 


### PR DESCRIPTION
Let's be more clear about the usage of these types. 