### PR TITLE
Turbopack: remove canary version check for turbopackPersistentCachingForDev

### DIFF
--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -133,20 +133,6 @@ describe('loadConfig', () => {
       )
     })
 
-    it('errors when using persistentCachingForDev if not in canary', async () => {
-      await expect(
-        loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
-          customConfig: {
-            experimental: {
-              turbopackPersistentCachingForDev: true,
-            },
-          },
-        })
-      ).rejects.toThrow(
-        /The experimental feature "experimental.turbopackPersistentCachingForDev" can only be enabled when using the latest canary version of Next.js./
-      )
-    })
-
     it('errors when using persistentCachingForBuild if not in canary', async () => {
       await expect(
         loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -354,10 +354,6 @@ function assignDefaultsAndValidate(
       throw new CanaryOnlyError({ feature: 'experimental.ppr' })
     } else if (result.experimental?.cacheComponents) {
       throw new CanaryOnlyError({ feature: 'experimental.cacheComponents' })
-    } else if (result.experimental?.turbopackPersistentCachingForDev) {
-      throw new CanaryOnlyError({
-        feature: 'experimental.turbopackPersistentCachingForDev',
-      })
     } else if (result.experimental?.turbopackPersistentCachingForBuild) {
       throw new CanaryOnlyError({
         feature: 'experimental.turbopackPersistentCachingForBuild',


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes PACK-5596