### PR TITLE
Fix dynamic catchall parameter interpolation in parallel routes

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -861,5 +861,6 @@
   "860": "Client Max Body Size must be a valid number (bytes) or filesize format string (e.g., \"5mb\")",
   "861": "Client Max Body Size must be larger than 0 bytes",
   "862": "Request body exceeded %s",
-  "863": "\\`<Link legacyBehavior>\\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \\`<a>\\` tag."
+  "863": "\\`<Link legacyBehavior>\\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \\`<a>\\` tag.",
+  "864": "Missing value for segment key: \"%s\" with dynamic param type: %s"
 }

--- a/packages/next/src/build/segment-config/app/app-segments.ts
+++ b/packages/next/src/build/segment-config/app/app-segments.ts
@@ -12,7 +12,7 @@ import {
   isAppPageRouteModule,
 } from '../../../server/route-modules/checks'
 import { isClientReference } from '../../../lib/client-and-server-references'
-import { getSegmentParam } from '../../../server/app-render/get-segment-param'
+import { getSegmentParam } from '../../../shared/lib/router/utils/get-segment-param'
 import {
   getLayoutOrPageModule,
   type LoaderTree,

--- a/packages/next/src/build/segment-config/app/collect-root-param-keys.ts
+++ b/packages/next/src/build/segment-config/app/collect-root-param-keys.ts
@@ -1,4 +1,4 @@
-import { getSegmentParam } from '../../../server/app-render/get-segment-param'
+import { getSegmentParam } from '../../../shared/lib/router/utils/get-segment-param'
 import type AppPageRouteModule from '../../../server/route-modules/app-page/module'
 import {
   isAppPageRouteModule,

--- a/packages/next/src/build/webpack/loaders/next-root-params-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-root-params-loader.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path'
 import * as fs from 'node:fs/promises'
 import { normalizeAppPath } from '../../../shared/lib/router/utils/app-paths'
 import { ensureLeadingSlash } from '../../../shared/lib/page-path/ensure-leading-slash'
-import { getSegmentParam } from '../../../server/app-render/get-segment-param'
+import { getSegmentParam } from '../../../shared/lib/router/utils/get-segment-param'
 
 export type RootParamsLoaderOpts = {
   appDir: string

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -86,7 +86,7 @@ import {
   getDigestForWellKnownError,
 } from './create-error-handler'
 import { dynamicParamTypes } from './get-short-dynamic-param-type'
-import { getSegmentParam } from './get-segment-param'
+import { getSegmentParam } from '../../shared/lib/router/utils/get-segment-param'
 import { getScriptNonceFromHeader } from './get-script-nonce-from-header'
 import { parseAndValidateFlightRouterState } from './parse-and-validate-flight-router-state'
 import { createFlightRouterStateFromLoaderTree } from './create-flight-router-state-from-loader-tree'
@@ -181,7 +181,7 @@ import { InvariantError } from '../../shared/lib/invariant-error'
 
 import { HTML_CONTENT_TYPE_HEADER, INFINITE_CACHE } from '../../lib/constants'
 import { createComponentStylesAndScripts } from './create-component-styles-and-scripts'
-import { parseLoaderTree } from './parse-loader-tree'
+import { parseLoaderTree } from '../../shared/lib/router/utils/parse-loader-tree'
 import {
   createPrerenderResumeDataCache,
   createRenderResumeDataCache,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -202,7 +202,10 @@ import { isReactLargeShellError } from './react-large-shell-error'
 import type { GlobalErrorComponent } from '../../client/components/builtin/global-error'
 import { normalizeConventionFilePath } from './segment-explorer-path'
 import { getRequestMeta } from '../request-meta'
-import { getDynamicParam } from '../../shared/lib/router/utils/get-dynamic-param'
+import {
+  getDynamicParam,
+  interpolateParallelRouteParams,
+} from '../../shared/lib/router/utils/get-dynamic-param'
 import type { ExperimentalConfig } from '../config-shared'
 import type { Params } from '../request/params'
 import { createPromiseWithResolvers } from '../../shared/lib/promise-with-resolvers'
@@ -394,8 +397,7 @@ function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
  * Returns a function that parses the dynamic segment and return the associated value.
  */
 function makeGetDynamicParamFromSegment(
-  params: { [key: string]: any },
-  pagePath: string,
+  interpolatedParams: Params,
   fallbackRouteParams: OpaqueFallbackRouteParams | null
 ): GetDynamicParamFromSegment {
   return function getDynamicParamFromSegment(
@@ -409,10 +411,9 @@ function makeGetDynamicParamFromSegment(
     const segmentKey = segmentParam.param
     const dynamicParamType = dynamicParamTypes[segmentParam.type]
     return getDynamicParam(
-      params,
+      interpolatedParams,
       segmentKey,
       dynamicParamType,
-      pagePath,
       fallbackRouteParams
     )
   }
@@ -1481,6 +1482,7 @@ async function renderToHTMLOrFlightImpl(
   postponedState: PostponedState | null,
   serverComponentsHmrCache: ServerComponentsHmrCache | undefined,
   sharedContext: AppSharedContext,
+  interpolatedParams: Params,
   fallbackRouteParams: OpaqueFallbackRouteParams | null
 ) {
   const isNotFoundPath = pagePath === '/404'
@@ -1695,14 +1697,8 @@ async function renderToHTMLOrFlightImpl(
   // HTML request ID.
   htmlRequestId = parsedRequestHeaders.htmlRequestId || requestId
 
-  /**
-   * Dynamic parameters. E.g. when you visit `/dashboard/vercel` which is rendered by `/dashboard/[slug]` the value will be {"slug": "vercel"}.
-   */
-  const params = renderOpts.params ?? {}
-
   const getDynamicParamFromSegment = makeGetDynamicParamFromSegment(
-    params,
-    pagePath,
+    interpolatedParams,
     fallbackRouteParams
   )
 
@@ -2032,6 +2028,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
   const { isPrefetchRequest, previouslyRevalidatedTags, nonce } =
     parsedRequestHeaders
 
+  let interpolatedParams: Params
   let postponedState: PostponedState | null = null
 
   // If provided, the postpone state should be parsed so it can be provided to
@@ -2043,10 +2040,23 @@ export const renderToHTMLOrFlight: AppPageRender = (
       )
     }
 
+    interpolatedParams = interpolateParallelRouteParams(
+      renderOpts.ComponentMod.routeModule.userland.loaderTree,
+      renderOpts.params ?? {},
+      pagePath,
+      fallbackRouteParams
+    )
+
     postponedState = parsePostponedState(
       renderOpts.postponed,
+      interpolatedParams
+    )
+  } else {
+    interpolatedParams = interpolateParallelRouteParams(
+      renderOpts.ComponentMod.routeModule.userland.loaderTree,
+      renderOpts.params ?? {},
       pagePath,
-      renderOpts.params
+      fallbackRouteParams
     )
   }
 
@@ -2085,6 +2095,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
     postponedState,
     serverComponentsHmrCache,
     sharedContext,
+    interpolatedParams,
     fallbackRouteParams
   )
 }

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -11,7 +11,7 @@ import {
 import { getLayoutOrPageModule } from '../lib/app-dir-module'
 import type { LoaderTree } from '../lib/app-dir-module'
 import { interopDefault } from './interop-default'
-import { parseLoaderTree } from './parse-loader-tree'
+import { parseLoaderTree } from '../../shared/lib/router/utils/parse-loader-tree'
 import type { AppRenderContext, GetDynamicParamFromSegment } from './app-render'
 import { createComponentStylesAndScripts } from './create-component-styles-and-scripts'
 import { getLayerAssets } from './get-layer-assets'

--- a/packages/next/src/server/app-render/postponed-state.test.ts
+++ b/packages/next/src/server/app-render/postponed-state.test.ts
@@ -52,7 +52,7 @@ describe('getDynamicHTMLPostponedState', () => {
       isCacheComponentsEnabled
     )
 
-    const parsed = parsePostponedState(state, '/blog/[slug]', { slug: '123' })
+    const parsed = parsePostponedState(state, { slug: '123' })
 
     expect(parsed).toMatchInlineSnapshot(`
      {
@@ -110,7 +110,7 @@ describe('getDynamicHTMLPostponedState', () => {
 
     const value = 'hello'
     const params = { slug: value }
-    const parsed = parsePostponedState(state, '/blog/[slug]', params)
+    const parsed = parsePostponedState(state, params)
     expect(parsed).toEqual({
       type: DynamicState.HTML,
       data: [1, { [value]: value }],
@@ -138,7 +138,7 @@ describe('parsePostponedState', () => {
     const params = {
       slug: Math.random().toString(16).slice(3),
     }
-    const parsed = parsePostponedState(state, '/blog/[slug]', params)
+    const parsed = parsePostponedState(state, params)
 
     // Ensure that it parsed it correctly.
     expect(parsed).toEqual({
@@ -154,7 +154,7 @@ describe('parsePostponedState', () => {
   it('parses a HTML postponed state without fallback params', () => {
     const state = `2:{}null`
     const params = {}
-    const parsed = parsePostponedState(state, '/blog', params)
+    const parsed = parsePostponedState(state, params)
 
     // Ensure that it parsed it correctly.
     expect(parsed).toEqual({
@@ -166,7 +166,7 @@ describe('parsePostponedState', () => {
 
   it('parses a data postponed state', () => {
     const state = '4:nullnull'
-    const parsed = parsePostponedState(state, '/blog', undefined)
+    const parsed = parsePostponedState(state, {})
 
     // Ensure that it parsed it correctly.
     expect(parsed).toEqual({

--- a/packages/next/src/server/app-render/postponed-state.ts
+++ b/packages/next/src/server/app-render/postponed-state.ts
@@ -116,8 +116,7 @@ export async function getDynamicDataPostponedState(
 
 export function parsePostponedState(
   state: string,
-  pagePath: string,
-  params: Params | undefined
+  interpolatedParams: Params
 ): PostponedState {
   try {
     const postponedStringLengthMatch = state.match(/^([0-9]*):/)?.[1]
@@ -162,7 +161,10 @@ export function parsePostponedState(
         ) as OpaqueFallbackRouteParamEntries
 
         let postponed = postponedString.slice(match.length + length)
-        for (const [key, [searchValue, dynamicParamType]] of replacements) {
+        for (const [
+          segmentKey,
+          [searchValue, dynamicParamType],
+        ] of replacements) {
           const {
             treeSegment: [
               ,
@@ -172,10 +174,9 @@ export function parsePostponedState(
               value,
             ],
           } = getDynamicParam(
-            params ?? {},
-            key,
+            interpolatedParams,
+            segmentKey,
             dynamicParamType,
-            pagePath,
             null
           )
 

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -18,7 +18,7 @@ import type { AppRenderContext } from './app-render'
 import { hasLoadingComponentInTree } from './has-loading-component-in-tree'
 import { addSearchParamsIfPageSegment } from '../../shared/lib/segment'
 import { createComponentTree } from './create-component-tree'
-import { getSegmentParam } from './get-segment-param'
+import { getSegmentParam } from '../../shared/lib/router/utils/get-segment-param'
 
 /**
  * Use router state to decide at what common layout to render the page.

--- a/packages/next/src/shared/lib/router/utils/get-dynamic-param.test.ts
+++ b/packages/next/src/shared/lib/router/utils/get-dynamic-param.test.ts
@@ -11,7 +11,7 @@ describe('getDynamicParam', () => {
   describe('basic dynamic parameters (d, di)', () => {
     it('should handle simple string parameter', () => {
       const params: Params = { slug: 'hello-world' }
-      const result = getDynamicParam(params, 'slug', 'd', '/blog/[slug]', null)
+      const result = getDynamicParam(params, 'slug', 'd', null)
 
       expect(result).toEqual({
         param: 'slug',
@@ -23,7 +23,7 @@ describe('getDynamicParam', () => {
 
     it('should encode special characters in string parameters', () => {
       const params: Params = { slug: 'hello world & stuff' }
-      const result = getDynamicParam(params, 'slug', 'd', '/blog/[slug]', null)
+      const result = getDynamicParam(params, 'slug', 'd', null)
 
       expect(result).toEqual({
         param: 'slug',
@@ -35,7 +35,7 @@ describe('getDynamicParam', () => {
 
     it('should handle unicode characters', () => {
       const params: Params = { slug: 'caf�-na�ve' }
-      const result = getDynamicParam(params, 'slug', 'd', '/blog/[slug]', null)
+      const result = getDynamicParam(params, 'slug', 'd', null)
 
       expect(result).toEqual({
         param: 'slug',
@@ -49,35 +49,33 @@ describe('getDynamicParam', () => {
       const params: Params = {}
 
       expect(() => {
-        getDynamicParam(params, 'slug', 'd', '/blog/[slug]', null)
+        getDynamicParam(params, 'slug', 'd', null)
       }).toThrow(InvariantError)
       expect(() => {
-        getDynamicParam(params, 'slug', 'd', '/blog/[slug]', null)
-      }).toThrow('Unexpected dynamic param type: d')
+        getDynamicParam(params, 'slug', 'd', null)
+      }).toThrow(
+        `Invariant: Missing value for segment key: "slug" with dynamic param type: d. This is a bug in Next.js.`
+      )
     })
 
     it('should throw InvariantError for dynamic intercepted parameter without value', () => {
       const params: Params = {}
 
       expect(() => {
-        getDynamicParam(params, 'slug', 'di', '/blog/[slug]', null)
+        getDynamicParam(params, 'slug', 'di', null)
       }).toThrow(InvariantError)
       expect(() => {
-        getDynamicParam(params, 'slug', 'di', '/blog/[slug]', null)
-      }).toThrow('Unexpected dynamic param type: di')
+        getDynamicParam(params, 'slug', 'di', null)
+      }).toThrow(
+        'Invariant: Missing value for segment key: "slug" with dynamic param type: di. This is a bug in Next.js.'
+      )
     })
   })
 
   describe('catchall parameters (c, ci)', () => {
     it('should handle array of values for catchall', () => {
       const params: Params = { slug: ['docs', 'getting-started'] }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'c',
-        '/docs/[...slug]',
-        null
-      )
+      const result = getDynamicParam(params, 'slug', 'c', null)
 
       expect(result).toEqual({
         param: 'slug',
@@ -89,13 +87,7 @@ describe('getDynamicParam', () => {
 
     it('should encode array values for catchall', () => {
       const params: Params = { slug: ['docs & guides', 'getting started'] }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'c',
-        '/docs/[...slug]',
-        null
-      )
+      const result = getDynamicParam(params, 'slug', 'c', null)
 
       expect(result).toEqual({
         param: 'slug',
@@ -107,13 +99,7 @@ describe('getDynamicParam', () => {
 
     it('should handle single string value for catchall', () => {
       const params: Params = { slug: 'single-page' }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'c',
-        '/docs/[...slug]',
-        null
-      )
+      const result = getDynamicParam(params, 'slug', 'c', null)
 
       expect(result).toEqual({
         param: 'slug',
@@ -123,33 +109,9 @@ describe('getDynamicParam', () => {
       })
     })
 
-    it('should use pagePath fallback when catchall has no value', () => {
-      const params: Params = {}
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'c',
-        '/dashboard/analytics/reports',
-        null
-      )
-
-      expect(result).toEqual({
-        param: 'slug',
-        value: ['dashboard', 'analytics', 'reports'],
-        type: 'c',
-        treeSegment: ['slug', 'dashboard/analytics/reports', 'c'],
-      })
-    })
-
     it('should handle catchall intercepted (ci) with array values', () => {
       const params: Params = { path: ['photo', '123'] }
-      const result = getDynamicParam(
-        params,
-        'path',
-        'ci',
-        '/(.)photo/[...path]',
-        null
-      )
+      const result = getDynamicParam(params, 'path', 'ci', null)
 
       expect(result).toEqual({
         param: 'path',
@@ -159,104 +121,12 @@ describe('getDynamicParam', () => {
       })
     })
 
-    it('should parse pagePath with dynamic segments for catchall fallback', () => {
-      const params: Params = { category: 'electronics' }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'c',
-        '/shop/[category]/products',
-        null
-      )
-
-      expect(result).toEqual({
-        param: 'slug',
-        value: ['shop', 'electronics', 'products'],
-        type: 'c',
-        treeSegment: ['slug', 'shop/electronics/products', 'c'],
-      })
-    })
-
-    it('should handle pagePath with parallel routes for catchall', () => {
-      const params: Params = { category: 'books' }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'c',
-        '/shop/[category]/@modal/product-details',
-        null
-      )
-
-      expect(result).toEqual({
-        param: 'slug',
-        value: ['shop', 'books', '@modal', 'product-details'],
-        type: 'c',
-        treeSegment: ['slug', 'shop/books/@modal/product-details', 'c'],
-      })
-    })
-
-    it('should handle pagePath with multiple parallel routes for catchall', () => {
-      const params: Params = {
-        category: 'electronics',
-        brand: 'apple',
-      }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'c',
-        '/shop/[category]/[brand]/@sidebar/@modal/details',
-        null
-      )
-
-      expect(result).toEqual({
-        param: 'slug',
-        value: [
-          'shop',
-          'electronics',
-          'apple',
-          '@sidebar',
-          '@modal',
-          'details',
-        ],
-        type: 'c',
-        treeSegment: [
-          'slug',
-          'shop/electronics/apple/@sidebar/@modal/details',
-          'c',
-        ],
-      })
-    })
-
-    it('should handle pagePath with parallel routes and static segments for optional catchall when param missing', () => {
-      const params: Params = { userId: '123' }
-      const result = getDynamicParam(
-        params,
-        'path',
-        'oc',
-        '/dashboard/[userId]/@analytics/reports/monthly',
-        null
-      )
-
-      expect(result).toEqual({
-        param: 'path',
-        value: null,
-        type: 'oc',
-        treeSegment: ['path', '', 'oc'],
-      })
-    })
-
     it('should handle parallel routes with fallback params for catchall', () => {
       const params: Params = { category: 'electronics' }
       const fallbackParams = createMockOpaqueFallbackRouteParams({
         slug: ['%%drp:slug:parallel123%%', 'd'],
       })
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'd',
-        '/shop/[category]/@modal/@sidebar/product',
-        fallbackParams
-      )
+      const result = getDynamicParam(params, 'slug', 'd', fallbackParams)
 
       expect(result).toEqual({
         param: 'slug',
@@ -265,133 +135,12 @@ describe('getDynamicParam', () => {
         treeSegment: ['slug', '%%drp:slug:parallel123%%', 'd'],
       })
     })
-
-    it('should handle parallel routes with catchall parameters in the parallel segment', () => {
-      const params: Params = {
-        category: 'books',
-        modalPath: ['details', 'reviews', 'summary'],
-      }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'c',
-        '/shop/[category]/@modal/[...modalPath]/content',
-        null
-      )
-
-      expect(result).toEqual({
-        param: 'slug',
-        value: [
-          'shop',
-          'books',
-          '@modal',
-          'details',
-          'reviews',
-          'summary',
-          'content',
-        ],
-        type: 'c',
-        treeSegment: [
-          'slug',
-          'shop/books/@modal/details/reviews/summary/content',
-          'c',
-        ],
-      })
-    })
-
-    it('should handle parallel routes with optional catchall in parallel segment', () => {
-      const params: Params = {
-        userId: '456',
-        tabPath: ['settings', 'profile'],
-      }
-      const result = getDynamicParam(
-        params,
-        'content',
-        'c',
-        '/dashboard/[userId]/@tabs/[[...tabPath]]/layout',
-        null
-      )
-
-      expect(result).toEqual({
-        param: 'content',
-        value: ['dashboard', '456', '@tabs', 'settings', 'profile', 'layout'],
-        type: 'c',
-        treeSegment: [
-          'content',
-          'dashboard/456/@tabs/settings/profile/layout',
-          'c',
-        ],
-      })
-    })
-
-    it('should handle multiple parallel routes each with catchall segments', () => {
-      const params: Params = {
-        category: 'electronics',
-        modalPath: ['photo', 'gallery'],
-        sidebarPath: ['filters', 'brands'],
-      }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'c',
-        '/shop/[category]/@modal/[...modalPath]/@sidebar/[...sidebarPath]/page',
-        null
-      )
-
-      expect(result).toEqual({
-        param: 'slug',
-        value: [
-          'shop',
-          'electronics',
-          '@modal',
-          'photo',
-          'gallery',
-          '@sidebar',
-          'filters',
-          'brands',
-          'page',
-        ],
-        type: 'c',
-        treeSegment: [
-          'slug',
-          'shop/electronics/@modal/photo/gallery/@sidebar/filters/brands/page',
-          'c',
-        ],
-      })
-    })
-
-    it('should handle parallel routes with missing catchall in parallel segment', () => {
-      const params: Params = {
-        category: 'electronics',
-        // modalPath is missing
-      }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'c',
-        '/shop/[category]/@modal/[...modalPath]/content',
-        null
-      )
-
-      expect(result).toEqual({
-        param: 'slug',
-        value: ['shop', 'electronics', '@modal', 'modalPath', 'content'],
-        type: 'c',
-        treeSegment: ['slug', 'shop/electronics/@modal/modalPath/content', 'c'],
-      })
-    })
   })
 
   describe('optional catchall parameters (oc)', () => {
     it('should handle array of values for optional catchall', () => {
       const params: Params = { slug: ['api', 'users', 'create'] }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'oc',
-        '/api/[[...slug]]',
-        null
-      )
+      const result = getDynamicParam(params, 'slug', 'oc', null)
 
       expect(result).toEqual({
         param: 'slug',
@@ -403,13 +152,7 @@ describe('getDynamicParam', () => {
 
     it('should return null value for optional catchall without value', () => {
       const params: Params = {}
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'oc',
-        '/api/[[...slug]]',
-        null
-      )
+      const result = getDynamicParam(params, 'slug', 'oc', null)
 
       expect(result).toEqual({
         param: 'slug',
@@ -421,13 +164,7 @@ describe('getDynamicParam', () => {
 
     it('should encode array values for optional catchall', () => {
       const params: Params = { slug: ['hello world', 'caf�'] }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'oc',
-        '/api/[[...slug]]',
-        null
-      )
+      const result = getDynamicParam(params, 'slug', 'oc', null)
 
       expect(result).toEqual({
         param: 'slug',
@@ -439,13 +176,7 @@ describe('getDynamicParam', () => {
 
     it('should handle single string value for optional catchall', () => {
       const params: Params = { slug: 'documentation' }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'oc',
-        '/docs/[[...slug]]',
-        null
-      )
+      const result = getDynamicParam(params, 'slug', 'oc', null)
 
       expect(result).toEqual({
         param: 'slug',
@@ -467,7 +198,7 @@ describe('getDynamicParam', () => {
         params,
         'slug',
         'd',
-        '/blog/[slug]',
+
         fallbackParams
       )
 
@@ -489,7 +220,7 @@ describe('getDynamicParam', () => {
         params,
         'slug',
         'd',
-        '/blog/[slug]',
+
         fallbackParams
       )
 
@@ -502,13 +233,7 @@ describe('getDynamicParam', () => {
         slug: ['%%drp:slug:def456%%', 'c'],
       })
 
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'c',
-        '/docs/[...slug]',
-        fallbackParams
-      )
+      const result = getDynamicParam(params, 'slug', 'c', fallbackParams)
 
       expect(result).toEqual({
         param: 'slug',
@@ -524,13 +249,7 @@ describe('getDynamicParam', () => {
         slug: ['%%drp:slug:ghi789%%', 'oc'],
       })
 
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'oc',
-        '/api/[[...slug]]',
-        fallbackParams
-      )
+      const result = getDynamicParam(params, 'slug', 'oc', fallbackParams)
 
       expect(result).toEqual({
         param: 'slug',
@@ -550,7 +269,7 @@ describe('getDynamicParam', () => {
         params,
         'slug',
         'd',
-        '/blog/[slug]',
+
         fallbackParams
       )
 
@@ -563,69 +282,20 @@ describe('getDynamicParam', () => {
       const params: Params = { slug: '' }
 
       expect(() => {
-        getDynamicParam(params, 'slug', 'd', '/blog/[slug]', null)
+        getDynamicParam(params, 'slug', 'd', null)
       }).toThrow(InvariantError)
       expect(() => {
-        getDynamicParam(params, 'slug', 'd', '/blog/[slug]', null)
-      }).toThrow('Unexpected dynamic param type: d')
-    })
-
-    it('should handle empty array for catchall', () => {
-      const params: Params = { slug: [] }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'c',
-        '/docs/guide/tutorial',
-        null
+        getDynamicParam(params, 'slug', 'd', null)
+      }).toThrow(
+        `Invariant: Missing value for segment key: "slug" with dynamic param type: d. This is a bug in Next.js.`
       )
-
-      expect(result).toEqual({
-        param: 'slug',
-        value: [],
-        type: 'c',
-        treeSegment: ['slug', '', 'c'],
-      })
-    })
-
-    it('should handle complex pagePath parsing for catchall', () => {
-      const params: Params = {
-        category: 'electronics',
-        brand: 'apple',
-      }
-      const result = getDynamicParam(
-        params,
-        'slug',
-        'c',
-        '/shop/[category]/[brand]/products/featured',
-        null
-      )
-
-      expect(result).toEqual({
-        param: 'slug',
-        value: ['shop', 'electronics', 'apple', 'products', 'featured'],
-        type: 'c',
-        treeSegment: ['slug', 'shop/electronics/apple/products/featured', 'c'],
-      })
-    })
-
-    it('should handle root path for catchall without value', () => {
-      const params: Params = {}
-      const result = getDynamicParam(params, 'slug', 'c', '/', null)
-
-      expect(result).toEqual({
-        param: 'slug',
-        value: [''],
-        type: 'c',
-        treeSegment: ['slug', '', 'c'],
-      })
     })
 
     it('should handle undefined param values', () => {
       const params: Params = { slug: undefined }
 
       expect(() => {
-        getDynamicParam(params, 'slug', 'd', '/blog/[slug]', null)
+        getDynamicParam(params, 'slug', 'd', null)
       }).toThrow(InvariantError)
     })
   })

--- a/packages/next/src/shared/lib/router/utils/get-dynamic-param.test.ts
+++ b/packages/next/src/shared/lib/router/utils/get-dynamic-param.test.ts
@@ -2,10 +2,12 @@ import {
   getDynamicParam,
   parseParameter,
   parseMatchedParameter,
+  interpolateParallelRouteParams,
 } from './get-dynamic-param'
 import type { Params } from '../../../../server/request/params'
 import { InvariantError } from '../../invariant-error'
 import { createMockOpaqueFallbackRouteParams } from '../../../../server/app-render/postponed-state.test'
+import type { LoaderTree } from '../../../../server/lib/app-dir-module'
 
 describe('getDynamicParam', () => {
   describe('basic dynamic parameters (d, di)', () => {
@@ -398,5 +400,63 @@ describe('parseMatchedParameter', () => {
       repeat: false,
       optional: true,
     })
+  })
+})
+
+describe('interpolateParallelRouteParams', () => {
+  it('should interpolate parallel route params', () => {
+    const loaderTree = [
+      '',
+      {
+        children: [
+          'optional-catch-all',
+          {
+            children: [
+              '[[...path]]',
+              {
+                children: [
+                  '__PAGE__',
+                  {},
+                  {
+                    page: [
+                      null,
+                      '/private/var/folders/xy/84vxj27s21x2brb851sdl_5c0000gn/T/next-install-1265b780415069863d37bb613af21623e2ce3eecc0c3a770cbbc66e0a4cf18aa/app/optional-catch-all/[[...path]]/page.tsx',
+                    ],
+                  },
+                ],
+              },
+              {
+                layout: [
+                  null,
+                  '/private/var/folders/xy/84vxj27s21x2brb851sdl_5c0000gn/T/next-install-1265b780415069863d37bb613af21623e2ce3eecc0c3a770cbbc66e0a4cf18aa/app/optional-catch-all/[[...path]]/layout.tsx',
+                ],
+              },
+            ],
+          },
+          {},
+        ],
+      },
+      {
+        'global-error': [
+          null,
+          'next/dist/client/components/builtin/global-error.js',
+        ],
+        'not-found': [null, 'next/dist/client/components/builtin/not-found.js'],
+        forbidden: [null, 'next/dist/client/components/builtin/forbidden.js'],
+        unauthorized: [
+          null,
+          'next/dist/client/components/builtin/unauthorized.js',
+        ],
+      },
+    ] as unknown as LoaderTree
+
+    expect(
+      interpolateParallelRouteParams(
+        loaderTree,
+        {},
+        '/optional-catch-all/[[...path]]',
+        null
+      )
+    ).toEqual({})
   })
 })

--- a/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
+++ b/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
@@ -1,27 +1,30 @@
 import type { DynamicParam } from '../../../../server/app-render/app-render'
+import type { LoaderTree } from '../../../../server/lib/app-dir-module'
 import type { OpaqueFallbackRouteParams } from '../../../../server/request/fallback-params'
 import type { Params } from '../../../../server/request/params'
 import type { DynamicParamTypesShort } from '../../app-router-types'
 import { InvariantError } from '../../invariant-error'
+import { parseLoaderTree } from '../../../../server/app-render/parse-loader-tree'
+import { getSegmentParam } from '../../../../server/app-render/get-segment-param'
 
 /**
  * Gets the value of a param from the params object. This correctly handles the
  * case where the param is a fallback route param and encodes the resulting
  * value.
  *
- * @param params - The params object.
+ * @param interpolatedParams - The params object.
  * @param segmentKey - The key of the segment.
  * @param fallbackRouteParams - The fallback route params.
  * @returns The value of the param.
  */
 function getParamValue(
-  params: Params,
+  interpolatedParams: Params,
   segmentKey: string,
   fallbackRouteParams: OpaqueFallbackRouteParams | null
 ) {
-  let value = params[segmentKey]
+  let value = interpolatedParams[segmentKey]
 
-  if (fallbackRouteParams && fallbackRouteParams.has(segmentKey)) {
+  if (fallbackRouteParams?.has(segmentKey)) {
     // We know that the fallback route params has the segment key because we
     // checked that above.
     const [searchValue] = fallbackRouteParams.get(segmentKey)!
@@ -33,6 +36,85 @@ function getParamValue(
   }
 
   return value
+}
+
+export function interpolateParallelRouteParams(
+  loaderTree: LoaderTree,
+  params: Params,
+  pagePath: string,
+  fallbackRouteParams: OpaqueFallbackRouteParams | null
+) {
+  const interpolated = structuredClone(params)
+
+  // Stack-based traversal with depth tracking
+  const stack: Array<{ tree: LoaderTree; depth: number }> = [
+    { tree: loaderTree, depth: 0 },
+  ]
+
+  // Derive value from pagePath based on depth and parameter type
+  const pathSegments = pagePath.split('/').slice(1) // Remove first empty string
+
+  while (stack.length > 0) {
+    const { tree, depth } = stack.pop()!
+    const { segment, parallelRoutes } = parseLoaderTree(tree)
+
+    // Check if current segment contains a parameter
+    const segmentParam = getSegmentParam(segment)
+    if (
+      segmentParam &&
+      !interpolated.hasOwnProperty(segmentParam.param) &&
+      // If the param is in the fallback route params, we don't need to
+      // interpolate it because it's already marked as being unknown.
+      !fallbackRouteParams?.has(segmentParam.param)
+    ) {
+      if (
+        segmentParam.type === 'catchall' ||
+        segmentParam.type === 'optional-catchall'
+      ) {
+        // For catchall parameters, take all remaining segments from this depth
+        const remainingSegments = pathSegments.slice(depth)
+
+        // Process each segment to handle any dynamic params
+        const processedSegments = remainingSegments.flatMap((pathSegment) => {
+          const param = parseParameter(pathSegment)
+          // If the segment matches a param, return the param value otherwise,
+          // it's a static segment, so just return that. We don't use the
+          // `getParamValue` function here because we don't want the values to
+          // be encoded, that's handled on get by the `getDynamicParam`
+          // function.
+          return interpolated[param.key] ?? param.key
+        })
+
+        interpolated[segmentParam.param] = processedSegments
+      } else if (
+        segmentParam.type === 'dynamic' ||
+        segmentParam.type === 'dynamic-intercepted'
+      ) {
+        // For regular dynamic parameters, take the segment at this depth
+        if (depth < pathSegments.length) {
+          const pathSegment = pathSegments[depth]
+          const param = parseParameter(pathSegment)
+
+          interpolated[segmentParam.param] =
+            interpolated[param.key] ?? param.key
+        }
+      }
+    }
+
+    // Calculate next depth - increment if this is not a route group and not empty
+    let nextDepth = depth
+    const isRouteGroup = segment.startsWith('(') && segment.endsWith(')')
+    if (!isRouteGroup && segment !== '') {
+      nextDepth++
+    }
+
+    // Add all parallel routes to the stack for processing
+    for (const route of Object.values(parallelRoutes)) {
+      stack.push({ tree: route, depth: nextDepth })
+    }
+  }
+
+  return interpolated
 }
 
 /**
@@ -47,70 +129,32 @@ function getParamValue(
  * and optional is, alas, unfortunate.
  */
 export function getDynamicParam(
-  params: Params,
+  interpolatedParams: Params,
   segmentKey: string,
   dynamicParamType: DynamicParamTypesShort,
-  pagePath: string,
   fallbackRouteParams: OpaqueFallbackRouteParams | null
 ): DynamicParam {
   let value: string | string[] | undefined = getParamValue(
-    params,
+    interpolatedParams,
     segmentKey,
     fallbackRouteParams
   )
 
-  if (!value) {
-    const isCatchall = dynamicParamType === 'c'
-    const isOptionalCatchall = dynamicParamType === 'oc'
-
-    if (isCatchall || isOptionalCatchall) {
-      // handle the case where an optional catchall does not have a value,
-      // e.g. `/dashboard/[[...slug]]` when requesting `/dashboard`
-      if (isOptionalCatchall) {
-        return {
-          param: segmentKey,
-          value: null,
-          type: dynamicParamType,
-          treeSegment: [segmentKey, '', dynamicParamType],
-        }
-      }
-
-      // handle the case where a catchall or optional catchall does not have a value,
-      // e.g. `/foo/bar/hello` and `@slot/[...catchall]` or `@slot/[[...catchall]]` is matched
-      // FIXME: (NAR-335) this should handle prefixed segments
-      value = pagePath
-        .split('/')
-        // remove the first empty string
-        .slice(1)
-        // replace any dynamic params with the actual values
-        .flatMap((pathSegment) => {
-          const param = parseParameter(pathSegment)
-
-          // if the segment matches a param, return the param value
-          // otherwise, it's a static segment, so just return that
-          return (
-            getParamValue(params, param.key, fallbackRouteParams) ?? param.key
-          )
-        })
-
-      if (!value) {
-        throw new InvariantError(
-          `No value found for segment key: "${segmentKey}"`
-        )
-      }
-
+  // handle the case where an optional catchall does not have a value,
+  // e.g. `/dashboard/[[...slug]]` when requesting `/dashboard`
+  if (!value || value.length === 0) {
+    if (dynamicParamType === 'oc') {
       return {
         param: segmentKey,
-        value,
+        value: null,
         type: dynamicParamType,
-        // This value always has to be a string.
-        treeSegment: [segmentKey, value.join('/'), dynamicParamType],
+        treeSegment: [segmentKey, '', dynamicParamType],
       }
-    } else {
-      throw new InvariantError(
-        `Unexpected dynamic param type: ${dynamicParamType}`
-      )
     }
+
+    throw new InvariantError(
+      `Missing value for segment key: "${segmentKey}" with dynamic param type: ${dynamicParamType}`
+    )
   }
 
   return {

--- a/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
+++ b/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
@@ -4,8 +4,8 @@ import type { OpaqueFallbackRouteParams } from '../../../../server/request/fallb
 import type { Params } from '../../../../server/request/params'
 import type { DynamicParamTypesShort } from '../../app-router-types'
 import { InvariantError } from '../../invariant-error'
-import { parseLoaderTree } from '../../../../server/app-render/parse-loader-tree'
-import { getSegmentParam } from '../../../../server/app-render/get-segment-param'
+import { parseLoaderTree } from './parse-loader-tree'
+import { getSegmentParam } from './get-segment-param'
 
 /**
  * Gets the value of a param from the params object. This correctly handles the

--- a/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
+++ b/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
@@ -67,37 +67,44 @@ export function interpolateParallelRouteParams(
       // interpolate it because it's already marked as being unknown.
       !fallbackRouteParams?.has(segmentParam.param)
     ) {
-      if (
-        segmentParam.type === 'catchall' ||
-        segmentParam.type === 'optional-catchall'
-      ) {
-        // For catchall parameters, take all remaining segments from this depth
-        const remainingSegments = pathSegments.slice(depth)
+      switch (segmentParam.type) {
+        case 'catchall':
+        case 'optional-catchall':
+        case 'catchall-intercepted':
+          // For catchall parameters, take all remaining segments from this depth
+          const remainingSegments = pathSegments.slice(depth)
 
-        // Process each segment to handle any dynamic params
-        const processedSegments = remainingSegments.flatMap((pathSegment) => {
-          const param = parseParameter(pathSegment)
-          // If the segment matches a param, return the param value otherwise,
-          // it's a static segment, so just return that. We don't use the
-          // `getParamValue` function here because we don't want the values to
-          // be encoded, that's handled on get by the `getDynamicParam`
-          // function.
-          return interpolated[param.key] ?? param.key
-        })
+          // Process each segment to handle any dynamic params
+          const processedSegments = remainingSegments
+            .flatMap((pathSegment) => {
+              const param = getSegmentParam(pathSegment)
+              // If the segment matches a param, return the param value otherwise,
+              // it's a static segment, so just return that. We don't use the
+              // `getParamValue` function here because we don't want the values to
+              // be encoded, that's handled on get by the `getDynamicParam`
+              // function.
+              return param ? interpolated[param.param] : pathSegment
+            })
+            .filter((s) => s !== undefined)
 
-        interpolated[segmentParam.param] = processedSegments
-      } else if (
-        segmentParam.type === 'dynamic' ||
-        segmentParam.type === 'dynamic-intercepted'
-      ) {
-        // For regular dynamic parameters, take the segment at this depth
-        if (depth < pathSegments.length) {
-          const pathSegment = pathSegments[depth]
-          const param = parseParameter(pathSegment)
+          if (processedSegments.length > 0) {
+            interpolated[segmentParam.param] = processedSegments
+          }
+          break
+        case 'dynamic':
+        case 'dynamic-intercepted':
+          // For regular dynamic parameters, take the segment at this depth
+          if (depth < pathSegments.length) {
+            const pathSegment = pathSegments[depth]
+            const param = getSegmentParam(pathSegment)
 
-          interpolated[segmentParam.param] =
-            interpolated[param.key] ?? param.key
-        }
+            interpolated[segmentParam.param] = param
+              ? interpolated[param.param]
+              : pathSegment
+          }
+          break
+        default:
+          segmentParam.type satisfies never
       }
     }
 

--- a/packages/next/src/shared/lib/router/utils/get-segment-param.tsx
+++ b/packages/next/src/shared/lib/router/utils/get-segment-param.tsx
@@ -1,5 +1,5 @@
-import { INTERCEPTION_ROUTE_MARKERS } from '../../shared/lib/router/utils/interception-routes'
-import type { DynamicParamTypes } from '../../shared/lib/app-router-types'
+import { INTERCEPTION_ROUTE_MARKERS } from './interception-routes'
+import type { DynamicParamTypes } from '../../app-router-types'
 
 /**
  * Parse dynamic route segment to type of parameter

--- a/packages/next/src/shared/lib/router/utils/parse-loader-tree.ts
+++ b/packages/next/src/shared/lib/router/utils/parse-loader-tree.ts
@@ -1,5 +1,5 @@
-import { DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
-import type { LoaderTree } from '../lib/app-dir-module'
+import { DEFAULT_SEGMENT_KEY } from '../../segment'
+import type { LoaderTree } from '../../../../server/lib/app-dir-module'
 
 export function parseLoaderTree(tree: LoaderTree) {
   const [segment, parallelRoutes, modules] = tree

--- a/test/e2e/app-dir/parallel-route-navigations/app/[teamID]/@slot/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/parallel-route-navigations/app/[teamID]/@slot/[...catchAll]/page.tsx
@@ -1,0 +1,12 @@
+import Component from '../../../component'
+
+export default async function Page(props: {
+  params: Promise<Record<string, string | string[]>>
+}) {
+  return (
+    <Component
+      file="/[teamID]/@slot/[...catchAll]/page.tsx"
+      params={props.params}
+    />
+  )
+}

--- a/test/e2e/app-dir/parallel-route-navigations/app/[teamID]/layout.tsx
+++ b/test/e2e/app-dir/parallel-route-navigations/app/[teamID]/layout.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export default function Layout(props: {
+  slot: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <ul>
+        <li>
+          <Link href="/vercel/sub/folder">/vercel/sub/folder</Link>
+        </li>
+        <li>
+          <Link href="/vercel/sub/other-folder">/vercel/sub/other-folder</Link>
+        </li>
+      </ul>
+      <div data-slot>{props.slot}</div>
+      <div data-children>{props.children}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-route-navigations/app/[teamID]/sub/folder/page.tsx
+++ b/test/e2e/app-dir/parallel-route-navigations/app/[teamID]/sub/folder/page.tsx
@@ -1,0 +1,9 @@
+import Component from '../../../component'
+
+export default async function Page(props: {
+  params: Promise<Record<string, string | string[]>>
+}) {
+  return (
+    <Component file="/[teamID]/sub/folder/page.tsx" params={props.params} />
+  )
+}

--- a/test/e2e/app-dir/parallel-route-navigations/app/[teamID]/sub/other-folder/page.tsx
+++ b/test/e2e/app-dir/parallel-route-navigations/app/[teamID]/sub/other-folder/page.tsx
@@ -1,0 +1,12 @@
+import Component from '../../../component'
+
+export default async function Page(props: {
+  params: Promise<Record<string, string | string[]>>
+}) {
+  return (
+    <Component
+      file="/[teamID]/sub/other-folder/page.tsx"
+      params={props.params}
+    />
+  )
+}

--- a/test/e2e/app-dir/parallel-route-navigations/app/component.client.tsx
+++ b/test/e2e/app-dir/parallel-route-navigations/app/component.client.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export default function ComponentClient(props: { file: string }) {
+  const params = useParams()
+  return (
+    <code
+      data-client-file={props.file}
+      data-client-params={JSON.stringify(params)}
+    >
+      {JSON.stringify(params)}
+    </code>
+  )
+}

--- a/test/e2e/app-dir/parallel-route-navigations/app/component.tsx
+++ b/test/e2e/app-dir/parallel-route-navigations/app/component.tsx
@@ -1,0 +1,34 @@
+import { Suspense } from 'react'
+import ComponentClient from './component.client'
+
+type Props = {
+  file: string
+  params: Promise<Record<string, string | string[]>>
+}
+
+async function ComponentServer(props: Props) {
+  const params = await props.params
+  return (
+    <code
+      data-server-file={props.file}
+      data-server-params={JSON.stringify(params)}
+    >
+      {JSON.stringify(params)}
+    </code>
+  )
+}
+
+export default function Component(props: Props) {
+  return (
+    <div data-file={props.file}>
+      <div>File: {props.file}</div>
+
+      <Suspense fallback={<div data-loading>Loading Server...</div>}>
+        <ComponentServer {...props} />
+      </Suspense>
+      <Suspense fallback={<div data-loading>Loading Client...</div>}>
+        <ComponentClient file={props.file} />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-route-navigations/app/layout.css
+++ b/test/e2e/app-dir/parallel-route-navigations/app/layout.css
@@ -1,0 +1,10 @@
+[data-loading] {
+  background-color: red;
+}
+
+[data-file] {
+  font-family: monospace;
+  padding: 10px;
+  background-color: blue;
+  color: white;
+}

--- a/test/e2e/app-dir/parallel-route-navigations/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-route-navigations/app/layout.tsx
@@ -1,0 +1,9 @@
+import './layout.css'
+
+export default function Layout(props: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{props.children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-route-navigations/next.config.js
+++ b/test/e2e/app-dir/parallel-route-navigations/next.config.js
@@ -1,0 +1,13 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    // cacheComponents: true,
+    // clientSegmentCache: true,
+    // clientParamParsing: true,
+    // rdcForNavigations: false,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-route-navigations/next.config.js
+++ b/test/e2e/app-dir/parallel-route-navigations/next.config.js
@@ -1,13 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  experimental: {
-    // cacheComponents: true,
-    // clientSegmentCache: true,
-    // clientParamParsing: true,
-    // rdcForNavigations: false,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-route-navigations/parallel-route-navigations.test.ts
+++ b/test/e2e/app-dir/parallel-route-navigations/parallel-route-navigations.test.ts
@@ -1,5 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+import { setTimeout } from 'node:timers/promises'
 
 async function stable(action: () => Promise<void>, stableForMS: number = 1000) {
   // Wait for it to reach the initial state.
@@ -10,7 +11,7 @@ async function stable(action: () => Promise<void>, stableForMS: number = 1000) {
   // Wait for the stableForMS to ensure that it doesn't change.
   for (let i = 0; i < 10; i++) {
     await action()
-    await new Promise((resolve) => setTimeout(resolve, stableForMS / 10))
+    await setTimeout(stableForMS / 10)
   }
 }
 
@@ -107,7 +108,8 @@ describe('parallel-route-navigations', () => {
     await stable(async () => {
       if (
         process.env.__NEXT_EXPERIMENTAL_PPR === 'true' ||
-        process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true'
+        process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true' ||
+        process.env.__NEXT_EXPERIMENTAL_CLIENT_SEGMENT_CACHE === 'true'
       ) {
         // When we're in PPR or Cache Components, we'll see one dynamic
         // request.

--- a/test/e2e/app-dir/parallel-route-navigations/parallel-route-navigations.test.ts
+++ b/test/e2e/app-dir/parallel-route-navigations/parallel-route-navigations.test.ts
@@ -19,6 +19,8 @@ describe('parallel-route-navigations', () => {
     files: __dirname,
   })
 
+  // We're skipping this in development because there's no prefetching
+  // during development.
   if (isNextDev) {
     it.skip('skipping in dev', async () => {
       await Promise.resolve()

--- a/test/e2e/app-dir/parallel-route-navigations/parallel-route-navigations.test.ts
+++ b/test/e2e/app-dir/parallel-route-navigations/parallel-route-navigations.test.ts
@@ -1,0 +1,136 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+async function stable(action: () => Promise<void>, stableForMS: number = 1000) {
+  // Wait for it to reach the initial state.
+  await retry(async () => {
+    await action()
+  })
+
+  // Wait for the stableForMS to ensure that it doesn't change.
+  for (let i = 0; i < 10; i++) {
+    await action()
+    await new Promise((resolve) => setTimeout(resolve, stableForMS / 10))
+  }
+}
+
+describe('parallel-route-navigations', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    it.skip('skipping in dev', async () => {
+      await Promise.resolve()
+    })
+    return
+  }
+
+  it('should render the right parameters on the server', async () => {
+    const $ = await next.render$('/vercel/sub/folder')
+
+    expect({
+      client: $(
+        '[data-client-file="/[teamID]/@slot/[...catchAll]/page.tsx"][data-client-params]'
+      ).data('client-params'),
+      server: $(
+        '[data-server-file="/[teamID]/@slot/[...catchAll]/page.tsx"][data-server-params]'
+      ).data('server-params'),
+    }).toEqual({
+      client: {
+        teamID: 'vercel',
+        catchAll: ['sub', 'folder'],
+      },
+      server: {
+        teamID: 'vercel',
+        catchAll: ['sub', 'folder'],
+      },
+    })
+  })
+
+  it('should render the right parameters on client navigations', async () => {
+    let hadLocked = 0
+    let lock: Promise<void> | false = false
+
+    const browser = await next.browser('/vercel/sub/folder', {
+      beforePageLoad(page) {
+        page.route('**/*', async (route, request) => {
+          if (lock) {
+            hadLocked++
+            await lock
+          }
+
+          await route.continue()
+        })
+      },
+    })
+
+    // Wait for the network idle state, then pause the network requests to the
+    // other folder. This will let us inspect the pre-dynamic render navigation
+    // state.
+    await browser.waitForIdleNetwork()
+
+    let unlock: () => void
+    lock = new Promise((resolve) => {
+      unlock = resolve
+    })
+
+    // Click the navigation link, and wait for the new page component to load.
+    await browser.elementByCss('a[href="/vercel/sub/other-folder"]').click()
+
+    // If it's PPR or Cache Components, we'll see an immediate transition for
+    // the client component.
+    if (
+      process.env.__NEXT_EXPERIMENTAL_PPR === 'true' ||
+      process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true'
+    ) {
+      await browser.waitForElementByCss(
+        '[data-file="/[teamID]/sub/other-folder/page.tsx"]'
+      )
+
+      // Now we should look at the dom and see what the parameters are set to.
+      const client = await browser
+        .elementByCss(
+          '[data-client-file="/[teamID]/@slot/[...catchAll]/page.tsx"][data-client-params]'
+        )
+        .getAttribute('data-client-params')
+
+      expect(JSON.parse(client)).toEqual({
+        teamID: 'vercel',
+        catchAll: ['sub', 'other-folder'],
+      })
+    }
+
+    // Wait for the dynamic RSC request to lock, then unlock that request.
+    await stable(async () => {
+      if (
+        process.env.__NEXT_EXPERIMENTAL_PPR === 'true' ||
+        process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true'
+      ) {
+        // When we're in PPR or Cache Components, we'll see one dynamic
+        // request.
+        expect(hadLocked).toBe(1)
+      } else {
+        // When we're not in PPR or Cache Components, we'll see two dynamic
+        // requests. One made to refetch each of the slots.
+        expect(hadLocked).toBe(2)
+      }
+    })
+    unlock()
+
+    // Now we should look at the dom and see what the parameters are set to and
+    // that they remain the same.
+    await stable(async () => {
+      const client = await browser
+        .elementByCss(
+          '[data-client-file="/[teamID]/@slot/[...catchAll]/page.tsx"][data-client-params]'
+        )
+        .getAttribute('data-client-params')
+
+      expect(JSON.parse(client)).toEqual({
+        teamID: 'vercel',
+        catchAll: ['sub', 'other-folder'],
+      })
+    })
+  })
+})


### PR DESCRIPTION
### Fixing a bug

- Tests added with comprehensive e2e test suite for parallel route navigations
- Error handling improved with clearer error messages for missing dynamic parameters

### What?

Fixes incorrect parameter interpolation where catchall parameters in parallel routes included unintended prefix segments.

### Why?

In parallel routes with dynamic catchall parameters, the parameter interpolation was incorrectly including prefix segments from the route path. For example, with a route structure like `/[teamSlug]/@slot/[...catchAll]`, a request to `/vercel/test/path` would incorrectly set `catchAll = ["vercel", "test", "path"]` instead of the correct `catchAll = ["test", "path"]`. 

This bug affected the accuracy of dynamic parameter values in parallel routes, leading to incorrect behavior in applications relying on these parameters for routing logic.

### How?

- Introduced `interpolateParallelRouteParams()` function that properly handles path depth traversal for complex route structures
- Refactored parameter interpolation to occur earlier in the render process, ensuring consistency across both postponed and regular rendering scenarios
- Updated the `getDynamicParam()` function to use pre-interpolated parameters instead of performing inline path parsing
- Added comprehensive e2e tests to cover various parallel route navigation scenarios and parameter interpolation edge cases
- Improved error handling with more descriptive error messages for missing dynamic parameters

The fix ensures that dynamic parameters are correctly extracted based on their position in the route hierarchy, respecting the boundaries defined by parallel route slots.

NAR-335