### PR TITLE
Make turbopack the default bundler for custom servers

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -849,5 +849,6 @@
   "848": "%sused %s. \\`searchParams\\` is a Promise and must be unwrapped with \\`await\\` or \\`React.use()\\` before accessing its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
   "849": "Route %s with \\`dynamic = \"error\"\\` couldn't be rendered statically because it used \\`cookies()\\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
   "850": "metadataBase is not a valid URL: %s",
-  "851": "Pass either `webpack` or `turbopack`, not both."
+  "851": "Pass either `webpack` or `turbopack`, not both.",
+  "852": "Only custom servers can pass `webpack`, `turbo`, or `turbopack`."
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -848,5 +848,6 @@
   "847": "Route %s with \\`dynamic = \"error\"\\` couldn't be rendered statically because it used \\`connection()\\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
   "848": "%sused %s. \\`searchParams\\` is a Promise and must be unwrapped with \\`await\\` or \\`React.use()\\` before accessing its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
   "849": "Route %s with \\`dynamic = \"error\"\\` couldn't be rendered statically because it used \\`cookies()\\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
-  "850": "metadataBase is not a valid URL: %s"
+  "850": "metadataBase is not a valid URL: %s",
+  "851": "Pass either `webpack` or `turbopack`, not both."
 }

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -52,6 +52,15 @@ export type NextServerOptions = Omit<
 > &
   Partial<Pick<ServerOptions | DevServerOptions, 'conf'>>
 
+export type NextBundlerOptions = {
+  /** @deprecated Use `turbopack` instead */
+  turbo?: boolean
+  /** Selects Turbopack as the bundler */
+  turbopack?: boolean
+  /** Selects Webpack as the bundler */
+  webpack?: boolean
+}
+
 export type RequestHandler = (
   req: IncomingMessage,
   res: ServerResponse,
@@ -531,14 +540,11 @@ class NextCustomServer implements NextWrapperServer {
 
 // This file is used for when users run `require('next')`
 function createServer(
-  options: NextServerOptions & {
-    turbo?: boolean
-    turbopack?: boolean
-    webpack?: boolean
-  }
+  options: NextServerOptions & NextBundlerOptions
 ): NextWrapperServer {
   // next sets customServer to false when calling this function, in that case we don't want to modify the environment variables
-  if (options?.customServer !== false) {
+  const isCustomServer = options?.customServer ?? true
+  if (isCustomServer) {
     const selectTurbopack =
       options &&
       (options.turbo || options.turbopack || process.env.IS_TURBOPACK_TEST)

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -534,15 +534,30 @@ function createServer(
   options: NextServerOptions & {
     turbo?: boolean
     turbopack?: boolean
+    webpack?: boolean
   }
 ): NextWrapperServer {
-  if (
-    options &&
-    (options.turbo || options.turbopack || process.env.IS_TURBOPACK_TEST)
-  ) {
-    // Configure TURBOPACK if it isn't already set
-    process.env.TURBOPACK ??= '1'
+  // next sets customServer to false when calling this function, in that case we don't want to modify the environment variables
+  if (options?.customServer !== false) {
+    const selectTurbopack =
+      options &&
+      (options.turbo || options.turbopack || process.env.IS_TURBOPACK_TEST)
+    const selectWebpack =
+      options && (options.webpack || process.env.IS_WEBPACK_TEST)
+    if (selectTurbopack && selectWebpack) {
+      throw new Error('Pass either `webpack` or `turbopack`, not both.')
+    }
+    if (selectTurbopack || !selectWebpack) {
+      process.env.TURBOPACK ??= selectTurbopack ? '1' : 'auto'
+    }
+  } else {
+    if (options && (options.webpack || options.turbo || options.turbopack)) {
+      throw new Error(
+        'Only custom servers can pass `webpack`, `turbo`, or `turbopack`.'
+      )
+    }
   }
+
   // The package is used as a TypeScript plugin.
   if (
     options &&


### PR DESCRIPTION
Make Turbopack the default bundler for custom servers 🚀 

In the same line as #84216 we want to ship turbopack by default, but now for programmatic usecases.

### What?

Have the custom server entrypoint perform the same 'turbopack by default' logic as the main next entrypoints.  This was a little tricky since next itself uses the custom server entrypoints.  So i have adjusted this function to only perform the logic if it is a custom server since otherwise the next process already has the correct environment variables set

Also deprecate the `turbo` property while we are there.


Closes PACK-5620