### PR TITLE
just make it fail

### DIFF
--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -164,22 +164,18 @@ export async function validateTurboNextConfig({
   // configuration. Otherwise the user explicitly picked turbopack and thus we expect that
   // they have configured it correctly.
   if (process.env.TURBOPACK === 'auto' && hasWebpackConfig && !hasTurboConfig) {
-    const logMethod = isDev ? Log.warn : Log.error
-    // In a production build with auto-detected Turbopack, we want to fail the build.
-    logMethod(
+    // If we defaulted to Turbopack, we want to fail the build.
+    Log.error(
       `Webpack is configured while Turbopack is not. This may be a mistake.`
     )
-    logMethod(
+    Log.error(
       `To configure Turbopack, see:\n  https://nextjs.org/docs/app/api-reference/next-config-js/turbopack`
     )
-    logMethod(
+    Log.error(
       `TIP: Silence this ${isDev ? 'warning' : 'error'} by passing the --turbopack or --webpack flag explicitly.`
     )
 
-    // For production builds we want to simply fail to prevent accidental misconfiguration.
-    if (!isDev) {
-      process.exit(1)
-    }
+    process.exit(1)
   }
 
   if (unsupportedConfig.length) {

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -164,15 +164,16 @@ export async function validateTurboNextConfig({
   // configuration. Otherwise the user explicitly picked turbopack and thus we expect that
   // they have configured it correctly.
   if (process.env.TURBOPACK === 'auto' && hasWebpackConfig && !hasTurboConfig) {
-    // If we defaulted to Turbopack, we want to fail the build.
+    // If we defaulted to Turbopack, we want to fail the build to avoid surprising developers upgrading.
+    // This can be removed in a future release.
     Log.error(
       `Webpack is configured while Turbopack is not. This may be a mistake.`
     )
     Log.error(
-      `To configure Turbopack, see:\n  https://nextjs.org/docs/app/api-reference/next-config-js/turbopack`
+      `To configure Turbopack, see https://nextjs.org/docs/app/api-reference/next-config-js/turbopack`
     )
     Log.error(
-      `TIP: Silence this ${isDev ? 'warning' : 'error'} by passing the --turbopack or --webpack flag explicitly.`
+      `TIP: Silence this by passing the --turbopack or --webpack flag explicitly.`
     )
 
     process.exit(1)


### PR DESCRIPTION
Consistently break if only webpack is configured when turbopack is automatically selected.

Initially we decided to only warn in dev, but since this is going out in a `beta` release, by always failing we should get more feedback on how annoying or useful this is.


Closes PACK-5607