### PR TITLE
FIX: POST request succeeds for pages with next dev #38863

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -556,6 +556,16 @@ export default class DevServer extends Server {
     res: NodeNextResponse,
     parsedUrl?: NextUrlWithParsedQuery
   ): Promise<void> {
+    const pathname = req.url?.split('?')[0] || '/'
+    const isPageRoute = await this.hasPage(pathname)
+    if (isPageRoute && req.method !== 'GET' && req.method !== 'HEAD') {
+      //If a non GET/HEAD request is sent to a page, send a 405 unsupported error
+      res.statusCode = 405
+      res.setHeader('Allow', ['GET', 'HEAD'])
+      res.body('Method Not Allowed').send()
+      return
+    }
+
     const span = trace('handle-request', undefined, { url: req.url })
     const result = await span.traceAsyncFn(async () => {
       await this.ready?.promise


### PR DESCRIPTION
## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### What?
This PR is meant to fix the issue where POST requests to pages succeed in next dev.

### Why?
This is an issue as an improper 200 OK status code is returned when a POST request is sent to a page.

### How?
Added a check to next-dev-server.ts to check if a POST request is sent to a page

Closes NEXT-POST request succeeds for pages with next dev
Fixes #38863