### PR TITLE
[turbopack] Remove a bunch of dead code from the source map implementation

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -1491,12 +1491,10 @@ pub async fn project_trace_source_operation(
         return Ok(Vc::cell(None));
     };
 
-    let token = map
-        .lookup_token(
-            line.saturating_sub(1),
-            frame.column.unwrap_or(1).saturating_sub(1),
-        )
-        .await?;
+    let token = map.lookup_token(
+        line.saturating_sub(1),
+        frame.column.unwrap_or(1).saturating_sub(1),
+    );
 
     let (original_file, line, column, method_name) = match token {
         Token::Original(token) => (

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -63,12 +63,18 @@ pub trait GenerateSourceMap {
 /// The distinction between the source map spec's [sourcemap::Index] and our
 /// [SourceMap::Sectioned] is whether the sections are represented with Vcs
 /// pointers.
-#[turbo_tasks::value(shared, cell = "new")]
+#[turbo_tasks::value(shared, cell = "new", eq = "manual")]
 #[derive(Debug)]
 pub struct SourceMap {
     /// A decoded source map contains no Vcs.
     #[turbo_tasks(trace_ignore)]
-    inner: InnerSourceMap,
+    map: Arc<CrateMapWrapper>,
+}
+impl Eq for SourceMap {}
+impl PartialEq for SourceMap {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.map, &other.map)
+    }
 }
 
 #[turbo_tasks::value(transparent)]
@@ -213,7 +219,7 @@ impl SourceMap {
     /// Creates a new SourceMap::Decoded Vc out of a [DecodedMap] instance.
     fn new_decoded(map: DecodedMap) -> Self {
         SourceMap {
-            inner: InnerSourceMap::new(map),
+            map: Arc::new(CrateMapWrapper(map)),
         }
     }
 
@@ -242,7 +248,7 @@ impl SourceMap {
 
 impl SourceMap {
     pub fn to_source_map(&self) -> Arc<CrateMapWrapper> {
-        self.inner.map.clone()
+        self.map.clone()
     }
 }
 
@@ -317,27 +323,23 @@ impl SourceMap {
     }
 
     /// Stringifies the source map into JSON bytes.
-    pub async fn to_rope(&self) -> Result<Rope> {
+    pub fn to_rope(&self) -> Result<Rope> {
         let mut bytes = vec![];
-        self.inner.0.to_writer(&mut bytes)?;
+        self.map.0.to_writer(&mut bytes)?;
         Ok(Rope::from(bytes))
     }
 
     /// Traces a generated line/column into an mapping token representing either
     /// synthetic code or user-authored original code.
-    pub async fn lookup_token(&self, line: u32, column: u32) -> Result<Token> {
-        let (token, _) = self
-            .lookup_token_and_source_internal(line, column, true)
-            .await?;
-        Ok(token)
+    pub fn lookup_token(&self, line: u32, column: u32) -> Token {
+        let (token, _) = self.lookup_token_and_source_internal(line, column, true);
+        token
     }
 
     /// Traces a generated line/column into an mapping token representing either
     /// synthetic code or user-authored original code.
     pub async fn lookup_token_and_source(&self, line: u32, column: u32) -> Result<TokenWithSource> {
-        let (token, content) = self
-            .lookup_token_and_source_internal(line, column, true)
-            .await?;
+        let (token, content) = self.lookup_token_and_source_internal(line, column, true);
         Ok(TokenWithSource {
             token,
             source_content: match content {
@@ -468,7 +470,7 @@ impl SourceMap {
             }))
         }
 
-        let map = Box::pin(decoded_map_with_resolved_sources(&self.inner.map, origin)).await?;
+        let map = Box::pin(decoded_map_with_resolved_sources(&self.map, origin)).await?;
         Ok(Self::new_decoded(map.0))
     }
 }
@@ -486,16 +488,16 @@ async fn sourcemap_content_source(path: RcStr, content: RcStr) -> Result<Vc<Box<
 }
 
 impl SourceMap {
-    async fn lookup_token_and_source_internal(
+    fn lookup_token_and_source_internal(
         &self,
         line: u32,
         column: u32,
         need_source_content: bool,
-    ) -> Result<(Token, Option<Vc<Box<dyn Source>>>)> {
+    ) -> (Token, Option<Vc<Box<dyn Source>>>) {
         let mut content: Option<Vc<Box<dyn Source>>> = None;
 
         let token: Token = {
-            let map = &self.inner;
+            let map = &self.map;
 
             let tok = map.lookup_token(line, column);
             let mut token = tok.map(Token::from).unwrap_or_else(|| {
@@ -510,7 +512,7 @@ impl SourceMap {
                 guessed_original_file,
                 ..
             }) = &mut token
-                && let DecodedMap::Regular(map) = &map.map.0
+                && let DecodedMap::Regular(map) = &map.0
                 && map.get_source_count() == 1
             {
                 let source = map.sources().next().unwrap().clone();
@@ -519,7 +521,7 @@ impl SourceMap {
 
             if need_source_content
                 && content.is_none()
-                && let Some(map) = map.map.as_regular_source_map()
+                && let Some(map) = map.as_regular_source_map()
             {
                 content = tok.and_then(|tok| {
                     let src_id = tok.get_src_id();
@@ -538,44 +540,15 @@ impl SourceMap {
             token
         };
 
-        Ok((token, content))
+        (token, content)
     }
 }
 
 #[turbo_tasks::value_impl]
 impl GenerateSourceMap for SourceMap {
     #[turbo_tasks::function]
-    async fn generate_source_map(self: ResolvedVc<Self>) -> Result<Vc<OptionStringifiedSourceMap>> {
-        Ok(Vc::cell(Some(self.await?.to_rope().await?)))
-    }
-}
-
-/// A regular source map covers an entire file.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct InnerSourceMap {
-    map: Arc<CrateMapWrapper>,
-}
-
-impl InnerSourceMap {
-    pub fn new(map: DecodedMap) -> Self {
-        InnerSourceMap {
-            map: Arc::new(CrateMapWrapper(map)),
-        }
-    }
-}
-
-impl Deref for InnerSourceMap {
-    type Target = Arc<CrateMapWrapper>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.map
-    }
-}
-
-impl Eq for InnerSourceMap {}
-impl PartialEq for InnerSourceMap {
-    fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.map, &other.map)
+    fn generate_source_map(&self) -> Result<Vc<OptionStringifiedSourceMap>> {
+        Ok(Vc::cell(Some(self.to_rope()?)))
     }
 }
 
@@ -606,17 +579,6 @@ pub struct RegularMapWrapper(RegularMap);
 // required to cache in a Vc. So, we have wrap it in 4 layers of cruft to do it.
 unsafe impl Send for RegularMapWrapper {}
 unsafe impl Sync for RegularMapWrapper {}
-
-#[derive(Debug)]
-pub struct CrateIndexWrapper {
-    pub sections: Vec<CrateSectionWrapper>,
-}
-
-#[derive(Debug)]
-pub struct CrateSectionWrapper {
-    pub offset: SourcePos,
-    pub map: Arc<CrateMapWrapper>,
-}
 
 impl CrateMapWrapper {
     pub fn as_regular_source_map(&self) -> Option<Cow<'_, RegularMap>> {
@@ -651,48 +613,5 @@ impl<'de> Deserialize<'de> for CrateMapWrapper {
         let bytes = <&[u8]>::deserialize(deserializer)?;
         let map = DecodedMap::from_reader(bytes).map_err(Error::custom)?;
         Ok(CrateMapWrapper(map))
-    }
-}
-
-/// A sectioned source map contains many (possibly recursive) maps covering
-/// different regions of the file.
-#[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
-pub struct SectionedSourceMap {
-    sections: Vec<SourceMapSection>,
-}
-
-impl SectionedSourceMap {
-    pub fn new(sections: Vec<SourceMapSection>) -> Self {
-        Self { sections }
-    }
-
-    pub fn to_crate_wrapper(&self) -> Result<CrateIndexWrapper> {
-        let mut sections = Vec::with_capacity(self.sections.len());
-        for section in &self.sections {
-            sections.push(section.to_crate_wrapper());
-        }
-        Ok(CrateIndexWrapper { sections })
-    }
-}
-
-/// A section of a larger sectioned source map, which applies at source
-/// positions >= the offset (until the next section starts).
-#[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
-pub struct SourceMapSection {
-    offset: SourcePos,
-    map: SourceMap,
-}
-
-impl SourceMapSection {
-    pub fn new(offset: SourcePos, map: SourceMap) -> Self {
-        Self { offset, map }
-    }
-
-    pub fn to_crate_wrapper(&self) -> CrateSectionWrapper {
-        let map = self.map.to_source_map();
-        CrateSectionWrapper {
-            offset: self.offset,
-            map,
-        }
     }
 }

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -65,12 +65,10 @@ pub trait GenerateSourceMap {
 /// pointers.
 #[turbo_tasks::value(shared, cell = "new")]
 #[derive(Debug)]
-pub enum SourceMap {
+pub struct SourceMap {
     /// A decoded source map contains no Vcs.
-    Decoded(#[turbo_tasks(trace_ignore)] InnerSourceMap),
-    /// A sectioned source map contains many (possibly recursive) maps covering
-    /// different regions of the file.
-    Sectioned(#[turbo_tasks(trace_ignore)] SectionedSourceMap),
+    #[turbo_tasks(trace_ignore)]
+    inner: InnerSourceMap,
 }
 
 #[turbo_tasks::value(transparent)]
@@ -207,49 +205,23 @@ impl TryInto<swc_sourcemap::RawToken> for Token {
 }
 
 impl SourceMap {
-    pub fn empty_uncelled() -> Self {
-        let mut builder = SourceMapBuilder::new(None);
-        builder.add(0, 0, 0, 0, None, None, false);
-        SourceMap::new_regular(builder.into_sourcemap())
-    }
-
     /// Creates a new SourceMap::Decoded Vc out of a [RegularMap] instance.
-    pub fn new_regular(map: RegularMap) -> Self {
+    fn new_regular(map: RegularMap) -> Self {
         Self::new_decoded(DecodedMap::Regular(map))
     }
 
     /// Creates a new SourceMap::Decoded Vc out of a [DecodedMap] instance.
-    pub fn new_decoded(map: DecodedMap) -> Self {
-        SourceMap::Decoded(InnerSourceMap::new(map))
-    }
-
-    /// Creates a new SourceMap::Sectioned Vc out of a collection of source map
-    /// sections.
-    pub fn new_sectioned(sections: Vec<SourceMapSection>) -> Self {
-        SourceMap::Sectioned(SectionedSourceMap::new(sections))
+    fn new_decoded(map: DecodedMap) -> Self {
+        SourceMap {
+            inner: InnerSourceMap::new(map),
+        }
     }
 
     pub fn new_from_rope(content: &Rope) -> Result<Option<Self>> {
         let Ok(map) = DecodedMap::from_reader(content.read()) else {
             return Ok(None);
         };
-        Ok(Some(SourceMap::Decoded(InnerSourceMap::new(map))))
-    }
-
-    pub async fn new_from_file(file: FileSystemPath) -> Result<Option<Self>> {
-        let read = file.read();
-        Self::new_from_file_content(read).await
-    }
-
-    pub async fn new_from_file_content(content: Vc<FileContent>) -> Result<Option<Self>> {
-        let content = &content.await?;
-        let Some(contents) = content.as_content() else {
-            return Ok(None);
-        };
-        let Ok(map) = DecodedMap::from_reader(contents.read()) else {
-            return Ok(None);
-        };
-        Ok(Some(SourceMap::Decoded(InnerSourceMap::new(map))))
+        Ok(Some(SourceMap::new_decoded(map)))
     }
 }
 
@@ -269,27 +241,8 @@ impl SourceMap {
 }
 
 impl SourceMap {
-    pub async fn to_source_map(&self) -> Result<Arc<CrateMapWrapper>> {
-        Ok(match self {
-            Self::Decoded(m) => m.map.clone(),
-            Self::Sectioned(m) => {
-                let wrapped = m.to_crate_wrapper().await?;
-                let sections = wrapped
-                    .sections
-                    .iter()
-                    .map(|s| {
-                        swc_sourcemap::SourceMapSection::new(
-                            (s.offset.line, s.offset.column),
-                            None,
-                            Some(s.map.0.clone()),
-                        )
-                    })
-                    .collect::<Vec<swc_sourcemap::SourceMapSection>>();
-                Arc::new(CrateMapWrapper(DecodedMap::Index(SourceMapIndex::new(
-                    None, sections,
-                ))))
-            }
-        })
+    pub fn to_source_map(&self) -> Arc<CrateMapWrapper> {
+        self.inner.map.clone()
     }
 }
 
@@ -356,33 +309,18 @@ impl SourceMap {
             rope += "}";
         }
 
-        rope += "]
-}";
+        rope += "]";
+
+        rope += "\n}";
 
         Ok(rope.build())
     }
 
     /// Stringifies the source map into JSON bytes.
     pub async fn to_rope(&self) -> Result<Rope> {
-        let rope = match self {
-            SourceMap::Decoded(r) => {
-                let mut bytes = vec![];
-                r.0.to_writer(&mut bytes)?;
-                Rope::from(bytes)
-            }
-
-            SourceMap::Sectioned(s) => {
-                let sections = s
-                    .sections
-                    .iter()
-                    .map(async |s| Ok((s.offset, s.map.to_rope().await?)))
-                    .try_join()
-                    .await?;
-
-                Self::sections_to_rope(sections)?
-            }
-        };
-        Ok(rope)
+        let mut bytes = vec![];
+        self.inner.0.to_writer(&mut bytes)?;
+        Ok(Rope::from(bytes))
     }
 
     /// Traces a generated line/column into an mapping token representing either
@@ -529,20 +467,9 @@ impl SourceMap {
                 }
             }))
         }
-        Ok(match self {
-            Self::Decoded(m) => {
-                let map = Box::pin(decoded_map_with_resolved_sources(&m.map, origin)).await?;
-                Self::Decoded(InnerSourceMap::new(map.0))
-            }
-            Self::Sectioned(m) => {
-                let mut sections = Vec::with_capacity(m.sections.len());
-                for section in &m.sections {
-                    let map = Box::pin(section.map.with_resolved_sources(origin.clone())).await?;
-                    sections.push(SourceMapSection::new(section.offset, map));
-                }
-                SourceMap::new_sectioned(sections)
-            }
-        })
+
+        let map = Box::pin(decoded_map_with_resolved_sources(&self.inner.map, origin)).await?;
+        Ok(Self::new_decoded(map.0))
     }
 }
 
@@ -567,95 +494,48 @@ impl SourceMap {
     ) -> Result<(Token, Option<Vc<Box<dyn Source>>>)> {
         let mut content: Option<Vc<Box<dyn Source>>> = None;
 
-        let token: Token = match self {
-            SourceMap::Decoded(map) => {
-                let tok = map.lookup_token(line, column);
-                let mut token = tok.map(Token::from).unwrap_or_else(|| {
-                    Token::Synthetic(SyntheticToken {
-                        generated_line: line,
-                        generated_column: column,
-                        guessed_original_file: None,
-                    })
-                });
+        let token: Token = {
+            let map = &self.inner;
 
-                if let Token::Synthetic(SyntheticToken {
-                    guessed_original_file,
-                    ..
-                }) = &mut token
-                    && let DecodedMap::Regular(map) = &map.map.0
-                    && map.get_source_count() == 1
-                {
-                    let source = map.sources().next().unwrap().clone();
-                    *guessed_original_file = Some(RcStr::from(source));
-                }
-
-                if need_source_content
-                    && content.is_none()
-                    && let Some(map) = map.map.as_regular_source_map()
-                {
-                    content = tok.and_then(|tok| {
-                        let src_id = tok.get_src_id();
-
-                        let name = map.get_source(src_id);
-                        let content = map.get_source_contents(src_id);
-
-                        let (name, content) = name.zip(content)?;
-                        Some(sourcemap_content_source(
-                            name.clone().into(),
-                            content.clone().into(),
-                        ))
-                    });
-                }
-
-                token
-            }
-
-            SourceMap::Sectioned(map) => {
-                let len = map.sections.len();
-                let mut low = 0;
-                let mut high = len;
-                let pos = SourcePos { line, column };
-
-                // A "greatest lower bound" binary search. We're looking for the closest section
-                // offset <= to our line/col.
-                while low < high {
-                    let mid = (low + high) / 2;
-                    if pos < map.sections[mid].offset {
-                        high = mid;
-                    } else {
-                        low = mid + 1;
-                    }
-                }
-
-                // Our GLB search will return the section immediately to the right of the
-                // section we actually want to recurse into, because the binary search does not
-                // early exit on an exact match (it'll `low = mid + 1`).
-                if low > 0 && low <= len {
-                    let SourceMapSection { map, offset } = &map.sections[low - 1];
-                    // We're looking for the position `l` lines into region covered by this
-                    // sourcemap's section.
-                    let l = line - offset.line;
-                    // The source map starts offset by the section's column only on its first line.
-                    // On the 2nd+ line, the source map covers starting at column 0.
-                    let c = if line == offset.line {
-                        column - offset.column
-                    } else {
-                        column
-                    };
-
-                    if need_source_content {
-                        let result = Box::pin(map.lookup_token_and_source(l, c)).await?;
-                        return Ok((result.token, result.source_content.map(|v| *v)));
-                    } else {
-                        return Ok((Box::pin(map.lookup_token(l, c)).await?, None));
-                    }
-                }
+            let tok = map.lookup_token(line, column);
+            let mut token = tok.map(Token::from).unwrap_or_else(|| {
                 Token::Synthetic(SyntheticToken {
                     generated_line: line,
                     generated_column: column,
                     guessed_original_file: None,
                 })
+            });
+
+            if let Token::Synthetic(SyntheticToken {
+                guessed_original_file,
+                ..
+            }) = &mut token
+                && let DecodedMap::Regular(map) = &map.map.0
+                && map.get_source_count() == 1
+            {
+                let source = map.sources().next().unwrap().clone();
+                *guessed_original_file = Some(RcStr::from(source));
             }
+
+            if need_source_content
+                && content.is_none()
+                && let Some(map) = map.map.as_regular_source_map()
+            {
+                content = tok.and_then(|tok| {
+                    let src_id = tok.get_src_id();
+
+                    let name = map.get_source(src_id);
+                    let content = map.get_source_contents(src_id);
+
+                    let (name, content) = name.zip(content)?;
+                    Some(sourcemap_content_source(
+                        name.clone().into(),
+                        content.clone().into(),
+                    ))
+                });
+            }
+
+            token
         };
 
         Ok((token, content))
@@ -786,10 +666,10 @@ impl SectionedSourceMap {
         Self { sections }
     }
 
-    pub async fn to_crate_wrapper(&self) -> Result<CrateIndexWrapper> {
+    pub fn to_crate_wrapper(&self) -> Result<CrateIndexWrapper> {
         let mut sections = Vec::with_capacity(self.sections.len());
         for section in &self.sections {
-            sections.push(section.to_crate_wrapper().await?);
+            sections.push(section.to_crate_wrapper());
         }
         Ok(CrateIndexWrapper { sections })
     }
@@ -808,11 +688,11 @@ impl SourceMapSection {
         Self { offset, map }
     }
 
-    pub async fn to_crate_wrapper(&self) -> Result<CrateSectionWrapper> {
-        let map = Box::pin(self.map.to_source_map()).await?;
-        Ok(CrateSectionWrapper {
+    pub fn to_crate_wrapper(&self) -> CrateSectionWrapper {
+        let map = self.map.to_source_map();
+        CrateSectionWrapper {
             offset: self.offset,
             map,
-        })
+        }
     }
 }

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -405,9 +405,10 @@ impl SourceMap {
             let mut new_sources = Vec::with_capacity(count);
             let mut new_source_contents = Vec::with_capacity(count);
             for (source, source_content) in sources.into_iter().zip(source_contents.into_iter()) {
-                let (source, name) = resolve_source(source, source_content, origin.clone()).await?;
+                let (source, source_content) =
+                    resolve_source(source, source_content, origin.clone()).await?;
                 new_sources.push(source);
-                new_source_contents.push(Some(name));
+                new_source_contents.push(Some(source_content));
             }
             let mut map =
                 RegularMap::new(file, tokens, names, new_sources, Some(new_source_contents));

--- a/turbopack/crates/turbopack-node/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/mod.rs
@@ -232,7 +232,7 @@ async fn resolve_source_mapping(
     let Some(sm) = &*SourceMap::new_from_rope_cached(sm).await? else {
         return Ok(ResolvedSourceMapping::NoSourceMap);
     };
-    let trace = trace_source_map(sm, line, column, name.map(|s| &**s)).await?;
+    let trace = trace_source_map(sm, line, column, name.map(|s| &**s));
     match trace {
         TraceResult::Found(frame) => {
             let lib_code = frame.file.contains("/node_modules/");

--- a/turbopack/crates/turbopack-node/src/source_map/trace.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/trace.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, fmt::Display};
 
-use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbopack_core::source_map::{SourceMap, Token};
 use turbopack_ecmascript::magic_identifier::unmangle_identifiers;
@@ -91,16 +90,14 @@ pub enum TraceResult {
 /// memory hog, it'd be so much faster if we could just directly access
 /// the individual sections of the JS file's map without the
 /// serialization.
-pub async fn trace_source_map(
+pub fn trace_source_map(
     map: &SourceMap,
     line: u32,
     column: u32,
     name: Option<&str>,
-) -> Result<TraceResult> {
-    let token = map
-        .lookup_token(line.saturating_sub(1), column.saturating_sub(1))
-        .await?;
-    let result = match token {
+) -> TraceResult {
+    let token = map.lookup_token(line.saturating_sub(1), column.saturating_sub(1));
+    match token {
         Token::Original(t) => TraceResult::Found(StackFrame {
             file: Cow::Owned(t.original_file.into_owned()),
             line: Some(t.original_line.saturating_add(1)),
@@ -113,7 +110,5 @@ pub async fn trace_source_map(
                 .map(Cow::Owned),
         }),
         _ => TraceResult::NotFound,
-    };
-
-    Ok(result)
+    }
 }


### PR DESCRIPTION
The `SourceMap::Sectioned` enum was only used recursively.  once i noticed that a bunch of dead code fell out.

Part-of PACK-417

Closes PACK-5594