### PR TITLE
[test] Ignore pnpm update notifier

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ packages:
   - 'turbopack/crates/*/js'
   - 'turbopack/crates/turbopack-tests/tests/execution'
   - 'turbopack/packages/*'
+updateNotifier: false


### PR DESCRIPTION
This notification even pops up in our e2e test:
```
╭───────────────────────────────────────────────────────────────╮
│                                                               |
│              Update available! 8.15.7 → 10.17.1.              │
│                                                               |
|                          Changelog:                           │
│      https://github.com/pnpm/pnpm/releases/tag/v10.17.1       │
│   Run "corepack prepare pnpm@10.17.1 --activate" to update.   │
│                                                               │
│    Follow @pnpmjs for updates: https://twitter.com/pnpmjs     │
│                                                               │
╰───────────────────────────────────────────────────────────────╯
```

I'd consider this message noise. If we want to be notified of updates, we can subscribe to pnpm release. Constantly notifying is annoying.