### PR TITLE
[test] Stop downloading unused test browsers when generating PR stats

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -111,7 +111,8 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
                   // changes from merging latest changes
                   ` && pnpm install --no-frozen-lockfile`
                 : ' && yarn install --network-timeout 1000000'
-            }`
+            }`,
+            { env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1' } }
           )
 
           await exec.spawnPromise(

--- a/.github/actions/next-stats-action/src/util/exec.js
+++ b/.github/actions/next-stats-action/src/util/exec.js
@@ -36,7 +36,7 @@ exec.spawn = function spawn(command = '', opts = {}) {
 
 exec.spawnPromise = function spawnPromise(command = '', opts = {}) {
   return new Promise((resolve, reject) => {
-    const child = exec.spawn(command)
+    const child = exec.spawn(command, opts)
     child.on('exit', (code, signal) => {
       if (code || signal) {
         return reject(


### PR DESCRIPTION
These browsers are used by Playwright which isn't used for PR stats.