### PR TITLE
docs: Explicit link to app version of cli and Link

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -232,7 +232,7 @@ program
   )
   .addHelpText(
     'after',
-    `\nLearn more: ${cyan('https://nextjs.org/docs/api-reference/cli#info')}`
+    `\nLearn more: ${cyan('https://nextjs.org/docs/app/api-reference/cli#info')}`
   )
   .option('--verbose', 'Collects additional information for debugging.')
   .action((options: NextInfoOptions) =>

--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -319,7 +319,7 @@ declare module 'next/link' {
   export type LinkProps<RouteInferType> = LinkRestProps & {
     /**
      * The path or URL to navigate to. This is the only required prop. It can also be an object.
-     * @see https://nextjs.org/docs/api-reference/next/link
+     * @see https://nextjs.org/docs/app/api-reference/components/link
      */
     href: __next_route_internal_types__.RouteImpl<RouteInferType> | UrlObject
   }


### PR DESCRIPTION
We should use explicit links when point to the docs.