### PR TITLE
Fix(docs): update the `sendGTMEvent` link when referencing gtag.js docs

### DIFF
--- a/docs/01-app/02-guides/third-party-libraries.mdx
+++ b/docs/01-app/02-guides/third-party-libraries.mdx
@@ -161,7 +161,7 @@ export function EventButton() {
 </PagesOnly>
 
 Refer to the Tag Manager [developer
-documentation](https://developers.google.com/tag-platform/gtagjs/reference/parameters) to learn about the
+documentation](https://developers.google.com/tag-platform/gtagjs/reference/events) to learn about the
 different variables and events that can be passed into the function.
 
 #### Server-side Tagging

--- a/docs/01-app/02-guides/third-party-libraries.mdx
+++ b/docs/01-app/02-guides/third-party-libraries.mdx
@@ -161,7 +161,7 @@ export function EventButton() {
 </PagesOnly>
 
 Refer to the Tag Manager [developer
-documentation](https://developers.google.com/tag-platform/tag-manager/datalayer) to learn about the
+documentation](https://developers.google.com/tag-platform/gtagjs/reference/parameters) to learn about the
 different variables and events that can be passed into the function.
 
 #### Server-side Tagging


### PR DESCRIPTION
## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
Updating an external link pointing to Google Tag Manager docs.

### Why?

Because it's written to "refer to google tag manager docs [...] for a full list of variables", but the link pointed to is a dead-end not displaying all parameters.
I therefore updated the link to the gtag.js docs where the parameters are described.

### How?

I propose to update the link in the following:
Current link:
<img width="1877" height="979" alt="CleanShot 2025-09-29 at 13 28 14" src="https://github.com/user-attachments/assets/707bb1cd-c823-42ad-b93c-6d405dda443c" />


Proposed link:
<img width="1878" height="979" alt="CleanShot 2025-09-29 at 13 30 55" src="https://github.com/user-attachments/assets/3bcaf2e9-f943-4f70-b2c3-be81d733d58e" />

