### PR TITLE
fix: remove package name from standalone build output paths

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -736,10 +736,11 @@ async function writeStandaloneDirectory(
       ]) {
         // requiredServerFiles.appDir Refers to the application directory, not App Router.
         const filePath = path.join(requiredServerFiles.appDir, file)
+        // For standalone builds, core server files should be placed directly in standalone directory
         const outputPath = path.join(
           distDir,
           STANDALONE_DIRECTORY,
-          path.relative(outputFileTracingRoot, filePath)
+          path.basename(filePath) === 'server.js' ? 'server.js' : path.relative(outputFileTracingRoot, filePath)
         )
         await fs.mkdir(path.dirname(outputPath), {
           recursive: true,
@@ -751,7 +752,6 @@ async function writeStandaloneDirectory(
         const middlewareOutput = path.join(
           distDir,
           STANDALONE_DIRECTORY,
-          path.relative(outputFileTracingRoot, distDir),
           SERVER_DIRECTORY,
           'middleware.js'
         )
@@ -768,7 +768,6 @@ async function writeStandaloneDirectory(
         path.join(
           distDir,
           STANDALONE_DIRECTORY,
-          path.relative(outputFileTracingRoot, distDir),
           SERVER_DIRECTORY,
           'pages'
         ),
@@ -782,7 +781,6 @@ async function writeStandaloneDirectory(
             path.join(
               distDir,
               STANDALONE_DIRECTORY,
-              path.relative(outputFileTracingRoot, distDir),
               SERVER_DIRECTORY,
               'app'
             ),

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1134,11 +1134,7 @@ export async function copyTracedFiles(
 
     // we always copy the package.json to the standalone
     // folder to ensure any resolving logic is maintained
-    const packageJsonOutputPath = path.join(
-      outputPath,
-      path.relative(tracingRoot, dir),
-      'package.json'
-    )
+    const packageJsonOutputPath = path.join(outputPath, 'package.json')
     await fs.mkdir(path.dirname(packageJsonOutputPath), { recursive: true })
     await fs.writeFile(packageJsonOutputPath, packageJsonContent)
   } catch {}
@@ -1156,9 +1152,13 @@ export async function copyTracedFiles(
         await copySema.acquire()
 
         const tracedFilePath = path.join(traceFileDir, relativeFile)
+        const relativeFromTracingRoot = path.relative(tracingRoot, tracedFilePath)
+        // For standalone builds, ensure server.js goes directly to standalone root
         const fileOutputPath = path.join(
           outputPath,
-          path.relative(tracingRoot, tracedFilePath)
+          relativeFromTracingRoot.endsWith('/server.js') || relativeFromTracingRoot === 'server.js'
+            ? 'server.js'
+            : relativeFromTracingRoot
         )
 
         if (!copiedFiles.has(fileOutputPath)) {
@@ -1267,11 +1267,7 @@ export async function copyTracedFiles(
   }
 
   await handleTraceFiles(path.join(distDir, 'next-server.js.nft.json'))
-  const serverOutputPath = path.join(
-    outputPath,
-    path.relative(tracingRoot, dir),
-    'server.js'
-  )
+  const serverOutputPath = path.join(outputPath, 'server.js')
   await fs.mkdir(path.dirname(serverOutputPath), { recursive: true })
 
   await fs.writeFile(


### PR DESCRIPTION
### What?
Fixed standalone build output paths to exclude workspace package names when using pnpm workspaces.

### Why?
In Next.js 15.5.0+, when using `output: 'standalone'` with pnpm workspaces, the server.js file was incorrectly placed at `.next/standalone/{package_name}/server.js` instead of the expected `.next/standalone/server.js`. This broke existing deployment scripts and Docker configurations that expect the standard location.

### How?
Modified the path calculation logic in two files:
- `packages/next/src/build/utils.ts`: Fixed server.js and package.json paths in `copyTracedFiles` function
- `packages/next/src/build/index.ts`: Fixed server.js path in `writeStandaloneDirectory` function and removed package name from middleware, pages, and app directory paths

- The fix ensures core server files are placed directly in the standalone directory while preserving directory structure for other files.

### Related Issues
- fixes: #84257