### PR TITLE
Turbopack: only replace edge dynamic calls in dev

### DIFF
--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -174,14 +174,18 @@ pub async fn get_next_server_transforms_rules(
     }
 
     if let NextRuntime::Edge = next_runtime {
-        rules.push(get_middleware_dynamic_assert_rule(mdx_rs));
+        let mode = *mode.await?;
+
+        if mode == NextMode::Development {
+            rules.push(get_middleware_dynamic_assert_rule(mdx_rs));
+        }
 
         if !foreign_code {
             rules.push(next_edge_node_api_assert(
                 mdx_rs,
                 matches!(context_ty, ServerContextType::Middleware { .. })
-                    && matches!(*mode.await?, NextMode::Build),
-                matches!(*mode.await?, NextMode::Build),
+                    && mode == NextMode::Build,
+                mode == NextMode::Build,
             ));
         }
 

--- a/crates/next-custom-transforms/src/transforms/middleware_dynamic.rs
+++ b/crates/next-custom-transforms/src/transforms/middleware_dynamic.rs
@@ -12,12 +12,13 @@ enum WrappedExpr {
     WasmInstantiate,
 }
 
-/// Replaces call / expr to dynamic evaluation in the give code to
-/// wrapped expression (__next_eval__, __next_webassembly_compile__,..) to raise
-/// corresponding error.
+/// Replaces call / expr to dynamic evaluation in the give code to wrapped expression
+/// (__next_eval__, __next_webassembly_compile__,..) to raise a (nicer) error message.
 ///
-/// This transform is specific to edge runtime which are not allowed to
-/// call certain dynamic evaluation (eval, webassembly.instantiate, etc)
+/// This should only be only used in development mode.
+///
+/// This transform is specific to edge runtime which are not allowed to call certain dynamic
+/// evaluation (eval, webassembly.instantiate, etc)
 ///
 /// check middleware-plugin for corresponding webpack side transform.
 pub fn next_middleware_dynamic() -> MiddlewareDynamic {


### PR DESCRIPTION
This replacement should only happen in dev, it's really only to be able to have nicer error messages.

This previously failed the deployment tests.

Related: https://github.com/vercel/next.js/issues/40625

Closes PACK-5591