### PR TITLE
Update cases for build complete with adapters

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -391,9 +391,11 @@ export async function handleBuildComplete({
       const exportFiles = await recursiveReadDir(configOutDir)
 
       for (const file of exportFiles) {
-        const pathname = (
+        let pathname = (
           file.endsWith('.html') ? file.replace(/\.html$/, '') : file
         ).replace(/\\/g, '/')
+
+        pathname = pathname.startsWith('/') ? pathname : `/${pathname}`
 
         outputs.staticFiles.push({
           id: file,

--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -35,6 +35,8 @@ import {
   JSON_CONTENT_TYPE_HEADER,
   NEXT_RESUME_HEADER,
 } from '../../lib/constants'
+import { normalizeLocalePath } from '../../shared/lib/i18n/normalize-locale-path'
+import { addPathPrefix } from '../../shared/lib/router/utils/add-path-prefix'
 
 interface SharedRouteFields {
   /**
@@ -61,6 +63,12 @@ interface SharedRouteFields {
    * is the absolute path to the file
    */
   assets: Record<string, string>
+
+  /**
+   * wasmAssets are bundled wasm files with mapping of name
+   * to filePath on disk
+   */
+  wasmAssets?: Record<string, string>
 
   /**
    * config related to the route
@@ -297,9 +305,30 @@ export interface NextAdapter {
   }) => Promise<void> | void
 }
 
+function normalizePathnames(
+  config: NextConfigComplete,
+  outputs: AdapterOutputs
+) {
+  // normalize pathname field with basePath
+  if (config.basePath) {
+    for (const output of [
+      ...outputs.pages,
+      ...outputs.pagesApi,
+      ...outputs.appPages,
+      ...outputs.appRoutes,
+      ...outputs.prerenders,
+      ...outputs.staticFiles,
+      ...(outputs.middleware ? [outputs.middleware] : []),
+    ]) {
+      output.pathname = addPathPrefix(output.pathname, config.basePath)
+    }
+  }
+}
+
 export async function handleBuildComplete({
   dir,
   config,
+  configOutDir,
   distDir,
   pageKeys,
   tracingRoot,
@@ -318,6 +347,7 @@ export async function handleBuildComplete({
 }: {
   dir: string
   distDir: string
+  configOutDir: string
   adapterPath: string
   tracingRoot: string
   nextVersion: string
@@ -341,16 +371,32 @@ export async function handleBuildComplete({
   if (typeof adapterMod.onBuildComplete === 'function') {
     Log.info(`Running onBuildComplete from ${adapterMod.name}`)
 
-    try {
-      const outputs: AdapterOutputs = {
-        pages: [],
-        pagesApi: [],
-        appPages: [],
-        appRoutes: [],
-        prerenders: [],
-        staticFiles: [],
-      }
+    const outputs: AdapterOutputs = {
+      pages: [],
+      pagesApi: [],
+      appPages: [],
+      appRoutes: [],
+      prerenders: [],
+      staticFiles: [],
+    }
 
+    if (config.output === 'export') {
+      // collect export assets and provide as static files
+      const exportFiles = await recursiveReadDir(configOutDir)
+
+      for (const file of exportFiles) {
+        const pathname = file.endsWith('.html')
+          ? file.replace(/\.html$/, '')
+          : file
+
+        outputs.staticFiles.push({
+          id: file,
+          pathname,
+          filePath: path.join(configOutDir, file),
+          type: AdapterOutputType.STATIC_FILE,
+        } satisfies AdapterOutput['STATIC_FILE'])
+      }
+    } else {
       const staticFiles = await recursiveReadDir(path.join(distDir, 'static'))
 
       for (const file of staticFiles) {
@@ -460,6 +506,7 @@ export async function handleBuildComplete({
               ''
           ),
           assets: {},
+          wasmAssets: {},
           config:
             type === AdapterOutputType.MIDDLEWARE
               ? {
@@ -482,8 +529,14 @@ export async function handleBuildComplete({
         for (const file of page.files) {
           handleFile(file)
         }
-        for (const item of [...(page.wasm || []), ...(page.assets || [])]) {
+        for (const item of [...(page.assets || [])]) {
           handleFile(item.filePath)
+        }
+        for (const item of page.wasm || []) {
+          if (!output.wasmAssets) {
+            output.wasmAssets = {}
+          }
+          output.wasmAssets[item.name] = item.filePath
         }
 
         if (type === AdapterOutputType.MIDDLEWARE) {
@@ -528,12 +581,28 @@ export async function handleBuildComplete({
         // if it's an auto static optimized page it's just
         // a static file
         if (staticPages.has(page)) {
-          outputs.staticFiles.push({
-            id: page,
-            pathname: route,
-            type: AdapterOutputType.STATIC_FILE,
-            filePath: pageFile.replace(/\.js$/, '.html'),
-          } satisfies AdapterOutput['STATIC_FILE'])
+          if (config.i18n) {
+            for (const locale of config.i18n.locales || []) {
+              const localePage =
+                page === '/' ? `/${locale}` : addPathPrefix(page, `/${locale}`)
+              outputs.staticFiles.push({
+                id: localePage,
+                pathname: localePage,
+                type: AdapterOutputType.STATIC_FILE,
+                filePath: path.join(
+                  pagesDistDir,
+                  `${normalizePagePath(localePage)}.html`
+                ),
+              } satisfies AdapterOutput['STATIC_FILE'])
+            }
+          } else {
+            outputs.staticFiles.push({
+              id: page,
+              pathname: route,
+              type: AdapterOutputType.STATIC_FILE,
+              filePath: pageFile.replace(/\.js$/, '.html'),
+            } satisfies AdapterOutput['STATIC_FILE'])
+          }
           continue
         }
 
@@ -639,7 +708,12 @@ export async function handleBuildComplete({
         childRoute: string,
         allowMissing?: boolean
       ) => {
-        const parentOutput = pageOutputMap[srcRoute] || appOutputMap[srcRoute]
+        const normalizedSrcRoute = normalizeLocalePath(
+          srcRoute,
+          config.i18n?.locales || []
+        ).pathname
+        const parentOutput =
+          pageOutputMap[normalizedSrcRoute] || appOutputMap[normalizedSrcRoute]
 
         if (!parentOutput && !allowMissing) {
           console.error({
@@ -966,7 +1040,11 @@ export async function handleBuildComplete({
         }
         prerenderGroupId += 1
       }
+    }
 
+    normalizePathnames(config, outputs)
+
+    try {
       await adapterMod.onBuildComplete({
         routes: {
           dynamicRoutes: routesManifest.dynamicRoutes,

--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -85,6 +85,12 @@ interface SharedRouteFields {
      * region preferences to the provider being used
      */
     preferredRegion?: string | string[]
+
+    /**
+     * env is the environment variables to expose, this is only
+     * populated for edge runtime currently
+     */
+    env?: Record<string, string>
   }
 }
 
@@ -385,9 +391,9 @@ export async function handleBuildComplete({
       const exportFiles = await recursiveReadDir(configOutDir)
 
       for (const file of exportFiles) {
-        const pathname = file.endsWith('.html')
-          ? file.replace(/\.html$/, '')
-          : file
+        const pathname = (
+          file.endsWith('.html') ? file.replace(/\.html$/, '') : file
+        ).replace(/\\/g, '/')
 
         outputs.staticFiles.push({
           id: file,
@@ -507,12 +513,14 @@ export async function handleBuildComplete({
           ),
           assets: {},
           wasmAssets: {},
-          config:
-            type === AdapterOutputType.MIDDLEWARE
+          config: {
+            ...(type === AdapterOutputType.MIDDLEWARE
               ? {
                   matchers: page.matchers,
                 }
-              : {},
+              : {}),
+            env: page.env,
+          },
         }
 
         function handleFile(file: string) {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3822,7 +3822,7 @@ export default async function build(
                       dataRoute: path.posix.join(
                         '/_next/data',
                         buildId,
-                        `${file}.json`
+                        `${localePage}.json`
                       ),
                       prefetchDataRoute: undefined,
                       allowHeader: ALLOWED_HEADERS,
@@ -4122,6 +4122,9 @@ export default async function build(
           })
       }
 
+      // This should come after output: export handling but before
+      // output: standalone, in the future output: standalone might
+      // not be allowed if an adapter with onBuildComplete is configured
       const adapterPath = config.experimental.adapterPath
       if (adapterPath) {
         await nextBuildSpan
@@ -4131,6 +4134,7 @@ export default async function build(
               dir,
               distDir,
               config,
+              configOutDir: path.join(dir, configOutDir),
               staticPages,
               nextVersion: process.env.__NEXT_VERSION as string,
               tracingRoot: outputFileTracingRoot,

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -774,983 +774,983 @@ export function runTests(ctx) {
           .replace(/\\\\/g, '\\')
           .replace(new RegExp(escapeRegex(ctx.buildId), 'g'), 'BUILD_ID')
       ).toMatchInlineSnapshot(`
-        "{
-          "/do": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/index.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/do-BE": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/index.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/do-BE/404": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/404.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/do-BE/frank": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/frank.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/do-BE/gsp": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/gsp.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/do-BE/gsp/fallback/always": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/do-BE/gsp/fallback/always.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/do-BE/not-found": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/not-found.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/do/404": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/404.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/do/frank": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/frank.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/do/gsp": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/gsp.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/do/gsp/fallback/always": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/do/gsp/fallback/always.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/do/not-found": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/not-found.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/index.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/index.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US/404": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/404.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US/frank": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/frank.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US/gsp": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/gsp.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US/gsp/fallback/always": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/fallback/always.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US/gsp/fallback/first": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/fallback/first.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US/gsp/fallback/second": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/fallback/second.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US/gsp/no-fallback/first": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/no-fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/no-fallback/first.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US/gsp/no-fallback/second": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/no-fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/no-fallback/second.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US/not-found": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/not-found.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US/not-found/blocking-fallback/first": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/not-found/blocking-fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/blocking-fallback/first.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US/not-found/blocking-fallback/second": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/not-found/blocking-fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/blocking-fallback/second.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US/not-found/fallback/first": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/not-found/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/fallback/first.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en-US/not-found/fallback/second": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/not-found/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/fallback/second.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en/404": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/404.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en/frank": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/frank.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en/gsp": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/gsp.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en/gsp/fallback/always": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/en/gsp/fallback/always.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/en/not-found": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/not-found.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/fr": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/index.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/fr-BE": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/index.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/fr-BE/404": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/404.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/fr-BE/frank": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/frank.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/fr-BE/gsp": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/gsp.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/fr-BE/gsp/fallback/always": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/fr-BE/gsp/fallback/always.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/fr-BE/not-found": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/not-found.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/fr/404": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/404.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/fr/frank": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/frank.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/fr/gsp": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/gsp.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/fr/gsp/fallback/always": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/fr/gsp/fallback/always.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/fr/not-found": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/not-found.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/go": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/index.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/go-BE": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/index.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/go-BE/404": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/404.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/go-BE/frank": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/frank.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/go-BE/gsp": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/gsp.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/go-BE/gsp/fallback/always": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/go-BE/gsp/fallback/always.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/go-BE/not-found": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/not-found.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/go/404": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/404.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/go/frank": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/frank.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/go/gsp": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/gsp.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/go/gsp/fallback/always": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/go/gsp/fallback/always.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/go/not-found": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/not-found.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/index.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl-BE": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/index.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl-BE/404": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/404.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl-BE/frank": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/frank.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl-BE/gsp": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/gsp.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl-BE/gsp/fallback/always": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/nl-BE/gsp/fallback/always.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl-BE/not-found": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/not-found.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl-NL": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/index.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl-NL/404": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/404.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl-NL/frank": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/frank.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl-NL/gsp": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/gsp.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl-NL/gsp/fallback/always": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/nl-NL/gsp/fallback/always.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl-NL/gsp/no-fallback/second": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/no-fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/nl-NL/gsp/no-fallback/second.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl-NL/not-found": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/not-found.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl/404": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/404.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl/frank": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/frank.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl/gsp": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/gsp.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl/gsp/fallback/always": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": "/gsp/fallback/[slug]",
-            "dataRoute": "/_next/data/BUILD_ID/nl/gsp/fallback/always.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          },
-          "/nl/not-found": {
-            "initialRevalidateSeconds": false,
-            "srcRoute": null,
-            "dataRoute": "/_next/data/BUILD_ID/not-found.json",
-            "allowHeader": [
-              "host",
-              "x-matched-path",
-              "x-prerender-revalidate",
-              "x-prerender-revalidate-if-generated",
-              "x-next-revalidated-tags",
-              "x-next-revalidate-tag-token"
-            ]
-          }
-        }"
+       "{
+         "/do": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/do.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/do-BE": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/do-BE.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/do-BE/404": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/do-BE/404.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/do-BE/frank": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/do-BE/frank.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/do-BE/gsp": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/do-BE/gsp.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/do-BE/gsp/fallback/always": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/do-BE/gsp/fallback/always.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/do-BE/not-found": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/do-BE/not-found.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/do/404": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/do/404.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/do/frank": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/do/frank.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/do/gsp": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/do/gsp.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/do/gsp/fallback/always": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/do/gsp/fallback/always.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/do/not-found": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/do/not-found.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/en.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/en-US.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US/404": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/en-US/404.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US/frank": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/en-US/frank.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US/gsp": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/en-US/gsp.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US/gsp/fallback/always": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/fallback/always.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US/gsp/fallback/first": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/fallback/first.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US/gsp/fallback/second": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/fallback/second.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US/gsp/no-fallback/first": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/no-fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/no-fallback/first.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US/gsp/no-fallback/second": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/no-fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/en-US/gsp/no-fallback/second.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US/not-found": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/en-US/not-found.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US/not-found/blocking-fallback/first": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/not-found/blocking-fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/blocking-fallback/first.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US/not-found/blocking-fallback/second": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/not-found/blocking-fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/blocking-fallback/second.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US/not-found/fallback/first": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/not-found/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/fallback/first.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en-US/not-found/fallback/second": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/not-found/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/en-US/not-found/fallback/second.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en/404": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/en/404.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en/frank": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/en/frank.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en/gsp": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/en/gsp.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en/gsp/fallback/always": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/en/gsp/fallback/always.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/en/not-found": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/en/not-found.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/fr": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/fr.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/fr-BE": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/fr-BE.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/fr-BE/404": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/fr-BE/404.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/fr-BE/frank": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/fr-BE/frank.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/fr-BE/gsp": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/fr-BE/gsp.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/fr-BE/gsp/fallback/always": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/fr-BE/gsp/fallback/always.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/fr-BE/not-found": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/fr-BE/not-found.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/fr/404": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/fr/404.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/fr/frank": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/fr/frank.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/fr/gsp": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/fr/gsp.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/fr/gsp/fallback/always": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/fr/gsp/fallback/always.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/fr/not-found": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/fr/not-found.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/go": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/go.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/go-BE": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/go-BE.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/go-BE/404": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/go-BE/404.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/go-BE/frank": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/go-BE/frank.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/go-BE/gsp": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/go-BE/gsp.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/go-BE/gsp/fallback/always": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/go-BE/gsp/fallback/always.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/go-BE/not-found": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/go-BE/not-found.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/go/404": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/go/404.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/go/frank": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/go/frank.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/go/gsp": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/go/gsp.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/go/gsp/fallback/always": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/go/gsp/fallback/always.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/go/not-found": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/go/not-found.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl-BE": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl-BE.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl-BE/404": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl-BE/404.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl-BE/frank": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl-BE/frank.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl-BE/gsp": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl-BE/gsp.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl-BE/gsp/fallback/always": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/nl-BE/gsp/fallback/always.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl-BE/not-found": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl-BE/not-found.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl-NL": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl-NL.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl-NL/404": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl-NL/404.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl-NL/frank": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl-NL/frank.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl-NL/gsp": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl-NL/gsp.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl-NL/gsp/fallback/always": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/nl-NL/gsp/fallback/always.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl-NL/gsp/no-fallback/second": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/no-fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/nl-NL/gsp/no-fallback/second.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl-NL/not-found": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl-NL/not-found.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl/404": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl/404.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl/frank": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl/frank.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl/gsp": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl/gsp.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl/gsp/fallback/always": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": "/gsp/fallback/[slug]",
+           "dataRoute": "/_next/data/BUILD_ID/nl/gsp/fallback/always.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         },
+         "/nl/not-found": {
+           "initialRevalidateSeconds": false,
+           "srcRoute": null,
+           "dataRoute": "/_next/data/BUILD_ID/nl/not-found.json",
+           "allowHeader": [
+             "host",
+             "x-matched-path",
+             "x-prerender-revalidate",
+             "x-prerender-revalidate-if-generated",
+             "x-next-revalidated-tags",
+             "x-next-revalidate-tag-token"
+           ]
+         }
+       }"
       `)
 
       expect(

--- a/test/production/adapter-config/adapter-config-export.test.ts
+++ b/test/production/adapter-config/adapter-config-export.test.ts
@@ -1,0 +1,87 @@
+import fs from 'fs'
+import type { NextAdapter } from 'next'
+import { nextTestSetup } from 'e2e-utils'
+import { version as nextVersion } from 'next/package.json'
+
+process.env.TEST_EXPORT = '1'
+
+describe('adapter-config export', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  it('should call onBuildComplete with correct context', async () => {
+    const nonExportFiles = [
+      'app/node-app/page.tsx',
+      'app/node-route/route.ts',
+      'app/edge-route/route.ts',
+      'app/isr-route/route.ts',
+      'app/isr-route/[slug]/route.ts',
+      'app/edge-app/page.tsx',
+      'pages/api/edge-pages.ts',
+      'pages/api/node-pages.ts',
+      'pages/edge-pages/index.tsx',
+      'pages/node-pages/index.tsx',
+    ]
+
+    for (const file of nonExportFiles) {
+      await next.remove(file)
+    }
+
+    await next.build()
+    expect(next.cliOutput).toContain('onBuildComplete called')
+
+    const {
+      outputs,
+      routes,
+      config,
+      ...ctx
+    }: Parameters<NextAdapter['onBuildComplete']>[0] = await next.readJSON(
+      'build-complete.json'
+    )
+
+    for (const field of ['distDir', 'projectDir', 'repoRoot']) {
+      expect(ctx[field]).toBeString()
+
+      if (!fs.existsSync(ctx[field])) {
+        throw new Error(
+          `Invalid dir value provided for ${field} value ${ctx[field]}`
+        )
+      }
+    }
+
+    expect(ctx.nextVersion).toBe(nextVersion)
+    expect(config?.basePath).toBe('/docs')
+
+    const combinedRouteOutputs = [
+      ...outputs.appPages,
+      ...outputs.appRoutes,
+      ...outputs.pages,
+      ...outputs.pagesApi,
+    ]
+
+    expect(outputs.middleware).toBeFalsy()
+    expect(outputs.prerenders).toEqual([])
+    expect(combinedRouteOutputs).toEqual([])
+
+    for (const output of outputs.staticFiles) {
+      expect(output.id).toBeTruthy()
+
+      if (output.filePath.endsWith('.html')) {
+        expect(output.pathname.endsWith('.html')).toBe(false)
+      }
+      expect(output.pathname).toStartWith('/docs/')
+
+      const stats = await fs.promises.stat(output.filePath)
+      expect(stats.isFile()).toBe(true)
+    }
+
+    expect(routes).toEqual({
+      dynamicRoutes: expect.toBeArray(),
+      rewrites: expect.toBeObject(),
+      redirects: expect.toBeArray(),
+      headers: expect.toBeArray(),
+    })
+  })
+})

--- a/test/production/adapter-config/adapter-config.test.ts
+++ b/test/production/adapter-config/adapter-config.test.ts
@@ -153,6 +153,15 @@ describe('adapter-config', () => {
         expect(route.config).toBeObject()
         expect(route.pathname).toBeString()
         expect(route.runtime).toBe('edge')
+        expect(route.config.env).toEqual(
+          expect.objectContaining({
+            NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: expect.toBeString(),
+            __NEXT_BUILD_ID: expect.toBeString(),
+            __NEXT_PREVIEW_MODE_ENCRYPTION_KEY: expect.toBeString(),
+            __NEXT_PREVIEW_MODE_ID: expect.toBeString(),
+            __NEXT_PREVIEW_MODE_SIGNING_KEY: expect.toBeString(),
+          })
+        )
 
         const stats = await fs.promises.stat(route.filePath)
         expect(stats.isFile()).toBe(true)

--- a/test/production/adapter-config/adapter-config.test.ts
+++ b/test/production/adapter-config/adapter-config.test.ts
@@ -95,7 +95,7 @@ describe('adapter-config', () => {
       if (output.filePath.endsWith('.html')) {
         expect(output.pathname.endsWith('.html')).toBe(false)
       } else {
-        expect(output.pathname).toStartWith('/_next/static')
+        expect(output.pathname).toStartWith('/docs/_next/static')
       }
 
       const stats = await fs.promises.stat(output.filePath)

--- a/test/production/adapter-config/next.config.mjs
+++ b/test/production/adapter-config/next.config.mjs
@@ -7,6 +7,7 @@ const nextConfig = {
     adapterPath: require.resolve('./my-adapter.mjs'),
     ppr: Boolean(process.env.TEST_PPR),
   },
+  output: process.env.TEST_EXPORT ? 'export' : undefined,
 }
 
 export default nextConfig

--- a/test/production/adapter-config/pages/isr-pages-fallback-false/[slug]/index.tsx
+++ b/test/production/adapter-config/pages/isr-pages-fallback-false/[slug]/index.tsx
@@ -27,7 +27,8 @@ export function getStaticProps({ params }) {
       params,
       now: Date.now(),
     },
-    revalidate: params.slug === 'first' ? 60 : undefined,
+    revalidate:
+      !process.env.TEST_EXPORT && params.slug === 'first' ? 60 : undefined,
   }
 }
 

--- a/test/production/adapter-config/pages/isr-pages-fallback-true/[slug]/index.tsx
+++ b/test/production/adapter-config/pages/isr-pages-fallback-true/[slug]/index.tsx
@@ -27,7 +27,8 @@ export function getStaticProps({ params }) {
       params,
       now: Date.now(),
     },
-    revalidate: params.slug === 'first' ? 60 : undefined,
+    revalidate:
+      !process.env.TEST_EXPORT && params.slug === 'first' ? 60 : undefined,
   }
 }
 

--- a/test/production/adapter-config/pages/isr-pages/[slug]/index.tsx
+++ b/test/production/adapter-config/pages/isr-pages/[slug]/index.tsx
@@ -27,7 +27,8 @@ export function getStaticProps({ params }) {
       params,
       now: Date.now(),
     },
-    revalidate: params.slug === 'first' ? 60 : undefined,
+    revalidate:
+      !process.env.TEST_EXPORT && params.slug === 'first' ? 60 : undefined,
   }
 }
 


### PR DESCRIPTION
This handles `i18n` cases, ensures `pathname` field is prefixed with `basePath` when configured, and fixes interop with `output: 'export'` configured. 