### PR TITLE
[DRAFT] Turbopack: Always encode `turbopack:///[fs]/` urls as valid URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4313,6 +4313,7 @@ dependencies = [
  "turbopack-nodejs",
  "turbopack-static",
  "turbopack-trace-utils",
+ "turbopack-url",
 ]
 
 [[package]]
@@ -4880,9 +4881,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -9284,6 +9285,7 @@ dependencies = [
  "mime",
  "notify",
  "parking_lot",
+ "percent-encoding",
  "regex",
  "rstest",
  "rustc-hash 2.1.1",
@@ -9302,6 +9304,7 @@ dependencies = [
  "turbo-tasks-hash",
  "turbo-tasks-testing",
  "turbo-unix-path",
+ "url",
  "urlencoding",
 ]
 
@@ -9541,6 +9544,7 @@ dependencies = [
  "indexmap 2.9.0",
  "once_cell",
  "patricia_tree",
+ "percent-encoding",
  "petgraph 0.6.3",
  "ref-cast",
  "regex",
@@ -9564,6 +9568,7 @@ dependencies = [
  "turbo-tasks-hash",
  "turbo-tasks-testing",
  "turbo-unix-path",
+ "turbopack-url",
  "url",
  "urlencoding",
 ]
@@ -10024,6 +10029,14 @@ dependencies = [
  "turbopack",
  "turbopack-core",
  "turbopack-resolve",
+]
+
+[[package]]
+name = "turbopack-url"
+version = "0.1.0"
+dependencies = [
+ "percent-encoding",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,6 +305,7 @@ turbopack-swc-utils = { path = "turbopack/crates/turbopack-swc-utils" }
 turbopack-test-utils = { path = "turbopack/crates/turbopack-test-utils" }
 turbopack-trace-server = { path = "turbopack/crates/turbopack-trace-server" }
 turbopack-trace-utils = { path = "turbopack/crates/turbopack-trace-utils" }
+turbopack-url = { path = "turbopack/crates/turbopack-url" }
 turbopack-wasm = { path = "turbopack/crates/turbopack-wasm" }
 
 # SWC crates
@@ -398,6 +399,7 @@ owo-colors = "4.2.2"
 parcel_selectors = "0.28.2"
 parking_lot = "0.12.1"
 pathdiff = "0.2.1"
+percent-encoding = "2.3.2"
 petgraph = "0.6.3"
 pin-project-lite = "0.2.9"
 postcard = "1.0.4"

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -682,6 +682,7 @@ impl Project {
         DiskFileSystem::new(rcstr!("output"), self.root_path.clone())
     }
 
+    // TODO: This should not be a turbo-task function as it is not portable across machines.
     #[turbo_tasks::function]
     pub fn dist_dir_absolute(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell(

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -33,7 +33,7 @@ rustc-hash = { workspace = true }
 react_remove_properties = { workspace = true }
 remove_console = { workspace = true }
 itertools = { workspace = true }
-percent-encoding = "2.3.1"
+percent-encoding = { workspace = true }
 serde_path_to_error = { workspace = true }
 swc_sourcemap = { workspace = true }
 
@@ -80,6 +80,7 @@ turbopack-node = { workspace = true }
 turbopack-nodejs = { workspace = true }
 turbopack-static = { workspace = true }
 turbopack-trace-utils = { workspace = true }
+turbopack-url = { workspace = true }
 
 [features]
 next-font-local = []

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use either::Either;
 use indoc::formatdoc;
 use itertools::Itertools;
+use percent_encoding::utf8_percent_encode;
 use rustc_hash::FxHashMap;
 use serde::Serialize;
 use tracing::Instrument;
@@ -19,13 +20,14 @@ use turbopack_core::{
     output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
 };
 use turbopack_ecmascript::utils::StringifyJs;
+use turbopack_url::ENCODE_URI_COMPONENT;
 
 use crate::{
     mode::NextMode,
     next_app::ClientReferencesChunks,
     next_client_reference::{ClientReferenceGraphResult, ClientReferenceType},
     next_config::{CrossOriginConfig, NextConfig},
-    next_manifests::{ModuleId, encode_uri_component::encode_uri_component},
+    next_manifests::ModuleId,
     util::NextRuntime,
 };
 
@@ -290,7 +292,9 @@ async fn build_manifest(
                         format!(
                             "{}{}{}",
                             prefix_path,
-                            path.split('/').map(encode_uri_component).format("/"),
+                            path.split('/')
+                                .map(|segment| utf8_percent_encode(segment, ENCODE_URI_COMPONENT))
+                                .format("/"),
                             suffix_path
                         )
                     })

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -1,7 +1,6 @@
 //! Type definitions for the Next.js manifest formats.
 
 pub mod client_reference_manifest;
-mod encode_uri_component;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -241,8 +241,7 @@ export interface Project {
   getSourceMapSync(filePath: string): string | null
 
   traceSource(
-    stackFrame: TurbopackStackFrame,
-    currentDirectoryFileUrl: string
+    stackFrame: TurbopackStackFrame
   ): Promise<TurbopackStackFrame | null>
 
   updateInfoSubscribe(

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -43,10 +43,6 @@ async function batchedTraceSource(
   frame: TurbopackStackFrame
 ): Promise<{ frame: IgnorableStackFrame; source: string | null } | undefined> {
   const file = frame.file
-    ? // TODO(veil): Why are the frames sent encoded?
-      decodeURIComponent(frame.file)
-    : undefined
-
   if (!file) return
 
   // For node internals they cannot traced the actual source code with project.traceSource,
@@ -65,9 +61,7 @@ async function batchedTraceSource(
     }
   }
 
-  const currentDirectoryFileUrl = pathToFileURL(process.cwd()).href
-
-  const sourceFrame = await project.traceSource(frame, currentDirectoryFileUrl)
+  const sourceFrame = await project.traceSource(frame)
   if (!sourceFrame) {
     return {
       frame: {

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -37,6 +37,7 @@ jsonc-parser = { version = "0.26.3", features = ["serde"] }
 mime = { workspace = true }
 notify = { workspace = true }
 parking_lot = { workspace = true }
+percent-encoding = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
@@ -50,6 +51,7 @@ turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-hash = { workspace = true }
 turbo-unix-path = { workspace = true }
+url = { workspace = true }
 urlencoding = { workspace = true }
 
 [dev-dependencies]

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -511,6 +511,10 @@ impl DiskFileSystem {
         })
     }
 
+    pub fn root_sys_path(&self) -> &Path {
+        self.inner.root_path()
+    }
+
     pub fn to_sys_path(&self, fs_path: FileSystemPath) -> Result<PathBuf> {
         let path = self.inner.root_path();
         Ok(if fs_path.path.is_empty() {

--- a/turbopack/crates/turbo-tasks-fs/src/util.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/util.rs
@@ -3,10 +3,7 @@ use std::{
     path::Path,
 };
 
-use anyhow::{Context, Result, anyhow};
-use turbo_tasks::ResolvedVc;
-
-use crate::{DiskFileSystem, FileSystemPath};
+use anyhow::{Result, anyhow};
 
 /// Converts a disk access Result<T> into a Result<Some<T>>, where a NotFound
 /// error results in a None value. This is purely to reduce boilerplate code
@@ -17,58 +14,4 @@ pub fn extract_disk_access<T>(value: io::Result<T>, path: &Path) -> Result<Optio
         Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::InvalidFilename) => Ok(None),
         Err(e) => Err(anyhow!(e).context(format!("reading file {}", path.display()))),
     }
-}
-
-#[cfg(not(target_os = "windows"))]
-pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<String> {
-    use turbo_unix_path::sys_to_unix;
-
-    let root_fs = root.fs;
-    let root_fs = &*ResolvedVc::try_downcast_type::<DiskFileSystem>(root_fs)
-        .context("Expected root to have a DiskFileSystem")?
-        .await?;
-
-    Ok(format!(
-        "file://{}",
-        &sys_to_unix(
-            &root_fs
-                .to_sys_path(match path {
-                    Some(path) => root.join(path)?,
-                    None => root,
-                })?
-                .to_string_lossy()
-        )
-        .split('/')
-        .map(|s| urlencoding::encode(s))
-        .collect::<Vec<_>>()
-        .join("/")
-    ))
-}
-
-#[cfg(target_os = "windows")]
-pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<String> {
-    let root_fs = root.fs;
-    let root_fs = &*ResolvedVc::try_downcast_type::<DiskFileSystem>(root_fs)
-        .context("Expected root to have a DiskFileSystem")?
-        .await?;
-
-    let sys_path = root_fs.to_sys_path(match path {
-        Some(path) => root.join(path.into())?,
-        None => root,
-    })?;
-
-    let raw_path = sys_path.to_string_lossy().to_string();
-    let normalized_path = raw_path.replace('\\', "/");
-
-    let mut segments = normalized_path.split('/');
-
-    let first = segments.next().unwrap_or_default(); // e.g., "C:"
-    let encoded_path = std::iter::once(first.to_string()) // keep "C:" intact
-        .chain(segments.map(|s| urlencoding::encode(s).into_owned()))
-        .collect::<Vec<_>>()
-        .join("/");
-
-    let uri = format!("file:///{}", encoded_path);
-
-    Ok(uri)
 }

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -24,6 +24,7 @@ either = { workspace = true }
 indexmap = { workspace = true }
 once_cell = { workspace = true }
 patricia_tree = "0.5.5"
+percent-encoding = { workspace = true }
 petgraph = { workspace = true, features = ["serde-1"] }
 roaring = { workspace = true, features = ["serde"] }
 ref-cast = "1.0.20"
@@ -43,9 +44,9 @@ turbo-tasks-env = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 turbo-tasks-hash = { workspace = true }
 turbo-unix-path = { workspace = true }
+turbopack-url = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
-
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/turbopack/crates/turbopack-url/Cargo.toml
+++ b/turbopack/crates/turbopack-url/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "turbopack-url"
+version = "0.1.0"
+description = "TBD"
+license = "MIT"
+edition = "2024"
+
+[lib]
+bench = false
+
+[lints]
+workspace = true
+
+[dependencies]
+url = { workspace = true }
+percent-encoding = { workspace = true }

--- a/turbopack/crates/turbopack-url/src/url_spec.rs
+++ b/turbopack/crates/turbopack-url/src/url_spec.rs
@@ -1,0 +1,52 @@
+// Copyright 2013-2016 The rust-url developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Percent encoding sets defined in the WHATWG URL spec.
+//!
+//! These are taken from the `url` crate:
+//! https://github.com/servo/rust-url/blob/22b925f93ad505a830f1089538a9ed6f5fd90612/url/src/parser.rs#L19-L46
+
+use percent_encoding::{AsciiSet, CONTROLS};
+
+/// https://url.spec.whatwg.org/#fragment-percent-encode-set
+pub const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
+
+/// https://url.spec.whatwg.org/#path-percent-encode-set
+pub const PATH: &AsciiSet = &FRAGMENT.add(b'#').add(b'?').add(b'{').add(b'}');
+
+/// https://url.spec.whatwg.org/#userinfo-percent-encode-set
+pub const USERINFO: &AsciiSet = &PATH
+    .add(b'/')
+    .add(b':')
+    .add(b';')
+    .add(b'=')
+    .add(b'@')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'|');
+
+pub const PATH_SEGMENT: &AsciiSet = &PATH.add(b'/').add(b'%');
+
+/// An extended variant of [`PATH_SEGMENT`] for `http`, `https`, `ws`, `wss`, `ftp`, and `file` url
+/// schemes.
+///
+/// The backslash (\) character is treated as a path separator in special URLs so it needs to be
+/// additionally escaped in that case.
+pub const SPECIAL_PATH_SEGMENT: &AsciiSet = &PATH_SEGMENT.add(b'\\');
+
+// https://url.spec.whatwg.org/#query-state
+pub const QUERY: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
+
+/// An extended variant of [`QUERY`] for `http`, `https`, `ws`, `wss`, `ftp`, and `file` url
+/// schemes.
+///
+/// The backslash (\) character is treated as a path separator in special URLs so it needs to be
+/// additionally escaped in that case.
+pub const SPECIAL_QUERY: &AsciiSet = &QUERY.add(b'\'');


### PR DESCRIPTION
We have a mix of some code that treats `turbopack:///` urls as proper URLs and attempts to percent encode/decode them, and some code that assumes it's just a dumb prefixed file path.

They look and smell like URLs, and the source map spec says they should be URLs, so let's treat them as actual URLs everywhere.

## TODO

- [ ] Replace remaining callsites of the `urlencoding` crate with `percent-encoding` so that we're only using one encoding library.
- [ ] Adjust changes from https://github.com/vercel/next.js/pull/84611
- [ ] Make sure I didn't horribly break everything.