### PR TITLE
Improve tests

### DIFF
--- a/test/e2e/app-dir/app/app/script-manual-nonce/show-order.js
+++ b/test/e2e/app-dir/app/app/script-manual-nonce/show-order.js
@@ -10,7 +10,9 @@ export function ShowScriptOrder() {
       <button
         id="get-order"
         onClick={() => {
-          setOrder(window._script_order)
+          // Copy the array, otherwise React won't rerender after the
+          // `window._script_order.push()` call
+          setOrder([...(window._script_order || [])])
         }}
       >
         get order

--- a/test/e2e/app-dir/app/app/script-nonce/show-order.js
+++ b/test/e2e/app-dir/app/app/script-nonce/show-order.js
@@ -10,7 +10,9 @@ export function ShowScriptOrder() {
       <button
         id="get-order"
         onClick={() => {
-          setOrder(window._script_order)
+          // Copy the array, otherwise React won't rerender after the
+          // `window._script_order.push()` call
+          setOrder([...(window._script_order || [])])
         }}
       >
         get order

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -1719,15 +1719,12 @@ describe('app dir - basic', () => {
         expect(element.attribs.nonce).toBeTruthy()
       })
 
-      if (!isNextDev) {
-        const browser = await next.browser('/script-nonce')
-
-        await retry(async () => {
-          await browser.elementByCss('#get-order').click()
-          const order = JSON.parse(await browser.elementByCss('#order').text())
-          expect(order?.length).toBe(2)
-        })
-      }
+      const browser = await next.browser('/script-nonce')
+      await retry(async () => {
+        await browser.elementByCss('#get-order').click()
+        const order = JSON.parse(await browser.elementByCss('#order').text())
+        expect(order).toEqual([2, 1])
+      })
     })
 
     it('should pass manual `nonce`', async () => {
@@ -1745,15 +1742,12 @@ describe('app dir - basic', () => {
         expect(element.attribs.nonce).toBeTruthy()
       })
 
-      if (!isNextDev) {
-        const browser = await next.browser('/script-manual-nonce')
-
-        await retry(async () => {
-          await browser.elementByCss('#get-order').click()
-          const order = JSON.parse(await browser.elementByCss('#order').text())
-          expect(order?.length).toBe(2)
-        })
-      }
+      const browser = await next.browser('/script-manual-nonce')
+      await retry(async () => {
+        await browser.elementByCss('#get-order').click()
+        const order = JSON.parse(await browser.elementByCss('#order').text())
+        expect(order).toEqual([2, 1])
+      })
     })
 
     it('should pass manual `nonce` pages', async () => {
@@ -1771,14 +1765,12 @@ describe('app dir - basic', () => {
         expect(element.attribs.nonce).toBeTruthy()
       })
 
-      if (!isNextDev) {
-        await retry(async () => {
-          const browser = await next.browser('/pages-script-manual-nonce')
-          await browser.elementByCss('#get-order').click()
-          const order = JSON.parse(await browser.elementByCss('#order').text())
-          expect(order?.length).toBe(2)
-        })
-      }
+      const browser = await next.browser('/pages-script-manual-nonce')
+      await retry(async () => {
+        await browser.elementByCss('#get-order').click()
+        const order = JSON.parse(await browser.elementByCss('#order').text())
+        expect(order).toEqual([2, 1])
+      })
     })
 
     it('should pass nonce when using next/font', async () => {

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -187,9 +187,9 @@ describe('app dir - basic', () => {
     // Turbopack doesn't recreate the original folder structure for the output chunks
     if (!process.env.IS_TURBOPACK_TEST) {
       expect(requests).toEqual(
-        // e.g. _next/static/chunks/app/dynamic-client/%5Bcategory%5D/%5Bid%5D/page-6e188d657a208f8e.js
+        // e.g. _next/static/chunks/app/dynamic-client/%5Bcategory%5D/%5Bid%5D/page-6e188d657a208f8e.js?dpl=...
         expect.arrayContaining([
-          expect.stringMatching(/.*%5Bcategory%5D\/%5Bid%5D.*\.js$/),
+          expect.stringMatching(/.*%5Bcategory%5D\/%5Bid%5D.*\.js/),
         ])
       )
     }

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -1719,12 +1719,15 @@ describe('app dir - basic', () => {
         expect(element.attribs.nonce).toBeTruthy()
       })
 
-      const browser = await next.browser('/script-nonce')
-      await retry(async () => {
-        await browser.elementByCss('#get-order').click()
-        const order = JSON.parse(await browser.elementByCss('#order').text())
-        expect(order).toEqual([2, 1])
-      })
+      if (!isNextDev) {
+        // Fails in dev due to CSP header
+        const browser = await next.browser('/script-nonce')
+        await retry(async () => {
+          await browser.elementByCss('#get-order').click()
+          const order = JSON.parse(await browser.elementByCss('#order').text())
+          expect(order).toEqual([2, 1])
+        })
+      }
     })
 
     it('should pass manual `nonce`', async () => {

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -111,6 +111,13 @@ export class NextDeployInstance extends NextInstance {
       )
     }
 
+    if (process.env.IS_TURBOPACK_TEST) {
+      additionalEnv.push(`IS_TURBOPACK_TEST=1`)
+    }
+    if (process.env.IS_WEBPACK_TEST) {
+      additionalEnv.push(`IS_WEBPACK_TEST=1`)
+    }
+
     const deployRes = await execa(
       'vercel',
       [


### PR DESCRIPTION
- should encode chunk path correctly
    - Run a base version for all bundlers
    - Use `beforePageLoad`
- nonce test:
    - open page once and wait for scripts to load
    - doesn't make sense to retry the whole thing

Closes PACK-5604