### PR TITLE
Turbopack: lock database when accessing it to prevent multiple processes on the same db

### DIFF
--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -184,7 +184,7 @@ impl Inner {
 
     /// Creates the directory and initializes it.
     fn create_and_init_directory(path: &Path) -> Result<Self> {
-        fs::create_dir_all(&path)?;
+        fs::create_dir_all(path)?;
         Self::init_directory(path)
     }
 

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -415,7 +415,7 @@ impl<S: ParallelScheduler> TurboPersistence<S> {
         path: PathBuf,
         parallel_scheduler: S,
     ) -> Result<Self> {
-        let inner = Inner::open_directory(&path, false, &parallel_scheduler)?;
+        let inner = Inner::open_directory(&path, true, &parallel_scheduler)?;
         Ok(Self::new(path, true, inner, parallel_scheduler))
     }
 

--- a/turbopack/crates/turbo-tasks-testing/src/run.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/run.rs
@@ -114,6 +114,10 @@ where
     let start = std::time::Instant::now();
     tt.stop_and_wait().await;
     println!("Stopping TurboTasks took {:?}", start.elapsed());
+    assert!(Arc::strong_count(&tt) == 1);
+    let start = std::time::Instant::now();
+    drop(tt);
+    println!("Dropping TurboTasks took {:?}", start.elapsed());
     for i in 10..20 {
         let tt = registration.create_turbo_tasks(&name, false);
         println!("Run #{i} (with persistent cache if available, new TurboTasks instance)");
@@ -123,6 +127,10 @@ where
         let start = std::time::Instant::now();
         tt.stop_and_wait().await;
         println!("Stopping TurboTasks took {:?}", start.elapsed());
+        assert!(Arc::strong_count(&tt) == 1);
+        let start = std::time::Instant::now();
+        drop(tt);
+        println!("Dropping TurboTasks took {:?}", start.elapsed());
         assert_eq!(first, third);
     }
     Ok(())


### PR DESCRIPTION
### What?

Keep a OS file lock on the `CURRENT` file to prevent multiple processes operating on the same database.

Improve error handling on database open.