### PR TITLE
[Breaking] Bump minimum TypeScript version to 5.1.0

### DIFF
--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -284,7 +284,7 @@ export default function Page() {
 
 ## Set up TypeScript
 
-> Minimum TypeScript version: `v5.0.0`
+> Minimum TypeScript version: `v5.1.0`
 
 Next.js comes with built-in TypeScript support. To add TypeScript to your project, rename a file to `.ts` / `.tsx` and run `next dev`. Next.js will automatically install the necessary dependencies and add a `tsconfig.json` file with the recommended config options.
 

--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -284,7 +284,7 @@ export default function Page() {
 
 ## Set up TypeScript
 
-> Minimum TypeScript version: `v4.5.2`
+> Minimum TypeScript version: `v5.0.0`
 
 Next.js comes with built-in TypeScript support. To add TypeScript to your project, rename a file to `.ts` / `.tsx` and run `next dev`. Next.js will automatically install the necessary dependencies and add a `tsconfig.json` file with the recommended config options.
 

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -51,13 +51,8 @@ function getDesiredCompilerOptions(
     allowJs: { suggested: true },
     skipLibCheck: { suggested: true },
     strict: { suggested: false },
-    ...(semver.lt(typescriptVersion, '5.0.0')
-      ? { forceConsistentCasingInFileNames: { suggested: true } }
-      : undefined),
     noEmit: { suggested: true },
-    ...(semver.gte(typescriptVersion, '4.4.2')
-      ? { incremental: { suggested: true } }
-      : undefined),
+    incremental: { suggested: true },
 
     // These values are required and cannot be changed by the user
     // Keep this in sync with the webpack config

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -113,9 +113,9 @@ export async function verifyTypeScriptSetup({
 
     const typescriptVersion = typescriptPackageJson.version
 
-    if (semver.lt(typescriptVersion, '5.0.0')) {
+    if (semver.lt(typescriptVersion, '5.1.0')) {
       log.warn(
-        `Minimum recommended TypeScript version is v5.0.0, older versions can potentially be incompatible with Next.js. Detected: ${typescriptVersion}`
+        `Minimum recommended TypeScript version is v5.1.0, older versions can potentially be incompatible with Next.js. Detected: ${typescriptVersion}`
       )
     }
 

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -113,9 +113,9 @@ export async function verifyTypeScriptSetup({
 
     const typescriptVersion = typescriptPackageJson.version
 
-    if (semver.lt(typescriptVersion, '4.5.2')) {
+    if (semver.lt(typescriptVersion, '5.0.0')) {
       log.warn(
-        `Minimum recommended TypeScript version is v4.5.2, older versions can potentially be incompatible with Next.js. Detected: ${typescriptVersion}`
+        `Minimum recommended TypeScript version is v5.0.0, older versions can potentially be incompatible with Next.js. Detected: ${typescriptVersion}`
       )
     }
 

--- a/test/e2e/typescript-version-warning/typescript-version-warning.test.ts
+++ b/test/e2e/typescript-version-warning/typescript-version-warning.test.ts
@@ -22,7 +22,7 @@ describe('typescript-version-warning', () => {
   it('should print warning when old typescript version is used with next build', async () => {
     await next.start().catch(() => {})
     expect(next.cliOutput).toContain(
-      'Minimum recommended TypeScript version is v5.0.0, older versions can potentially be incompatible with Next.js. Detected: 4.0.6'
+      'Minimum recommended TypeScript version is v5.1.0, older versions can potentially be incompatible with Next.js. Detected: 4.0.6'
     )
   })
 })

--- a/test/e2e/typescript-version-warning/typescript-version-warning.test.ts
+++ b/test/e2e/typescript-version-warning/typescript-version-warning.test.ts
@@ -22,7 +22,7 @@ describe('typescript-version-warning', () => {
   it('should print warning when old typescript version is used with next build', async () => {
     await next.start().catch(() => {})
     expect(next.cliOutput).toContain(
-      'Minimum recommended TypeScript version is v4.5.2, older versions can potentially be incompatible with Next.js. Detected: 4.0.6'
+      'Minimum recommended TypeScript version is v5.0.0, older versions can potentially be incompatible with Next.js. Detected: 4.0.6'
     )
   })
 })


### PR DESCRIPTION
This PR bumps the minimum TS version required for Next.js to `5.1.0`, which is the version that supports React Components that return a promise via `JSX.ElementType`.

https://devblogs.microsoft.com/typescript/announcing-typescript-5-1/#decoupled-type-checking-between-jsx-elements-and-jsx-tag-types