### PR TITLE
[Segment Cache]: add missing optimistic behavior

### DIFF
--- a/test/e2e/app-dir/searchparams-reuse-loading/app/onclick-navs/version-1/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/onclick-navs/version-1/page.tsx
@@ -7,7 +7,7 @@ export default function Page() {
   return (
     <>
       <div>
-        <Link href="/search-params?id=1" prefetch>
+        <Link href="/search-params?id=1" prefetch="unstable_forceStale">
           /search-params?id=1 (prefetch: true)
         </Link>
       </div>

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/onclick-navs/version-2/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/onclick-navs/version-2/page.tsx
@@ -7,7 +7,7 @@ export default function Page() {
   return (
     <>
       <div>
-        <Link href="/search-params" prefetch>
+        <Link href="/search-params" prefetch="unstable_forceStale">
           /search-params (prefetch: true)
         </Link>
       </div>

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/onclick-navs/version-3/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/onclick-navs/version-3/page.tsx
@@ -7,7 +7,7 @@ export default function Page() {
   return (
     <>
       <div>
-        <Link href="/search-params?id=1" prefetch>
+        <Link href="/search-params?id=1" prefetch="unstable_forceStale">
           /search-params?id=1 (prefetch: true)
         </Link>
       </div>

--- a/test/experimental-tests-manifest.json
+++ b/test/experimental-tests-manifest.json
@@ -18,14 +18,6 @@
       ],
       "failed": []
     },
-    "test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts": {
-      "passed": [],
-      "failed": [
-        "searchparams-reuse-loading should re-use loading from \"full\" prefetch for param-full URL when navigating to param-full route",
-        "searchparams-reuse-loading should re-use loading from \"full\" prefetch for param-full URL when navigating to param-less route",
-        "searchparams-reuse-loading should re-use loading from \"full\" prefetch for param-less URL when navigating to param-full route"
-      ]
-    },
     "test/production/app-dir/browser-chunks/browser-chunks.test.ts": {
       "passed": [
         "browser-chunks must not bundle any server modules into browser chunks",


### PR DESCRIPTION
With `clientSegmentCache` enabled, navigations from a prefetched URL with search params (eg `/?id=1`) to the same route without params (eg `/`) were still blocking because the optimistic path only looked for cached entries with an empty search. Symmetrically handling both directions had a TODO. This implements the missing behavior by adding a per-pathname index for route cache entries so optimistic navigations can reuse prefetched data both from "no search -> search" and "search -> no search" flows.

This re-enables the disabled test for the experimental test runners. To make it compatible with `cacheComponents`, I also had to change `prefetch={true}` to `prefetch="unstable_forceStale"` to match the behavior that was being tested as part of this test as well. 