### PR TITLE
[Segment Cache] Re-implement refresh reducer

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -8,7 +8,6 @@ import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-
 import { extractPathFromFlightRouterState } from './compute-changed-path'
 
 import type { AppRouterState } from './router-reducer-types'
-import { addRefreshMarkerToActiveParallelSegments } from './refetch-inactive-parallel-segments'
 import { getFlightDataPartsFromPath } from '../../flight-data-helpers'
 
 export interface InitialRouterStateParameters {
@@ -63,8 +62,6 @@ export function createInitialRouterState({
       ? // window.location does not have the same type as URL but has all the fields createHrefFromUrl needs.
         createHrefFromUrl(location)
       : initialCanonicalUrl
-
-  addRefreshMarkerToActiveParallelSegments(initialTree, canonicalUrl)
 
   // When the cache hasn't been seeded yet we fill the cache with the head.
   if (initialParallelRoutes === null || initialParallelRoutes.size === 0) {

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -15,9 +15,13 @@ import type {
 } from '../../../shared/lib/app-router-types'
 import { DEFAULT_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { matchSegment } from '../match-segments'
+import { revalidateEntireCache } from '../segment-cache/cache'
 import { createHrefFromUrl } from './create-href-from-url'
 import { createRouterCacheKey } from './create-router-cache-key'
-import type { FetchServerResponseResult } from './fetch-server-response'
+import {
+  fetchServerResponse,
+  type FetchServerResponseResult,
+} from './fetch-server-response'
 import { isNavigatingToNewRootLayout } from './is-navigating-to-new-root-layout'
 import { DYNAMIC_STALETIME_MS } from './reducers/navigate-reducer'
 
@@ -40,6 +44,10 @@ type SPANavigationTask = {
   // If all the segments are static, then this will be null, and no server
   // request is required.
   dynamicRequestTree: FlightRouterState | null
+  // The URL that should be used to fetch the dynamic data. This is only set
+  // when the segment cannot be refetched from the current route, because it's
+  // part of a "default" parallel slot that was reused during a navigation.
+  refreshUrl: string | null
   children: Map<string, SPANavigationTask> | null
 }
 
@@ -49,6 +57,7 @@ type MPANavigationTask = {
   route: null
   node: null
   dynamicRequestTree: null
+  refreshUrl: null
   children: null
 }
 
@@ -56,10 +65,16 @@ const MPA_NAVIGATION_TASK: MPANavigationTask = {
   route: null,
   node: null,
   dynamicRequestTree: null,
+  refreshUrl: null,
   children: null,
 }
 
 export type Task = SPANavigationTask | MPANavigationTask
+
+export type NavigationRequestAccumulation = {
+  scrollableSegments: Array<FlightSegmentPath>
+  separateRefreshUrls: Set<string> | null
+}
 
 // Creates a new Cache Node tree (i.e. copy-on-write) that represents the
 // optimistic result of a navigation, using both the current Cache Node tree and
@@ -100,7 +115,7 @@ export function startPPRNavigation(
   prefetchHead: HeadData | null,
   isPrefetchHeadPartial: boolean,
   isSamePageNavigation: boolean,
-  scrollableSegmentsResult: Array<FlightSegmentPath>
+  accumulation: NavigationRequestAccumulation
 ): Task | null {
   const segmentPath: Array<FlightSegmentPath> = []
   return updateCacheNodeOnNavigation(
@@ -115,7 +130,48 @@ export function startPPRNavigation(
     isPrefetchHeadPartial,
     isSamePageNavigation,
     segmentPath,
-    scrollableSegmentsResult
+    accumulation
+  )
+}
+
+export function startPPRRefresh(
+  navigatedAt: number,
+  currentRouterState: FlightRouterState,
+  currentNextUrl: string | null,
+  accumulation: NavigationRequestAccumulation
+): Task | null {
+  // A refresh is a special case of a navigation where all the dynamic data in
+  // the page is re-fetched. There is no "shared layout" to consider because
+  // the route hasn't changed.
+
+  // TODO: Currently, all refreshes purge the prefetch cache. In the future,
+  // only client-side refreshes will have this behavior; the server-side
+  // `refresh` should send new data without purging the prefetch cache.
+  revalidateEntireCache(currentNextUrl, currentRouterState)
+
+  // TODO: Currently refreshes do not read from the prefetch cache, as in the
+  // pre-Segment Cache implementation. This will be added in a subsequent PR.
+  const prefetchData = null
+  const prefetchHead = null
+  const isPrefetchHeadPartial = true
+
+  const isRefresh = true
+  const refreshUrl = null
+  // During a refresh, we intentionally don't pass in the previous
+  // CacheNode tree.
+  const existingCacheNode = undefined
+  const segmentPath: FlightSegmentPath = []
+  return createCacheNodeOnNavigation(
+    isRefresh,
+    refreshUrl,
+    navigatedAt,
+    currentRouterState,
+    existingCacheNode,
+    prefetchData,
+    prefetchHead,
+    isPrefetchHeadPartial,
+    segmentPath,
+    accumulation
   )
 }
 
@@ -131,7 +187,7 @@ function updateCacheNodeOnNavigation(
   isPrefetchHeadPartial: boolean,
   isSamePageNavigation: boolean,
   segmentPath: FlightSegmentPath,
-  scrollableSegmentsResult: Array<FlightSegmentPath>
+  accumulation: NavigationRequestAccumulation
 ): Task | null {
   // Diff the old and new trees to reuse the shared layouts.
   const oldRouterStateChildren = oldRouterState[1]
@@ -247,7 +303,7 @@ function updateCacheNodeOnNavigation(
           prefetchHead,
           isPrefetchHeadPartial,
           newSegmentPathChild,
-          scrollableSegmentsResult
+          accumulation
         )
       }
     } else if (
@@ -288,7 +344,7 @@ function updateCacheNodeOnNavigation(
         prefetchHead,
         isPrefetchHeadPartial,
         newSegmentPathChild,
-        scrollableSegmentsResult
+        accumulation
       )
     } else if (
       oldRouterStateChild !== undefined &&
@@ -313,7 +369,7 @@ function updateCacheNodeOnNavigation(
           isPrefetchHeadPartial,
           isSamePageNavigation,
           newSegmentPathChild,
-          scrollableSegmentsResult
+          accumulation
         )
       } else {
         // There's no existing Cache Node for this segment. Switch to the
@@ -328,7 +384,7 @@ function updateCacheNodeOnNavigation(
           prefetchHead,
           isPrefetchHeadPartial,
           newSegmentPathChild,
-          scrollableSegmentsResult
+          accumulation
         )
       }
     } else {
@@ -343,7 +399,7 @@ function updateCacheNodeOnNavigation(
         prefetchHead,
         isPrefetchHeadPartial,
         newSegmentPathChild,
-        scrollableSegmentsResult
+        accumulation
       )
     }
 
@@ -426,6 +482,9 @@ function updateCacheNodeOnNavigation(
           dynamicRequestTreeChildren
         )
       : null,
+    // This function is never called during a refresh, only a regular
+    // navigation, so we can always set this to null.
+    refreshUrl: null,
     children: taskChildren,
   }
 }
@@ -440,7 +499,7 @@ function beginRenderingNewRouteTree(
   possiblyPartialPrefetchHead: HeadData | null,
   isPrefetchHeadPartial: boolean,
   segmentPath: FlightSegmentPath,
-  scrollableSegmentsResult: Array<FlightSegmentPath>
+  accumulation: NavigationRequestAccumulation
 ): Task {
   if (!didFindRootLayout) {
     // The route tree changed before we reached a layout. (The highest-level
@@ -470,7 +529,11 @@ function beginRenderingNewRouteTree(
       return MPA_NAVIGATION_TASK
     }
   }
+  const isRefresh = false
+  const refreshUrl = null
   return createCacheNodeOnNavigation(
+    isRefresh,
+    refreshUrl,
     navigatedAt,
     newRouterState,
     existingCacheNode,
@@ -478,11 +541,13 @@ function beginRenderingNewRouteTree(
     possiblyPartialPrefetchHead,
     isPrefetchHeadPartial,
     segmentPath,
-    scrollableSegmentsResult
+    accumulation
   )
 }
 
 function createCacheNodeOnNavigation(
+  isRefresh: boolean,
+  parentRefreshUrl: string | null,
   navigatedAt: number,
   routerState: FlightRouterState,
   existingCacheNode: CacheNode | void,
@@ -490,7 +555,7 @@ function createCacheNodeOnNavigation(
   possiblyPartialPrefetchHead: HeadData | null,
   isPrefetchHeadPartial: boolean,
   segmentPath: FlightSegmentPath,
-  scrollableSegmentsResult: Array<FlightSegmentPath>
+  accumulation: NavigationRequestAccumulation
 ): SPANavigationTask {
   // Same traversal as updateCacheNodeNavigation, but we switch to this path
   // once we reach the part of the tree that was not in the previous route. We
@@ -500,6 +565,28 @@ function createCacheNodeOnNavigation(
   // on corresponding logic in fill-lazy-items-till-leaf-with-head.ts
   const routerStateChildren = routerState[1]
   const isLeafSegment = Object.keys(routerStateChildren).length === 0
+
+  let refreshUrl: string | null
+  if (isRefresh) {
+    // During a refresh navigation, there's a special case that happens when
+    // entering a "default" slot. The default slot may not be part of the
+    // current route; it may have been reused from an older route. If so,
+    // we need to fetch its data from the old route's URL rather than current
+    // route's URL. Keep track of this as we traverse the tree. See
+    // spawnPendingTask for more details.
+    const href = routerState[2]
+    refreshUrl =
+      typeof href === 'string' && routerState[3] === 'refresh'
+        ? // This segment is not present in the current route. Track its
+          // refresh URL as we continue traversing the tree.
+          href
+        : // Inherit the refresh URL from the parent.
+          parentRefreshUrl
+  } else {
+    // This is not a refresh, so there's no need to track the refresh URL as
+    // we traverse the tree.
+    refreshUrl = null
+  }
 
   // Even we're rendering inside the "new" part of the target tree, we may have
   // a locally cached segment that we can reuse. This may come from either 1)
@@ -515,6 +602,10 @@ function createCacheNodeOnNavigation(
     // DYNAMIC_STALETIME_MS defaults to 0, but it can be increased using
     // the experimental.staleTimes.dynamic config. When set, we'll avoid
     // refetching dynamic data if it was fetched within the given threshold.
+    // TODO: We should use this same logic for popstate navigations, replacing
+    // the `updateCacheNodeOnPopstateRestoration` function. That way we can
+    // handle the case where the data is missing here, like we would for a
+    // normal navigation, rather than rely on the lazy fetch in LazyRouter.
     existingCacheNode.navigatedAt + DYNAMIC_STALETIME_MS > navigatedAt
   ) {
     // We have an existing CacheNode for this segment, and it's not stale. We
@@ -546,13 +637,15 @@ function createCacheNodeOnNavigation(
       // We only have partial data from this segment. Like missing segments, we
       // must request the full data from the server.
       return spawnPendingTask(
+        isRefresh,
+        refreshUrl,
         navigatedAt,
         routerState,
         prefetchData,
         possiblyPartialPrefetchHead,
         isPrefetchHeadPartial,
         segmentPath,
-        scrollableSegmentsResult
+        accumulation
       )
     } else {
       // The prefetch data is fully static, so we can omit it from the
@@ -564,13 +657,15 @@ function createCacheNodeOnNavigation(
     // Create a terminal task node that will later be fulfilled by
     // server response.
     return spawnPendingTask(
+      isRefresh,
+      refreshUrl,
       navigatedAt,
       routerState,
       null,
       possiblyPartialPrefetchHead,
       isPrefetchHeadPartial,
       segmentPath,
-      scrollableSegmentsResult
+      accumulation
     )
   }
 
@@ -593,7 +688,7 @@ function createCacheNodeOnNavigation(
     // TODO: We should use a string to represent the segment path instead of
     // an array. We already use a string representation for the path when
     // accessing the Segment Cache, so we can use the same one.
-    scrollableSegmentsResult.push(segmentPath)
+    accumulation.scrollableSegments.push(segmentPath)
   } else {
     for (let parallelRouteKey in routerStateChildren) {
       const routerStateChild: FlightRouterState =
@@ -619,6 +714,8 @@ function createCacheNodeOnNavigation(
           : undefined
 
       const taskChild = createCacheNodeOnNavigation(
+        isRefresh,
+        refreshUrl,
         navigatedAt,
         routerStateChild,
         existingCacheNodeChild,
@@ -626,7 +723,7 @@ function createCacheNodeOnNavigation(
         possiblyPartialPrefetchHead,
         isPrefetchHeadPartial,
         segmentPathChild,
-        scrollableSegmentsResult
+        accumulation
       )
       taskChildren.set(parallelRouteKey, taskChild)
       const dynamicRequestTreeChild = taskChild.dynamicRequestTree
@@ -667,6 +764,7 @@ function createCacheNodeOnNavigation(
     dynamicRequestTree: needsDynamicRequest
       ? patchRouterStateWithNewChildren(routerState, dynamicRequestTreeChildren)
       : null,
+    refreshUrl,
     children: taskChildren,
   }
 }
@@ -692,13 +790,15 @@ function patchRouterStateWithNewChildren(
 }
 
 function spawnPendingTask(
+  isRefresh: boolean,
+  refreshUrl: string | null,
   navigatedAt: number,
   routerState: FlightRouterState,
   prefetchData: CacheNodeSeedData | null,
   prefetchHead: HeadData | null,
   isPrefetchHeadPartial: boolean,
   segmentPath: FlightSegmentPath,
-  scrollableSegmentsResult: Array<FlightSegmentPath>
+  accumulation: NavigationRequestAccumulation
 ): SPANavigationTask {
   // Create a task that will later be fulfilled by data from the server.
 
@@ -710,25 +810,53 @@ function spawnPendingTask(
   )
   dynamicRequestTree[3] = 'refetch'
 
+  if (isRefresh && refreshUrl !== null) {
+    accumulateRefreshUrl(accumulation, refreshUrl)
+  }
+
   const newTask: Task = {
     route: routerState,
 
     // Corresponds to the part of the route that will be rendered on the server.
     node: createPendingCacheNode(
+      isRefresh,
       navigatedAt,
       routerState,
       prefetchData,
       prefetchHead,
       isPrefetchHeadPartial,
       segmentPath,
-      scrollableSegmentsResult
+      accumulation
     ),
     // Because this is non-null, and it gets propagated up through the parent
     // tasks, the root task will know that it needs to perform a server request.
     dynamicRequestTree,
+    refreshUrl,
     children: null,
   }
   return newTask
+}
+
+function accumulateRefreshUrl(
+  accumulation: NavigationRequestAccumulation,
+  refreshUrl: string
+) {
+  // This is a refresh navigation, and we're inside a "default" slot that's
+  // not part of the current route; it was reused from an older route. In
+  // order to get fresh data for this reused route, we need to issue a
+  // separate request using the old route's URL.
+  //
+  // Track these extra URLs in the accumulated result. Later, we'll construct
+  // an appropriate request for each unique URL in the final set. The reason
+  // we don't do it immediately here is so we can deduplicate multiple
+  // instances of the same URL into a single request. See
+  // listenForDynamicRequest for more details.
+  const separateRefreshUrls = accumulation.separateRefreshUrls
+  if (separateRefreshUrls === null) {
+    accumulation.separateRefreshUrls = new Set([refreshUrl])
+  } else {
+    separateRefreshUrls.add(refreshUrl)
+  }
 }
 
 function reuseActiveSegmentInDefaultSlot(
@@ -766,6 +894,9 @@ function reuseActiveSegmentInDefaultSlot(
     route: reusedRouterState,
     node: null,
     dynamicRequestTree: null,
+    // This function is never called during a refresh, only a regular
+    // navigation, so we can always set this to null.
+    refreshUrl: null,
     children: null,
   }
 }
@@ -786,53 +917,154 @@ function reuseActiveSegmentInDefaultSlot(
 // This does _not_ create a new tree; it modifies the existing one in place.
 // Which means it must follow the Suspense rules of cache safety.
 export function listenForDynamicRequest(
+  url: URL,
+  nextUrl: string | null,
   task: SPANavigationTask,
-  responsePromise: Promise<FetchServerResponseResult>
-) {
-  responsePromise.then(
-    (result: FetchServerResponseResult) => {
-      if (typeof result === 'string') {
-        // Happens when navigating to page in `pages` from `app`. We shouldn't
-        // get here because should have already handled this during
-        // the prefetch.
-        return
-      }
-      const { flightData, debugInfo } = result
-      for (const normalizedFlightData of flightData) {
-        const {
-          segmentPath,
-          tree: serverRouterState,
-          seedData: dynamicData,
-          head: dynamicHead,
-        } = normalizedFlightData
-
-        if (!dynamicData) {
-          // This shouldn't happen. PPR should always send back a response.
-          // However, `FlightDataPath` is a shared type and the pre-PPR handling of
-          // this might return null.
-          continue
-        }
-
-        writeDynamicDataIntoPendingTask(
+  dynamicRequestTree: FlightRouterState,
+  existingDynamicRequestPromise: Promise<FetchServerResponseResult> | null,
+  accumulation: NavigationRequestAccumulation
+): void {
+  const requestPromises = []
+  const separateRefreshUrls = accumulation.separateRefreshUrls
+  if (separateRefreshUrls === null) {
+    // Normal case. All the data can be fetched from the same URL.
+    if (existingDynamicRequestPromise !== null) {
+      // A dynamic request was already initiated. This can happen if the route
+      // tree was not already prefetched/cached before navigation.
+      requestPromises.push(
+        attachServerResponseListener(task, existingDynamicRequestPromise)
+      )
+    } else {
+      // Initiate a new dynamic request.
+      requestPromises.push(
+        attachServerResponseListener(
           task,
-          segmentPath,
-          serverRouterState,
-          dynamicData,
-          dynamicHead,
-          debugInfo
+          fetchServerResponse(url, {
+            flightRouterState: dynamicRequestTree,
+            nextUrl,
+          })
+        )
+      )
+    }
+  } else {
+    // This is a refresh navigation, and there are multiple URLs that we need to
+    // request the data from. This happens when a "default" parallel route slot
+    // is present in the tree, and its data cannot be fetched from the current
+    // route. We need to split the combined dynamic request tree into separate
+    // requests per URL.
+    //
+    // First construct a request tree for the main URL. This will prune away
+    // the parts of the tree that are not present in the current route. (`null`
+    // as the second argument is used to represent the main URL.)
+    if (existingDynamicRequestPromise !== null) {
+      // A dynamic request was already initiated. This can happen if the route
+      // tree was not already prefetched/cached before navigation.
+      requestPromises.push(
+        attachServerResponseListener(task, existingDynamicRequestPromise)
+      )
+    } else {
+      // Initiate a new dynamic request.
+      // TODO: Create a scoped dynamic request tree that omits anything that
+      // is not relevant to the given URL. Without doing this, the server may
+      // sometimes render more data than necessary; this is not a regression
+      // compared to the pre-Segment Cache implementation, though, just an
+      // optimization we can make in the future.
+      // const primaryDynamicRequestTree = splitTaskByURL(task, null)
+      const primaryDynamicRequestTree = dynamicRequestTree
+      if (primaryDynamicRequestTree !== null) {
+        requestPromises.push(
+          attachServerResponseListener(
+            task,
+            fetchServerResponse(url, {
+              flightRouterState: primaryDynamicRequestTree,
+              nextUrl,
+            })
+          )
         )
       }
-
-      // Now that we've exhausted all the data we received from the server, if
-      // there are any remaining pending tasks in the tree, abort them now.
-      // If there's any missing data, it will trigger a lazy fetch.
-      abortTask(task, null, debugInfo)
-    },
-    (error: any) => {
-      // This will trigger an error during render
-      abortTask(task, error, null)
     }
+    // Then construct a request tree for each additional refresh URL. This will
+    // prune away everything except the parts of the tree that match the
+    // given refresh URL.
+    const canonicalUrl = createHrefFromUrl(url)
+    for (const refreshUrl of separateRefreshUrls) {
+      if (refreshUrl === canonicalUrl) {
+        // We already initiated a request for the this URL, above. Skip it.
+        // TODO: This only happens because the main URL is not tracked as
+        // part of the separateRefreshURLs set. There's probably a better way
+        // to structure this so this case doesn't happen.
+        continue
+      }
+      // TODO: Create a scoped dynamic request tree that omits anything that
+      // is not relevant to the given URL. Without doing this, the server may
+      // sometimes render more data than necessary; this is not a regression
+      // compared to the pre-Segment Cache implementation, though, just an
+      // optimization we can make in the future.
+      // const scopedDynamicRequestTree = splitTaskByURL(task, refreshUrl)
+      const scopedDynamicRequestTree = dynamicRequestTree
+      if (scopedDynamicRequestTree !== null) {
+        requestPromises.push(
+          attachServerResponseListener(
+            task,
+            fetchServerResponse(new URL(refreshUrl, url.origin), {
+              flightRouterState: scopedDynamicRequestTree,
+              nextUrl,
+            })
+          )
+        )
+      }
+    }
+  }
+
+  // Once we've exhausted all the data we received from the server, if there are
+  // any remaining pending tasks in the tree, abort them. As a last ditch
+  // effort, this will trigger the "old" fetching path (server-patch-reducer)
+  // in LayoutRouter, though in the future we'll remove server-patch-reducer
+  // and handle server failures using some more robust mechanism. Perhaps by
+  // throwing a special offline error, or by triggering an MPA refresh.
+  Promise.all(requestPromises).then(
+    () => abortTask(task, null, null),
+    () => abortTask(task, null, null)
   )
+}
+
+function attachServerResponseListener(
+  task: SPANavigationTask,
+  requestPromise: Promise<FetchServerResponseResult>
+): Promise<void> {
+  return requestPromise.then((result) => {
+    if (typeof result === 'string') {
+      // Happens when navigating to page in `pages` from `app`. We shouldn't
+      // get here because should have already handled this during
+      // the prefetch.
+      return
+    }
+    const { flightData, debugInfo } = result
+    for (const normalizedFlightData of flightData) {
+      const {
+        segmentPath,
+        tree: serverRouterState,
+        seedData: dynamicData,
+        head: dynamicHead,
+      } = normalizedFlightData
+
+      if (!dynamicData) {
+        // This shouldn't happen. PPR should always send back a response.
+        // However, `FlightDataPath` is a shared type and the pre-PPR handling of
+        // this might return null.
+        continue
+      }
+
+      writeDynamicDataIntoPendingTask(
+        task,
+        segmentPath,
+        serverRouterState,
+        dynamicData,
+        dynamicHead,
+        debugInfo
+      )
+    }
+  })
 }
 
 function writeDynamicDataIntoPendingTask(
@@ -914,8 +1146,6 @@ function finishTaskUsingDynamicDataPayload(
         dynamicHead,
         debugInfo
       )
-      // Set this to null to indicate that this task is now complete.
-      task.dynamicRequestTree = null
     }
     return
   }
@@ -956,16 +1186,24 @@ function finishTaskUsingDynamicDataPayload(
 }
 
 function createPendingCacheNode(
+  isRefresh: boolean,
   navigatedAt: number,
   routerState: FlightRouterState,
   prefetchData: CacheNodeSeedData | null,
   prefetchHead: HeadData | null,
   isPrefetchHeadPartial: boolean,
   segmentPath: FlightSegmentPath,
-  scrollableSegmentsResult: Array<FlightSegmentPath>
+  accumulation: NavigationRequestAccumulation
 ): ReadyCacheNode {
   const routerStateChildren = routerState[1]
   const prefetchDataChildren = prefetchData !== null ? prefetchData[1] : null
+
+  if (isRefresh) {
+    const refreshUrl = routerState[2]
+    if (typeof refreshUrl === 'string' && routerState[3] === 'refresh') {
+      accumulateRefreshUrl(accumulation, refreshUrl)
+    }
+  }
 
   const parallelRoutes = new Map()
   for (let parallelRouteKey in routerStateChildren) {
@@ -984,13 +1222,14 @@ function createPendingCacheNode(
     const segmentKeyChild = createRouterCacheKey(segmentChild)
 
     const newCacheNodeChild = createPendingCacheNode(
+      isRefresh,
       navigatedAt,
       routerStateChild,
       prefetchDataChild === undefined ? null : prefetchDataChild,
       prefetchHead,
       isPrefetchHeadPartial,
       segmentPathChild,
-      scrollableSegmentsResult
+      accumulation
     )
 
     const newSegmentMapChild: ChildSegmentMap = new Map()
@@ -1009,7 +1248,7 @@ function createPendingCacheNode(
     // TODO: We should use a string to represent the segment path instead of
     // an array. We already use a string representation for the path when
     // accessing the Segment Cache, so we can use the same one.
-    scrollableSegmentsResult.push(segmentPath)
+    accumulation.scrollableSegments.push(segmentPath)
   }
 
   const maybePrefetchRsc = prefetchData !== null ? prefetchData[0] : null
@@ -1085,35 +1324,27 @@ function finishPendingCacheNode(
     if (cacheNodeChild !== undefined) {
       if (
         serverStateChild !== undefined &&
-        matchSegment(taskSegmentChild, serverStateChild[0])
+        matchSegment(taskSegmentChild, serverStateChild[0]) &&
+        dataChild !== undefined &&
+        dataChild !== null
       ) {
-        if (dataChild !== undefined && dataChild !== null) {
-          // This is the happy path. Recursively update all the children.
-          finishPendingCacheNode(
-            cacheNodeChild,
-            taskStateChild,
-            serverStateChild,
-            dataChild,
-            dynamicHead,
-            debugInfo
-          )
-        } else {
-          // The server never returned data for this segment. Trigger a lazy
-          // fetch during render. This shouldn't happen because the Route Tree
-          // and the Seed Data tree sent by the server should always be the same
-          // shape when part of the same server response.
-          abortPendingCacheNode(taskStateChild, cacheNodeChild, null, debugInfo)
-        }
+        finishPendingCacheNode(
+          cacheNodeChild,
+          taskStateChild,
+          serverStateChild,
+          dataChild,
+          dynamicHead,
+          debugInfo
+        )
       } else {
-        // The server never returned data for this segment. Trigger a lazy
-        // fetch during render.
-        abortPendingCacheNode(taskStateChild, cacheNodeChild, null, debugInfo)
+        // The response does not include data for this segment, but it may
+        // be included in a separate response. Don't abort the task until all
+        // responses are received.
       }
     } else {
-      // The server response matches what was expected to receive, but there's
-      // no matching Cache Node in the task tree. This is a bug in the
-      // implementation because we should have created a node for every
-      // segment in the tree that's associated with this task.
+      // There's no matching Cache Node in the task tree. This is a bug in the
+      // implementation because we should have created a node for every segment
+      // in the tree that's associated with this task.
     }
   }
 

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -67,7 +67,7 @@ export function generateSegmentsFromPatch(
   return segments
 }
 
-function handleNavigationResult(
+export function handleNavigationResult(
   url: URL,
   state: ReadonlyReducerState,
   mutable: Mutable,
@@ -112,7 +112,13 @@ function handleNavigationResult(
       mutable.patchedTree = result.data.flightRouterState
       mutable.renderedSearch = result.data.renderedSearch
       mutable.canonicalUrl = result.data.canonicalUrl
-      mutable.scrollableSegments = result.data.scrollableSegments
+      // TODO: During a refresh, we don't set the `scrollableSegments`. There's
+      // some confusing and subtle logic in `handleMutable` that decides what
+      // to do when `shouldScroll` is set but `scrollableSegments` is not. I'm
+      // not convinced it's totally coherent but the tests assert on this
+      // particular behavior so I've ported the logic as-is from the previous
+      // router implementation, for now.
+      mutable.scrollableSegments = result.data.scrollableSegments ?? undefined
       mutable.shouldScroll = result.data.shouldScroll
       mutable.hashFragment = result.data.hash
       return handleMutable(state, mutable)

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -1,148 +1,27 @@
-import {
-  fetchServerResponse,
-  type FetchServerResponseResult,
-} from '../fetch-server-response'
-import { createHrefFromUrl } from '../create-href-from-url'
-import { applyRouterStatePatchToTree } from '../apply-router-state-patch-to-tree'
-import { isNavigatingToNewRootLayout } from '../is-navigating-to-new-root-layout'
 import type {
   Mutable,
   ReadonlyReducerState,
   ReducerState,
   RefreshAction,
 } from '../router-reducer-types'
-import { handleExternalUrl } from './navigate-reducer'
-import { handleMutable } from '../handle-mutable'
-import type { CacheNode } from '../../../../shared/lib/app-router-types'
-import { fillLazyItemsTillLeafWithHead } from '../fill-lazy-items-till-leaf-with-head'
-import { createEmptyCacheNode } from '../../app-router'
-import { handleSegmentMismatch } from '../handle-segment-mismatch'
-import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
-import { refreshInactiveParallelSegments } from '../refetch-inactive-parallel-segments'
-import { revalidateEntireCache } from '../../segment-cache/cache'
+import { handleNavigationResult } from './navigate-reducer'
+import { refresh as refreshUsingSegmentCache } from '../../segment-cache/navigation'
 
 export function refreshReducer(
   state: ReadonlyReducerState,
   action: RefreshAction
 ): ReducerState {
-  const { origin } = action
+  const currentUrl = new URL(state.canonicalUrl, action.origin)
+  const result = refreshUsingSegmentCache(
+    currentUrl,
+    state.tree,
+    state.nextUrl,
+    state.renderedSearch,
+    state.canonicalUrl
+  )
+
   const mutable: Mutable = {}
-  const href = state.canonicalUrl
-
-  let currentTree = state.tree
-
   mutable.preserveCustomHistoryState = false
 
-  const cache: CacheNode = createEmptyCacheNode()
-
-  // If the current tree was intercepted, the nextUrl should be included in the request.
-  // This is to ensure that the refresh request doesn't get intercepted, accidentally triggering the interception route.
-  const includeNextUrl = hasInterceptionRouteInCurrentTree(state.tree)
-
-  // TODO-APP: verify that `href` is not an external url.
-  // Fetch data from the root of the tree.
-  cache.lazyData = fetchServerResponse(new URL(href, origin), {
-    flightRouterState: [
-      currentTree[0],
-      currentTree[1],
-      currentTree[2],
-      'refetch',
-    ],
-    nextUrl: includeNextUrl ? state.nextUrl : null,
-  })
-
-  const navigatedAt = Date.now()
-  return cache.lazyData.then(
-    async (result: FetchServerResponseResult) => {
-      // Handle case when navigating to page in `pages` from `app`
-      if (typeof result === 'string') {
-        return handleExternalUrl(
-          state,
-          mutable,
-          result,
-          state.pushRef.pendingPush
-        )
-      }
-
-      const { flightData, canonicalUrl, renderedSearch } = result
-
-      // Remove cache.lazyData as it has been resolved at this point.
-      cache.lazyData = null
-
-      for (const normalizedFlightData of flightData) {
-        const {
-          tree: treePatch,
-          seedData: cacheNodeSeedData,
-          head,
-          isRootRender,
-        } = normalizedFlightData
-
-        if (!isRootRender) {
-          // TODO-APP: handle this case better
-          console.log('REFRESH FAILED')
-          return state
-        }
-
-        const newTree = applyRouterStatePatchToTree(
-          // TODO-APP: remove ''
-          [''],
-          currentTree,
-          treePatch,
-          state.canonicalUrl
-        )
-
-        if (newTree === null) {
-          return handleSegmentMismatch(state, action, treePatch)
-        }
-
-        if (isNavigatingToNewRootLayout(currentTree, newTree)) {
-          return handleExternalUrl(
-            state,
-            mutable,
-            href,
-            state.pushRef.pendingPush
-          )
-        }
-
-        mutable.canonicalUrl = createHrefFromUrl(canonicalUrl)
-
-        // Handles case where prefetch only returns the router tree patch without rendered components.
-        if (cacheNodeSeedData !== null) {
-          const rsc = cacheNodeSeedData[0]
-          const loading = cacheNodeSeedData[2]
-          cache.rsc = rsc
-          cache.prefetchRsc = null
-          cache.loading = loading
-          fillLazyItemsTillLeafWithHead(
-            navigatedAt,
-            cache,
-            // Existing cache is not passed in as `router.refresh()` has to invalidate the entire cache.
-            undefined,
-            treePatch,
-            cacheNodeSeedData,
-            head
-          )
-          revalidateEntireCache(state.nextUrl, newTree)
-        }
-
-        await refreshInactiveParallelSegments({
-          navigatedAt,
-          state,
-          updatedTree: newTree,
-          updatedCache: cache,
-          includeNextUrl,
-          canonicalUrl: mutable.canonicalUrl || state.canonicalUrl,
-        })
-
-        mutable.cache = cache
-        mutable.patchedTree = newTree
-        mutable.renderedSearch = renderedSearch
-
-        currentTree = newTree
-      }
-
-      return handleMutable(state, mutable)
-    },
-    () => state
-  )
+  return handleNavigationResult(currentUrl, state, mutable, false, result)
 }

--- a/test/e2e/app-dir/segment-cache/refresh/app/dashboard/@main/analytics/page.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/app/dashboard/@main/analytics/page.tsx
@@ -1,0 +1,3 @@
+export default function AnalyticsPage() {
+  return <div>Analytics page</div>
+}

--- a/test/e2e/app-dir/segment-cache/refresh/app/dashboard/@main/default.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/app/dashboard/@main/default.tsx
@@ -1,0 +1,3 @@
+export default function DefaultDashboardMain() {
+  return <div>(Default dashboard main)</div>
+}

--- a/test/e2e/app-dir/segment-cache/refresh/app/dashboard/@main/page.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/app/dashboard/@main/page.tsx
@@ -1,0 +1,3 @@
+export default function DashboardMainLandingPage() {
+  return <div>Dashboard main landing page</div>
+}

--- a/test/e2e/app-dir/segment-cache/refresh/app/dashboard/@navbar/client.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/app/dashboard/@navbar/client.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useState } from 'react'
+
+export function RenderCounterClient({ uuid }: { uuid: string }) {
+  const [counter, setCounter] = useState(0)
+  const [prevUuid, setPrevUuid] = useState(uuid)
+  if (prevUuid !== uuid) {
+    // A new dynamic value was received from the server. Increment the counter.
+    setPrevUuid(uuid)
+    setCounter(counter + 1)
+  }
+  return counter
+}

--- a/test/e2e/app-dir/segment-cache/refresh/app/dashboard/@navbar/default.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/app/dashboard/@navbar/default.tsx
@@ -1,0 +1,3 @@
+export default function DefaultDashboardNavbar() {
+  return <div>(Default dashboard navbar)</div>
+}

--- a/test/e2e/app-dir/segment-cache/refresh/app/dashboard/@navbar/page.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/app/dashboard/@navbar/page.tsx
@@ -1,0 +1,28 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import { RenderCounterClient } from './client'
+
+async function DynamicRenderCounter(): Promise<React.ReactNode> {
+  // Renders a count of the number of times the client receives new dynamic data
+  // from the server. The count is computed on the client and stored in React
+  // state, so it gets reset if the state of the tree is reset.
+  await connection()
+  const uuid = crypto.randomUUID()
+  return <RenderCounterClient uuid={uuid} />
+}
+
+export default function DashboardNavbarLandingPage() {
+  return (
+    <div>
+      <p>Navbar</p>
+      <Suspense fallback={<div>Loading...</div>}>
+        <p>
+          Navbar dynamic render counter:{' '}
+          <span id="navbar-dynamic-render-counter">
+            <DynamicRenderCounter />
+          </span>
+        </p>
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/refresh/app/dashboard/client.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/app/dashboard/client.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+export function ClientRefreshButton() {
+  const router = useRouter()
+  return (
+    <button
+      id="client-refresh-button"
+      onClick={() => {
+        router.refresh()
+      }}
+    >
+      Refresh
+    </button>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/refresh/app/dashboard/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/app/dashboard/layout.tsx
@@ -1,0 +1,30 @@
+import { LinkAccordion } from '../../components/link-accordion'
+import { ClientRefreshButton } from './client'
+
+export default function DashboardLayout({
+  navbar,
+  main,
+}: {
+  navbar: React.ReactNode
+  main: React.ReactNode
+}) {
+  return (
+    <div>
+      <div style={{ border: '1px solid black', padding: '1rem' }}>
+        {navbar}
+        <div>
+          <ClientRefreshButton />
+        </div>
+        <ul>
+          <li>
+            <LinkAccordion href="/dashboard">Dashboard Home</LinkAccordion>
+          </li>
+          <li>
+            <LinkAccordion href="/dashboard/analytics">Analytics</LinkAccordion>
+          </li>
+        </ul>
+      </div>
+      <div>{main}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/refresh/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/refresh/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/app/page.tsx
@@ -1,0 +1,5 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default async function Page() {
+  return <LinkAccordion href="/dashboard">Dashboard</LinkAccordion>
+}

--- a/test/e2e/app-dir/segment-cache/refresh/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/refresh/next.config.js
+++ b/test/e2e/app-dir/segment-cache/refresh/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  productionBrowserSourceMaps: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
+++ b/test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
@@ -1,0 +1,55 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('segment cache (refresh)', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    test('disabled in development', () => {})
+    return
+  }
+
+  it('refreshes data inside reused default parallel route slots', async () => {
+    // Load the main Dashboard page. This will render the nav bar into the
+    // @navbar slot.
+    let page: Playwright.Page
+    const browser = await next.browser('/dashboard', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Navigate to the Analytics page. The analytics page does not match the
+    // @navbar slot, so the client reuses the one that was rendered by the
+    // previous page.
+    await act(async () => {
+      const toggleAnalyticsLink = await browser.elementByCss(
+        'input[data-link-accordion="/dashboard/analytics"]'
+      )
+      await toggleAnalyticsLink.click()
+      const link = await browser.elementByCss('a[href="/dashboard/analytics"]')
+      await link.click()
+    })
+
+    // Click the refresh button and confirm the navigation bar is re-rendered,
+    // even though it's not part of the Analytics page.
+    await act(
+      async () => {
+        const refreshButton = await browser.elementById('client-refresh-button')
+        await refreshButton.click()
+      },
+      {
+        includes: 'Navbar dynamic render counter',
+      }
+    )
+
+    const navbarDynamicRenderCounter = await browser.elementById(
+      'navbar-dynamic-render-counter'
+    )
+    // If this is still 0, then the nav bar was not successfully refreshed
+    expect(await navbarDynamicRenderCounter.textContent()).toBe('1')
+  })
+})


### PR DESCRIPTION
This re-implements the refresh reducer to use the Segment Cache-style flow, similar to how the navigate reducer already works.

Most of the logic can be reused from what was already implemented for navigations. The bulk of the changes are related to the case where a "default" parallel route slot is not present on the current page, and so needs to be refreshed from an older page's URL.

Theoretically, this should be the last remaining case where we rely on the lazy fetching logic in LayoutRouter. I think there may still be some error cases where we still rely on that, though. Once these are all addressed, we can remove the lazy-fetching mechanism entirely.