### PR TITLE
Guard WebSocket upgrades & register at init

### DIFF
--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -392,7 +392,7 @@ class NextCustomServer implements NextWrapperServer {
       quiet: this.options.quiet,
     })
     this.init = initResult
-    this.setupWebSocketHandler(this.options.httpServer ?? initResult.server)
+    this.setupWebSocketHandler(this.options.httpServer)
   }
 
   private setupWebSocketHandler(customServer?: import('http').Server) {

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -392,21 +392,36 @@ class NextCustomServer implements NextWrapperServer {
       quiet: this.options.quiet,
     })
     this.init = initResult
+    this.setupWebSocketHandler(this.options.httpServer ?? initResult.server)
   }
 
-  private setupWebSocketHandler(
-    customServer?: import('http').Server,
-    _req?: IncomingMessage
-  ) {
+  private setupWebSocketHandler(customServer?: import('http').Server) {
     if (!this.didWebSocketSetup) {
       this.didWebSocketSetup = true
-      customServer = customServer || (_req?.socket as any)?.server
-
-      if (customServer) {
-        customServer.on('upgrade', async (req, socket, head) => {
-          this.upgradeHandler(req, socket, head)
+      const server = customServer
+      if (server) {
+        server.on('upgrade', (req, socket, head) => {
+          try {
+            // Basic handshake guards before delegating:
+            const toStr = (v: string | string[] | undefined) =>
+              Array.isArray(v) ? v.join(',') : v || ''
+            const isGet = req.method === 'GET'
+            const upgrade = toStr(req.headers.upgrade).toLowerCase()
+            const connection = toStr(req.headers.connection).toLowerCase()
+            if (!isGet || upgrade !== 'websocket' || !connection.includes('upgrade')) {
+              socket.write('HTTP/1.1 400 Bad Request\r\n\r\n')
+              socket.destroy()
+              return
+            }
+            Promise.resolve(this.upgradeHandler(req, socket, head)).catch(() => {
+              try { socket.destroy() } catch {}
+            })
+          } catch {
+            try { socket.destroy() } catch {}
+          }
         })
       }
+
     }
   }
 
@@ -416,8 +431,6 @@ class NextCustomServer implements NextWrapperServer {
       res: ServerResponse,
       parsedUrl?: UrlWithParsedQuery
     ) => {
-      this.setupWebSocketHandler(this.options.httpServer, req)
-
       if (parsedUrl) {
         req.url = formatUrl(parsedUrl)
       }
@@ -428,7 +441,6 @@ class NextCustomServer implements NextWrapperServer {
 
   async render(...args: Parameters<NextWrapperServer['render']>) {
     let [req, res, pathname, query, parsedUrl] = args
-    this.setupWebSocketHandler(this.options.httpServer, req as IncomingMessage)
 
     if (!pathname.startsWith('/')) {
       console.error(`Cannot render page with path "${pathname}"`)


### PR DESCRIPTION
Move WS upgrade listener registration to prepare() (trusted server), drop request-derived server detection, add basic handshake checks, and ensure errors destroy the socket.

Reduces unguarded upgrade surface and avoids side-effecty setup from arbitrary requests.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
