### PR TITLE
Fix race: only set didWebSocketSetup after attaching 'upgrade' listener

### DIFF
--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -408,8 +408,15 @@ class NextCustomServer implements NextWrapperServer {
     if (!server) {
       return
     }
-    // Already attached to this server.
-    if (this.didWebSocketSetup && this.attachedUpgradeServer === server) {
+    
+    // Already set up websocket handling
+    if (this.didWebSocketSetup) {
+      // Warn if a different server is being used
+      if (this.attachedUpgradeServer !== server) {
+        log.warn(
+          'Detected multiple HTTP servers. WebSocket upgrades are only attached to the first server encountered.'
+        )
+      }
       return
     }
 

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -335,6 +335,7 @@ export class NextServer implements NextWrapperServer {
 /** The wrapper server used for `import next from "next" (in a custom server)` */
 class NextCustomServer implements NextWrapperServer {
   private didWebSocketSetup: boolean = false
+  private attachedUpgradeServer?: import('http').Server
   protected cleanupListeners?: AsyncCallbackSet
 
   protected init?: ServerInitResult
@@ -398,17 +399,28 @@ class NextCustomServer implements NextWrapperServer {
     customServer?: import('http').Server,
     _req?: IncomingMessage
   ) {
-    if (!this.didWebSocketSetup) {
-      this.didWebSocketSetup = true
-      customServer = customServer || (_req?.socket as any)?.server
+    // Resolve the underlying HTTP server (if available)
+    const server =
+      customServer ??
+      (((_req?.socket as any)?.server as import('http').Server | undefined))
 
-      if (customServer) {
-        customServer.on('upgrade', async (req, socket, head) => {
-          this.upgradeHandler(req, socket, head)
-        })
-      }
+    // If we don't have a server yet, do nothing; try again on the next request.
+    if (!server) {
+      return
     }
-  }
+    // Already attached to this server.
+    if (this.didWebSocketSetup && this.attachedUpgradeServer === server) {
+      return
+    }
+
+    server.on('upgrade', (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+      this.upgradeHandler(req, socket, head)
+    })
+
+    this.didWebSocketSetup = true
+    this.attachedUpgradeServer = server
+   }
+
 
   getRequestHandler(): RequestHandler {
     return async (


### PR DESCRIPTION
Avoids leaving websocket upgrades unattached by deferring the flag until a server exists and the handler is actually wired.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
