### PR TITLE
Add email template update step to with-supabase example

### DIFF
--- a/examples/with-supabase/components/tutorial/sign-up-user-steps.tsx
+++ b/examples/with-supabase/components/tutorial/sign-up-user-steps.tsx
@@ -6,8 +6,7 @@ export function SignUpUserSteps() {
   return (
     <ol className="flex flex-col gap-6">
       {process.env.VERCEL_ENV === "preview" ||
-      process.env.VERCEL_ENV === "production" ||
-      true ? (
+      process.env.VERCEL_ENV === "production" ? (
         <TutorialStep title="Set up redirect urls">
           <p>It looks like this App is hosted on Vercel.</p>
           <p className="mt-4">

--- a/examples/with-supabase/components/tutorial/sign-up-user-steps.tsx
+++ b/examples/with-supabase/components/tutorial/sign-up-user-steps.tsx
@@ -6,7 +6,8 @@ export function SignUpUserSteps() {
   return (
     <ol className="flex flex-col gap-6">
       {process.env.VERCEL_ENV === "preview" ||
-      process.env.VERCEL_ENV === "production" ? (
+      process.env.VERCEL_ENV === "production" ||
+      true ? (
         <TutorialStep title="Set up redirect urls">
           <p>It looks like this App is hosted on Vercel.</p>
           <p className="mt-4">
@@ -73,6 +74,50 @@ export function SignUpUserSteps() {
           </Link>
         </TutorialStep>
       ) : null}
+      <TutorialStep title="Update email template links">
+        <p>
+          To use the auth routes in this template, you'll need to change the
+          email template to support a server-side authentication flow.
+        </p>
+
+        <p className="mt-4">
+          Go to the{" "}
+          <Link
+            className="text-primary hover:text-foreground"
+            href={"https://supabase.com/dashboard/project/_/auth/templates"}
+          >
+            Auth templates
+          </Link>{" "}
+          page in your dashboard. In the{" "}
+          <span className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-xs font-medium text-secondary-foreground border">
+            Confirm signup
+          </span>{" "}
+          template, change{" "}
+          <span className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-xs font-medium text-secondary-foreground border">
+            {`{{ .ConfirmationURL }}`}
+          </span>{" "}
+          to:
+        </p>
+        <pre className="mt-4 text-black text-xs font-mono p-3 rounded border max-h-32 overflow-auto">
+          {`{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email&next={{ .RedirectTo }}`}
+        </pre>
+
+        <p className="mt-4">
+          You'll need to make a similar change for all email templates that use{" "}
+          <span className="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-xs font-medium text-secondary-foreground border">
+            {`{{ .ConfirmationURL }}`}
+          </span>
+          .
+        </p>
+        <Link
+          href="https://supabase.com/docs/guides/auth/server-side/nextjs"
+          target="_blank"
+          className="text-primary/50 hover:text-primary flex items-center text-sm gap-1 mt-4"
+        >
+          Setting up Server-Side Auth for Next.js Docs{" "}
+          <ArrowUpRight size={14} />
+        </Link>
+      </TutorialStep>
       <TutorialStep title="Sign up your first user">
         <p>
           Head over to the{" "}


### PR DESCRIPTION
### What?
The `with-supabase` example includes some setup steps, but misses the critical step of updating auth email templates to support the server-side auth flow.

### Why?
To help users get started with less confusion and debugging 😄 

### How?
Updated the sign-up steps in the template to match the [Supabase Next.js auth docs](https://supabase.com/docs/guides/auth/server-side/nextjs)

### Additional context
This change corresponds to a similar update in the Supabase Next.js server-side auth guide: https://github.com/supabase/supabase/pull/39186

### Demo
<img width="1624" height="995" alt="Screenshot 2025-10-01 at 4 21 16 PM" src="https://github.com/user-attachments/assets/095a2bd7-2244-45d8-878c-c6e912d134f5" />
