### PR TITLE
fix: false behavior with loading.tsx in production

### DIFF
--- a/packages/next/src/client/components/router-reducer/handle-mutable.ts
+++ b/packages/next/src/client/components/router-reducer/handle-mutable.ts
@@ -14,7 +14,7 @@ export function handleMutable(
   mutable: Mutable
 ): ReducerState {
   // shouldScroll is true by default, can override to false.
-  const shouldScroll = mutable.shouldScroll ?? true
+  const shouldScroll = mutable.shouldScroll ?? state.focusAndScrollRef.apply === false ? false : true
 
   let nextUrl = state.nextUrl
 


### PR DESCRIPTION
fixes: #84423

### What?

- Fixed an issue where `router.push({ scroll: false })` still scrolls to top when using `loading.tsx` in production mode.

### Why?

- When a `loading.tsx` file is present, it creates a suspense boundary that shows a loading UI during navigation. When this boundary resolves, it triggers server patches that were resetting the scroll behavior back to `true`, ignoring the original `{ scroll: false }` option.

### How?

- Modified the `shouldScroll` logic in `handleMutable` function to preserve existing scroll state when server patches occur:


// Before:
const shouldScroll = mutable.shouldScroll ?? true

// After: 
const shouldScroll = mutable.shouldScroll ?? state.focusAndScrollRef.apply === false ? false : true