### PR TITLE
Add note about $ACTION_ properties, remove reference to .entries()

### DIFF
--- a/docs/01-app/02-guides/forms.mdx
+++ b/docs/01-app/02-guides/forms.mdx
@@ -50,7 +50,7 @@ export default function Page() {
 }
 ```
 
-> **Good to know:** When working with forms that have multiple fields, you can use the [`entries()`](https://developer.mozilla.org/en-US/docs/Web/API/FormData/entries) method with JavaScript's [`Object.fromEntries()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries). For example: `const rawFormData = Object.fromEntries(formData)`.
+> **Good to know:** When working with forms that have multiple fields, use JavaScript's [`Object.fromEntries()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries). For example: `const rawFormData = Object.fromEntries(formData)`. Note that this object will contain extra properties prefixed with `$ACTION_`.
 
 ## Passing additional arguments
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

Make a note about the `$ACTION_` properties in `formData`

### Why?

Starting with next@14.1.3, `$ACTION_` properties have appeared in the `formData`, which cause validation errors when used with a strict validation with a library such as Zod or Yup:

```tsx
// Form Client Component
export default function Form() {
  const [state, formAction] = useFormState(action, {
    type: 'initial',
  });

  return (
    <form action={action}>
      {/* ... */}
    </form>
  );
}

// Server Action
export async function action(
  prevState: ServerActionReturnValue,
  formData: FormData,
): Promise<ServerActionReturnValue> {
  const validationResult = await schema.validate(
    Object.fromEntries(formData.entries()),
  );
```

The errors from Yup:

Errors:

- this field has unspecified keys: $ACTION_REF_1, $ACTION_1:0, $ACTION_1:1, $ACTION_KEY
The data in the formData.entries()

```js
{
  '$ACTION_REF_1': '',
  '$ACTION_1:0': '{"id":"59f475b...","bound":"$@1"}',
  '$ACTION_1:1': '[{"type":"initial"}]',
  '$ACTION_KEY': 'k187677481',
  // Real form data starts here:
  year: '2024',
```

### How?

1. Document additional properties with keys starting with the prefix `$ACTION_`
2. Remove the obsolete mention of `.entries()`, since that is not being used in the code example anymore (previously, it was `const rawFormData = Object.fromEntries(formData.entries())`)

### History

- The `$ACTION_` property change was added in https://github.com/vercel/next.js/pull/63048
- The `docs/01-app/02-guides/forms.mdx` file was added in PR https://github.com/vercel/next.js/pull/79288 , without the `$ACTION_` property change

cc @delbaoliveira