### PR TITLE
Turbopack: improve incremental build performance when deployment id changes

### DIFF
--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -157,14 +157,14 @@ impl MiddlewareEndpoint {
             parse_segment_config_from_source(*self.await?.source, ParseSegmentMode::Base).await?;
         let runtime = config.runtime.unwrap_or(NextRuntime::Edge);
 
-        let next_config = this.project.next_config().await?;
-        let has_i18n = next_config.i18n.is_some();
-        let has_i18n_locales = next_config
-            .i18n
+        let next_config = this.project.next_config();
+        let i18n = next_config.i18n().await?;
+        let has_i18n = i18n.is_some();
+        let has_i18n_locales = i18n
             .as_ref()
             .map(|i18n| i18n.locales.len() > 1)
             .unwrap_or(false);
-        let base_path = next_config.base_path.as_ref();
+        let base_path = next_config.base_path().await?;
 
         let matchers = if let Some(matchers) = config.middleware_matcher.as_ref() {
             matchers
@@ -202,7 +202,7 @@ impl MiddlewareEndpoint {
 
                     source.insert_str(0, "/:nextData(_next/data/[^/]{1,})?");
 
-                    if let Some(base_path) = base_path {
+                    if let Some(base_path) = base_path.as_ref() {
                         source.insert_str(0, base_path);
                     }
 

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -408,7 +408,9 @@ pub async fn all_assets_from_entries_filtered(
                         Ok((
                             *asset,
                             if emit_spans {
-                                Some(asset.path().to_string().await?)
+                                // INVALIDATION: we don't need to invalidate the list of assets when
+                                // the span name changes
+                                Some(asset.path_string().untracked().await?)
                             } else {
                                 None
                             },
@@ -498,7 +500,9 @@ async fn get_referenced_server_assets(
             Ok(Some((
                 *asset,
                 if emit_spans {
-                    Some(asset.path().to_string().await?)
+                    // INVALIDATION: we don't need to invalidate the list of assets when the span
+                    // name changes
+                    Some(asset.path_string().untracked().await?)
                 } else {
                     None
                 },

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use tracing::{Instrument, Level, Span};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexSet, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc,
+    FxIndexSet, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc,
     graph::{AdjacencyMap, GraphTraversal, Visit, VisitControlFlow},
 };
 use turbo_tasks_fs::{FileSystemPath, rebase};
@@ -161,7 +161,9 @@ pub async fn all_assets_from_entries(entries: Vc<OutputAssets>) -> Result<Vc<Out
                         Ok((
                             *asset,
                             if emit_spans {
-                                Some(asset.path().to_string().await?)
+                                // INVALIDATION: we don't need to invalidate when the span name
+                                // changes
+                                Some(asset.path_string().untracked().await?)
                             } else {
                                 None
                             },
@@ -195,7 +197,9 @@ async fn get_referenced_assets(
             Ok((
                 *asset,
                 if emit_spans {
-                    Some(asset.path().to_string().await?)
+                    // INVALIDATION: we don't need to invalidate the list of assets when the span
+                    // name changes
+                    Some(asset.path_string().untracked().await?)
                 } else {
                     None
                 },

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -48,7 +48,7 @@ pub async fn get_app_page_entry(
     let server_component_transition =
         ResolvedVc::upcast(NextServerComponentTransition::new().to_resolved().await?);
 
-    let base_path = next_config.await?.base_path.clone();
+    let base_path = next_config.base_path().owned().await?;
     let loader_tree = AppPageLoaderTreeModule::build(
         loader_tree,
         module_asset_context,

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -60,8 +60,8 @@ pub async fn get_app_route_entry(
     let inner = rcstr!("INNER_APP_ROUTE");
 
     let output_type: &str = next_config
+        .output()
         .await?
-        .output
         .as_ref()
         .map(|o| match o {
             OutputType::Standalone => "\"standalone\"",

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -447,7 +447,7 @@ pub async fn get_client_chunking_context(
 
     let next_mode = mode.await?;
     let asset_prefix = asset_prefix.owned().await?;
-    let chunk_suffix_path = chunk_suffix_path.owned().await?;
+    let chunk_suffix_path = chunk_suffix_path.to_resolved().await?;
     let mut builder = BrowserChunkingContext::builder(
         root_path,
         client_root.clone(),

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -3,10 +3,10 @@ use std::future::Future;
 use anyhow::Result;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
-use tracing::Instrument;
+use tracing::{Instrument, Level, Span};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
+    FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TryJoinIterExt, Vc,
     debug::ValueDebugFormat,
     graph::{AdjacencyMap, GraphTraversal, Visit, VisitControlFlow},
     trace::TraceRawVcs,
@@ -121,14 +121,23 @@ pub async fn find_server_entries(
     include_traced: bool,
 ) -> Result<Vc<ServerEntries>> {
     async move {
+        let emit_spans = tracing::enabled!(Level::INFO);
         let graph = AdjacencyMap::new()
             .skip_duplicates()
             .visit(
                 vec![FindServerEntriesNode::Internal(
                     entry,
-                    entry.ident().to_string().await?,
+                    if emit_spans {
+                        // INVALIDATION: we don't need to invalidate when the span name changes
+                        Some(entry.ident_string().untracked().await?)
+                    } else {
+                        None
+                    },
                 )],
-                FindServerEntries { include_traced },
+                FindServerEntries {
+                    include_traced,
+                    emit_spans,
+                },
             )
             .await
             .completed()?
@@ -161,6 +170,7 @@ pub async fn find_server_entries(
 struct FindServerEntries {
     /// Whether to walk ChunkingType::Traced references
     include_traced: bool,
+    emit_spans: bool,
 }
 
 #[derive(
@@ -177,9 +187,12 @@ struct FindServerEntries {
 )]
 enum FindServerEntriesNode {
     ClientReference,
-    ServerComponentEntry(ResolvedVc<NextServerComponentModule>, ReadRef<RcStr>),
-    ServerUtilEntry(ResolvedVc<NextServerUtilityModule>, ReadRef<RcStr>),
-    Internal(ResolvedVc<Box<dyn Module>>, ReadRef<RcStr>),
+    ServerComponentEntry(
+        ResolvedVc<NextServerComponentModule>,
+        Option<ReadRef<RcStr>>,
+    ),
+    ServerUtilEntry(ResolvedVc<NextServerUtilityModule>, Option<ReadRef<RcStr>>),
+    Internal(ResolvedVc<Box<dyn Module>>, Option<ReadRef<RcStr>>),
 }
 
 impl Visit<FindServerEntriesNode> for FindServerEntries {
@@ -208,6 +221,7 @@ impl Visit<FindServerEntriesNode> for FindServerEntries {
             FindServerEntriesNode::ServerUtilEntry(module, _) => Vc::upcast(**module),
             FindServerEntriesNode::ServerComponentEntry(module, _) => Vc::upcast(**module),
         };
+        let emit_spans = self.emit_spans;
         async move {
             // Pass include_traced to reuse the same cached `primary_chunkable_referenced_modules`
             // task result, but the traced references will be filtered out again afterwards.
@@ -235,7 +249,13 @@ impl Visit<FindServerEntriesNode> for FindServerEntries {
                     {
                         return Ok(FindServerEntriesNode::ServerComponentEntry(
                             server_component_asset,
-                            server_component_asset.ident().to_string().await?,
+                            if emit_spans {
+                                // INVALIDATION: we don't need to invalidate when the span name
+                                // changes
+                                Some(server_component_asset.ident_string().untracked().await?)
+                            } else {
+                                None
+                            },
                         ));
                     }
 
@@ -244,13 +264,24 @@ impl Visit<FindServerEntriesNode> for FindServerEntries {
                     {
                         return Ok(FindServerEntriesNode::ServerUtilEntry(
                             server_util_module,
-                            module.ident().to_string().await?,
+                            if emit_spans {
+                                // INVALIDATION: we don't need to invalidate when the span name
+                                // changes
+                                Some(module.ident_string().untracked().await?)
+                            } else {
+                                None
+                            },
                         ));
                     }
 
                     Ok(FindServerEntriesNode::Internal(
                         *module,
-                        module.ident().to_string().await?,
+                        if emit_spans {
+                            // INVALIDATION: we don't need to invalidate when the span name changes
+                            Some(module.ident_string().untracked().await?)
+                        } else {
+                            None
+                        },
                     ))
                 });
 
@@ -261,18 +292,21 @@ impl Visit<FindServerEntriesNode> for FindServerEntries {
     }
 
     fn span(&mut self, node: &FindServerEntriesNode) -> tracing::Span {
+        if !self.emit_spans {
+            return Span::current();
+        }
         match node {
             FindServerEntriesNode::ClientReference => {
                 tracing::info_span!("client reference")
             }
             FindServerEntriesNode::Internal(_, name) => {
-                tracing::info_span!("module", name = display(name))
+                tracing::info_span!("module", name = display(name.as_ref().unwrap()))
             }
             FindServerEntriesNode::ServerUtilEntry(_, name) => {
-                tracing::info_span!("server util", name = display(name))
+                tracing::info_span!("server util", name = display(name.as_ref().unwrap()))
             }
             FindServerEntriesNode::ServerComponentEntry(_, name) => {
-                tracing::info_span!("layout segment", name = display(name))
+                tracing::info_span!("layout segment", name = display(name.as_ref().unwrap()))
             }
         }
     }

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -107,7 +107,7 @@ pub struct NextConfig {
     pub i18n: Option<I18NConfig>,
     cross_origin: Option<CrossOriginConfig>,
     pub dev_indicators: Option<DevIndicatorsConfig>,
-    pub output: Option<OutputType>,
+    output: Option<OutputType>,
     pub turbopack: Option<TurbopackConfig>,
     production_browser_source_maps: bool,
     output_file_tracing_includes: Option<serde_json::Value>,
@@ -287,13 +287,16 @@ pub struct I18NConfig {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum OutputType {
     Standalone,
     Export,
 }
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionOutputType(Option<OutputType>);
 
 #[derive(
     Debug,
@@ -1863,6 +1866,11 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn cross_origin(&self) -> Vc<OptionCrossOriginConfig> {
         Vc::cell(self.cross_origin.clone())
+    }
+
+    #[turbo_tasks::function]
+    pub fn output(&self) -> Vc<OptionOutputType> {
+        Vc::cell(self.output.clone())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -75,40 +75,40 @@ impl Default for CacheKinds {
 #[derive(Clone, Debug, Default, PartialEq)]
 #[serde(default, rename_all = "camelCase")]
 pub struct NextConfig {
-    // TODO all fields should be private and access should be wrapped within a turbo-tasks function
-    // Otherwise changing NextConfig will lead to invalidating all tasks accessing it.
-    pub config_file: Option<RcStr>,
-    pub config_file_name: RcStr,
+    // IMPORTANT: all fields should be private and access should be wrapped within a turbo-tasks
+    // function. Otherwise changing NextConfig will lead to invalidating all tasks accessing it.
+    config_file: Option<RcStr>,
+    config_file_name: RcStr,
 
     /// In-memory cache size in bytes.
     ///
     /// If `cache_max_memory_size: 0` disables in-memory caching.
-    pub cache_max_memory_size: Option<f64>,
+    cache_max_memory_size: Option<f64>,
     /// custom path to a cache handler to use
-    pub cache_handler: Option<RcStr>,
+    cache_handler: Option<RcStr>,
 
-    pub env: FxIndexMap<String, JsonValue>,
-    pub experimental: ExperimentalConfig,
-    pub images: ImageConfig,
-    pub page_extensions: Vec<RcStr>,
-    pub react_compiler: Option<ReactCompilerOptionsOrBoolean>,
-    pub react_production_profiling: Option<bool>,
-    pub react_strict_mode: Option<bool>,
-    pub transpile_packages: Option<Vec<RcStr>>,
-    pub modularize_imports: Option<FxIndexMap<String, ModularizeImportPackageConfig>>,
-    pub dist_dir: Option<RcStr>,
-    pub deployment_id: Option<RcStr>,
+    env: FxIndexMap<String, JsonValue>,
+    experimental: ExperimentalConfig,
+    images: ImageConfig,
+    page_extensions: Vec<RcStr>,
+    react_compiler: Option<ReactCompilerOptionsOrBoolean>,
+    react_production_profiling: Option<bool>,
+    react_strict_mode: Option<bool>,
+    transpile_packages: Option<Vec<RcStr>>,
+    modularize_imports: Option<FxIndexMap<String, ModularizeImportPackageConfig>>,
+    dist_dir: Option<RcStr>,
+    deployment_id: Option<RcStr>,
     sass_options: Option<serde_json::Value>,
-    pub trailing_slash: Option<bool>,
-    pub asset_prefix: Option<RcStr>,
-    pub base_path: Option<RcStr>,
-    pub skip_middleware_url_normalize: Option<bool>,
-    pub skip_trailing_slash_redirect: Option<bool>,
-    pub i18n: Option<I18NConfig>,
+    trailing_slash: Option<bool>,
+    asset_prefix: Option<RcStr>,
+    base_path: Option<RcStr>,
+    skip_middleware_url_normalize: Option<bool>,
+    skip_trailing_slash_redirect: Option<bool>,
+    i18n: Option<I18NConfig>,
     cross_origin: Option<CrossOriginConfig>,
-    pub dev_indicators: Option<DevIndicatorsConfig>,
+    dev_indicators: Option<DevIndicatorsConfig>,
     output: Option<OutputType>,
-    pub turbopack: Option<TurbopackConfig>,
+    turbopack: Option<TurbopackConfig>,
     production_browser_source_maps: bool,
     output_file_tracing_includes: Option<serde_json::Value>,
     output_file_tracing_excludes: Option<serde_json::Value>,
@@ -119,21 +119,21 @@ pub struct NextConfig {
     /// server-side bundles.
     ///
     /// [API Reference](https://nextjs.org/docs/pages/api-reference/next-config-js/bundlePagesRouterDependencies)
-    pub bundle_pages_router_dependencies: Option<bool>,
+    bundle_pages_router_dependencies: Option<bool>,
 
     /// A list of packages that should be treated as external on the server
     /// build.
     ///
     /// [API Reference](https://nextjs.org/docs/app/api-reference/next-config-js/serverExternalPackages)
-    pub server_external_packages: Option<Vec<RcStr>>,
+    server_external_packages: Option<Vec<RcStr>>,
 
     #[serde(rename = "_originalRedirects")]
-    pub original_redirects: Option<Vec<Redirect>>,
+    original_redirects: Option<Vec<Redirect>>,
 
     // Partially supported
-    pub compiler: Option<CompilerConfig>,
+    compiler: Option<CompilerConfig>,
 
-    pub optimize_fonts: Option<bool>,
+    optimize_fonts: Option<bool>,
 
     clean_dist_dir: bool,
     compress: bool,
@@ -265,7 +265,7 @@ struct HttpAgentConfig {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct DomainLocale {
@@ -276,7 +276,7 @@ pub struct DomainLocale {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct I18NConfig {
@@ -285,6 +285,9 @@ pub struct I18NConfig {
     pub locale_detection: Option<bool>,
     pub locales: Vec<String>,
 }
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionI18NConfig(Option<I18NConfig>);
 
 #[derive(
     Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
@@ -1337,6 +1340,11 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
+    pub fn base_path(&self) -> Vc<Option<RcStr>> {
+        Vc::cell(self.base_path.clone())
+    }
+
+    #[turbo_tasks::function]
     pub fn cache_handler(&self, project_path: FileSystemPath) -> Result<Vc<OptionFileSystemPath>> {
         if let Some(handler) = &self.cache_handler {
             Ok(Vc::cell(Some(project_path.join(handler)?)))
@@ -1538,6 +1546,11 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
+    pub fn inline_css(&self) -> Vc<bool> {
+        Vc::cell(self.experimental.inline_css.unwrap_or(false))
+    }
+
+    #[turbo_tasks::function]
     pub fn mdx_rs(&self) -> Vc<OptionalMdxTransformOptions> {
         let options = &self.experimental.mdx_rs;
 
@@ -1570,6 +1583,11 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn modularize_imports(&self) -> Vc<ModularizeImports> {
         Vc::cell(self.modularize_imports.clone().unwrap_or_default())
+    }
+
+    #[turbo_tasks::function]
+    pub fn dist_dir(&self) -> Vc<Option<RcStr>> {
+        Vc::cell(self.dist_dir.clone())
     }
 
     #[turbo_tasks::function]
@@ -1866,6 +1884,11 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn cross_origin(&self) -> Vc<OptionCrossOriginConfig> {
         Vc::cell(self.cross_origin.clone())
+    }
+
+    #[turbo_tasks::function]
+    pub fn i18n(&self) -> Vc<OptionI18NConfig> {
+        Vc::cell(self.i18n.clone())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -105,7 +105,7 @@ pub struct NextConfig {
     pub skip_middleware_url_normalize: Option<bool>,
     pub skip_trailing_slash_redirect: Option<bool>,
     pub i18n: Option<I18NConfig>,
-    pub cross_origin: Option<CrossOriginConfig>,
+    cross_origin: Option<CrossOriginConfig>,
     pub dev_indicators: Option<DevIndicatorsConfig>,
     pub output: Option<OutputType>,
     pub turbopack: Option<TurbopackConfig>,
@@ -157,13 +157,16 @@ pub struct NextConfig {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum CrossOriginConfig {
     Anonymous,
     UseCredentials,
 }
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionCrossOriginConfig(Option<CrossOriginConfig>);
 
 #[derive(
     Clone,
@@ -1855,6 +1858,11 @@ impl NextConfig {
                 .as_ref()
                 .map(|path| path.to_owned().into()),
         ))
+    }
+
+    #[turbo_tasks::function]
+    pub fn cross_origin(&self) -> Vc<OptionCrossOriginConfig> {
+        Vc::cell(self.cross_origin.clone())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -438,8 +438,7 @@ async fn build_manifest(
                 cached_chunk_paths(&mut client_chunk_path_cache, client_chunks.iter().copied())
                     .await?;
             // Inlining breaks HMR so it is always disabled in dev.
-            let inlined_css =
-                next_config.await?.experimental.inline_css.unwrap_or(false) && mode.is_production();
+            let inlined_css = *next_config.inline_css().await? && mode.is_production();
 
             for (chunk, chunk_path) in client_chunks_with_path {
                 if let Some(path) = client_relative_path.get_path_to(&chunk_path) {

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -175,11 +175,7 @@ async fn build_manifest(
         // TODO: Add `suffix` to the manifest for React to use.
         // entry_manifest.module_loading.prefix = prefix_path;
 
-        entry_manifest.module_loading.cross_origin = next_config
-            .await?
-            .cross_origin
-            .as_ref()
-            .map(|p| p.to_owned());
+        entry_manifest.module_loading.cross_origin = next_config.cross_origin().owned().await?;
         let ClientReferencesChunks {
             client_component_client_chunks,
             layout_segment_client_chunks,

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -399,6 +399,17 @@ impl BrowserChunkingContext {
     pub fn minify_type(&self) -> Vc<MinifyType> {
         self.minify_type.cell()
     }
+
+    /// Returns the minify type.
+    #[turbo_tasks::function]
+    fn chunk_path_info(&self) -> Vc<ChunkPathInfo> {
+        ChunkPathInfo {
+            root_path: self.root_path.clone(),
+            chunk_root_path: self.chunk_root_path.clone(),
+            content_hashing: self.content_hashing,
+        }
+        .cell()
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -439,7 +450,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
     #[turbo_tasks::function]
     async fn chunk_path(
-        &self,
+        self: Vc<Self>,
         asset: Option<Vc<Box<dyn Asset>>>,
         ident: Vc<AssetIdent>,
         prefix: Option<RcStr>,
@@ -449,11 +460,15 @@ impl ChunkingContext for BrowserChunkingContext {
             extension.starts_with("."),
             "`extension` should include the leading '.', got '{extension}'"
         );
-        let root_path = self.chunk_root_path.clone();
-        let name = match self.content_hashing {
+        let ChunkPathInfo {
+            chunk_root_path,
+            content_hashing,
+            root_path,
+        } = &*self.chunk_path_info().await?;
+        let name = match *content_hashing {
             None => {
                 ident
-                    .output_name(self.root_path.clone(), prefix, extension)
+                    .output_name(root_path.clone(), prefix, extension)
                     .owned()
                     .await?
             }
@@ -478,7 +493,7 @@ impl ChunkingContext for BrowserChunkingContext {
                 }
             }
         };
-        Ok(root_path.join(&name)?.cell())
+        Ok(chunk_root_path.join(&name)?.cell())
     }
 
     #[turbo_tasks::function]
@@ -797,4 +812,11 @@ impl ChunkingContext for BrowserChunkingContext {
     async fn debug_ids_enabled(self: Vc<Self>) -> Result<Vc<bool>> {
         Ok(Vc::cell(self.await?.debug_ids))
     }
+}
+
+#[turbo_tasks::value]
+struct ChunkPathInfo {
+    root_path: FileSystemPath,
+    chunk_root_path: FileSystemPath,
+    content_hashing: Option<ContentHashing>,
 }

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -125,8 +125,8 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
-    pub fn chunk_suffix_path(mut self, chunk_suffix_path: Option<RcStr>) -> Self {
-        self.chunking_context.chunk_suffix_path = chunk_suffix_path;
+    pub fn chunk_suffix_path(mut self, chunk_suffix_path: ResolvedVc<Option<RcStr>>) -> Self {
+        self.chunking_context.chunk_suffix_path = Some(chunk_suffix_path);
         self
     }
 
@@ -222,7 +222,7 @@ pub struct BrowserChunkingContext {
     chunk_base_path: Option<RcStr>,
     /// Suffix path that will be appended to all chunk URLs when loading them.
     /// This path will not appear in chunk paths or chunk data.
-    chunk_suffix_path: Option<RcStr>,
+    chunk_suffix_path: Option<ResolvedVc<Option<RcStr>>>,
     /// URL prefix that will be prepended to all static asset URLs when loading
     /// them.
     asset_base_path: Option<RcStr>,
@@ -381,7 +381,11 @@ impl BrowserChunkingContext {
     /// Returns the asset suffix path.
     #[turbo_tasks::function]
     pub fn chunk_suffix_path(&self) -> Vc<Option<RcStr>> {
-        Vc::cell(self.chunk_suffix_path.clone())
+        if let Some(chunk_suffix_path) = self.chunk_suffix_path {
+            *chunk_suffix_path
+        } else {
+            Vc::cell(None)
+        }
     }
 
     /// Returns the source map type.

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -400,7 +400,7 @@ impl BrowserChunkingContext {
         self.minify_type.cell()
     }
 
-    /// Returns the minify type.
+    /// Returns the chunk path information.
     #[turbo_tasks::function]
     fn chunk_path_info(&self) -> Vc<ChunkPathInfo> {
         ChunkPathInfo {

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -1,4 +1,6 @@
-use turbo_tasks::{ResolvedVc, TaskInput, Vc};
+use anyhow::Result;
+use turbo_rcstr::RcStr;
+use turbo_tasks::{ResolvedVc, TaskInput, ValueToString, Vc};
 
 use crate::{asset::Asset, ident::AssetIdent, reference::ModuleReferences};
 
@@ -17,6 +19,13 @@ pub trait Module: Asset {
     /// all properties of the [Module].
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent>;
+
+    /// The identifier of the [Module] as string. It's expected to be unique and capture
+    /// all properties of the [Module].
+    #[turbo_tasks::function]
+    async fn ident_string(self: Vc<Self>) -> Result<Vc<RcStr>> {
+        Ok(self.ident().resolve().await?.to_string())
+    }
 
     /// Other [Module]s or [OutputAsset]s referenced from this [Module].
     // TODO refactor to avoid returning [OutputAsset]s here

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, TaskInput, ValueToString, Vc};
 
@@ -23,8 +22,8 @@ pub trait Module: Asset {
     /// The identifier of the [Module] as string. It's expected to be unique and capture
     /// all properties of the [Module].
     #[turbo_tasks::function]
-    async fn ident_string(self: Vc<Self>) -> Result<Vc<RcStr>> {
-        Ok(self.ident().resolve().await?.to_string())
+    fn ident_string(self: Vc<Self>) -> Vc<RcStr> {
+        self.ident().to_string()
     }
 
     /// Other [Module]s or [OutputAsset]s referenced from this [Module].

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1702,7 +1702,8 @@ impl SingleModuleGraphBuilderNode {
         Ok(Self::Module {
             module,
             ident: if emit_spans {
-                Some(ident.to_string().await?)
+                // INVALIDATION: we don't need to invalidate when the span name changes
+                Some(ident.to_string().untracked().await?)
             } else {
                 None
             },
@@ -1718,13 +1719,15 @@ impl SingleModuleGraphBuilderNode {
             ref_data,
             source,
             source_ident: if emit_spans {
-                Some(source.ident().to_string().await?)
+                // INVALIDATION: we don't need to invalidate when the span name changes
+                Some(source.ident_string().untracked().await?)
             } else {
                 None
             },
             target,
             target_ident: if emit_spans {
-                Some(target.ident().to_string().await?)
+                // INVALIDATION: we don't need to invalidate when the span name changes
+                Some(target.ident_string().untracked().await?)
             } else {
                 None
             },

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
-use turbo_tasks::{FxIndexSet, ResolvedVc, Vc};
+use turbo_rcstr::RcStr;
+use turbo_tasks::{FxIndexSet, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::asset::Asset;
@@ -15,6 +16,13 @@ pub trait OutputAsset: Asset {
     /// capture all properties of the [OutputAsset].
     #[turbo_tasks::function]
     fn path(&self) -> Vc<FileSystemPath>;
+
+    /// The identifier of the [OutputAsset] as string. It's expected to be unique and
+    /// capture all properties of the [OutputAsset].
+    #[turbo_tasks::function]
+    async fn path_string(self: Vc<Self>) -> Result<Vc<RcStr>> {
+        Ok(self.path().resolve().await?.to_string())
+    }
 
     /// Other references [OutputAsset]s from this [OutputAsset].
     #[turbo_tasks::function]


### PR DESCRIPTION
### What?

* avoid dependencies due to tracing
* Avoid invalidating client chunking context when chunk_suffix_path changes
* BrowserChunkingContext::chunk_path only depends on a selected subset of fields
* select cross_origin field instead of depending on the whole config
* select NextConfig::output field instead of depending on the whole config
* make all next config fields private to ensure using selector functions


Closes PACK-5617