### PR TITLE
[ci]: fix build-output-prerender to support segment cache env

### DIFF
--- a/test/client-segment-cache-tests-manifest.json
+++ b/test/client-segment-cache-tests-manifest.json
@@ -86,14 +86,6 @@
       "failed": [
         "app dir - form prefetching should prefetch a loading state for the form's target"
       ]
-    },
-    "test/production/app-dir/build-output-prerender/build-output-prerender.test.ts": {
-      "failed": [
-        "build-output-prerender with a next config file with --debug-prerender prints a warning and the customized experimental flags",
-        "build-output-prerender with a next config file without --debug-prerender prints only the user-selected experimental flags (and the ones enabled via env variable)",
-        "build-output-prerender without a next config file with --debug-prerender prints a warning and the customized experimental flags",
-        "build-output-prerender without a next config file without --debug-prerender prints no experimental flags (unless enabled via env variable)"
-      ]
     }
   },
   "rules": {

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -7,6 +7,9 @@ const cacheComponentsEnabled =
 
 const pprEnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
 
+const clientSegmentCacheEnabled =
+  process.env.__NEXT_EXPERIMENTAL_CLIENT_SEGMENT_CACHE === 'true'
+
 const isRspack = !!process.env.NEXT_RSPACK
 
 describe('build-output-prerender', () => {
@@ -66,6 +69,28 @@ describe('build-output-prerender', () => {
                   ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+            `)
+          }
+        } else if (clientSegmentCacheEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ cacheComponents
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_CLIENT_SEGMENT_CACHE\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
+                  ✓ ppr (enabled by \`experimental.cacheComponents\`)
+                  ✓ rdcForNavigations (enabled by \`experimental.ppr\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z (webpack)
+                - Experiments (use with caution):
+                  ✓ cacheComponents
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_CLIENT_SEGMENT_CACHE\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
+                  ✓ ppr (enabled by \`experimental.cacheComponents\`)
+                  ✓ rdcForNavigations (enabled by \`experimental.ppr\`)"
             `)
           }
         } else {
@@ -206,6 +231,36 @@ describe('build-output-prerender', () => {
                   ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
           }
+        } else if (clientSegmentCacheEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ cacheComponents
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_CLIENT_SEGMENT_CACHE\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
+                  ✓ ppr (enabled by \`experimental.cacheComponents\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ rdcForNavigations (enabled by \`experimental.ppr\`)
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z (webpack)
+                - Experiments (use with caution):
+                  ✓ cacheComponents
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_CLIENT_SEGMENT_CACHE\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
+                  ✓ ppr (enabled by \`experimental.cacheComponents\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ rdcForNavigations (enabled by \`experimental.ppr\`)
+                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          }
         } else {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
@@ -335,6 +390,20 @@ describe('build-output-prerender', () => {
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
             `)
           }
+        } else if (clientSegmentCacheEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_CLIENT_SEGMENT_CACHE\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z (webpack)
+                - Experiments (use with caution):
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_CLIENT_SEGMENT_CACHE\`)"
+            `)
+          }
         } else {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(
@@ -421,6 +490,30 @@ describe('build-output-prerender', () => {
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          }
+        } else if (clientSegmentCacheEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z (Turbopack)
+                - Experiments (use with caution):
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_CLIENT_SEGMENT_CACHE\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+                ▲ Next.js x.y.z (webpack)
+                - Experiments (use with caution):
+                  ✓ clientSegmentCache (enabled by \`__NEXT_EXPERIMENTAL_CLIENT_SEGMENT_CACHE\`)
+                  ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
+                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                   ⨯ serverMinification (disabled by \`--debug-prerender\`)
                   ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)


### PR DESCRIPTION
These tests were only failing with segment cache because I added an env variable to test `clientSegmentCache` independently. This updates the snapshots.