### PR TITLE
telemetry track mcp server usage

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1512,7 +1512,6 @@ export const defaultConfig = Object.freeze({
     browserDebugInfoInTerminal: false,
     isolatedDevBuild:
       process.env.__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD === 'true',
-    mcpServer: !!process.env.__NEXT_EXPERIMENTAL_MCP_SERVER,
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1116,6 +1116,13 @@ function assignDefaultsAndValidate(
     result.htmlLimitedBots = HTML_LIMITED_BOT_UA_RE_STRING
   }
 
+  if (
+    typeof result.experimental.mcpServer === 'undefined' &&
+    process.env.__NEXT_EXPERIMENTAL_MCP_SERVER === 'true'
+  ) {
+    result.experimental.mcpServer = true
+  }
+
   // "use cache" was originally implicitly enabled with the cacheComponents flag, so
   // we transfer the value for cacheComponents to the explicit useCache flag to ensure
   // backwards compatibility.

--- a/packages/next/src/telemetry/events/version.ts
+++ b/packages/next/src/telemetry/events/version.ts
@@ -40,6 +40,7 @@ type EventCliSessionStarted = {
   reactCompiler: boolean
   reactCompilerCompilationMode: string | null
   reactCompilerPanicThreshold: string | null
+  mcpServer: boolean | null
 }
 
 export function eventCliSession(
@@ -74,6 +75,7 @@ export function eventCliSession(
     | 'reactCompiler'
     | 'reactCompilerCompilationMode'
     | 'reactCompilerPanicThreshold'
+    | 'mcpServer'
     | 'isRspack'
   >
 ): { eventName: string; payload: EventCliSessionStarted }[] {
@@ -131,6 +133,10 @@ export function eventCliSession(
     reactCompilerPanicThreshold:
       typeof nextConfig.reactCompiler !== 'boolean'
         ? (nextConfig.reactCompiler?.panicThreshold ?? null)
+        : null,
+    mcpServer:
+      typeof nextConfig.experimental.mcpServer === 'boolean'
+        ? nextConfig.experimental.mcpServer
         : null,
   }
   return [{ eventName: EVENT_VERSION, payload }]


### PR DESCRIPTION
* Track the `experimental.mcpServer` usage through telemetry
* Set the default mcpServer as `undefined` unless you enable through env var