### PR TITLE
fix: Missing link in Lazy Loading docs

### DIFF
--- a/docs/01-app/02-guides/lazy-loading.mdx
+++ b/docs/01-app/02-guides/lazy-loading.mdx
@@ -24,6 +24,7 @@ By default, Server Components are automatically [code split](https://developer.m
 ## Examples
 
 <AppOnly>
+
 ### Importing Client Components
 
 ```jsx filename="app/page.js"


### PR DESCRIPTION
Add missing space before "Importing Client Components" in Lazy Loading /app docs.

This fixes the missing link in "On this page" sidebar:

<img width="1092" height="446" alt="image" src="https://github.com/user-attachments/assets/0981467d-ad61-494d-80b2-c0a0e323dd0b" />

In the current state, the first link is "Skipping SSR" (second link) instead of "Importing Client Components"