### PR TITLE
make withRspack idempotent

### DIFF
--- a/packages/next-rspack/index.js
+++ b/packages/next-rspack/index.js
@@ -1,11 +1,16 @@
+Error.stackTraceLimit = 100
 module.exports = function withRspack(config) {
-  process.env.NEXT_RSPACK = 'true'
-  process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent'
+  if (process.env.NEXT_RSPACK === 'true') {
+    // we have already been called.  This can happen when using build workers.
+    return config
+  }
   if (process.env.TURBOPACK === 'auto') {
-    // If next has defaulted to turbopack, override it.
     delete process.env.TURBOPACK
+    process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent'
+    process.env.NEXT_RSPACK = 'true'
   } else {
-    console.error(
+    // Either The TURBOPACK flag wasn't set which means --wepack was, or the TURBOPACK flag was set to 1 because --turbopack was passed.
+    console.trace(
       `Cannot call withRspack and pass the ${process.env.TURBOPACK ? '--turbopack' : '--webpack'} flag.`
     )
     console.error('Please configure only one bundler.')


### PR DESCRIPTION
`loadConfig` can get called multiple times in a build or dev session.

in `dev` it gets called multiple times at the end of a session and of course whenever a session restarts
in `build` it can get called multiple times due to build workers

For that reason it needs to be idempotent, so change `withRspack` to detect if it has  already run and short circuit.  Otherwise it will always fail the second time complaining that you passed `--wepack` (because the first run deleted the TURBOPACK env var).

See discussion: https://github.com/vercel/next.js/pull/84394#issuecomment-3364615461


Closes PACK-5621