### PR TITLE
add @tursodatabase/*-wasm packages to server-external

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverExternalPackages.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverExternalPackages.mdx
@@ -36,6 +36,8 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@sparticuz/chromium`
 - `@sparticuz/chromium-min`
 - `@swc/core`
+- `@tursodatabase/database-wasm`
+- `@tursodatabase/sync-wasm`
 - `@xenova/transformers`
 - `argon2`
 - `autoprefixer`

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
@@ -36,7 +36,7 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@sparticuz/chromium`
 - `@sparticuz/chromium-min`
 - `@swc/core`
-- `@tursodatabase/datbase-wasm`
+- `@tursodatabase/database-wasm`
 - `@tursodatabase/sync-wasm`
 - `@xenova/transformers`
 - `argon2`

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/serverExternalPackages.mdx
@@ -36,6 +36,8 @@ Next.js includes a [short list of popular packages](https://github.com/vercel/ne
 - `@sparticuz/chromium`
 - `@sparticuz/chromium-min`
 - `@swc/core`
+- `@tursodatabase/datbase-wasm`
+- `@tursodatabase/sync-wasm`
 - `@xenova/transformers`
 - `argon2`
 - `autoprefixer`

--- a/packages/next/src/lib/server-external-packages.json
+++ b/packages/next/src/lib/server-external-packages.json
@@ -17,6 +17,8 @@
   "@sparticuz/chromium",
   "@sparticuz/chromium-min",
   "@swc/core",
+  "@tursodatabase/database-wasm",
+  "@tursodatabase/sync-wasm",
   "@xenova/transformers",
   "argon2",
   "autoprefixer",


### PR DESCRIPTION
These packages needs to be externalized to have it's wasm dependencies traced properly for node runtime so this adds it to the default list.