### PR TITLE
[docs] update other params type of metadata image routes

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/app-icons.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/app-icons.mdx
@@ -262,6 +262,7 @@ export default function Icon() {}
 
 ## Version History
 
-| Version   | Changes                                      |
-| --------- | -------------------------------------------- |
-| `v13.3.0` | `favicon` `icon` and `apple-icon` introduced |
+| Version   | Changes                                              |
+| --------- | ---------------------------------------------------- |
+| `v16.0.0` | `params` is now a promise that resolves to an object |
+| `v13.3.0` | `favicon` `icon` and `apple-icon` introduced         |

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/app-icons.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/app-icons.mdx
@@ -199,11 +199,11 @@ export default async function Icon({ params }) {
 }
 ```
 
-| Route                           | URL         | `params`                  |
-| ------------------------------- | ----------- | ------------------------- |
-| `app/shop/icon.js`              | `/shop`     | `undefined`               |
-| `app/shop/[slug]/icon.js`       | `/shop/1`   | `{ slug: '1' }`           |
-| `app/shop/[tag]/[item]/icon.js` | `/shop/1/2` | `{ tag: '1', item: '2' }` |
+| Route                           | URL         | `params`                           |
+| ------------------------------- | ----------- | ---------------------------------- |
+| `app/shop/icon.js`              | `/shop`     | `Promise<undefined>`               |
+| `app/shop/[slug]/icon.js`       | `/shop/1`   | `Promise<{ slug: '1' >}`           |
+| `app/shop/[tag]/[item]/icon.js` | `/shop/1/2` | `Promise<{ tag: '1', item: '2' >}` |
 
 ### Returns
 

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/app-icons.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/app-icons.mdx
@@ -177,16 +177,24 @@ The default export function receives the following props:
 
 #### `params` (optional)
 
-An object containing the [dynamic route parameters](/docs/app/api-reference/file-conventions/dynamic-routes) object from the root segment down to the segment `icon` or `apple-icon` is colocated in.
+A promise that resolves to an object containing the [dynamic route parameters](/docs/app/api-reference/file-conventions/dynamic-routes) object from the root segment down to the segment `icon` or `apple-icon` is colocated in.
+
+> **Good to know**: If you use [`generateImageMetadata`](/docs/app/api-reference/functions/generate-image-metadata), the function will also receive an `id` prop that is a promise resolving to the `id` value from one of the items returned by `generateImageMetadata`.
 
 ```tsx filename="app/shop/[slug]/icon.tsx" switcher
-export default function Icon({ params }: { params: { slug: string } }) {
+export default async function Icon({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
   // ...
 }
 ```
 
 ```jsx filename="app/shop/[slug]/icon.js" switcher
-export default function Icon({ params }) {
+export default async function Icon({ params }) {
+  const { slug } = await params
   // ...
 }
 ```

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/app-icons.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/app-icons.mdx
@@ -201,9 +201,9 @@ export default async function Icon({ params }) {
 
 | Route                           | URL         | `params`                           |
 | ------------------------------- | ----------- | ---------------------------------- |
-| `app/shop/icon.js`              | `/shop`     | `Promise<undefined>`               |
-| `app/shop/[slug]/icon.js`       | `/shop/1`   | `Promise<{ slug: '1' >}`           |
-| `app/shop/[tag]/[item]/icon.js` | `/shop/1/2` | `Promise<{ tag: '1', item: '2' >}` |
+| `app/shop/icon.js`              | `/shop`     | `undefined`                        |
+| `app/shop/[slug]/icon.js`       | `/shop/1`   | `Promise<{ slug: '1' }>`           |
+| `app/shop/[tag]/[item]/icon.js` | `/shop/1/2` | `Promise<{ tag: '1', item: '2' }>` |
 
 ### Returns
 

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -220,16 +220,22 @@ The default export function receives the following props:
 
 #### `params` (optional)
 
-An object containing the [dynamic route parameters](/docs/app/api-reference/file-conventions/dynamic-routes) object from the root segment down to the segment `opengraph-image` or `twitter-image` is colocated in.
+A promise that resolves to an object containing the [dynamic route parameters](/docs/app/api-reference/file-conventions/dynamic-routes) object from the root segment down to the segment `opengraph-image` or `twitter-image` is colocated in.
 
 ```tsx filename="app/shop/[slug]/opengraph-image.tsx" switcher
-export default function Image({ params }: { params: { slug: string } }) {
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
   // ...
 }
 ```
 
 ```jsx filename="app/shop/[slug]/opengraph-image.js" switcher
-export default function Image({ params }) {
+export default async function Image({ params }) {
+  const { slug } = await params
   // ...
 }
 ```
@@ -334,8 +340,13 @@ export const size = {
 }
 export const contentType = 'image/png'
 
-export default async function Image({ params }: { params: { slug: string } }) {
-  const post = await fetch(`https://.../posts/${params.slug}`).then((res) =>
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const post = await fetch(`https://.../posts/${slug}`).then((res) =>
     res.json()
   )
 
@@ -373,7 +384,8 @@ export const size = {
 export const contentType = 'image/png'
 
 export default async function Image({ params }) {
-  const post = await fetch(`https://.../posts/${params.slug}`).then((res) =>
+  const { slug } = await params
+  const post = await fetch(`https://.../posts/${slug}`).then((res) =>
     res.json()
   )
 
@@ -509,6 +521,7 @@ export default async function Image() {
 
 ## Version History
 
-| Version   | Changes                                           |
-| --------- | ------------------------------------------------- |
-| `v13.3.0` | `opengraph-image` and `twitter-image` introduced. |
+| Version   | Changes                                                                       |
+| --------- | ----------------------------------------------------------------------------- |
+| `v13.3.0` | `opengraph-image` and `twitter-image` introduced.                             |
+| `v16.0.0` | `params` prop changed from an object to a promise that resolves to an object. |

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -222,6 +222,8 @@ The default export function receives the following props:
 
 A promise that resolves to an object containing the [dynamic route parameters](/docs/app/api-reference/file-conventions/dynamic-routes) object from the root segment down to the segment `opengraph-image` or `twitter-image` is colocated in.
 
+> **Good to know**: If you use [`generateImageMetadata`](/docs/app/api-reference/functions/generate-image-metadata), the function will also receive an `id` prop that is a promise resolving to the `id` value from one of the items returned by `generateImageMetadata`.
+
 ```tsx filename="app/shop/[slug]/opengraph-image.tsx" switcher
 export default async function Image({
   params,

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -242,11 +242,11 @@ export default async function Image({ params }) {
 }
 ```
 
-| Route                                      | URL         | `params`                  |
-| ------------------------------------------ | ----------- | ------------------------- |
-| `app/shop/opengraph-image.js`              | `/shop`     | `undefined`               |
-| `app/shop/[slug]/opengraph-image.js`       | `/shop/1`   | `{ slug: '1' }`           |
-| `app/shop/[tag]/[item]/opengraph-image.js` | `/shop/1/2` | `{ tag: '1', item: '2' }` |
+| Route                                      | URL         | `params`                           |
+| ------------------------------------------ | ----------- | ---------------------------------- |
+| `app/shop/opengraph-image.js`              | `/shop`     | `Promise<undefined>`               |
+| `app/shop/[slug]/opengraph-image.js`       | `/shop/1`   | `Promise<{ slug: '1' }>`           |
+| `app/shop/[tag]/[item]/opengraph-image.js` | `/shop/1/2` | `Promise<{ tag: '1', item: '2' }>` |
 
 ### Returns
 

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -244,7 +244,7 @@ export default async function Image({ params }) {
 
 | Route                                      | URL         | `params`                           |
 | ------------------------------------------ | ----------- | ---------------------------------- |
-| `app/shop/opengraph-image.js`              | `/shop`     | `Promise<undefined>`               |
+| `app/shop/opengraph-image.js`              | `/shop`     | `undefined`                        |
 | `app/shop/[slug]/opengraph-image.js`       | `/shop/1`   | `Promise<{ slug: '1' }>`           |
 | `app/shop/[tag]/[item]/opengraph-image.js` | `/shop/1/2` | `Promise<{ tag: '1', item: '2' }>` |
 

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -525,5 +525,5 @@ export default async function Image() {
 
 | Version   | Changes                                                                       |
 | --------- | ----------------------------------------------------------------------------- |
-| `v13.3.0` | `opengraph-image` and `twitter-image` introduced.                             |
 | `v16.0.0` | `params` prop changed from an object to a promise that resolves to an object. |
+| `v13.3.0` | `opengraph-image` and `twitter-image` introduced.                             |

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -523,7 +523,7 @@ export default async function Image() {
 
 ## Version History
 
-| Version   | Changes                                                                       |
-| --------- | ----------------------------------------------------------------------------- |
-| `v16.0.0` | `params` prop changed from an object to a promise that resolves to an object. |
-| `v13.3.0` | `opengraph-image` and `twitter-image` introduced.                             |
+| Version   | Changes                                              |
+| --------- | ---------------------------------------------------- |
+| `v16.0.0` | `params` is now a promise that resolves to an object |
+| `v13.3.0` | `opengraph-image` and `twitter-image` introduced.    |

--- a/docs/01-app/03-api-reference/04-functions/generate-image-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-image-metadata.mdx
@@ -42,7 +42,7 @@ export function generateImageMetadata({ params }) {
 
 ## Returns
 
-The `generateImageMetadata` function should return an `array` of objects containing the image's metadata such as `alt` and `size`. In addition, each item **must** include an `id` value which will be passed to the props of the image generating function.
+The `generateImageMetadata` function should return an `array` of objects containing the image's metadata such as `alt` and `size`. In addition, each item **must** include an `id` value which will be passed as a promise to the props of the image generating function.
 
 | Image Metadata Object | Type                                |
 | --------------------- | ----------------------------------- |
@@ -69,7 +69,8 @@ export function generateImageMetadata() {
   ]
 }
 
-export default function Icon({ id }: { id: string }) {
+export default async function Icon({ id }: { id: Promise<string | number> }) {
+  const iconId = await id
   return new ImageResponse(
     (
       <div
@@ -84,7 +85,7 @@ export default function Icon({ id }: { id: string }) {
           color: '#fafafa',
         }}
       >
-        Icon {id}
+        Icon {iconId}
       </div>
     )
   )
@@ -109,7 +110,8 @@ export function generateImageMetadata() {
   ]
 }
 
-export default function Icon({ id }) {
+export default async function Icon({ id }) {
+  const iconId = await id
   return new ImageResponse(
     (
       <div
@@ -124,10 +126,54 @@ export default function Icon({ id }) {
           color: '#fafafa',
         }}
       >
-        Icon {id}
+        Icon {iconId}
       </div>
     )
   )
+}
+```
+
+## Image generation function props
+
+When using `generateImageMetadata`, the default export image generation function receives the following props:
+
+#### `id`
+
+A promise that resolves to the `id` value from one of the items returned by `generateImageMetadata`. The `id` will be a `string` or `number` depending on what was returned from `generateImageMetadata`.
+
+```tsx filename="icon.tsx" switcher
+export default async function Icon({ id }: { id: Promise<string | number> }) {
+  const iconId = await id
+  // Use iconId to generate the image
+}
+```
+
+```jsx filename="icon.js" switcher
+export default async function Icon({ id }) {
+  const iconId = await id
+  // Use iconId to generate the image
+}
+```
+
+#### `params` (optional)
+
+A promise that resolves to an object containing the [dynamic route parameters](/docs/app/api-reference/file-conventions/dynamic-routes) from the root segment down to the segment the image is colocated in.
+
+```tsx filename="icon.tsx" switcher
+export default async function Icon({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  // Use slug to generate the image
+}
+```
+
+```jsx filename="icon.js" switcher
+export default async function Icon({ params }) {
+  const { slug } = await params
+  // Use slug to generate the image
 }
 ```
 
@@ -160,11 +206,11 @@ export default async function Image({
   params,
   id,
 }: {
-  params: { id: string }
-  id: number
+  params: Promise<{ id: string }>
+  id: Promise<number>
 }) {
   const productId = (await params).id
-  const imageId = id
+  const imageId = await id
   const text = await getCaptionForImage(productId, imageId)
 
   return new ImageResponse(
@@ -200,7 +246,7 @@ export async function generateImageMetadata({ params }) {
 
 export default async function Image({ params, id }) {
   const productId = (await params).id
-  const imageId = id
+  const imageId = await id
   const text = await getCaptionForImage(productId, imageId)
 
   return new ImageResponse(

--- a/docs/01-app/03-api-reference/04-functions/generate-image-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-image-metadata.mdx
@@ -34,11 +34,11 @@ export function generateImageMetadata({ params }) {
 }
 ```
 
-| Route                           | URL         | `params`                           |
-| ------------------------------- | ----------- | ---------------------------------- |
-| `app/shop/icon.js`              | `/shop`     | `undefined`                        |
-| `app/shop/[slug]/icon.js`       | `/shop/1`   | `Promise<{ slug: '1' }>`           |
-| `app/shop/[tag]/[item]/icon.js` | `/shop/1/2` | `Promise<{ tag: '1', item: '2' }>` |
+| Route                           | URL         | `params`                  |
+| ------------------------------- | ----------- | ------------------------- |
+| `app/shop/icon.js`              | `/shop`     | `undefined`               |
+| `app/shop/[slug]/icon.js`       | `/shop/1`   | `{ slug: '1' }`           |
+| `app/shop/[tag]/[item]/icon.js` | `/shop/1/2` | `{ tag: '1', item: '2' }` |
 
 ## Returns
 
@@ -267,8 +267,8 @@ export default async function Image({ params, id }) {
 
 ## Version History
 
-| Version   | Changes                                                     |
-| --------- | ----------------------------------------------------------- |
-| `v16.0.0` | `id` is now a promise that resolves to `string` or `number` |
-| `v16.0.0` | `params` is now a promise that resolves to an object        |
-| `v13.3.0` | `generateImageMetadata` introduced.                         |
+| Version   | Changes                                                                                             |
+| --------- | --------------------------------------------------------------------------------------------------- |
+| `v16.0.0` | `id` passed to the Image generation function is now a promise that resolves to `string` or `number` |
+| `v16.0.0` | `params` passed to the Image generation function is now a promise that resolves to an object        |
+| `v13.3.0` | `generateImageMetadata` introduced.                                                                 |

--- a/docs/01-app/03-api-reference/04-functions/generate-image-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-image-metadata.mdx
@@ -267,6 +267,8 @@ export default async function Image({ params, id }) {
 
 ## Version History
 
-| Version   | Changes                             |
-| --------- | ----------------------------------- |
-| `v13.3.0` | `generateImageMetadata` introduced. |
+| Version   | Changes                                                     |
+| --------- | ----------------------------------------------------------- |
+| `v16.0.0` | `id` is now a promise that resolves to `string` or `number` |
+| `v16.0.0` | `params` is now a promise that resolves to an object        |
+| `v13.3.0` | `generateImageMetadata` introduced.                         |

--- a/docs/01-app/03-api-reference/04-functions/generate-image-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-image-metadata.mdx
@@ -34,11 +34,11 @@ export function generateImageMetadata({ params }) {
 }
 ```
 
-| Route                           | URL         | `params`                  |
-| ------------------------------- | ----------- | ------------------------- |
-| `app/shop/icon.js`              | `/shop`     | `undefined`               |
-| `app/shop/[slug]/icon.js`       | `/shop/1`   | `{ slug: '1' }`           |
-| `app/shop/[tag]/[item]/icon.js` | `/shop/1/2` | `{ tag: '1', item: '2' }` |
+| Route                           | URL         | `params`                           |
+| ------------------------------- | ----------- | ---------------------------------- |
+| `app/shop/icon.js`              | `/shop`     | `Promise<undefined>`               |
+| `app/shop/[slug]/icon.js`       | `/shop/1`   | `Promise<{ slug: '1' >}`           |
+| `app/shop/[tag]/[item]/icon.js` | `/shop/1/2` | `Promise<{ tag: '1', item: '2' >}` |
 
 ## Returns
 

--- a/docs/01-app/03-api-reference/04-functions/generate-image-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-image-metadata.mdx
@@ -36,9 +36,9 @@ export function generateImageMetadata({ params }) {
 
 | Route                           | URL         | `params`                           |
 | ------------------------------- | ----------- | ---------------------------------- |
-| `app/shop/icon.js`              | `/shop`     | `Promise<undefined>`               |
-| `app/shop/[slug]/icon.js`       | `/shop/1`   | `Promise<{ slug: '1' >}`           |
-| `app/shop/[tag]/[item]/icon.js` | `/shop/1/2` | `Promise<{ tag: '1', item: '2' >}` |
+| `app/shop/icon.js`              | `/shop`     | `undefined`                        |
+| `app/shop/[slug]/icon.js`       | `/shop/1`   | `Promise<{ slug: '1' }>`           |
+| `app/shop/[tag]/[item]/icon.js` | `/shop/1/2` | `Promise<{ tag: '1', item: '2' }>` |
 
 ## Returns
 


### PR DESCRIPTION
In v6, the `params` argument of metadata image routes will become params, which is aligned with other page routes in App Router.
The 2nd argument `id` will become `Promise<string>` if you use `generateImageMetadata`