### PR TITLE
simplify the way we check for turbopack config to ensure we support an empty turbopack object

### DIFF
--- a/test/e2e/config-turbopack/index.test.ts
+++ b/test/e2e/config-turbopack/index.test.ts
@@ -89,11 +89,7 @@ export default function Page() {
             'next.config.js': `
             module.exports = {
               turbopack: {
-                rules: {
-                  '*.foo': {
-                    loaders: ['foo-loader']
-                  }
-                }
+               
               },
               webpack: (config) => {
                 return config


### PR DESCRIPTION
Previously we 'flattened' all the keys in the config to find unsupported leaf properties, but this meant that an empty object woudln't produce any keys.

instead just directly check for the `webpack` and `turbopack` properties and only use the scanning to look for experimental turbopack options and unsupported experimental configuration.

Fixes an issue where you cannot bypass the warning simply by adding `turbopack: {}`


Closes PACK-5618