### PR TITLE
[segment cache]: fix interception route handling

### DIFF
--- a/packages/next/src/client/components/segment-cache-impl/navigation.ts
+++ b/packages/next/src/client/components/segment-cache-impl/navigation.ts
@@ -26,12 +26,8 @@ import {
   type FulfilledRouteCacheEntry,
 } from './cache'
 import { createCacheKey } from './cache-key'
-import {
-  addSearchParamsIfPageSegment,
-  DEFAULT_SEGMENT_KEY,
-} from '../../../shared/lib/segment'
+import { addSearchParamsIfPageSegment } from '../../../shared/lib/segment'
 import { NavigationResultTag } from '../segment-cache'
-import { matchSegment } from '../match-segments'
 
 type MPANavigationResult = {
   tag: NavigationResultTag.MPA
@@ -498,7 +494,10 @@ function simulatePrefetchTreeUsingDynamicTreePatch(
   // Takes the current FlightRouterState and applies the router state patch
   // received from the server, to create a full FlightRouterState tree that we
   // can pretend was returned by a prefetch.
-
+  //
+  // (It sounds similar to what applyRouterStatePatch does, but it doesn't need
+  // to handle stuff like interception routes or diffing since that will be
+  // handled later.)
   let baseTree = currentTree
   for (const { segmentPath, tree: treePatch } of flightData) {
     // If the server sends us multiple tree patches, we only need to clone the
@@ -510,7 +509,6 @@ function simulatePrefetchTreeUsingDynamicTreePatch(
       treePatch,
       segmentPath,
       canMutateInPlace,
-      flightData,
       0
     )
   }
@@ -523,7 +521,6 @@ function simulatePrefetchTreeUsingDynamicTreePatchImpl(
   patch: FlightRouterState,
   segmentPath: FlightSegmentPath,
   canMutateInPlace: boolean,
-  allFlightData: Array<NormalizedFlightData>,
   index: number
 ) {
   if (index === segmentPath.length) {
@@ -547,28 +544,6 @@ function simulatePrefetchTreeUsingDynamicTreePatchImpl(
 
   const baseChildren = baseRouterState[1]
   const newChildren: { [parallelRouteKey: string]: FlightRouterState } = {}
-
-  // Build a set of parallel routes being updated at this level by any patch.
-  const parallelRoutesBeingUpdated = new Set<string>()
-  for (const flightData of allFlightData) {
-    // This patch doesn't reach this far down the tree.
-    if (flightData.segmentPath.length <= index) continue
-
-    // Check if this patch's segment path matches our current position
-    let matches = true
-    for (let i = 0; i < index; i++) {
-      if (!matchSegment(flightData.segmentPath[i], segmentPath[i])) {
-        matches = false
-        break
-      }
-    }
-
-    if (matches) {
-      // This patch updates a parallel route at this level
-      parallelRoutesBeingUpdated.add(flightData.segmentPath[index])
-    }
-  }
-
   for (const parallelRouteKey in baseChildren) {
     if (parallelRouteKey === updatedParallelRouteKey) {
       const childBaseRouterState = baseChildren[parallelRouteKey]
@@ -578,29 +553,13 @@ function simulatePrefetchTreeUsingDynamicTreePatchImpl(
           patch,
           segmentPath,
           canMutateInPlace,
-          allFlightData,
           // Advance the index by two and keep cloning until we reach
           // the end of the segment path.
           index + 2
         )
     } else {
-      // This parallel route is not in the current segment path being patched.
-      const childRouterState = baseChildren[parallelRouteKey]
-      const childSegment = childRouterState[0]
-
-      // Mark this parallel route as __DEFAULT__ if:
-      // 1. It's already __DEFAULT__ (preserve inactive state), OR
-      // 2. It's not being updated by any patch at this level (no data coming for it)
-      const shouldReplaceWithDefault =
-        childSegment === DEFAULT_SEGMENT_KEY ||
-        !parallelRoutesBeingUpdated.has(parallelRouteKey)
-
-      if (shouldReplaceWithDefault) {
-        newChildren[parallelRouteKey] = [DEFAULT_SEGMENT_KEY, {}]
-      } else {
-        // This child is not being patched. Copy it over as-is.
-        newChildren[parallelRouteKey] = childRouterState
-      }
+      // This child is not being patched. Copy it over as-is.
+      newChildren[parallelRouteKey] = baseChildren[parallelRouteKey]
     }
   }
 

--- a/packages/next/src/client/components/segment-cache-impl/navigation.ts
+++ b/packages/next/src/client/components/segment-cache-impl/navigation.ts
@@ -26,8 +26,12 @@ import {
   type FulfilledRouteCacheEntry,
 } from './cache'
 import { createCacheKey } from './cache-key'
-import { addSearchParamsIfPageSegment } from '../../../shared/lib/segment'
+import {
+  addSearchParamsIfPageSegment,
+  DEFAULT_SEGMENT_KEY,
+} from '../../../shared/lib/segment'
 import { NavigationResultTag } from '../segment-cache'
+import { matchSegment } from '../match-segments'
 
 type MPANavigationResult = {
   tag: NavigationResultTag.MPA
@@ -494,10 +498,7 @@ function simulatePrefetchTreeUsingDynamicTreePatch(
   // Takes the current FlightRouterState and applies the router state patch
   // received from the server, to create a full FlightRouterState tree that we
   // can pretend was returned by a prefetch.
-  //
-  // (It sounds similar to what applyRouterStatePatch does, but it doesn't need
-  // to handle stuff like interception routes or diffing since that will be
-  // handled later.)
+
   let baseTree = currentTree
   for (const { segmentPath, tree: treePatch } of flightData) {
     // If the server sends us multiple tree patches, we only need to clone the
@@ -509,6 +510,7 @@ function simulatePrefetchTreeUsingDynamicTreePatch(
       treePatch,
       segmentPath,
       canMutateInPlace,
+      flightData,
       0
     )
   }
@@ -521,6 +523,7 @@ function simulatePrefetchTreeUsingDynamicTreePatchImpl(
   patch: FlightRouterState,
   segmentPath: FlightSegmentPath,
   canMutateInPlace: boolean,
+  allFlightData: Array<NormalizedFlightData>,
   index: number
 ) {
   if (index === segmentPath.length) {
@@ -544,6 +547,28 @@ function simulatePrefetchTreeUsingDynamicTreePatchImpl(
 
   const baseChildren = baseRouterState[1]
   const newChildren: { [parallelRouteKey: string]: FlightRouterState } = {}
+
+  // Build a set of parallel routes being updated at this level by any patch.
+  const parallelRoutesBeingUpdated = new Set<string>()
+  for (const flightData of allFlightData) {
+    // This patch doesn't reach this far down the tree.
+    if (flightData.segmentPath.length <= index) continue
+
+    // Check if this patch's segment path matches our current position
+    let matches = true
+    for (let i = 0; i < index; i++) {
+      if (!matchSegment(flightData.segmentPath[i], segmentPath[i])) {
+        matches = false
+        break
+      }
+    }
+
+    if (matches) {
+      // This patch updates a parallel route at this level
+      parallelRoutesBeingUpdated.add(flightData.segmentPath[index])
+    }
+  }
+
   for (const parallelRouteKey in baseChildren) {
     if (parallelRouteKey === updatedParallelRouteKey) {
       const childBaseRouterState = baseChildren[parallelRouteKey]
@@ -553,13 +578,29 @@ function simulatePrefetchTreeUsingDynamicTreePatchImpl(
           patch,
           segmentPath,
           canMutateInPlace,
+          allFlightData,
           // Advance the index by two and keep cloning until we reach
           // the end of the segment path.
           index + 2
         )
     } else {
-      // This child is not being patched. Copy it over as-is.
-      newChildren[parallelRouteKey] = baseChildren[parallelRouteKey]
+      // This parallel route is not in the current segment path being patched.
+      const childRouterState = baseChildren[parallelRouteKey]
+      const childSegment = childRouterState[0]
+
+      // Mark this parallel route as __DEFAULT__ if:
+      // 1. It's already __DEFAULT__ (preserve inactive state), OR
+      // 2. It's not being updated by any patch at this level (no data coming for it)
+      const shouldReplaceWithDefault =
+        childSegment === DEFAULT_SEGMENT_KEY ||
+        !parallelRoutesBeingUpdated.has(parallelRouteKey)
+
+      if (shouldReplaceWithDefault) {
+        newChildren[parallelRouteKey] = [DEFAULT_SEGMENT_KEY, {}]
+      } else {
+        // This child is not being patched. Copy it over as-is.
+        newChildren[parallelRouteKey] = childRouterState
+      }
     }
   }
 

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -16,10 +16,7 @@ import {
 } from './create-flight-router-state-from-loader-tree'
 import type { AppRenderContext } from './app-render'
 import { hasLoadingComponentInTree } from './has-loading-component-in-tree'
-import {
-  DEFAULT_SEGMENT_KEY,
-  addSearchParamsIfPageSegment,
-} from '../../shared/lib/segment'
+import { addSearchParamsIfPageSegment } from '../../shared/lib/segment'
 import { createComponentTree } from './create-component-tree'
 import { getSegmentParam } from './get-segment-param'
 
@@ -218,6 +215,7 @@ export async function walkTreeWithFlightRouterState({
       getDynamicParamFromSegment,
       query
     )
+
     // Create component tree using the slice of the loaderTree
     const seedData = await createComponentTree(
       // This ensures flightRouterPath is valid and filters down the tree
@@ -298,17 +296,6 @@ export async function walkTreeWithFlightRouterState({
     })
 
     for (const subPath of subPaths) {
-      // we don't need to send over default routes in the flight data
-      // because they are always ignored by the client, unless it's a refetch
-      if (
-        subPath[0] === DEFAULT_SEGMENT_KEY &&
-        flightRouterState &&
-        !!flightRouterState[1][parallelRouteKey][0] &&
-        flightRouterState[1][parallelRouteKey][3] !== 'refetch'
-      ) {
-        continue
-      }
-
       paths.push([actualSegment, parallelRouteKey, ...subPath])
     }
   }

--- a/test/client-segment-cache-tests-manifest.json
+++ b/test/client-segment-cache-tests-manifest.json
@@ -43,11 +43,6 @@
         "app dir - navigation middleware redirect should change browser location when router.refresh() gets a redirect response"
       ]
     },
-    "test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts": {
-      "failed": [
-        "parallel-routes-and-interception route intercepting should support intercepting local dynamic sibling routes"
-      ]
-    },
     "test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts": {
       "failed": [
         "parallel-routes-revalidation router.refresh (dynamic) - searchParams: false should correctly refresh data for previously intercepted modal and active page slot",


### PR DESCRIPTION
With `clientSegmentCache` enabled, if you are already on a route that was intercepted/could have been intercepted, and then you navigated to it again, the router would get stuck in a state where it was infinitely suspended on data it would never receive.

When no prefetch is available, we assume that the FlightRouterState sent by the server contains everything that is needed to describe the rendering shape of the page. However this isn't quite true: in `walk-tree-with-flight-router-state` (the function that populates prefetch responses), we skip sending down the `__DEFAULT__` segment. As a result, the client would get into a state where it thinks it needs to request data from the server, but the server will never send it. 

This updates the code to not special-case `__DEFAULT__` segments. We should separately see how we can restore this optimization to keep those payloads as small as possible, but it causes problems with back/forward nav that need to be investigated.