### PR TITLE
test: Use nextTestSetup in scss tests

### DIFF
--- a/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
@@ -1,29 +1,64 @@
 /* eslint-env jest */
 
-import { remove } from 'fs-extra'
-import { nextBuild } from 'next-test-utils'
-import { join } from 'path'
+import { isNextStart, nextTestSetup } from 'e2e-utils'
+import { assertHasRedbox, getRedboxSource } from 'next-test-utils'
 
 describe('Invalid Global CSS with Custom App', () => {
-  const appDir = __dirname
-
-  beforeAll(async () => {
-    await remove(join(appDir, '.next'))
+  const { next, skipped, isTurbopack, isRspack } = nextTestSetup({
+    files: __dirname,
+    skipStart: isNextStart,
+    skipDeployment: true,
+    dependencies: { sass: '1.54.0' },
   })
 
-  it('should fail to build', async () => {
-    const { code, stderr } = await nextBuild(appDir, [], {
-      stderr: true,
+  if (skipped) {
+    return
+  }
+
+  if (isNextStart) {
+    it('should fail to build', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      expect(exitCode).not.toBe(0)
+      expect(cliOutput).toContain('Failed to compile')
+      expect(cliOutput).toContain('styles/global.scss')
+      expect(cliOutput).toMatch(
+        /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
+      )
+      // Skip: Rspack loaders cannot access module issuer info for location details
+      if (!process.env.NEXT_RSPACK) {
+        expect(cliOutput).toMatch(/Location:.*pages[\\/]index\.js/)
+      }
     })
-    expect(code).not.toBe(0)
-    expect(stderr).toContain('Failed to compile')
-    expect(stderr).toContain('styles/global.scss')
-    expect(stderr).toMatch(
-      /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
-    )
-    // Skip: Rspack loaders cannot access module issuer info for location details
-    if (!process.env.NEXT_RSPACK) {
-      expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
-    }
-  })
+  } else {
+    it('should show a build error', async () => {
+      const browser = await next.browser('/')
+
+      await assertHasRedbox(browser)
+      const errorSource = await getRedboxSource(browser)
+
+      if (isTurbopack) {
+        expect(errorSource).toMatchInlineSnapshot(`
+         "./pages/index.js
+         Failed to compile
+             Global CSS cannot be imported from files other than your Custom <App>. Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
+             Read more: https://nextjs.org/docs/messages/css-global
+         Location: pages/index.js
+         Import path: ../styles/global.scss"
+        `)
+      } else if (isRspack) {
+        expect(errorSource).toMatchInlineSnapshot(`
+         "./styles/global.scss
+           │ Global CSS cannot be imported from files other than your Custom <App>. Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
+           │ Read more: https://nextjs.org/docs/messages/css-global"
+        `)
+      } else {
+        expect(errorSource).toMatchInlineSnapshot(`
+         "./styles/global.scss
+         Global CSS cannot be imported from files other than your Custom <App>. Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
+         Read more: https://nextjs.org/docs/messages/css-global
+         Location: pages/index.js"
+        `)
+      }
+    })
+  }
 })

--- a/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
@@ -1,29 +1,64 @@
 /* eslint-env jest */
 
-import { remove } from 'fs-extra'
-import { nextBuild } from 'next-test-utils'
-import { join } from 'path'
+import { isNextStart, nextTestSetup } from 'e2e-utils'
+import { assertHasRedbox, getRedboxSource } from 'next-test-utils'
 
 describe('Invalid Global CSS', () => {
-  const appDir = __dirname
-
-  beforeAll(async () => {
-    await remove(join(appDir, '.next'))
+  const { next, skipped, isTurbopack, isRspack } = nextTestSetup({
+    files: __dirname,
+    skipStart: isNextStart,
+    skipDeployment: true,
+    dependencies: { sass: '1.54.0' },
   })
 
-  it('should fail to build', async () => {
-    const { code, stderr } = await nextBuild(appDir, [], {
-      stderr: true,
+  if (skipped) {
+    return
+  }
+
+  if (isNextStart) {
+    it('should fail to build', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      expect(exitCode).not.toBe(0)
+      expect(cliOutput).toContain('Failed to compile')
+      expect(cliOutput).toContain('styles/global.scss')
+      expect(cliOutput).toMatch(
+        /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
+      )
+      // Skip: Rspack loaders cannot access module issuer info for location details
+      if (!process.env.NEXT_RSPACK) {
+        expect(cliOutput).toMatch(/Location:.*pages[\\/]index\.js/)
+      }
     })
-    expect(code).not.toBe(0)
-    expect(stderr).toContain('Failed to compile')
-    expect(stderr).toContain('styles/global.scss')
-    expect(stderr).toMatch(
-      /Please move all first-party global CSS imports.*?pages(\/|\\)_app/
-    )
-    // Skip: Rspack loaders cannot access module issuer info for location details
-    if (!process.env.NEXT_RSPACK) {
-      expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
-    }
-  })
+  } else {
+    it('should show a build error', async () => {
+      const browser = await next.browser('/')
+
+      await assertHasRedbox(browser)
+      const errorSource = await getRedboxSource(browser)
+
+      if (isTurbopack) {
+        expect(errorSource).toMatchInlineSnapshot(`
+         "./pages/index.js
+         Failed to compile
+             Global CSS cannot be imported from files other than your Custom <App>. Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
+             Read more: https://nextjs.org/docs/messages/css-global
+         Location: pages/index.js
+         Import path: ../styles/global.scss"
+        `)
+      } else if (isRspack) {
+        expect(errorSource).toMatchInlineSnapshot(`
+         "./styles/global.scss
+           │ Global CSS cannot be imported from files other than your Custom <App>. Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
+           │ Read more: https://nextjs.org/docs/messages/css-global"
+        `)
+      } else {
+        expect(errorSource).toMatchInlineSnapshot(`
+         "./styles/global.scss
+         Global CSS cannot be imported from files other than your Custom <App>. Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
+         Read more: https://nextjs.org/docs/messages/css-global
+         Location: pages/index.js"
+        `)
+      }
+    })
+  }
 })

--- a/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
+++ b/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
@@ -1,40 +1,57 @@
 /* eslint-env jest */
 
-import { remove } from 'fs-extra'
-import { nextBuild } from 'next-test-utils'
-import { join } from 'path'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
+import { isNextStart, nextTestSetup } from 'e2e-utils'
+import { assertHasRedbox, getRedboxSource } from 'next-test-utils'
 
 // Importing module CSS in _document is allowed in Turbopack
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'Invalid SCSS in _document',
   () => {
-    ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-      'production only',
-      () => {
-        const appDir = __dirname
+    const { next, skipped, isRspack } = nextTestSetup({
+      files: __dirname,
+      skipStart: isNextStart,
+      skipDeployment: true,
+      dependencies: { sass: '1.54.0' },
+    })
 
-        beforeAll(async () => {
-          await remove(join(appDir, '.next'))
-        })
+    if (skipped) {
+      return
+    }
 
-        it('should fail to build', async () => {
-          const { code, stderr } = await nextBuild(appDir, [], {
-            stderr: true,
-          })
-          expect(code).not.toBe(0)
-          expect(stderr).toContain('Failed to compile')
-          expect(stderr).toContain('styles.module.scss')
-          expect(stderr).toMatch(
-            /CSS.*cannot.*be imported within.*pages[\\/]_document\.js/
-          )
-          // Skip: Rspack loaders cannot access module issuer info for location details
-          if (!process.env.NEXT_RSPACK) {
-            expect(stderr).toMatch(/Location:.*pages[\\/]_document\.js/)
-          }
-        })
-      }
-    )
+    if (isNextStart) {
+      it('should fail to build', async () => {
+        const { exitCode, cliOutput } = await next.build()
+        expect(exitCode).not.toBe(0)
+        expect(cliOutput).toContain('Failed to compile')
+        expect(cliOutput).toContain('styles.module.scss')
+        expect(cliOutput).toMatch(
+          /CSS.*cannot.*be imported within.*pages[\\/]_document\.js/
+        )
+        // Skip: Rspack loaders cannot access module issuer info for location details
+        if (!process.env.NEXT_RSPACK) {
+          expect(cliOutput).toMatch(/Location:.*pages[\\/]_document\.js/)
+        }
+      })
+    } else {
+      it('should show a build error', async () => {
+        const browser = await next.browser('/')
+
+        await assertHasRedbox(browser)
+        const errorSource = await getRedboxSource(browser)
+
+        if (isRspack) {
+          expect(errorSource).toMatchInlineSnapshot(`
+           "./styles.module.scss
+             │ CSS cannot be imported within pages/_document.js. Please move global styles to pages/_app.js."
+          `)
+        } else {
+          expect(errorSource).toMatchInlineSnapshot(`
+           "./styles.module.scss
+           CSS cannot be imported within pages/_document.js. Please move global styles to pages/_app.js.
+           Location: pages/_document.js"
+          `)
+        }
+      })
+    }
   }
 )

--- a/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
+++ b/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
@@ -1,30 +1,73 @@
 /* eslint-env jest */
 
-import { remove } from 'fs-extra'
-import { nextBuild } from 'next-test-utils'
-import { join } from 'path'
-// In order for the global isNextStart to be set
-import 'e2e-utils'
-
-console.log({ global })
+import { isNextStart, nextTestSetup } from 'e2e-utils'
+import { assertHasRedbox, getRedboxSource } from 'next-test-utils'
 
 describe('CSS Import from node_modules', () => {
-  ;(Boolean((global as any).isNextStart) ? describe : describe.skip)(
-    'production only',
-    () => {
-      const appDir = __dirname
+  const { next, skipped, isTurbopack, isRspack } = nextTestSetup({
+    files: __dirname,
+    skipStart: isNextStart,
+    skipDeployment: true,
+    dependencies: { sass: '1.54.0' },
+  })
 
-      beforeAll(async () => {
-        await remove(join(appDir, '.next'))
-      })
+  if (skipped) {
+    return
+  }
 
-      it('should fail the build', async () => {
-        const { code, stderr } = await nextBuild(appDir, [], { stderr: true })
+  if (isNextStart) {
+    it('should fail the build', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      expect(exitCode).not.toBe(0)
+      if (isRspack) {
+        expect(cliOutput).toMatch(
+          /RspackResolver\(NotFound\(\\?"nprogress\/nprogress.css\\?"\)\)/
+        )
+      } else {
+        expect(cliOutput).toMatch(/Can't resolve '[^']*?nprogress[^']*?'/)
+      }
+      expect(cliOutput).toMatch(/Build failed|Build error occurred/)
+    })
+  } else {
+    it('should show a build error', async () => {
+      const browser = await next.browser('/')
 
-        expect(code).toBe(0)
-        expect(stderr).not.toMatch(/Can't resolve '[^']*?nprogress[^']*?'/)
-        expect(stderr).not.toMatch(/Build error occurred/)
-      })
-    }
-  )
+      await assertHasRedbox(browser)
+      const errorSource = await getRedboxSource(browser)
+
+      if (isTurbopack) {
+        expect(errorSource).toMatchInlineSnapshot(`
+         "./styles/global.scss.css (1:9)
+         Module not found: Can't resolve 'nprogress/nprogress.css'
+         > 1 | @import 'nprogress/nprogress.css';
+             |         ^
+           2 |
+
+         Import trace:
+           Browser:
+             ./styles/global.scss.css
+             ./pages/_app.js
+
+         https://nextjs.org/docs/messages/module-not-found"
+        `)
+      } else if (isRspack) {
+        expect(errorSource).toMatchInlineSnapshot(`
+         "./node_modules/.pnpm/next@file+..+next-repo-9363c99f3d71d8f039ab2f44b0982247ca3f251f6a3cb48f6f97e14bd6290b68_3cf165911481a65b93532bfb8e2c9025/node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[8].oneOf[14].use[1]!./node_modules/.pnpm/next@file+..+next-repo-9363c99f3d71d8f039ab2f44b0982247ca3f251f6a3cb48f6f97e14bd6290b68_3cf165911481a65b93532bfb8e2c9025/node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[8].oneOf[14].use[2]!./node_modules/.pnpm/next@file+..+next-repo-9363c99f3d71d8f039ab2f44b0982247ca3f251f6a3cb48f6f97e14bd6290b68_3cf165911481a65b93532bfb8e2c9025/node_modules/next/dist/build/webpack/loaders/resolve-url-loader/index.js??ruleSet[1].rules[8].oneOf[14].use[3]!./node_modules/.pnpm/next@file+..+next-repo-9363c99f3d71d8f039ab2f44b0982247ca3f251f6a3cb48f6f97e14bd6290b68_3cf165911481a65b93532bfb8e2c9025/node_modules/next/dist/compiled/sass-loader/cjs.js??ruleSet[1].rules[8].oneOf[14].use[4]!./styles/global.scss
+           × Module build failed:
+           ╰─▶   × Error: RspackResolver(NotFound("nprogress/nprogress.css"))"
+        `)
+      } else {
+        expect(errorSource).toMatchInlineSnapshot(`
+         "./styles/global.scss
+         Module not found: Can't resolve 'nprogress/nprogress.css'
+
+         https://nextjs.org/docs/messages/module-not-found
+
+         Import trace for requested module:
+         ./styles/global.scss
+         ./pages/_app.js"
+        `)
+      }
+    })
+  }
 })

--- a/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
@@ -1,27 +1,64 @@
 /* eslint-env jest */
 
-import { remove } from 'fs-extra'
-import { nextBuild } from 'next-test-utils'
-import { join } from 'path'
+import { isNextStart, nextTestSetup } from 'e2e-utils'
+import { assertHasRedbox, getRedboxSource } from 'next-test-utils'
 
 describe('Valid and Invalid Global CSS with Custom App', () => {
-  const appDir = __dirname
-
-  beforeAll(async () => {
-    await remove(join(appDir, '.next'))
+  const { next, skipped, isTurbopack, isRspack } = nextTestSetup({
+    files: __dirname,
+    skipStart: isNextStart,
+    skipDeployment: true,
+    dependencies: { sass: '1.54.0' },
   })
 
-  it('should fail to build', async () => {
-    const { code, stderr } = await nextBuild(appDir, [], {
-      stderr: true,
+  if (skipped) {
+    return
+  }
+
+  if (isNextStart) {
+    it('should fail to build', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      expect(exitCode).not.toBe(0)
+      expect(cliOutput).toContain('Failed to compile')
+      expect(cliOutput).toContain('styles/global.scss')
+      expect(cliOutput).toContain(
+        'Please move all first-party global CSS imports'
+      )
+      // Skip: Rspack loaders cannot access module issuer info for location details
+      if (!process.env.NEXT_RSPACK) {
+        expect(cliOutput).toMatch(/Location:.*pages[\\/]index\.js/)
+      }
     })
-    expect(code).not.toBe(0)
-    expect(stderr).toContain('Failed to compile')
-    expect(stderr).toContain('styles/global.scss')
-    expect(stderr).toContain('Please move all first-party global CSS imports')
-    // Skip: Rspack loaders cannot access module issuer info for location details
-    if (!process.env.NEXT_RSPACK) {
-      expect(stderr).toMatch(/Location:.*pages[\\/]index\.js/)
-    }
-  })
+  } else {
+    it('should show a build error', async () => {
+      const browser = await next.browser('/')
+
+      await assertHasRedbox(browser)
+      const errorSource = await getRedboxSource(browser)
+
+      if (isTurbopack) {
+        expect(errorSource).toMatchInlineSnapshot(`
+         "./pages/index.js
+         Failed to compile
+             Global CSS cannot be imported from files other than your Custom <App>. Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
+             Read more: https://nextjs.org/docs/messages/css-global
+         Location: pages/index.js
+         Import path: ../styles/global.scss"
+        `)
+      } else if (isRspack) {
+        expect(errorSource).toMatchInlineSnapshot(`
+         "./styles/global.scss
+           │ Global CSS cannot be imported from files other than your Custom <App>. Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
+           │ Read more: https://nextjs.org/docs/messages/css-global"
+        `)
+      } else {
+        expect(errorSource).toMatchInlineSnapshot(`
+         "./styles/global.scss
+         Global CSS cannot be imported from files other than your Custom <App>. Due to the Global nature of stylesheets, and to avoid conflicts, Please move all first-party global CSS imports to pages/_app.js. Or convert the import to Component-Level CSS (CSS Modules).
+         Read more: https://nextjs.org/docs/messages/css-global
+         Location: pages/index.js"
+        `)
+      }
+    })
+  }
 })

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -104,6 +104,8 @@ export const isNextDeploy = testMode === 'deploy'
  */
 export const isNextStart = !isNextDev && !isNextDeploy
 
+export const isRspack = !!process.env.NEXT_RSPACK
+
 if (!testMode) {
   throw new Error(
     `No 'NEXT_TEST_MODE' set in environment, this is required for e2e-utils`
@@ -234,6 +236,7 @@ export function nextTestSetup(
   isNextDeploy: boolean
   isNextStart: boolean
   isTurbopack: boolean
+  isRspack: boolean
   next: NextInstance
   skipped: boolean
 } {
@@ -287,17 +290,19 @@ export function nextTestSetup(
     get isNextDev() {
       return isNextDev
     },
-    get isTurbopack(): boolean {
-      return Boolean(
-        !process.env.NEXT_TEST_WASM && (options.turbo ?? shouldUseTurbopack())
-      )
-    },
-
     get isNextDeploy() {
       return isNextDeploy
     },
     get isNextStart() {
       return isNextStart
+    },
+    get isTurbopack() {
+      return Boolean(
+        !process.env.NEXT_TEST_WASM && (options.turbo ?? shouldUseTurbopack())
+      )
+    },
+    get isRspack() {
+      return isRspack
     },
     get next() {
       return nextProxy


### PR DESCRIPTION
This ensures the tests have some coverage for `next dev`, and ensures proper test isolation. Previously they were just using `__dirname`, which is wrong.

Closes PACK-5624