### PR TITLE
Turbopack: Use strongly consistent reads in `random_change` unit test

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/tests/random_change.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/random_change.rs
@@ -3,8 +3,8 @@
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
 use anyhow::{Result, bail};
-use rand::Rng;
-use turbo_tasks::{State, Vc};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use turbo_tasks::{ResolvedVc, State, Vc};
 use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
@@ -12,15 +12,21 @@ static REGISTRATION: Registration = register!();
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn random_change() {
     run_once(&REGISTRATION, || async {
-        let state = make_state();
-        let value = rand::rng().random_range(0..100);
-        state.await?.state.set(value);
+        let state = make_state_operation().resolve_strongly_consistent().await?;
 
-        let result = func(state, 0).await?;
-        assert_eq!(result.value, value);
+        let mut rng = StdRng::from_seed(Default::default());
+        let func_op = func_operation(state);
+        let func2_op = func2_operation(state);
+        for _i in 0..10 {
+            let value = rng.random_range(0..100);
+            state.await?.state.set(value);
 
-        let result = func2(state).await?;
-        assert_eq!(result.value, value);
+            let result = func_op.read_strongly_consistent().await?;
+            assert_eq!(result.value, value);
+
+            let result = func2_op.read_strongly_consistent().await?;
+            assert_eq!(result.value, value);
+        }
 
         anyhow::Ok(())
     })
@@ -40,20 +46,25 @@ struct ValueContainer {
     state: State<i32>,
 }
 
-#[turbo_tasks::function]
-fn make_state() -> Vc<ValueContainer> {
+#[turbo_tasks::function(operation)]
+fn make_state_operation() -> Vc<ValueContainer> {
     ValueContainer {
         state: State::new(0),
     }
     .cell()
 }
 
-#[turbo_tasks::function]
-async fn func2(input: Vc<ValueContainer>) -> Result<Vc<Value>> {
+#[turbo_tasks::function(operation)]
+async fn func2_operation(input: ResolvedVc<ValueContainer>) -> Result<Vc<Value>> {
     let state = input.await?;
     let value = state.state.get();
     println!("func2 {}", *value);
-    Ok(func(input, -*value))
+    Ok(func(*input, -*value))
+}
+
+#[turbo_tasks::function(operation)]
+async fn func_operation(input: ResolvedVc<ValueContainer>) -> Vc<Value> {
+    func(*input, 0)
 }
 
 #[turbo_tasks::function]


### PR DESCRIPTION
I can't reproduce it locally, but I've noticed this test flake a few times in CI. Use strongly consistent reads to hopefully fix that.

Closes PACK-5622