### PR TITLE
[segment cache]: collectSegmentData should respect experimental.staleTime config

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4833,7 +4833,8 @@ async function collectSegmentData(
     serverModuleMap: getServerModuleMap(),
   }
 
-  const staleTime = prerenderStore.stale
+  const selectStaleTime = createSelectStaleTime(renderOpts.experimental)
+  const staleTime = selectStaleTime(prerenderStore.stale)
   return await ComponentMod.collectSegmentData(
     renderOpts.experimental.clientParamParsing,
     fullPageDataBuffer,


### PR DESCRIPTION
When we calculate the desired `staleTime` value we leverage the `selectStaleTime` util which has some logic to fallback to the `experimental.staleTimes` configuration if not otherwise overridden in the prerenderStore. Without this change, the static staleTime from the `/_tree` requests would always be the max (1 year), regardless of user configuration. 

This was caught by `prefetching.stale-times.test.ts` which I have re-enabled & refactored in the next PR in the stack. 