### PR TITLE
[test]: convert prefetching tests to be segmentCache compatible

### DIFF
--- a/test/client-segment-cache-tests-manifest.json
+++ b/test/client-segment-cache-tests-manifest.json
@@ -11,26 +11,6 @@
         "app-dir action handling should reset the form state when the action redirects to itself"
       ]
     },
-    "test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts": {
-      "failed": [
-        "app dir - prefetching (custom staleTime) should fetch again when a static page was prefetched when navigating to it after the stale time has passed",
-        "app dir - prefetching (custom staleTime) should fetch again when the initially visited static page is visited after the stale time has passed",
-        "app dir - prefetching (custom staleTime) should not fetch again when a static page was prefetched when navigating to it twice",
-        "app dir - prefetching (custom staleTime) should renew the stale time after refetching expired RSC data"
-      ]
-    },
-    "test/e2e/app-dir/app-prefetch/prefetching.test.ts": {
-      "failed": [
-        "app dir - prefetching fetch priority should have an auto priority for all other fetch operations",
-        "app dir - prefetching fetch priority should prefetch with high priority when navigating to a page without a prefetch entry",
-        "app dir - prefetching prefetch cache seeding should not re-fetch the initial dynamic page if the same page is prefetched with prefetch={true}",
-        "app dir - prefetching prefetch cache seeding should not re-fetch the initial static page if the same page is prefetched with prefetch={true}",
-        "app dir - prefetching should calculate `_rsc` query based on `Next-Url`",
-        "app dir - prefetching should immediately render the loading state for a dynamic segment when fetched from higher up in the tree",
-        "app dir - prefetching should not fetch again when a static page was prefetched",
-        "app dir - prefetching should not unintentionally modify the requested prefetch by escaping the uri encoded query params"
-      ]
-    },
     "test/e2e/app-dir/navigation/navigation.test.ts": {
       "failed": [
         "app dir - navigation middleware redirect should change browser location when router.refresh() gets a redirect response"

--- a/test/e2e/app-dir/app-prefetch/app/components/link-accordion.tsx
+++ b/test/e2e/app-dir/app-prefetch/app/components/link-accordion.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({ href, children, id }) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+        id={`accordion-${id}`}
+      />
+      {isVisible ? (
+        <Link href={href} id={id}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/app-prefetch/app/dashboard/loading.js
+++ b/test/e2e/app-dir/app-prefetch/app/dashboard/loading.js
@@ -1,3 +1,3 @@
 export default function DashboardLoading() {
-  return <>Loading dashboard...</>
+  return <>Loading dashboard... [dashboard-prefetch-sentinel]</>
 }

--- a/test/e2e/app-dir/app-prefetch/app/dashboard/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/dashboard/page.js
@@ -13,7 +13,7 @@ export default async function DashboardPage(props) {
 
   return (
     <>
-      <p id="dashboard-page">{message}</p>
+      <p id="dashboard-page">{message} [dashboard-prefetch-sentinel]</p>
       <Link href="/static-page" id="to-static-page">
         To Static Page
       </Link>

--- a/test/e2e/app-dir/app-prefetch/app/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/page.js
@@ -1,22 +1,27 @@
-import Link from 'next/link'
+import { LinkAccordion } from './components/link-accordion'
+
 export default function HomePage() {
   return (
     <>
-      <Link href="/dashboard" id="to-dashboard">
+      <p id="home-page">Home Page [prefetch-sentinel]</p>
+      <LinkAccordion href="/dashboard" id="to-dashboard">
         To Dashboard
-      </Link>
-      <Link href="/static-page" id="to-static-page">
+      </LinkAccordion>
+      <LinkAccordion href="/static-page" id="to-static-page">
         To Static Page
-      </Link>
-      <Link href="/static-page-no-prefetch" id="to-static-page-no-prefetch">
+      </LinkAccordion>
+      <LinkAccordion
+        href="/static-page-no-prefetch"
+        id="to-static-page-no-prefetch"
+      >
         To Static Page No Prefetch
-      </Link>
-      <Link href="/dynamic-page" id="to-dynamic-page-no-params">
+      </LinkAccordion>
+      <LinkAccordion href="/dynamic-page" id="to-dynamic-page-no-params">
         To Dynamic Page
-      </Link>
-      <Link href="/prefetch-auto/foobar" id="to-dynamic-page">
+      </LinkAccordion>
+      <LinkAccordion href="/prefetch-auto/foobar" id="to-dynamic-page">
         To Dynamic Slug Page
-      </Link>
+      </LinkAccordion>
       <a href="/static-page" id="to-static-page-hard">
         Hard Nav to Static Page
       </a>

--- a/test/e2e/app-dir/app-prefetch/app/static-page-no-prefetch/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/static-page-no-prefetch/page.js
@@ -1,13 +1,15 @@
-import Link from 'next/link'
+import { LinkAccordion } from '../components/link-accordion'
 
 export default async function Page() {
   return (
     <>
-      <p id="static-page-no-prefetch">Static Page No Prefetch</p>
+      <p id="static-page-no-prefetch">
+        Static Page No Prefetch [prefetch-sentinel]
+      </p>
       <p>
-        <Link href="/" id="to-home">
+        <LinkAccordion href="/" id="to-home">
           To home
-        </Link>
+        </LinkAccordion>
       </p>
     </>
   )

--- a/test/e2e/app-dir/app-prefetch/app/static-page/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/static-page/page.js
@@ -1,19 +1,19 @@
-import Link from 'next/link'
+import { LinkAccordion } from '../components/link-accordion'
 import { BackButton } from './back-button'
 
 export default async function Page() {
   return (
     <>
-      <p id="static-page">Static Page</p>
+      <p id="static-page">Static Page [prefetch-sentinel]</p>
       <p>
-        <Link href="/" id="to-home">
+        <LinkAccordion href="/" id="to-home">
           To home
-        </Link>
+        </LinkAccordion>
       </p>
       <p>
-        <Link href="/static-page" prefetch>
-          To Same Page
-        </Link>
+        <LinkAccordion href="/static-page" id="to-same-page">
+          To Static Page (self)
+        </LinkAccordion>
       </p>
       <p>
         <BackButton />

--- a/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
@@ -1,14 +1,18 @@
-import { nextTestSetup } from 'e2e-utils'
-import { retry, waitFor } from 'next-test-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
+import { createRouterAct } from './router-act'
+import { createTimeController } from './test-utils'
+import { join } from 'path'
 
 describe('app dir - prefetching (custom staleTime)', () => {
   const { next, isNextDev } = nextTestSetup({
-    files: __dirname,
+    files: {
+      app: new FileRef(join(__dirname, 'app')),
+    },
     skipDeployment: true,
     nextConfig: {
       experimental: {
         staleTimes: {
-          static: 10,
+          static: 30, // Minimum enforced by clientSegmentCache is 30 seconds
           dynamic: 5,
         },
       },
@@ -21,218 +25,299 @@ describe('app dir - prefetching (custom staleTime)', () => {
   }
 
   it('should not fetch again when a static page was prefetched when navigating to it twice', async () => {
-    const browser = await next.browser('/404')
-    let requests: string[] = []
-
-    browser.on('request', (req) => {
-      requests.push(new URL(req.url()).pathname)
-    })
-    await browser.eval('location.href = "/"')
-
-    await retry(async () => {
-      expect(
-        requests.filter((request) => request === '/static-page')
-      ).toHaveLength(1)
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
     })
 
-    await browser
-      .elementByCss('#to-static-page')
-      .click()
-      .waitForElementByCss('#static-page')
+    // Reveal the link to trigger prefetch and wait for it to complete
+    const link = await act(
+      async () => {
+        const reveal = await browser.elementByCss('#accordion-to-static-page')
+        await reveal.click()
+        await browser.waitForElementByCss('#to-static-page')
+        return await browser.elementByCss('#to-static-page')
+      },
+      { includes: 'Static Page [prefetch-sentinel]' }
+    )
 
-    await browser
-      .elementByCss('#to-home')
-      // Go back to home page
-      .click()
-      // Wait for homepage to load
-      .waitForElementByCss('#to-static-page')
-      // Click on the link to the static page again
-      .click()
-      // Wait for the static page to load again
-      .waitForElementByCss('#static-page')
+    // Navigate to static page - should use prefetched data with no additional requests
+    await act(async () => {
+      await link.click()
+      await browser.waitForElementByCss('#static-page')
+      const staticPageText = await browser.elementByCss('#static-page').text()
+      expect(staticPageText).toBe('Static Page [prefetch-sentinel]')
+    }, 'no-requests')
 
-    await retry(async () => {
-      expect(
-        requests.filter((request) => request === '/static-page')
-      ).toHaveLength(1)
-    })
+    // Reveal the "to-home" link and navigate back
+    // Note: Not using act() here because behavior differs between cache models.
+    // With clientSegmentCache, revealing may trigger a prefetch. Without it, home is already
+    // cached so no prefetch occurs. Either way, navigation works with cached data.
+    const reveal = await browser.elementByCss('#accordion-to-home')
+    await reveal.click()
+    const homeLink = await browser.waitForElementByCss('#to-home')
+    await homeLink.click()
+    await browser.waitForElementByCss('#accordion-to-static-page')
+
+    // Reveal the static page link again since accordion is hidden after navigation
+    await browser.elementByCss('#accordion-to-static-page').click()
+    await browser.waitForElementByCss('#to-static-page')
+
+    // Navigate to static page again using the accordion - should still use cached data with no additional requests
+    await act(async () => {
+      await browser.elementByCss('#to-static-page').click()
+      await browser.waitForElementByCss('#static-page')
+      const staticPageText = await browser.elementByCss('#static-page').text()
+      expect(staticPageText).toBe('Static Page [prefetch-sentinel]')
+    }, 'no-requests')
   })
 
   it('should fetch again when a static page was prefetched when navigating to it after the stale time has passed', async () => {
-    const browser = await next.browser('/404')
-    let requests: string[] = []
-
-    browser.on('request', (req) => {
-      requests.push(new URL(req.url()).pathname)
-    })
-    await browser.eval('location.href = "/"')
-
-    await retry(async () => {
-      expect(
-        requests.filter((request) => request === '/static-page')
-      ).toHaveLength(1)
+    let act: ReturnType<typeof createRouterAct>
+    const timeController = createTimeController()
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
     })
 
-    await browser
-      .elementByCss('#to-static-page')
-      .click()
-      .waitForElementByCss('#static-page')
+    // Install time controller
+    await timeController.install(browser)
 
-    const linkToStaticPage = await browser
-      .elementByCss('#to-home')
-      // Go back to home page
-      .click()
-      // Wait for homepage to load
-      .waitForElementByCss('#to-static-page')
+    // Reveal the static-page link to trigger prefetch and wait for it to complete
+    let link = await act(
+      async () => {
+        const reveal = await browser.elementByCss('#accordion-to-static-page')
+        await reveal.click()
+        await browser.waitForElementByCss('#to-static-page')
+        return await browser.elementByCss('#to-static-page')
+      },
+      { includes: 'Static Page [prefetch-sentinel]' }
+    )
 
-    // Wait for the stale time to pass.
-    await waitFor(10000)
-    // Click on the link to the static page again
-    await linkToStaticPage.click()
-    // Wait for the static page to load again
-    await browser.waitForElementByCss('#static-page')
+    // Navigate to static page - should use prefetched data with no additional requests
+    await act(async () => {
+      await link.click()
+      await browser.waitForElementByCss('#static-page')
+    }, 'no-requests')
 
-    await retry(async () => {
-      expect(
-        requests.filter((request) => request === '/static-page')
-      ).toHaveLength(2)
-    })
+    // Reveal the "to-home" link and navigate back
+    const reveal = await browser.elementByCss('#accordion-to-home')
+    await reveal.click()
+    const homeLink = await browser.waitForElementByCss('#to-home')
+    await homeLink.click()
+    await browser.waitForElementByCss('#accordion-to-static-page')
+
+    // Advance time past the stale time
+    await timeController.advance(browser, 31000)
+
+    // Reveal the static-page link to trigger prefetch and wait for it to complete
+    link = await act(
+      async () => {
+        const reveal = await browser.elementByCss('#accordion-to-static-page')
+        await reveal.click()
+        await browser.waitForElementByCss('#to-static-page')
+        return await browser.elementByCss('#to-static-page')
+      },
+      { includes: 'Static Page [prefetch-sentinel]' }
+    )
+
+    // Navigate to static page - should use prefetched data with no additional requests
+    await act(async () => {
+      await link.click()
+      await browser.waitForElementByCss('#static-page')
+    }, 'no-requests')
   })
 
   it('should not re-fetch cached data when navigating back to a route group', async () => {
-    const browser = await next.browser('/prefetch-auto-route-groups')
-    // once the page has loaded, we expect a data fetch
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/prefetch-auto-route-groups', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Once the page has loaded, we expect a data fetch (initial page load)
     expect(await browser.elementById('count').text()).toBe('1')
 
-    // once navigating to a sub-page, we expect another data fetch
-    await browser
-      .elementByCss("[href='/prefetch-auto-route-groups/sub/foo']")
-      .click()
+    // Navigate to a sub-page - this will trigger a data fetch
+    await act(async () => {
+      await browser
+        .elementByCss("[href='/prefetch-auto-route-groups/sub/foo']")
+        .click()
+    })
 
-    // navigating back to the route group page shouldn't trigger any data fetch
-    await browser.elementByCss("[href='/prefetch-auto-route-groups']").click()
+    // Navigate back to the route group page - should use cached data with no additional fetch
+    await act(async () => {
+      await browser.elementByCss("[href='/prefetch-auto-route-groups']").click()
+      // Confirm that the dashboard page is still rendering the stale fetch count, as it should be cached
+      expect(await browser.elementById('count').text()).toBe('1')
+    }, 'no-requests')
 
-    // confirm that the dashboard page is still rendering the stale fetch count, as it should be cached
-    expect(await browser.elementById('count').text()).toBe('1')
+    // Navigate to a new sub-page - this will trigger another data fetch
+    await act(async () => {
+      await browser
+        .elementByCss("[href='/prefetch-auto-route-groups/sub/bar']")
+        .click()
+    })
 
-    // navigating to a new sub-page, we expect another data fetch
-    await browser
-      .elementByCss("[href='/prefetch-auto-route-groups/sub/bar']")
-      .click()
+    // Finally, go back to the route group page - should use cached data with no additional fetch
+    await act(async () => {
+      await browser.elementByCss("[href='/prefetch-auto-route-groups']").click()
+      // Confirm that the dashboard page is still rendering the stale fetch count, as it should be cached
+      expect(await browser.elementById('count').text()).toBe('1')
+    }, 'no-requests')
 
-    // finally, going back to the route group page shouldn't trigger any data fetch
-    await browser.elementByCss("[href='/prefetch-auto-route-groups']").click()
-
-    // confirm that the dashboard page is still rendering the stale fetch count, as it should be cached
-    expect(await browser.elementById('count').text()).toBe('1')
-
+    // Reload the page to get the accurate total number of fetches
     await browser.refresh()
-    // reloading the page, we should now get an accurate total number of fetches
-    // the initial fetch, 2 sub-page fetches, and a final fetch when reloading the page
+    // The initial fetch, 2 sub-page fetches, and a final fetch when reloading the page
     expect(await browser.elementById('count').text()).toBe('4')
   })
 
   it('should fetch again when the initially visited static page is visited after the stale time has passed', async () => {
-    const browser = await next.browser('/404')
-    let requests: string[] = []
-
-    browser.on('request', (req) => {
-      const path = new URL(req.url()).pathname
-      const headers = req.headers()
-
-      if (headers['rsc']) {
-        requests.push(path)
-      }
+    let act: ReturnType<typeof createRouterAct>
+    const timeController = createTimeController()
+    const browser = await next.browser('/static-page-no-prefetch', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
     })
 
-    await browser.eval('location.href = "/static-page-no-prefetch"')
+    // Install time controller
+    await timeController.install(browser)
 
-    await browser
-      .elementByCss('#to-home')
-      .click()
-      .waitForElementByCss('#to-static-page')
-
-    // Wait for the stale time to pass.
-    await waitFor(10000)
-
-    await browser.elementByCss('#to-static-page-no-prefetch').click()
-
-    // Wait for the static page to load again
+    // Wait for the page to load (initial navigation request happened during browser load)
     await browser.waitForElementByCss('#static-page-no-prefetch')
 
-    await retry(async () => {
-      expect(
-        requests.filter((request) => request === '/static-page-no-prefetch')
-      ).toHaveLength(1)
-    })
+    // Reveal the home link and wait for prefetch to complete, then navigate
+    const homeLink = await act(
+      async () => {
+        const reveal = await browser.elementByCss('#accordion-to-home')
+        await reveal.click()
+        await browser.waitForElementByCss('#to-home')
+        return await browser.elementByCss('#to-home')
+      },
+      { includes: 'Home Page [prefetch-sentinel]' }
+    )
+
+    // Navigate to home - no additional requests since we just prefetched
+    await homeLink.click()
+    await browser.waitForElementByCss('#accordion-to-static-page')
+
+    // Advance time past the stale time
+    await timeController.advance(browser, 31000)
+
+    // Reveal the link to static-page-no-prefetch and wait for prefetch
+    const link = await act(
+      async () => {
+        const reveal = await browser.elementByCss(
+          '#accordion-to-static-page-no-prefetch'
+        )
+        await reveal.click()
+        await browser.waitForElementByCss('#to-static-page-no-prefetch')
+        return await browser.elementByCss('#to-static-page-no-prefetch')
+      },
+      { includes: 'Static Page No Prefetch [prefetch-sentinel]' }
+    )
+
+    // Navigate back to static-page-no-prefetch - should use the fresh prefetch data
+    await act(async () => {
+      await link.click()
+      await browser.waitForElementByCss('#static-page-no-prefetch')
+      const staticPageText = await browser
+        .elementByCss('#static-page-no-prefetch')
+        .text()
+      expect(staticPageText).toBe('Static Page No Prefetch [prefetch-sentinel]')
+    }, 'no-requests')
   })
 
   it('should renew the stale time after refetching expired RSC data', async () => {
-    const browser = await next.browser('/404')
-    let requests: string[] = []
-
-    browser.on('request', (req) => {
-      requests.push(new URL(req.url()).pathname)
+    let act: ReturnType<typeof createRouterAct>
+    const timeController = createTimeController()
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
     })
 
-    // Navigate to home and wait for static page to be prefetched
-    await browser.eval('location.href = "/"')
+    // Install time controller
+    await timeController.install(browser)
 
-    await retry(async () => {
-      expect(
-        requests.filter((request) => request === '/static-page')
-      ).toHaveLength(1)
-    })
+    // Reveal the static-page link to trigger prefetch and wait for it to complete
+    let link = await act(
+      async () => {
+        const reveal = await browser.elementByCss('#accordion-to-static-page')
+        await reveal.click()
+        await browser.waitForElementByCss('#to-static-page')
+        return await browser.elementByCss('#to-static-page')
+      },
+      { includes: 'Static Page [prefetch-sentinel]' }
+    )
 
-    // Navigate to static page (should use cached data)
-    await browser
-      .elementByCss('#to-static-page')
-      .click()
-      .waitForElementByCss('#static-page')
+    // Navigate to static page (should use prefetched data with no additional requests)
+    await act(async () => {
+      await link.click()
+      await browser.waitForElementByCss('#static-page')
+    }, 'no-requests')
 
-    // Go back to home
-    await browser
-      .elementByCss('#to-home')
-      .click()
-      .waitForElementByCss('#to-static-page')
+    // Reveal the "to-home" link and navigate back
+    // Note: Not using act() here because behavior differs between cache models.
+    // With clientSegmentCache, revealing may trigger a prefetch. Without it, home is already
+    // cached so no prefetch occurs. Either way, navigation works with cached data.
+    const reveal = await browser.elementByCss('#accordion-to-home')
+    await reveal.click()
+    const homeLink = await browser.waitForElementByCss('#to-home')
+    await homeLink.click()
+    await browser.waitForElementByCss('#accordion-to-static-page')
 
-    // Wait for stale time to expire (10 seconds)
-    await waitFor(10000)
+    // Advance time past the stale time
+    await timeController.advance(browser, 31000)
 
-    // Navigate to static page again (should refetch due to expired cache)
-    await browser
-      .elementByCss('#to-static-page')
-      .click()
-      .waitForElementByCss('#static-page')
+    // Reveal the static-page link to trigger prefetch and wait for it to complete
+    link = await act(
+      async () => {
+        const reveal = await browser.elementByCss('#accordion-to-static-page')
+        await reveal.click()
+        await browser.waitForElementByCss('#to-static-page')
+        return await browser.elementByCss('#to-static-page')
+      },
+      { includes: 'Static Page [prefetch-sentinel]' }
+    )
 
-    // Verify that refetch happened
-    await retry(async () => {
-      expect(
-        requests.filter((request) => request === '/static-page')
-      ).toHaveLength(2)
-    })
+    // Navigate to static page again (should use freshly prefetched data with no additional requests)
+    await act(async () => {
+      await link.click()
+      await browser.waitForElementByCss('#static-page')
+    }, 'no-requests')
 
-    // Go back to home
-    await browser
-      .elementByCss('#to-home')
-      .click()
-      .waitForElementByCss('#to-static-page')
+    // Go back to home (reveal the link and navigate)
+    // Note: Not using act() here because behavior differs between cache models.
+    const reveal2 = await browser.elementByCss('#accordion-to-home')
+    await reveal2.click()
+    const homeLink2 = await browser.waitForElementByCss('#to-home')
+    await homeLink2.click()
+    await browser.waitForElementByCss('#accordion-to-static-page')
 
-    // Wait less than the stale time (5 seconds - should still be fresh)
-    await waitFor(5000)
+    // Advance time but not past the stale time (20 seconds < 30 second stale time - should still be fresh)
+    await timeController.advance(browser, 20000)
+
+    // Reveal the static-page link to trigger prefetch (should use cached data, not refetch)
+    link = await act(async () => {
+      const reveal = await browser.elementByCss('#accordion-to-static-page')
+      await reveal.click()
+      await browser.waitForElementByCss('#to-static-page')
+      return await browser.elementByCss('#to-static-page')
+    }, 'no-requests')
 
     // Navigate to static page again (should NOT refetch - stale time should be renewed)
-    await browser
-      .elementByCss('#to-static-page')
-      .click()
-      .waitForElementByCss('#static-page')
-
-    // This should still be 2 - no new request should have been made
-    // If this fails, it means the stale time was not renewed after the refetch
-    await retry(async () => {
-      expect(
-        requests.filter((request) => request === '/static-page')
-      ).toHaveLength(2)
-    })
+    // If this assertion passes, it means the stale time was properly renewed after the refetch
+    await act(async () => {
+      await link.click()
+      await browser.waitForElementByCss('#static-page')
+      const staticPageText = await browser.elementByCss('#static-page').text()
+      expect(staticPageText).toBe('Static Page [prefetch-sentinel]')
+    }, 'no-requests')
   })
 })

--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -1,37 +1,18 @@
-import { nextTestSetup } from 'e2e-utils'
-import { check, waitFor, retry } from 'next-test-utils'
+import { FileRef, nextTestSetup } from 'e2e-utils'
+import { waitFor, retry } from 'next-test-utils'
 import { NEXT_RSC_UNION_QUERY } from 'next/dist/client/components/app-router-headers'
 import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
-
-const browserConfigWithFixedTime = {
-  beforePageLoad: (page) => {
-    page.addInitScript(() => {
-      const startTime = new Date()
-      const fixedTime = new Date('2023-04-17T00:00:00Z')
-
-      // Override the Date constructor
-      // @ts-ignore
-      // eslint-disable-next-line no-native-reassign
-      Date = class extends Date {
-        constructor() {
-          super()
-          // @ts-ignore
-          return new startTime.constructor(fixedTime)
-        }
-
-        static now() {
-          return fixedTime.getTime()
-        }
-      }
-    })
-  },
-}
+import { createRouterAct } from './router-act'
+import { createTimeController } from './test-utils'
+import { join } from 'path'
 
 const itHeaded = process.env.HEADLESS ? it.skip : it
 
 describe('app dir - prefetching', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
-    files: __dirname,
+    files: {
+      app: new FileRef(join(__dirname, 'app')),
+    },
   })
 
   // TODO: re-enable for dev after https://vercel.slack.com/archives/C035J346QQL/p1663822388387959 is resolved (Sep 22nd 2022)
@@ -45,15 +26,30 @@ describe('app dir - prefetching', () => {
   })
 
   it('should show layout eagerly when prefetched with loading one level down', async () => {
-    const browser = await next.browser('/', browserConfigWithFixedTime)
-    // Ensure the page is prefetched
-    await waitFor(1000)
+    let act: ReturnType<typeof createRouterAct>
+    const timeController = createTimeController()
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    await timeController.install(browser)
+
+    // Reveal the dashboard accordion and wait for prefetch to complete
+    const dashboardLink = await act(
+      async () => {
+        const reveal = await browser.elementByCss('#accordion-to-dashboard')
+        await reveal.click()
+        await browser.waitForElementByCss('#to-dashboard')
+        return await browser.elementByCss('#to-dashboard')
+      },
+      { includes: '[dashboard-prefetch-sentinel]' }
+    )
 
     const before = Date.now()
-    await browser
-      .elementByCss('#to-dashboard')
-      .click()
-      .waitForElementByCss('#dashboard-layout')
+    await dashboardLink.click()
+    await browser.waitForElementByCss('#dashboard-layout')
     const after = Date.now()
     const timeToComplete = after - before
 
@@ -66,15 +62,15 @@ describe('app dir - prefetching', () => {
     await browser.waitForElementByCss('#dashboard-page')
 
     expect(await browser.waitForElementByCss('#dashboard-page').text()).toBe(
-      'Welcome to the dashboard'
+      'Welcome to the dashboard [dashboard-prefetch-sentinel]'
     )
   })
 
   it('should not have prefetch error for static path', async () => {
     const browser = await next.browser('/')
-    await browser.eval('window.nd.router.prefetch("/dashboard/123")')
+    await browser.eval('window.next.router.prefetch("/dashboard/123")')
     await waitFor(3000)
-    await browser.eval('window.nd.router.push("/dashboard/123")')
+    await browser.eval('window.next.router.push("/dashboard/123")')
     expect(next.cliOutput).not.toContain('ReferenceError')
     expect(next.cliOutput).not.toContain('is not defined')
   })
@@ -116,89 +112,51 @@ describe('app dir - prefetching', () => {
   })
 
   it('should not fetch again when a static page was prefetched', async () => {
-    const browser = await next.browser('/404', browserConfigWithFixedTime)
-    let requests: string[] = []
-
-    browser.on('request', (req) => {
-      requests.push(new URL(req.url()).pathname)
+    let act: ReturnType<typeof createRouterAct>
+    const timeController = createTimeController()
+    const browser = await next.browser('/404', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
     })
-    await browser.eval('location.href = "/"')
 
-    await browser.eval(
-      'window.nd.router.prefetch("/static-page", {kind: "auto"})'
+    await browser.eval('location.href = "/"')
+    await browser.waitForElementByCss('#accordion-to-static-page')
+    await timeController.install(browser)
+
+    // Reveal the static-page accordion to trigger prefetch
+    await act(
+      async () => {
+        const reveal = await browser.elementByCss('#accordion-to-static-page')
+        await reveal.click()
+        await browser.waitForElementByCss('#to-static-page')
+      },
+      { includes: 'Static Page [prefetch-sentinel]' }
     )
 
-    await check(() => {
-      return requests.some(
-        (req) =>
-          req.includes('static-page') && !req.includes(NEXT_RSC_UNION_QUERY)
-      )
-        ? 'success'
-        : JSON.stringify(requests)
-    }, 'success')
+    // Navigate to static page using cached prefetch
+    await act(async () => {
+      await browser.elementByCss('#to-static-page').click()
+      await browser.waitForElementByCss('#static-page')
+    }, 'no-requests')
 
-    await browser
-      .elementByCss('#to-static-page')
-      .click()
-      .waitForElementByCss('#static-page')
+    // Return to the home page - reveal accordion and navigate
+    const reveal = await browser.elementByCss('#accordion-to-home')
+    await reveal.click()
+    const homeLink = await browser.waitForElementByCss('#to-home')
 
-    expect(
-      requests.filter((request) => request === '/static-page').length
-    ).toBe(1)
+    await homeLink.click()
+    await browser.waitForElementByCss('#accordion-to-static-page')
 
-    // return to the home page
-    await browser.elementByCss('#to-home').click()
+    // Reveal the static-page accordion again - should not trigger new prefetch (cache still fresh)
+    await browser.elementByCss('#accordion-to-static-page').click()
     await browser.waitForElementByCss('#to-static-page')
-    // there shouldn't be any additional prefetches
-    expect(
-      requests.filter((request) => request === '/static-page').length
-    ).toBe(1)
 
-    // navigate to the static page again
-    await browser.elementByCss('#to-static-page').click()
-    await browser.waitForElementByCss('#static-page')
-
-    // there still should only be the initial request to the static page
-    expect(
-      requests.filter((request) => request === '/static-page').length
-    ).toBe(1)
-  })
-
-  it('should calculate `_rsc` query based on `Next-Url`', async () => {
-    const browser = await next.browser('/404', browserConfigWithFixedTime)
-    let staticPageRequests: string[] = []
-
-    browser.on('request', (req) => {
-      const url = new URL(req.url())
-      if (url.toString().includes(`/static-page?${NEXT_RSC_UNION_QUERY}=`)) {
-        staticPageRequests.push(`${url.pathname}${url.search}`)
-      }
-    })
-    await browser.eval('location.href = "/"')
-    await browser.eval(
-      `window.nd.router.prefetch("/static-page", {kind: "auto"})`
-    )
-    await check(() => {
-      return staticPageRequests.length === 1
-        ? 'success'
-        : JSON.stringify(staticPageRequests)
-    }, 'success')
-
-    // Unable to clear router cache so mpa navigation
-    await browser.eval('location.href = "/dashboard"')
-    await browser.eval(
-      `window.nd.router.prefetch("/static-page", {kind: "auto"})`
-    )
-    await check(() => {
-      return staticPageRequests.length === 2
-        ? 'success'
-        : JSON.stringify(staticPageRequests)
-    }, 'success')
-
-    expect(staticPageRequests[0]).toMatch('/static-page?_rsc=')
-    expect(staticPageRequests[1]).toMatch('/static-page?_rsc=')
-    // `_rsc` does not match because it depends on the `Next-Url`
-    expect(staticPageRequests[0]).not.toBe(staticPageRequests[1])
+    // Navigate to the static page again using cached data
+    await act(async () => {
+      await browser.elementByCss('#to-static-page').click()
+      await browser.waitForElementByCss('#static-page')
+    }, 'no-requests')
   })
 
   it('should not prefetch for a bot user agent', async () => {
@@ -214,6 +172,11 @@ describe('app dir - prefetching', () => {
       )}"`
     )
 
+    // Reveal the static-page accordion
+    await browser.elementByCss('#accordion-to-static-page').click()
+    await browser.waitForElementByCss('#to-static-page')
+
+    // Hover over the link - bot agents should not trigger prefetch
     await browser.elementByCss('#to-static-page').moveTo()
 
     // check five times to ensure prefetch didn't occur
@@ -339,15 +302,36 @@ describe('app dir - prefetching', () => {
   })
 
   it('should immediately render the loading state for a dynamic segment when fetched from higher up in the tree', async () => {
-    const browser = await next.browser('/')
-    const loadingText = await browser
-      .elementById('to-dynamic-page')
-      .click()
-      .waitForElementByCss('#loading-text')
-      .text()
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
 
-    expect(loadingText).toBe('Loading Prefetch Auto')
+    // Reveal the accordion and wait for prefetch - should get loading state
+    const link = await act(
+      async () => {
+        const reveal = await browser.elementByCss('#accordion-to-dynamic-page')
+        await reveal.click()
+        await browser.waitForElementByCss('#to-dynamic-page')
+        return await browser.elementByCss('#to-dynamic-page')
+      },
+      { includes: 'Loading Prefetch Auto' }
+    )
 
+    // Click the link to navigate - should trigger dynamic data fetch
+    await act(
+      async () => {
+        await link.click()
+        await browser.waitForElementByCss('#loading-text')
+        const loadingText = await browser.elementByCss('#loading-text').text()
+        expect(loadingText).toBe('Loading Prefetch Auto')
+      },
+      { includes: 'prefetch-auto-page-data' }
+    )
+
+    // Wait for final data to appear
     await browser.waitForElementByCss('#prefetch-auto-page-data')
   })
 
@@ -372,133 +356,29 @@ describe('app dir - prefetching', () => {
     // The space encoding of the prefetch request should be the same as the href, and should not be replaced with a +
     await retry(async () => {
       expect(
-        rscRequests.filter((req) => req.includes('/?param=with%20space'))
-      ).toHaveLength(1)
+        rscRequests.filter((req) => req.includes('/?param=with%20space')).length
+      ).toBeGreaterThanOrEqual(1)
     })
+
+    const initialRequestCount = rscRequests.filter((req) =>
+      req.includes('/?param=with%20space')
+    ).length
 
     // Click the link
     await browser.elementById('prefetch-via-link').click()
 
-    // Assert that we're on the homepage
-    expect(await browser.hasElementByCssSelector('#to-dashboard')).toBe(true)
+    // Assert that we're on the homepage (check for accordion since links are hidden)
+    expect(
+      await browser.hasElementByCssSelector('#accordion-to-dashboard')
+    ).toBe(true)
 
     await browser.waitForIdleNetwork()
 
     // No new requests should be made since it is correctly prefetched
     await retry(async () => {
       expect(
-        rscRequests.filter((req) => req.includes('/?param=with%20space'))
-      ).toHaveLength(1)
-    })
-  })
-
-  describe('prefetch cache seeding', () => {
-    it('should not re-fetch the initial static page if the same page is prefetched with prefetch={true}', async () => {
-      const rscRequests = []
-      const browser = await next.browser('/static-page', {
-        beforePageLoad(page) {
-          page.on('request', async (req) => {
-            const url = new URL(req.url())
-            if (url.pathname === '/static-page' || url.pathname === '/') {
-              const headers = await req.allHeaders()
-              if (headers['rsc']) {
-                rscRequests.push(url.pathname)
-              }
-            }
-          })
-        },
-      })
-
-      expect(
-        await browser.hasElementByCssSelector('[href="/static-page"]')
-      ).toBe(true)
-
-      // sanity check: we should see a prefetch request to the root page
-      await retry(async () => {
-        expect(rscRequests.filter((req) => req === '/').length).toBe(1)
-      })
-
-      // We shouldn't see any requests to the static page since the prefetch cache was seeded as part of the SSR render
-      await retry(async () => {
-        expect(rscRequests.filter((req) => req === '/static-page').length).toBe(
-          0
-        )
-      })
-
-      // navigate to index
-      await browser.elementByCss('[href="/"]').click()
-
-      // we should be on the index page
-      await browser.waitForElementByCss('#to-dashboard')
-
-      // navigate to the static page
-      await browser.elementByCss('[href="/static-page"]').click()
-
-      // we should be on the static page
-      await browser.waitForElementByCss('#static-page')
-
-      await browser.waitForIdleNetwork()
-
-      // We still shouldn't see any requests since it respects the static staletime (default 5m)
-      await retry(async () => {
-        expect(rscRequests.filter((req) => req === '/static-page').length).toBe(
-          0
-        )
-      })
-    })
-
-    it('should not re-fetch the initial dynamic page if the same page is prefetched with prefetch={true}', async () => {
-      const rscRequests = []
-      const browser = await next.browser('/dynamic-page', {
-        beforePageLoad(page) {
-          page.on('request', async (req) => {
-            const url = new URL(req.url())
-            if (url.pathname === '/dynamic-page' || url.pathname === '/') {
-              const headers = await req.allHeaders()
-              if (headers['rsc']) {
-                rscRequests.push(url.pathname)
-              }
-            }
-          })
-        },
-      })
-
-      expect(
-        await browser.hasElementByCssSelector('[href="/dynamic-page"]')
-      ).toBe(true)
-
-      // sanity check: we should see a prefetch request to the root page
-      await retry(async () => {
-        expect(rscRequests.filter((req) => req === '/').length).toBe(1)
-      })
-
-      // We shouldn't see any requests to the dynamic page since the prefetch cache was seeded as part of the SSR render
-      await retry(async () => {
-        expect(
-          rscRequests.filter((req) => req === '/dynamic-page').length
-        ).toBe(0)
-      })
-
-      // navigate to index
-      await browser.elementByCss('[href="/"]').click()
-
-      // we should be on the index page
-      await browser.waitForElementByCss('#to-dashboard')
-
-      // navigate to the dynamic page
-      await browser.elementByCss('[href="/dynamic-page"]').click()
-
-      // we should be on the dynamic page
-      await browser.waitForElementByCss('#dynamic-page')
-
-      await browser.waitForIdleNetwork()
-
-      // We should see a request for the dynamic page since it respects the dynamic staletime (default 0)
-      await retry(async () => {
-        expect(
-          rscRequests.filter((req) => req === '/dynamic-page').length
-        ).toBe(1)
-      })
+        rscRequests.filter((req) => req.includes('/?param=with%20space')).length
+      ).toBe(initialRequestCount)
     })
   })
 
@@ -517,7 +397,11 @@ describe('app dir - prefetching', () => {
             .elementByCss(`[href="${basePath}/test-page/sub-page"]`)
             .click()
 
-          await check(() => browser.hasElementByCssSelector('#sub-page'), true)
+          await retry(async () => {
+            expect(await browser.hasElementByCssSelector('#sub-page')).toBe(
+              true
+            )
+          })
 
           const newRandomNumber = await browser
             .elementById('random-number')
@@ -525,38 +409,38 @@ describe('app dir - prefetching', () => {
 
           expect(initialRandomNumber).toBe(newRandomNumber)
 
-          await check(() => {
+          await retry(async () => {
             const logOccurrences =
               next.cliOutput.slice(logStartIndex).split('re-fetching in layout')
                 .length - 1
 
-            return logOccurrences
-          }, 1)
+            expect(logOccurrences).toBe(1)
+          })
         })
 
         it('should update search params following a link click', async () => {
           const browser = await next.browser(`${basePath}/search-params`)
-          await check(
-            () => browser.elementById('search-params-data').text(),
-            /{}/
-          )
+          await retry(async () => {
+            const text = await browser.elementById('search-params-data').text()
+            expect(text).toMatch(/{}/)
+          })
           await browser.elementByCss('[href="?foo=true"]').click()
-          await check(
-            () => browser.elementById('search-params-data').text(),
-            /{"foo":"true"}/
-          )
+          await retry(async () => {
+            const text = await browser.elementById('search-params-data').text()
+            expect(text).toMatch(/{"foo":"true"}/)
+          })
           await browser
             .elementByCss(`[href="${basePath}/search-params"]`)
             .click()
-          await check(
-            () => browser.elementById('search-params-data').text(),
-            /{}/
-          )
+          await retry(async () => {
+            const text = await browser.elementById('search-params-data').text()
+            expect(text).toMatch(/{}/)
+          })
           await browser.elementByCss('[href="?foo=true"]').click()
-          await check(
-            () => browser.elementById('search-params-data').text(),
-            /{"foo":"true"}/
-          )
+          await retry(async () => {
+            const text = await browser.elementById('search-params-data').text()
+            expect(text).toMatch(/{"foo":"true"}/)
+          })
         })
       })
     })
@@ -566,14 +450,18 @@ describe('app dir - prefetching', () => {
     it('should not throw when an invalid URL is passed to Link', async () => {
       const browser = await next.browser('/invalid-url/from-link')
 
-      await check(() => browser.hasElementByCssSelector('h1'), true)
+      await retry(async () => {
+        expect(await browser.hasElementByCssSelector('h1')).toBe(true)
+      })
       expect(await browser.elementByCss('h1').text()).toEqual('Hello, world!')
     })
 
     it('should throw when an invalid URL is passed to router.prefetch', async () => {
       const browser = await next.browser('/invalid-url/from-router-prefetch')
 
-      await check(() => browser.hasElementByCssSelector('h1'), true)
+      await retry(async () => {
+        expect(await browser.hasElementByCssSelector('h1')).toBe(true)
+      })
       expect(await browser.elementByCss('h1').text()).toEqual(
         'A prefetch threw an error'
       )
@@ -598,39 +486,18 @@ describe('app dir - prefetching', () => {
         },
       })
 
+      // Reveal an accordion to trigger prefetch
+      await browser.elementByCss('#accordion-to-static-page').click()
       await browser.waitForIdleNetwork()
 
       await retry(async () => {
-        expect(requests.length).toBeGreaterThan(0)
-        expect(requests.every((req) => req.priority === 'low')).toBe(true)
-      })
-    })
-
-    it('should prefetch with high priority when navigating to a page without a prefetch entry', async () => {
-      const requests: { priority: string; url: string }[] = []
-      const browser = await next.browser('/prefetch-false/initial', {
-        beforePageLoad(page) {
-          page.on('request', async (req) => {
-            const url = new URL(req.url())
-            const headers = await req.allHeaders()
-            if (headers['rsc']) {
-              requests.push({
-                priority: headers['next-test-fetch-priority'],
-                url: url.pathname,
-              })
-            }
-          })
-        },
-      })
-
-      await browser.waitForIdleNetwork()
-
-      expect(requests.length).toBe(0)
-
-      await browser.elementByCss('#to-prefetch-false-result').click()
-      await retry(async () => {
-        expect(requests.length).toBe(1)
-        expect(requests[0].priority).toBe('high')
+        const staticPageRequests = requests.filter(
+          (req) => req.url === '/static-page'
+        )
+        expect(staticPageRequests.length).toBeGreaterThan(0)
+        expect(staticPageRequests.every((req) => req.priority === 'low')).toBe(
+          true
+        )
       })
     })
 
@@ -651,6 +518,11 @@ describe('app dir - prefetching', () => {
         },
       })
 
+      // Reveal the dashboard accordion
+      await browser.elementByCss('#accordion-to-dashboard').click()
+      await browser.waitForElementByCss('#to-dashboard')
+
+      // Click to navigate
       await browser.elementByCss('#to-dashboard').click()
       await browser.waitForIdleNetwork()
 
@@ -658,9 +530,15 @@ describe('app dir - prefetching', () => {
         const dashboardRequests = requests.filter(
           (req) => req.url === '/dashboard'
         )
-        expect(dashboardRequests.length).toBe(2)
-        expect(dashboardRequests[0].priority).toBe('low') // the first request is the prefetch
-        expect(dashboardRequests[1].priority).toBe('auto') // the second request is the lazy fetch to fill in missing data
+        expect(dashboardRequests.length).toBeGreaterThanOrEqual(2)
+        // Should have at least one low priority prefetch request
+        expect(dashboardRequests.some((req) => req.priority === 'low')).toBe(
+          true
+        )
+        // Should have at least one auto priority fetch to fill in missing data
+        expect(dashboardRequests.some((req) => req.priority === 'auto')).toBe(
+          true
+        )
       })
     })
 

--- a/test/e2e/app-dir/app-prefetch/router-act.ts
+++ b/test/e2e/app-dir/app-prefetch/router-act.ts
@@ -1,0 +1,504 @@
+import type * as Playwright from 'playwright'
+import { diff } from 'jest-diff'
+import { equals } from '@jest/expect-utils'
+
+type Batch = {
+  pendingRequestChecks: Set<Promise<void>>
+  pendingRequests: Set<PendingRSCRequest>
+}
+
+type PendingRSCRequest = {
+  url: string
+  route: Playwright.Route | null
+  result: Promise<{
+    text: string
+    body: any
+    headers: Record<string, string>
+    status: number
+  }>
+  didProcess: boolean
+}
+
+let currentBatch: Batch | null = null
+
+type ExpectedResponseConfig = { includes: string; block?: boolean | 'reject' }
+
+/**
+ * Represents the expected responses sent by the server to fulfill requests
+ * initiated by the `scope` function.
+ *
+ * - `includes` is a substring of an expected response body.
+ * - `block` indicates whether the response should not yet be sent to the
+ *   client. This option is only supported when nested inside an outer `act`
+ *   scope. The blocked response will be fulfilled when the outer
+ *   scope completes.
+ *
+ * The list of expected responses does not need to be exhaustive — any
+ * responses that don't match will proceed like normal. However, `act` will
+ * error if the expected substring is not found in any of the responses, or
+ * if the expected responses are received out of order. It will also error
+ * if the same expected substring is found in multiple responses.
+ *
+ * If no expected responses are provided, the only expectation is that at
+ * least one request is initiated. (This is the same as passing an
+ * empty array.)
+ *
+ * Alternatively, if no network activity is expected, pass "no-requests".
+ */
+type ActConfig =
+  | ExpectedResponseConfig
+  | Array<ExpectedResponseConfig>
+  | 'block'
+  | 'no-requests'
+  | null
+
+export function createRouterAct(
+  page: Playwright.Page
+): <T>(scope: () => Promise<T> | T, config?: ActConfig) => Promise<T> {
+  /**
+   * Test utility for requests initiated by the Next.js Router, such as
+   * prefetches and navigations. Calls the given async function then intercepts
+   * any router requests that are initiated as a result. It will then wait for
+   * all the requests to complete before exiting. Inspired by the React
+   * `act` API.
+   */
+  async function act<T>(
+    scope: () => Promise<T> | T,
+    config?: ActConfig
+  ): Promise<T> {
+    // Capture a stack trace for better async error messages.
+    const error = new Error()
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(error, act)
+    }
+
+    let expectedResponses: Array<ExpectedResponseConfig> | null
+    let forbiddenResponses: Array<ExpectedResponseConfig> | null = null
+    let shouldBlockAll = false
+    if (config === undefined || config === null) {
+      // Default. Expect at least one request, but don't assert on the response.
+      expectedResponses = []
+    } else if (config === 'block') {
+      // Expect at least one request, and block them all from being fulfilled.
+      if (currentBatch === null) {
+        error.message =
+          '`block` option only supported when nested inside an outer ' +
+          '`act` scope.'
+        throw error
+      }
+      expectedResponses = []
+      shouldBlockAll = true
+    } else if (config === 'no-requests') {
+      // Expect no requests to be initiated.
+      expectedResponses = null
+    } else if (!Array.isArray(config)) {
+      // Shortcut for a single expected response.
+      if (config.block === true && currentBatch === null) {
+        error.message =
+          '`block: true` option only supported when nested inside an outer ' +
+          '`act` scope.'
+        throw error
+      }
+      if (config.block !== 'reject') {
+        expectedResponses = [config]
+      } else {
+        expectedResponses = []
+        forbiddenResponses = [config]
+      }
+    } else {
+      expectedResponses = []
+      for (const item of config) {
+        if (item.block === true && currentBatch === null) {
+          error.message =
+            '`block: true` option only supported when nested inside an outer ' +
+            '`act` scope.'
+          throw error
+        }
+        if (item.block !== 'reject') {
+          expectedResponses.push(item)
+        } else {
+          if (forbiddenResponses === null) {
+            forbiddenResponses = [item]
+          } else {
+            forbiddenResponses.push(item)
+          }
+        }
+      }
+    }
+
+    // Attach a route handler to intercept router requests for the duration
+    // of the `act` scope. It will be removed before `act` exits.
+    let onDidIssueFirstRequest: (() => void) | null = null
+    const routeHandler = async (route: Playwright.Route) => {
+      const request = route.request()
+
+      const pendingRequests = batch.pendingRequests
+      const pendingRequestChecks = batch.pendingRequestChecks
+
+      // Because determining whether we need to intercept the request is an
+      // async operation, we collect these promises so we can await them at the
+      // end of the `act` scope to see whether any additional requests
+      // were initiated.
+      // NOTE: The default check doesn't actually need to be async, but since
+      // this logic is subtle, to preserve the ability to add an async
+      // check later, I'm treating it as if it could possibly be async.
+      const checkIfRouterRequest = (async () => {
+        const headers = request.headers()
+
+        // The default check includes navigations, prefetches, and actions.
+        const isRouterRequest =
+          headers['rsc'] !== undefined || // Matches navigations and prefetches
+          headers['next-action'] !== undefined // Matches Server Actions
+
+        if (isRouterRequest) {
+          // This request was initiated by the Next.js Router. Intercept it and
+          // add it to the current batch.
+          pendingRequests.add({
+            url: request.url(),
+            route,
+            // `act` controls the timing of when responses reach the client,
+            // but it should not affect the timing of when requests reach the
+            // server; we pass the request to the server the immediately.
+            result: new Promise(async (resolve) => {
+              const originalResponse = await page.request.fetch(request, {
+                maxRedirects: 0,
+              })
+
+              // WORKAROUND:
+              // intercepting responses with 'Transfer-Encoding: chunked' (used for streaming)
+              // seems to be problematic sometimes, making the browser error with `net::ERR_INCOMPLETE_CHUNKED_ENCODING`.
+              // In particular, this seems to happen when blocking a streaming navigation response. (but not always)
+              // Playwright buffers the whole body anyway, so we can remove the header to sidestep this.
+              const headers = originalResponse.headers()
+              delete headers['transfer-encoding']
+
+              resolve({
+                text: await originalResponse.text(),
+                body: await originalResponse.body(),
+                headers,
+                status: originalResponse.status(),
+              })
+            }),
+            didProcess: false,
+          })
+          if (onDidIssueFirstRequest !== null) {
+            onDidIssueFirstRequest()
+            onDidIssueFirstRequest = null
+          }
+          return
+        }
+        // This is some other request not related to the Next.js Router. Allow
+        // it to continue as normal.
+        route.continue()
+      })()
+
+      pendingRequestChecks.add(checkIfRouterRequest)
+      await checkIfRouterRequest
+      // Once we've read the header, we can remove it from the pending set.
+      pendingRequestChecks.delete(checkIfRouterRequest)
+    }
+
+    let didHardNavigate = false
+    const hardNavigationHandler = async () => {
+      // If a hard navigation occurs, the current batch of requests is no longer
+      // valid. In fact, Playwright will hang indefinitely if we attempt to
+      // await the response of an orphaned request. Reset the batch and unblock
+      // all the orphaned requests.
+      const orphanedRequests = batch.pendingRequests
+      batch.pendingRequests = new Set()
+      batch.pendingRequestChecks = new Set()
+      await Promise.all(
+        Array.from(orphanedRequests).map((item) => item.route.continue())
+      )
+      didHardNavigate = true
+    }
+
+    const waitForPendingRequestChecks = async () => {
+      const prevChecks = batch.pendingRequestChecks
+      batch.pendingRequestChecks = new Set()
+      await Promise.all(prevChecks)
+    }
+
+    const prevBatch = currentBatch
+    const batch: Batch = {
+      pendingRequestChecks: new Set(),
+      pendingRequests: new Set(),
+    }
+    currentBatch = batch
+    await page.route('**/*', routeHandler)
+    await page.on('framedetached', hardNavigationHandler)
+    try {
+      // Call the user-provided scope function
+      const returnValue = await scope()
+
+      // Wait until the first request is initiated, up to some timeout.
+      if (expectedResponses !== null && batch.pendingRequests.size === 0) {
+        await new Promise<void>((resolve, reject) => {
+          const timerId = setTimeout(() => {
+            error.message = 'Timed out waiting for a request to be initiated.'
+            reject(error)
+          }, 500)
+          onDidIssueFirstRequest = () => {
+            clearTimeout(timerId)
+            resolve()
+          }
+        })
+      }
+
+      // Fulfill all the requests that were initiated by the scope function. But
+      // first, wait an additional browser task. This simulates the real world
+      // behavior where the network response is received in an async event/task
+      // that comes after the scope function, rather than immediately when the
+      // scope function exits.
+      //
+      // We use requestIdleCallback to schedule the task because that's
+      // guaranteed to fire after any IntersectionObserver events, which the
+      // router uses to track the visibility of links.
+      await page.evaluate(
+        () => new Promise<void>((res) => requestIdleCallback(() => res()))
+      )
+
+      // Checking whether a request needs to be intercepted is an async
+      // operation, so we need to wait for all the checks to complete before
+      // checking whether the queue is empty.
+      await waitForPendingRequestChecks()
+
+      // Because responding to one request may unblock additional requests,
+      // keep checking for more requests until the queue has settled.
+      const remaining = new Set<PendingRSCRequest>()
+      let actualResponses: Array<ExpectedResponseConfig> = []
+      let alreadyMatched = new Map<string, string>()
+      while (batch.pendingRequests.size > 0) {
+        const pending = batch.pendingRequests
+        batch.pendingRequests = new Set()
+        for (const item of pending) {
+          const route = item.route
+          const url = item.url
+
+          let shouldBlock = false
+          const fulfilled = await item.result
+          if (item.didProcess) {
+            // This response was already processed by an inner `act` call.
+          } else {
+            item.didProcess = true
+            if (expectedResponses === null) {
+              error.message = `
+Expected no network requests to be initiated.
+
+URL: ${url}
+Headers: ${JSON.stringify(fulfilled.headers)}
+
+Response:
+${fulfilled.body}
+`
+
+              throw error
+            }
+            if (fulfilled.status >= 400) {
+              error.message = `
+Received a response with an error status code.
+
+Status: ${fulfilled.status}
+URL: ${url}
+Headers: ${JSON.stringify(fulfilled.headers)}
+
+Response:
+${fulfilled.body}
+`
+              throw error
+            }
+            if (forbiddenResponses !== null) {
+              for (const forbiddenResponse of forbiddenResponses) {
+                const includes = forbiddenResponse.includes
+                if (fulfilled.body.includes(includes)) {
+                  error.message = `
+Received a response containing an unexpected substring:
+
+Rejected substring: ${includes}
+
+Response:
+${fulfilled.body}
+`
+                  throw error
+                }
+              }
+            }
+            if (expectedResponses !== null) {
+              for (const expectedResponse of expectedResponses) {
+                const includes = expectedResponse.includes
+                const block = expectedResponse.block
+                if (fulfilled.body.includes(includes)) {
+                  // Match. Don't check yet whether the responses are received
+                  // in the expected order. Instead collect all the matches and
+                  // check at the end so we can include a diff in the
+                  // error message.
+                  const otherResponse = alreadyMatched.get(includes)
+                  if (otherResponse !== undefined) {
+                    error.message = `
+Received multiple responses containing the same expected substring.
+
+Expected substring:
+${includes}
+
+Responses:
+
+${otherResponse}
+
+${fulfilled.body}
+
+Choose a more specific substring to assert on.
+`
+                    throw error
+                  }
+                  alreadyMatched.set(includes, fulfilled.body)
+                  if (actualResponses === null) {
+                    actualResponses = [expectedResponse]
+                  } else {
+                    actualResponses.push(expectedResponse)
+                  }
+                  if (block) {
+                    shouldBlock = true
+                  }
+                  // Keep checking all the expected responses to verify there
+                  // are no duplicate matches
+                }
+              }
+            }
+          }
+
+          if (shouldBlock || shouldBlockAll) {
+            // This response was blocked by the `block` option. Don't
+            // fulfill it yet.
+            remaining.add(item)
+            if (route === null) {
+              error.message = `
+The "block" option is not supported for requests that are redirected.
+
+URL: ${url}
+Headers: ${JSON.stringify(fulfilled.headers)}
+
+Response:
+${fulfilled.body}
+`
+
+              throw error
+            }
+          } else {
+            if (route !== null) {
+              const request = route.request()
+              await route.fulfill({
+                body: fulfilled.body,
+                headers: fulfilled.headers,
+                status: fulfilled.status,
+              })
+              const browserResponse = await request.response()
+              if (browserResponse !== null) {
+                await browserResponse.finished()
+              }
+            }
+          }
+
+          if (fulfilled.status === 307 || fulfilled.status === 308) {
+            // When fulfilling a redirect, for some reason, the page.route()
+            // handler installed earlier will not intercept the
+            // redirect request. Install a one-off event listener to wait for
+            // the redirected request to finish. This works for this case
+            // because we don't need to modify to delay the response; we only
+            // need to observe when it has finished.
+            // TODO: Because this request cannot be intercepted, it's
+            // incompatible with the "block" option. I haven't yet figured out
+            // a strategy to make that work. In the meantime, attempting to
+            // write a test that blocks a redirect will result in an error
+            // (see error above).
+            await new Promise<void>((resolve) => {
+              page.once('request', (req) => {
+                const handleResponse = (res: Playwright.Response) => {
+                  if (res.url() === req.url()) {
+                    batch.pendingRequests.add({
+                      url: req.url(),
+                      route: null,
+                      result: new Promise(async (resolve) => {
+                        resolve({
+                          text: await res.text(),
+                          body: await res.body(),
+                          headers: res.headers(),
+                          status: res.status(),
+                        })
+                      }),
+                      didProcess: false,
+                    })
+                    page.off('response', handleResponse)
+                    resolve()
+                  }
+                }
+                page.on('response', handleResponse)
+              })
+            })
+          }
+        }
+
+        // After flushing the queue, wait for the microtask queue to be
+        // exhausted, then check if any additional requests are initiated. A
+        // single macrotask should be enough because if the router queue is
+        // network throttled, the next request is issued either directly within
+        // the task of the previous request's completion event, or in the
+        // microtask queue of that event.
+        await page.evaluate(
+          () => new Promise<void>((res) => requestIdleCallback(() => res()))
+        )
+
+        await waitForPendingRequestChecks()
+      }
+
+      if (didHardNavigate) {
+        error.message =
+          'A hard navigation or refresh was triggerd during the `act` scope. ' +
+          'This is not supported.'
+        throw error
+      }
+
+      if (expectedResponses !== null) {
+        // Assert that the responses were received in the expected order
+        if (!equals(actualResponses, expectedResponses)) {
+          // Print a helpful error message.
+
+          if (expectedResponses.length === 1) {
+            error.message =
+              'Expected a response containing the given string:\n\n' +
+              expectedResponses[0].includes +
+              '\n'
+          } else {
+            const expectedSubstrings = expectedResponses.map(
+              (item) => item.includes
+            )
+            const actualSubstrings = actualResponses.map(
+              (item) => item.includes
+            )
+            error.message =
+              'Expected sequence of responses does not match:\n\n' +
+              diff(expectedSubstrings, actualSubstrings) +
+              '\n'
+          }
+          throw error
+        }
+      }
+
+      // Some of the requests were blocked. Transfer them to the outer `act`
+      // batch so it can flush them.
+      if (remaining.size !== 0 && prevBatch !== null) {
+        for (const item of remaining) {
+          prevBatch.pendingRequests.add(item)
+        }
+      }
+
+      return returnValue
+    } finally {
+      // Clean up
+      currentBatch = prevBatch
+      await page.unroute('**/*', routeHandler)
+      await page.off('framedetached', hardNavigationHandler)
+    }
+  }
+
+  return act
+}

--- a/test/e2e/app-dir/app-prefetch/test-utils.ts
+++ b/test/e2e/app-dir/app-prefetch/test-utils.ts
@@ -1,0 +1,108 @@
+export function createTimeController() {
+  let fixedTime = Date.now()
+
+  return {
+    install: (browser) => {
+      return browser.eval(`
+        (() => {
+          const OriginalDate = Date;
+          const originalSetTimeout = globalThis.setTimeout;
+          const originalSetInterval = globalThis.setInterval;
+          const originalClearTimeout = globalThis.clearTimeout;
+          const originalClearInterval = globalThis.clearInterval;
+
+          let fixedTime = ${fixedTime};
+          let timerIdCounter = 1;
+          const timers = new Map();
+
+          // Override the Date constructor
+          globalThis.Date = class extends OriginalDate {
+            constructor(...args) {
+              if (args.length === 0) {
+                super(fixedTime);
+              } else {
+                super(...args);
+              }
+            }
+
+            static now() {
+              return fixedTime;
+            }
+          };
+
+          // Preserve static methods
+          Object.setPrototypeOf(globalThis.Date, OriginalDate);
+
+          // Override setTimeout
+          globalThis.setTimeout = function(callback, delay, ...args) {
+            const id = timerIdCounter++;
+            timers.set(id, {
+              callback,
+              args,
+              fireTime: fixedTime + (delay || 0),
+              interval: false
+            });
+            return id;
+          };
+
+          // Override setInterval
+          globalThis.setInterval = function(callback, delay, ...args) {
+            const id = timerIdCounter++;
+            timers.set(id, {
+              callback,
+              args,
+              fireTime: fixedTime + (delay || 0),
+              interval: true,
+              delay: delay || 0
+            });
+            return id;
+          };
+
+          // Override clearTimeout
+          globalThis.clearTimeout = function(id) {
+            timers.delete(id);
+          };
+
+          // Override clearInterval
+          globalThis.clearInterval = function(id) {
+            timers.delete(id);
+          };
+
+          // Add method to advance time
+          globalThis.__advanceTime = (ms) => {
+            fixedTime += ms;
+
+            // Fire any timers that should have fired
+            const toFire = [];
+            for (const [id, timer] of timers.entries()) {
+              if (timer.fireTime <= fixedTime) {
+                toFire.push({ id, timer });
+              }
+            }
+
+            for (const { id, timer } of toFire) {
+              try {
+                timer.callback(...timer.args);
+              } catch (e) {
+                console.error('Timer callback error:', e);
+              }
+
+              if (timer.interval) {
+                // Reschedule interval timer
+                timer.fireTime = fixedTime + timer.delay;
+              } else {
+                // Remove one-time timer
+                timers.delete(id);
+              }
+            }
+          };
+        })();
+      `)
+    },
+
+    advance: async (browser, ms: number) => {
+      fixedTime += ms
+      await browser.eval(`globalThis.__advanceTime(${ms})`)
+    },
+  }
+}


### PR DESCRIPTION
Refactors some older prefetching tests to be compatible with `clientSegmentCache`. The old tests were too tightly coupled to router implementation details. Some of the ones that don't make sense to convert were removed (for ex, asserting on prefetch cache seeding behavior, or fetch priority of "high", as fetch priority is managed differently with the new router).

This refactors the tests to leverage the `act` util from `segment-cache` test suites, and implemented the accordion behavior to more granularly control when prefetches are dispatched. I copied those implementations for now since we don't have a global util for it. 