### PR TITLE
fix: use consistent CSS precedence for dynamic imports

### DIFF
--- a/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
@@ -49,11 +49,15 @@ export function PreloadChunks({
         // For stylesheets we actually need to render the CSS because nothing else is going to do it so it needs to be part of the component tree.
         // The `preload` for stylesheet is not optional.
         if (isCss) {
+          // Match the precedence used by renderCssResource for consistency
+          const precedence =
+            process.env.NODE_ENV === 'development' ? 'next_' + chunk : 'next'
+
           return (
             <link
               key={chunk}
               // @ts-ignore
-              precedence="dynamic"
+              precedence={precedence}
               href={href}
               rel="stylesheet"
               as="style"

--- a/test/e2e/app-dir/css-duplicate-preload/app/both/page.js
+++ b/test/e2e/app-dir/css-duplicate-preload/app/both/page.js
@@ -1,0 +1,20 @@
+'use client'
+
+import dynamicImport from 'next/dynamic'
+import '../../components/dynamic-styles.css'
+
+const DynamicComponent = dynamicImport(
+  () => import('../../components/dynamic-with-css')
+)
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Page with Static and Dynamic CSS</h1>
+      <div className="dynamic-text">Static usage of shared CSS</div>
+      <DynamicComponent />
+    </div>
+  )
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/css-duplicate-preload/app/layout.js
+++ b/test/e2e/app-dir/css-duplicate-preload/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/css-duplicate-preload/app/test/page.js
+++ b/test/e2e/app-dir/css-duplicate-preload/app/test/page.js
@@ -1,0 +1,18 @@
+'use client'
+
+import dynamicImport from 'next/dynamic'
+
+const DynamicComponent = dynamicImport(
+  () => import('../../components/dynamic-with-css')
+)
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Test Page with Dynamic CSS</h1>
+      <DynamicComponent />
+    </div>
+  )
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/css-duplicate-preload/components/dynamic-styles.css
+++ b/test/e2e/app-dir/css-duplicate-preload/components/dynamic-styles.css
@@ -1,0 +1,7 @@
+.dynamic-text {
+  color: purple;
+  font-weight: bold;
+  padding: 20px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border-radius: 8px;
+}

--- a/test/e2e/app-dir/css-duplicate-preload/components/dynamic-with-css.js
+++ b/test/e2e/app-dir/css-duplicate-preload/components/dynamic-with-css.js
@@ -1,0 +1,5 @@
+import './dynamic-styles.css'
+
+export default function DynamicWithCss() {
+  return <div className="dynamic-text">Dynamic Component with CSS</div>
+}

--- a/test/e2e/app-dir/css-duplicate-preload/css-duplicate-preload.test.ts
+++ b/test/e2e/app-dir/css-duplicate-preload/css-duplicate-preload.test.ts
@@ -1,0 +1,59 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('css-duplicate-preload', () => {
+  const { next, isNextDev } = nextTestSetup({ files: __dirname })
+
+  it('should use consistent precedence for dynamic CSS', async () => {
+    const $ = await next.render$('/test')
+    const cssLinks = $('link[rel="stylesheet"][data-precedence]')
+
+    expect(cssLinks.length).toBeGreaterThan(0)
+
+    const precedences = cssLinks
+      .map((_, el) => $(el).attr('data-precedence'))
+      .get()
+      .filter(Boolean)
+
+    const uniquePrecedences = [...new Set(precedences)]
+
+    if (!isNextDev) {
+      expect(uniquePrecedences).toEqual(['next'])
+    } else {
+      uniquePrecedences.forEach((p) => {
+        expect(p).toMatch(/^next_/)
+      })
+    }
+  })
+
+  it('should not produce duplicate CSS link tags', async () => {
+    const $ = await next.render$('/test')
+    const cssLinks = $('link[rel="stylesheet"][data-precedence]')
+    const hrefs = cssLinks
+      .map((_, el) => $(el).attr('href'))
+      .get()
+      .filter(Boolean)
+
+    expect(hrefs.length).toBe(new Set(hrefs).size)
+  })
+
+  it('should not duplicate when imported both statically and dynamically', async () => {
+    const $ = await next.render$('/both')
+    const cssLinks = $('link[rel="stylesheet"][data-precedence]')
+    const hrefs = cssLinks
+      .map((_, el) => $(el).attr('href'))
+      .get()
+      .filter(Boolean)
+
+    expect(hrefs.length).toBe(new Set(hrefs).size)
+
+    // At least one CSS file should be present for the shared stylesheet
+    const cssHref = hrefs.find((h) => h.includes('.css'))
+    expect(cssHref).toBeDefined()
+  })
+
+  it('should render dynamic component with styles applied', async () => {
+    const browser = await next.browser('/test')
+    const text = await browser.waitForElementByCss('.dynamic-text').text()
+    expect(text).toBe('Dynamic Component with CSS')
+  })
+})

--- a/test/e2e/app-dir/css-duplicate-preload/next.config.js
+++ b/test/e2e/app-dir/css-duplicate-preload/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    cssChunking: true, // Default setting where the bug occurs
+  },
+}

--- a/test/e2e/app-dir/dynamic-css/index.test.ts
+++ b/test/e2e/app-dir/dynamic-css/index.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 describe('app dir - dynamic css', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next, skipped, isNextDev } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
   })
@@ -13,8 +13,19 @@ describe('app dir - dynamic css', () => {
 
   it('should preload all chunks of dynamic component during SSR', async () => {
     const $ = await next.render$('/ssr')
-    const cssLinks = $('link[rel="stylesheet"][data-precedence="dynamic"]')
+    // CSS from dynamic imports now uses the same precedence as static imports
+    const cssLinks = $('link[rel="stylesheet"][data-precedence]')
+    expect(cssLinks.length).toBeGreaterThan(0)
     expect(cssLinks.attr('href')).toContain('.css')
+
+    const precedence = cssLinks.attr('data-precedence')
+    if (isNextDev) {
+      // In development: precedence="next_" + chunk path
+      expect(precedence).toMatch(/^next_/)
+    } else {
+      // In production: precedence="next"
+      expect(precedence).toBe('next')
+    }
 
     const preloadJsChunks = $('link[rel="preload"]')
     expect(preloadJsChunks.attr('as')).toBe('script')


### PR DESCRIPTION
This PR fixes CSS ordering inconsistencies in the App Router by ensuring that CSS from dynamic imports (`next/dynamic`) uses the same precedence values as CSS from static imports.

Fixes #42082

### Problem

When using `next/dynamic` in the App Router, CSS files were being loaded with different React precedence attributes depending on how they were imported:

- **Static imports**: Used `precedence="next"` (production) or `precedence="next_<path>"` (development)
- **Dynamic imports**: Used `precedence="dynamic"`

This inconsistency caused unpredictable CSS ordering, particularly when the same stylesheet was referenced through both static and dynamic import paths.
  
React's resource deduplication relies on matching `href` attributes to prevent duplicate stylesheets, but different precedence values could lead to inconsistent ordering behavior.

### Solution

Modified `PreloadChunks` component in `preload-chunks.tsx` to use the same precedence pattern as `renderCssResource`:

```tsx
// Before
precedence="dynamic"

// After
const precedence = process.env.NODE_ENV === 'development' ? 'next_' + chunk : 'next'
```

This ensures:
- Production: All CSS uses precedence="next"
- Development: All CSS uses precedence="next_<path>" for proper HMR ordering
- Consistency: Same precedence regardless of import method