### PR TITLE
Fix/action forward loop guard

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -169,6 +169,20 @@ async function createForwardedActionResponse(
   workerPathname: string,
   basePath: string
 ) {
+  // If this action request was already forwarded once, do not forward again to avoid infinite middleware rewrite loops
+  try {
+    const incoming: Headers = (req as any)?.headers?.get
+      ? (req.headers as unknown as Headers)
+      : HeadersAdapter.from((req as any).headers)
+
+    if (incoming?.get('x-action-forwarded') === '1') {
+      // already forwarded once - don't forward again, return undefined so caller can handle this gracefully
+      return
+    }
+  } catch {
+    // if header parser fails, continue
+  }
+
   if (!host) {
     throw new Error(
       'Invariant: Missing `host` header from a forwarded Server Actions request.'


### PR DESCRIPTION
## What?

Fixes #84504

Add a minimal loop-detection guard to `createForwardedActionResponse` so a Server Action request that has **already** been forwarded (marked by `x-action-forwarded=1`) is **not** forwarded again. Instead, we return early (no second forward).

- File: `packages/next/src/server/app-render/action-handler.ts`
- Behavior change: if `x-action-forwarded=1` is present on the **incoming** request, return from `createForwardedActionResponse` without forwarding again.

## Why?

In apps that use Middleware rewrites, a forwarded Server Action request can be rewritten to a path that triggers forwarding **again**, causing an infinite loop (e.g. `/rewrite/other → /rewrite/... → /rewrite/rewrite/... → …`). This leads to repeated logs and a server action that never resolves.

This guard breaks the cycle with very low risk by only affecting requests that were already forwarded once.

- Repro repo: https://github.com/blairmcalpine/forwarded-server-action-request-loop-repro
- Steps:
  1) `npm i && npm run dev`
  2) Visit `http://localhost:3000`
  3) Click **Run action**, then quickly (<500ms) click **Navigate to other page**
  4) **Before this change:** infinite loop/log spam; action never resolves.
  5) **After this change:** no loop; request is not re-forwarded again.

## How?

At the start of `createForwardedActionResponse`, inspect the incoming headers:

- If `x-action-forwarded=1` is present → **return** (do not forward again).
- Otherwise, proceed as before and set `x-action-forwarded=1` on the outgoing forwarded request.

Works in both Node and Edge:
- If `req.headers` is already a `Headers` (Edge), use it.
- Otherwise adapt Node headers via `HeadersAdapter`.

## Test Plan

**Manual (using the public repro)**

- With this patch built and packed into the repro app:
  - Trigger the fast **Run action → Navigate** sequence.
  - Confirm:
    - No repeated `/rewrite/...` requests or log spam.
    - The page no longer gets stuck due to an infinite forwarding loop.

**Notes:** This PR intentionally focuses on **loop prevention**. A broader follow-up could make forwarded requests mirror the *pre-rewrite* target to ensure resolution semantics remain identical under rewrites. That would be a separate change.

## Risk

Low:
- Only affects requests that already bear `x-action-forwarded=1`.
- Does not change the initial legitimate forward.
- Keeps all other server action behavior intact.

---

## For Contributors Checklist

- [x] Bug fix
- [x] Related issue linked (`Fixes #84504`)
- [x] Repro steps included (public repo)
- [x] Ran `pnpm prettier-fix` locally
- [ ] Tests: this is a minimal guard; happy to add a small e2e that simulates a rewrite + quick navigation if maintainers prefer (guidance welcome)


