### PR TITLE
Turbopack: delete .next folder before throwing due to "pages/app directory must be in the same folder"

### DIFF
--- a/packages/next/src/lib/recursive-delete.ts
+++ b/packages/next/src/lib/recursive-delete.ts
@@ -74,7 +74,7 @@ export async function recursiveDeleteSyncWithAsyncRetries(
   dir: string,
   /** Exclude based on relative file path */
   exclude?: RegExp,
-  /** Ensures that parameter dir exists, this is not passed recursively */
+  /** Relative path to the directory being deleted, used for exclude */
   previousPath: string = ''
 ): Promise<void> {
   let result


### PR DESCRIPTION
### What?

I expect an empty .next folder after an error, so it should delete it before doing the check, so that an error doesn't result in a stale .next folder

Closes PACK-5644