### PR TITLE
CI: Enable `experimental.isolatedDevBuild` for `test-prod`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -988,6 +988,7 @@ jobs:
         export NEXT_EXTERNAL_TESTS_FILTERS="test/experimental-tests-manifest.json"
         export NEXT_TEST_MODE=start
         export IS_WEBPACK_TEST=1
+        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
 
         node run-tests.js \
           --timings \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -846,6 +846,7 @@ jobs:
         export IS_WEBPACK_TEST=1
         export NEXT_TEST_MODE=start
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
+        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
 
         node run-tests.js --timings -g ${{ matrix.group }} --type production
       stepName: 'test-prod-react-${{ matrix.react }}-${{ matrix.group }}'
@@ -988,7 +989,6 @@ jobs:
         export NEXT_EXTERNAL_TESTS_FILTERS="test/experimental-tests-manifest.json"
         export NEXT_TEST_MODE=start
         export IS_WEBPACK_TEST=1
-        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
 
         node run-tests.js \
           --timings \


### PR DESCRIPTION
Enabling `experimental.isolatedDevBuild` required many changes to the current workflow, so we will incrementally roll out to the tests.

Enabling on test-prod instead of test-experimental-prod because `-experimental` CIs are filtered via `experimental-tests-manifest.json` and they don't cover all tests. We want to enable this feature by default so we should ensure this incremental rollout is covered on all test cases.

1. ~~test-experimental-dev ([link](https://github.com/vercel/next.js/pull/84099))~~
2. test-dev ([link](https://github.com/vercel/next.js/pull/84562))
3. test-prod (here)
4. test-integration
5. test-unit
6. Enable by default, remove the flag, and update the rest

x-ref: https://github.com/vercel/next.js/pull/84043