### PR TITLE
CI: Enable `experimental.isolatedDevBuild` for `test-integration`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -888,6 +888,7 @@ jobs:
       afterBuild: |
         export IS_WEBPACK_TEST=1
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
+        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
 
         node run-tests.js \
           --timings \
@@ -939,7 +940,6 @@ jobs:
         export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/experimental-tests-manifest.json"
         export IS_WEBPACK_TEST=1
-        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
 
         node run-tests.js \
           --timings \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -939,6 +939,7 @@ jobs:
         export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/experimental-tests-manifest.json"
         export IS_WEBPACK_TEST=1
+        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
 
         node run-tests.js \
           --timings \

--- a/test/integration/api-support/test/index.test.js
+++ b/test/integration/api-support/test/index.test.js
@@ -19,12 +19,21 @@ import {
 import json from '../big.json'
 
 const appDir = join(__dirname, '../')
+const originalIsNextDev = global.isNextDev
 let appPort
 let stderr
 let mode
 let app
 
 function runTests(dev = false) {
+  beforeAll(() => {
+    // isNextDev is used for getDistDir, where it is used for reading the build manifest files.
+    global.isNextDev = dev
+  })
+  afterAll(() => {
+    global.isNextDev = originalIsNextDev
+  })
+
   it('should not strip .json from API route', async () => {
     const res = await fetchViaHTTP(appPort, '/api/hello.json')
     expect(res.status).toBe(200)

--- a/test/integration/dist-dir/test/index.test.js
+++ b/test/integration/dist-dir/test/index.test.js
@@ -10,6 +10,7 @@ import {
   killApp,
   renderViaHTTP,
   launchApp,
+  getDistDir,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -42,7 +43,9 @@ describe('distDir', () => {
           ).toBeTruthy()
         })
         it('should not build the app within the default `.next` directory', async () => {
-          expect(await fs.exists(join(__dirname, '/../.next'))).toBeFalsy()
+          expect(
+            await fs.exists(join(__dirname, `/../${getDistDir()}`))
+          ).toBeFalsy()
         })
       }
     )
@@ -51,7 +54,7 @@ describe('distDir', () => {
     'development mode',
     () => {
       beforeAll(async () => {
-        await fs.remove(join(appDir, '.next'))
+        await fs.remove(join(appDir, getDistDir()))
         await fs.remove(join(appDir, 'dist'))
         appPort = await findPort()
         app = await launchApp(appDir, appPort)
@@ -64,12 +67,21 @@ describe('distDir', () => {
       })
 
       it('should build the app within the given `dist` directory', async () => {
-        expect(
-          await fs.exists(join(__dirname, `/../dist/${BUILD_MANIFEST}`))
-        ).toBeTruthy()
+        // In isolated dev build, the distDir for development is `distDir/dev`
+        if (process.env.__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD === 'true') {
+          expect(
+            await fs.exists(join(__dirname, `/../dist/dev/${BUILD_MANIFEST}`))
+          ).toBeTruthy()
+        } else {
+          expect(
+            await fs.exists(join(__dirname, `/../dist/${BUILD_MANIFEST}`))
+          ).toBeTruthy()
+        }
       })
       it('should not build the app within the default `.next` directory', async () => {
-        expect(await fs.exists(join(__dirname, '/../.next'))).toBeFalsy()
+        expect(
+          await fs.exists(join(__dirname, `/../${getDistDir()}`))
+        ).toBeFalsy()
       })
     }
   )

--- a/test/integration/externals-pages-bundle/test/externals.test.js
+++ b/test/integration/externals-pages-bundle/test/externals.test.js
@@ -8,6 +8,7 @@ import {
   findPort,
   File,
   renderViaHTTP,
+  getDistDir,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -21,7 +22,7 @@ describe('default', () => {
       const app = await launchApp(appDir, port)
       await renderViaHTTP(port, '/')
       if (process.env.IS_TURBOPACK_TEST) {
-        const ssrPath = join(appDir, '.next/server/chunks/ssr')
+        const ssrPath = join(appDir, `${getDistDir()}/server/chunks/ssr`)
         const pageBundleBasenames = (await fs.readdir(ssrPath)).filter((p) =>
           p.match(/\.js$/)
         )
@@ -37,7 +38,7 @@ describe('default', () => {
         expect(allBundles).not.toContain('"external-package content"')
       } else {
         const output = await fs.readFile(
-          join(appDir, '.next/server/pages/index.js'),
+          join(appDir, `${getDistDir()}/server/pages/index.js`),
           'utf8'
         )
         expect(output).toContain('require("external-package")')

--- a/test/integration/externals-pages-bundle/test/externals.test.js
+++ b/test/integration/externals-pages-bundle/test/externals.test.js
@@ -18,7 +18,10 @@ describe('default', () => {
     const port = await findPort()
     const config = new File(join(appDir, 'next.config.js'))
     config.delete()
+    const originalIsNextDev = global.isNextDev
     try {
+      // launchApp is for dev mode, and isNextDev is used in getDistDir
+      global.isNextDev = true
       const app = await launchApp(appDir, port)
       await renderViaHTTP(port, '/')
       if (process.env.IS_TURBOPACK_TEST) {
@@ -46,6 +49,7 @@ describe('default', () => {
       await killApp(app)
     } finally {
       config.restore()
+      global.isNextDev = originalIsNextDev
     }
   })
 })

--- a/test/integration/image-optimizer/test/content-disposition-type.test.ts
+++ b/test/integration/image-optimizer/test/content-disposition-type.test.ts
@@ -2,12 +2,10 @@ import { join } from 'path'
 import { setupTests } from './util'
 
 const appDir = join(__dirname, '../app')
-const imagesDir = join(appDir, '.next', 'cache', 'images')
 
 describe('with contentDispositionType inline', () => {
   setupTests({
     nextConfigImages: { contentDispositionType: 'inline' },
     appDir,
-    imagesDir,
   })
 })

--- a/test/integration/image-optimizer/test/dangerously-allow-svg.test.ts
+++ b/test/integration/image-optimizer/test/dangerously-allow-svg.test.ts
@@ -2,12 +2,10 @@ import { join } from 'path'
 import { setupTests } from './util'
 
 const appDir = join(__dirname, '../app')
-const imagesDir = join(appDir, '.next', 'cache', 'images')
 
 describe('with dangerouslyAllowSVG config', () => {
   setupTests({
     nextConfigImages: { dangerouslyAllowSVG: true },
     appDir,
-    imagesDir,
   })
 })

--- a/test/integration/image-optimizer/test/disable-write-to-cache-dir.test.ts
+++ b/test/integration/image-optimizer/test/disable-write-to-cache-dir.test.ts
@@ -2,12 +2,10 @@ import { join } from 'path'
 import { setupTests } from './util'
 
 const appDir = join(__dirname, '../app')
-const imagesDir = join(appDir, '.next', 'cache', 'images')
 
 describe('with isrFlushToDisk false config', () => {
   setupTests({
     appDir,
-    imagesDir,
     nextConfigExperimental: { isrFlushToDisk: false },
   })
 })

--- a/test/integration/image-optimizer/test/index.test.ts
+++ b/test/integration/image-optimizer/test/index.test.ts
@@ -10,12 +10,13 @@ import {
   nextStart,
   retry,
   waitFor,
+  getDistDir,
 } from 'next-test-utils'
 import { join } from 'path'
 import { cleanImagesDir, expectWidth, fsToJson } from './util'
 
 const appDir = join(__dirname, '../app')
-const imagesDir = join(appDir, '.next', 'cache', 'images')
+const imagesDir = join(appDir, getDistDir(), 'cache', 'images')
 const nextConfig = new File(join(appDir, 'next.config.js'))
 const largeSize = 1080 // defaults defined in server/config.ts
 
@@ -718,7 +719,7 @@ describe('Image Optimizer', () => {
       }`
           )
           await nextBuild(appDir)
-          await cleanImagesDir({ imagesDir })
+          await cleanImagesDir(imagesDir)
           appPort = await findPort()
           app = await nextStart(appDir, appPort)
         })
@@ -786,7 +787,7 @@ describe('Image Optimizer', () => {
         },
       })
       nextConfig.replace('{ /* replaceme */ }', json)
-      await cleanImagesDir({ imagesDir })
+      await cleanImagesDir(imagesDir)
       appPort = await findPort()
       app = await launchApp(appDir, appPort)
     })
@@ -816,7 +817,7 @@ describe('Image Optimizer', () => {
           },
         })
       )
-      await cleanImagesDir({ imagesDir })
+      await cleanImagesDir(imagesDir)
       appPort = await findPort()
       app = await launchApp(appDir, appPort)
     })
@@ -846,7 +847,7 @@ describe('Image Optimizer', () => {
           },
         })
       )
-      await cleanImagesDir({ imagesDir })
+      await cleanImagesDir(imagesDir)
       appPort = await findPort()
       app = await launchApp(appDir, appPort)
     })
@@ -884,7 +885,7 @@ describe('Image Optimizer', () => {
       }`
           nextConfig.replace('{ /* replaceme */ }', newConfig)
           await nextBuild(appDir)
-          await cleanImagesDir({ imagesDir })
+          await cleanImagesDir(imagesDir)
           appPort = await findPort()
           app = await nextStart(appDir, appPort)
         })
@@ -894,7 +895,7 @@ describe('Image Optimizer', () => {
         })
 
         it('should return response when image is served from an external rewrite', async () => {
-          await cleanImagesDir({ imagesDir })
+          await cleanImagesDir(imagesDir)
 
           const query = { url: '/next-js/next-js-bg.png', w: 64, q: 75 }
           const opts = { headers: { accept: 'image/webp' } }
@@ -943,7 +944,7 @@ describe('Image Optimizer', () => {
         },
       })
       nextConfig.replace('{ /* replaceme */ }', json)
-      await cleanImagesDir({ imagesDir })
+      await cleanImagesDir(imagesDir)
       appPort = await findPort()
       app = await launchApp(appDir, appPort)
     })

--- a/test/integration/image-optimizer/test/minimum-cache-ttl.test.ts
+++ b/test/integration/image-optimizer/test/minimum-cache-ttl.test.ts
@@ -2,7 +2,6 @@ import { join } from 'path'
 import { setupTests } from './util'
 
 const appDir = join(__dirname, '../app')
-const imagesDir = join(appDir, '.next', 'cache', 'images')
 
 describe('with minimumCacheTTL of 5 sec', () => {
   setupTests({
@@ -21,6 +20,5 @@ describe('with minimumCacheTTL of 5 sec', () => {
       minimumCacheTTL: 5,
     },
     appDir,
-    imagesDir,
   })
 })

--- a/test/integration/image-optimizer/test/sharp.test.ts
+++ b/test/integration/image-optimizer/test/sharp.test.ts
@@ -2,8 +2,7 @@ import { join } from 'path'
 import { setupTests } from './util'
 
 const appDir = join(__dirname, '../app')
-const imagesDir = join(appDir, '.next', 'cache', 'images')
 
 describe('with latest sharp', () => {
-  setupTests({ appDir, imagesDir })
+  setupTests({ appDir })
 })

--- a/test/integration/ondemand/test/index.test.js
+++ b/test/integration/ondemand/test/index.test.js
@@ -33,10 +33,15 @@ const startServer = async (optEnv = {}, opts) => {
   'On Demand Entries',
   () => {
     it('should pass', () => {})
+    const originalIsNextDev = global.isNextDev
     beforeAll(async () => {
+      // The server.js sets "dev" via process.env.NODE_ENV.
+      // isNextDev is used for getDistDir, where it is used for reading the build manifest files.
+      global.isNextDev = process.env.NODE_ENV !== 'production'
       await startServer()
     })
     afterAll(async () => {
+      global.isNextDev = originalIsNextDev
       await killApp(context.server)
     })
 

--- a/test/integration/trailing-slash-dist/test/index.test.js
+++ b/test/integration/trailing-slash-dist/test/index.test.js
@@ -11,11 +11,17 @@ import {
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
-
+const originalIsNextDev = global.isNextDev
 let appPort
 let app
 
 const runTest = (mode = 'server') => {
+  beforeAll(() => {
+    global.isNextDev = mode === 'dev'
+  })
+  afterAll(() => {
+    global.isNextDev = originalIsNextDev
+  })
   it('supports trailing slash', async () => {
     // Make sure the page is built before getting the file
     await renderViaHTTP(appPort, '/')

--- a/test/integration/typescript-app-type-declarations/test/index.test.js
+++ b/test/integration/typescript-app-type-declarations/test/index.test.js
@@ -8,6 +8,18 @@ const appDir = join(__dirname, '..')
 const appTypeDeclarations = join(appDir, 'next-env.d.ts')
 
 describe('TypeScript App Type Declarations', () => {
+  if (process.env.__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD === 'true') {
+    it.skip('should skip on isolated dev build', () => {
+      // We use static fixture "next-env.d.ts" but the content should differ
+      // based on the isolated dev build flag. We can't do something like
+      // "next-env-dev.d.ts" because Next.js Types Plugin emits a file
+      // "next-env.d.ts", and we have to change its behavior for this test case.
+      // Rather than that, just skip the test as we're going to remove this flag soon.
+      // Then modify the content to be ".next/dev/types/routes.d.ts"
+    })
+    return
+  }
+
   it('should write a new next-env.d.ts if none exist', async () => {
     const prevContent = await fs.readFile(appTypeDeclarations, 'utf8')
     try {

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1226,11 +1226,11 @@ function readJson(path: string) {
 }
 
 export function getBuildManifest(dir: string) {
-  return readJson(path.join(dir, '.next/build-manifest.json'))
+  return readJson(path.join(dir, getDistDir(), 'build-manifest.json'))
 }
 
 export function getImagesManifest(dir: string) {
-  return readJson(path.join(dir, '.next/images-manifest.json'))
+  return readJson(path.join(dir, getDistDir(), 'images-manifest.json'))
 }
 
 export function getPageFilesFromBuildManifest(dir: string, page: string) {
@@ -1250,7 +1250,7 @@ export function getContentOfPageFilesFromBuildManifest(
   const pageFiles = getPageFilesFromBuildManifest(dir, page)
 
   return pageFiles
-    .map((file) => readFileSync(path.join(dir, '.next', file), 'utf8'))
+    .map((file) => readFileSync(path.join(dir, getDistDir(), file), 'utf8'))
     .join('\n')
 }
 
@@ -1271,17 +1271,17 @@ export function getPageFileFromBuildManifest(dir: string, page: string) {
 
 export function readNextBuildClientPageFile(appDir: string, page: string) {
   const pageFile = getPageFileFromBuildManifest(appDir, page)
-  return readFileSync(path.join(appDir, '.next', pageFile), 'utf8')
+  return readFileSync(path.join(appDir, getDistDir(), pageFile), 'utf8')
 }
 
 export function getPagesManifest(dir: string) {
-  const serverFile = path.join(dir, '.next/server/pages-manifest.json')
+  const serverFile = path.join(dir, getDistDir(), 'server/pages-manifest.json')
 
   return readJson(serverFile)
 }
 
 export function updatePagesManifest(dir: string, content: any) {
-  const serverFile = path.join(dir, '.next/server/pages-manifest.json')
+  const serverFile = path.join(dir, getDistDir(), 'server/pages-manifest.json')
 
   return writeFile(serverFile, content)
 }
@@ -1298,13 +1298,16 @@ export function getPageFileFromPagesManifest(dir: string, page: string) {
 
 export function readNextBuildServerPageFile(appDir: string, page: string) {
   const pageFile = getPageFileFromPagesManifest(appDir, page)
-  return readFileSync(path.join(appDir, '.next', 'server', pageFile), 'utf8')
+  return readFileSync(
+    path.join(appDir, getDistDir(), 'server', pageFile),
+    'utf8'
+  )
 }
 
 export function getClientBuildManifest(dir: string) {
-  let buildId = readFileSync(path.join(dir, '.next/BUILD_ID'), 'utf8')
+  let buildId = readFileSync(path.join(dir, getDistDir(), 'BUILD_ID'), 'utf8')
   let code = readFileSync(
-    path.join(dir, '.next/static', buildId, '_buildManifest.js'),
+    path.join(dir, getDistDir(), 'static', buildId, '_buildManifest.js'),
     'utf8'
   )
   // eslint-disable-next-line no-eval
@@ -1887,11 +1890,10 @@ export function normalizeManifest<T>(
   )
 }
 
-export function getDistDir(isNextDev?: boolean): '.next' | '.next/dev' {
+export function getDistDir(): '.next' | '.next/dev' {
   // global.isNextDev is set in e2e/development/production tests.
-  // TODO: If a test utils that are used in integration/unit tests can set
-  // global.isNextDev flag, we could possibly remove the parameter.
-  return (isNextDev ?? (global as any).isNextDev) &&
+  // NEXT_TEST_MODE is set in CI or local test-* commands.
+  return ((global as any).isNextDev || process.env.NEXT_TEST_MODE === 'dev') &&
     // Flag for incremental rollout of isolated dev build, set in CI.
     process.env.__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD === 'true'
     ? '.next/dev'


### PR DESCRIPTION
Enabling `experimental.isolatedDevBuild` required many changes to the current workflow, so we will incrementally roll out to the tests.

Enabling on test-integration instead of test-experimental-integration because `-experimental` CIs are filtered via `experimental-tests-manifest.json` and they don't cover all tests. We want to enable this feature by default so we should ensure this incremental rollout is covered on all test cases.

1. ~~test-experimental-dev ([link](https://github.com/vercel/next.js/pull/84099))~~
2. test-dev ([link](https://github.com/vercel/next.js/pull/84562))
2. test-prod ([link](https://github.com/vercel/next.js/pull/84556))
3. test-integration (here)
4. test-unit
5. Enable by default, remove the flag, and update the rest

x-ref: https://github.com/vercel/next.js/pull/84043