### PR TITLE
CI: Enable `experimental.isolatedDevBuild` for `test-unit`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -542,7 +542,9 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: ${{ matrix.node }}
-      afterBuild: node run-tests.js --type unit
+      afterBuild: |
+        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
+        node run-tests.js --type unit
       stepName: 'test-unit-${{ matrix.node }}'
 
     secrets: inherit

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -38,7 +38,12 @@ describe('config', () => {
 
   it('Should assign object defaults deeply to user config', async () => {
     const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
-    expect(config.distDir).toEqual('.next')
+    // In isolatedDevBuild, the default distDir is ".next/dev" during PHASE_DEVELOPMENT_SERVER.
+    if (process.env.__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD === 'true') {
+      expect(config.distDir).toEqual('.next/dev')
+    } else {
+      expect(config.distDir).toEqual('.next')
+    }
     expect(config.onDemandEntries.maxInactiveAge).toBeDefined()
   })
 


### PR DESCRIPTION
Enabling `experimental.isolatedDevBuild` required many changes to the current workflow, so we will incrementally roll out to the tests.

1. ~~test-experimental-dev ([link](https://github.com/vercel/next.js/pull/84099))~~
2. test-dev ([link](https://github.com/vercel/next.js/pull/84562))
2. test-prod ([link](https://github.com/vercel/next.js/pull/84556))
3. test-integration ([link](https://github.com/vercel/next.js/pull/84558))
4. test-unit (here)
5. Enable by default, remove the flag, and update the rest

x-ref: https://github.com/vercel/next.js/pull/84043