### PR TITLE
[Breaking] Enable `experimental.isolatedDevBuild` by default

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -542,9 +542,7 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: ${{ matrix.node }}
-      afterBuild: |
-        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
-        node run-tests.js --type unit
+      afterBuild: node run-tests.js --type unit
       stepName: 'test-unit-${{ matrix.node }}'
 
     secrets: inherit
@@ -735,7 +733,6 @@ jobs:
         export IS_WEBPACK_TEST=1
         export NEXT_TEST_MODE=dev
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
-        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
 
         node run-tests.js \
           --timings \
@@ -849,7 +846,6 @@ jobs:
         export IS_WEBPACK_TEST=1
         export NEXT_TEST_MODE=start
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
-        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
 
         node run-tests.js --timings -g ${{ matrix.group }} --type production
       stepName: 'test-prod-react-${{ matrix.react }}-${{ matrix.group }}'
@@ -889,7 +885,6 @@ jobs:
       afterBuild: |
         export IS_WEBPACK_TEST=1
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
-        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
 
         node run-tests.js \
           --timings \

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2738,6 +2738,10 @@ export default async function build(
           invocationCount: config.experimental.ppr ? 1 : 0,
         },
         {
+          featureName: 'experimental/isolatedDevBuild',
+          invocationCount: config.experimental.isolatedDevBuild ? 1 : 0,
+        },
+        {
           featureName: 'turbopackFileSystemCache',
           invocationCount: isFileSystemCacheEnabledForBuild(config) ? 1 : 0,
         },

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1525,9 +1525,8 @@ export const defaultConfig = Object.freeze({
     slowModuleDetection: undefined,
     globalNotFound: false,
     browserDebugInfoInTerminal: false,
-    isolatedDevBuild:
-      process.env.__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD === 'true',
     lockDistDir: true,
+    isolatedDevBuild: true,
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -175,6 +175,7 @@ export type EventBuildFeatureUsage = {
     | 'experimental/cacheComponents'
     | 'experimental/optimizeCss'
     | 'experimental/ppr'
+    | 'experimental/isolatedDevBuild'
     | 'swcLoader'
     | 'swcRelay'
     | 'swcStyledComponents'

--- a/scripts/devlow-bench.mjs
+++ b/scripts/devlow-bench.mjs
@@ -482,6 +482,7 @@ const nextDevWorkflow =
         const cacheLocation = join(
           benchmarkDir,
           '.next',
+          'dev',
           'cache',
           'webpack',
           'client-development'

--- a/test/development/app-dir/isolated-dev-build/next.config.js
+++ b/test/development/app-dir/isolated-dev-build/next.config.js
@@ -1,10 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  experimental: {
-    isolatedDevBuild: true,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/test/integration/dist-dir/test/index.test.js
+++ b/test/integration/dist-dir/test/index.test.js
@@ -68,15 +68,9 @@ describe('distDir', () => {
 
       it('should build the app within the given `dist` directory', async () => {
         // In isolated dev build, the distDir for development is `distDir/dev`
-        if (process.env.__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD === 'true') {
-          expect(
-            await fs.exists(join(__dirname, `/../dist/dev/${BUILD_MANIFEST}`))
-          ).toBeTruthy()
-        } else {
-          expect(
-            await fs.exists(join(__dirname, `/../dist/${BUILD_MANIFEST}`))
-          ).toBeTruthy()
-        }
+        expect(
+          await fs.exists(join(__dirname, `/../dist/dev/${BUILD_MANIFEST}`))
+        ).toBeTruthy()
       })
       it('should not build the app within the default `.next` directory', async () => {
         expect(

--- a/test/integration/typescript-app-type-declarations/next-env.d.ts
+++ b/test/integration/typescript-app-type-declarations/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/test/integration/typescript-app-type-declarations/test/index.test.js
+++ b/test/integration/typescript-app-type-declarations/test/index.test.js
@@ -8,18 +8,6 @@ const appDir = join(__dirname, '..')
 const appTypeDeclarations = join(appDir, 'next-env.d.ts')
 
 describe('TypeScript App Type Declarations', () => {
-  if (process.env.__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD === 'true') {
-    it.skip('should skip on isolated dev build', () => {
-      // We use static fixture "next-env.d.ts" but the content should differ
-      // based on the isolated dev build flag. We can't do something like
-      // "next-env-dev.d.ts" because Next.js Types Plugin emits a file
-      // "next-env.d.ts", and we have to change its behavior for this test case.
-      // Rather than that, just skip the test as we're going to remove this flag soon.
-      // Then modify the content to be ".next/dev/types/routes.d.ts"
-    })
-    return
-  }
-
   it('should write a new next-env.d.ts if none exist', async () => {
     const prevContent = await fs.readFile(appTypeDeclarations, 'utf8')
     try {

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1893,9 +1893,7 @@ export function normalizeManifest<T>(
 export function getDistDir(): '.next' | '.next/dev' {
   // global.isNextDev is set in e2e/development/production tests.
   // NEXT_TEST_MODE is set in CI or local test-* commands.
-  return ((global as any).isNextDev || process.env.NEXT_TEST_MODE === 'dev') &&
-    // Flag for incremental rollout of isolated dev build, set in CI.
-    process.env.__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD === 'true'
+  return (global as any).isNextDev || process.env.NEXT_TEST_MODE === 'dev'
     ? '.next/dev'
     : '.next'
 }

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -38,12 +38,7 @@ describe('config', () => {
 
   it('Should assign object defaults deeply to user config', async () => {
     const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfigFn)
-    // In isolatedDevBuild, the default distDir is ".next/dev" during PHASE_DEVELOPMENT_SERVER.
-    if (process.env.__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD === 'true') {
-      expect(config.distDir).toEqual('.next/dev')
-    } else {
-      expect(config.distDir).toEqual('.next')
-    }
+    expect(config.distDir.replace(/\\/g, '/')).toEqual('.next/dev')
     expect(config.onDemandEntries.maxInactiveAge).toBeDefined()
   })
 


### PR DESCRIPTION
### Why?

This PR cleans up the incremental rollout of enabling `isolatedDevBuild` throughout the CI, as it required many test changes (x-ref: https://github.com/vercel/next.js/pull/84043).

- https://github.com/vercel/next.js/pull/84556
- https://github.com/vercel/next.js/pull/84558
- https://github.com/vercel/next.js/pull/84559
- https://github.com/vercel/next.js/pull/84562

This PR enables `experimental.isolatedDevBuild` by default so that users can run `next dev` and `next build` in the same directory, and they would not conflict. This occasionally happens when developing with AI tools, where you have a running dev server, but the Agent runs `next build`.

### How?

- Removed `__NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD` flag and its usage from CI and tests
- Updated tests that were not caught via rollout (e.g., missed out on test-*-windows)
- Moved `isolatedDevBuild` option out of experimental
- Added Telemetry

Will follow up with docs.