### PR TITLE
CI: Enable `experimental.isolatedDevBuild` for `test-dev`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -735,6 +735,7 @@ jobs:
         export IS_WEBPACK_TEST=1
         export NEXT_TEST_MODE=dev
         export NEXT_TEST_REACT_VERSION="${{ matrix.react }}"
+        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
 
         node run-tests.js \
           --timings \
@@ -964,7 +965,6 @@ jobs:
         export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/experimental-tests-manifest.json"
         export NEXT_TEST_MODE=dev
-        export __NEXT_EXPERIMENTAL_ISOLATED_DEV_BUILD=true
         export IS_WEBPACK_TEST=1
 
         node run-tests.js \

--- a/test/development/basic/hmr/run-error-recovery-hmr-test.util.ts
+++ b/test/development/basic/hmr/run-error-recovery-hmr-test.util.ts
@@ -9,6 +9,7 @@ import {
   retry,
   waitFor,
   trimEndMultiline,
+  getDistDir,
 } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 import { outdent } from 'outdent'
@@ -767,7 +768,7 @@ export function runErrorRecoveryHmrTest(nextConfig: {
 
   if (!process.env.IS_TURBOPACK_TEST) {
     it('should have client HMR events in trace file', async () => {
-      const traceData = await next.readFile('.next/trace')
+      const traceData = await next.readFile(`${getDistDir()}/trace`)
       expect(traceData).toContain('client-hmr-latency')
       expect(traceData).toContain('client-error')
       expect(traceData).toContain('client-success')

--- a/test/development/mcp-server/mcp-server-get-server-action-by-id.test.ts
+++ b/test/development/mcp-server/mcp-server-get-server-action-by-id.test.ts
@@ -1,6 +1,7 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import fs from 'fs/promises'
+import { getDistDir } from 'next-test-utils'
 
 describe('mcp-server get_server_action_by_id tool', () => {
   const { next } = nextTestSetup({
@@ -16,7 +17,7 @@ describe('mcp-server get_server_action_by_id tool', () => {
     // Read the manifest to get a valid action ID
     const manifestPath = path.join(
       next.testDir,
-      '.next',
+      getDistDir(),
       'server',
       'server-reference-manifest.json'
     )
@@ -114,7 +115,7 @@ describe('mcp-server get_server_action_by_id tool', () => {
     // Read the manifest to get inline action ID
     const manifestPath = path.join(
       next.testDir,
-      '.next',
+      getDistDir(),
       'server',
       'server-reference-manifest.json'
     )

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -1,4 +1,4 @@
-import { assertNoRedbox, check, retry } from 'next-test-utils'
+import { assertNoRedbox, check, getDistDir, retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 import { nextTestSetup } from 'e2e-utils'
 
@@ -303,7 +303,7 @@ describe('middleware - development errors', () => {
               '\n    at <unknown> (middleware.js:3)' +
               // TODO: Should be ignore-listed
               '\n    at eval (middleware.js:3:13)' +
-              '\n    at (middleware)/./middleware.js (.next/server/middleware.js:18:1)' +
+              `\n    at (middleware)/./middleware.js (${getDistDir()}/server/middleware.js:18:1)` +
               '\n    at __webpack_require__ '
       )
     })

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -2,7 +2,7 @@
 
 import cheerio from 'cheerio'
 import { nextTestSetup } from 'e2e-utils'
-import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
+import { fetchViaHTTP, getDistDir, renderViaHTTP } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { BUILD_MANIFEST, REACT_LOADABLE_MANIFEST } from 'next/constants'
 import path from 'path'
@@ -333,11 +333,13 @@ describe('Client Navigation rendering', () => {
       // build dynamic page
       await fetch('/dynamic/ssr')
 
-      const buildManifest = await next.readJSON(`.next/${BUILD_MANIFEST}`)
+      const buildManifest = await next.readJSON(
+        `${getDistDir()}/${BUILD_MANIFEST}`
+      )
       const reactLoadableManifest = await next.readJSON(
         process.env.IS_TURBOPACK_TEST
-          ? `.next/server/pages/dynamic/ssr/${REACT_LOADABLE_MANIFEST}`
-          : `.next/${REACT_LOADABLE_MANIFEST}`
+          ? `${getDistDir()}/server/pages/dynamic/ssr/${REACT_LOADABLE_MANIFEST}`
+          : `${getDistDir()}/${REACT_LOADABLE_MANIFEST}`
       )
       const resources = []
 

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -6,6 +6,7 @@ import {
   check,
   waitFor,
   getRedboxSource,
+  getDistDir,
 } from 'next-test-utils'
 import type { Request, Response } from 'playwright'
 import fs from 'node:fs/promises'
@@ -32,7 +33,7 @@ describe('app-dir action handling', () => {
   if (isNextStart) {
     it('should output exportName and filename info in manifest', async () => {
       const referenceManifest = await next.readJSON(
-        '.next/server/server-reference-manifest.json'
+        `${getDistDir()}/server/server-reference-manifest.json`
       )
       let foundExportNames = []
 
@@ -935,7 +936,7 @@ describe('app-dir action handling', () => {
     it('should not expose action content in sourcemaps', async () => {
       // We check all sourcemaps in the `static` folder for sensitive information given that chunking
       const sourcemaps = await fs
-        .readdir(join(next.testDir, '.next', 'static'), {
+        .readdir(join(next.testDir, getDistDir(), 'static'), {
           recursive: true,
           encoding: 'utf8',
         })
@@ -944,7 +945,7 @@ describe('app-dir action handling', () => {
             files
               .filter((f) => f.endsWith('.js.map'))
               .map((f) =>
-                fs.readFile(join(next.testDir, '.next', 'static', f), {
+                fs.readFile(join(next.testDir, getDistDir(), 'static', f), {
                   encoding: 'utf8',
                 })
               )
@@ -1022,14 +1023,14 @@ describe('app-dir action handling', () => {
     it('should bundle external libraries if they are on the action layer', async () => {
       await next.fetch('/client')
       const pageBundle = await fs.readFile(
-        join(next.testDir, '.next', 'server', 'app', 'client', 'page.js'),
+        join(next.testDir, getDistDir(), 'server', 'app', 'client', 'page.js'),
         { encoding: 'utf8' }
       )
       if (isTurbopack) {
         const chunkPaths = pageBundle.matchAll(/R\.c\("([^"]*)"\)/g)
         const reads = [...chunkPaths].map(async (match) => {
           const bundle = await fs.readFile(
-            join(next.testDir, '.next', ...match[1].split(/[\\/]/g)),
+            join(next.testDir, getDistDir(), ...match[1].split(/[\\/]/g)),
             { encoding: 'utf8' }
           )
           return bundle.includes('node_modules/nanoid/index.js')

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { assertNoRedbox, check, retry } from 'next-test-utils'
+import { assertNoRedbox, check, getDistDir, retry } from 'next-test-utils'
 
 async function resolveStreamResponse(response: any, onData?: any) {
   let result = ''
@@ -274,7 +274,7 @@ describe('app dir - external dependency', () => {
     expect(html).toContain('resolve response')
 
     const outputFile = await next.readFile(
-      '.next/server/app/cjs/server/page.js'
+      `${getDistDir()}/server/app/cjs/server/page.js`
     )
     expect(outputFile).not.toContain('image-response')
   })

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import imageSize from 'image-size'
-import { check } from 'next-test-utils'
+import { check, getDistDir } from 'next-test-utils'
 
 const CACHE_HEADERS = {
   NONE: 'no-cache, no-store',
@@ -228,12 +228,12 @@ describe('app dir - metadata dynamic routes', () => {
 
       if (isNextDev) {
         await check(async () => {
-          next.hasFile('.next/server/app-paths-manifest.json')
+          next.hasFile(`${getDistDir()}/server/app-paths-manifest.json`)
           return 'success'
         }, /success/)
 
         const appPathsManifest = JSON.parse(
-          await next.readFile('.next/server/app-paths-manifest.json')
+          await next.readFile(`${getDistDir()}/server/app-paths-manifest.json`)
         )
         const entryKeys = Object.keys(appPathsManifest)
         // Only has one route for twitter-image with catch-all routes in dev

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { check } from 'next-test-utils'
+import { check, getDistDir } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 import cheerio from 'cheerio'
 import {
@@ -42,7 +42,7 @@ describe('app dir - rsc basics', () => {
         const clientReferenceManifest = JSON.parse(
           (
             await next.readFile(
-              '.next/server/app/page_client-reference-manifest.js'
+              `${getDistDir()}/server/app/page_client-reference-manifest.js`
             )
           ).match(/]=(.+)$/)[1]
         )
@@ -632,13 +632,15 @@ describe('app dir - rsc basics', () => {
   if (isNextStart) {
     it('should generate edge SSR manifests for Node.js', async () => {
       const requiredServerFiles = JSON.parse(
-        await next.readFile('.next/required-server-files.json')
+        await next.readFile(`${getDistDir()}/required-server-files.json`)
       ).files
 
       const files = ['middleware-build-manifest.js', 'middleware-manifest.json']
 
       let promises = files.map(async (file) => {
-        expect(await next.hasFile(path.join('.next/server', file))).toBe(true)
+        expect(
+          await next.hasFile(path.join(`${getDistDir()}/server`, file))
+        ).toBe(true)
       })
       await Promise.all(promises)
 

--- a/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
+++ b/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { getDistDir } from 'next-test-utils'
 
 describe('typed-routes-validator', () => {
   const { next, isNextStart, skipped } = nextTestSetup({
@@ -11,7 +12,7 @@ describe('typed-routes-validator', () => {
   }
 
   it('should generate route validation correctly', async () => {
-    const dts = await next.readFile('.next/types/validator.ts')
+    const dts = await next.readFile(`${getDistDir()}/types/validator.ts`)
     // sanity check that dev generation is working
     expect(dts).toContain('const handler = {} as typeof import(')
   })


### PR DESCRIPTION
Enabling `experimental.isolatedDevBuild` required many changes to the current workflow, so we will incrementally roll out to the tests.

Enabling on test-dev instead of test-experimental-dev because `-experimental` CIs are filtered via `experimental-tests-manifest.json` and they don't cover all tests. We want to enable this feature by default so we should ensure this incremental rollout is covered on all test cases.

The flag was enabled for `test-experimental-dev` at https://github.com/vercel/next.js/pull/84099, and this PR moves the flag to the `test-dev` job.

1. ~~test-experimental-dev ([link](https://github.com/vercel/next.js/pull/84099))~~
2. test-dev (here)
3. test-prod
4. test-integration
5. test-unit
6. Enable by default, remove the flag, and update the rest

x-ref: https://github.com/vercel/next.js/pull/84043