### PR TITLE
[MCP] Fix: Do not dedup by URL for MCP get_page_metadata

### DIFF
--- a/packages/next/src/server/mcp/tools/get-page-metadata.ts
+++ b/packages/next/src/server/mcp/tools/get-page-metadata.ts
@@ -59,16 +59,17 @@ export function registerGetPageMetadataTool(
           }
         }
 
-        const metadataByUrl = new Map<string, PageMetadata>()
+        const sessionMetadata: Array<{ url: string; metadata: PageMetadata }> =
+          []
         for (const response of responses) {
           if (response.data) {
             // TODO: Add other metadata for the current page render here. Currently, we only have segment trie data.
             const pageMetadata = convertSegmentTrieToPageMetadata(response.data)
-            metadataByUrl.set(response.url, pageMetadata)
+            sessionMetadata.push({ url: response.url, metadata: pageMetadata })
           }
         }
 
-        if (metadataByUrl.size === 0) {
+        if (sessionMetadata.length === 0) {
           return {
             content: [
               {
@@ -79,7 +80,7 @@ export function registerGetPageMetadataTool(
           }
         }
 
-        const output = formatPageMetadata(metadataByUrl)
+        const output = formatPageMetadata(sessionMetadata)
 
         return {
           content: [
@@ -145,10 +146,12 @@ function convertSegmentTrieToPageMetadata(data: SegmentTrieData): PageMetadata {
   }
 }
 
-function formatPageMetadata(metadataByUrl: Map<string, PageMetadata>): string {
-  let output = `# Page metadata from ${metadataByUrl.size} browser session(s)\n\n`
+function formatPageMetadata(
+  sessionMetadata: Array<{ url: string; metadata: PageMetadata }>
+): string {
+  let output = `# Page metadata from ${sessionMetadata.length} browser session(s)\n\n`
 
-  for (const [url, metadata] of metadataByUrl) {
+  for (const { url, metadata } of sessionMetadata) {
     let displayUrl = url
     try {
       const urlObj = new URL(url)

--- a/test/development/mcp-server/mcp-server-get-page-metadata.test.ts
+++ b/test/development/mcp-server/mcp-server-get-page-metadata.test.ts
@@ -180,6 +180,33 @@ describe('mcp-server get_page_metadata tool', () => {
         await session2.close()
       }
     })
+
+    it('should count multiple browser tabs with the same URL separately', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 500))
+
+      const session1 = await launchStandaloneSession(next.url, '/')
+      const session2 = await launchStandaloneSession(next.url, '/')
+
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+
+        let metadata: string = ''
+        await retry(async () => {
+          const sessionId = 'test-same-url-' + Date.now()
+          metadata = await callGetPageMetadata(next.url, sessionId)
+          const rootSessions = (metadata.match(/## Session: \/(?!\w)/g) || [])
+            .length
+          expect(rootSessions).toBeGreaterThanOrEqual(2)
+        })
+
+        const rootSessions = (metadata.match(/## Session: \/(?!\w)/g) || [])
+          .length
+        expect(rootSessions).toBeGreaterThanOrEqual(2)
+      } finally {
+        await session1.close()
+        await session2.close()
+      }
+    })
   })
 
   describe('pages router', () => {


### PR DESCRIPTION
The `get_page_metadata` MCP tool was incorrectly grouping browser sessions by URL instead of counting each session individually. When multiple browser tabs were open to the same URL, the tool would report only 1 session instead of the actual number of sessions.