### PR TITLE
Add `.next/dev/types` to CNA templates tsconfig include

### DIFF
--- a/packages/create-next-app/templates/app-api/ts/tsconfig.json
+++ b/packages/create-next-app/templates/app-api/ts/tsconfig.json
@@ -27,6 +27,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
   "exclude": ["node_modules"]

--- a/packages/create-next-app/templates/app-empty/ts/tsconfig.json
+++ b/packages/create-next-app/templates/app-empty/ts/tsconfig.json
@@ -27,6 +27,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
   "exclude": ["node_modules"]

--- a/packages/create-next-app/templates/app-tw-empty/ts/tsconfig.json
+++ b/packages/create-next-app/templates/app-tw-empty/ts/tsconfig.json
@@ -27,6 +27,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
   "exclude": ["node_modules"]

--- a/packages/create-next-app/templates/app-tw/ts/tsconfig.json
+++ b/packages/create-next-app/templates/app-tw/ts/tsconfig.json
@@ -27,6 +27,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
   "exclude": ["node_modules"]

--- a/packages/create-next-app/templates/app/ts/tsconfig.json
+++ b/packages/create-next-app/templates/app/ts/tsconfig.json
@@ -27,6 +27,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
   "exclude": ["node_modules"]

--- a/packages/create-next-app/templates/default-empty/ts/tsconfig.json
+++ b/packages/create-next-app/templates/default-empty/ts/tsconfig.json
@@ -22,6 +22,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
   "exclude": ["node_modules"]

--- a/packages/create-next-app/templates/default-tw-empty/ts/tsconfig.json
+++ b/packages/create-next-app/templates/default-tw-empty/ts/tsconfig.json
@@ -22,6 +22,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
   "exclude": ["node_modules"]

--- a/packages/create-next-app/templates/default-tw/ts/tsconfig.json
+++ b/packages/create-next-app/templates/default-tw/ts/tsconfig.json
@@ -22,6 +22,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
   "exclude": ["node_modules"]

--- a/packages/create-next-app/templates/default/ts/tsconfig.json
+++ b/packages/create-next-app/templates/default/ts/tsconfig.json
@@ -22,6 +22,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Since we're going to enable `experimental.isolatedDevBuild` by default, add `".next/dev/types"` to CNA templates tsconfig include. This is required for CNA test `projectShouldHaveNoGitChanges()` as Next.js automatically adds this when the `isolatedDevBuild` is enabled.