### PR TITLE
Allow silencing unhandled rejection filter warnings and improve debugging

### DIFF
--- a/test/e2e/app-dir/cache-components-errors/cache-components-console-patch.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-console-patch.test.ts
@@ -7,7 +7,6 @@ describe('Cache Components Errors', () => {
     skipDeployment: true,
     skipStart: !isNextDev,
     env: {
-      NEXT_USE_UNHANDLED_REJECTION_FILTER: 'enabled',
       NODE_OPTIONS: '--require ./patch-console.js',
     },
   })

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -7,9 +7,6 @@ describe('Cache Components Errors', () => {
     files: __dirname + '/fixtures/default',
     skipStart: !isNextDev,
     skipDeployment: true,
-    env: {
-      NEXT_USE_UNHANDLED_REJECTION_FILTER: 'enabled',
-    },
   })
   const isRspack = !!process.env.NEXT_RSPACK
 


### PR DESCRIPTION
The original debug logs were added to help validate the filter worked correctly in real applications. They leak implementation details which is more permissive than ideal. One reason to keep these around however is if you end up seeing the filter being removed you might want to understand what code is actually doing the removal. The debug mode now allows you to receive stacks so you can pinpoint what is manipulating the listeners.

Additionally if you are ok with whatever is leading to these warnings you might want to quiet them. This introduces a silent mode

Additionally this removes any warnings except for the one about uninstalling the filter because doing so is so likely to be a bad idea that we must highlight it if it is happening.
