### PR TITLE
docs: Add more details to `useLightningcss` docs

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/useLightningcss.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/useLightningcss.mdx
@@ -4,14 +4,18 @@ description: Enable experimental support for Lightning CSS.
 version: experimental
 ---
 
-Experimental support for using [Lightning CSS](https://lightningcss.dev), a fast CSS bundler and minifier, written in Rust.
+Experimental support for using [Lightning CSS](https://lightningcss.dev) with webpack. Lightning CSS is a fast CSS transformer and minifier, written in Rust.
+
+If this option is not set, Next.js on webpack uses [PostCSS](https://postcss.org/) with [`postcss-preset-env`](https://www.npmjs.com/package/postcss-preset-env) by default.
+
+Turbopack uses Lightning CSS by default since Next 14.2. This configuration option has no effect on Turbopack. Turbopack always uses Lightning CSS.
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   experimental: {
-    useLightningcss: true,
+    useLightningcss: false, // default, ignored on Turbopack
   },
 }
 
@@ -22,9 +26,16 @@ export default nextConfig
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
-    useLightningcss: true,
+    useLightningcss: true, // disables PostCSS on webpack
   },
 }
 
 module.exports = nextConfig
 ```
+
+## Version History
+
+| Version  | Changes                                                                                                                                                                                      |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `15.1.0` | Support for `useSwcCss` was removed from Turbopack.                                                                                                                                          |
+| `14.2.0` | Turbopack's default CSS processor was changed from `@swc/css` to Lightning CSS. `useLightningcss` became ignored on Turbopack, and a legacy `experimental.turbo.useSwcCss` option was added. |

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -40,6 +40,9 @@ const unsupportedTurbopackNextConfigOptions = [
   'experimental.fullySpecified',
   'experimental.urlImports',
   'experimental.slowModuleDetection',
+
+  // We always use lightningcss
+  'experimental.useLightningcss',
 ]
 
 /**  */


### PR DESCRIPTION
Adds a bit more context about the current state of the world.

Adds a warning if you set this to anything other than `undefined` on Turbopack:

![Screenshot 2025-10-09 at 4.18.02 PM.png](https://app.graphite.dev/user-attachments/assets/fbe4c8f5-6b1f-466c-953c-b16ae2f33751.png)

Closes PACK-5662