### PR TITLE
Turbopack: don't ignore TS parse errors

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -65,6 +65,7 @@ test/development/mcp-server/fixtures/default-template/app/build-error/page.tsx
 /turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/error/input/broken.js
 /turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/invalid-export/broken.js
 /turbopack/crates/turbopack-tests/tests/execution/turbopack/**/not-compiled.js
+/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts
 /turbopack/crates/turbopack-tests/tests/snapshot/import-meta/cjs/input/mod.cjs
 /turbopack/crates/turbopack-tests/tests/snapshot/source_maps/*
 /turbopack/crates/turbopack-tests/tests/**/output*

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -348,18 +348,16 @@ async fn parse_file_content(
                             Syntax::Typescript(TsSyntax {
                                 decorators: true,
                                 dts: false,
-                                no_early_errors: true,
                                 tsx,
-                                disallow_ambiguous_jsx_like: false,
+                                ..Default::default()
                             })
                         }
                         EcmascriptModuleAssetType::TypescriptDeclaration => {
                             Syntax::Typescript(TsSyntax {
                                 decorators: true,
                                 dts: true,
-                                no_early_errors: true,
                                 tsx: false,
-                                disallow_ambiguous_jsx_like: false,
+                                ..Default::default()
                             })
                         }
                     },

--- a/turbopack/crates/turbopack-swc-ast-explorer/src/main.rs
+++ b/turbopack/crates/turbopack-swc-ast-explorer/src/main.rs
@@ -35,10 +35,7 @@ fn main() -> Result<()> {
     let target = EsVersion::latest();
     let syntax = Syntax::Typescript(TsSyntax {
         tsx: true,
-        decorators: false,
-        dts: false,
-        no_early_errors: true,
-        disallow_ambiguous_jsx_like: false,
+        ..Default::default()
     });
 
     let compiler = Compiler::new(sm.clone());

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/index.js
@@ -1,0 +1,1 @@
+import './other.ts'

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts
@@ -1,0 +1,5 @@
+function x() {
+  ;[1, 2] = [1, 2]
+}
+
+console.log(x());

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/issues/Parsing ecmascript source code failed-ae2e69.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/issues/Parsing ecmascript source code failed-ae2e69.txt
@@ -1,0 +1,16 @@
+error - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts:2:7  Parsing ecmascript source code failed
+       1 | function x() {
+         +        v
+       2 +   ;[1, 2] = [1, 2]
+         +        ^
+       3 | }
+       4 | 
+       5 | console.log(x());
+       6 | 
+  
+  Cannot assign to this
+  
+  Import trace:
+    test:
+      ./turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts
+      ./turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/issues/Parsing ecmascript source code failed-d7f72a.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/issues/Parsing ecmascript source code failed-d7f72a.txt
@@ -1,0 +1,16 @@
+error - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts:2:4  Parsing ecmascript source code failed
+       1 | function x() {
+         +     v
+       2 +   ;[1, 2] = [1, 2]
+         +     ^
+       3 | }
+       4 | 
+       5 | console.log(x());
+       6 | 
+  
+  Cannot assign to this
+  
+  Import trace:
+    test:
+      ./turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts
+      ./turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/index.js

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/output/aaf3a_crates_turbopack-tests_tests_snapshot_basic_ts-parse-error_input_0fc6be51._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/output/aaf3a_crates_turbopack-tests_tests_snapshot_basic_ts-parse-error_input_0fc6be51._.js
@@ -1,0 +1,17 @@
+(globalThis.TURBOPACK || (globalThis.TURBOPACK = [])).push(["output/aaf3a_crates_turbopack-tests_tests_snapshot_basic_ts-parse-error_input_0fc6be51._.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts [test] (ecmascript)", ((__turbopack_context__, module, exports) => {
+
+const e = new Error("Could not parse module '[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts'\n\nCannot assign to this");
+e.code = 'MODULE_UNPARSABLE';
+throw e;
+}),
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/index.js [test] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([]);
+var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$basic$2f$ts$2d$parse$2d$error$2f$input$2f$other$2e$ts__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts [test] (ecmascript)");
+;
+}),
+]);
+
+//# sourceMappingURL=aaf3a_crates_turbopack-tests_tests_snapshot_basic_ts-parse-error_input_0fc6be51._.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/output/aaf3a_crates_turbopack-tests_tests_snapshot_basic_ts-parse-error_input_0fc6be51._.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/output/aaf3a_crates_turbopack-tests_tests_snapshot_basic_ts-parse-error_input_0fc6be51._.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 10, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/index.js"],"sourcesContent":["import './other.ts'\n"],"names":[],"mappings":";AAAA"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/output/aaf3a_crates_turbopack-tests_tests_snapshot_basic_ts-parse-error_input_index_15722878.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/output/aaf3a_crates_turbopack-tests_tests_snapshot_basic_ts-parse-error_input_index_15722878.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/output/ba425_crates_turbopack-tests_tests_snapshot_basic_ts-parse-error_input_index_15722878.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/output/ba425_crates_turbopack-tests_tests_snapshot_basic_ts-parse-error_input_index_15722878.js
@@ -1,0 +1,5 @@
+(globalThis.TURBOPACK || (globalThis.TURBOPACK = [])).push([
+    "output/ba425_crates_turbopack-tests_tests_snapshot_basic_ts-parse-error_input_index_15722878.js",
+    {"otherChunks":["output/aaf3a_crates_turbopack-tests_tests_snapshot_basic_ts-parse-error_input_0fc6be51._.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime


### PR DESCRIPTION
`no_early_errors: true` was causing parse errors to be discarded.
For example with https://github.com/swc-project/swc/issues/11142 where there was a parse error (though it was a bug in this case), that left a `Invalid` AST node in the output, which only broke minification/SSG later on in the build (and potentially would have resulted in some error at runtime, if that specific chunk was never executed during SSG).

Closes PACK-5643