### PR TITLE
Build: Add time to logline of every step

### DIFF
--- a/packages/next/src/build/duration-to-string.ts
+++ b/packages/next/src/build/duration-to-string.ts
@@ -11,3 +11,12 @@ export function durationToString(compilerDuration: number) {
   }
   return durationString
 }
+
+export function hrtimeToSeconds(hrtime: [number, number]): number {
+  // hrtime is a tuple of [seconds, nanoseconds]
+  return hrtime[0] + hrtime[1] / 1e9
+}
+
+export function hrtimeDurationToString(hrtime: [number, number]): string {
+  return durationToString(hrtimeToSeconds(hrtime))
+}

--- a/packages/next/src/build/progress.ts
+++ b/packages/next/src/build/progress.ts
@@ -1,4 +1,5 @@
 import * as Log from '../build/output/log'
+import { hrtimeDurationToString } from './duration-to-string'
 import createSpinner from './spinner'
 
 function divideSegments(number: number, segments: number): number[] {
@@ -15,6 +16,8 @@ function divideSegments(number: number, segments: number): number[] {
 }
 
 export const createProgress = (total: number, label: string) => {
+  const progressStart = process.hrtime()
+
   const segments = divideSegments(total, 4)
 
   if (total === 0) {
@@ -74,7 +77,8 @@ export const createProgress = (total: number, label: string) => {
     } else {
       progressSpinner?.stop()
       if (isFinished) {
-        Log.event(message)
+        const progressEnd = process.hrtime(progressStart)
+        Log.event(`${message} in ${hrtimeDurationToString(progressEnd)}`)
       } else {
         Log.info(`${message} ${process.stdout.isTTY ? '\n' : '\r'}`)
       }

--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -9,6 +9,7 @@ import { verifyAndLint } from '../lib/verifyAndLint'
 import createSpinner from './spinner'
 import { eventTypeCheckCompleted } from '../telemetry/events'
 import isError from '../lib/is-error'
+import { hrtimeDurationToString } from './duration-to-string'
 
 /**
  * typescript will be loaded in "next/lib/verify-typescript-setup" and
@@ -156,7 +157,13 @@ export async function startTypeChecking({
           )
         }),
     ])
-    typeCheckingAndLintingSpinner?.stopAndPersist()
+
+    if (typeCheckingAndLintingSpinner) {
+      typeCheckingAndLintingSpinner.setText(
+        `${typeCheckingAndLintingSpinnerPrefixText} in ${hrtimeDurationToString(typeCheckEnd)}`
+      )
+      typeCheckingAndLintingSpinner.stopAndPersist()
+    }
 
     if (!ignoreTypeScriptErrors && verifyResult) {
       telemetry.record(

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -40,14 +40,9 @@ import type { UnwrapPromise } from '../../lib/coalesced-function'
 
 import origDebug from 'next/dist/compiled/debug'
 import { Telemetry } from '../../telemetry/storage'
-import { durationToString } from '../duration-to-string'
+import { durationToString, hrtimeToSeconds } from '../duration-to-string'
 
 const debug = origDebug('next:build:webpack-build')
-
-function hrtimeToSeconds(hrtime: [number, number]): number {
-  // hrtime is a tuple of [seconds, nanoseconds]
-  return hrtime[0] + hrtime[1] / 1e9
-}
 
 type CompilerResult = {
   errors: webpack.StatsError[]


### PR DESCRIPTION
## What?

Add timing to every step of the `next build` process for both Turbopack and webpack.

Besides the existing `compiled successfully in` time for Turbopack/webpack these now also have timings:

```
 ✓ Linting and checking validity of types in 954ms    
 ✓ Collecting page data in 205ms    
 ✓ Generating static pages (4/4) in 307ms
 ✓ Collecting build traces in 3.3s    
 ✓ Finalizing page optimization in 3.3s 
```

Closes PACK-5638