### PR TITLE
[turbopack] No op the webpack bundle analyzer under turbopack

### DIFF
--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -4,6 +4,13 @@ module.exports =
     if (!enabled) {
       return nextConfig
     }
+    if (process.env.TURBOPACK) {
+      console.warn(
+        'The Next Bundle Analyzer is not compatible with turbopack builds, disabling analysis.\n\n' +
+          'To run this analysis pass the `--webpack` flag to `next build`'
+      )
+      return nextConfig
+    }
 
     const extension = analyzerMode === 'json' ? '.json' : '.html'
 

--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -6,7 +6,7 @@ module.exports =
     }
     if (process.env.TURBOPACK) {
       console.warn(
-        'The Next Bundle Analyzer is not compatible with Turbopack builds. Disabling analysis.\n\n' +
+        'The Next Bundle Analyzer is not compatible with Turbopack builds yet, no report will be generated.\n\n' +
           'To run this analysis pass the `--webpack` flag to `next build`'
       )
       return nextConfig

--- a/packages/next-bundle-analyzer/index.js
+++ b/packages/next-bundle-analyzer/index.js
@@ -6,7 +6,7 @@ module.exports =
     }
     if (process.env.TURBOPACK) {
       console.warn(
-        'The Next Bundle Analyzer is not compatible with turbopack builds, disabling analysis.\n\n' +
+        'The Next Bundle Analyzer is not compatible with Turbopack builds. Disabling analysis.\n\n' +
           'To run this analysis pass the `--webpack` flag to `next build`'
       )
       return nextConfig


### PR DESCRIPTION
This never worked with turbopack, but with the recent default flip using this now breaks the build since it complains about configuring webpack in a turbopack build.

So print a warning and no-op the analyzer.  This isn't ideal but it is more actionable than a crash for users.

Closes PACK-5653