### PR TITLE
Add middleware to routes order doc

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx
@@ -90,10 +90,11 @@ The order Next.js routes are checked is:
 
 1. [headers](/docs/app/api-reference/config/next-config-js/headers) are checked/applied
 2. [redirects](/docs/app/api-reference/config/next-config-js/redirects) are checked/applied
-3. `beforeFiles` rewrites are checked/applied
-4. static files from the [public directory](/docs/app/api-reference/file-conventions/public-folder), `_next/static` files, and non-dynamic pages are checked/served
-5. `afterFiles` rewrites are checked/applied, if one of these rewrites is matched we check dynamic routes/static files after each match
-6. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked. If you use [fallback: true/'blocking'](/docs/pages/api-reference/functions/get-static-paths#fallback-true) in `getStaticPaths`, the fallback `rewrites` defined in your `next.config.js` will _not_ be run.
+3. [middleware](/docs/app/api-reference/file-conventions/middleware)
+4. `beforeFiles` rewrites are checked/applied
+5. static files from the [public directory](/docs/app/api-reference/file-conventions/public-folder), `_next/static` files, and non-dynamic pages are checked/served
+6. `afterFiles` rewrites are checked/applied, if one of these rewrites is matched we check dynamic routes/static files after each match
+7. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked. If you use [fallback: true/'blocking'](/docs/pages/api-reference/functions/get-static-paths#fallback-true) in `getStaticPaths`, the fallback `rewrites` defined in your `next.config.js` will _not_ be run.
 
 </AppOnly>
 


### PR DESCRIPTION
This adds `middleware` in the routes order to clarify where it comes in priority. 