### PR TITLE
feat(next/image)!: deprecate and warn on `images.domains` config

### DIFF
--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -871,9 +871,11 @@ You can optionally configure `inline` to allow the browser to render the image w
 
 #### `domains`
 
-> **Warning**: Deprecated since Next.js 14 in favor of strict [`remotePatterns`](#remotepatterns) in order to protect your application from malicious users. Only use `domains` if you own all the content served from the domain.
+> **Warning**: Deprecated since Next.js 14 in favor of strict [`remotePatterns`](#remotepatterns) in order to protect your application from malicious users.
 
 Similar to [`remotePatterns`](#remotepatterns), the `domains` configuration can be used to provide a list of allowed hostnames for external images. However, the `domains` configuration does not support wildcard pattern matching and it cannot restrict protocol, port, or pathname.
+
+Since most remote image servers are shared between multiple tenants, it's safer to use `remotePatterns` to ensure only the intended images are optimized.
 
 Below is an example of the `domains` property in the `next.config.js` file:
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -120,6 +120,15 @@ function checkDeprecations(
     silent
   )
 
+  if (userConfig.images?.domains?.length) {
+    warnOptionHasBeenDeprecated(
+      userConfig,
+      'images.domains',
+      `\`images.domains\` is deprecated in favor of \`images.remotePatterns\`. Please update ${configFileName} to protect your application from malicious users.`,
+      silent
+    )
+  }
+
   // i18n deprecation for App Router
   if (userConfig.i18n) {
     const hasAppDir = Boolean(findDir(dir, 'app'))
@@ -498,11 +507,6 @@ function assignDefaultsAndValidate(
       if (!Array.isArray(images.domains)) {
         throw new Error(
           `Specified images.domains should be an Array received ${typeof images.domains}.\nSee more info here: https://nextjs.org/docs/messages/invalid-images-config`
-        )
-      }
-      if (images.domains.length > 0) {
-        Log.warnOnce(
-          '`images.domains` is deprecated. Use `images.remotePatterns` instead to protect your application from malicious users. https://nextjs.org/docs/app/api-reference/components/image#domains'
         )
       }
     }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -500,6 +500,11 @@ function assignDefaultsAndValidate(
           `Specified images.domains should be an Array received ${typeof images.domains}.\nSee more info here: https://nextjs.org/docs/messages/invalid-images-config`
         )
       }
+      if (images.domains.length > 0) {
+        Log.warnOnce(
+          '`images.domains` is deprecated. Use `images.remotePatterns` instead to protect your application from malicious users. https://nextjs.org/docs/app/api-reference/components/image#domains'
+        )
+      }
     }
 
     if (!images.loader) {

--- a/packages/next/src/shared/lib/image-config.ts
+++ b/packages/next/src/shared/lib/image-config.ts
@@ -133,6 +133,9 @@ export const imageConfigDefault: ImageConfigComplete = {
   path: '/_next/image',
   loader: 'default',
   loaderFile: '',
+  /**
+   * @deprecated Use `remotePatterns` instead to protect your application from malicious users.
+   */
   domains: [],
   disableStaticImages: false,
   minimumCacheTTL: 14400, // 4 hours

--- a/test/integration/next-image-new/image-from-node-modules/test/index.test.ts
+++ b/test/integration/next-image-new/image-from-node-modules/test/index.test.ts
@@ -29,7 +29,7 @@ function runTests(getOutput: () => string) {
 
   it('should warn when using images.domains config', async () => {
     expect(getOutput()).toContain(
-      '`images.domains` is deprecated. Use `images.remotePatterns` instead to protect'
+      '`images.domains` is deprecated in favor of `images.remotePatterns`. Please update next.config.js to protect your application from malicious users.'
     )
   })
 }

--- a/test/integration/next-image-new/image-from-node-modules/test/index.test.ts
+++ b/test/integration/next-image-new/image-from-node-modules/test/index.test.ts
@@ -13,7 +13,7 @@ const appDir = join(__dirname, '../')
 let appPort
 let app
 
-function runTests() {
+function runTests(getOutput: () => string) {
   it('should apply image config for node_modules', async () => {
     const browser = await webdriver(appPort, '/')
     const src = await browser
@@ -26,14 +26,25 @@ function runTests() {
       .getAttribute('srcset')
     expect(srcset).toMatch('1234')
   })
+
+  it('should warn when using images.domains config', async () => {
+    expect(getOutput()).toContain(
+      '`images.domains` is deprecated. Use `images.remotePatterns` instead to protect'
+    )
+  })
 }
 
 describe('Image Component from node_modules prod mode', () => {
   ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
     'production mode',
     () => {
+      let output = ''
       beforeAll(async () => {
-        await nextBuild(appDir)
+        const result = await nextBuild(appDir, [], {
+          stderr: true,
+          stdout: true,
+        })
+        output = (result.stderr ?? '') + (result.stdout ?? '')
         appPort = await findPort()
         app = await nextStart(appDir, appPort)
       })
@@ -41,19 +52,23 @@ describe('Image Component from node_modules prod mode', () => {
         await killApp(app)
       })
 
-      runTests()
+      runTests(() => output)
     }
   )
 })
 
 describe('Image Component from node_modules development mode', () => {
+  let output = ''
   beforeAll(async () => {
     appPort = await findPort()
-    app = await launchApp(appDir, appPort)
+    app = await launchApp(appDir, appPort, {
+      onStderr: (msg) => (output += msg),
+      onStdout: (msg) => (output += msg),
+    })
   })
   afterAll(async () => {
     await killApp(app)
   })
 
-  runTests()
+  runTests(() => output)
 })


### PR DESCRIPTION
This was docs deprecated in Next.js 14 so we should begin warning in Next.js 16 when `images.domains` config is used.

This will guide users to providing a strict `images.remotePatterns` config ensuring only expected images can be optimized.