### PR TITLE
[Segment Cache] Add refresh URL to reused default segments

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -203,8 +203,10 @@ export function navigateReducer(
     // Temporary glue code between the router reducer and the new navigation
     // implementation. Eventually we'll rewrite the router reducer to a
     // state machine.
+    const currentUrl = new URL(state.canonicalUrl, location.origin)
     const result = navigateUsingSegmentCache(
       url,
+      currentUrl,
       state.cache,
       state.tree,
       state.nextUrl,
@@ -267,13 +269,14 @@ export function navigateReducer(
         return handleExternalUrl(state, mutable, flightData, pendingPush)
       }
 
+      const oldCanonicalUrl = state.canonicalUrl
       const updatedCanonicalUrl = canonicalUrlOverride
         ? createHrefFromUrl(canonicalUrlOverride)
         : href
 
       const onlyHashChange =
         !!hash &&
-        state.canonicalUrl.split('#', 1)[0] ===
+        oldCanonicalUrl.split('#', 1)[0] ===
           updatedCanonicalUrl.split('#', 1)[0]
 
       // If only the hash has changed, the server hasn't sent us any new data. We can just update
@@ -339,6 +342,7 @@ export function navigateReducer(
           ) {
             const task = startPPRNavigation(
               navigatedAt,
+              new URL(oldCanonicalUrl, url.origin),
               currentCache,
               currentTree,
               treePatch,

--- a/packages/next/src/client/components/segment-cache-impl/navigation.ts
+++ b/packages/next/src/client/components/segment-cache-impl/navigation.ts
@@ -77,6 +77,7 @@ export type NavigationResult =
  */
 export function navigate(
   url: URL,
+  currentUrl: URL,
   currentCacheNode: CacheNode,
   currentFlightRouterState: FlightRouterState,
   nextUrl: string | null,
@@ -124,6 +125,7 @@ export function navigate(
     return navigateUsingPrefetchedRouteTree(
       now,
       url,
+      currentUrl,
       nextUrl,
       isSamePageNavigation,
       currentCacheNode,
@@ -156,6 +158,7 @@ export function navigate(
     return navigateUsingPrefetchedRouteTree(
       now,
       url,
+      currentUrl,
       nextUrl,
       isSamePageNavigation,
       currentCacheNode,
@@ -176,6 +179,7 @@ export function navigate(
     data: navigateDynamicallyWithNoPrefetch(
       now,
       url,
+      currentUrl,
       nextUrl,
       isSamePageNavigation,
       currentCacheNode,
@@ -189,6 +193,7 @@ export function navigate(
 function navigateUsingPrefetchedRouteTree(
   now: number,
   url: URL,
+  currentUrl: URL,
   nextUrl: string | null,
   isSamePageNavigation: boolean,
   currentCacheNode: CacheNode,
@@ -210,6 +215,7 @@ function navigateUsingPrefetchedRouteTree(
   const scrollableSegments: Array<FlightSegmentPath> = []
   const task = startPPRNavigation(
     now,
+    currentUrl,
     currentCacheNode,
     currentFlightRouterState,
     prefetchFlightRouterState,
@@ -383,6 +389,7 @@ function readRenderSnapshotFromCache(
 async function navigateDynamicallyWithNoPrefetch(
   now: number,
   url: URL,
+  currentUrl: URL,
   nextUrl: string | null,
   isSamePageNavigation: boolean,
   currentCacheNode: CacheNode,
@@ -442,6 +449,7 @@ async function navigateDynamicallyWithNoPrefetch(
   const scrollableSegments: Array<FlightSegmentPath> = []
   const task = startPPRNavigation(
     now,
+    currentUrl,
     currentCacheNode,
     currentFlightRouterState,
     prefetchFlightRouterState,

--- a/test/client-segment-cache-tests-manifest.json
+++ b/test/client-segment-cache-tests-manifest.json
@@ -18,13 +18,6 @@
     },
     "test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts": {
       "failed": [
-        "parallel-routes-revalidation router.refresh (dynamic) - searchParams: false should correctly refresh data for previously intercepted modal and active page slot",
-        "parallel-routes-revalidation router.refresh (dynamic) - searchParams: true should correctly refresh data for previously intercepted modal and active page slot",
-        "parallel-routes-revalidation router.refresh (dynamic) - searchParams: true should correctly refresh data for the intercepted route and previously active page slot",
-        "parallel-routes-revalidation router.refresh (regular) - searchParams: false should correctly refresh data for previously intercepted modal and active page slot",
-        "parallel-routes-revalidation router.refresh (regular) - searchParams: true should correctly refresh data for previously intercepted modal and active page slot",
-        "parallel-routes-revalidation router.refresh (regular) - searchParams: true should correctly refresh data for the intercepted route and previously active page slot",
-        "parallel-routes-revalidation server action revalidation handles refreshing when multiple parallel slots are active",
         "parallel-routes-revalidation server action revalidation should not trigger a refresh for the page that is being redirected to"
       ]
     },


### PR DESCRIPTION
When segment is reused in the "default" parallel route slot, it is not part of the new page. So if the page is refreshed, we must fetch its data from the previous URL, not the new URL. To track this we add the previous URL to a special field in the FlightRouterState.

Currently this field is added by addRefreshMarkerToActiveParallelSegments; this updates the "ppr-navigations" module to add it during the main traversal used by navigations, so we can eventually get rid addRefreshMarkerToActiveParallelSegments.

Note that we don't need to add the marker to _all_ page segments, just the ones that are not part of the new page.