### PR TITLE
Turbopack: only show database timing when it's slower than a second

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1184,10 +1184,12 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         if new_items {
             let elapsed = start.elapsed();
-            turbo_tasks().send_compilation_event(Arc::new(TimingEvent::new(
-                "Finished writing to filesystem cache".to_string(),
-                elapsed,
-            )));
+            if elapsed.as_secs() >= 1 {
+                turbo_tasks().send_compilation_event(Arc::new(TimingEvent::new(
+                    "Finished writing to filesystem cache".to_string(),
+                    elapsed,
+                )));
+            }
         }
 
         Some((snapshot_time, new_items))

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -135,8 +135,10 @@ fn do_compact(
     })?;
     if ran {
         let elapsed = start.elapsed();
-        turbo_tasks()
-            .send_compilation_event(Arc::new(TimingEvent::new(message.to_string(), elapsed)));
+        if elapsed.as_secs() >= 1 {
+            turbo_tasks()
+                .send_compilation_event(Arc::new(TimingEvent::new(message.to_string(), elapsed)));
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->


Closes PACK-5658