### PR TITLE
[Cache Components] separate runtime stage in dev render

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -878,5 +878,6 @@
   "877": "Config options `experimental.externalProxyRewritesResolve` and `experimental.externalMiddlewareRewritesResolve` cannot be set at the same time. Please use `experimental.externalProxyRewritesResolve` instead.",
   "878": "Config options `skipProxyUrlNormalize` and `skipMiddlewareUrlNormalize` cannot be set at the same time. Please use `skipProxyUrlNormalize` instead.",
   "879": "Config options `experimental.proxyClientMaxBodySize` and `experimental.middlewareClientMaxBodySize` cannot be set at the same time. Please use `experimental.proxyClientMaxBodySize` instead.",
-  "880": "Config options `experimental.proxyPrefetch` and `experimental.middlewarePrefetch` cannot be set at the same time. Please use `experimental.proxyPrefetch` instead."
+  "880": "Config options `experimental.proxyPrefetch` and `experimental.middlewarePrefetch` cannot be set at the same time. Please use `experimental.proxyPrefetch` instead.",
+  "881": "Invalid render stage: %s"
 }

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -50,6 +50,7 @@ import {
 import { scheduleOnNextTick } from '../../lib/scheduler'
 import { BailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { InvariantError } from '../../shared/lib/invariant-error'
+import { RenderStage } from './staged-rendering'
 
 const hasPostpone = typeof React.unstable_postpone === 'function'
 
@@ -298,8 +299,12 @@ export function trackSynchronousPlatformIOAccessInDev(
   requestStore: RequestStore
 ): void {
   // We don't actually have a controller to abort but we do the semantic equivalent by
-  // advancing the request store out of prerender mode
-  requestStore.prerenderPhase = false
+  // advancing the request store out of the prerender stage
+  if (requestStore.stagedRendering) {
+    // TODO: error for sync IO in the runtime stage
+    // (which is not currently covered by the validation render in `spawnDynamicValidationInDev`)
+    requestStore.stagedRendering.advanceStage(RenderStage.Dynamic)
+  }
 }
 
 /**

--- a/packages/next/src/server/app-render/staged-rendering.ts
+++ b/packages/next/src/server/app-render/staged-rendering.ts
@@ -1,0 +1,90 @@
+import { InvariantError } from '../../shared/lib/invariant-error'
+import { createPromiseWithResolvers } from '../../shared/lib/promise-with-resolvers'
+
+export enum RenderStage {
+  Static = 1,
+  Runtime = 2,
+  Dynamic = 3,
+}
+
+export type NonStaticRenderStage = RenderStage.Runtime | RenderStage.Dynamic
+
+export class StagedRenderingController {
+  currentStage: RenderStage = RenderStage.Static
+
+  private runtimeStagePromise = createPromiseWithResolvers<void>()
+  private dynamicStagePromise = createPromiseWithResolvers<void>()
+
+  constructor(private abortSignal: AbortSignal | null = null) {
+    if (abortSignal) {
+      abortSignal.addEventListener(
+        'abort',
+        () => {
+          const { reason } = abortSignal
+          if (this.currentStage < RenderStage.Runtime) {
+            this.runtimeStagePromise.promise.catch(ignoreReject) // avoid unhandled rejections
+            this.runtimeStagePromise.reject(reason)
+          }
+          if (this.currentStage < RenderStage.Dynamic) {
+            this.dynamicStagePromise.promise.catch(ignoreReject) // avoid unhandled rejections
+            this.dynamicStagePromise.reject(reason)
+          }
+        },
+        { once: true }
+      )
+    }
+  }
+
+  advanceStage(stage: NonStaticRenderStage) {
+    // If we're already at the target stage or beyond, do nothing.
+    // (this can happen e.g. if sync IO advanced us to the dynamic stage)
+    if (this.currentStage >= stage) {
+      return
+    }
+    this.currentStage = stage
+    // Note that we might be going directly from Static to Dynamic,
+    // so we need to resolve the runtime stage as well.
+    if (stage >= RenderStage.Runtime) {
+      this.runtimeStagePromise.resolve()
+    }
+    if (stage >= RenderStage.Dynamic) {
+      this.dynamicStagePromise.resolve()
+    }
+  }
+
+  delayUntilStage<T>(stage: NonStaticRenderStage, resolvedValue: T) {
+    let stagePromise: Promise<void>
+    switch (stage) {
+      case RenderStage.Runtime: {
+        stagePromise = this.runtimeStagePromise.promise
+        break
+      }
+      case RenderStage.Dynamic: {
+        stagePromise = this.dynamicStagePromise.promise
+        break
+      }
+      default: {
+        stage satisfies never
+        throw new InvariantError(`Invalid render stage: ${stage}`)
+      }
+    }
+
+    // FIXME: this seems to be the only form that leads to correct API names
+    // being displayed in React Devtools (in the "suspended by" section).
+    // If we use `promise.then(() => resolvedValue)`, the names are lost.
+    // It's a bit strange that only one of those works right.
+    const promise = new Promise<T>((resolve, reject) => {
+      stagePromise.then(resolve.bind(null, resolvedValue), reject)
+    })
+
+    // Analogously to `makeHangingPromise`, we might reject this promise if the signal is invoked.
+    // (e.g. in the case where we don't want want the render to proceed to the dynamic stage and abort it).
+    // We shouldn't consider this an unhandled rejection, so we attach a noop catch handler here to suppress this warning.
+    if (this.abortSignal) {
+      promise.catch(ignoreReject)
+    }
+    return promise
+  }
+}
+
+function ignoreReject() {}

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -19,6 +19,7 @@ import type { ImplicitTags } from '../lib/implicit-tags'
 import type { WorkStore } from './work-async-storage.external'
 import { NEXT_HMR_REFRESH_HASH_COOKIE } from '../../client/components/app-router-headers'
 import { InvariantError } from '../../shared/lib/invariant-error'
+import type { StagedRenderingController } from './staged-rendering'
 
 export type WorkUnitPhase = 'action' | 'render' | 'after'
 
@@ -67,8 +68,8 @@ export interface RequestStore extends CommonWorkUnitStore {
 
   // DEV-only
   usedDynamic?: boolean
-  prerenderPhase?: boolean
   devFallbackParams?: OpaqueFallbackRouteParams | null
+  stagedRendering?: StagedRenderingController | null
   cacheSignal?: CacheSignal | null
   prerenderResumeDataCache?: PrerenderResumeDataCache | null
 }

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -1,3 +1,6 @@
+import type { NonStaticRenderStage } from './app-render/staged-rendering'
+import type { RequestStore } from './app-render/work-unit-async-storage.external'
+
 export function isHangingPromiseRejectionError(
   err: unknown
 ): err is HangingPromiseRejectionError {
@@ -73,7 +76,15 @@ export function makeHangingPromise<T>(
 
 function ignoreReject() {}
 
-export function makeDevtoolsIOAwarePromise<T>(underlying: T): Promise<T> {
+export function makeDevtoolsIOAwarePromise<T>(
+  underlying: T,
+  requestStore: RequestStore,
+  stage: NonStaticRenderStage
+): Promise<T> {
+  if (requestStore.stagedRendering) {
+    // We resolve each stage in a timeout, so React DevTools will pick this up as IO.
+    return requestStore.stagedRendering.delayUntilStage(stage, underlying)
+  }
   // in React DevTools if we resolve in a setTimeout we will observe
   // the promise resolution as something that can suspend a boundary or root.
   return new Promise<T>((resolve) => {

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -86,7 +86,7 @@ export function io(expression: string, type: ApiType) {
       break
     }
     case 'request':
-      if (workUnitStore.prerenderPhase === true) {
+      if (process.env.NODE_ENV === 'development') {
         trackSynchronousPlatformIOAccessInDev(workUnitStore)
       }
       break

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -14,6 +14,7 @@ import {
   makeDevtoolsIOAwarePromise,
 } from '../dynamic-rendering-utils'
 import { isRequestAPICallableInsideAfter } from './utils'
+import { RenderStage } from '../app-render/staged-rendering'
 
 /**
  * This function allows you to indicate that you require an actual user Request before continuing.
@@ -105,7 +106,11 @@ export function connection(): Promise<void> {
             // Semantically we only need the dev tracking when running in `next dev`
             // but since you would never use next dev with production NODE_ENV we use this
             // as a proxy so we can statically exclude this code from production builds.
-            return makeDevtoolsIOAwarePromise(undefined)
+            return makeDevtoolsIOAwarePromise(
+              undefined,
+              workUnitStore,
+              RenderStage.Dynamic
+            )
           } else {
             return Promise.resolve(undefined)
           }

--- a/test/development/app-dir/cache-components-dev-warmup/app/apis/[param]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/app/apis/[param]/page.tsx
@@ -28,7 +28,7 @@ export default function Page({ params, searchParams }) {
 
 function LogAfter({ label, api }: { label: string; api: () => Promise<any> }) {
   return (
-    <Suspense fallback={`Waiting for ${label}...`}>
+    <Suspense fallback={<div>Waiting for {label}...</div>}>
       <LogAfterInner label={label} api={api} />
     </Suspense>
   )
@@ -43,5 +43,5 @@ async function LogAfterInner({
 }) {
   await api()
   console.log(`after ${label}`)
-  return null
+  return <div>Finished {label}</div>
 }

--- a/test/development/app-dir/cache-components-dev-warmup/cache-components.dev-warmup.test.ts
+++ b/test/development/app-dir/cache-components-dev-warmup/cache-components.dev-warmup.test.ts
@@ -29,7 +29,7 @@ describe('cache-components-dev-warmup', () => {
   ) {
     // Match logs that contain the message, with any environment.
     const logPattern = new RegExp(
-      `^(?=.*\\b${message}\\b)(?=.*\\b(Cache|Prerender|Server)\\b).*`
+      `^(?=.*\\b${message}\\b)(?=.*\\b(Cache|Prerender|Prefetch|Server)\\b).*`
     )
     const logMessages = logs.map((log) => log.message)
     const messages = logMessages.filter((message) => logPattern.test(message))
@@ -175,13 +175,13 @@ describe('cache-components-dev-warmup', () => {
 
           // Private caches are dynamic holes in static prerenders,
           // so they shouldn't resolve in the static stage.
-          assertLog(logs, 'after private cache read - page', 'Server') // TODO: 'Runtime Prerender'
-          assertLog(logs, 'after private cache read - layout', 'Server') // TODO: 'Runtime Prerender'
+          assertLog(logs, 'after private cache read - page', 'Prefetch')
+          assertLog(logs, 'after private cache read - layout', 'Prefetch')
           assertLog(
             logs,
             'after successive private cache reads - page',
-            'Server'
-          ) // TODO: 'Runtime Prerender'
+            'Prefetch'
+          )
 
           assertLog(logs, 'after uncached fetch - layout', 'Server')
           assertLog(logs, 'after uncached fetch - page', 'Server')
@@ -204,8 +204,8 @@ describe('cache-components-dev-warmup', () => {
 
           // Short lived caches are dynamic holes in static prerenders,
           // so they shouldn't resolve in the static stage.
-          assertLog(logs, 'after short-lived cache read - page', 'Server')
-          assertLog(logs, 'after short-lived cache read - layout', 'Server')
+          assertLog(logs, 'after short-lived cache read - page', 'Prefetch')
+          assertLog(logs, 'after short-lived cache read - layout', 'Prefetch')
 
           assertLog(logs, 'after uncached fetch - layout', 'Server')
           assertLog(logs, 'after uncached fetch - page', 'Server')
@@ -246,18 +246,13 @@ describe('cache-components-dev-warmup', () => {
         const logs = await browser.log()
         assertLog(logs, 'after cache read - page', 'Prerender')
 
-        for (const apiName of [
-          'cookies',
-          'headers',
-          // TODO(restart-on-cache-miss): these two are currently broken/flaky,
-          // because they're created outside of render and can resolve too early.
-          // This will be fixed in a follow-up.
-          // 'params',
-          // 'searchParams',
-          'connection',
-        ]) {
-          assertLog(logs, `after ${apiName}`, 'Server')
-        }
+        // TODO: we should only label this as "Prefetch" if there's a prefetch config.
+        assertLog(logs, `after cookies`, 'Prefetch')
+        assertLog(logs, `after headers`, 'Prefetch')
+        assertLog(logs, `after params`, 'Prefetch')
+        assertLog(logs, `after searchParams`, 'Prefetch')
+
+        assertLog(logs, 'after connection', 'Server')
       }
 
       if (isInitialLoad) {


### PR DESCRIPTION
This PR extends dev rendering with an extra stage - Runtime, where we resolve Runtime APIs (`cookies()`, `params`, etc), but not dynamic APIs (e.g. `connection()`, uncached fetches). This separation requires some changes to `makeDevtoolsIOPromise` and other tasky delay code that we've had in place before.|

I've implemented this as `StagedRenderingController` (generally accessed via `requestStore.stagedRendering`), which allows creating promises that resolve in the correct stage.
```ts
stagedRendering.delayUntilStage(RenderStage.Runtime, cookiesObject) // resolves in the runtime stage
stagedRendering.delayUntilStage(RenderStage.Dynamic, somethingDynamic)  // resolves in the dynamic stage
```

Notably, in the case where the initial render has cache misses and we only use it as a cache warmup, we can also use this to _not_ resolve dynamic promises, which saves us from doing some unncecessary (uncached) work. This means that, if the render ends up being a warmup, dynamic promises can be left hanging (and later aborted), similar to how `makeHangingPromise` works in a prerender.

For simplicity and compatibility with other codepaths, most callsites that need a staged promise still use `makeDevtoolsIOAwarePromise`, but now they pass in a stage argument to control the timing if we are rendering with stages.

---

Based on the stage, we now add a third environment label -- "Prefetch", to correspond with runtime prefetches. This label is currently applied even if there's no prefetch config in place, which is a bit confusing, and will be addressed in a follow-up (if there's no runtime prefetch config, we want to label runtime logs as "Server" even if they run in a separate stage).