### PR TITLE
[turbopack] Only send the filesystem caching timing messages for slow events

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1184,10 +1184,13 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         if new_items {
             let elapsed = start.elapsed();
-            turbo_tasks().send_compilation_event(Arc::new(TimingEvent::new(
-                "Finished writing to filesystem cache".to_string(),
-                elapsed,
-            )));
+            // avoid spamming the event queue with information about fast operations
+            if elapsed > Duration::from_secs(10) {
+                turbo_tasks().send_compilation_event(Arc::new(TimingEvent::new(
+                    "Finished writing to filesystem cache".to_string(),
+                    elapsed,
+                )));
+            }
         }
 
         Some((snapshot_time, new_items))

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -1,4 +1,10 @@
-use std::{cmp::max, path::PathBuf, sync::Arc, thread::available_parallelism, time::Instant};
+use std::{
+    cmp::max,
+    path::PathBuf,
+    sync::Arc,
+    thread::available_parallelism,
+    time::{Duration, Instant},
+};
 
 use anyhow::{Ok, Result};
 use parking_lot::Mutex;
@@ -135,8 +141,11 @@ fn do_compact(
     })?;
     if ran {
         let elapsed = start.elapsed();
-        turbo_tasks()
-            .send_compilation_event(Arc::new(TimingEvent::new(message.to_string(), elapsed)));
+        // avoid spamming the event queue with information about fast operations
+        if elapsed > Duration::from_secs(10) {
+            turbo_tasks()
+                .send_compilation_event(Arc::new(TimingEvent::new(message.to_string(), elapsed)));
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
These are not very actionable for end users, but if they take more than 10s it might be a useful clue about system performance.

Closes PACK-5655