### PR TITLE
docs: `experimental.isolatedDevBuild`

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/isolatedDevBuild.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/isolatedDevBuild.mdx
@@ -4,13 +4,21 @@ description: Use isolated build outputs for development server to prevent confli
 version: experimental
 ---
 
-The experimental `isolatedDevBuild` option separates development and production build outputs into different directories. When enabled, development builds use `.next/dev` instead of `.next`, preventing conflicts when running `next dev` and `next build` concurrently.
+The experimental `isolatedDevBuild` option separates development and production build outputs into different directories. When enabled, the development server (`next dev`) writes its output to `.next/dev` instead of `.next`, preventing conflicts when running `next dev` and `next build` concurrently.
 
-This helps when you're running AI agents when it wants to run `next build` to verify changes it no longer breaks your development server.
+This is especially helpful when automated tools (for example, AI agents) run `next build` to validate changes while your development server is running, ensuring the dev server is not affected by changes made by the build process.
 
-This feature is **enabled by default** to provide better build isolation and prevent potential issues from mixed build artifacts.
+This feature is **enabled by default** to keep development and production outputs separate and prevent conflicts.
 
-To opt out of this feature, set `isolatedDevBuild` to `false` in your `next.config.ts`:
+## How it Works
+
+- During `next dev`, artifacts are written to `.next/dev/` (e.g., compiled pages, HMR bundles).
+- During `next build`, artifacts continue to be written to `.next/`.
+- The directories are independent, so starting or stopping one does not affect the other.
+
+## Configuration
+
+To opt out of this feature, set `isolatedDevBuild` to `false` in your configuration:
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
@@ -34,3 +42,9 @@ const nextConfig = {
 
 export default nextConfig
 ```
+
+## Version History
+
+| Version   | Changes                                        |
+| --------- | ---------------------------------------------- |
+| `v16.0.0` | `experimental.isolatedDevBuild` is introduced. |

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/isolatedDevBuild.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/isolatedDevBuild.mdx
@@ -1,0 +1,36 @@
+---
+title: isolatedDevBuild
+description: Use isolated build outputs for development server to prevent conflicts with production builds.
+version: experimental
+---
+
+The experimental `isolatedDevBuild` option separates development and production build outputs into different directories. When enabled, development builds use `.next/dev` instead of `.next`, preventing conflicts when running `next dev` and `next build` concurrently.
+
+This helps when you're running AI agents when it wants to run `next build` to verify changes it no longer breaks your development server.
+
+This feature is **enabled by default** to provide better build isolation and prevent potential issues from mixed build artifacts.
+
+To opt out of this feature, set `isolatedDevBuild` to `false` in your `next.config.ts`:
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    isolatedDevBuild: false, // defaults to true
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.mjs" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    isolatedDevBuild: false, // defaults to true
+  },
+}
+
+export default nextConfig
+```

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/isolatedDevBuild.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/isolatedDevBuild.mdx
@@ -10,12 +10,6 @@ This is especially helpful when automated tools (for example, AI agents) run `ne
 
 This feature is **enabled by default** to keep development and production outputs separate and prevent conflicts.
 
-## How it Works
-
-- During `next dev`, artifacts are written to `.next/dev/` (e.g., compiled pages, HMR bundles).
-- During `next build`, artifacts continue to be written to `.next/`.
-- The directories are independent, so starting or stopping one does not affect the other.
-
 ## Configuration
 
 To opt out of this feature, set `isolatedDevBuild` to `false` in your configuration:

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/isolatedDevBuild.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/isolatedDevBuild.mdx
@@ -1,0 +1,7 @@
+---
+title: isolatedDevBuild
+description: Use isolated directories for development builds to prevent conflicts with production builds.
+source: app/api-reference/config/next-config-js/isolatedDevBuild
+---
+
+{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}


### PR DESCRIPTION
This doc is mainly to provide the users with information on how to opt out of this feature. We could later remove these docs and the option when the need to opt out is low.