### PR TITLE
[create-next-app]: add eslint to default template

### DIFF
--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -234,7 +234,7 @@ async function run(): Promise<void> {
     const defaults: typeof preferences = {
       typescript: true,
       eslint: false,
-      linter: 'none',
+      linter: 'eslint',
       tailwind: true,
       app: true,
       srcDir: false,


### PR DESCRIPTION
Sets eslint as the default linter when using recommended defaults. 