### PR TITLE
[cna] Preserve existing config option when enabling React Compiler

### DIFF
--- a/packages/create-next-app/templates/app-api/js/next.config.mjs
+++ b/packages/create-next-app/templates/app-api/js/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  /* config options here */
+};
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app-empty/js/next.config.mjs
+++ b/packages/create-next-app/templates/app-empty/js/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  /* config options here */
+};
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app-tw-empty/js/next.config.mjs
+++ b/packages/create-next-app/templates/app-tw-empty/js/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  /* config options here */
+};
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app-tw/js/next.config.mjs
+++ b/packages/create-next-app/templates/app-tw/js/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  /* config options here */
+};
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app/js/next.config.mjs
+++ b/packages/create-next-app/templates/app/js/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  /* config options here */
+};
 
 export default nextConfig;

--- a/packages/create-next-app/templates/default-empty/js/next.config.mjs
+++ b/packages/create-next-app/templates/default-empty/js/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  /* config options here */
   reactStrictMode: true,
 };
 

--- a/packages/create-next-app/templates/default-tw-empty/js/next.config.mjs
+++ b/packages/create-next-app/templates/default-tw-empty/js/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  /* config options here */
   reactStrictMode: true,
 };
 

--- a/packages/create-next-app/templates/default-tw/js/next.config.mjs
+++ b/packages/create-next-app/templates/default-tw/js/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  /* config options here */
   reactStrictMode: true,
 };
 

--- a/packages/create-next-app/templates/default/js/next.config.mjs
+++ b/packages/create-next-app/templates/default/js/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  /* config options here */
   reactStrictMode: true,
 };
 

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -103,17 +103,10 @@ export const installTemplate = async ({
     );
     let configContent = await fs.readFile(nextConfigFile, "utf8");
 
-    if (mode === "ts") {
-      configContent = configContent.replace(
-        "const nextConfig: NextConfig = {\n  /* config options here */\n};",
-        `const nextConfig: NextConfig = {\n  reactCompiler: true,\n};`,
-      );
-    } else {
-      configContent = configContent.replace(
-        "const nextConfig = {};",
-        `const nextConfig = {\n  reactCompiler: true,\n};`,
-      );
-    }
+    configContent = configContent.replace(
+      "/* config options here */\n",
+      "/* config options here */\n  reactCompiler: true,\n",
+    );
 
     await fs.writeFile(nextConfigFile, configContent);
   }


### PR DESCRIPTION
Used the magic comment to insert the config option. The ts templates already had a magic comment to use. Added the same to the js templates.