### PR TITLE
[cna] Update compiler template to 1.0.0

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -247,8 +247,7 @@ export const installTemplate = async ({
   }
 
   if (reactCompiler) {
-    // TODO: Use "^19" when React Compiler is stable
-    packageJson.devDependencies["babel-plugin-react-compiler"] = "19.1.0-rc.3";
+    packageJson.devDependencies["babel-plugin-react-compiler"] = "1.0.0";
   }
 
   /**


### PR DESCRIPTION
React Compiler 1.0 was just announced at ReactConf. This PR updates the create-next-app template to use this latest version.