### PR TITLE
[test] Assert on stable error codes

### DIFF
--- a/test/development/error-overlay/app/known-client-error/page.tsx
+++ b/test/development/error-overlay/app/known-client-error/page.tsx
@@ -1,23 +1,18 @@
 'use client'
 
-import Link from 'next/link'
 import React from 'react'
 
 export default function Page() {
-  const broken = (
-    <>
-      <Link href="/invalid" as="mailto:john@example.com">
-        <a>Invalid link</a>
-      </Link>
-    </>
-  )
-
   const [shouldShow, setShouldShow] = React.useState(false)
+  if (shouldShow) {
+    const error = new Error('Client error!')
+    ;(error as any).__NEXT_ERROR_CODE = 'E40'
+    throw error
+  }
 
   return (
     <div>
       <button onClick={() => setShouldShow(true)}>break on client</button>
-      {shouldShow && broken}
     </div>
   )
 }

--- a/test/development/error-overlay/app/known-rsc-error/page.tsx
+++ b/test/development/error-overlay/app/known-rsc-error/page.tsx
@@ -1,12 +1,7 @@
-import { unstable_cache } from 'next/cache'
-import { headers } from 'next/headers'
-import React from 'react'
-
 export default async function Page() {
-  const getData = unstable_cache(async () => {
-    const h = await headers()
-    return h.get('x-test-header')
-  }, ['test-header-key'])
+  const error = new Error('Client error!')
+  ;(error as any).__NEXT_ERROR_CODE = 'E40'
+  throw error
 
-  return <div>{await getData()}</div>
+  return null
 }

--- a/test/development/error-overlay/index.test.tsx
+++ b/test/development/error-overlay/index.test.tsx
@@ -14,7 +14,7 @@ describe('DevErrorOverlay', () => {
 
     const errorCode = await browser.elementByCss('[data-nextjs-error-code]')
     const code = await errorCode.getAttribute('data-nextjs-error-code')
-    expect(code).toBe('E838')
+    expect(code).toBe('E40')
   })
 
   it('sends feedback when clicking helpful button', async () => {
@@ -41,7 +41,7 @@ describe('DevErrorOverlay', () => {
           .textContent()
       ).toEqual('Thanks for your feedback!')
       expect(feedbackRequests).toEqual([
-        '/__nextjs_error_feedback?errorCode=E794&wasHelpful=true',
+        '/__nextjs_error_feedback?errorCode=E40&wasHelpful=true',
       ])
     })
   })
@@ -70,7 +70,7 @@ describe('DevErrorOverlay', () => {
           .textContent()
       ).toEqual('Thanks for your feedback!')
       expect(feedbackRequests).toEqual([
-        '/__nextjs_error_feedback?errorCode=E794&wasHelpful=false',
+        '/__nextjs_error_feedback?errorCode=E40&wasHelpful=false',
       ])
     })
   })


### PR DESCRIPTION
Fixes
```
DevErrorOverlay › sends feedback when clicking not helpful button

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

      Array [
    -   "/__nextjs_error_feedback?errorCode=E794&wasHelpful=false",
    +   "/__nextjs_error_feedback?errorCode=E209&wasHelpful=false",
      ]
```

-- https://github.com/vercel/next.js/actions/runs/18360913450/job/52306369449#step:34:793