### PR TITLE
chore: Attempt to fix ppr-partial-hydration flakiness

### DIFF
--- a/test/e2e/app-dir/ppr-partial-hydration/app/with-shell/with-streaming-metadata/page.tsx
+++ b/test/e2e/app-dir/ppr-partial-hydration/app/with-shell/with-streaming-metadata/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { connection } from 'next/server'
-import { setTimeout } from 'timers/promises'
 import { HydrationIndicator } from '../../hydration-indicator'
+import waitForMarkerFile from '../../../waitForMarkerFile'
 import type { Metadata } from 'next'
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -20,16 +20,16 @@ export default function Page() {
         <HydrationIndicator id="shell-hydrated" />
         <hr />
         <Suspense fallback={<div id="dynamic-fallback">Loading...</div>}>
-          <SlowServerComponent delay={500} />
+          <SlowServerComponent />
         </Suspense>
       </div>
     </main>
   )
 }
 
-async function SlowServerComponent({ delay }: { delay: number }) {
+async function SlowServerComponent() {
   await connection()
-  await setTimeout(delay)
+  await waitForMarkerFile()
   const randomValue = Math.floor(Math.random() * 1000)
   return (
     <div id="dynamic">

--- a/test/e2e/app-dir/ppr-partial-hydration/app/with-shell/without-metadata/page.tsx
+++ b/test/e2e/app-dir/ppr-partial-hydration/app/with-shell/without-metadata/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { connection } from 'next/server'
-import { setTimeout } from 'timers/promises'
 import { HydrationIndicator } from '../../hydration-indicator'
+import waitForMarkerFile from '../../../waitForMarkerFile'
 
 export default function Page() {
   return (
@@ -12,16 +12,16 @@ export default function Page() {
         <HydrationIndicator id="shell-hydrated" />
         <hr />
         <Suspense fallback={<div id="dynamic-fallback">Loading...</div>}>
-          <SlowServerComponent delay={500} />
+          <SlowServerComponent />
         </Suspense>
       </div>
     </main>
   )
 }
 
-async function SlowServerComponent({ delay }: { delay: number }) {
+async function SlowServerComponent() {
   await connection()
-  await setTimeout(delay)
+  await waitForMarkerFile()
   const randomValue = Math.floor(Math.random() * 1000)
   return (
     <div id="dynamic">

--- a/test/e2e/app-dir/ppr-partial-hydration/app/without-shell/with-streaming-metadata/page.tsx
+++ b/test/e2e/app-dir/ppr-partial-hydration/app/without-shell/with-streaming-metadata/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { connection } from 'next/server'
-import { setTimeout } from 'timers/promises'
 import { HydrationIndicator } from '../../hydration-indicator'
+import waitForMarkerFile from '../../../waitForMarkerFile'
 import type { Metadata } from 'next'
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -23,16 +23,16 @@ export default async function Page() {
         <HydrationIndicator id="shell-hydrated" />
         <hr />
         <Suspense fallback={<div id="dynamic-fallback">Loading...</div>}>
-          <SlowServerComponent delay={500} />
+          <SlowServerComponent />
         </Suspense>
       </div>
     </main>
   )
 }
 
-async function SlowServerComponent({ delay }: { delay: number }) {
+async function SlowServerComponent() {
   await connection()
-  await setTimeout(delay)
+  await waitForMarkerFile()
   const randomValue = Math.floor(Math.random() * 1000)
   return (
     <div id="dynamic">

--- a/test/e2e/app-dir/ppr-partial-hydration/app/without-shell/without-metadata/page.tsx
+++ b/test/e2e/app-dir/ppr-partial-hydration/app/without-shell/without-metadata/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { connection } from 'next/server'
-import { setTimeout } from 'timers/promises'
 import { HydrationIndicator } from '../../hydration-indicator'
+import waitForMarkerFile from '../../../waitForMarkerFile'
 
 export default async function Page() {
   // Trigger the Suspense-around-body in the root layout so that no static shell is produced
@@ -15,16 +15,16 @@ export default async function Page() {
         <HydrationIndicator id="shell-hydrated" />
         <hr />
         <Suspense fallback={<div id="dynamic-fallback">Loading...</div>}>
-          <SlowServerComponent delay={500} />
+          <SlowServerComponent />
         </Suspense>
       </div>
     </main>
   )
 }
 
-async function SlowServerComponent({ delay }: { delay: number }) {
+async function SlowServerComponent() {
   await connection()
-  await setTimeout(delay)
+  await waitForMarkerFile()
   const randomValue = Math.floor(Math.random() * 1000)
   return (
     <div id="dynamic">

--- a/test/e2e/app-dir/ppr-partial-hydration/waitForMarkerFile.ts
+++ b/test/e2e/app-dir/ppr-partial-hydration/waitForMarkerFile.ts
@@ -1,0 +1,20 @@
+import { setTimeout } from 'node:timers/promises'
+import { access } from 'node:fs/promises'
+import path from 'node:path'
+import React from 'react'
+
+export default async function waitForMarkerFile() {
+  const signal = React.cacheSignal()
+  if (!signal) {
+    throw new Error('cacheSignal returned null, are we not rendering?')
+  }
+  while (true) {
+    try {
+      await access(path.join(process.cwd(), 'slowComponentReady'))
+      return
+    } catch (e) {
+      await setTimeout(100, { signal })
+      continue
+    }
+  }
+}


### PR DESCRIPTION
Write to a marker file to determine when the slow server component finishes rendering instead of trying to sleep for some fixed amount of time.

Closes PACK-5700