### PR TITLE
Turbopack: use vector instead of hash map

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -232,7 +232,7 @@ impl ServerActionsGraph {
                 })
                 .try_flat_join()
                 .await?;
-            Ok(Vc::cell(actions.into_iter().collect()))
+            Ok(Vc::cell(actions))
         }
         .instrument(span)
         .await
@@ -730,7 +730,7 @@ impl GlobalBuildInformation {
                     .try_flat_join()
                     .await?;
 
-                Ok(Vc::cell(result.into_iter().collect()))
+                Ok(Vc::cell(result))
             }
         }
         .instrument(span)

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -416,7 +416,7 @@ fn is_turbopack_internal_var(with: &Option<Box<ObjectLit>>) -> bool {
         .unwrap_or(false)
 }
 
-type HashToLayerNameModule = FxIndexMap<String, (ActionLayer, String, ResolvedVc<Box<dyn Module>>)>;
+type HashToLayerNameModule = Vec<(String, (ActionLayer, String, ResolvedVc<Box<dyn Module>>))>;
 
 /// A mapping of every module which exports a Server Action, with the hashed id
 /// and exported name of each found action.
@@ -427,7 +427,7 @@ pub struct AllActions(HashToLayerNameModule);
 impl AllActions {
     #[turbo_tasks::function]
     pub fn empty() -> Vc<Self> {
-        Vc::cell(FxIndexMap::default())
+        Vc::cell(Default::default())
     }
 }
 


### PR DESCRIPTION
No need to use a hashmap here.

Closes PACK-5664