### PR TITLE
docs: Replace Middleware docs to Proxy

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
@@ -8,7 +8,7 @@ related:
     - app/api-reference/functions/next-response
 ---
 
-The `middleware.js|ts` file is used to write [Middleware](/docs/app/getting-started/route-handlers-and-middleware#middleware) and run code on the server before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
+The `middleware.js|ts` file is used to write [Middleware](/docs/app/getting-started/#middleware) and run code on the server before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
 
 Middleware executes before routes are rendered. It's particularly useful for implementing custom server-side logic like authentication, logging, or handling redirects.
 

--- a/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/middleware.mdx
@@ -353,7 +353,7 @@ export function middleware(request) {
   })
   cookie = response.cookies.get('vercel')
   console.log(cookie) // => { name: 'vercel', value: 'fast', Path: '/' }
-  // The outgoing response will have a `Set-Cookie:vercel=fast;path=/test` header.
+  // The outgoing response will have a `Set-Cookie:vercel=fast;path=/` header.
 
   return response
 }

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -1,0 +1,697 @@
+---
+title: middleware.js
+description: API reference for the middleware.js file.
+related:
+  title: Learn more about Middleware
+  links:
+    - app/api-reference/functions/next-request
+    - app/api-reference/functions/next-response
+---
+
+The `middleware.js|ts` file is used to write [Middleware](/docs/app/getting-started/route-handlers-and-middleware#middleware) and run code on the server before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
+
+Middleware executes before routes are rendered. It's particularly useful for implementing custom server-side logic like authentication, logging, or handling redirects.
+
+> **Good to know**:
+>
+> Middleware is meant to be invoked separately of your render code and in optimized cases deployed to your CDN for fast redirect/rewrite handling, you should not attempt relying on shared modules or globals.
+>
+> To pass information from Middleware to your application, use [headers](#setting-headers), [cookies](#using-cookies), [rewrites](/docs/app/api-reference/functions/next-response#rewrite), [redirects](/docs/app/api-reference/functions/next-response#redirect), or the URL.
+
+Create a `middleware.ts` (or `.js`) file in the project root, or inside `src` if applicable, so that it is located at the same level as `pages` or `app`.
+
+If you’ve customized [`pageExtensions`](/docs/app/api-reference/config/next-config-js/pageExtensions), for example to `.page.ts` or `.page.js`, name your file `middleware.page.ts` or `middleware.page.js` accordingly.
+
+```tsx filename="middleware.ts" switcher
+import { NextResponse, NextRequest } from 'next/server'
+
+// This function can be marked `async` if using `await` inside
+export function middleware(request: NextRequest) {
+  return NextResponse.redirect(new URL('/home', request.url))
+}
+
+export const config = {
+  matcher: '/about/:path*',
+}
+```
+
+```js filename="middleware.js" switcher
+import { NextResponse } from 'next/server'
+
+// This function can be marked `async` if using `await` inside
+export function middleware(request) {
+  return NextResponse.redirect(new URL('/home', request.url))
+}
+
+export const config = {
+  matcher: '/about/:path*',
+}
+```
+
+## Exports
+
+### Middleware function
+
+The file must export a single function, either as a default export or named `middleware`. Note that multiple middleware from the same file are not supported.
+
+```js filename="middleware.js"
+// Example of default export
+export default function middleware(request) {
+  // Middleware logic
+}
+```
+
+### Config object (optional)
+
+Optionally, a config object can be exported alongside the Middleware function. This object includes the [matcher](#matcher) to specify paths where the Middleware applies.
+
+### Matcher
+
+The `matcher` option allows you to target specific paths for the Middleware to run on. You can specify these paths in several ways:
+
+- For a single path: Directly use a string to define the path, like `'/about'`.
+- For multiple paths: Use an array to list multiple paths, such as `matcher: ['/about', '/contact']`, which applies the Middleware to both `/about` and `/contact`.
+
+```js filename="middleware.js"
+export const config = {
+  matcher: ['/about/:path*', '/dashboard/:path*'],
+}
+```
+
+Additionally, the `matcher` option supports complex path specifications through regular expressions, such as `matcher: ['/((?!api|_next/static|_next/image|.*\\.png$).*)']`, enabling precise control over which paths to include or exclude.
+
+The `matcher` option accepts an array of objects with the following keys:
+
+- `source`: The path or pattern used to match the request paths. It can be a string for direct path matching or a pattern for more complex matching.
+- `regexp` (optional): A regular expression string that fine-tunes the matching based on the source. It provides additional control over which paths are included or excluded.
+- `locale` (optional): A boolean that, when set to `false`, ignores locale-based routing in path matching.
+- `has` (optional): Specifies conditions based on the presence of specific request elements such as headers, query parameters, or cookies.
+- `missing` (optional): Focuses on conditions where certain request elements are absent, like missing headers or cookies.
+
+```js filename="middleware.js"
+export const config = {
+  matcher: [
+    {
+      source: '/api/*',
+      regexp: '^/api/(.*)',
+      locale: false,
+      has: [
+        { type: 'header', key: 'Authorization', value: 'Bearer Token' },
+        { type: 'query', key: 'userId', value: '123' },
+      ],
+      missing: [{ type: 'cookie', key: 'session', value: 'active' }],
+    },
+  ],
+}
+```
+
+Configured matchers:
+
+1. MUST start with `/`
+2. Can include named parameters: `/about/:path` matches `/about/a` and `/about/b` but not `/about/a/c`
+3. Can have modifiers on named parameters (starting with `:`): `/about/:path*` matches `/about/a/b/c` because `*` is _zero or more_. `?` is _zero or one_ and `+` _one or more_
+4. Can use regular expression enclosed in parenthesis: `/about/(.*)` is the same as `/about/:path*`
+
+Read more details on [path-to-regexp](https://github.com/pillarjs/path-to-regexp#path-to-regexp-1) documentation.
+
+> **Good to know**:
+>
+> - The `matcher` values need to be constants so they can be statically analyzed at build-time. Dynamic values such as variables will be ignored.
+> - For backward compatibility, Next.js always considers `/public` as `/public/index`. Therefore, a matcher of `/public/:path` will match.
+
+## Params
+
+### `request`
+
+When defining Middleware, the default export function accepts a single parameter, `request`. This parameter is an instance of `NextRequest`, which represents the incoming HTTP request.
+
+```tsx filename="middleware.ts" switcher
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  // Middleware logic goes here
+}
+```
+
+```js filename="middleware.js" switcher
+export function middleware(request) {
+  // Middleware logic goes here
+}
+```
+
+> **Good to know**:
+>
+> - `NextRequest` is a type that represents incoming HTTP requests in Next.js Middleware, whereas [`NextResponse`](#nextresponse) is a class used to manipulate and send back HTTP responses.
+
+## NextResponse
+
+The `NextResponse` API allows you to:
+
+- `redirect` the incoming request to a different URL
+- `rewrite` the response by displaying a given URL
+- Set request headers for API Routes, `getServerSideProps`, and `rewrite` destinations
+- Set response cookies
+- Set response headers
+
+<AppOnly>
+
+To produce a response from Middleware, you can:
+
+1. `rewrite` to a route ([Page](/docs/app/api-reference/file-conventions/page) or [Route Handler](/docs/app/api-reference/file-conventions/route)) that produces a response
+2. return a `NextResponse` directly. See [Producing a Response](#producing-a-response)
+
+> **Good to know**: For redirects, you can also use `Response.redirect` instead of `NextResponse.redirect`.
+
+</AppOnly>
+
+<PagesOnly>
+
+To produce a response from Middleware, you can:
+
+1. `rewrite` to a route ([Page](/docs/pages/building-your-application/routing/pages-and-layouts) or [Edge API Route](/docs/pages/building-your-application/routing/api-routes)) that produces a response
+2. return a `NextResponse` directly. See [Producing a Response](#producing-a-response)
+
+</PagesOnly>
+
+## Execution order
+
+Middleware will be invoked for **every route in your project**. Given this, it's crucial to use [matchers](#matcher) to precisely target or exclude specific routes. The following is the execution order:
+
+1. `headers` from `next.config.js`
+2. `redirects` from `next.config.js`
+3. Middleware (`rewrites`, `redirects`, etc.)
+4. `beforeFiles` (`rewrites`) from `next.config.js`
+5. Filesystem routes (`public/`, `_next/static/`, `pages/`, `app/`, etc.)
+6. `afterFiles` (`rewrites`) from `next.config.js`
+7. Dynamic Routes (`/blog/[slug]`)
+8. `fallback` (`rewrites`) from `next.config.js`
+
+## Runtime
+
+Middleware defaults to using the Edge runtime. As of v15.5, we have support for using the Node.js runtime. To enable, in your middleware file, set the runtime to `nodejs` in the `config` object:
+
+```js highlight={2} filename="middleware.js" switcher
+export const config = {
+  runtime: 'nodejs',
+}
+```
+
+```ts highlight={2} filename="middleware.ts" switcher
+export const config = {
+  runtime: 'nodejs',
+}
+```
+
+## Advanced Middleware flags
+
+In `v13.1` of Next.js two additional flags were introduced for middleware, `skipMiddlewareUrlNormalize` and `skipTrailingSlashRedirect` to handle advanced use cases.
+
+`skipTrailingSlashRedirect` disables Next.js redirects for adding or removing trailing slashes. This allows custom handling inside middleware to maintain the trailing slash for some paths but not others, which can make incremental migrations easier.
+
+```js filename="next.config.js"
+module.exports = {
+  skipTrailingSlashRedirect: true,
+}
+```
+
+```js filename="middleware.js"
+const legacyPrefixes = ['/docs', '/blog']
+
+export default async function middleware(req) {
+  const { pathname } = req.nextUrl
+
+  if (legacyPrefixes.some((prefix) => pathname.startsWith(prefix))) {
+    return NextResponse.next()
+  }
+
+  // apply trailing slash handling
+  if (
+    !pathname.endsWith('/') &&
+    !pathname.match(/((?!\.well-known(?:\/.*)?)(?:[^/]+\/)*[^/]+\.\w+)/)
+  ) {
+    return NextResponse.redirect(
+      new URL(`${req.nextUrl.pathname}/`, req.nextUrl)
+    )
+  }
+}
+```
+
+`skipMiddlewareUrlNormalize` allows for disabling the URL normalization in Next.js to make handling direct visits and client-transitions the same. In some advanced cases, this option provides full control by using the original URL.
+
+```js filename="next.config.js"
+module.exports = {
+  skipMiddlewareUrlNormalize: true,
+}
+```
+
+```js filename="middleware.js"
+export default async function middleware(req) {
+  const { pathname } = req.nextUrl
+
+  // GET /_next/data/build-id/hello.json
+
+  console.log(pathname)
+  // with the flag this now /_next/data/build-id/hello.json
+  // without the flag this would be normalized to /hello
+}
+```
+
+## Examples
+
+### Conditional Statements
+
+```ts filename="middleware.ts" switcher
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname.startsWith('/about')) {
+    return NextResponse.rewrite(new URL('/about-2', request.url))
+  }
+
+  if (request.nextUrl.pathname.startsWith('/dashboard')) {
+    return NextResponse.rewrite(new URL('/dashboard/user', request.url))
+  }
+}
+```
+
+```js filename="middleware.js" switcher
+import { NextResponse } from 'next/server'
+
+export function middleware(request) {
+  if (request.nextUrl.pathname.startsWith('/about')) {
+    return NextResponse.rewrite(new URL('/about-2', request.url))
+  }
+
+  if (request.nextUrl.pathname.startsWith('/dashboard')) {
+    return NextResponse.rewrite(new URL('/dashboard/user', request.url))
+  }
+}
+```
+
+### Using Cookies
+
+Cookies are regular headers. On a `Request`, they are stored in the `Cookie` header. On a `Response` they are in the `Set-Cookie` header. Next.js provides a convenient way to access and manipulate these cookies through the `cookies` extension on `NextRequest` and `NextResponse`.
+
+1. For incoming requests, `cookies` comes with the following methods: `get`, `getAll`, `set`, and `delete` cookies. You can check for the existence of a cookie with `has` or remove all cookies with `clear`.
+2. For outgoing responses, `cookies` have the following methods `get`, `getAll`, `set`, and `delete`.
+
+```ts filename="middleware.ts" switcher
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  // Assume a "Cookie:nextjs=fast" header to be present on the incoming request
+  // Getting cookies from the request using the `RequestCookies` API
+  let cookie = request.cookies.get('nextjs')
+  console.log(cookie) // => { name: 'nextjs', value: 'fast', Path: '/' }
+  const allCookies = request.cookies.getAll()
+  console.log(allCookies) // => [{ name: 'nextjs', value: 'fast' }]
+
+  request.cookies.has('nextjs') // => true
+  request.cookies.delete('nextjs')
+  request.cookies.has('nextjs') // => false
+
+  // Setting cookies on the response using the `ResponseCookies` API
+  const response = NextResponse.next()
+  response.cookies.set('vercel', 'fast')
+  response.cookies.set({
+    name: 'vercel',
+    value: 'fast',
+    path: '/',
+  })
+  cookie = response.cookies.get('vercel')
+  console.log(cookie) // => { name: 'vercel', value: 'fast', Path: '/' }
+  // The outgoing response will have a `Set-Cookie:vercel=fast;path=/` header.
+
+  return response
+}
+```
+
+```js filename="middleware.js" switcher
+import { NextResponse } from 'next/server'
+
+export function middleware(request) {
+  // Assume a "Cookie:nextjs=fast" header to be present on the incoming request
+  // Getting cookies from the request using the `RequestCookies` API
+  let cookie = request.cookies.get('nextjs')
+  console.log(cookie) // => { name: 'nextjs', value: 'fast', Path: '/' }
+  const allCookies = request.cookies.getAll()
+  console.log(allCookies) // => [{ name: 'nextjs', value: 'fast' }]
+
+  request.cookies.has('nextjs') // => true
+  request.cookies.delete('nextjs')
+  request.cookies.has('nextjs') // => false
+
+  // Setting cookies on the response using the `ResponseCookies` API
+  const response = NextResponse.next()
+  response.cookies.set('vercel', 'fast')
+  response.cookies.set({
+    name: 'vercel',
+    value: 'fast',
+    path: '/',
+  })
+  cookie = response.cookies.get('vercel')
+  console.log(cookie) // => { name: 'vercel', value: 'fast', Path: '/' }
+  // The outgoing response will have a `Set-Cookie:vercel=fast;path=/test` header.
+
+  return response
+}
+```
+
+### Setting Headers
+
+You can set request and response headers using the `NextResponse` API (setting _request_ headers is available since Next.js v13.0.0).
+
+```ts filename="middleware.ts" switcher
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  // Clone the request headers and set a new header `x-hello-from-middleware1`
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('x-hello-from-middleware1', 'hello')
+
+  // You can also set request headers in NextResponse.next
+  const response = NextResponse.next({
+    request: {
+      // New request headers
+      headers: requestHeaders,
+    },
+  })
+
+  // Set a new response header `x-hello-from-middleware2`
+  response.headers.set('x-hello-from-middleware2', 'hello')
+  return response
+}
+```
+
+```js filename="middleware.js" switcher
+import { NextResponse } from 'next/server'
+
+export function middleware(request) {
+  // Clone the request headers and set a new header `x-hello-from-middleware1`
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('x-hello-from-middleware1', 'hello')
+
+  // You can also set request headers in NextResponse.next
+  const response = NextResponse.next({
+    request: {
+      // New request headers
+      headers: requestHeaders,
+    },
+  })
+
+  // Set a new response header `x-hello-from-middleware2`
+  response.headers.set('x-hello-from-middleware2', 'hello')
+  return response
+}
+```
+
+Note that the snippet uses:
+
+- `NextResponse.next({ request: { headers: requestHeaders } })` to make `requestHeaders` available upstream
+- **NOT** `NextResponse.next({ headers: requestHeaders })` which makes `requestHeaders` available to clients
+
+Learn more in [NextResponse headers in Middleware](/docs/app/api-reference/functions/next-response#next).
+
+> **Good to know**: Avoid setting large headers as it might cause [431 Request Header Fields Too Large](https://developer.mozilla.org/docs/Web/HTTP/Status/431) error depending on your backend web server configuration.
+
+### CORS
+
+You can set CORS headers in Middleware to allow cross-origin requests, including [simple](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests) and [preflighted](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests) requests.
+
+```tsx filename="middleware.ts" switcher
+import { NextRequest, NextResponse } from 'next/server'
+
+const allowedOrigins = ['https://acme.com', 'https://my-app.org']
+
+const corsOptions = {
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+}
+
+export function middleware(request: NextRequest) {
+  // Check the origin from the request
+  const origin = request.headers.get('origin') ?? ''
+  const isAllowedOrigin = allowedOrigins.includes(origin)
+
+  // Handle preflighted requests
+  const isPreflight = request.method === 'OPTIONS'
+
+  if (isPreflight) {
+    const preflightHeaders = {
+      ...(isAllowedOrigin && { 'Access-Control-Allow-Origin': origin }),
+      ...corsOptions,
+    }
+    return NextResponse.json({}, { headers: preflightHeaders })
+  }
+
+  // Handle simple requests
+  const response = NextResponse.next()
+
+  if (isAllowedOrigin) {
+    response.headers.set('Access-Control-Allow-Origin', origin)
+  }
+
+  Object.entries(corsOptions).forEach(([key, value]) => {
+    response.headers.set(key, value)
+  })
+
+  return response
+}
+
+export const config = {
+  matcher: '/api/:path*',
+}
+```
+
+```jsx filename="middleware.js" switcher
+import { NextResponse } from 'next/server'
+
+const allowedOrigins = ['https://acme.com', 'https://my-app.org']
+
+const corsOptions = {
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+}
+
+export function middleware(request) {
+  // Check the origin from the request
+  const origin = request.headers.get('origin') ?? ''
+  const isAllowedOrigin = allowedOrigins.includes(origin)
+
+  // Handle preflighted requests
+  const isPreflight = request.method === 'OPTIONS'
+
+  if (isPreflight) {
+    const preflightHeaders = {
+      ...(isAllowedOrigin && { 'Access-Control-Allow-Origin': origin }),
+      ...corsOptions,
+    }
+    return NextResponse.json({}, { headers: preflightHeaders })
+  }
+
+  // Handle simple requests
+  const response = NextResponse.next()
+
+  if (isAllowedOrigin) {
+    response.headers.set('Access-Control-Allow-Origin', origin)
+  }
+
+  Object.entries(corsOptions).forEach(([key, value]) => {
+    response.headers.set(key, value)
+  })
+
+  return response
+}
+
+export const config = {
+  matcher: '/api/:path*',
+}
+```
+
+<AppOnly>
+
+> **Good to know:** You can configure CORS headers for individual routes in [Route Handlers](/docs/app/api-reference/file-conventions/route#cors).
+
+</AppOnly>
+
+### Producing a response
+
+You can respond from Middleware directly by returning a `Response` or `NextResponse` instance. (This is available since [Next.js v13.1.0](https://nextjs.org/blog/next-13-1#nextjs-advanced-middleware))
+
+```ts filename="middleware.ts" switcher
+import type { NextRequest } from 'next/server'
+import { isAuthenticated } from '@lib/auth'
+
+// Limit the middleware to paths starting with `/api/`
+export const config = {
+  matcher: '/api/:function*',
+}
+
+export function middleware(request: NextRequest) {
+  // Call our authentication function to check the request
+  if (!isAuthenticated(request)) {
+    // Respond with JSON indicating an error message
+    return Response.json(
+      { success: false, message: 'authentication failed' },
+      { status: 401 }
+    )
+  }
+}
+```
+
+```js filename="middleware.js" switcher
+import { isAuthenticated } from '@lib/auth'
+
+// Limit the middleware to paths starting with `/api/`
+export const config = {
+  matcher: '/api/:function*',
+}
+
+export function middleware(request) {
+  // Call our authentication function to check the request
+  if (!isAuthenticated(request)) {
+    // Respond with JSON indicating an error message
+    return Response.json(
+      { success: false, message: 'authentication failed' },
+      { status: 401 }
+    )
+  }
+}
+```
+
+### Negative matching
+
+The `matcher` config allows full regex so matching like negative lookaheads or character matching is supported. An example of a negative lookahead to match all except specific paths can be seen here:
+
+```js filename="middleware.js"
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico, sitemap.xml, robots.txt (metadata files)
+     */
+    '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+  ],
+}
+```
+
+You can also bypass Middleware for certain requests by using the `missing` or `has` arrays, or a combination of both:
+
+```js filename="middleware.js"
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico, sitemap.xml, robots.txt (metadata files)
+     */
+    {
+      source:
+        '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+
+    {
+      source:
+        '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+      has: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+
+    {
+      source:
+        '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+      has: [{ type: 'header', key: 'x-present' }],
+      missing: [{ type: 'header', key: 'x-missing', value: 'prefetch' }],
+    },
+  ],
+}
+```
+
+### `waitUntil` and `NextFetchEvent`
+
+The `NextFetchEvent` object extends the native [`FetchEvent`](https://developer.mozilla.org/docs/Web/API/FetchEvent) object, and includes the [`waitUntil()`](https://developer.mozilla.org/docs/Web/API/ExtendableEvent/waitUntil) method.
+
+The `waitUntil()` method takes a promise as an argument, and extends the lifetime of the Middleware until the promise settles. This is useful for performing work in the background.
+
+```ts filename="middleware.ts"
+import { NextResponse } from 'next/server'
+import type { NextFetchEvent, NextRequest } from 'next/server'
+
+export function middleware(req: NextRequest, event: NextFetchEvent) {
+  event.waitUntil(
+    fetch('https://my-analytics-platform.com', {
+      method: 'POST',
+      body: JSON.stringify({ pathname: req.nextUrl.pathname }),
+    })
+  )
+
+  return NextResponse.next()
+}
+```
+
+### Unit testing (experimental)
+
+Starting in Next.js 15.1, the `next/experimental/testing/server` package contains utilities to help unit test middleware files. Unit testing middleware can help ensure that it's only run on desired paths and that custom routing logic works as intended before code reaches production.
+
+The `unstable_doesMiddlewareMatch` function can be used to assert whether middleware will run for the provided URL, headers, and cookies.
+
+```js
+import { unstable_doesMiddlewareMatch } from 'next/experimental/testing/server'
+
+expect(
+  unstable_doesMiddlewareMatch({
+    config,
+    nextConfig,
+    url: '/test',
+  })
+).toEqual(false)
+```
+
+The entire middleware function can also be tested.
+
+```js
+import { isRewrite, getRewrittenUrl } from 'next/experimental/testing/server'
+
+const request = new NextRequest('https://nextjs.org/docs')
+const response = await middleware(request)
+expect(isRewrite(response)).toEqual(true)
+expect(getRewrittenUrl(response)).toEqual('https://other-domain.com/docs')
+// getRedirectUrl could also be used if the response were a redirect
+```
+
+## Platform support
+
+| Deployment Option                                                   | Supported         |
+| ------------------------------------------------------------------- | ----------------- |
+| [Node.js server](/docs/app/getting-started/deploying#nodejs-server) | Yes               |
+| [Docker container](/docs/app/getting-started/deploying#docker)      | Yes               |
+| [Static export](/docs/app/getting-started/deploying#static-export)  | No                |
+| [Adapters](/docs/app/getting-started/deploying#adapters)            | Platform-specific |
+
+Learn how to [configure Middleware](/docs/app/guides/self-hosting#middleware) when self-hosting Next.js.
+
+## Version history
+
+| Version   | Changes                                                                                       |
+| --------- | --------------------------------------------------------------------------------------------- |
+| `v15.5.0` | Middleware can now use the Node.js runtime (stable)                                           |
+| `v15.2.0` | Middleware can now use the Node.js runtime (experimental)                                     |
+| `v13.1.0` | Advanced Middleware flags added                                                               |
+| `v13.0.0` | Middleware can modify request headers, response headers, and send responses                   |
+| `v12.2.0` | Middleware is stable, please see the [upgrade guide](/docs/messages/middleware-upgrade-guide) |
+| `v12.0.9` | Enforce absolute URLs in Edge Runtime ([PR](https://github.com/vercel/next.js/pull/33410))    |
+| `v12.0.0` | Middleware (Beta) added                                                                       |

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -1,32 +1,32 @@
 ---
-title: middleware.js
-description: API reference for the middleware.js file.
+title: proxy.js
+description: API reference for the proxy.js file.
 related:
-  title: Learn more about Middleware
+  title: Learn more about Proxy
   links:
     - app/api-reference/functions/next-request
     - app/api-reference/functions/next-response
 ---
 
-The `middleware.js|ts` file is used to write [Middleware](/docs/app/getting-started/route-handlers-and-middleware#middleware) and run code on the server before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
+The `proxy.js|ts` file is used to write [Proxy](/docs/app/getting-started/route-handlers-and-proxy#proxy) and run code on the server before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
 
-Middleware executes before routes are rendered. It's particularly useful for implementing custom server-side logic like authentication, logging, or handling redirects.
+Proxy executes before routes are rendered. It's particularly useful for implementing custom server-side logic like authentication, logging, or handling redirects.
 
 > **Good to know**:
 >
-> Middleware is meant to be invoked separately of your render code and in optimized cases deployed to your CDN for fast redirect/rewrite handling, you should not attempt relying on shared modules or globals.
+> Proxy is meant to be invoked separately of your render code and in optimized cases deployed to your CDN for fast redirect/rewrite handling, you should not attempt relying on shared modules or globals.
 >
-> To pass information from Middleware to your application, use [headers](#setting-headers), [cookies](#using-cookies), [rewrites](/docs/app/api-reference/functions/next-response#rewrite), [redirects](/docs/app/api-reference/functions/next-response#redirect), or the URL.
+> To pass information from Proxy to your application, use [headers](#setting-headers), [cookies](#using-cookies), [rewrites](/docs/app/api-reference/functions/next-response#rewrite), [redirects](/docs/app/api-reference/functions/next-response#redirect), or the URL.
 
-Create a `middleware.ts` (or `.js`) file in the project root, or inside `src` if applicable, so that it is located at the same level as `pages` or `app`.
+Create a `proxy.ts` (or `.js`) file in the project root, or inside `src` if applicable, so that it is located at the same level as `pages` or `app`.
 
-If you’ve customized [`pageExtensions`](/docs/app/api-reference/config/next-config-js/pageExtensions), for example to `.page.ts` or `.page.js`, name your file `middleware.page.ts` or `middleware.page.js` accordingly.
+If you’ve customized [`pageExtensions`](/docs/app/api-reference/config/next-config-js/pageExtensions), for example to `.page.ts` or `.page.js`, name your file `proxy.page.ts` or `proxy.page.js` accordingly.
 
-```tsx filename="middleware.ts" switcher
+```tsx filename="proxy.ts" switcher
 import { NextResponse, NextRequest } from 'next/server'
 
 // This function can be marked `async` if using `await` inside
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   return NextResponse.redirect(new URL('/home', request.url))
 }
 
@@ -35,11 +35,11 @@ export const config = {
 }
 ```
 
-```js filename="middleware.js" switcher
+```js filename="proxy.js" switcher
 import { NextResponse } from 'next/server'
 
 // This function can be marked `async` if using `await` inside
-export function middleware(request) {
+export function proxy(request) {
   return NextResponse.redirect(new URL('/home', request.url))
 }
 
@@ -50,29 +50,29 @@ export const config = {
 
 ## Exports
 
-### Middleware function
+### Proxy function
 
-The file must export a single function, either as a default export or named `middleware`. Note that multiple middleware from the same file are not supported.
+The file must export a single function, either as a default export or named `proxy`. Note that multiple proxy from the same file are not supported.
 
-```js filename="middleware.js"
+```js filename="proxy.js"
 // Example of default export
-export default function middleware(request) {
-  // Middleware logic
+export default function proxy(request) {
+  // Proxy logic
 }
 ```
 
 ### Config object (optional)
 
-Optionally, a config object can be exported alongside the Middleware function. This object includes the [matcher](#matcher) to specify paths where the Middleware applies.
+Optionally, a config object can be exported alongside the Proxy function. This object includes the [matcher](#matcher) to specify paths where the Proxy applies.
 
 ### Matcher
 
-The `matcher` option allows you to target specific paths for the Middleware to run on. You can specify these paths in several ways:
+The `matcher` option allows you to target specific paths for the Proxy to run on. You can specify these paths in several ways:
 
 - For a single path: Directly use a string to define the path, like `'/about'`.
-- For multiple paths: Use an array to list multiple paths, such as `matcher: ['/about', '/contact']`, which applies the Middleware to both `/about` and `/contact`.
+- For multiple paths: Use an array to list multiple paths, such as `matcher: ['/about', '/contact']`, which applies the Proxy to both `/about` and `/contact`.
 
-```js filename="middleware.js"
+```js filename="proxy.js"
 export const config = {
   matcher: ['/about/:path*', '/dashboard/:path*'],
 }
@@ -88,7 +88,7 @@ The `matcher` option accepts an array of objects with the following keys:
 - `has` (optional): Specifies conditions based on the presence of specific request elements such as headers, query parameters, or cookies.
 - `missing` (optional): Focuses on conditions where certain request elements are absent, like missing headers or cookies.
 
-```js filename="middleware.js"
+```js filename="proxy.js"
 export const config = {
   matcher: [
     {
@@ -123,25 +123,25 @@ Read more details on [path-to-regexp](https://github.com/pillarjs/path-to-regexp
 
 ### `request`
 
-When defining Middleware, the default export function accepts a single parameter, `request`. This parameter is an instance of `NextRequest`, which represents the incoming HTTP request.
+When defining Proxy, the default export function accepts a single parameter, `request`. This parameter is an instance of `NextRequest`, which represents the incoming HTTP request.
 
-```tsx filename="middleware.ts" switcher
+```tsx filename="proxy.ts" switcher
 import type { NextRequest } from 'next/server'
 
-export function middleware(request: NextRequest) {
-  // Middleware logic goes here
+export function proxy(request: NextRequest) {
+  // Proxy logic goes here
 }
 ```
 
-```js filename="middleware.js" switcher
-export function middleware(request) {
-  // Middleware logic goes here
+```js filename="proxy.js" switcher
+export function proxy(request) {
+  // Proxy logic goes here
 }
 ```
 
 > **Good to know**:
 >
-> - `NextRequest` is a type that represents incoming HTTP requests in Next.js Middleware, whereas [`NextResponse`](#nextresponse) is a class used to manipulate and send back HTTP responses.
+> - `NextRequest` is a type that represents incoming HTTP requests in Next.js Proxy, whereas [`NextResponse`](#nextresponse) is a class used to manipulate and send back HTTP responses.
 
 ## NextResponse
 
@@ -155,7 +155,7 @@ The `NextResponse` API allows you to:
 
 <AppOnly>
 
-To produce a response from Middleware, you can:
+To produce a response from Proxy, you can:
 
 1. `rewrite` to a route ([Page](/docs/app/api-reference/file-conventions/page) or [Route Handler](/docs/app/api-reference/file-conventions/route)) that produces a response
 2. return a `NextResponse` directly. See [Producing a Response](#producing-a-response)
@@ -166,7 +166,7 @@ To produce a response from Middleware, you can:
 
 <PagesOnly>
 
-To produce a response from Middleware, you can:
+To produce a response from Proxy, you can:
 
 1. `rewrite` to a route ([Page](/docs/pages/building-your-application/routing/pages-and-layouts) or [Edge API Route](/docs/pages/building-your-application/routing/api-routes)) that produces a response
 2. return a `NextResponse` directly. See [Producing a Response](#producing-a-response)
@@ -175,11 +175,11 @@ To produce a response from Middleware, you can:
 
 ## Execution order
 
-Middleware will be invoked for **every route in your project**. Given this, it's crucial to use [matchers](#matcher) to precisely target or exclude specific routes. The following is the execution order:
+Proxy will be invoked for **every route in your project**. Given this, it's crucial to use [matchers](#matcher) to precisely target or exclude specific routes. The following is the execution order:
 
 1. `headers` from `next.config.js`
 2. `redirects` from `next.config.js`
-3. Middleware (`rewrites`, `redirects`, etc.)
+3. Proxy (`rewrites`, `redirects`, etc.)
 4. `beforeFiles` (`rewrites`) from `next.config.js`
 5. Filesystem routes (`public/`, `_next/static/`, `pages/`, `app/`, etc.)
 6. `afterFiles` (`rewrites`) from `next.config.js`
@@ -188,25 +188,25 @@ Middleware will be invoked for **every route in your project**. Given this, it's
 
 ## Runtime
 
-Middleware defaults to using the Edge runtime. As of v15.5, we have support for using the Node.js runtime. To enable, in your middleware file, set the runtime to `nodejs` in the `config` object:
+Proxy defaults to using the Edge runtime. As of v15.5, we have support for using the Node.js runtime. To enable, in your proxy file, set the runtime to `nodejs` in the `config` object:
 
-```js highlight={2} filename="middleware.js" switcher
+```js highlight={2} filename="proxy.js" switcher
 export const config = {
   runtime: 'nodejs',
 }
 ```
 
-```ts highlight={2} filename="middleware.ts" switcher
+```ts highlight={2} filename="proxy.ts" switcher
 export const config = {
   runtime: 'nodejs',
 }
 ```
 
-## Advanced Middleware flags
+## Advanced Proxy flags
 
-In `v13.1` of Next.js two additional flags were introduced for middleware, `skipMiddlewareUrlNormalize` and `skipTrailingSlashRedirect` to handle advanced use cases.
+In `v13.1` of Next.js two additional flags were introduced for proxy, `skipMiddlewareUrlNormalize` and `skipTrailingSlashRedirect` to handle advanced use cases.
 
-`skipTrailingSlashRedirect` disables Next.js redirects for adding or removing trailing slashes. This allows custom handling inside middleware to maintain the trailing slash for some paths but not others, which can make incremental migrations easier.
+`skipTrailingSlashRedirect` disables Next.js redirects for adding or removing trailing slashes. This allows custom handling inside proxy to maintain the trailing slash for some paths but not others, which can make incremental migrations easier.
 
 ```js filename="next.config.js"
 module.exports = {
@@ -214,10 +214,10 @@ module.exports = {
 }
 ```
 
-```js filename="middleware.js"
+```js filename="proxy.js"
 const legacyPrefixes = ['/docs', '/blog']
 
-export default async function middleware(req) {
+export default async function proxy(req) {
   const { pathname } = req.nextUrl
 
   if (legacyPrefixes.some((prefix) => pathname.startsWith(prefix))) {
@@ -244,8 +244,8 @@ module.exports = {
 }
 ```
 
-```js filename="middleware.js"
-export default async function middleware(req) {
+```js filename="proxy.js"
+export default async function proxy(req) {
   const { pathname } = req.nextUrl
 
   // GET /_next/data/build-id/hello.json
@@ -260,11 +260,11 @@ export default async function middleware(req) {
 
 ### Conditional Statements
 
-```ts filename="middleware.ts" switcher
+```ts filename="proxy.ts" switcher
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   if (request.nextUrl.pathname.startsWith('/about')) {
     return NextResponse.rewrite(new URL('/about-2', request.url))
   }
@@ -275,10 +275,10 @@ export function middleware(request: NextRequest) {
 }
 ```
 
-```js filename="middleware.js" switcher
+```js filename="proxy.js" switcher
 import { NextResponse } from 'next/server'
 
-export function middleware(request) {
+export function proxy(request) {
   if (request.nextUrl.pathname.startsWith('/about')) {
     return NextResponse.rewrite(new URL('/about-2', request.url))
   }
@@ -296,11 +296,11 @@ Cookies are regular headers. On a `Request`, they are stored in the `Cookie` hea
 1. For incoming requests, `cookies` comes with the following methods: `get`, `getAll`, `set`, and `delete` cookies. You can check for the existence of a cookie with `has` or remove all cookies with `clear`.
 2. For outgoing responses, `cookies` have the following methods `get`, `getAll`, `set`, and `delete`.
 
-```ts filename="middleware.ts" switcher
+```ts filename="proxy.ts" switcher
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   // Assume a "Cookie:nextjs=fast" header to be present on the incoming request
   // Getting cookies from the request using the `RequestCookies` API
   let cookie = request.cookies.get('nextjs')
@@ -328,10 +328,10 @@ export function middleware(request: NextRequest) {
 }
 ```
 
-```js filename="middleware.js" switcher
+```js filename="proxy.js" switcher
 import { NextResponse } from 'next/server'
 
-export function middleware(request) {
+export function proxy(request) {
   // Assume a "Cookie:nextjs=fast" header to be present on the incoming request
   // Getting cookies from the request using the `RequestCookies` API
   let cookie = request.cookies.get('nextjs')
@@ -363,14 +363,14 @@ export function middleware(request) {
 
 You can set request and response headers using the `NextResponse` API (setting _request_ headers is available since Next.js v13.0.0).
 
-```ts filename="middleware.ts" switcher
+```ts filename="proxy.ts" switcher
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-export function middleware(request: NextRequest) {
-  // Clone the request headers and set a new header `x-hello-from-middleware1`
+export function proxy(request: NextRequest) {
+  // Clone the request headers and set a new header `x-hello-from-proxy1`
   const requestHeaders = new Headers(request.headers)
-  requestHeaders.set('x-hello-from-middleware1', 'hello')
+  requestHeaders.set('x-hello-from-proxy1', 'hello')
 
   // You can also set request headers in NextResponse.next
   const response = NextResponse.next({
@@ -380,19 +380,19 @@ export function middleware(request: NextRequest) {
     },
   })
 
-  // Set a new response header `x-hello-from-middleware2`
-  response.headers.set('x-hello-from-middleware2', 'hello')
+  // Set a new response header `x-hello-from-proxy2`
+  response.headers.set('x-hello-from-proxy2', 'hello')
   return response
 }
 ```
 
-```js filename="middleware.js" switcher
+```js filename="proxy.js" switcher
 import { NextResponse } from 'next/server'
 
-export function middleware(request) {
-  // Clone the request headers and set a new header `x-hello-from-middleware1`
+export function proxy(request) {
+  // Clone the request headers and set a new header `x-hello-from-proxy1`
   const requestHeaders = new Headers(request.headers)
-  requestHeaders.set('x-hello-from-middleware1', 'hello')
+  requestHeaders.set('x-hello-from-proxy1', 'hello')
 
   // You can also set request headers in NextResponse.next
   const response = NextResponse.next({
@@ -402,8 +402,8 @@ export function middleware(request) {
     },
   })
 
-  // Set a new response header `x-hello-from-middleware2`
-  response.headers.set('x-hello-from-middleware2', 'hello')
+  // Set a new response header `x-hello-from-proxy2`
+  response.headers.set('x-hello-from-proxy2', 'hello')
   return response
 }
 ```
@@ -413,15 +413,15 @@ Note that the snippet uses:
 - `NextResponse.next({ request: { headers: requestHeaders } })` to make `requestHeaders` available upstream
 - **NOT** `NextResponse.next({ headers: requestHeaders })` which makes `requestHeaders` available to clients
 
-Learn more in [NextResponse headers in Middleware](/docs/app/api-reference/functions/next-response#next).
+Learn more in [NextResponse headers in Proxy](/docs/app/api-reference/functions/next-response#next).
 
 > **Good to know**: Avoid setting large headers as it might cause [431 Request Header Fields Too Large](https://developer.mozilla.org/docs/Web/HTTP/Status/431) error depending on your backend web server configuration.
 
 ### CORS
 
-You can set CORS headers in Middleware to allow cross-origin requests, including [simple](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests) and [preflighted](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests) requests.
+You can set CORS headers in Proxy to allow cross-origin requests, including [simple](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests) and [preflighted](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests) requests.
 
-```tsx filename="middleware.ts" switcher
+```tsx filename="proxy.ts" switcher
 import { NextRequest, NextResponse } from 'next/server'
 
 const allowedOrigins = ['https://acme.com', 'https://my-app.org']
@@ -431,7 +431,7 @@ const corsOptions = {
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
 }
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   // Check the origin from the request
   const origin = request.headers.get('origin') ?? ''
   const isAllowedOrigin = allowedOrigins.includes(origin)
@@ -466,7 +466,7 @@ export const config = {
 }
 ```
 
-```jsx filename="middleware.js" switcher
+```jsx filename="proxy.js" switcher
 import { NextResponse } from 'next/server'
 
 const allowedOrigins = ['https://acme.com', 'https://my-app.org']
@@ -476,7 +476,7 @@ const corsOptions = {
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
 }
 
-export function middleware(request) {
+export function proxy(request) {
   // Check the origin from the request
   const origin = request.headers.get('origin') ?? ''
   const isAllowedOrigin = allowedOrigins.includes(origin)
@@ -519,18 +519,18 @@ export const config = {
 
 ### Producing a response
 
-You can respond from Middleware directly by returning a `Response` or `NextResponse` instance. (This is available since [Next.js v13.1.0](https://nextjs.org/blog/next-13-1#nextjs-advanced-middleware))
+You can respond from Proxy directly by returning a `Response` or `NextResponse` instance. (This is available since [Next.js v13.1.0](https://nextjs.org/blog/next-13-1#nextjs-advanced-proxy))
 
-```ts filename="middleware.ts" switcher
+```ts filename="proxy.ts" switcher
 import type { NextRequest } from 'next/server'
 import { isAuthenticated } from '@lib/auth'
 
-// Limit the middleware to paths starting with `/api/`
+// Limit the proxy to paths starting with `/api/`
 export const config = {
   matcher: '/api/:function*',
 }
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   // Call our authentication function to check the request
   if (!isAuthenticated(request)) {
     // Respond with JSON indicating an error message
@@ -542,15 +542,15 @@ export function middleware(request: NextRequest) {
 }
 ```
 
-```js filename="middleware.js" switcher
+```js filename="proxy.js" switcher
 import { isAuthenticated } from '@lib/auth'
 
-// Limit the middleware to paths starting with `/api/`
+// Limit the proxy to paths starting with `/api/`
 export const config = {
   matcher: '/api/:function*',
 }
 
-export function middleware(request) {
+export function proxy(request) {
   // Call our authentication function to check the request
   if (!isAuthenticated(request)) {
     // Respond with JSON indicating an error message
@@ -566,7 +566,7 @@ export function middleware(request) {
 
 The `matcher` config allows full regex so matching like negative lookaheads or character matching is supported. An example of a negative lookahead to match all except specific paths can be seen here:
 
-```js filename="middleware.js"
+```js filename="proxy.js"
 export const config = {
   matcher: [
     /*
@@ -581,9 +581,9 @@ export const config = {
 }
 ```
 
-You can also bypass Middleware for certain requests by using the `missing` or `has` arrays, or a combination of both:
+You can also bypass Proxy for certain requests by using the `missing` or `has` arrays, or a combination of both:
 
-```js filename="middleware.js"
+```js filename="proxy.js"
 export const config = {
   matcher: [
     /*
@@ -625,13 +625,13 @@ export const config = {
 
 The `NextFetchEvent` object extends the native [`FetchEvent`](https://developer.mozilla.org/docs/Web/API/FetchEvent) object, and includes the [`waitUntil()`](https://developer.mozilla.org/docs/Web/API/ExtendableEvent/waitUntil) method.
 
-The `waitUntil()` method takes a promise as an argument, and extends the lifetime of the Middleware until the promise settles. This is useful for performing work in the background.
+The `waitUntil()` method takes a promise as an argument, and extends the lifetime of the Proxy until the promise settles. This is useful for performing work in the background.
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import { NextResponse } from 'next/server'
 import type { NextFetchEvent, NextRequest } from 'next/server'
 
-export function middleware(req: NextRequest, event: NextFetchEvent) {
+export function proxy(req: NextRequest, event: NextFetchEvent) {
   event.waitUntil(
     fetch('https://my-analytics-platform.com', {
       method: 'POST',
@@ -645,15 +645,15 @@ export function middleware(req: NextRequest, event: NextFetchEvent) {
 
 ### Unit testing (experimental)
 
-Starting in Next.js 15.1, the `next/experimental/testing/server` package contains utilities to help unit test middleware files. Unit testing middleware can help ensure that it's only run on desired paths and that custom routing logic works as intended before code reaches production.
+Starting in Next.js 15.1, the `next/experimental/testing/server` package contains utilities to help unit test proxy files. Unit testing proxy can help ensure that it's only run on desired paths and that custom routing logic works as intended before code reaches production.
 
-The `unstable_doesMiddlewareMatch` function can be used to assert whether middleware will run for the provided URL, headers, and cookies.
+The `unstable_doesProxyMatch` function can be used to assert whether proxy will run for the provided URL, headers, and cookies.
 
 ```js
-import { unstable_doesMiddlewareMatch } from 'next/experimental/testing/server'
+import { unstable_doesProxyMatch } from 'next/experimental/testing/server'
 
 expect(
-  unstable_doesMiddlewareMatch({
+  unstable_doesProxyMatch({
     config,
     nextConfig,
     url: '/test',
@@ -661,13 +661,13 @@ expect(
 ).toEqual(false)
 ```
 
-The entire middleware function can also be tested.
+The entire proxy function can also be tested.
 
 ```js
 import { isRewrite, getRewrittenUrl } from 'next/experimental/testing/server'
 
 const request = new NextRequest('https://nextjs.org/docs')
-const response = await middleware(request)
+const response = await proxy(request)
 expect(isRewrite(response)).toEqual(true)
 expect(getRewrittenUrl(response)).toEqual('https://other-domain.com/docs')
 // getRedirectUrl could also be used if the response were a redirect
@@ -682,16 +682,16 @@ expect(getRewrittenUrl(response)).toEqual('https://other-domain.com/docs')
 | [Static export](/docs/app/getting-started/deploying#static-export)  | No                |
 | [Adapters](/docs/app/getting-started/deploying#adapters)            | Platform-specific |
 
-Learn how to [configure Middleware](/docs/app/guides/self-hosting#middleware) when self-hosting Next.js.
+Learn how to [configure Proxy](/docs/app/guides/self-hosting#proxy) when self-hosting Next.js.
 
 ## Version history
 
-| Version   | Changes                                                                                       |
-| --------- | --------------------------------------------------------------------------------------------- |
-| `v15.5.0` | Middleware can now use the Node.js runtime (stable)                                           |
-| `v15.2.0` | Middleware can now use the Node.js runtime (experimental)                                     |
-| `v13.1.0` | Advanced Middleware flags added                                                               |
-| `v13.0.0` | Middleware can modify request headers, response headers, and send responses                   |
-| `v12.2.0` | Middleware is stable, please see the [upgrade guide](/docs/messages/middleware-upgrade-guide) |
-| `v12.0.9` | Enforce absolute URLs in Edge Runtime ([PR](https://github.com/vercel/next.js/pull/33410))    |
-| `v12.0.0` | Middleware (Beta) added                                                                       |
+| Version   | Changes                                                                                    |
+| --------- | ------------------------------------------------------------------------------------------ |
+| `v15.5.0` | Proxy can now use the Node.js runtime (stable)                                             |
+| `v15.2.0` | Proxy can now use the Node.js runtime (experimental)                                       |
+| `v13.1.0` | Advanced Proxy flags added                                                                 |
+| `v13.0.0` | Proxy can modify request headers, response headers, and send responses                     |
+| `v12.2.0` | Proxy is stable, please see the [upgrade guide](/docs/messages/proxy-upgrade-guide)        |
+| `v12.0.9` | Enforce absolute URLs in Edge Runtime ([PR](https://github.com/vercel/next.js/pull/33410)) |
+| `v12.0.0` | Proxy (Beta) added                                                                         |

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -8,7 +8,7 @@ related:
     - app/api-reference/functions/next-response
 ---
 
-The `proxy.js|ts` file is used to write [Proxy](/docs/app/getting-started/route-handlers-and-proxy#proxy) and run code on the server before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
+The `proxy.js|ts` file is used to write [Proxy](/docs/app/getting-started/proxy) and run code on the server before a request is completed. Then, based on the incoming request, you can modify the response by rewriting, redirecting, modifying the request or response headers, or responding directly.
 
 Proxy executes before routes are rendered. It's particularly useful for implementing custom server-side logic like authentication, logging, or handling redirects.
 

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -353,7 +353,7 @@ export function proxy(request) {
   })
   cookie = response.cookies.get('vercel')
   console.log(cookie) // => { name: 'vercel', value: 'fast', Path: '/' }
-  // The outgoing response will have a `Set-Cookie:vercel=fast;path=/test` header.
+  // The outgoing response will have a `Set-Cookie:vercel=fast;path=/` header.
 
   return response
 }
@@ -686,12 +686,13 @@ Learn how to [configure Proxy](/docs/app/guides/self-hosting#proxy) when self-ho
 
 ## Version history
 
-| Version   | Changes                                                                                    |
-| --------- | ------------------------------------------------------------------------------------------ |
-| `v15.5.0` | Proxy can now use the Node.js runtime (stable)                                             |
-| `v15.2.0` | Proxy can now use the Node.js runtime (experimental)                                       |
-| `v13.1.0` | Advanced Proxy flags added                                                                 |
-| `v13.0.0` | Proxy can modify request headers, response headers, and send responses                     |
-| `v12.2.0` | Proxy is stable, please see the [upgrade guide](/docs/messages/proxy-upgrade-guide)        |
-| `v12.0.9` | Enforce absolute URLs in Edge Runtime ([PR](https://github.com/vercel/next.js/pull/33410)) |
-| `v12.0.0` | Proxy (Beta) added                                                                         |
+| Version   | Changes                                                                                       |
+| --------- | --------------------------------------------------------------------------------------------- |
+| `v16.0.0` | Middleware is deprecated and renamed to Proxy                                                 |
+| `v15.5.0` | Middleware can now use the Node.js runtime (stable)                                           |
+| `v15.2.0` | Middleware can now use the Node.js runtime (experimental)                                     |
+| `v13.1.0` | Advanced Middleware flags added                                                               |
+| `v13.0.0` | Middleware can modify request headers, response headers, and send responses                   |
+| `v12.2.0` | Middleware is stable, please see the [upgrade guide](/docs/messages/middleware-upgrade-guide) |
+| `v12.0.9` | Enforce absolute URLs in Edge Runtime ([PR](https://github.com/vercel/next.js/pull/33410))    |
+| `v12.0.0` | Middleware (Beta) added                                                                       |

--- a/docs/02-pages/04-api-reference/02-file-conventions/proxy.mdx
+++ b/docs/02-pages/04-api-reference/02-file-conventions/proxy.mdx
@@ -1,0 +1,7 @@
+---
+title: Middleware
+description: Learn how to use Middleware to run code before a request is completed.
+source: app/api-reference/file-conventions/middleware
+---
+
+{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/docs/02-pages/04-api-reference/02-file-conventions/proxy.mdx
+++ b/docs/02-pages/04-api-reference/02-file-conventions/proxy.mdx
@@ -1,7 +1,7 @@
 ---
-title: Middleware
-description: Learn how to use Middleware to run code before a request is completed.
-source: app/api-reference/file-conventions/middleware
+title: Proxy
+description: Learn how to use Proxy to run code before a request is completed.
+source: app/api-reference/file-conventions/proxy
 ---
 
 {/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/errors/deleting-query-params-in-middlewares.mdx
+++ b/errors/deleting-query-params-in-middlewares.mdx
@@ -14,7 +14,7 @@ import { NextResponse } from 'next/server'
 
 export default function middleware(request: NextRequest) {
   const nextUrl = request.nextUrl
-  nextUrl.searchParams.delete('key') // <-- this is now possible! 🎉
+  nextUrl.searchParams.delete('key') // <-- this is now possible!
   return NextResponse.rewrite(nextUrl)
 }
 ```

--- a/errors/deleting-query-params-in-proxy.mdx
+++ b/errors/deleting-query-params-in-proxy.mdx
@@ -1,0 +1,37 @@
+---
+title: Deleting Query Parameters In Middlewares
+---
+
+## Why This Error Occurred
+
+In previous versions of Next.js, we were merging query parameters with the incoming request for rewrites happening in middlewares, to match the behavior of static rewrites declared in the config. This forced Next.js users to use empty query parameters values to delete keys.
+
+We are changing this behavior to allow extra flexibility and a more streamlined experience for users. So from now on, query parameters will not be merged and thus the warning.
+
+```ts filename="middleware.ts"
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export default function middleware(request: NextRequest) {
+  const nextUrl = request.nextUrl
+  nextUrl.searchParams.delete('key') // <-- this is now possible! 🎉
+  return NextResponse.rewrite(nextUrl)
+}
+```
+
+## Possible Ways to Fix It
+
+If you are relying on the old behavior, please add the query parameters manually to the rewritten URL. Using `request.nextUrl` would do that automatically for you.
+
+```ts filename="middleware.ts"
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export default function middleware(request: NextRequest) {
+  const nextUrl = request.nextUrl
+  nextUrl.pathname = '/dest'
+  return NextResponse.rewrite(nextUrl)
+}
+```
+
+This warning will be removed in the next version of Next.js.

--- a/errors/deleting-query-params-in-proxy.mdx
+++ b/errors/deleting-query-params-in-proxy.mdx
@@ -1,18 +1,18 @@
 ---
-title: Deleting Query Parameters In Middlewares
+title: Deleting Query Parameters In Proxies
 ---
 
 ## Why This Error Occurred
 
-In previous versions of Next.js, we were merging query parameters with the incoming request for rewrites happening in middlewares, to match the behavior of static rewrites declared in the config. This forced Next.js users to use empty query parameters values to delete keys.
+In previous versions of Next.js, we were merging query parameters with the incoming request for rewrites happening in proxies, to match the behavior of static rewrites declared in the config. This forced Next.js users to use empty query parameters values to delete keys.
 
 We are changing this behavior to allow extra flexibility and a more streamlined experience for users. So from now on, query parameters will not be merged and thus the warning.
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
-export default function middleware(request: NextRequest) {
+export default function proxy(request: NextRequest) {
   const nextUrl = request.nextUrl
   nextUrl.searchParams.delete('key') // <-- this is now possible! 🎉
   return NextResponse.rewrite(nextUrl)
@@ -23,11 +23,11 @@ export default function middleware(request: NextRequest) {
 
 If you are relying on the old behavior, please add the query parameters manually to the rewritten URL. Using `request.nextUrl` would do that automatically for you.
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
-export default function middleware(request: NextRequest) {
+export default function proxy(request: NextRequest) {
   const nextUrl = request.nextUrl
   nextUrl.pathname = '/dest'
   return NextResponse.rewrite(nextUrl)

--- a/errors/deleting-query-params-in-proxy.mdx
+++ b/errors/deleting-query-params-in-proxy.mdx
@@ -14,7 +14,7 @@ import { NextResponse } from 'next/server'
 
 export default function proxy(request: NextRequest) {
   const nextUrl = request.nextUrl
-  nextUrl.searchParams.delete('key') // <-- this is now possible! 🎉
+  nextUrl.searchParams.delete('key') // <-- this is now possible!
   return NextResponse.rewrite(nextUrl)
 }
 ```

--- a/errors/middleware-parse-user-agent.mdx
+++ b/errors/middleware-parse-user-agent.mdx
@@ -13,7 +13,7 @@ export function middleware(request: NextRequest) {
   const viewport = request.ua.device.type === 'mobile' ? 'mobile' : 'desktop'
 
   request.nextUrl.searchParams.set('viewport', viewport)
-  return NextResponse.rewrites(request.nextUrl)
+  return NextResponse.rewrite(request.nextUrl)
 }
 ```
 

--- a/errors/middleware-request-page.mdx
+++ b/errors/middleware-request-page.mdx
@@ -10,7 +10,7 @@ Your application is interacting with `request.page` which has been deprecated.
 import { NextRequest, NextResponse } from 'next/server'
 
 export function middleware(request: NextRequest) {
-  const { params } = event.request.page
+  const { params } = request.page
   const { locale, slug } = params
 
   if (locale && slug) {

--- a/errors/nested-proxy.mdx
+++ b/errors/nested-proxy.mdx
@@ -1,0 +1,31 @@
+---
+title: Nested Middleware
+---
+
+## Why This Error Occurred
+
+You are defining a Middleware file in a location different from `<root>/middleware`, which is not allowed.
+
+While in beta, a Middleware file under specific pages would _only_ be executed when pages below its declaration were matched, allowing nesting Middleware files. Based on customer feedback, we have replaced this API with a single root Middleware.
+
+## Possible Ways to Fix It
+
+Declare your Middleware in the root folder and use `NextRequest` parsed URL to define which path the Middleware should be executed for.
+
+For example, a Middleware at `pages/about/_middleware.ts` can move the logic to `<root>/middleware.ts` in the root of your repository. Then, a conditional statement can be used to only run the Middleware when it matches the `about/*` path:
+
+```ts filename="middleware.ts"
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname.startsWith('/about')) {
+    // This logic is only applied to /about
+  }
+
+  if (request.nextUrl.pathname.startsWith('/dashboard')) {
+    // This logic is only applied to /dashboard
+  }
+}
+```
+
+If you have more than one Middleware, you should combine them into a single file and model their execution depending on the incoming request.

--- a/errors/nested-proxy.mdx
+++ b/errors/nested-proxy.mdx
@@ -1,23 +1,23 @@
 ---
-title: Nested Middleware
+title: Nested Proxy
 ---
 
 ## Why This Error Occurred
 
-You are defining a Middleware file in a location different from `<root>/middleware`, which is not allowed.
+You are defining a Proxy file in a location different from `<root>/proxy`, which is not allowed.
 
-While in beta, a Middleware file under specific pages would _only_ be executed when pages below its declaration were matched, allowing nesting Middleware files. Based on customer feedback, we have replaced this API with a single root Middleware.
+While in beta, a Proxy file under specific pages would _only_ be executed when pages below its declaration were matched, allowing nesting Proxy files. Based on customer feedback, we have replaced this API with a single root Proxy.
 
 ## Possible Ways to Fix It
 
-Declare your Middleware in the root folder and use `NextRequest` parsed URL to define which path the Middleware should be executed for.
+Declare your Proxy in the root folder and use `NextRequest` parsed URL to define which path the Proxy should be executed for.
 
-For example, a Middleware at `pages/about/_middleware.ts` can move the logic to `<root>/middleware.ts` in the root of your repository. Then, a conditional statement can be used to only run the Middleware when it matches the `about/*` path:
+For example, a Proxy at `pages/about/_proxy.ts` can move the logic to `<root>/proxy.ts` in the root of your repository. Then, a conditional statement can be used to only run the Proxy when it matches the `about/*` path:
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import type { NextRequest } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   if (request.nextUrl.pathname.startsWith('/about')) {
     // This logic is only applied to /about
   }
@@ -28,4 +28,4 @@ export function middleware(request: NextRequest) {
 }
 ```
 
-If you have more than one Middleware, you should combine them into a single file and model their execution depending on the incoming request.
+If you have more than one Proxy, you should combine them into a single file and model their execution depending on the incoming request.

--- a/errors/proxy-dynamic-wasm-compilation.mdx
+++ b/errors/proxy-dynamic-wasm-compilation.mdx
@@ -1,0 +1,29 @@
+---
+title: Dynamic WASM compilation is not available in Middlewares
+---
+
+## Why This Error Occurred
+
+Compiling WASM binaries dynamically is not allowed in Middlewares. Specifically,
+the following APIs are not supported:
+
+- `WebAssembly.compile`
+- `WebAssembly.instantiate` with [a buffer parameter](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate#primary_overload_%E2%80%94_taking_wasm_binary_code)
+
+## Possible Ways to Fix It
+
+Bundle your WASM binaries using `import`:
+
+```ts filename="middleware.ts"
+import { NextResponse } from 'next/server'
+import squareWasm from './square.wasm?module'
+
+export default async function middleware() {
+  const m = await WebAssembly.instantiate(squareWasm)
+  const answer = m.exports.square(9)
+  const response = NextResponse.next()
+
+  response.headers.set('x-square', answer.toString())
+  return response
+}
+```

--- a/errors/proxy-dynamic-wasm-compilation.mdx
+++ b/errors/proxy-dynamic-wasm-compilation.mdx
@@ -1,10 +1,10 @@
 ---
-title: Dynamic WASM compilation is not available in Middlewares
+title: Dynamic WASM compilation is not available in Proxies
 ---
 
 ## Why This Error Occurred
 
-Compiling WASM binaries dynamically is not allowed in Middlewares. Specifically,
+Compiling WASM binaries dynamically is not allowed in Proxies. Specifically,
 the following APIs are not supported:
 
 - `WebAssembly.compile`
@@ -14,11 +14,11 @@ the following APIs are not supported:
 
 Bundle your WASM binaries using `import`:
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import { NextResponse } from 'next/server'
 import squareWasm from './square.wasm?module'
 
-export default async function middleware() {
+export default async function proxy() {
   const m = await WebAssembly.instantiate(squareWasm)
   const answer = m.exports.square(9)
   const response = NextResponse.next()

--- a/errors/proxy-new-signature.mdx
+++ b/errors/proxy-new-signature.mdx
@@ -1,0 +1,37 @@
+---
+title: Deprecated Middleware API Signature
+---
+
+## Why This Error Occurred
+
+Your application is using a Middleware function that is using parameters from the deprecated API.
+
+```ts filename="middleware.ts"
+import { NextResponse } from 'next/server'
+
+export function middleware(event) {
+  if (event.request.nextUrl.pathname === '/blocked') {
+    event.respondWith(
+      new NextResponse(null, {
+        status: 403,
+      })
+    )
+  }
+}
+```
+
+## Possible Ways to Fix It
+
+Update to use the new API for Middleware:
+
+```ts filename="middleware.ts"
+import { NextResponse } from 'next/server'
+
+export function middleware(request) {
+  if (request.nextUrl.pathname === '/blocked') {
+    return new NextResponse(null, {
+      status: 403,
+    })
+  }
+}
+```

--- a/errors/proxy-new-signature.mdx
+++ b/errors/proxy-new-signature.mdx
@@ -1,15 +1,15 @@
 ---
-title: Deprecated Middleware API Signature
+title: Deprecated Proxy API Signature
 ---
 
 ## Why This Error Occurred
 
-Your application is using a Middleware function that is using parameters from the deprecated API.
+Your application is using a Proxy function that is using parameters from the deprecated API.
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import { NextResponse } from 'next/server'
 
-export function middleware(event) {
+export function proxy(event) {
   if (event.request.nextUrl.pathname === '/blocked') {
     event.respondWith(
       new NextResponse(null, {
@@ -22,12 +22,12 @@ export function middleware(event) {
 
 ## Possible Ways to Fix It
 
-Update to use the new API for Middleware:
+Update to use the new API for Proxy:
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import { NextResponse } from 'next/server'
 
-export function middleware(request) {
+export function proxy(request) {
   if (request.nextUrl.pathname === '/blocked') {
     return new NextResponse(null, {
       status: 403,

--- a/errors/proxy-parse-user-agent.mdx
+++ b/errors/proxy-parse-user-agent.mdx
@@ -1,0 +1,34 @@
+---
+title: Removed parsed User Agent from Middleware API
+---
+
+## Why This Error Occurred
+
+Your application is interacting with `req.ua` which has been deprecated.
+
+```ts filename="middleware.ts"
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const viewport = request.ua.device.type === 'mobile' ? 'mobile' : 'desktop'
+
+  request.nextUrl.searchParams.set('viewport', viewport)
+  return NextResponse.rewrites(request.nextUrl)
+}
+```
+
+## Possible Ways to Fix It
+
+The internal logic has been moved into a separate `userAgent` function that you can import from `next/server` and wrap your request instead.
+
+```ts filename="middleware.ts"
+import { NextRequest, NextResponse, userAgent } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const { device } = userAgent(request)
+  const viewport = device.type === 'mobile' ? 'mobile' : 'desktop'
+
+  request.nextUrl.searchParams.set('viewport', viewport)
+  return NextResponse.rewrite(request.nextUrl)
+}
+```

--- a/errors/proxy-parse-user-agent.mdx
+++ b/errors/proxy-parse-user-agent.mdx
@@ -1,15 +1,15 @@
 ---
-title: Removed parsed User Agent from Middleware API
+title: Removed parsed User Agent from Proxy API
 ---
 
 ## Why This Error Occurred
 
 Your application is interacting with `req.ua` which has been deprecated.
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import { NextRequest, NextResponse } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const viewport = request.ua.device.type === 'mobile' ? 'mobile' : 'desktop'
 
   request.nextUrl.searchParams.set('viewport', viewport)
@@ -21,10 +21,10 @@ export function middleware(request: NextRequest) {
 
 The internal logic has been moved into a separate `userAgent` function that you can import from `next/server` and wrap your request instead.
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import { NextRequest, NextResponse, userAgent } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { device } = userAgent(request)
   const viewport = device.type === 'mobile' ? 'mobile' : 'desktop'
 

--- a/errors/proxy-parse-user-agent.mdx
+++ b/errors/proxy-parse-user-agent.mdx
@@ -13,7 +13,7 @@ export function proxy(request: NextRequest) {
   const viewport = request.ua.device.type === 'mobile' ? 'mobile' : 'desktop'
 
   request.nextUrl.searchParams.set('viewport', viewport)
-  return NextResponse.rewrites(request.nextUrl)
+  return NextResponse.rewrite(request.nextUrl)
 }
 ```
 

--- a/errors/proxy-relative-urls.mdx
+++ b/errors/proxy-relative-urls.mdx
@@ -1,0 +1,40 @@
+---
+title: Middleware Relative URLs
+---
+
+## Why This Error Occurred
+
+You are using a Middleware function that uses `Response.redirect(url)`, `NextResponse.redirect(url)` or `NextResponse.rewrite(url)` where `url` is a relative or an invalid URL. Prior to Next.js 12.1, we allowed passing relative URLs. However, constructing a request with `new Request(url)` or running `fetch(url)` when `url` is a relative URL **does not** work. For this reason and to bring consistency to Next.js Middleware, this behavior has been deprecated and now removed.
+
+## Possible Ways to Fix It
+
+To fix this error you must always pass absolute URL for redirecting and rewriting. There are several ways to get the absolute URL but the recommended way is to clone `NextURL` and mutate it:
+
+```ts filename="middleware.ts"
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const url = request.nextUrl.clone()
+  url.pathname = '/dest'
+  return NextResponse.rewrite(url)
+}
+```
+
+Another way to fix this error could be to use the original URL as the base but this will not consider configuration like `basePath` or `locale`:
+
+```ts filename="middleware.ts"
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  return NextResponse.rewrite(new URL('/dest', request.url))
+}
+```
+
+You can also pass directly a string containing a valid absolute URL.
+
+## Useful Links
+
+- [URL Documentation](https://developer.mozilla.org/docs/Web/API/URL)
+- [Response Documentation](https://developer.mozilla.org/docs/Web/API/Response)

--- a/errors/proxy-relative-urls.mdx
+++ b/errors/proxy-relative-urls.mdx
@@ -1,20 +1,20 @@
 ---
-title: Middleware Relative URLs
+title: Proxy Relative URLs
 ---
 
 ## Why This Error Occurred
 
-You are using a Middleware function that uses `Response.redirect(url)`, `NextResponse.redirect(url)` or `NextResponse.rewrite(url)` where `url` is a relative or an invalid URL. Prior to Next.js 12.1, we allowed passing relative URLs. However, constructing a request with `new Request(url)` or running `fetch(url)` when `url` is a relative URL **does not** work. For this reason and to bring consistency to Next.js Middleware, this behavior has been deprecated and now removed.
+You are using a Proxy function that uses `Response.redirect(url)`, `NextResponse.redirect(url)` or `NextResponse.rewrite(url)` where `url` is a relative or an invalid URL. Prior to Next.js 12.1, we allowed passing relative URLs. However, constructing a request with `new Request(url)` or running `fetch(url)` when `url` is a relative URL **does not** work. For this reason and to bring consistency to Next.js Proxy, this behavior has been deprecated and now removed.
 
 ## Possible Ways to Fix It
 
 To fix this error you must always pass absolute URL for redirecting and rewriting. There are several ways to get the absolute URL but the recommended way is to clone `NextURL` and mutate it:
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const url = request.nextUrl.clone()
   url.pathname = '/dest'
   return NextResponse.rewrite(url)
@@ -23,11 +23,11 @@ export function middleware(request: NextRequest) {
 
 Another way to fix this error could be to use the original URL as the base but this will not consider configuration like `basePath` or `locale`:
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   return NextResponse.rewrite(new URL('/dest', request.url))
 }
 ```

--- a/errors/proxy-request-page.mdx
+++ b/errors/proxy-request-page.mdx
@@ -1,0 +1,61 @@
+---
+title: Removed page from Middleware API
+---
+
+## Why This Error Occurred
+
+Your application is interacting with `request.page` which has been deprecated.
+
+```ts filename="middleware.ts"
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const { params } = event.request.page
+  const { locale, slug } = params
+
+  if (locale && slug) {
+    const { search, protocol, host } = request.nextUrl
+    const url = new URL(`${protocol}//${locale}.${host}/${slug}${search}`)
+    return NextResponse.redirect(url)
+  }
+}
+```
+
+## Possible Ways to Fix It
+
+You can use [URLPattern](https://developer.mozilla.org/docs/Web/API/URLPattern) instead to have the same behavior:
+
+```ts filename="middleware.ts"
+import { NextRequest, NextResponse } from 'next/server'
+
+const PATTERNS = [
+  [
+    new URLPattern({ pathname: '/:locale/:slug' }),
+    ({ pathname }) => pathname.groups,
+  ],
+]
+
+const params = (url) => {
+  const input = url.split('?')[0]
+  let result = {}
+
+  for (const [pattern, handler] of PATTERNS) {
+    const patternResult = pattern.exec(input)
+    if (patternResult !== null && 'pathname' in patternResult) {
+      result = handler(patternResult)
+      break
+    }
+  }
+  return result
+}
+
+export function middleware(request: NextRequest) {
+  const { locale, slug } = params(request.url)
+
+  if (locale && slug) {
+    const { search, protocol, host } = request.nextUrl
+    const url = new URL(`${protocol}//${locale}.${host}/${slug}${search}`)
+    return NextResponse.redirect(url)
+  }
+}
+```

--- a/errors/proxy-request-page.mdx
+++ b/errors/proxy-request-page.mdx
@@ -10,7 +10,7 @@ Your application is interacting with `request.page` which has been deprecated.
 import { NextRequest, NextResponse } from 'next/server'
 
 export function proxy(request: NextRequest) {
-  const { params } = event.request.page
+  const { params } = request.page
   const { locale, slug } = params
 
   if (locale && slug) {

--- a/errors/proxy-request-page.mdx
+++ b/errors/proxy-request-page.mdx
@@ -1,15 +1,15 @@
 ---
-title: Removed page from Middleware API
+title: Removed page from Proxy API
 ---
 
 ## Why This Error Occurred
 
 Your application is interacting with `request.page` which has been deprecated.
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import { NextRequest, NextResponse } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { params } = event.request.page
   const { locale, slug } = params
 
@@ -25,7 +25,7 @@ export function middleware(request: NextRequest) {
 
 You can use [URLPattern](https://developer.mozilla.org/docs/Web/API/URLPattern) instead to have the same behavior:
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import { NextRequest, NextResponse } from 'next/server'
 
 const PATTERNS = [
@@ -49,7 +49,7 @@ const params = (url) => {
   return result
 }
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { locale, slug } = params(request.url)
 
   if (locale && slug) {

--- a/errors/proxy-user-agent.mdx
+++ b/errors/proxy-user-agent.mdx
@@ -1,0 +1,34 @@
+---
+title: Removed req.ua from Middleware API
+---
+
+## Why This Error Occurred
+
+Your middleware is interacting with `req.ua` and this feature needs to opt-in.
+
+```ts filename="middleware.ts"
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const url = request.nextUrl
+  const viewport = request.ua.device.type === 'mobile' ? 'mobile' : 'desktop'
+  url.searchParams.set('viewport', viewport)
+  return NextResponse.rewrite(url)
+}
+```
+
+## Possible Ways to Fix It
+
+To parse the user agent, import `userAgent` function from `next/server` and give it your request:
+
+```ts filename="middleware.ts"
+import { NextRequest, NextResponse, userAgent } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const url = request.nextUrl
+  const { device } = userAgent(request)
+  const viewport = device.type === 'mobile' ? 'mobile' : 'desktop'
+  url.searchParams.set('viewport', viewport)
+  return NextResponse.rewrite(url)
+}
+```

--- a/errors/proxy-user-agent.mdx
+++ b/errors/proxy-user-agent.mdx
@@ -1,15 +1,15 @@
 ---
-title: Removed req.ua from Middleware API
+title: Removed req.ua from Proxy API
 ---
 
 ## Why This Error Occurred
 
-Your middleware is interacting with `req.ua` and this feature needs to opt-in.
+Your proxy is interacting with `req.ua` and this feature needs to opt-in.
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import { NextRequest, NextResponse } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const url = request.nextUrl
   const viewport = request.ua.device.type === 'mobile' ? 'mobile' : 'desktop'
   url.searchParams.set('viewport', viewport)
@@ -21,10 +21,10 @@ export function middleware(request: NextRequest) {
 
 To parse the user agent, import `userAgent` function from `next/server` and give it your request:
 
-```ts filename="middleware.ts"
+```ts filename="proxy.ts"
 import { NextRequest, NextResponse, userAgent } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const url = request.nextUrl
   const { device } = userAgent(request)
   const viewport = device.type === 'mobile' ? 'mobile' : 'desktop'


### PR DESCRIPTION
> [!NOTE]
> Best reviewed by each commit for better diff view.

This PR clones the Middleware docs for Proxy and removes the Middleware docs.

Did not clone the list of docs:

- `errors/middleware-upgrade.mdx` - It's a middleware upgrade guide from v12.2
- `errors/beta-middleware.mdx` - It's an error when using middleware before v12.2
- `errors/returning-response-body.mdx` - Legacy behavior from versions < v12.2