### PR TITLE
Add Learn more docs to Middleware deprecation warning

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -690,7 +690,7 @@ Learn how to [configure Proxy](/docs/app/guides/self-hosting#proxy) when self-ho
 
 ### Why the Change
 
-The reason behind the renaming of `middleware` is that the term "middleware can often be confused with Express.js middleware, leading to a misinterpretation of its purpose. Also, Middleware is highly capable, so it may encourage the usage; however, this feature is recommended to be used as a last resort.
+The reason behind the renaming of `middleware` is that the term "middleware" can often be confused with Express.js middleware, leading to a misinterpretation of its purpose. Also, Middleware is highly capable, so it may encourage the usage; however, this feature is recommended to be used as a last resort.
 
 Next.js is moving forward to provide better APIs with better ergonomics so that developers can achieve their goals without Middleware. This is the reason behind the renaming of `middleware`.
 

--- a/errors/middleware-to-proxy.mdx
+++ b/errors/middleware-to-proxy.mdx
@@ -1,0 +1,34 @@
+---
+title: Renaming Middleware to Proxy
+---
+
+## Why This Error Occurred
+
+You are using the `middleware` file convention, which is deprecated and has been renamed to [`proxy`](/docs/app/api-reference/file-conventions/proxy).
+
+## Possible Ways to Fix It
+
+Next.js provides a codemod to migrate from `middleware` to `proxy`. You can run the following command to migrate:
+
+```bash
+npx @next/codemod@canary middleware-to-proxy .
+```
+
+We recommend users avoid relying on Middleware unless no other options exist. Our goal is to give them APIs with better ergonomics so they can achieve their goals without Middleware.
+
+The term “middleware” often confuses users with Express.js middleware, which can encourage misuse. To clarify our direction, we are renaming the file convention to “proxy.” This highlights that we are moving away from Middleware, breaking down its overloaded features, and making the Proxy clear in its purpose.
+
+Next.js provides a codemod to migrate from `middleware.ts` to `proxy.ts`. You can run the following command to migrate:
+
+```bash
+npx @next/codemod@canary middleware-to-proxy .
+```
+
+The codemod will rename the file and the function name from `middleware` to `proxy`.
+
+```diff
+// middleware.ts -> proxy.ts
+
+- export function middleware() {
++ export function proxy() {
+```

--- a/errors/middleware-to-proxy.mdx
+++ b/errors/middleware-to-proxy.mdx
@@ -6,13 +6,19 @@ title: Renaming Middleware to Proxy
 
 You are using the `middleware` file convention, which is deprecated and has been renamed to [`proxy`](/docs/app/api-reference/file-conventions/proxy).
 
-## Possible Ways to Fix It
+## Migration to Proxy
 
-Next.js provides a codemod to migrate from `middleware` to `proxy`. You can run the following command to migrate:
+### Why the Change
 
-```bash
-npx @next/codemod@canary middleware-to-proxy .
-```
+The reason behind the renaming of `middleware` is that the term "middleware can often be confused with Express.js middleware, leading to a misinterpretation of its purpose. Also, Middleware is highly capable, so it may encourage the usage; however, this feature is recommended to be used as a last resort.
+
+Next.js is moving forward to provide better APIs with better ergonomics so that developers can achieve their goals without Middleware. This is the reason behind the renaming of `middleware`.
+
+### Why "Proxy"
+
+The name Proxy clarifies what Middleware is capable of. The term "proxy" implies that it has a network boundary in front of the app, which is the behavior of Middleware. Also, Middleware defaults to run at the [Edge Runtime](/docs/app/api-reference/edge), which can run closer to the client, separated from the app's region. These behaviors align better with the term "proxy" and provide a clearer purpose of the feature.
+
+### How to Migrate
 
 We recommend users avoid relying on Middleware unless no other options exist. Our goal is to give them APIs with better ergonomics so they can achieve their goals without Middleware.
 
@@ -32,3 +38,7 @@ The codemod will rename the file and the function name from `middleware` to `pro
 - export function middleware() {
 + export function proxy() {
 ```
+
+## Useful Links
+
+- [Proxy Docs](/docs/app/api-reference/file-conventions/proxy)

--- a/errors/middleware-to-proxy.mdx
+++ b/errors/middleware-to-proxy.mdx
@@ -10,7 +10,7 @@ You are using the `middleware` file convention, which is deprecated and has been
 
 ### Why the Change
 
-The reason behind the renaming of `middleware` is that the term "middleware can often be confused with Express.js middleware, leading to a misinterpretation of its purpose. Also, Middleware is highly capable, so it may encourage the usage; however, this feature is recommended to be used as a last resort.
+The reason behind the renaming of `middleware` is that the term "middleware" can often be confused with Express.js middleware, leading to a misinterpretation of its purpose. Also, Middleware is highly capable, so it may encourage the usage; however, this feature is recommended to be used as a last resort.
 
 Next.js is moving forward to provide better APIs with better ergonomics so that developers can achieve their goals without Middleware. This is the reason behind the renaming of `middleware`.
 

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -896,5 +896,6 @@
   "895": "Invalid React HTML document. Should start with doctype prefix.",
   "896": "oops",
   "897": "Expected HTML document to start with doctype prefix",
-  "898": "When using Cache Components, all `generateStaticParams` functions must return at least one result. This is to ensure that we can perform build-time validation that there is no other dynamic accesses that would cause a runtime error.\n\nLearn more: https://nextjs.org/docs/messages/empty-generate-static-params"
+  "898": "When using Cache Components, all `generateStaticParams` functions must return at least one result. This is to ensure that we can perform build-time validation that there is no other dynamic accesses that would cause a runtime error.\n\nLearn more: https://nextjs.org/docs/messages/empty-generate-static-params",
+  "899": "Both \"%s\" and \"%s\" files are detected. Please use \"%s\" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -897,5 +897,6 @@
   "896": "oops",
   "897": "Expected HTML document to start with doctype prefix",
   "898": "When using Cache Components, all `generateStaticParams` functions must return at least one result. This is to ensure that we can perform build-time validation that there is no other dynamic accesses that would cause a runtime error.\n\nLearn more: https://nextjs.org/docs/messages/empty-generate-static-params",
-  "899": "Both \"%s\" and \"%s\" files are detected. Please use \"%s\" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy"
+  "899": "Both \"%s\" and \"%s\" files are detected. Please use \"%s\" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy",
+  "900": "Both %s file \"./%s\" and %s file \"./%s\" are detected. Please use \"./%s\" only. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy"
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1243,7 +1243,7 @@ export default async function build(
           const absoluteMiddlewarePath = path.join(rootDir, middlewareFilePath)
 
           throw new Error(
-            `Both ${MIDDLEWARE_FILENAME} file "./${path.relative(cwd, absoluteMiddlewarePath)}" and ${PROXY_FILENAME} file "./${path.relative(cwd, absoluteProxyPath)}" are detected. Please use "./${path.relative(cwd, absoluteProxyPath)}" only.`
+            `Both ${MIDDLEWARE_FILENAME} file "./${path.relative(cwd, absoluteMiddlewarePath)}" and ${PROXY_FILENAME} file "./${path.relative(cwd, absoluteProxyPath)}" are detected. Please use "./${path.relative(cwd, absoluteProxyPath)}" only. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`
           )
         }
         Log.warnOnce(

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1246,7 +1246,7 @@ export default async function build(
             `Both ${MIDDLEWARE_FILENAME} file "./${path.relative(cwd, absoluteMiddlewarePath)}" and ${PROXY_FILENAME} file "./${path.relative(cwd, absoluteProxyPath)}" are detected. Please use "./${path.relative(cwd, absoluteProxyPath)}" only.`
           )
         }
-        Log.warn(
+        Log.warnOnce(
           `The "${MIDDLEWARE_FILENAME}" file convention is deprecated. Please use "${PROXY_FILENAME}" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`
         )
       }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1246,8 +1246,8 @@ export default async function build(
             `Both ${MIDDLEWARE_FILENAME} file "./${path.relative(cwd, absoluteMiddlewarePath)}" and ${PROXY_FILENAME} file "./${path.relative(cwd, absoluteProxyPath)}" are detected. Please use "./${path.relative(cwd, absoluteProxyPath)}" only.`
           )
         }
-        Log.warnOnce(
-          `The "${MIDDLEWARE_FILENAME}" file convention is deprecated. Please use "${PROXY_FILENAME}" instead.`
+        Log.warn(
+          `The "${MIDDLEWARE_FILENAME}" file convention is deprecated. Please use "${PROXY_FILENAME}" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`
         )
       }
 

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -432,7 +432,7 @@ async function startWatcher(
             const cwd = process.cwd()
 
             throw new Error(
-              `Both ${MIDDLEWARE_FILENAME} file "./${path.relative(cwd, middlewareFilePath)}" and ${PROXY_FILENAME} file "./${path.relative(cwd, proxyFilePath)}" are detected. Please use "./${path.relative(cwd, proxyFilePath)}" only.  Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`
+`Both ${MIDDLEWARE_FILENAME} file "./${path.relative(cwd, middlewareFilePath)}" and ${PROXY_FILENAME} file "./${path.relative(cwd, proxyFilePath)}" are detected. Please use "./${path.relative(cwd, proxyFilePath)}" only. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`
             )
           }
           Log.warnOnce(

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -432,11 +432,11 @@ async function startWatcher(
             const cwd = process.cwd()
 
             throw new Error(
-              `Both ${MIDDLEWARE_FILENAME} file "./${path.relative(cwd, middlewareFilePath)}" and ${PROXY_FILENAME} file "./${path.relative(cwd, proxyFilePath)}" are detected. Please use "./${path.relative(cwd, proxyFilePath)}" only.`
+              `Both ${MIDDLEWARE_FILENAME} file "./${path.relative(cwd, middlewareFilePath)}" and ${PROXY_FILENAME} file "./${path.relative(cwd, proxyFilePath)}" are detected. Please use "./${path.relative(cwd, proxyFilePath)}" only.  Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`
             )
           }
           Log.warnOnce(
-            `The "${MIDDLEWARE_FILENAME}" file convention is deprecated. Please use "${PROXY_FILENAME}" instead.`
+            `The "${MIDDLEWARE_FILENAME}" file convention is deprecated. Please use "${PROXY_FILENAME}" instead. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`
           )
         }
 

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -432,7 +432,7 @@ async function startWatcher(
             const cwd = process.cwd()
 
             throw new Error(
-`Both ${MIDDLEWARE_FILENAME} file "./${path.relative(cwd, middlewareFilePath)}" and ${PROXY_FILENAME} file "./${path.relative(cwd, proxyFilePath)}" are detected. Please use "./${path.relative(cwd, proxyFilePath)}" only. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`
+              `Both ${MIDDLEWARE_FILENAME} file "./${path.relative(cwd, middlewareFilePath)}" and ${PROXY_FILENAME} file "./${path.relative(cwd, proxyFilePath)}" are detected. Please use "./${path.relative(cwd, proxyFilePath)}" only. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`
             )
           }
           Log.warnOnce(


### PR DESCRIPTION
This PR adds an error doc for the Middleware deprecation warning that it can refer to.

  - Explain why this error occurred
  - Provide migration guide
  - Explain the rationale for the renaming to Proxy