### PR TITLE
tweak middlewareClientMaxBodySize handling

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/middlewareClientMaxBodySize.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/middlewareClientMaxBodySize.mdx
@@ -1,0 +1,118 @@
+---
+title: experimental.middlewareClientMaxBodySize
+description: Configure the maximum request body size when using middleware.
+version: experimental
+---
+
+When middleware is used, Next.js automatically clones the request body and buffers it in memory to enable multiple reads - both in middleware and the underlying route handler. To prevent excessive memory usage, this configuration option sets a size limit on the buffered body.
+
+By default, the maximum body size is **10MB**. If a request body exceeds this limit, the body will only be buffered up to the limit, and a warning will be logged indicating which route exceeded the limit.
+
+## Options
+
+### String format (recommended)
+
+Specify the size using a human-readable string format:
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    middlewareClientMaxBodySize: '1mb',
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    middlewareClientMaxBodySize: '1mb',
+  },
+}
+
+module.exports = nextConfig
+```
+
+Supported units: `b`, `kb`, `mb`, `gb`
+
+### Number format
+
+Alternatively, specify the size in bytes as a number:
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    middlewareClientMaxBodySize: 1048576, // 1MB in bytes
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    middlewareClientMaxBodySize: 1048576, // 1MB in bytes
+  },
+}
+
+module.exports = nextConfig
+```
+
+## Behavior
+
+When a request body exceeds the configured limit:
+
+1. Next.js will buffer only the first N bytes (up to the limit)
+2. A warning will be logged to the console indicating the route that exceeded the limit
+3. The request will continue processing normally, but only the partial body will be available
+4. The request will **not** fail or return an error to the client
+
+If your application needs to process the full request body, you should either:
+
+- Increase the `middlewareClientMaxBodySize` limit
+- Handle the partial body gracefully in your application logic
+
+## Example
+
+```ts filename="middleware.ts"
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function middleware(request: NextRequest) {
+  // Next.js automatically buffers the body with the configured size limit
+  // You can read the body in middleware...
+  const body = await request.text()
+
+  // If the body exceeded the limit, only partial data will be available
+  console.log('Body size:', body.length)
+
+  return NextResponse.next()
+}
+```
+
+```ts filename="app/api/upload/route.ts"
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  // ...and the body is still available in your route handler
+  const body = await request.text()
+
+  console.log('Body in route handler:', body.length)
+
+  return NextResponse.json({ received: body.length })
+}
+```
+
+## Good to know
+
+- This setting only applies when middleware is used in your application
+- The default limit of 10MB is designed to balance memory usage and typical use cases
+- The limit applies per-request, not globally across all concurrent requests
+- For applications handling large file uploads, consider increasing the limit accordingly

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/middlewareClientMaxBodySize.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/middlewareClientMaxBodySize.mdx
@@ -1,0 +1,7 @@
+---
+title: experimental.middlewareClientMaxBodySize
+description: Configure the maximum request body size when using middleware.
+source: app/api-reference/config/next-config-js/middlewareClientMaxBodySize
+---
+
+{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/packages/next/src/server/body-streams.ts
+++ b/packages/next/src/server/body-streams.ts
@@ -92,11 +92,12 @@ export function getCloneableBody<T extends IncomingMessage>(
 
         if (bytesRead > bodySizeLimit) {
           limitExceeded = true
-          const error = new Error(
-            `Request body exceeded ${bytes.format(bodySizeLimit)}`
+          const urlInfo = readable.url ? ` for ${readable.url}` : ''
+          console.warn(
+            `Request body exceeded ${bytes.format(bodySizeLimit)}${urlInfo}. Only the first ${bytes.format(bodySizeLimit)} will be available unless configured. See https://nextjs.org/docs/app/api-reference/config/next-config-js/middlewareClientMaxBodySize for more details.`
           )
-          p1.destroy(error)
-          p2.destroy(error)
+          p1.push(null)
+          p2.push(null)
           return
         }
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -230,6 +230,7 @@ export const experimentalSchema = {
   linkNoTouchStart: z.boolean().optional(),
   manualClientBasePath: z.boolean().optional(),
   middlewarePrefetch: z.enum(['strict', 'flexible']).optional(),
+  middlewareClientMaxBodySize: zSizeLimit.optional(),
   multiZoneDraftMode: z.boolean().optional(),
   cssChunking: z.union([z.boolean(), z.literal('strict')]).optional(),
   nextScriptWorkers: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1498,6 +1498,7 @@ export const defaultConfig = Object.freeze({
     browserDebugInfoInTerminal: false,
     lockDistDir: true,
     isolatedDevBuild: true,
+    middlewareClientMaxBodySize: 10_485_760, // 10MB
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/test/e2e/client-max-body-size/app/api/echo/route.ts
+++ b/test/e2e/client-max-body-size/app/api/echo/route.ts
@@ -1,5 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function POST(request: NextRequest) {
-  return new NextResponse('Hello World', { status: 200 })
+  const body = await request.text()
+  return new NextResponse(
+    JSON.stringify({
+      message: 'Hello World',
+      bodySize: body.length,
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  )
 }

--- a/test/e2e/client-max-body-size/index.test.ts
+++ b/test/e2e/client-max-body-size/index.test.ts
@@ -11,7 +11,7 @@ describe('client-max-body-size', () => {
 
     if (skipped) return
 
-    it('should reject request body over 10MB by default', async () => {
+    it('should accept request body over 10MB but only buffer up to limit', async () => {
       const bodySize = 11 * 1024 * 1024 // 11MB
       const body = 'x'.repeat(bodySize)
 
@@ -25,8 +25,15 @@ describe('client-max-body-size', () => {
         }
       )
 
-      expect(res.status).toBe(400)
-      expect(next.cliOutput).toContain('Request body exceeded 10MB')
+      expect(res.status).toBe(200)
+      const responseBody = await res.json()
+      expect(responseBody.message).toBe('Hello World')
+      // Should only buffer up to 10MB, not the full 11MB
+      expect(responseBody.bodySize).toBeLessThanOrEqual(10 * 1024 * 1024)
+      expect(responseBody.bodySize).toBeLessThan(bodySize)
+      expect(next.cliOutput).toContain(
+        'Request body exceeded 10MB for /api/echo'
+      )
     })
 
     it('should accept request body at exactly 10MB', async () => {
@@ -44,8 +51,9 @@ describe('client-max-body-size', () => {
       )
 
       expect(res.status).toBe(200)
-      const responseBody = await res.text()
-      expect(responseBody).toBe('Hello World')
+      const responseBody = await res.json()
+      expect(responseBody.message).toBe('Hello World')
+      expect(responseBody.bodySize).toBe(bodySize)
     })
 
     it('should accept request body under 10MB', async () => {
@@ -63,8 +71,9 @@ describe('client-max-body-size', () => {
       )
 
       expect(res.status).toBe(200)
-      const responseBody = await res.text()
-      expect(responseBody).toBe('Hello World')
+      const responseBody = await res.json()
+      expect(responseBody.message).toBe('Hello World')
+      expect(responseBody.bodySize).toBe(bodySize)
     })
   })
 
@@ -81,7 +90,7 @@ describe('client-max-body-size', () => {
 
     if (skipped) return
 
-    it('should reject request body over custom 5MB limit', async () => {
+    it('should accept request body over custom 5MB limit but only buffer up to limit', async () => {
       const bodySize = 6 * 1024 * 1024 // 6MB
       const body = 'a'.repeat(bodySize)
 
@@ -95,8 +104,15 @@ describe('client-max-body-size', () => {
         }
       )
 
-      expect(res.status).toBe(400)
-      expect(next.cliOutput).toContain('Request body exceeded 5MB')
+      expect(res.status).toBe(200)
+      const responseBody = await res.json()
+      expect(responseBody.message).toBe('Hello World')
+      // Should only buffer up to 5MB, not the full 6MB
+      expect(responseBody.bodySize).toBeLessThanOrEqual(5 * 1024 * 1024)
+      expect(responseBody.bodySize).toBeLessThan(bodySize)
+      expect(next.cliOutput).toContain(
+        'Request body exceeded 5MB for /api/echo'
+      )
     })
 
     it('should accept request body under custom 5MB limit', async () => {
@@ -114,8 +130,9 @@ describe('client-max-body-size', () => {
       )
 
       expect(res.status).toBe(200)
-      const responseBody = await res.text()
-      expect(responseBody).toBe('Hello World')
+      const responseBody = await res.json()
+      expect(responseBody.message).toBe('Hello World')
+      expect(responseBody.bodySize).toBe(bodySize)
     })
   })
 
@@ -132,7 +149,7 @@ describe('client-max-body-size', () => {
 
     if (skipped) return
 
-    it('should reject request body over custom 2MB limit', async () => {
+    it('should accept request body over custom 2MB limit but only buffer up to limit', async () => {
       const bodySize = 3 * 1024 * 1024 // 3MB
       const body = 'c'.repeat(bodySize)
 
@@ -146,8 +163,15 @@ describe('client-max-body-size', () => {
         }
       )
 
-      expect(res.status).toBe(400)
-      expect(next.cliOutput).toContain('Request body exceeded 2MB')
+      expect(res.status).toBe(200)
+      const responseBody = await res.json()
+      expect(responseBody.message).toBe('Hello World')
+      // Should only buffer up to 2MB, not the full 3MB
+      expect(responseBody.bodySize).toBeLessThanOrEqual(2 * 1024 * 1024)
+      expect(responseBody.bodySize).toBeLessThan(bodySize)
+      expect(next.cliOutput).toContain(
+        'Request body exceeded 2MB for /api/echo'
+      )
     })
 
     it('should accept request body under custom 2MB limit', async () => {
@@ -165,8 +189,9 @@ describe('client-max-body-size', () => {
       )
 
       expect(res.status).toBe(200)
-      const responseBody = await res.text()
-      expect(responseBody).toBe('Hello World')
+      const responseBody = await res.json()
+      expect(responseBody.message).toBe('Hello World')
+      expect(responseBody.bodySize).toBe(bodySize)
     })
   })
 
@@ -198,11 +223,12 @@ describe('client-max-body-size', () => {
       )
 
       expect(res.status).toBe(200)
-      const responseBody = await res.text()
-      expect(responseBody).toBe('Hello World')
+      const responseBody = await res.json()
+      expect(responseBody.message).toBe('Hello World')
+      expect(responseBody.bodySize).toBe(bodySize)
     })
 
-    it('should reject request body over custom 50MB limit', async () => {
+    it('should accept request body over custom 50MB limit but only buffer up to limit', async () => {
       const bodySize = 51 * 1024 * 1024 // 51MB
       const body = 'f'.repeat(bodySize)
 
@@ -216,8 +242,15 @@ describe('client-max-body-size', () => {
         }
       )
 
-      expect(res.status).toBe(400)
-      expect(next.cliOutput).toContain('Request body exceeded 50MB')
+      expect(res.status).toBe(200)
+      const responseBody = await res.json()
+      expect(responseBody.message).toBe('Hello World')
+      // Should only buffer up to 50MB, not the full 51MB
+      expect(responseBody.bodySize).toBeLessThanOrEqual(50 * 1024 * 1024)
+      expect(responseBody.bodySize).toBeLessThan(bodySize)
+      expect(next.cliOutput).toContain(
+        'Request body exceeded 50MB for /api/echo'
+      )
     })
   })
 })


### PR DESCRIPTION
This ensures we captured `middlewareClientMaxBodySize` in the config schema and rather than triggering a hard error, it will buffer up to the limit.