### PR TITLE
Fix tags check for expired/stale

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/tags-manifest.external.ts
+++ b/packages/next/src/server/lib/incremental-cache/tags-manifest.external.ts
@@ -12,9 +12,15 @@ export const tagsManifest = new Map<string, TagManifestEntry>()
 export const areTagsExpired = (tags: string[], timestamp: Timestamp) => {
   for (const tag of tags) {
     const entry = tagsManifest.get(tag)
+    const expiredAt = entry?.expired
 
-    if (entry) {
-      if (entry.expired && entry.expired >= timestamp) {
+    if (typeof expiredAt === 'number') {
+      const now = Date.now()
+      // For immediate expiration (expiredAt <= now) and tag was invalidated after entry was created
+      // OR for future expiration that has now passed (expiredAt > timestamp && expiredAt <= now)
+      const isImmediatelyExpired = expiredAt <= now && expiredAt > timestamp
+
+      if (isImmediatelyExpired) {
         return true
       }
     }
@@ -26,11 +32,10 @@ export const areTagsExpired = (tags: string[], timestamp: Timestamp) => {
 export const areTagsStale = (tags: string[], timestamp: Timestamp) => {
   for (const tag of tags) {
     const entry = tagsManifest.get(tag)
+    const staleAt = entry?.stale ?? 0
 
-    if (entry) {
-      if (entry.stale && entry.stale >= timestamp) {
-        return true
-      }
+    if (typeof staleAt === 'number' && staleAt > timestamp) {
+      return true
     }
   }
 

--- a/test/e2e/app-dir/app-static/app/api/revalidate-tag-node/route.ts
+++ b/test/e2e/app-dir/app-static/app/api/revalidate-tag-node/route.ts
@@ -5,6 +5,7 @@ export const revalidate = 0
 
 export async function GET(req) {
   const tag = req.nextUrl.searchParams.get('tag')
-  revalidateTag(tag, 'expireNow')
+  const profile = req.nextUrl.searchParams.get('profile')
+  revalidateTag(tag, profile || 'expireNow')
   return NextResponse.json({ revalidated: true, now: Date.now() })
 }


### PR DESCRIPTION
Corrects the expired/stale checks in the tags manifest and updates test case to capture this. 