### PR TITLE
[eslint-plugin] Remove `eslint-v8` testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,6 @@
     "eslint-plugin-mdx": "3.1.5",
     "eslint-plugin-react": "7.35.0",
     "eslint-plugin-react-hooks": "0.0.0-experimental-3025aa39-20251007",
-    "eslint-v8": "npm:eslint@^8.57.0",
     "event-stream": "4.0.1",
     "execa": "2.0.3",
     "expect": "29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,9 +303,6 @@ importers:
       eslint-plugin-react-hooks:
         specifier: 0.0.0-experimental-3025aa39-20251007
         version: 0.0.0-experimental-3025aa39-20251007(eslint@9.12.0(jiti@2.5.1))
-      eslint-v8:
-        specifier: npm:eslint@^8.57.0
-        version: eslint@8.57.1
       event-stream:
         specifier: 4.0.1
         version: 4.0.1
@@ -3358,17 +3355,9 @@ packages:
     resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
-  '@eslint/eslintrc@2.1.4':
-    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
   '@eslint/eslintrc@3.3.1':
     resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/js@8.57.1':
-    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@eslint/js@9.12.0':
     resolution: {integrity: sha512-eohesHH8WFRUprDNyEREgqP6beG6htMeUYeCpkEgBCieCMme5r9zFWjzAJp//9S+Kub4rqE+jXe9Cp1a7IYIIA==}
@@ -3590,11 +3579,6 @@ packages:
     resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
-  '@humanwhocodes/config-array@0.13.0':
-    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
-    engines: {node: '>=10.10.0'}
-    deprecated: Use @eslint/config-array instead
-
   '@humanwhocodes/config-array@0.5.0':
     resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
     engines: {node: '>=10.10.0'}
@@ -3606,10 +3590,6 @@ packages:
 
   '@humanwhocodes/object-schema@1.2.1':
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
-    deprecated: Use @eslint/object-schema instead
-
-  '@humanwhocodes/object-schema@2.0.3':
-    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
   '@humanwhocodes/retry@0.3.1':
@@ -9309,10 +9289,6 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
-  eslint-scope@7.2.2:
-    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -9346,12 +9322,6 @@ packages:
   eslint@7.32.0:
     resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
     engines: {node: ^10.12.0 || >=12.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
-    hasBin: true
-
-  eslint@8.57.1:
-    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
@@ -19551,20 +19521,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/eslintrc@2.1.4':
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.4.0
-      espree: 9.6.1
-      globals: 13.24.0
-      ignore: 5.3.2
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
@@ -19578,8 +19534,6 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-
-  '@eslint/js@8.57.1': {}
 
   '@eslint/js@9.12.0': {}
 
@@ -19851,14 +19805,6 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
 
-  '@humanwhocodes/config-array@0.13.0':
-    dependencies:
-      '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@humanwhocodes/config-array@0.5.0':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -19870,8 +19816,6 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@1.2.1': {}
-
-  '@humanwhocodes/object-schema@2.0.3': {}
 
   '@humanwhocodes/retry@0.3.1': {}
 
@@ -27036,11 +26980,6 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
-  eslint-scope@7.2.2:
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
@@ -27105,49 +27044,6 @@ snapshots:
       table: 6.8.0
       text-table: 0.2.0
       v8-compile-cache: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint@8.57.1:
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.12.0(jiti@2.5.1))
-      '@eslint-community/regexpp': 4.11.1
-      '@eslint/eslintrc': 2.1.4
-      '@eslint/js': 8.57.1
-      '@humanwhocodes/config-array': 0.13.0
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      '@ungap/structured-clone': 1.2.0
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.7
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.24.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
 

--- a/test/unit/eslint-plugin-next/google-font-display.test.ts
+++ b/test/unit/eslint-plugin-next/google-font-display.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['google-font-display']
@@ -164,18 +163,7 @@ const tests = {
 }
 
 describe('google-font-display', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2020,
       sourceType: 'module',
@@ -186,5 +174,5 @@ describe('google-font-display', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/google-font-preconnect.test.ts
+++ b/test/unit/eslint-plugin-next/google-font-preconnect.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['google-font-preconnect']
@@ -59,18 +58,7 @@ const tests = {
 }
 
 describe('google-font-preconnect', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2020,
       sourceType: 'module',
@@ -81,5 +69,5 @@ describe('google-font-preconnect', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/inline-script-id.test.ts
+++ b/test/unit/eslint-plugin-next/inline-script-id.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['inline-script-id']
@@ -179,18 +178,7 @@ const tests = {
 }
 
 describe('inline-script-id', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -201,5 +189,5 @@ describe('inline-script-id', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/next-script-for-ga.test.ts
+++ b/test/unit/eslint-plugin-next/next-script-for-ga.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['next-script-for-ga']
@@ -232,18 +231,7 @@ const tests = {
 }
 
 describe('next-script-for-ga', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -254,5 +242,5 @@ describe('next-script-for-ga', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-assign-module-variable.test.ts
+++ b/test/unit/eslint-plugin-next/no-assign-module-variable.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-assign-module-variable']
@@ -34,18 +33,7 @@ const tests = {
 }
 
 describe('no-assign-module-variable', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -56,5 +44,5 @@ describe('no-assign-module-variable', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-async-client-component.test.ts
+++ b/test/unit/eslint-plugin-next/no-async-client-component.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-async-client-component']
@@ -118,18 +117,7 @@ const tests = {
 }
 
 describe('no-async-client-component', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -140,5 +128,5 @@ describe('no-async-client-component', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-before-interactive-script-outside-document.test.ts
+++ b/test/unit/eslint-plugin-next/no-before-interactive-script-outside-document.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-before-interactive-script-outside-document']
@@ -281,18 +280,7 @@ const tests = {
 }
 
 describe('no-before-interactive-script-outside-document', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -303,5 +291,5 @@ describe('no-before-interactive-script-outside-document', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-css-tags.test.ts
+++ b/test/unit/eslint-plugin-next/no-css-tags.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-css-tags']
@@ -96,18 +95,7 @@ const tests = {
 }
 
 describe('no-css-tags', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -118,5 +106,5 @@ describe('no-css-tags', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-document-import-in-page.test.ts
+++ b/test/unit/eslint-plugin-next/no-document-import-in-page.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-document-import-in-page']
@@ -110,18 +109,7 @@ const tests = {
 }
 
 describe('no-document-import-in-page', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -132,5 +120,5 @@ describe('no-document-import-in-page', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-duplicate-head.test.ts
+++ b/test/unit/eslint-plugin-next/no-duplicate-head.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-duplicate-head']
@@ -132,18 +131,7 @@ const tests = {
 }
 
 describe('no-duplicate-head', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -154,5 +142,5 @@ describe('no-duplicate-head', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-head-element.test.ts
+++ b/test/unit/eslint-plugin-next/no-head-element.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-head-element']
@@ -110,18 +109,7 @@ const tests = {
 }
 
 describe('no-head-element', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -132,5 +120,5 @@ describe('no-head-element', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-head-import-in-document.test.ts
+++ b/test/unit/eslint-plugin-next/no-head-import-in-document.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-head-import-in-document']
@@ -168,18 +167,7 @@ const tests = {
 }
 
 describe('no-head-import-in-document', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -190,5 +178,5 @@ describe('no-head-import-in-document', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -1,6 +1,5 @@
 /* eslint-env jest */
-import { Linter as ESLintLinterV8 } from 'eslint-v8'
-import { Linter as ESLintLinterV9 } from 'eslint'
+import { Linter } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 import assert from 'assert'
 import path from 'path'
@@ -13,38 +12,22 @@ const withoutPagesDir = path.join(__dirname, 'without-pages-dir')
 const withAppDir = path.join(__dirname, 'with-app-dir')
 
 const linters = {
-  v8: {
-    withoutPages: new ESLintLinterV8({
-      cwd: withoutPagesDir,
-    }),
-    withApp: new ESLintLinterV8({
-      cwd: withAppDir,
-    }),
-    withNestedPages: new ESLintLinterV8({
-      cwd: withNestedPagesDir,
-    }),
-    withCustomPages: new ESLintLinterV8({
-      cwd: withCustomPagesDir,
-    }),
-  },
-  v9: {
-    withoutPages: new ESLintLinterV9({
-      cwd: withoutPagesDir,
-      configType: 'eslintrc',
-    }),
-    withApp: new ESLintLinterV9({
-      cwd: withAppDir,
-      configType: 'eslintrc',
-    }),
-    withNestedPages: new ESLintLinterV9({
-      cwd: withNestedPagesDir,
-      configType: 'eslintrc',
-    }),
-    withCustomPages: new ESLintLinterV9({
-      cwd: withCustomPagesDir,
-      configType: 'eslintrc',
-    }),
-  },
+  withoutPages: new Linter({
+    cwd: withoutPagesDir,
+    configType: 'eslintrc',
+  }),
+  withApp: new Linter({
+    cwd: withAppDir,
+    configType: 'eslintrc',
+  }),
+  withNestedPages: new Linter({
+    cwd: withNestedPagesDir,
+    configType: 'eslintrc',
+  }),
+  withCustomPages: new Linter({
+    cwd: withCustomPagesDir,
+    configType: 'eslintrc',
+  }),
 }
 
 const linterConfig: any = {
@@ -90,12 +73,10 @@ const linterConfigWithNestedContentRootDirDirectory = {
   },
 }
 
-for (const version of ['v8', 'v9'] as const) {
-  for (const linter of Object.values(linters[version])) {
-    linter.defineRules({
-      'no-html-link-for-pages': NextESLintRule,
-    })
-  }
+for (const linter of Object.values(linters)) {
+  linter.defineRules({
+    'no-html-link-for-pages': NextESLintRule,
+  })
 }
 
 const validCode = `
@@ -275,264 +256,243 @@ export class Blah extends Head {
 }
 `
 describe('no-html-link-for-pages', function () {
-  for (const version of ['v8', 'v9']) {
-    it(`does not print warning when there are "pages" or "app" directories with rootDir in context settings (${version})`, function () {
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
-      linters[version].withNestedPages.verify(
-        validCode,
-        linterConfigWithNestedContentRootDirDirectory,
-        { filename: 'foo.js' }
-      )
-      expect(consoleSpy).not.toHaveBeenCalled()
-      consoleSpy.mockRestore()
+  it('does not print warning when there are "pages" or "app" directories with rootDir in context settings', function () {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
+    linters.withNestedPages.verify(
+      validCode,
+      linterConfigWithNestedContentRootDirDirectory,
+      { filename: 'foo.js' }
+    )
+    expect(consoleSpy).not.toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+  it('prints warning when there are no "pages" or "app" directories', function () {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
+    linters.withoutPages.verify(validCode, linterConfig, {
+      filename: 'foo.js',
     })
-    it(`prints warning when there are no "pages" or "app" directories (${version})`, function () {
-      // TODO(jiwon): unskip v8 test
-      // If this test runs standalone, it correctly calls warning,
-      // but on the second run, it doesn't. Skip the v8 test for now as
-      // there were no rule changes. Maybe related to:
-      // https://github.com/facebook/react/issues/7047#issuecomment-228614964
-      if (version === 'v8') return
-
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
-      linters[version].withoutPages.verify(validCode, linterConfig, {
-        filename: 'foo.js',
-      })
-      expect(consoleSpy).toHaveBeenCalledWith(
-        `Pages directory cannot be found at ${path.join(
-          withoutPagesDir,
-          'pages'
-        )} or ${path.join(
-          withoutPagesDir,
-          'src',
-          'pages'
-        )}. If using a custom path, please configure with the \`no-html-link-for-pages\` rule in your eslint config file.`
-      )
-      consoleSpy.mockRestore()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      `Pages directory cannot be found at ${path.join(
+        withoutPagesDir,
+        'pages'
+      )} or ${path.join(
+        withoutPagesDir,
+        'src',
+        'pages'
+      )}. If using a custom path, please configure with the \`no-html-link-for-pages\` rule in your eslint config file.`
+    )
+    consoleSpy.mockRestore()
+  })
+  it('does not print warning when there is "app" directory and no "pages" directory', function () {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
+    linters.withApp.verify(validCode, linterConfig, {
+      filename: 'foo.js',
     })
-    it(`does not print warning when there is "app" directory and no "pages" directory (${version})`, function () {
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
-      linters[version].withApp.verify(validCode, linterConfig, {
-        filename: 'foo.js',
-      })
-      expect(consoleSpy).not.toHaveBeenCalled()
-      consoleSpy.mockRestore()
+    expect(consoleSpy).not.toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+  it('valid link element', function () {
+    const report = linters.withCustomPages.verify(
+      validCode,
+      linterConfigWithCustomDirectory,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
+  })
+  it('valid link element with multiple directories', function () {
+    const report = linters.withCustomPages.verify(
+      validCode,
+      linterConfigWithMultipleDirectories,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
+  })
+  it('valid anchor element', function () {
+    const report = linters.withCustomPages.verify(
+      validAnchorCode,
+      linterConfigWithCustomDirectory,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
+  })
+  it('valid external link element', function () {
+    const report = linters.withCustomPages.verify(
+      validExternalLinkCode,
+      linterConfigWithCustomDirectory,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
+  })
+  it('valid download link element', function () {
+    const report = linters.withCustomPages.verify(
+      validDownloadLinkCode,
+      linterConfigWithCustomDirectory,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
+  })
+  it('valid target="_blank" link element', function () {
+    const report = linters.withCustomPages.verify(
+      validTargetBlankLinkCode,
+      linterConfigWithCustomDirectory,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
+  })
+  it('valid public file link element', function () {
+    const report = linters.withCustomPages.verify(
+      validPublicFile,
+      linterConfigWithCustomDirectory,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
+  })
+  it('invalid static route', function () {
+    const [report] = linters.withCustomPages.verify(
+      invalidStaticCode,
+      linterConfigWithCustomDirectory,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('invalid dynamic route', function () {
+    const [report] = linters.withCustomPages.verify(
+      invalidDynamicCode,
+      linterConfigWithCustomDirectory,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/list/foo/bar/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+    const [secondReport] = linters.withCustomPages.verify(
+      secondInvalidDynamicCode,
+      linterConfigWithCustomDirectory,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(secondReport, undefined, 'No lint errors found.')
+    assert.equal(
+      secondReport.message,
+      'Do not use an `<a>` element to navigate to `/list/foo/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+    const [thirdReport] = linters.withCustomPages.verify(
+      thirdInvalidDynamicCode,
+      linterConfigWithCustomDirectory,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(thirdReport, undefined, 'No lint errors found.')
+    assert.equal(
+      thirdReport.message,
+      'Do not use an `<a>` element to navigate to `/list/lorem-ipsum/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('valid link element with appDir', function () {
+    const report = linters.withApp.verify(validCode, linterConfig, {
+      filename: 'foo.js',
     })
-    it(`valid link element (${version})`, function () {
-      const report = linters[version].withCustomPages.verify(
-        validCode,
-        linterConfigWithCustomDirectory,
-        { filename: 'foo.js' }
-      )
-      assert.deepEqual(report, [])
+    assert.deepEqual(report, [])
+  })
+  it('valid link element with multiple directories with appDir', function () {
+    const report = linters.withApp.verify(validCode, linterConfig, {
+      filename: 'foo.js',
     })
-    it(`valid link element with multiple directories (${version})`, function () {
-      const report = linters[version].withCustomPages.verify(
-        validCode,
-        linterConfigWithMultipleDirectories,
-        { filename: 'foo.js' }
-      )
-      assert.deepEqual(report, [])
+    assert.deepEqual(report, [])
+  })
+  it('valid anchor element with appDir', function () {
+    const report = linters.withApp.verify(validAnchorCode, linterConfig, {
+      filename: 'foo.js',
     })
-    it(`valid anchor element (${version})`, function () {
-      const report = linters[version].withCustomPages.verify(
-        validAnchorCode,
-        linterConfigWithCustomDirectory,
-        { filename: 'foo.js' }
-      )
-      assert.deepEqual(report, [])
+    assert.deepEqual(report, [])
+  })
+  it('valid external link element with appDir', function () {
+    const report = linters.withApp.verify(validExternalLinkCode, linterConfig, {
+      filename: 'foo.js',
     })
-    it(`valid external link element (${version})`, function () {
-      const report = linters[version].withCustomPages.verify(
-        validExternalLinkCode,
-        linterConfigWithCustomDirectory,
-        { filename: 'foo.js' }
-      )
-      assert.deepEqual(report, [])
+    assert.deepEqual(report, [])
+  })
+  it('valid download link element with appDir', function () {
+    const report = linters.withApp.verify(validDownloadLinkCode, linterConfig, {
+      filename: 'foo.js',
     })
-    it(`valid download link element (${version})`, function () {
-      const report = linters[version].withCustomPages.verify(
-        validDownloadLinkCode,
-        linterConfigWithCustomDirectory,
-        { filename: 'foo.js' }
-      )
-      assert.deepEqual(report, [])
+    assert.deepEqual(report, [])
+  })
+  it('valid target="_blank" link element with appDir', function () {
+    const report = linters.withApp.verify(
+      validTargetBlankLinkCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
+  })
+  it('valid public file link element with appDir', function () {
+    const report = linters.withApp.verify(validPublicFile, linterConfig, {
+      filename: 'foo.js',
     })
-    it(`valid target="_blank" link element (${version})`, function () {
-      const report = linters[version].withCustomPages.verify(
-        validTargetBlankLinkCode,
-        linterConfigWithCustomDirectory,
-        { filename: 'foo.js' }
-      )
-      assert.deepEqual(report, [])
+    assert.deepEqual(report, [])
+  })
+  it('invalid static route with appDir', function () {
+    const [report] = linters.withApp.verify(invalidStaticCode, linterConfig, {
+      filename: 'foo.js',
     })
-    it(`valid public file link element (${version})`, function () {
-      const report = linters[version].withCustomPages.verify(
-        validPublicFile,
-        linterConfigWithCustomDirectory,
-        { filename: 'foo.js' }
-      )
-      assert.deepEqual(report, [])
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('invalid dynamic route with appDir', function () {
+    const [report] = linters.withApp.verify(invalidDynamicCode, linterConfig, {
+      filename: 'foo.js',
     })
-    it(`invalid static route (${version})`, function () {
-      const [report] = linters[version].withCustomPages.verify(
-        invalidStaticCode,
-        linterConfigWithCustomDirectory,
-        { filename: 'foo.js' }
-      )
-      assert.notEqual(report, undefined, 'No lint errors found.')
-      assert.equal(
-        report.message,
-        'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
-      )
-    })
-    it(`invalid dynamic route (${version})`, function () {
-      const [report] = linters[version].withCustomPages.verify(
-        invalidDynamicCode,
-        linterConfigWithCustomDirectory,
-        { filename: 'foo.js' }
-      )
-      assert.notEqual(report, undefined, 'No lint errors found.')
-      assert.equal(
-        report.message,
-        'Do not use an `<a>` element to navigate to `/list/foo/bar/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
-      )
-      const [secondReport] = linters[version].withCustomPages.verify(
-        secondInvalidDynamicCode,
-        linterConfigWithCustomDirectory,
-        { filename: 'foo.js' }
-      )
-      assert.notEqual(secondReport, undefined, 'No lint errors found.')
-      assert.equal(
-        secondReport.message,
-        'Do not use an `<a>` element to navigate to `/list/foo/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
-      )
-      const [thirdReport] = linters[version].withCustomPages.verify(
-        thirdInvalidDynamicCode,
-        linterConfigWithCustomDirectory,
-        { filename: 'foo.js' }
-      )
-      assert.notEqual(thirdReport, undefined, 'No lint errors found.')
-      assert.equal(
-        thirdReport.message,
-        'Do not use an `<a>` element to navigate to `/list/lorem-ipsum/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
-      )
-    })
-    it(`valid link element with appDir (${version})`, function () {
-      const report = linters[version].withApp.verify(validCode, linterConfig, {
-        filename: 'foo.js',
-      })
-      assert.deepEqual(report, [])
-    })
-    it(`valid link element with multiple directories with appDir (${version})`, function () {
-      const report = linters[version].withApp.verify(validCode, linterConfig, {
-        filename: 'foo.js',
-      })
-      assert.deepEqual(report, [])
-    })
-    it(`valid anchor element with appDir (${version})`, function () {
-      const report = linters[version].withApp.verify(
-        validAnchorCode,
-        linterConfig,
-        { filename: 'foo.js' }
-      )
-      assert.deepEqual(report, [])
-    })
-    it(`valid external link element with appDir (${version})`, function () {
-      const report = linters[version].withApp.verify(
-        validExternalLinkCode,
-        linterConfig,
-        { filename: 'foo.js' }
-      )
-      assert.deepEqual(report, [])
-    })
-    it(`valid download link element with appDir (${version})`, function () {
-      const report = linters[version].withApp.verify(
-        validDownloadLinkCode,
-        linterConfig,
-        { filename: 'foo.js' }
-      )
-      assert.deepEqual(report, [])
-    })
-    it(`valid target="_blank" link element with appDir (${version})`, function () {
-      const report = linters[version].withApp.verify(
-        validTargetBlankLinkCode,
-        linterConfig,
-        { filename: 'foo.js' }
-      )
-      assert.deepEqual(report, [])
-    })
-    it(`valid public file link element with appDir (${version})`, function () {
-      const report = linters[version].withApp.verify(
-        validPublicFile,
-        linterConfig,
-        { filename: 'foo.js' }
-      )
-      assert.deepEqual(report, [])
-    })
-    it(`invalid static route with appDir (${version})`, function () {
-      const [report] = linters[version].withApp.verify(
-        invalidStaticCode,
-        linterConfig,
-        { filename: 'foo.js' }
-      )
-      assert.notEqual(report, undefined, 'No lint errors found.')
-      assert.equal(
-        report.message,
-        'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
-      )
-    })
-    it(`invalid dynamic route with appDir (${version})`, function () {
-      const [report] = linters[version].withApp.verify(
-        invalidDynamicCode,
-        linterConfig,
-        { filename: 'foo.js' }
-      )
-      assert.notEqual(report, undefined, 'No lint errors found.')
-      assert.equal(
-        report.message,
-        'Do not use an `<a>` element to navigate to `/list/foo/bar/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
-      )
-      const [secondReport] = linters[version].withApp.verify(
-        secondInvalidDynamicCode,
-        linterConfig,
-        { filename: 'foo.js' }
-      )
-      assert.notEqual(secondReport, undefined, 'No lint errors found.')
-      assert.equal(
-        secondReport.message,
-        'Do not use an `<a>` element to navigate to `/list/foo/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
-      )
-      const [thirdReport] = linters[version].withApp.verify(
-        thirdInvalidDynamicCode,
-        linterConfig,
-        { filename: 'foo.js' }
-      )
-      assert.notEqual(thirdReport, undefined, 'No lint errors found.')
-      assert.equal(
-        thirdReport.message,
-        'Do not use an `<a>` element to navigate to `/list/lorem-ipsum/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
-      )
-    })
-    it(`valid intercepted route with appDir (${version})`, function () {
-      const report = linters[version].withApp.verify(
-        validInterceptedRouteCode,
-        linterConfig,
-        { filename: 'foo.js' }
-      )
-      assert.deepEqual(report, [])
-    })
-    it(`invalid intercepted route with appDir (${version})`, function () {
-      const [report] = linters[version].withApp.verify(
-        invalidInterceptedRouteCode,
-        linterConfig,
-        { filename: 'foo.js' }
-      )
-      assert.notEqual(report, undefined, 'No lint errors found.')
-      assert.equal(
-        report.message,
-        'Do not use an `<a>` element to navigate to `/photo/1/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
-      )
-    })
-  }
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/list/foo/bar/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+    const [secondReport] = linters.withApp.verify(
+      secondInvalidDynamicCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(secondReport, undefined, 'No lint errors found.')
+    assert.equal(
+      secondReport.message,
+      'Do not use an `<a>` element to navigate to `/list/foo/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+    const [thirdReport] = linters.withApp.verify(
+      thirdInvalidDynamicCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(thirdReport, undefined, 'No lint errors found.')
+    assert.equal(
+      thirdReport.message,
+      'Do not use an `<a>` element to navigate to `/list/lorem-ipsum/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('valid intercepted route with appDir', function () {
+    const report = linters.withApp.verify(
+      validInterceptedRouteCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
+  })
+  it('invalid intercepted route with appDir', function () {
+    const [report] = linters.withApp.verify(
+      invalidInterceptedRouteCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/photo/1/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
 })

--- a/test/unit/eslint-plugin-next/no-img-element.test.ts
+++ b/test/unit/eslint-plugin-next/no-img-element.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-img-element']
@@ -156,18 +155,7 @@ return new ImageResponse(
 }
 
 describe('no-img-element', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -178,5 +166,5 @@ describe('no-img-element', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-page-custom-font.test.ts
+++ b/test/unit/eslint-plugin-next/no-page-custom-font.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-page-custom-font']
@@ -192,18 +191,7 @@ const tests = {
 }
 
 describe('no-page-custom-font', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -214,5 +202,5 @@ describe('no-page-custom-font', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-script-component-in-head.test.ts
+++ b/test/unit/eslint-plugin-next/no-script-component-in-head.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-script-component-in-head']
@@ -42,18 +41,7 @@ const tests = {
 }
 
 describe('no-script-component-in-head', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -64,5 +52,5 @@ describe('no-script-component-in-head', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-styled-jsx-in-document.test.ts
+++ b/test/unit/eslint-plugin-next/no-styled-jsx-in-document.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-styled-jsx-in-document']
@@ -116,18 +115,7 @@ const tests = {
 }
 
 describe('no-styled-jsx-in-document', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -138,5 +126,5 @@ describe('no-styled-jsx-in-document', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-sync-scripts.test.ts
+++ b/test/unit/eslint-plugin-next/no-sync-scripts.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-sync-scripts']
@@ -72,18 +71,7 @@ const tests = {
 }
 
 describe('no-sync-scripts', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -94,5 +82,5 @@ describe('no-sync-scripts', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-title-in-document-head.test.ts
+++ b/test/unit/eslint-plugin-next/no-title-in-document-head.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-title-in-document-head']
@@ -61,18 +60,7 @@ const tests = {
 }
 
 describe('no-title-in-document-head', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -83,5 +71,5 @@ describe('no-title-in-document-head', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-typos.test.ts
+++ b/test/unit/eslint-plugin-next/no-typos.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-typos']
@@ -121,18 +120,7 @@ const tests = {
 }
 
 describe('no-typos', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -143,5 +131,5 @@ describe('no-typos', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })

--- a/test/unit/eslint-plugin-next/no-unwanted-polyfillio.test.ts
+++ b/test/unit/eslint-plugin-next/no-unwanted-polyfillio.test.ts
@@ -1,5 +1,4 @@
-import { RuleTester as ESLintTesterV8 } from 'eslint-v8'
-import { RuleTester as ESLintTesterV9 } from 'eslint'
+import { RuleTester } from 'eslint'
 import { rules } from '@next/eslint-plugin-next'
 
 const NextESLintRule = rules['no-unwanted-polyfillio']
@@ -137,18 +136,7 @@ const tests = {
 }
 
 describe('no-unwanted-polyfillio', () => {
-  new ESLintTesterV8({
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        modules: true,
-        jsx: true,
-      },
-    },
-  }).run('eslint-v8', NextESLintRule, tests)
-
-  new ESLintTesterV9({
+  new RuleTester({
     languageOptions: {
       ecmaVersion: 2018,
       sourceType: 'module',
@@ -159,5 +147,5 @@ describe('no-unwanted-polyfillio', () => {
         },
       },
     },
-  }).run('eslint-v9', NextESLintRule, tests)
+  }).run('eslint', NextESLintRule, tests)
 })


### PR DESCRIPTION
ESLint plugin defaults to flat config, and we also dropped the built-in lint check at https://github.com/vercel/next.js/pull/83136, so we can sunset the deprecated ESLint v8 testing.