### PR TITLE
[next-upgrade] misc: update comment

### DIFF
--- a/packages/next-codemod/lib/utils.ts
+++ b/packages/next-codemod/lib/utils.ts
@@ -39,6 +39,7 @@ export function onCancel() {
  * When adding a new codemod, ensure to set the target canary version
  * instead of the stable version. This is for `@next/codemod upgrade`
  * to correctly pick up the codemod for the next pre-release version.
+ * This is also essential for correctly upgrading from canary to canary.
  */
 export const TRANSFORMER_INQUIRER_CHOICES = [
   {


### PR DESCRIPTION
Not affect release. Just a follow-up for https://github.com/vercel/next.js/pull/84726
Improved comment of emphasizing we should set the codemod version to the canary version for upgrading canary to canary.