### PR TITLE
Update test/CNA templates React version to 19.2.0

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -14,7 +14,7 @@ import { Bundler, GetTemplateFileArgs, InstallTemplateArgs } from "./types";
 
 // Do not rename or format. sync-react script relies on this line.
 // prettier-ignore
-const nextjsReactPeerVersion = "19.1.0";
+const nextjsReactPeerVersion = "19.2.0";
 
 /**
  * Get the file path for a given file in a template, e.g. "next.config.js".

--- a/run-tests.js
+++ b/run-tests.js
@@ -16,7 +16,7 @@ const { getTestFilter } = require('./test/get-test-filter')
 
 // Do not rename or format. sync-react script relies on this line.
 // prettier-ignore
-const nextjsReactPeerVersion = "19.1.0";
+const nextjsReactPeerVersion = "19.2.0";
 
 let argv = require('yargs/yargs')(process.argv.slice(2))
   .string('type')

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -360,7 +360,7 @@ Or, run this command with no arguments to use the most recently published versio
       /const nextjsReactPeerVersion = "[^"]+";/,
       `const nextjsReactPeerVersion = "${highestPagesRouterReactVersion}";`
     )
-    if (activePagesRouterReact === null && updatedSource === previousSource) {
+    if (updatedSource === previousSource) {
       errors.push(
         new Error(
           `${fileName}: Failed to update ${baseVersionStr} to ${highestPagesRouterReactVersion}. Is this file still referencing the React peer dependency version?`

--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -353,23 +353,21 @@ Or, run this command with no arguments to use the most recently published versio
   )
   const { sha: baseSha, dateString: baseDateString } = baseVersionInfo
 
-  if (syncPagesRouterReact) {
-    for (const fileName of filesReferencingReactPeerDependencyVersion) {
-      const filePath = path.join(cwd, fileName)
-      const previousSource = await fsp.readFile(filePath, 'utf-8')
-      const updatedSource = previousSource.replace(
-        /const nextjsReactPeerVersion = "[^"]+";/,
-        `const nextjsReactPeerVersion = "${highestPagesRouterReactVersion}";`
-      )
-      if (activePagesRouterReact === null && updatedSource === previousSource) {
-        errors.push(
-          new Error(
-            `${fileName}: Failed to update ${baseVersionStr} to ${highestPagesRouterReactVersion}. Is this file still referencing the React peer dependency version?`
-          )
+  for (const fileName of filesReferencingReactPeerDependencyVersion) {
+    const filePath = path.join(cwd, fileName)
+    const previousSource = await fsp.readFile(filePath, 'utf-8')
+    const updatedSource = previousSource.replace(
+      /const nextjsReactPeerVersion = "[^"]+";/,
+      `const nextjsReactPeerVersion = "${highestPagesRouterReactVersion}";`
+    )
+    if (activePagesRouterReact === null && updatedSource === previousSource) {
+      errors.push(
+        new Error(
+          `${fileName}: Failed to update ${baseVersionStr} to ${highestPagesRouterReactVersion}. Is this file still referencing the React peer dependency version?`
         )
-      } else {
-        await fsp.writeFile(filePath, updatedSource)
-      }
+      )
+    } else {
+      await fsp.writeFile(filePath, updatedSource)
     }
   }
 

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -114,7 +114,7 @@ describe('Error overlay for hydration errors in Pages router', () => {
        +                     client
        -                     server
                      ...",
-         "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
+         "description": "Hydration failed because the server rendered text didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Recoverable Error",
          "source": "index.js (5:9) @ Mismatch

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -65,7 +65,7 @@ type OmitFirstArgument<F> = F extends (
 
 // Do not rename or format. sync-react script relies on this line.
 // prettier-ignore
-const nextjsReactPeerVersion = "19.1.0";
+const nextjsReactPeerVersion = "19.2.0";
 
 export class NextInstance {
   protected files: ResolvedFileConfig


### PR DESCRIPTION
The peerDeps are already bumped to 19.2.0 at https://github.com/vercel/next.js/pull/84463, but the test/CNA templates weren't updated as the `syncPagesRouterReact` value is always false at the moment, which blocked the update.

Therefore, remove the `syncPagesRouterReact` condition to match the actual peerDeps bump.