### PR TITLE
Write `.next/dev/types/**/*.d.ts` to default tsconfig

### DIFF
--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -27,7 +27,8 @@ function verifyTypeScriptSetup(
   cacheDir: string | undefined,
   enableWorkerThreads: boolean | undefined,
   hasAppDir: boolean,
-  hasPagesDir: boolean
+  hasPagesDir: boolean,
+  isolatedDevBuild: boolean | undefined
 ) {
   const typeCheckWorker = new Worker(
     require.resolve('../lib/verify-typescript-setup'),
@@ -54,6 +55,7 @@ function verifyTypeScriptSetup(
       cacheDir,
       hasAppDir,
       hasPagesDir,
+      isolatedDevBuild,
     })
     .then((result) => {
       typeCheckWorker.end()
@@ -116,7 +118,8 @@ export async function startTypeChecking({
           cacheDir,
           config.experimental.workerThreads,
           !!appDir,
-          !!pagesDir
+          !!pagesDir,
+          config.experimental.isolatedDevBuild
         ).then((resolved) => {
           const checkEnd = process.hrtime(typeCheckAndLintStart)
           return [resolved, checkEnd] as const

--- a/packages/next/src/cli/next-test.ts
+++ b/packages/next/src/cli/next-test.ts
@@ -146,6 +146,7 @@ async function runPlaywright(
       disableStaticImages: nextConfig.images.disableStaticImages,
       hasAppDir: !!appDir,
       hasPagesDir: !!pagesDir,
+      isolatedDevBuild: nextConfig.experimental.isolatedDevBuild,
     })
 
     const isUsingTypeScript = !!typeScriptVersion

--- a/packages/next/src/cli/next-typegen.ts
+++ b/packages/next/src/cli/next-typegen.ts
@@ -60,6 +60,7 @@ const nextTypegen = async (
     disableStaticImages: nextConfig.images.disableStaticImages,
     hasAppDir: !!appDir,
     hasPagesDir: !!pagesDir,
+    isolatedDevBuild: nextConfig.experimental.isolatedDevBuild,
   })
 
   console.log('Generating route types...')

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.test.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.test.ts
@@ -15,6 +15,7 @@ describe('writeConfigurationDefaults()', () => {
   let tsConfigPath: string
   let isFirstTimeSetup: boolean
   let hasPagesDir: boolean
+  let isolatedDevBuild = true
 
   beforeEach(async () => {
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
@@ -45,7 +46,8 @@ describe('writeConfigurationDefaults()', () => {
         isFirstTimeSetup,
         hasAppDir,
         distDir,
-        hasPagesDir
+        hasPagesDir,
+        isolatedDevBuild
       )
 
       const tsConfig = JSON.parse(
@@ -53,70 +55,71 @@ describe('writeConfigurationDefaults()', () => {
       )
 
       expect(tsConfig).toMatchInlineSnapshot(`
+       {
+         "compilerOptions": {
+           "allowJs": true,
+           "esModuleInterop": true,
+           "incremental": true,
+           "isolatedModules": true,
+           "jsx": "react-jsx",
+           "lib": [
+             "dom",
+             "dom.iterable",
+             "esnext",
+           ],
+           "module": "esnext",
+           "moduleResolution": "node",
+           "noEmit": true,
+           "plugins": [
              {
-               "compilerOptions": {
-                 "allowJs": true,
-                 "esModuleInterop": true,
-                 "incremental": true,
-                 "isolatedModules": true,
-                 "jsx": "react-jsx",
-                 "lib": [
-                   "dom",
-                   "dom.iterable",
-                   "esnext",
-                 ],
-                 "module": "esnext",
-                 "moduleResolution": "node",
-                 "noEmit": true,
-                 "plugins": [
-                   {
-                     "name": "next",
-                   },
-                 ],
-                 "resolveJsonModule": true,
-                 "skipLibCheck": true,
-                 "strict": false,
-                 "target": "ES2017",
-               },
-               "exclude": [
-                 "node_modules",
-               ],
-               "include": [
-                 "next-env.d.ts",
-                 ".next/types/**/*.ts",
-                 "**/*.mts",
-                 "**/*.ts",
-                 "**/*.tsx",
-               ],
-             }
-          `)
+               "name": "next",
+             },
+           ],
+           "resolveJsonModule": true,
+           "skipLibCheck": true,
+           "strict": false,
+           "target": "ES2017",
+         },
+         "exclude": [
+           "node_modules",
+         ],
+         "include": [
+           "next-env.d.ts",
+           ".next/types/**/*.ts",
+           ".next/dev/types/**/*.ts",
+           "**/*.mts",
+           "**/*.ts",
+           "**/*.tsx",
+         ],
+       }
+      `)
 
       expect(stripAnsi(consoleLogSpy.mock.calls.flat().join('\n')))
         .toMatchInlineSnapshot(`
-        "
-           We detected TypeScript in your project and reconfigured your tsconfig.json file for you. Strict-mode is set to false by default.
-           The following suggested values were added to your tsconfig.json. These values can be changed to fit your project's needs:
+       "
+          We detected TypeScript in your project and reconfigured your tsconfig.json file for you. Strict-mode is set to false by default.
+          The following suggested values were added to your tsconfig.json. These values can be changed to fit your project's needs:
 
-           	- target was set to ES2017 (For top-level \`await\`. Note: Next.js only polyfills for the esmodules target.)
-           	- lib was set to dom,dom.iterable,esnext
-           	- allowJs was set to true
-           	- skipLibCheck was set to true
-           	- strict was set to false
-           	- noEmit was set to true
-           	- incremental was set to true
-           	- include was set to ['next-env.d.ts', '.next/types/**/*.ts', '**/*.mts', '**/*.ts', '**/*.tsx']
-           	- plugins was updated to add { name: 'next' }
-           	- exclude was set to ['node_modules']
+          	- target was set to ES2017 (For top-level \`await\`. Note: Next.js only polyfills for the esmodules target.)
+          	- lib was set to dom,dom.iterable,esnext
+          	- allowJs was set to true
+          	- skipLibCheck was set to true
+          	- strict was set to false
+          	- noEmit was set to true
+          	- incremental was set to true
+          	- include was set to ['next-env.d.ts', '.next/types/**/*.ts', '.next/dev/types/**/*.ts', '**/*.mts', '**/*.ts', '**/*.tsx']
+          	- plugins was updated to add { name: 'next' }
+          	- exclude was set to ['node_modules']
 
-           The following mandatory changes were made to your tsconfig.json:
+          The following mandatory changes were made to your tsconfig.json:
 
-           	- module was set to esnext (for dynamic import() support)
-           	- esModuleInterop was set to true (requirement for SWC / babel)
-           	- moduleResolution was set to node (to match webpack resolution)
-           	- resolveJsonModule was set to true (to match webpack resolution)
-           	- isolatedModules was set to true (requirement for SWC / Babel)
-           	- jsx was set to react-jsx (next.js uses the React automatic runtime)
-        "
+          	- module was set to esnext (for dynamic import() support)
+          	- esModuleInterop was set to true (requirement for SWC / babel)
+          	- moduleResolution was set to node (to match webpack resolution)
+          	- resolveJsonModule was set to true (to match webpack resolution)
+          	- isolatedModules was set to true (requirement for SWC / Babel)
+          	- jsx was set to react-jsx (next.js uses the React automatic runtime)
+       "
       `)
     })
 
@@ -133,7 +136,8 @@ describe('writeConfigurationDefaults()', () => {
         isFirstTimeSetup,
         hasAppDir,
         distDir,
-        hasPagesDir
+        hasPagesDir,
+        isolatedDevBuild
       )
 
       expect(stripAnsi(consoleLogSpy.mock.calls.flat().join('\n'))).not.toMatch(
@@ -165,7 +169,8 @@ describe('writeConfigurationDefaults()', () => {
             isFirstTimeSetup,
             hasAppDir,
             distDir,
-            hasPagesDir
+            hasPagesDir,
+            isolatedDevBuild
           )
         ).resolves.not.toThrow()
 

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -43,6 +43,7 @@ export async function verifyTypeScriptSetup({
   disableStaticImages,
   hasAppDir,
   hasPagesDir,
+  isolatedDevBuild,
 }: {
   dir: string
   distDir: string
@@ -53,6 +54,7 @@ export async function verifyTypeScriptSetup({
   disableStaticImages: boolean
   hasAppDir: boolean
   hasPagesDir: boolean
+  isolatedDevBuild: boolean | undefined
 }): Promise<{ result?: TypeCheckResult; version: string | null }> {
   const tsConfigFileName = tsconfigPath || 'tsconfig.json'
   const resolvedTsConfigPath = path.join(dir, tsConfigFileName)
@@ -126,7 +128,8 @@ export async function verifyTypeScriptSetup({
       intent.firstTimeSetup,
       hasAppDir,
       distDir,
-      hasPagesDir
+      hasPagesDir,
+      isolatedDevBuild
     )
     // Write out the necessary `next-env.d.ts` file to correctly register
     // Next.js' types:

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -145,6 +145,7 @@ async function verifyTypeScript(opts: SetupOpts) {
     disableStaticImages: opts.nextConfig.images.disableStaticImages,
     hasAppDir: !!opts.appDir,
     hasPagesDir: !!opts.pagesDir,
+    isolatedDevBuild: opts.nextConfig.experimental.isolatedDevBuild,
   })
 
   if (verifyResult.version) {

--- a/test/e2e/app-dir/log-file/tsconfig.json
+++ b/test/e2e/app-dir/log-file/tsconfig.json
@@ -27,6 +27,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
   "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]

--- a/test/integration/tsconfig-verifier/test/index.test.js
+++ b/test/integration/tsconfig-verifier/test/index.test.js
@@ -54,6 +54,7 @@ import path from 'path'
          "include": [
            "next-env.d.ts",
            ".next/types/**/*.ts",
+           ".next/dev/types/**/*.ts",
            "**/*.mts",
            "**/*.ts",
            "**/*.tsx"
@@ -110,6 +111,7 @@ import path from 'path'
          "include": [
            "next-env.d.ts",
            ".next/types/**/*.ts",
+           ".next/dev/types/**/*.ts",
            "**/*.mts",
            "**/*.ts",
            "**/*.tsx"
@@ -185,6 +187,7 @@ import path from 'path'
          "include": [
            "next-env.d.ts",
            ".next/types/**/*.ts",
+           ".next/dev/types/**/*.ts",
            "**/*.mts",
            "**/*.ts",
            "**/*.tsx"
@@ -239,6 +242,7 @@ import path from 'path'
          "include": [
            "next-env.d.ts",
            ".next/types/**/*.ts",
+           ".next/dev/types/**/*.ts",
            "**/*.mts",
            "**/*.ts",
            "**/*.tsx"
@@ -292,6 +296,7 @@ import path from 'path'
          "include": [
            "next-env.d.ts",
            ".next/types/**/*.ts",
+           ".next/dev/types/**/*.ts",
            "**/*.mts",
            "**/*.ts",
            "**/*.tsx"
@@ -349,6 +354,7 @@ import path from 'path'
          "include": [
            "next-env.d.ts",
            ".next/types/**/*.ts",
+           ".next/dev/types/**/*.ts",
            "**/*.mts",
            "**/*.ts",
            "**/*.tsx"
@@ -406,6 +412,7 @@ import path from 'path'
          "include": [
            "next-env.d.ts",
            ".next/types/**/*.ts",
+           ".next/dev/types/**/*.ts",
            "**/*.mts",
            "**/*.ts",
            "**/*.tsx"
@@ -460,6 +467,7 @@ import path from 'path'
          "include": [
            "next-env.d.ts",
            ".next/types/**/*.ts",
+           ".next/dev/types/**/*.ts",
            "**/*.mts",
            "**/*.ts",
            "**/*.tsx"
@@ -517,6 +525,7 @@ import path from 'path'
          "include": [
            "next-env.d.ts",
            ".next/types/**/*.ts",
+           ".next/dev/types/**/*.ts",
            "**/*.mts",
            "**/*.ts",
            "**/*.tsx"
@@ -574,6 +583,7 @@ import path from 'path'
          "include": [
            "next-env.d.ts",
            ".next/types/**/*.ts",
+           ".next/dev/types/**/*.ts",
            "**/*.mts",
            "**/*.ts",
            "**/*.tsx"


### PR DESCRIPTION
The write default tsconfig didn't include `.next/dev/types/**/*.d.ts`, so it was unnecessarily logging on dev even on writing for the first time:

```
- include was updated to add '.next/dev/types/**/*.d.ts'
```