### PR TITLE
remove `clientParamParsing` configuration & bundle it with `cacheComponents`

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -199,9 +199,6 @@ export function getDefineEnv({
     'process.env.__NEXT_CLIENT_SEGMENT_CACHE': Boolean(
       config.experimental.clientSegmentCache
     ),
-    'process.env.__NEXT_CLIENT_PARAM_PARSING': Boolean(
-      config.experimental.clientParamParsing
-    ),
     'process.env.__NEXT_CLIENT_VALIDATE_RSC_REQUEST_HEADERS': Boolean(
       config.experimental.validateRSCRequestHeaders
     ),

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -468,8 +468,8 @@ export type RoutesManifest = {
     prefetchSegmentSuffix: typeof RSC_SEGMENT_SUFFIX
 
     /**
-     * Whether the client param parsing is enabled. This is only relevant for
-     * app pages when PPR is enabled.
+     * Whether the client param parsing is enabled. This is automatically enabled when
+     * cacheComponents is enabled.
      */
     clientParamParsing: boolean
 
@@ -1582,24 +1582,13 @@ export default async function build(
               prefetchSegmentHeader: NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
               prefetchSegmentSuffix: RSC_SEGMENT_SUFFIX,
               prefetchSegmentDirSuffix: RSC_SEGMENTS_DIR_SUFFIX,
-              clientParamParsing:
-                // NOTE: once this is the default for `clientSegmentCache`, this
-                // should exclusively be based on the `clientSegmentCache` flag.
-                config.experimental.clientParamParsing ?? false,
-              clientParamParsingOrigins: config.experimental.clientParamParsing
-                ? config.experimental.clientParamParsingOrigins
-                : undefined,
+              clientParamParsing: config.experimental.cacheComponents ?? false,
+              clientParamParsingOrigins:
+                config.experimental.clientParamParsingOrigins,
               dynamicRSCPrerender:
-                // Only enable RDC for Navigations if the feature is enabled.
-                // Once we've made RDC for Navigations the default for PPR, we
-                // can remove the check for `config.experimental.rdcForNavigations`.
                 isAppPPREnabled &&
                 config.experimental.rdcForNavigations === true &&
-                // Temporarily we require that clientParamParsing is enabled for
-                // RDC for Navigations. This is due to a builder configuration
-                // bug that manifests as invalid query params being passed to
-                // the resume lambdas.
-                config.experimental.clientParamParsing === true,
+                config.experimental.cacheComponents === true,
             },
             rewriteHeaders: {
               pathHeader: NEXT_REWRITTEN_PATH_HEADER,
@@ -2943,7 +2932,7 @@ export default async function build(
                     // completely static.
                     !(
                       config.experimental.clientSegmentCache &&
-                      config.experimental.clientParamParsing
+                      config.experimental.cacheComponents
                     )
                   ) {
                     return
@@ -3259,7 +3248,7 @@ export default async function build(
                   // this route.
                   !(
                     config.experimental.clientSegmentCache &&
-                    config.experimental.clientParamParsing &&
+                    config.experimental.cacheComponents &&
                     isRoutePPREnabled
                   )
                 ) {
@@ -3369,7 +3358,7 @@ export default async function build(
                     // this case. This only applies if we have PPR enabled for
                     // this route.
                     !config.experimental.clientSegmentCache ||
-                    !config.experimental.clientParamParsing ||
+                    !config.experimental.cacheComponents ||
                     !isRoutePPREnabled
                   ) {
                     prefetchDataRoute = path.posix.join(

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -296,11 +296,7 @@ export async function handler(
   const supportsRSCForNavigations =
     isRoutePPREnabled &&
     nextConfig.experimental.rdcForNavigations === true &&
-    // Temporarily we require that clientParamParsing is enabled for
-    // RDC for Navigations. This is due to a builder configuration
-    // bug that manifests as invalid query params being passed to
-    // the resume lambdas.
-    nextConfig.experimental.clientParamParsing === true
+    nextConfig.experimental.cacheComponents === true
 
   // In development, we always want to generate dynamic HTML.
   const supportsDynamicResponse: boolean =
@@ -558,9 +554,6 @@ export async function handler(
             clientSegmentCache: Boolean(
               nextConfig.experimental.clientSegmentCache
             ),
-            clientParamParsing: Boolean(
-              nextConfig.experimental.clientParamParsing
-            ),
             dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
             inlineCss: Boolean(nextConfig.experimental.inlineCss),
             authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
@@ -739,14 +732,14 @@ export async function handler(
           throw new NoFallbackError()
         }
 
-        // When client param parsing is enabled, we can use the fallback
+        // When cacheComponents is enabled, we can use the fallback
         // response if the request is not a dynamic RSC request because the
         // RSC data when this feature flag is enabled does not contain any
         // param references. Without this feature flag enabled, the RSC data
         // contains param references, and therefore we can't use the fallback.
         if (
           isRoutePPREnabled &&
-          (nextConfig.experimental.clientParamParsing
+          (nextConfig.experimental.cacheComponents
             ? !isDynamicRSCRequest
             : !isRSCRequest)
         ) {
@@ -1203,9 +1196,7 @@ export async function handler(
         if (typeof cachedData.rscData === 'undefined') {
           // If the response is not an RSC response, then we can't serve it.
           if (cachedData.html.contentType !== RSC_CONTENT_TYPE_HEADER) {
-            if (nextConfig.experimental.clientParamParsing) {
-              // If client param parsing is enabled, then we can return a 404.
-              // This was likely an old prefetch request.
+            if (nextConfig.experimental.cacheComponents) {
               res.statusCode = 404
               return sendRenderResult({
                 req,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -162,7 +162,6 @@ async function requestHandler(
         staleTimes: nextConfig.experimental.staleTimes,
         cacheComponents: Boolean(nextConfig.experimental.cacheComponents),
         clientSegmentCache: Boolean(nextConfig.experimental.clientSegmentCache),
-        clientParamParsing: Boolean(nextConfig.experimental.clientParamParsing),
         dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
         inlineCss: Boolean(nextConfig.experimental.inlineCss),
         authInterrupts: Boolean(nextConfig.experimental.authInterrupts),

--- a/packages/next/src/client/components/segment-cache-impl/cache.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache.ts
@@ -1127,9 +1127,7 @@ function convertTreePrefetchToRouteTree(
         const renderedSearch = '' as NormalizedSearch
         const childParamKey =
           // The server omits this field from the prefetch response when
-          // clientParamParsing is enabled. The flag only exists while we're
-          // testing the feature, in case there's a bug and we need to revert.
-          // TODO: Remove once clientParamParsing is enabled everywhere.
+          // cacheComponents is enabled.
           childServerSentParamKey !== null
             ? childServerSentParamKey
             : // If no param key was sent, use the value parsed on the client.

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -399,7 +399,6 @@ async function exportAppImpl(
         nextConfig.experimental.clientSegmentCache === 'client-only'
           ? 'client-only'
           : Boolean(nextConfig.experimental.clientSegmentCache),
-      clientParamParsing: nextConfig.experimental.clientParamParsing ?? false,
       clientParamParsingOrigins:
         nextConfig.experimental.clientParamParsingOrigins,
       dynamicOnHover: nextConfig.experimental.dynamicOnHover ?? false,

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -132,14 +132,10 @@ export async function exportAppPage(
     // properly so long as we don't have unknown route params. When a route doesn't
     // have unknown route params, there will not be any flight data.
     if (!flightData) {
-      // Unless the user has clientParamParsing enabled, we expect that routes
-      // that don't have fallback route params would have flight data. This is
-      // because when clientParamParsing is enabled, the absence of flight data
-      // means that the route has unknown route params.
       if (
         !fallbackRouteParams ||
         fallbackRouteParams.size === 0 ||
-        renderOpts.experimental.clientParamParsing
+        renderOpts.experimental.cacheComponents
       ) {
         throw new Error(`Invariant: failed to get page data for ${path}`)
       }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4996,7 +4996,7 @@ async function collectSegmentData(
   const selectStaleTime = createSelectStaleTime(renderOpts.experimental)
   const staleTime = selectStaleTime(prerenderStore.stale)
   return await ComponentMod.collectSegmentData(
-    renderOpts.experimental.clientParamParsing,
+    renderOpts.experimental.cacheComponents,
     fullPageDataBuffer,
     staleTime,
     clientReferenceManifest.clientModules as ManifestNode,

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -39,10 +39,9 @@ export type RootTreePrefetch = {
 export type TreePrefetch = {
   name: string
   paramType: DynamicParamTypesShort | null
-  // TODO: When clientParamParsing is enabled, this field is always null.
+  // When cacheComponents is enabled, this field is always null.
   // Instead we parse the param on the client, allowing us to omit it from
-  // the prefetch response and increase its cacheability. Remove this field
-  // once clientParamParsing is enabled everywhere.
+  // the prefetch response and increase its cacheability.
   paramKey: string | null
 
   // Child segments.
@@ -89,7 +88,7 @@ function onSegmentPrerenderError(error: unknown) {
 }
 
 export async function collectSegmentData(
-  isClientParamParsingEnabled: boolean,
+  isCacheComponentsEnabled: boolean,
   fullPageDataBuffer: Buffer,
   staleTime: number,
   clientModules: ManifestNode,
@@ -134,7 +133,7 @@ export async function collectSegmentData(
     // inside of it, the side effects are transferred to the new stream.
     // @ts-expect-error
     <PrefetchTreeData
-      isClientParamParsingEnabled={isClientParamParsingEnabled}
+      isClientParamParsingEnabled={isCacheComponentsEnabled}
       fullPageDataBuffer={fullPageDataBuffer}
       serverConsumerManifest={serverConsumerManifest}
       clientModules={clientModules}
@@ -319,10 +318,8 @@ function collectSegmentDataImpl(
   return {
     name,
     paramType,
-    // This value is ommitted from the prefetch response when clientParamParsing
-    // is enabled. The flag only exists while we're testing the feature, in
-    // case there's a bug and we need to revert.
-    // TODO: Remove once clientParamParsing is enabled everywhere.
+    // This value is ommitted from the prefetch response when cacheComponents
+    // is enabled.
     paramKey: isClientParamParsingEnabled ? null : paramKey,
     hasRuntimePrefetch,
     slots: slotMetadata,

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -132,7 +132,6 @@ export interface RenderOptsPartial {
     clientTraceMetadata: string[] | undefined
     cacheComponents: boolean
     clientSegmentCache: boolean | 'client-only'
-    clientParamParsing: boolean
 
     /**
      * The origins that are allowed to write the rewritten headers when

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -554,8 +554,6 @@ export default abstract class Server<
           this.nextConfig.experimental.clientSegmentCache === 'client-only'
             ? 'client-only'
             : Boolean(this.nextConfig.experimental.clientSegmentCache),
-        clientParamParsing:
-          this.nextConfig.experimental.clientParamParsing ?? false,
         clientParamParsingOrigins:
           this.nextConfig.experimental.clientParamParsingOrigins,
         dynamicOnHover: this.nextConfig.experimental.dynamicOnHover ?? false,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -196,7 +196,6 @@ export const experimentalSchema = {
     .union([z.boolean(), z.literal('client-only')])
     .optional(),
   rdcForNavigations: z.boolean().optional(),
-  clientParamParsing: z.boolean().optional(),
   clientParamParsingOrigins: z.array(z.string()).optional(),
   dynamicOnHover: z.boolean().optional(),
   disableOptimizedLoading: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -287,7 +287,6 @@ export interface ExperimentalConfig {
    * Partial Prerendering is enabled.
    */
   rdcForNavigations?: boolean
-  clientParamParsing?: boolean
 
   /**
    * The origins that are allowed to write the rewritten headers when
@@ -1434,7 +1433,6 @@ export const defaultConfig = Object.freeze({
     caseSensitiveRoutes: false,
     clientSegmentCache: true,
     rdcForNavigations: false,
-    clientParamParsing: false,
     clientParamParsingOrigins: undefined,
     dynamicOnHover: false,
     preloadEntriesOnStart: true,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1245,18 +1245,6 @@ function assignDefaultsAndValidate(
     )
   }
 
-  // We require clientSegmentCache to be enabled if clientParamParsing is
-  // enabled. This is because clientParamParsing is only relevant when
-  // clientSegmentCache is enabled.
-  if (
-    result.experimental.clientParamParsing &&
-    !result.experimental.clientSegmentCache
-  ) {
-    throw new Error(
-      `\`experimental.clientParamParsing\` can not be \`true\` when \`experimental.clientSegmentCache\` is \`false\`. Client param parsing is only relevant when client segment cache is enabled.`
-    )
-  }
-
   if (
     phase === PHASE_DEVELOPMENT_SERVER &&
     result.experimental?.isolatedDevBuild
@@ -1740,25 +1728,6 @@ function enforceExperimentalFeatures(
       false,
       configuredExperimentalFeatures
     )
-  }
-
-  // TODO: Remove this once we've made Client Param Parsing the default.
-  if (
-    process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true' &&
-    // We do respect an explicit value in the user config.
-    (config.experimental.clientParamParsing === undefined ||
-      (isDefaultConfig && !config.experimental.clientParamParsing))
-  ) {
-    config.experimental.clientParamParsing = true
-
-    if (configuredExperimentalFeatures) {
-      addConfiguredExperimentalFeature(
-        configuredExperimentalFeatures,
-        'clientParamParsing',
-        true,
-        'enabled by `__NEXT_EXPERIMENTAL_CACHE_COMPONENTS`'
-      )
-    }
   }
 
   // TODO: Remove this once we've made Cache Components the default.

--- a/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
+++ b/test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts
@@ -93,7 +93,11 @@ describe('segment cache (basic tests)', () => {
     )
   })
 
-  it('navigate to page with lazily-generated (not at build time) static param', async () => {
+  // TODO(cache-components): With `cacheComponents` enabled, this test is outdated, because
+  // we no longer put the param values in the prefetched RSC response. You'd have to opt into runtime
+  // prefetching for this test to pass until we ship the optimization that would mark this as fully static
+  // if you don't reference any dynamic params in the server components.
+  it.skip('navigate to page with lazily-generated (not at build time) static param', async () => {
     let act: ReturnType<typeof createRouterAct>
     const browser = await next.browser('/lazily-generated-params', {
       beforePageLoad(page) {

--- a/test/e2e/app-dir/segment-cache/no-prefetch/next.config.js
+++ b/test/e2e/app-dir/segment-cache/no-prefetch/next.config.js
@@ -2,7 +2,6 @@
 module.exports = {
   experimental: {
     clientSegmentCache: true,
-    clientParamParsing: true,
   },
   productionBrowserSourceMaps: true,
 }

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -26,7 +26,6 @@ describe('build-output-prerender', () => {
              "▲ Next.js x.y.z (Turbopack)
                 - Experiments (use with caution):
                   ✓ cacheComponents
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
@@ -36,7 +35,6 @@ describe('build-output-prerender', () => {
              "▲ Next.js x.y.z (webpack)
                 - Experiments (use with caution):
                   ✓ cacheComponents
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
@@ -48,7 +46,6 @@ describe('build-output-prerender', () => {
              "▲ Next.js x.y.z (Turbopack)
                 - Experiments (use with caution):
                   ✓ cacheComponents
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
@@ -58,7 +55,6 @@ describe('build-output-prerender', () => {
              "▲ Next.js x.y.z (webpack)
                 - Experiments (use with caution):
                   ✓ cacheComponents
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
@@ -142,7 +138,6 @@ describe('build-output-prerender', () => {
                 ▲ Next.js x.y.z (Turbopack)
                 - Experiments (use with caution):
                   ✓ cacheComponents
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
@@ -156,7 +151,6 @@ describe('build-output-prerender', () => {
                 ▲ Next.js x.y.z (webpack)
                 - Experiments (use with caution):
                   ✓ cacheComponents
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
@@ -172,7 +166,6 @@ describe('build-output-prerender', () => {
                 ▲ Next.js x.y.z (Turbopack)
                 - Experiments (use with caution):
                   ✓ cacheComponents
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
@@ -186,7 +179,6 @@ describe('build-output-prerender', () => {
                 ▲ Next.js x.y.z (webpack)
                 - Experiments (use with caution):
                   ✓ cacheComponents
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
@@ -283,7 +275,6 @@ describe('build-output-prerender', () => {
              "▲ Next.js x.y.z (Turbopack)
                 - Experiments (use with caution):
                   ✓ cacheComponents (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
@@ -293,7 +284,6 @@ describe('build-output-prerender', () => {
              "▲ Next.js x.y.z (webpack)
                 - Experiments (use with caution):
                   ✓ cacheComponents (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
@@ -304,7 +294,6 @@ describe('build-output-prerender', () => {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (Turbopack)
                 - Experiments (use with caution):
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
             `)
@@ -312,7 +301,6 @@ describe('build-output-prerender', () => {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (webpack)
                 - Experiments (use with caution):
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
             `)
@@ -352,7 +340,6 @@ describe('build-output-prerender', () => {
                 ▲ Next.js x.y.z (Turbopack)
                 - Experiments (use with caution):
                   ✓ cacheComponents (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
@@ -366,7 +353,6 @@ describe('build-output-prerender', () => {
                 ▲ Next.js x.y.z (webpack)
                 - Experiments (use with caution):
                   ✓ cacheComponents (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                   ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
@@ -381,7 +367,6 @@ describe('build-output-prerender', () => {
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
                 ▲ Next.js x.y.z (Turbopack)
                 - Experiments (use with caution):
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
@@ -394,7 +379,6 @@ describe('build-output-prerender', () => {
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
                 ▲ Next.js x.y.z (webpack)
                 - Experiments (use with caution):
-                  ✓ clientParamParsing (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)

--- a/test/production/app-dir/resume-data-cache/next.config.js
+++ b/test/production/app-dir/resume-data-cache/next.config.js
@@ -5,7 +5,6 @@ const nextConfig = {
   experimental: {
     cacheComponents: true,
     clientSegmentCache: true,
-    clientParamParsing: true,
     cacheLife: {
       expireNow: {
         stale: 0,

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -58,7 +58,6 @@ describe.skip('required server files app router', () => {
         experimental: {
           cacheComponents: true,
           clientSegmentCache: true,
-          clientParamParsing: true,
         },
         output: 'standalone',
       },


### PR DESCRIPTION
We can't optionally land this flag in `cacheComponents` so this ensures it's enabled when using that flag. We still keep around `rsc.clientParamParsing` as the Vercel CLI still reads from it to opt into some additional routing configuration, which can be removed in the future. 