### PR TITLE
Relax default.tsx validation for parallel routes leaf segments

### DIFF
--- a/packages/next/src/shared/lib/errors/missing-default-parallel-route-error.ts
+++ b/packages/next/src/shared/lib/errors/missing-default-parallel-route-error.ts
@@ -8,5 +8,9 @@ export class MissingDefaultParallelRouteError extends Error {
     )
 
     this.name = 'MissingDefaultParallelRouteError'
+
+    // This error is meant to interrupt the server start/build process
+    // but the stack trace isn't meaningful, as it points to internal code.
+    this.stack = undefined
   }
 }

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/README.md
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/README.md
@@ -1,0 +1,125 @@
+# Build Error Scenarios
+
+This fixture contains scenarios that **SHOULD throw `MissingDefaultParallelRouteError`** during build.
+
+## Why These Should Error
+
+All scenarios in this fixture have:
+1. ✅ Parallel routes (slots starting with `@`)
+2. ❌ **NO** `default.tsx` files for those parallel routes
+3. ✅ **Child routes** that make these **non-leaf segments**
+
+The presence of child routes means `default.tsx` files are required for the parallel slots.
+
+---
+
+## Scenario 1: Non-Leaf Segment with Children
+
+**Path:** `/with-children`
+
+```
+app/with-children/
+├── @header/
+│   └── page.tsx              ← Has page.tsx
+│   ❌ NO default.tsx!        ← Missing default.tsx
+├── @sidebar/
+│   └── page.tsx              ← Has page.tsx
+│   ❌ NO default.tsx!        ← Missing default.tsx
+├── layout.tsx                ← Uses @header and @sidebar
+├── page.tsx                  ← Parent page
+└── child/
+    └── page.tsx              ← ⚠️ CHILD ROUTE EXISTS!
+```
+
+**Expected Error:**
+```
+MissingDefaultParallelRouteError:
+  Missing required default.js file for parallel route at /with-children/@header
+  The parallel route slot "@header" is missing a default.js file.
+```
+
+**Why it errors:**
+- When navigating from `/with-children` to `/with-children/child`, the routing system needs to know what to render for the `@header` and `@sidebar` slots
+- Since `/with-children/child` doesn't define these parallel routes, Next.js looks for `default.tsx` files
+- No `default.tsx` files exist → ERROR!
+
+---
+
+## Scenario 2: Non-Leaf with Route Groups and Children
+
+**Path:** `/with-groups-and-children`
+
+```
+app/with-groups-and-children/(dashboard)/(overview)/
+├── @analytics/
+│   └── page.tsx              ← Has page.tsx
+│   ❌ NO default.tsx!        ← Missing default.tsx
+├── @metrics/
+│   └── page.tsx              ← Has page.tsx
+│   ❌ NO default.tsx!        ← Missing default.tsx
+├── layout.tsx                ← Uses @analytics and @metrics
+├── page.tsx                  ← Parent page
+└── nested/
+    └── page.tsx              ← ⚠️ CHILD ROUTE EXISTS!
+```
+
+**Route Groups:** `(dashboard)` and `(overview)` don't affect the URL
+
+**Expected Error:**
+```
+MissingDefaultParallelRouteError:
+  Missing required default.js file for parallel route at /with-groups-and-children/(dashboard)/(overview)/@analytics
+  The parallel route slot "@analytics" is missing a default.js file.
+```
+
+**Why it errors:**
+- Even with route groups, the segment has a child route (`/nested`)
+- The `hasChildRoutesForSegment()` helper correctly:
+  1. Filters out route groups `(dashboard)` and `(overview)`
+  2. Detects the `nested/page.tsx` child route
+  3. Identifies this as a **non-leaf segment**
+- No `default.tsx` files exist → ERROR!
+
+---
+
+## How to Fix These Errors
+
+To make these scenarios build successfully, add `default.tsx` files:
+
+### For Scenario 1:
+```tsx
+// app/with-children/@header/default.tsx
+export default function HeaderDefault() {
+  return <div>Header Fallback</div>
+}
+
+// app/with-children/@sidebar/default.tsx
+export default function SidebarDefault() {
+  return <div>Sidebar Fallback</div>
+}
+```
+
+### For Scenario 2:
+```tsx
+// app/with-groups-and-children/(dashboard)/(overview)/@analytics/default.tsx
+export default function AnalyticsDefault() {
+  return <div>Analytics Fallback</div>
+}
+
+// app/with-groups-and-children/(dashboard)/(overview)/@metrics/default.tsx
+export default function MetricsDefault() {
+  return <div>Metrics Fallback</div>
+}
+```
+
+---
+
+## Contrast with `no-build-error` Fixture
+
+The `no-build-error` fixture has similar parallel routes but:
+- ❌ **NO child routes** (leaf segments)
+- ✅ `default.tsx` files are **NOT required**
+
+This fixture (build-error) has:
+- ✅ **Child routes exist** (non-leaf segments)
+- ❌ `default.tsx` files **ARE required** but missing → **ERROR!**

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/page.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link'
+
+export default function HomePage() {
+  return (
+    <div>
+      <h1>Build Error Scenarios Test</h1>
+      <p>
+        These routes SHOULD cause MissingDefaultParallelRouteError because they
+        have parallel routes without default.tsx files AND have child routes.
+      </p>
+      <nav>
+        <ul>
+          <li>
+            <Link href="/with-children">
+              Non-Leaf Segment with Children (SHOULD ERROR)
+            </Link>
+          </li>
+          <li>
+            <Link href="/with-groups-and-children">
+              Non-Leaf with Route Groups and Children (SHOULD ERROR)
+            </Link>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/@header/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/@header/page.tsx
@@ -1,0 +1,8 @@
+export default function HeaderSlot() {
+  return (
+    <div>
+      <h3>Header Slot (Parent)</h3>
+      <p>This is the @header parallel route</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/@sidebar/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/@sidebar/page.tsx
@@ -1,0 +1,8 @@
+export default function SidebarSlot() {
+  return (
+    <div>
+      <h3>Sidebar Slot (Parent)</h3>
+      <p>This is the @sidebar parallel route</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/@sidebar/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/@sidebar/page.tsx
@@ -1,8 +1,0 @@
-export default function SidebarSlot() {
-  return (
-    <div>
-      <h3>Sidebar Slot (Parent)</h3>
-      <p>This is the @sidebar parallel route</p>
-    </div>
-  )
-}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/child/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/child/page.tsx
@@ -1,0 +1,13 @@
+export default function ChildPage() {
+  return (
+    <div>
+      <h2>Child Page</h2>
+      <p>
+        This child route exists, which means the parent segment is NOT a leaf.
+      </p>
+      <p>
+        ERROR: The @header and @sidebar slots should have default.tsx files!
+      </p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/layout.tsx
@@ -1,0 +1,19 @@
+export default function WithChildrenLayout({
+  children,
+  header,
+  sidebar,
+}: {
+  children: React.ReactNode
+  header: React.ReactNode
+  sidebar: React.ReactNode
+}) {
+  return (
+    <div>
+      <div className="header">{header}</div>
+      <div className="container">
+        <div className="sidebar">{sidebar}</div>
+        <div className="main">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/layout.tsx
@@ -1,17 +1,14 @@
 export default function WithChildrenLayout({
   children,
   header,
-  sidebar,
 }: {
   children: React.ReactNode
   header: React.ReactNode
-  sidebar: React.ReactNode
 }) {
   return (
     <div>
       <div className="header">{header}</div>
       <div className="container">
-        <div className="sidebar">{sidebar}</div>
         <div className="main">{children}</div>
       </div>
     </div>

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-children/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function WithChildrenPage() {
+  return (
+    <div>
+      <h2>Parent Page</h2>
+      <p>This is a NON-leaf segment with child routes.</p>
+      <nav>
+        <Link href="/with-children/child">Go to Child</Link>
+      </nav>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/@analytics/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/@analytics/page.tsx
@@ -1,8 +1,0 @@
-export default function AnalyticsSlot() {
-  return (
-    <div>
-      <h4>Analytics Slot (Parent)</h4>
-      <p>This is the @analytics parallel route with route groups</p>
-    </div>
-  )
-}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/@analytics/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/@analytics/page.tsx
@@ -1,0 +1,8 @@
+export default function AnalyticsSlot() {
+  return (
+    <div>
+      <h4>Analytics Slot (Parent)</h4>
+      <p>This is the @analytics parallel route with route groups</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/@metrics/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/@metrics/page.tsx
@@ -1,0 +1,8 @@
+export default function MetricsSlot() {
+  return (
+    <div>
+      <h4>Metrics Slot (Parent)</h4>
+      <p>This is the @metrics parallel route with route groups</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/layout.tsx
@@ -1,0 +1,20 @@
+export default function GroupedWithChildrenLayout({
+  children,
+  analytics,
+  metrics,
+}: {
+  children: React.ReactNode
+  analytics: React.ReactNode
+  metrics: React.ReactNode
+}) {
+  return (
+    <div>
+      <h2>Parent with Route Groups</h2>
+      <div className="grouped-container">
+        <div className="analytics">{analytics}</div>
+        <div className="main">{children}</div>
+        <div className="metrics">{metrics}</div>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/layout.tsx
@@ -1,17 +1,14 @@
 export default function GroupedWithChildrenLayout({
   children,
-  analytics,
   metrics,
 }: {
   children: React.ReactNode
-  analytics: React.ReactNode
   metrics: React.ReactNode
 }) {
   return (
     <div>
       <h2>Parent with Route Groups</h2>
       <div className="grouped-container">
-        <div className="analytics">{analytics}</div>
         <div className="main">{children}</div>
         <div className="metrics">{metrics}</div>
       </div>

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/nested/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/nested/page.tsx
@@ -1,0 +1,18 @@
+export default function NestedPage() {
+  return (
+    <div>
+      <h3>Nested Child Page</h3>
+      <p>
+        This child route exists under a path with route groups, making the
+        parent a non-leaf segment.
+      </p>
+      <p>
+        ERROR: The @analytics and @metrics slots should have default.tsx files!
+      </p>
+      <p>
+        Even though the parent has route groups, the hasChildRoutesForSegment
+        helper correctly filters them out and detects this nested child route.
+      </p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/build-error/app/with-groups-and-children/(dashboard)/(overview)/page.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function GroupedParentPage() {
+  return (
+    <div>
+      <h3>Parent with Route Groups</h3>
+      <p>
+        This segment has route groups (dashboard) and (overview), but it's NOT a
+        leaf because child routes exist.
+      </p>
+      <nav>
+        <Link href="/with-groups-and-children/nested">Go to Nested</Link>
+      </nav>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/catch-all-with-parallel/[...slug]/@footer/not/routable/component.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/catch-all-with-parallel/[...slug]/@footer/not/routable/component.tsx
@@ -1,0 +1,3 @@
+export default function NotRoutableComponent() {
+  return <div>Not routable component</div>
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/catch-all-with-parallel/[...slug]/@footer/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/catch-all-with-parallel/[...slug]/@footer/page.tsx
@@ -1,0 +1,11 @@
+import NotRoutableComponent from './not/routable/component'
+
+export default function FooterSlot() {
+  return (
+    <div>
+      <h3>Catch-All Footer Slot</h3>
+      <p>This is the @footer parallel route in a catch-all segment</p>
+      <NotRoutableComponent />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/catch-all-with-parallel/[...slug]/@header/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/catch-all-with-parallel/[...slug]/@header/page.tsx
@@ -1,0 +1,8 @@
+export default function HeaderSlot() {
+  return (
+    <div>
+      <h3>Catch-All Header Slot</h3>
+      <p>This is the @header parallel route in a catch-all segment</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/catch-all-with-parallel/[...slug]/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/catch-all-with-parallel/[...slug]/layout.tsx
@@ -1,0 +1,17 @@
+export default function CatchAllLayout({
+  children,
+  header,
+  footer,
+}: {
+  children: React.ReactNode
+  header: React.ReactNode
+  footer: React.ReactNode
+}) {
+  return (
+    <div className="catch-all-container">
+      <div className="header">{header}</div>
+      <div className="main">{children}</div>
+      <div className="footer">{footer}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/catch-all-with-parallel/[...slug]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/catch-all-with-parallel/[...slug]/page.tsx
@@ -1,0 +1,22 @@
+export default async function CatchAllPage({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>
+}) {
+  const { slug } = await params
+  return (
+    <div>
+      <h2>Catch-All Leaf Segment Page</h2>
+      <p>This is a catch-all route with parallel routes but NO child routes.</p>
+      <p className="slug-info">Current path: /{slug.join('/')}</p>
+      <p>
+        No default.tsx files are required for @header or @footer because there
+        are no child routes to navigate to.
+      </p>
+    </div>
+  )
+}
+
+export async function generateStaticParams() {
+  return [{ slug: ['a', 'b', 'c'] }]
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/catch-all-with-parallel/loading.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/catch-all-with-parallel/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>Loading...</div>
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-segment/@header/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-segment/@header/page.tsx
@@ -1,0 +1,8 @@
+export default function HeaderSlot() {
+  return (
+    <div>
+      <h3>Header Slot</h3>
+      <p>This is the @header parallel route</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-segment/@metrics/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-segment/@metrics/page.tsx
@@ -1,0 +1,8 @@
+export default function MetricsSlot() {
+  return (
+    <div>
+      <h3>Metrics Slot</h3>
+      <p>This is the @metrics parallel route</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-segment/@sidebar/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-segment/@sidebar/page.tsx
@@ -1,0 +1,8 @@
+export default function SidebarSlot() {
+  return (
+    <div>
+      <h3>Sidebar Slot</h3>
+      <p>This is the @sidebar parallel route</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-segment/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-segment/layout.tsx
@@ -1,0 +1,24 @@
+export default function LeafLayout({
+  children,
+  header,
+  sidebar,
+  metrics,
+}: {
+  children: React.ReactNode
+  header: React.ReactNode
+  sidebar: React.ReactNode
+  metrics: React.ReactNode
+}) {
+  return (
+    <div>
+      <div className="header">{header}</div>
+      <div className="container">
+        <div className="sidebar">{sidebar}</div>
+        <div className="main">
+          {children}
+          <div className="metrics">{metrics}</div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-segment/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-segment/page.tsx
@@ -1,0 +1,12 @@
+export default function LeafPage() {
+  return (
+    <div>
+      <h2>Leaf Segment Page</h2>
+      <p>This is a leaf segment with parallel routes but NO child routes.</p>
+      <p>
+        No default.tsx files are required for @header, @sidebar, or @metrics
+        because there are no child routes to navigate to.
+      </p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-with-groups/(dashboard)/(sections)/@analytics/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-with-groups/(dashboard)/(sections)/@analytics/page.tsx
@@ -1,0 +1,8 @@
+export default function AnalyticsSlot() {
+  return (
+    <div>
+      <h4>Analytics Slot</h4>
+      <p>This is the @analytics parallel route within route groups</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-with-groups/(dashboard)/(sections)/@reports/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-with-groups/(dashboard)/(sections)/@reports/page.tsx
@@ -1,0 +1,8 @@
+export default function ReportsSlot() {
+  return (
+    <div>
+      <h4>Reports Slot</h4>
+      <p>This is the @reports parallel route within route groups</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-with-groups/(dashboard)/(sections)/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-with-groups/(dashboard)/(sections)/layout.tsx
@@ -1,0 +1,20 @@
+export default function GroupedLeafLayout({
+  children,
+  analytics,
+  reports,
+}: {
+  children: React.ReactNode
+  analytics: React.ReactNode
+  reports: React.ReactNode
+}) {
+  return (
+    <div>
+      <h2>Leaf with Route Groups</h2>
+      <div className="grouped-container">
+        <div className="analytics">{analytics}</div>
+        <div className="main">{children}</div>
+        <div className="reports">{reports}</div>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-with-groups/(dashboard)/(sections)/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/leaf-with-groups/(dashboard)/(sections)/page.tsx
@@ -1,0 +1,17 @@
+export default function GroupedLeafPage() {
+  return (
+    <div>
+      <h3>Grouped Leaf Segment Page</h3>
+      <p>
+        This demonstrates a leaf segment with route groups (dashboard) and
+        (sections).
+      </p>
+      <p>
+        Even though the path includes route groups, the logic correctly
+        identifies this as a leaf segment because route groups don't contribute
+        to routing.
+      </p>
+      <p>No default.tsx required for @analytics or @reports!</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children/@slot/other/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children/@slot/other/page.tsx
@@ -1,0 +1,3 @@
+export default function NoChildrenOtherPage() {
+  return <div>No Children Other Page</div>
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children/default.tsx
@@ -1,0 +1,3 @@
+export default function NoChildrenDefault() {
+  return <div>No Children Default</div>
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/no-children/layout.tsx
@@ -1,0 +1,14 @@
+export default function NoChildrenLayout({
+  children,
+  slot,
+}: {
+  children: React.ReactNode
+  slot: React.ReactNode
+}) {
+  return (
+    <>
+      <div id="slot">{slot}</div>
+      <div id="children">{children}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/fixtures/no-build-error/app/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export default function HomePage() {
+  return (
+    <div>
+      <h1>Parallel Routes Leaf Segments Test</h1>
+      <nav>
+        <ul>
+          <li>
+            <Link href="/leaf-segment">Leaf Segment (No Default Required)</Link>
+          </li>
+          <li>
+            <Link href="/leaf-with-groups">
+              Leaf with Route Groups (No Default Required)
+            </Link>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
@@ -15,11 +15,7 @@ describe('parallel-routes-leaf-segments-build-error', () => {
   }
 
   if (isNextDev) {
-    beforeEach(() => next.start())
-    afterEach(async () => {
-      await next.stop()
-      await next.clean()
-    })
+    beforeAll(() => next.start())
   } else {
     beforeAll(async () => {
       try {
@@ -35,11 +31,24 @@ describe('parallel-routes-leaf-segments-build-error', () => {
       if (isNextDev) {
         const browser = await next.browser('/with-children/child')
         await assertHasRedbox(browser)
-      }
 
-      await retry(() => {
-        expect(next.cliOutput).toContain('/with-children/@header/default.js')
-      })
+        await retry(async () => {
+          const logs = await browser.log()
+          expect(logs).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                message: expect.stringContaining(
+                  '/with-children/@header/default.js'
+                ),
+              }),
+            ])
+          )
+        })
+      } else {
+        await retry(() => {
+          expect(next.cliOutput).toContain('/with-children/@header/default.js')
+        })
+      }
     })
   })
 
@@ -48,13 +57,26 @@ describe('parallel-routes-leaf-segments-build-error', () => {
       if (isNextDev) {
         const browser = await next.browser('/with-groups-and-children/nested')
         await assertHasRedbox(browser)
-      }
 
-      await retry(() => {
-        expect(next.cliOutput).toContain(
-          '/with-groups-and-children/(dashboard)/(overview)/@metrics/default.js'
-        )
-      })
+        await retry(async () => {
+          const logs = await browser.log()
+          expect(logs).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                message: expect.stringContaining(
+                  '/with-groups-and-children/(dashboard)/(overview)/@metrics/default.js'
+                ),
+              }),
+            ])
+          )
+        })
+      } else {
+        await retry(() => {
+          expect(next.cliOutput).toContain(
+            '/with-groups-and-children/(dashboard)/(overview)/@metrics/default.js'
+          )
+        })
+      }
     })
   })
 })

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
-import { assertHasRedbox } from 'next-test-utils'
+import { assertHasRedbox, retry } from 'next-test-utils'
 
 describe('parallel-routes-leaf-segments-build-error', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -16,7 +16,10 @@ describe('parallel-routes-leaf-segments-build-error', () => {
 
   if (isNextDev) {
     beforeEach(() => next.start())
-    afterEach(() => next.stop())
+    afterEach(async () => {
+      await next.stop()
+      await next.clean()
+    })
   } else {
     beforeAll(async () => {
       try {
@@ -34,7 +37,9 @@ describe('parallel-routes-leaf-segments-build-error', () => {
         await assertHasRedbox(browser)
       }
 
-      expect(next.cliOutput).toContain('/with-children/@header/default.js')
+      await retry(() => {
+        expect(next.cliOutput).toContain('/with-children/@header/default.js')
+      })
     })
   })
 
@@ -45,9 +50,11 @@ describe('parallel-routes-leaf-segments-build-error', () => {
         await assertHasRedbox(browser)
       }
 
-      expect(next.cliOutput).toContain(
-        '/with-groups-and-children/(dashboard)/(overview)/@metrics/default.js'
-      )
+      await retry(() => {
+        expect(next.cliOutput).toContain(
+          '/with-groups-and-children/(dashboard)/(overview)/@metrics/default.js'
+        )
+      })
     })
   })
 })

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
@@ -1,8 +1,9 @@
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
+import { assertHasRedbox } from 'next-test-utils'
 
 describe('parallel-routes-leaf-segments-build-error', () => {
-  const { next, isNextDev, skipped, isTurbopack, isRspack } = nextTestSetup({
+  const { next, isNextDev, skipped } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'build-error'),
     skipStart: true,
     skipDeployment: true,
@@ -30,51 +31,7 @@ describe('parallel-routes-leaf-segments-build-error', () => {
     it('should throw MissingDefaultParallelRouteError for @header slot', async () => {
       if (isNextDev) {
         const browser = await next.browser('/with-children/child')
-        if (isTurbopack) {
-          await expect(browser).toDisplayRedbox(`
-           {
-             "description": "Missing required default.js file for parallel route at /with-children/@header",
-             "environmentLabel": null,
-             "label": "Build Error",
-             "source": "./app/with-children/@header
-           Missing required default.js file for parallel route at /with-children/@header
-           The parallel route slot "@header" is missing a default.js file. When using parallel routes, each slot must have a default.js file to serve as a fallback.
-           Create a default.js file at: /with-children/@header/default.js
-           https://nextjs.org/docs/messages/slot-missing-default",
-             "stack": [],
-           }
-          `)
-        } else if (isRspack) {
-          await expect(browser).toDisplayRedbox(`
-           {
-             "description": "  × Missing required default.js file for parallel route at app/with-children/@header",
-             "environmentLabel": null,
-             "label": "Build Error",
-             "source": "app/with-children/child/page.tsx
-             × Missing required default.js file for parallel route at app/with-children/@header
-             │ The parallel route slot "@header" is missing a default.js file. When using parallel routes, each slot must have a default.js file to serve as a fallback.
-             │
-             │ Create a default.js file at: app/with-children/@header/default.js
-             │
-             │ https://nextjs.org/docs/messages/slot-missing-default",
-             "stack": [],
-           }
-          `)
-        } else {
-          await expect(browser).toDisplayRedbox(`
-           {
-             "description": "Missing required default.js file for parallel route at app/with-children/@header",
-             "environmentLabel": null,
-             "label": "Build Error",
-             "source": "app/with-children/child/page.tsx
-           Missing required default.js file for parallel route at app/with-children/@header
-           The parallel route slot "@header" is missing a default.js file. When using parallel routes, each slot must have a default.js file to serve as a fallback.
-           Create a default.js file at: app/with-children/@header/default.js
-           https://nextjs.org/docs/messages/slot-missing-default",
-             "stack": [],
-           }
-          `)
-        }
+        await assertHasRedbox(browser)
       }
 
       expect(next.cliOutput).toContain('/with-children/@header/default.js')
@@ -85,51 +42,7 @@ describe('parallel-routes-leaf-segments-build-error', () => {
     it('should throw MissingDefaultParallelRouteError for parallel slots', async () => {
       if (isNextDev) {
         const browser = await next.browser('/with-groups-and-children/nested')
-        if (isTurbopack) {
-          await expect(browser).toDisplayRedbox(`
-           {
-             "description": "Missing required default.js file for parallel route at /with-children/@header",
-             "environmentLabel": null,
-             "label": "Build Error",
-             "source": "./app/with-children/@header
-           Missing required default.js file for parallel route at /with-children/@header
-           The parallel route slot "@header" is missing a default.js file. When using parallel routes, each slot must have a default.js file to serve as a fallback.
-           Create a default.js file at: /with-children/@header/default.js
-           https://nextjs.org/docs/messages/slot-missing-default",
-             "stack": [],
-           }
-          `)
-        } else if (isRspack) {
-          await expect(browser).toDisplayRedbox(`
-           {
-             "description": "  × Missing required default.js file for parallel route at app/with-groups-and-children/(dashboard)/(overview)/@metrics",
-             "environmentLabel": null,
-             "label": "Build Error",
-             "source": "app/with-groups-and-children/(dashboard)/(overview)/nested/page.tsx
-             × Missing required default.js file for parallel route at app/with-groups-and-children/(dashboard)/(overview)/@metrics
-             │ The parallel route slot "@metrics" is missing a default.js file. When using parallel routes, each slot must have a default.js file to serve as a fallback.
-             │
-             │ Create a default.js file at: app/with-groups-and-children/(dashboard)/(overview)/@metrics/default.js
-             │
-             │ https://nextjs.org/docs/messages/slot-missing-default",
-             "stack": [],
-           }
-          `)
-        } else {
-          await expect(browser).toDisplayRedbox(`
-           {
-             "description": "Missing required default.js file for parallel route at app/with-groups-and-children/(dashboard)/(overview)/@metrics",
-             "environmentLabel": null,
-             "label": "Build Error",
-             "source": "app/with-groups-and-children/(dashboard)/(overview)/nested/page.tsx
-           Missing required default.js file for parallel route at app/with-groups-and-children/(dashboard)/(overview)/@metrics
-           The parallel route slot "@metrics" is missing a default.js file. When using parallel routes, each slot must have a default.js file to serve as a fallback.
-           Create a default.js file at: app/with-groups-and-children/(dashboard)/(overview)/@metrics/default.js
-           https://nextjs.org/docs/messages/slot-missing-default",
-             "stack": [],
-           }
-          `)
-        }
+        await assertHasRedbox(browser)
       }
 
       expect(next.cliOutput).toContain(

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
@@ -1,0 +1,140 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+
+describe('parallel-routes-leaf-segments-build-error', () => {
+  const { next, isNextDev, skipped, isTurbopack, isRspack } = nextTestSetup({
+    files: path.join(__dirname, 'fixtures', 'build-error'),
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    it.skip('skip test', () => {})
+    return
+  }
+
+  if (isNextDev) {
+    beforeEach(() => next.start())
+    afterEach(() => next.stop())
+  } else {
+    beforeAll(async () => {
+      try {
+        await next.build()
+      } catch {
+        // Expect build error
+      }
+    })
+  }
+
+  describe('Non-leaf segment with child routes', () => {
+    it('should throw MissingDefaultParallelRouteError for @header slot', async () => {
+      if (isNextDev) {
+        const browser = await next.browser('/with-children/child')
+        if (isTurbopack) {
+          await expect(browser).toDisplayRedbox(`
+           {
+             "description": "Missing required default.js file for parallel route at /with-children/@header",
+             "environmentLabel": null,
+             "label": "Build Error",
+             "source": "./app/with-children/@header
+           Missing required default.js file for parallel route at /with-children/@header
+           The parallel route slot "@header" is missing a default.js file. When using parallel routes, each slot must have a default.js file to serve as a fallback.
+           Create a default.js file at: /with-children/@header/default.js
+           https://nextjs.org/docs/messages/slot-missing-default",
+             "stack": [],
+           }
+          `)
+        } else if (isRspack) {
+          await expect(browser).toDisplayRedbox(`
+           {
+             "description": "  × Missing required default.js file for parallel route at app/with-children/@header",
+             "environmentLabel": null,
+             "label": "Build Error",
+             "source": "app/with-children/child/page.tsx
+             × Missing required default.js file for parallel route at app/with-children/@header
+             │ The parallel route slot "@header" is missing a default.js file. When using parallel routes, each slot must have a default.js file to serve as a fallback.
+             │
+             │ Create a default.js file at: app/with-children/@header/default.js
+             │
+             │ https://nextjs.org/docs/messages/slot-missing-default",
+             "stack": [],
+           }
+          `)
+        } else {
+          await expect(browser).toDisplayRedbox(`
+           {
+             "description": "Missing required default.js file for parallel route at app/with-children/@header",
+             "environmentLabel": null,
+             "label": "Build Error",
+             "source": "app/with-children/child/page.tsx
+           Missing required default.js file for parallel route at app/with-children/@header
+           The parallel route slot "@header" is missing a default.js file. When using parallel routes, each slot must have a default.js file to serve as a fallback.
+           Create a default.js file at: app/with-children/@header/default.js
+           https://nextjs.org/docs/messages/slot-missing-default",
+             "stack": [],
+           }
+          `)
+        }
+      }
+
+      expect(next.cliOutput).toContain('/with-children/@header/default.js')
+    })
+  })
+
+  describe('Non-leaf segment with route groups and child routes', () => {
+    it('should throw MissingDefaultParallelRouteError for parallel slots', async () => {
+      if (isNextDev) {
+        const browser = await next.browser('/with-groups-and-children/nested')
+        if (isTurbopack) {
+          await expect(browser).toDisplayRedbox(`
+           {
+             "description": "Missing required default.js file for parallel route at /with-children/@header",
+             "environmentLabel": null,
+             "label": "Build Error",
+             "source": "./app/with-children/@header
+           Missing required default.js file for parallel route at /with-children/@header
+           The parallel route slot "@header" is missing a default.js file. When using parallel routes, each slot must have a default.js file to serve as a fallback.
+           Create a default.js file at: /with-children/@header/default.js
+           https://nextjs.org/docs/messages/slot-missing-default",
+             "stack": [],
+           }
+          `)
+        } else if (isRspack) {
+          await expect(browser).toDisplayRedbox(`
+           {
+             "description": "  × Missing required default.js file for parallel route at app/with-groups-and-children/(dashboard)/(overview)/@metrics",
+             "environmentLabel": null,
+             "label": "Build Error",
+             "source": "app/with-groups-and-children/(dashboard)/(overview)/nested/page.tsx
+             × Missing required default.js file for parallel route at app/with-groups-and-children/(dashboard)/(overview)/@metrics
+             │ The parallel route slot "@metrics" is missing a default.js file. When using parallel routes, each slot must have a default.js file to serve as a fallback.
+             │
+             │ Create a default.js file at: app/with-groups-and-children/(dashboard)/(overview)/@metrics/default.js
+             │
+             │ https://nextjs.org/docs/messages/slot-missing-default",
+             "stack": [],
+           }
+          `)
+        } else {
+          await expect(browser).toDisplayRedbox(`
+           {
+             "description": "Missing required default.js file for parallel route at app/with-groups-and-children/(dashboard)/(overview)/@metrics",
+             "environmentLabel": null,
+             "label": "Build Error",
+             "source": "app/with-groups-and-children/(dashboard)/(overview)/nested/page.tsx
+           Missing required default.js file for parallel route at app/with-groups-and-children/(dashboard)/(overview)/@metrics
+           The parallel route slot "@metrics" is missing a default.js file. When using parallel routes, each slot must have a default.js file to serve as a fallback.
+           Create a default.js file at: app/with-groups-and-children/(dashboard)/(overview)/@metrics/default.js
+           https://nextjs.org/docs/messages/slot-missing-default",
+             "stack": [],
+           }
+          `)
+        }
+      }
+
+      expect(next.cliOutput).toContain(
+        '/with-groups-and-children/(dashboard)/(overview)/@metrics/default.js'
+      )
+    })
+  })
+})

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.no-build-error.test.ts
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.no-build-error.test.ts
@@ -66,4 +66,13 @@ describe('parallel-routes-leaf-segments-no-build-error', () => {
       expect($('.footer h3').text()).toBe('Catch-All Footer Slot')
     })
   })
+
+  describe('no children slot', () => {
+    it('should render the no children slot', async () => {
+      const $ = await next.render$('/no-children/other')
+
+      expect($('#slot').text()).toBe('No Children Other Page')
+      expect($('#children').text()).toBe('No Children Default')
+    })
+  })
 })

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.no-build-error.test.ts
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.no-build-error.test.ts
@@ -1,0 +1,69 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+
+describe('parallel-routes-leaf-segments-no-build-error', () => {
+  const { next } = nextTestSetup({
+    files: path.join(__dirname, 'fixtures', 'no-build-error'),
+  })
+
+  it('should build successfully without default.tsx for leaf segments', async () => {
+    // This test verifies that the build does not throw
+    // MissingDefaultParallelRouteError for leaf segments
+    expect(next.cliOutput).not.toContain('MissingDefaultParallelRouteError')
+  })
+
+  afterAll(() => {
+    if (next.cliOutput.includes('MissingDefaultParallelRouteError')) {
+      throw new Error('MissingDefaultParallelRouteError was thrown')
+    }
+  })
+
+  describe('leaf segment without child routes', () => {
+    it('should render the leaf segment page with all parallel slots', async () => {
+      const $ = await next.render$('/leaf-segment')
+
+      // Verify main page content
+      expect($('h2').text()).toBe('Leaf Segment Page')
+      expect($('.main p').first().text()).toContain(
+        'This is a leaf segment with parallel routes but NO child routes'
+      )
+
+      // Verify all parallel slots render
+      expect($('.header h3').text()).toBe('Header Slot')
+      expect($('.sidebar h3').text()).toBe('Sidebar Slot')
+      expect($('.metrics h3').text()).toBe('Metrics Slot')
+    })
+  })
+
+  describe('leaf segment with route groups', () => {
+    it('should render leaf segment with route groups and parallel slots', async () => {
+      const $ = await next.render$('/leaf-with-groups')
+
+      // Verify main page content
+      expect($('h3').first().text()).toBe('Grouped Leaf Segment Page')
+
+      // Verify route groups are handled correctly
+      expect($('p').first().text()).toContain('route groups')
+
+      // Verify parallel slots render
+      expect($('.analytics h4').text()).toBe('Analytics Slot')
+      expect($('.reports h4').text()).toBe('Reports Slot')
+    })
+  })
+
+  describe('leaf segment with catch-all parameter', () => {
+    it('should render catch-all segment with multiple path segments', async () => {
+      const $ = await next.render$('/catch-all-with-parallel/a/b/c')
+
+      // Verify main page content
+      expect($('h2').text()).toBe('Catch-All Leaf Segment Page')
+
+      // Verify the slug captures all segments
+      expect($('.slug-info').text()).toBe('Current path: /a/b/c')
+
+      // Verify parallel slots still render correctly
+      expect($('.header h3').text()).toBe('Catch-All Header Slot')
+      expect($('.footer h3').text()).toBe('Catch-All Footer Slot')
+    })
+  })
+})


### PR DESCRIPTION
### What?

Relaxes the overly strict `default.tsx` validation for parallel routes to only require the file when it's actually needed (non-leaf segments with routable children).

### Why?

The initial validation for parallel routes required `default.tsx` files for all parallel route slots to prevent a specific issue: when navigating to child routes, missing `default.tsx` files could cause silent 404s in slot content, creating a confusing user experience.

However, this validation was **too strict** - it required `default.tsx` even in cases where it wasn't actually necessary:

1. **Leaf segments** (routes with no child routes) - There are no child routes to navigate to, so the 404 issue cannot occur
2. **Route groups** - These are organizational folders and aren't routable themselves  
3. **Catch-all parameters** - The matched segments are dynamic parameter values, not actual child route segments

This caused false positive build errors for valid parallel route configurations that don't have the underlying navigational issue.

NAR-448