### PR TITLE
[backport] fix: missing `next/link` types with `typedRoutes` (#82814)

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -298,6 +298,8 @@ declare module 'next' {
 }
 
 declare module 'next/link' {
+  export { useLinkStatus } from 'next/dist/client/link.js'
+
   import type { LinkProps as OriginalLinkProps } from 'next/dist/client/link.js'
   import type { AnchorHTMLAttributes, DetailedHTMLProps } from 'react'
   import type { UrlObject } from 'url'


### PR DESCRIPTION
backports #82814