### PR TITLE
Prevent failing `types-and-precompiled` from corrupting terminal output

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "lint-eslint": "cross-env ESLINT_USE_FLAT_CONFIG=false eslint --ext js,jsx,mjs,ts,tsx,mts,mdx --config .eslintrc.cli.json --no-eslintrc",
     "lint-ast-grep": "ast-grep scan",
     "lint-no-typescript": "run-p prettier-check \"lint-eslint .\" lint-language",
-    "types-and-precompiled": "run-p lint-typescript check-compiler-fixtures types:test-lib && pnpm check-precompiled",
+    "types-and-precompiled": "run-p \"lint-typescript --log-order=stream\" check-compiler-fixtures types:test-lib && pnpm check-precompiled",
     "check-compiler-fixtures": "find crates/next-custom-transforms/tests/fixture -type f -name 'tsconfig.json' -print0 | xargs --null -n1 -I'{}' pnpm tsc --noEmit --project '{}'",
     "validate-externals-doc": "node ./scripts/validate-externals-doc.js",
     "lint": "run-p test-types lint-typescript prettier-check \"lint-eslint .\" lint-ast-grep lint-language",


### PR DESCRIPTION
Turbo's UI doesn't play nicely with `run-p`. It ended up continuing to print ANSI characters in the terminal after a subtask failed. 

This disables Turbo's UI when ran in `types-and-precompiled`