### PR TITLE
Turbopack build: Switch to using workerthreads for process

### DIFF
--- a/packages/next/src/build/turbopack-build/index.ts
+++ b/packages/next/src/build/turbopack-build/index.ts
@@ -7,6 +7,7 @@ async function turbopackBuildWithWorker() {
   try {
     const worker = new Worker(path.join(__dirname, 'impl.js'), {
       exposedMethods: ['workerMain', 'waitForShutdown'],
+      enableWorkerThreads: true,
       debuggerPortOffset: -1,
       isolatedMemory: false,
       numWorkers: 1,

--- a/packages/next/src/build/turbopack-build/index.ts
+++ b/packages/next/src/build/turbopack-build/index.ts
@@ -24,7 +24,6 @@ async function turbopackBuildWithWorker() {
       config: _config,
       ...prunedBuildContext
     } = NextBuildContext
-    console.log('prunedBuildContext', prunedBuildContext)
     const { buildTraceContext, duration } = await worker.workerMain({
       buildContext: prunedBuildContext,
     })

--- a/packages/next/src/build/turbopack-build/index.ts
+++ b/packages/next/src/build/turbopack-build/index.ts
@@ -3,7 +3,9 @@ import path from 'path'
 import { Worker } from '../../lib/worker'
 import { NextBuildContext } from '../build-context'
 
-async function turbopackBuildWithWorker() {
+async function turbopackBuildWithWorker(): ReturnType<
+  typeof import('./impl').turbopackBuild
+> {
   try {
     const worker = new Worker(path.join(__dirname, 'impl.js'), {
       exposedMethods: ['workerMain', 'waitForShutdown'],
@@ -31,7 +33,7 @@ async function turbopackBuildWithWorker() {
     return {
       // destroy worker when Turbopack has shutdown so it's not sticking around using memory
       // We need to wait for shutdown to make sure filesystem cache is flushed
-      shutDownPromise: worker.waitForShutdown().then(() => {
+      shutdownPromise: worker.waitForShutdown().then(() => {
         worker.end()
       }),
       buildTraceContext,

--- a/packages/next/src/build/turbopack-build/index.ts
+++ b/packages/next/src/build/turbopack-build/index.ts
@@ -18,18 +18,26 @@ async function turbopackBuildWithWorker() {
         },
       },
     }) as Worker & typeof import('./impl')
-    const { nextBuildSpan, ...prunedBuildContext } = NextBuildContext
-    const result = await worker.workerMain({
+    const {
+      nextBuildSpan,
+      // Config is not serializable and is loaded in the worker.
+      config: _config,
+      ...prunedBuildContext
+    } = NextBuildContext
+    console.log('prunedBuildContext', prunedBuildContext)
+    const { buildTraceContext, duration } = await worker.workerMain({
       buildContext: prunedBuildContext,
     })
 
-    // destroy worker when Turbopack has shutdown so it's not sticking around using memory
-    // We need to wait for shutdown to make sure filesystem cache is flushed
-    result.shutdownPromise = worker.waitForShutdown().then(() => {
-      worker.end()
-    })
-
-    return result
+    return {
+      // destroy worker when Turbopack has shutdown so it's not sticking around using memory
+      // We need to wait for shutdown to make sure filesystem cache is flushed
+      shutDownPromise: worker.waitForShutdown().then(() => {
+        worker.end()
+      }),
+      buildTraceContext,
+      duration,
+    }
   } catch (err: any) {
     // When the error is a serialized `Error` object we need to recreate the `Error` instance
     // in order to keep the consistent error reporting behavior.


### PR DESCRIPTION
## What?

Switches the worker booted to run Turbopack build (for fast memory cleanup when this step is done) to using worker threads instead of child process.

Closes PACK-5672