### PR TITLE
Revert "Fix flakey overlay feedback test"

### DIFF
--- a/test/development/error-overlay/index.test.tsx
+++ b/test/development/error-overlay/index.test.tsx
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { assertHasRedbox, retry } from 'next-test-utils'
+import { assertHasRedbox } from 'next-test-utils'
 
 describe('DevErrorOverlay', () => {
   const { next } = nextTestSetup({
@@ -33,17 +33,15 @@ describe('DevErrorOverlay', () => {
     await browser.elementByCss('button').click() // clicked "break on client"
     await browser.getByRole('button', { name: 'Mark as helpful' }).click()
 
-    await retry(async () => {
-      expect(
-        await browser
-          .getByRole('region', { name: 'Error feedback' })
-          .getByRole('status')
-          .textContent()
-      ).toEqual('Thanks for your feedback!')
-      expect(feedbackRequests).toEqual([
-        '/__nextjs_error_feedback?errorCode=E40&wasHelpful=true',
-      ])
-    })
+    expect(
+      await browser
+        .getByRole('region', { name: 'Error feedback' })
+        .getByRole('status')
+        .textContent()
+    ).toEqual('Thanks for your feedback!')
+    expect(feedbackRequests).toEqual([
+      '/__nextjs_error_feedback?errorCode=E40&wasHelpful=true',
+    ])
   })
 
   it('sends feedback when clicking not helpful button', async () => {
@@ -62,17 +60,15 @@ describe('DevErrorOverlay', () => {
     await browser.elementByCss('button').click() // clicked "break on client"
     await browser.getByRole('button', { name: 'Mark as not helpful' }).click()
 
-    await retry(async () => {
-      expect(
-        await browser
-          .getByRole('region', { name: 'Error feedback' })
-          .getByRole('status')
-          .textContent()
-      ).toEqual('Thanks for your feedback!')
-      expect(feedbackRequests).toEqual([
-        '/__nextjs_error_feedback?errorCode=E40&wasHelpful=false',
-      ])
-    })
+    expect(
+      await browser
+        .getByRole('region', { name: 'Error feedback' })
+        .getByRole('status')
+        .textContent()
+    ).toEqual('Thanks for your feedback!')
+    expect(feedbackRequests).toEqual([
+      '/__nextjs_error_feedback?errorCode=E40&wasHelpful=false',
+    ])
   })
 
   it('loads fonts successfully', async () => {


### PR DESCRIPTION
Reverts https://github.com/vercel/next.js/pull/84662

The referenced failure was not flake but consistent failure:
```
    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

      Array [
    -   "/__nextjs_error_feedback?errorCode=E794&wasHelpful=true",
    +   "/__nextjs_error_feedback?errorCode=E209&wasHelpful=true",
```

-- https://github.com/vercel/next.js/actions/runs/18360376124/job/52302677520?pr=84500

The proper fix was in https://github.com/vercel/next.js/pull/84671


 If feedback is not registered immediately, we'd be looking at a severe perf regression that's worth investigating instead of hiding it behind `retry`.