### PR TITLE
[mcp] capture next config schema errors

### DIFF
--- a/packages/next/src/server/mcp/tools/get-errors.ts
+++ b/packages/next/src/server/mcp/tools/get-errors.ts
@@ -21,6 +21,7 @@ import {
   handleBrowserPageResponse,
   DEFAULT_BROWSER_REQUEST_TIMEOUT_MS,
 } from './utils/browser-communication'
+import { NextInstanceErrorState } from './next-instance-error-state'
 
 export function registerGetErrorsTool(
   server: McpServer,
@@ -55,18 +56,21 @@ export function registerGetErrorsTool(
           DEFAULT_BROWSER_REQUEST_TIMEOUT_MS
         )
 
-        const errorsByUrl = new Map<string, OverlayState>()
+        // The error state for each route
+        // key is the route path, value is the error state
+        const routesErrorState = new Map<string, OverlayState>()
         for (const response of responses) {
           if (response.data) {
-            errorsByUrl.set(response.url, response.data)
+            routesErrorState.set(response.url, response.data)
           }
         }
 
-        const hasErrors = Array.from(errorsByUrl.values()).some(
+        const hasRouteErrors = Array.from(routesErrorState.values()).some(
           (state) => state.errors.length > 0 || !!state.buildError
         )
+        const hasInstanceErrors = NextInstanceErrorState.nextConfig.length > 0
 
-        if (!hasErrors) {
+        if (!hasRouteErrors && !hasInstanceErrors) {
           return {
             content: [
               {
@@ -80,7 +84,10 @@ export function registerGetErrorsTool(
           }
         }
 
-        const output = await formatErrors(errorsByUrl)
+        const output = await formatErrors(
+          routesErrorState,
+          NextInstanceErrorState
+        )
 
         return {
           content: [

--- a/packages/next/src/server/mcp/tools/get-errors.ts
+++ b/packages/next/src/server/mcp/tools/get-errors.ts
@@ -1,13 +1,17 @@
 /**
- * MCP tool for retrieving browser error state.
+ * MCP tool for retrieving error state from Next.js dev server.
  *
- * This tool demonstrates server-to-browser communication in Next.js dev mode.
- * It leverages the existing HMR infrastructure rather than creating new channels.
+ * This tool provides comprehensive error reporting including:
+ * - Next.js global errors (e.g., next.config validation errors)
+ * - Browser runtime errors with source-mapped stack traces
+ * - Build errors from webpack/turbopack compilation
+ *
+ * For browser errors, it leverages the HMR infrastructure for server-to-browser communication.
  *
  * Flow:
  *   MCP client → server generates request ID → HMR message to browser →
  *   browser queries error overlay state → HMR response back → server performs source mapping →
- *   formatted output.
+ *   combined with global errors → formatted output.
  */
 import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
 import type { OverlayState } from '../../../next-devtools/dev-overlay/shared'
@@ -32,7 +36,7 @@ export function registerGetErrorsTool(
     'get_errors',
     {
       description:
-        'Get the current error state of the app when rendered in the browser, including any build or runtime errors with source-mapped stack traces',
+        'Get the current error state from the Next.js dev server, including Next.js global errors (e.g., next.config validation), browser runtime errors, and build errors with source-mapped stack traces',
       inputSchema: {},
     },
     async (_request) => {

--- a/packages/next/src/server/mcp/tools/next-instance-error-state.ts
+++ b/packages/next/src/server/mcp/tools/next-instance-error-state.ts
@@ -1,0 +1,22 @@
+/**
+ * Global error state for Next.js instance-level errors that are not associated
+ * with a specific browser session or route. This state is exposed through the MCP server's `get_errors`
+ * tool as well. This covers the errors that are global to the Next.js instance, such as errors in next.config.js.
+ *
+ *
+ * ## Usage
+ *
+ * This state is directly manipulated by various parts of the Next.js dev server:
+ *
+ * // Reset the error state
+ * NextInstanceErrorState.[errorType] = []
+ *
+ * // Capture an error for a specific error type
+ * NextInstanceErrorState.[errorType].push(err)
+ *
+ */
+export const NextInstanceErrorState: {
+  nextConfig: unknown[]
+} = {
+  nextConfig: [],
+}

--- a/test/development/mcp-server/mcp-server-get-errors.test.ts
+++ b/test/development/mcp-server/mcp-server-get-errors.test.ts
@@ -312,6 +312,59 @@ describe('mcp-server get_errors tool', () => {
       await s2.close()
     }
   })
+
+  it('should capture next.config errors and clear when fixed', async () => {
+    // Read the original config
+    const originalConfig = await next.readFile('next.config.js')
+
+    // Stop server, write invalid config, and restart
+    await next.stop()
+    await next.patchFile(
+      'next.config.js',
+      `module.exports = {
+  experimental: {
+    mcpServer: true,
+    invalidTestProperty: 'this should cause a validation warning',
+  },
+}`
+    )
+    await next.start()
+
+    // Open a browser session
+    await next.browser('/')
+
+    // Check that the config error is captured
+    let errors: string = ''
+    await retry(async () => {
+      const sessionId = 'test-config-error-' + Date.now()
+      errors = await callGetErrors(sessionId)
+      expect(errors).toContain('Next.js Configuration Errors')
+      expect(errors).toContain('error(s) found in next.config')
+    })
+
+    const strippedErrors = stripAnsi(errors)
+    expect(strippedErrors).toContain('Next.js Configuration Errors')
+    expect(strippedErrors).toContain('Invalid next.config.js options detected')
+    expect(strippedErrors).toContain('invalidTestProperty')
+
+    // Stop server, fix the config, and restart
+    await next.stop()
+    await next.patchFile('next.config.js', originalConfig)
+    await next.start()
+
+    // Open a browser session
+    await next.browser('/')
+
+    // Verify the config error is now gone
+    await retry(async () => {
+      const sessionId = 'test-config-fixed-' + Date.now()
+      const fixedErrors = await callGetErrors(sessionId)
+      const strippedFixed = stripAnsi(fixedErrors)
+      expect(strippedFixed).not.toContain('Next.js Configuration Errors')
+      expect(strippedFixed).not.toContain('invalidTestProperty')
+      expect(strippedFixed).toContain('No errors detected')
+    })
+  })
 })
 
 /**


### PR DESCRIPTION
Capture the schema validation errors into mcp `get_errors()`

During dev, we also emit the schema validation errors when encounter errors while loading next.config. We capture those validation errors into a global error state for next instance, and expose them through mcp tool `get_errors`.

When users fix the next.config schema error in dev, the next config can be reloaded, in that case the process will be changed. So we use `process.pid` as part of the cache key for next config loader, in case we need a new validation to decide either we need to reset or update the config errors.