### PR TITLE
Add test for eslint-config-next

### DIFF
--- a/test/unit/eslint-config-next/core-web-vitals/eslint-config-next-core-web-vitals.test.ts
+++ b/test/unit/eslint-config-next/core-web-vitals/eslint-config-next-core-web-vitals.test.ts
@@ -1,0 +1,249 @@
+import { join } from 'path'
+import { execSync } from 'child_process'
+import { getEslintConfigSnapshot } from '../utils'
+
+describe('eslint-config-next/core-web-vitals', () => {
+  it('should match expected resolved configuration', () => {
+    const eslintConfigAfterSetupJSON = execSync(
+      // Pass explicit absolute path to not get affected by the root eslint config.
+      `pnpm eslint --config ${join(__dirname, 'eslint.config.mjs')} --print-config ${join(__dirname, 'test.js')}`,
+      {
+        cwd: __dirname,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'inherit'],
+      }
+    )
+
+    const { settings, languageOptions, ...eslintConfigAfterSetup } = JSON.parse(
+      eslintConfigAfterSetupJSON
+    )
+
+    expect({
+      parser: languageOptions.parser,
+      settings,
+    }).toEqual({
+      parser: expect.stringContaining('eslint-config-next'),
+      settings: {
+        'import/parsers': expect.any(Object),
+        'import/resolver': expect.any(Object),
+        react: {
+          version: 'detect',
+        },
+      },
+    })
+
+    expect(getEslintConfigSnapshot(eslintConfigAfterSetup))
+      .toMatchInlineSnapshot(`
+     {
+       "language": "@/js",
+       "linterOptions": {
+         "reportUnusedDisableDirectives": 1,
+       },
+       "plugins": [
+         "@",
+         "react",
+         "react-hooks:eslint-plugin-react-hooks@7.0.0",
+         "@next/next",
+         "import",
+         "jsx-a11y:eslint-plugin-jsx-a11y@6.10.2",
+       ],
+       "rules": {
+         "@next/next/google-font-display": [
+           1,
+         ],
+         "@next/next/google-font-preconnect": [
+           1,
+         ],
+         "@next/next/inline-script-id": [
+           2,
+         ],
+         "@next/next/next-script-for-ga": [
+           1,
+         ],
+         "@next/next/no-assign-module-variable": [
+           2,
+         ],
+         "@next/next/no-async-client-component": [
+           1,
+         ],
+         "@next/next/no-before-interactive-script-outside-document": [
+           1,
+         ],
+         "@next/next/no-css-tags": [
+           1,
+         ],
+         "@next/next/no-document-import-in-page": [
+           2,
+         ],
+         "@next/next/no-duplicate-head": [
+           2,
+         ],
+         "@next/next/no-head-element": [
+           1,
+         ],
+         "@next/next/no-head-import-in-document": [
+           2,
+         ],
+         "@next/next/no-html-link-for-pages": [
+           2,
+         ],
+         "@next/next/no-img-element": [
+           1,
+         ],
+         "@next/next/no-page-custom-font": [
+           1,
+         ],
+         "@next/next/no-script-component-in-head": [
+           2,
+         ],
+         "@next/next/no-styled-jsx-in-document": [
+           1,
+         ],
+         "@next/next/no-sync-scripts": [
+           2,
+         ],
+         "@next/next/no-title-in-document-head": [
+           1,
+         ],
+         "@next/next/no-typos": [
+           1,
+         ],
+         "@next/next/no-unwanted-polyfillio": [
+           1,
+         ],
+         "import/no-anonymous-default-export": [
+           1,
+         ],
+         "jsx-a11y/alt-text": [
+           1,
+           {
+             "elements": [
+               "img",
+             ],
+             "img": [
+               "Image",
+             ],
+           },
+         ],
+         "jsx-a11y/aria-props": [
+           1,
+         ],
+         "jsx-a11y/aria-proptypes": [
+           1,
+         ],
+         "jsx-a11y/aria-unsupported-elements": [
+           1,
+         ],
+         "jsx-a11y/role-has-required-aria-props": [
+           1,
+         ],
+         "jsx-a11y/role-supports-aria-props": [
+           1,
+         ],
+         "react-hooks/component-hook-factories": [
+           2,
+         ],
+         "react-hooks/config": [
+           2,
+         ],
+         "react-hooks/error-boundaries": [
+           2,
+         ],
+         "react-hooks/exhaustive-deps": [
+           1,
+         ],
+         "react-hooks/gating": [
+           2,
+         ],
+         "react-hooks/globals": [
+           2,
+         ],
+         "react-hooks/immutability": [
+           2,
+         ],
+         "react-hooks/incompatible-library": [
+           1,
+         ],
+         "react-hooks/preserve-manual-memoization": [
+           2,
+         ],
+         "react-hooks/purity": [
+           2,
+         ],
+         "react-hooks/refs": [
+           2,
+         ],
+         "react-hooks/rules-of-hooks": [
+           2,
+         ],
+         "react-hooks/set-state-in-effect": [
+           2,
+         ],
+         "react-hooks/set-state-in-render": [
+           2,
+         ],
+         "react-hooks/static-components": [
+           2,
+         ],
+         "react-hooks/unsupported-syntax": [
+           1,
+         ],
+         "react-hooks/use-memo": [
+           2,
+         ],
+         "react/display-name": [
+           2,
+         ],
+         "react/jsx-key": [
+           2,
+         ],
+         "react/jsx-no-comment-textnodes": [
+           2,
+         ],
+         "react/jsx-no-duplicate-props": [
+           2,
+         ],
+         "react/jsx-no-undef": [
+           2,
+         ],
+         "react/jsx-uses-react": [
+           2,
+         ],
+         "react/jsx-uses-vars": [
+           2,
+         ],
+         "react/no-children-prop": [
+           2,
+         ],
+         "react/no-danger-with-children": [
+           2,
+         ],
+         "react/no-deprecated": [
+           2,
+         ],
+         "react/no-direct-mutation-state": [
+           2,
+         ],
+         "react/no-find-dom-node": [
+           2,
+         ],
+         "react/no-is-mounted": [
+           2,
+         ],
+         "react/no-render-return-value": [
+           2,
+         ],
+         "react/no-string-refs": [
+           2,
+         ],
+         "react/no-unescaped-entities": [
+           2,
+         ],
+         "react/require-render-return": [
+           2,
+         ],
+       },
+     }
+    `)
+  })
+})

--- a/test/unit/eslint-config-next/core-web-vitals/eslint.config.mjs
+++ b/test/unit/eslint-config-next/core-web-vitals/eslint.config.mjs
@@ -1,0 +1,12 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { FlatCompat } from '@eslint/eslintrc'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+})
+
+export default compat.extends('next/core-web-vitals')

--- a/test/unit/eslint-config-next/core-web-vitals/test.js
+++ b/test/unit/eslint-config-next/core-web-vitals/test.js
@@ -1,0 +1,4 @@
+// Dummy file for testing eslint-config-next core-web-vitals configuration
+export default function Test() {
+  return <div>Hello World</div>
+}

--- a/test/unit/eslint-config-next/default/eslint-config-next-default.test.ts
+++ b/test/unit/eslint-config-next/default/eslint-config-next-default.test.ts
@@ -1,0 +1,250 @@
+import { join } from 'path'
+import { execSync } from 'child_process'
+import { getEslintConfigSnapshot } from '../utils'
+
+describe('eslint-config-next', () => {
+  it('should match expected resolved configuration', () => {
+    const eslintConfigAfterSetupJSON = execSync(
+      // Pass explicit absolute path to not get affected by the root eslint config.
+      `pnpm eslint --config ${join(__dirname, 'eslint.config.mjs')} --print-config ${join(__dirname, 'test.js')}`,
+      {
+        cwd: __dirname,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'inherit'],
+      }
+    )
+
+    const { settings, languageOptions, ...eslintConfigAfterSetup } = JSON.parse(
+      eslintConfigAfterSetupJSON
+    )
+
+    expect({
+      parser: languageOptions.parser,
+      settings,
+    }).toEqual({
+      // parser: require.resolve('eslint-config-next')
+      parser: expect.stringContaining('eslint-config-next'),
+      settings: {
+        'import/parsers': expect.any(Object),
+        'import/resolver': expect.any(Object),
+        react: {
+          version: 'detect',
+        },
+      },
+    })
+
+    expect(getEslintConfigSnapshot(eslintConfigAfterSetup))
+      .toMatchInlineSnapshot(`
+     {
+       "language": "@/js",
+       "linterOptions": {
+         "reportUnusedDisableDirectives": 1,
+       },
+       "plugins": [
+         "@",
+         "react",
+         "react-hooks:eslint-plugin-react-hooks@7.0.0",
+         "@next/next",
+         "import",
+         "jsx-a11y:eslint-plugin-jsx-a11y@6.10.2",
+       ],
+       "rules": {
+         "@next/next/google-font-display": [
+           1,
+         ],
+         "@next/next/google-font-preconnect": [
+           1,
+         ],
+         "@next/next/inline-script-id": [
+           2,
+         ],
+         "@next/next/next-script-for-ga": [
+           1,
+         ],
+         "@next/next/no-assign-module-variable": [
+           2,
+         ],
+         "@next/next/no-async-client-component": [
+           1,
+         ],
+         "@next/next/no-before-interactive-script-outside-document": [
+           1,
+         ],
+         "@next/next/no-css-tags": [
+           1,
+         ],
+         "@next/next/no-document-import-in-page": [
+           2,
+         ],
+         "@next/next/no-duplicate-head": [
+           2,
+         ],
+         "@next/next/no-head-element": [
+           1,
+         ],
+         "@next/next/no-head-import-in-document": [
+           2,
+         ],
+         "@next/next/no-html-link-for-pages": [
+           1,
+         ],
+         "@next/next/no-img-element": [
+           1,
+         ],
+         "@next/next/no-page-custom-font": [
+           1,
+         ],
+         "@next/next/no-script-component-in-head": [
+           2,
+         ],
+         "@next/next/no-styled-jsx-in-document": [
+           1,
+         ],
+         "@next/next/no-sync-scripts": [
+           1,
+         ],
+         "@next/next/no-title-in-document-head": [
+           1,
+         ],
+         "@next/next/no-typos": [
+           1,
+         ],
+         "@next/next/no-unwanted-polyfillio": [
+           1,
+         ],
+         "import/no-anonymous-default-export": [
+           1,
+         ],
+         "jsx-a11y/alt-text": [
+           1,
+           {
+             "elements": [
+               "img",
+             ],
+             "img": [
+               "Image",
+             ],
+           },
+         ],
+         "jsx-a11y/aria-props": [
+           1,
+         ],
+         "jsx-a11y/aria-proptypes": [
+           1,
+         ],
+         "jsx-a11y/aria-unsupported-elements": [
+           1,
+         ],
+         "jsx-a11y/role-has-required-aria-props": [
+           1,
+         ],
+         "jsx-a11y/role-supports-aria-props": [
+           1,
+         ],
+         "react-hooks/component-hook-factories": [
+           2,
+         ],
+         "react-hooks/config": [
+           2,
+         ],
+         "react-hooks/error-boundaries": [
+           2,
+         ],
+         "react-hooks/exhaustive-deps": [
+           1,
+         ],
+         "react-hooks/gating": [
+           2,
+         ],
+         "react-hooks/globals": [
+           2,
+         ],
+         "react-hooks/immutability": [
+           2,
+         ],
+         "react-hooks/incompatible-library": [
+           1,
+         ],
+         "react-hooks/preserve-manual-memoization": [
+           2,
+         ],
+         "react-hooks/purity": [
+           2,
+         ],
+         "react-hooks/refs": [
+           2,
+         ],
+         "react-hooks/rules-of-hooks": [
+           2,
+         ],
+         "react-hooks/set-state-in-effect": [
+           2,
+         ],
+         "react-hooks/set-state-in-render": [
+           2,
+         ],
+         "react-hooks/static-components": [
+           2,
+         ],
+         "react-hooks/unsupported-syntax": [
+           1,
+         ],
+         "react-hooks/use-memo": [
+           2,
+         ],
+         "react/display-name": [
+           2,
+         ],
+         "react/jsx-key": [
+           2,
+         ],
+         "react/jsx-no-comment-textnodes": [
+           2,
+         ],
+         "react/jsx-no-duplicate-props": [
+           2,
+         ],
+         "react/jsx-no-undef": [
+           2,
+         ],
+         "react/jsx-uses-react": [
+           2,
+         ],
+         "react/jsx-uses-vars": [
+           2,
+         ],
+         "react/no-children-prop": [
+           2,
+         ],
+         "react/no-danger-with-children": [
+           2,
+         ],
+         "react/no-deprecated": [
+           2,
+         ],
+         "react/no-direct-mutation-state": [
+           2,
+         ],
+         "react/no-find-dom-node": [
+           2,
+         ],
+         "react/no-is-mounted": [
+           2,
+         ],
+         "react/no-render-return-value": [
+           2,
+         ],
+         "react/no-string-refs": [
+           2,
+         ],
+         "react/no-unescaped-entities": [
+           2,
+         ],
+         "react/require-render-return": [
+           2,
+         ],
+       },
+     }
+    `)
+  })
+})

--- a/test/unit/eslint-config-next/default/eslint.config.mjs
+++ b/test/unit/eslint-config-next/default/eslint.config.mjs
@@ -1,0 +1,12 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { FlatCompat } from '@eslint/eslintrc'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+})
+
+export default compat.extends('next')

--- a/test/unit/eslint-config-next/default/test.js
+++ b/test/unit/eslint-config-next/default/test.js
@@ -1,0 +1,4 @@
+// Dummy file for testing eslint-config-next base configuration
+export default function Test() {
+  return <div>Hello World</div>
+}

--- a/test/unit/eslint-config-next/typescript/eslint-config-next-typescript.test.ts
+++ b/test/unit/eslint-config-next/typescript/eslint-config-next-typescript.test.ts
@@ -1,0 +1,124 @@
+import { join } from 'path'
+import { execSync } from 'child_process'
+import { getEslintConfigSnapshot } from '../utils'
+
+describe('eslint-config-next/typescript', () => {
+  it('should match expected resolved configuration', () => {
+    const eslintConfigAfterSetupJSON = execSync(
+      // Pass explicit absolute path to not get affected by the root eslint config.
+      `pnpm eslint --config ${join(__dirname, 'eslint.config.mjs')} --print-config ${join(__dirname, 'test.tsx')}`,
+      {
+        cwd: __dirname,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'inherit'],
+      }
+    )
+
+    const { languageOptions, ...eslintConfigAfterSetup } = JSON.parse(
+      eslintConfigAfterSetupJSON
+    )
+
+    expect({
+      parser: languageOptions.parser,
+    }).toEqual({
+      parser: expect.stringContaining('typescript-eslint'),
+    })
+
+    expect(getEslintConfigSnapshot(eslintConfigAfterSetup))
+      .toMatchInlineSnapshot(`
+     {
+       "language": "@/js",
+       "linterOptions": {
+         "reportUnusedDisableDirectives": 1,
+       },
+       "plugins": [
+         "@",
+         "@typescript-eslint:@typescript-eslint/eslint-plugin@8.46.0",
+       ],
+       "rules": {
+         "@typescript-eslint/ban-ts-comment": [
+           2,
+         ],
+         "@typescript-eslint/no-array-constructor": [
+           2,
+         ],
+         "@typescript-eslint/no-duplicate-enum-values": [
+           2,
+         ],
+         "@typescript-eslint/no-empty-object-type": [
+           2,
+         ],
+         "@typescript-eslint/no-explicit-any": [
+           2,
+         ],
+         "@typescript-eslint/no-extra-non-null-assertion": [
+           2,
+         ],
+         "@typescript-eslint/no-misused-new": [
+           2,
+         ],
+         "@typescript-eslint/no-namespace": [
+           2,
+         ],
+         "@typescript-eslint/no-non-null-asserted-optional-chain": [
+           2,
+         ],
+         "@typescript-eslint/no-require-imports": [
+           2,
+         ],
+         "@typescript-eslint/no-this-alias": [
+           2,
+         ],
+         "@typescript-eslint/no-unnecessary-type-constraint": [
+           2,
+         ],
+         "@typescript-eslint/no-unsafe-declaration-merging": [
+           2,
+         ],
+         "@typescript-eslint/no-unsafe-function-type": [
+           2,
+         ],
+         "@typescript-eslint/no-unused-expressions": [
+           1,
+           {
+             "allowShortCircuit": false,
+             "allowTaggedTemplates": false,
+             "allowTernary": false,
+           },
+         ],
+         "@typescript-eslint/no-unused-vars": [
+           1,
+         ],
+         "@typescript-eslint/no-wrapper-object-types": [
+           2,
+         ],
+         "@typescript-eslint/prefer-as-const": [
+           2,
+         ],
+         "@typescript-eslint/prefer-namespace-keyword": [
+           2,
+         ],
+         "@typescript-eslint/triple-slash-reference": [
+           2,
+         ],
+         "no-var": [
+           2,
+         ],
+         "prefer-const": [
+           2,
+           {
+             "destructuring": "any",
+             "ignoreReadBeforeAssign": false,
+           },
+         ],
+         "prefer-rest-params": [
+           2,
+         ],
+         "prefer-spread": [
+           2,
+         ],
+       },
+     }
+    `)
+  })
+})

--- a/test/unit/eslint-config-next/typescript/eslint.config.mjs
+++ b/test/unit/eslint-config-next/typescript/eslint.config.mjs
@@ -1,0 +1,12 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { FlatCompat } from '@eslint/eslintrc'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+})
+
+export default compat.extends('next/typescript')

--- a/test/unit/eslint-config-next/typescript/test.tsx
+++ b/test/unit/eslint-config-next/typescript/test.tsx
@@ -1,0 +1,8 @@
+// Dummy file for testing eslint-config-next typescript configuration
+interface Props {
+  message: string
+}
+
+export default function Test({ message }: Props) {
+  return <div>{message}</div>
+}

--- a/test/unit/eslint-config-next/utils.ts
+++ b/test/unit/eslint-config-next/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Rules being turned off (i.e. remove from snapshot) would be breaking change (requires removal of eslint-disable directive)
+ * Rules being added that are turned off would not be a breaking change (no eslint-disable directive required)
+ * Rules being added with a severity would be a breaking change (requires addition of eslint-disable directive)
+ */
+export function getEslintConfigSnapshot(eslintConfig: any) {
+  return {
+    ...eslintConfig,
+    rules: Object.fromEntries(
+      Object.entries(eslintConfig.rules).filter(
+        ([, config]: [ruleName: string, config: [severity: unknown]]) => {
+          const [severity] = config
+
+          return severity !== 0 && severity !== 'off'
+        }
+      )
+    ),
+  }
+}


### PR DESCRIPTION
Before migrating `eslint-config-next` project to TypeScript and Flat config, add a reliable test so that we can detect regression during the process.

The patterns and utils are ported from https://github.com/vercel/next.js/blob/ad17ea67c2d4140ac2c59caeb37d1ea6d8e6ad8b/test/production/eslint/test/next-build-and-lint.test.ts, which was removed at https://github.com/vercel/next.js/pull/83136.