### PR TITLE
[ci]: set NEXT_TEST_VERSION to release tag for deploy tests

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -30,7 +30,7 @@ env:
   TURBO_TOKEN: ${{ secrets.HOSTED_TURBO_TOKEN }}
   DD_ENV: 'ci'
 
-run-name: test-e2e-deploy ${{ inputs.nextVersion || 'canary' }}
+run-name: test-e2e-deploy ${{ inputs.nextVersion || (github.event_name == 'release' && github.event.release.tag_name) || 'canary' }}
 
 jobs:
   setup:
@@ -84,7 +84,7 @@ jobs:
         NEXT_TEST_MODE=deploy \
         IS_WEBPACK_TEST=1 \
         NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" \
-        NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || 'canary' }}" \
+        NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || needs.setup.outputs.next-version || 'canary' }}" \
         VERCEL_CLI_VERSION="${{ github.event.inputs.vercelCliVersion || 'vercel@latest' }}" \
         node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
       skipNativeBuild: 'yes'


### PR DESCRIPTION
When deploy tests run on release branches, they end up using "canary" rather than the version associated with the release. This means that the test files might be misaligned with the underlying versions they are testing.

We are already doing the work of collecting the next version, we just weren't plumbing it into `NEXT_TEST_VERSION`. 