### PR TITLE
improve next config schema validation errors

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -22,7 +22,7 @@ import { loadWebpackHook } from './config-utils'
 import { imageConfigDefault } from '../shared/lib/image-config'
 import type { ImageConfig } from '../shared/lib/image-config'
 import { loadEnvConfig, updateInitialEnv } from '@next/env'
-import { flushAndExit } from '../telemetry/flush-and-exit'
+import { flushTelemetry } from '../telemetry/flush-telemetry'
 import {
   findRootDirAndLockFiles,
   warnDuplicatedLockFiles,
@@ -53,40 +53,48 @@ export type { DomainLocale, NextConfig } from './config-shared'
 
 function normalizeNextConfigZodErrors(
   error: ZodError<NextConfig>
-): [errorMessages: string[], shouldExit: boolean] {
-  let shouldExit = false
+): [warnings: string[], fatalErrors: string[]] {
+  const warnings: string[] = []
+  const fatalErrors: string[] = []
   const issues = normalizeZodErrors(error)
-  return [
-    issues.flatMap(({ issue, message }) => {
-      if (issue.path[0] === 'images') {
-        // We exit the build when encountering an error in the images config
-        shouldExit = true
-      }
-      if (
-        issue.code === 'unrecognized_keys' &&
-        issue.path[0] === 'experimental'
-      ) {
-        if (message.includes('turbopackPersistentCachingForBuild')) {
-          // We exit the build when encountering an error in the turbopackPersistentCaching config
-          shouldExit = true
-          message +=
-            "\nUse 'experimental.turbopackFileSystemCacheForBuild' instead."
-          message +=
-            '\nLearn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache'
-        } else if (message.includes('turbopackPersistentCaching')) {
-          // We exit the build when encountering an error in the turbopackPersistentCaching config
-          shouldExit = true
-          message +=
-            "\nUse 'experimental.turbopackFileSystemCacheForDev' instead."
-          message +=
-            '\nLearn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache'
-        }
-      }
 
-      return message
-    }),
-    shouldExit,
-  ]
+  for (const { issue, message: originalMessage } of issues) {
+    let message = originalMessage
+    let shouldExit = false
+
+    if (issue.path[0] === 'images') {
+      // We exit the build when encountering an error in the images config
+      shouldExit = true
+    }
+    if (
+      issue.code === 'unrecognized_keys' &&
+      issue.path[0] === 'experimental'
+    ) {
+      if (message.includes('turbopackPersistentCachingForBuild')) {
+        // We exit the build when encountering an error in the turbopackPersistentCaching config
+        shouldExit = true
+        message +=
+          "\nUse 'experimental.turbopackFileSystemCacheForBuild' instead."
+        message +=
+          '\nLearn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache'
+      } else if (message.includes('turbopackPersistentCaching')) {
+        // We exit the build when encountering an error in the turbopackPersistentCaching config
+        shouldExit = true
+        message +=
+          "\nUse 'experimental.turbopackFileSystemCacheForDev' instead."
+        message +=
+          '\nLearn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache'
+      }
+    }
+
+    if (shouldExit) {
+      fatalErrors.push(message)
+    } else {
+      warnings.push(message)
+    }
+  }
+
+  return [warnings, fatalErrors]
 }
 
 export function warnOptionHasBeenDeprecated(
@@ -1938,36 +1946,67 @@ async function validateConfigSchema(
   const state = configSchema.safeParse(userConfig)
 
   if (!state.success) {
-    // error message header
-    const messages = [`Invalid ${configFileName} options detected: `]
+    const [warnings, fatalErrors] = normalizeNextConfigZodErrors(state.error)
+    const hasFatalErrors = fatalErrors.length > 0
 
-    const [errorMessages, shouldExit] = normalizeNextConfigZodErrors(
-      state.error
-    )
-    // ident list item
-    for (const error of errorMessages) {
-      messages.push(`    ${error.split('\n').join('\n    ')}`)
-    }
+    // Group warnings first
+    if (warnings.length > 0) {
+      const warningMessages = [`Invalid ${configFileName} options detected: `]
 
-    // error message footer
-    messages.push(
-      'See more info here: https://nextjs.org/docs/messages/invalid-next-config'
-    )
-
-    // Call the callback with validation messages if provided
-    if (onValidationMessages) {
-      onValidationMessages(messages)
-    }
-
-    if (shouldExit) {
-      for (const message of messages) {
-        console.error(message)
+      for (const error of warnings) {
+        warningMessages.push(`    ${error.split('\n').join('\n    ')}`)
       }
-      await flushAndExit(1)
-    } else {
-      for (const message of messages) {
+
+      warningMessages.push(
+        'See more info here: https://nextjs.org/docs/messages/invalid-next-config'
+      )
+
+      // Call the callback with validation messages if provided
+      if (onValidationMessages) {
+        onValidationMessages(warningMessages)
+      }
+
+      for (const message of warningMessages) {
         warn(message)
       }
+    }
+
+    // Then throw hard errors
+    if (hasFatalErrors) {
+      flushTelemetry()
+
+      const errorMessages = [
+        `Fatal next config errors found in ${configFileName} that must be fixed:`,
+      ]
+
+      for (const error of fatalErrors) {
+        errorMessages.push(`    ${error.split('\n').join('\n    ')}`)
+      }
+
+      errorMessages.push(
+        'These configuration options are required or have been migrated. Please update your configuration.'
+      )
+      errorMessages.push(
+        'See more info here: https://nextjs.org/docs/messages/invalid-next-config'
+      )
+
+      // Call the callback with validation messages if provided
+      if (onValidationMessages) {
+        onValidationMessages(errorMessages)
+      }
+
+      const fullErrorMessage = errorMessages.join('\n')
+
+      let err: Error
+      const stackTraceLimit = Error.stackTraceLimit
+      Error.stackTraceLimit = 0
+      try {
+        err = new Error(fullErrorMessage)
+      } finally {
+        Error.stackTraceLimit = stackTraceLimit
+      }
+
+      throw err
     }
   }
 }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1998,6 +1998,7 @@ async function validateConfigSchema(
       const fullErrorMessage = errorMessages.join('\n')
 
       let err: Error
+      // Hide the stack trace for this error as the trace is not useful here.
       const stackTraceLimit = Error.stackTraceLimit
       Error.stackTraceLimit = 0
       try {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1973,7 +1973,7 @@ async function validateConfigSchema(
 
     // Then throw hard errors
     if (hasFatalErrors) {
-      flushTelemetry()
+      await flushTelemetry()
 
       const errorMessages = [
         `Fatal next config errors found in ${configFileName} that must be fixed:`,

--- a/packages/next/src/telemetry/flush-telemetry.ts
+++ b/packages/next/src/telemetry/flush-telemetry.ts
@@ -1,11 +1,10 @@
 import { traceGlobals } from '../trace/shared'
 
-export async function flushAndExit(code: number) {
+export async function flushTelemetry() {
   let telemetry = traceGlobals.get('telemetry') as
     | InstanceType<typeof import('./storage').Telemetry>
     | undefined
   if (telemetry) {
     await telemetry.flush()
   }
-  process.exit(code)
 }

--- a/test-config-errors/app/page.js
+++ b/test-config-errors/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Test Page</div>
+}

--- a/test-config-errors/next.config.js
+++ b/test-config-errors/next.config.js
@@ -1,0 +1,13 @@
+// Test config with both warnings (unknown keys) and hard errors (images config error)
+module.exports = {
+  // This should be a warning - unknown experimental key
+  experimental: {
+    unknownExperimentalOption: true,
+    anotherUnknownOption: 'test',
+  },
+
+  // This should be a hard error - invalid images config
+  images: {
+    invalidOption: 'bad value',
+  },
+}

--- a/test/production/config-validation-fatal-errors/app/layout.js
+++ b/test/production/config-validation-fatal-errors/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/config-validation-fatal-errors/app/page.js
+++ b/test/production/config-validation-fatal-errors/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Test Page</div>
+}

--- a/test/production/config-validation-fatal-errors/index.test.ts
+++ b/test/production/config-validation-fatal-errors/index.test.ts
@@ -1,0 +1,35 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('config validation - fatal errors', () => {
+  const { next } = nextTestSetup({
+    skipStart: true,
+    skipDeployment: true,
+    files: __dirname,
+  })
+
+  it('should show warnings first, then throw fatal error', async () => {
+    const { exitCode, cliOutput } = await next.build()
+
+    // Build should fail
+    expect(exitCode).toBe(1)
+
+    // Should show warnings first
+    expect(cliOutput).toContain('Invalid next.config.js options detected')
+    expect(cliOutput).toContain(
+      "Unrecognized key(s) in object: 'unknownExperimentalOption', 'anotherUnknownOption'"
+    )
+    expect(cliOutput).toContain('at "experimental"')
+
+    // Should show fatal error
+    expect(cliOutput).toContain(
+      'Fatal next config errors found in next.config.js that must be fixed'
+    )
+    expect(cliOutput).toContain(
+      "Unrecognized key(s) in object: 'invalidOption'"
+    )
+    expect(cliOutput).toContain('at "images"')
+    expect(cliOutput).toContain(
+      'These configuration options are required or have been migrated'
+    )
+  })
+})

--- a/test/production/config-validation-fatal-errors/next.config.js
+++ b/test/production/config-validation-fatal-errors/next.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  // This should be a warning - unknown experimental key
+  experimental: {
+    unknownExperimentalOption: true,
+    anotherUnknownOption: 'test',
+  },
+
+  // This should be a fatal error - invalid images config
+  images: {
+    invalidOption: 'bad value',
+  },
+}

--- a/test/production/config-validation-warnings/app/layout.js
+++ b/test/production/config-validation-warnings/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/config-validation-warnings/app/page.js
+++ b/test/production/config-validation-warnings/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Test Page</div>
+}

--- a/test/production/config-validation-warnings/index.test.ts
+++ b/test/production/config-validation-warnings/index.test.ts
@@ -1,0 +1,29 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('config validation - warnings only', () => {
+  const { next } = nextTestSetup({
+    skipStart: true,
+    skipDeployment: true,
+    files: __dirname,
+  })
+
+  it('should show warnings but not block the build', async () => {
+    const { exitCode, cliOutput } = await next.build()
+
+    // Build should succeed
+    expect(exitCode).toBe(0)
+
+    // Should show warnings
+    expect(cliOutput).toContain('Invalid next.config.js options detected')
+    expect(cliOutput).toContain(
+      "Unrecognized key(s) in object: 'unknownExperimentalOption', 'anotherUnknownOption'"
+    )
+    expect(cliOutput).toContain('at "experimental"')
+
+    // Should NOT show fatal error message
+    expect(cliOutput).not.toContain('Fatal next config errors')
+
+    // Build should complete successfully
+    expect(cliOutput).toContain('Compiled successfully')
+  })
+})

--- a/test/production/config-validation-warnings/next.config.js
+++ b/test/production/config-validation-warnings/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  // This should be a warning - unknown experimental key
+  experimental: {
+    unknownExperimentalOption: true,
+    anotherUnknownOption: 'test',
+  },
+}


### PR DESCRIPTION
### Improvement

Display the config schema validation in a better way, showing both warnings and fala errors that causing the process exit all together but separate into different sections.

Previously we only say all the configs are invalid, but some are critical and some are not. When the critical invalid configurations are detected, process is exited without clear message that which one is the critical one. This will give users hard to on migrating the configs, casue they might miss migrating those configs after a while, ended up seeing bunch of invalid configs and failed build.

Now we separate those warnings and fatal errors into two sections, we log all the warnings first, and then if there're any critical bad next config property, we'll format them and throw a hard error without stack trace. The errors will highlight as red background on deployment platform like vercel so it's much more clear

### Examples

#### Warned + Errored Options
build will fail
```
 ⚠ Invalid next.config.js options detected:
 ⚠     Unrecognized key(s) in object: 'unknownExperimentalOption', 'anotherUnknownOption' at "experimental"
 ⚠ See more info here: https://nextjs.org/docs/messages/invalid-next-config

[Error: Fatal next config errors found in next.config.js that must be fixed:
    Unrecognized key(s) in object: 'invalidOption' at "images"
These configuration options are required or have been migrated. Please update your configuration.
See more info here: https://nextjs.org/docs/messages/invalid-next-config]
```

#### Warned Ones Only

build will succeed
```
 ⚠ Invalid next.config.js options detected:
 ⚠     Unrecognized key(s) in object: 'unknownExperimentalOption', 'anotherUnknownOption' at "experimental"
 ⚠ See more info here: https://nextjs.org/docs/messages/invalid-next-config

Creating an optimized production build ...
```