### PR TITLE
Use correct JSX runtime for library-owned JSX in React Server

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -399,6 +399,20 @@ export default defineConfig([
     },
   },
   {
+    files: [
+      'packages/next/src/server/app-render/**/*.js',
+      'packages/next/src/server/app-render/**/*.jsx',
+      'packages/next/src/server/app-render/**/*.ts',
+      'packages/next/src/server/app-render/**/*.tsx',
+    ],
+    plugins: {
+      '@next/internal': nextEslintPluginInternal,
+    },
+    rules: {
+      '@next/internal/no-jsx-in-app-router': 'error',
+    },
+  },
+  {
     files: ['examples/**/*'],
     linterOptions: {
       reportUnusedDisableDirectives: 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -400,16 +400,16 @@ export default defineConfig([
   },
   {
     files: [
-      'packages/next/src/server/app-render/**/*.js',
-      'packages/next/src/server/app-render/**/*.jsx',
-      'packages/next/src/server/app-render/**/*.ts',
-      'packages/next/src/server/app-render/**/*.tsx',
+      'packages/next/src/server/**/*.js',
+      'packages/next/src/server/**/*.jsx',
+      'packages/next/src/server/**/*.ts',
+      'packages/next/src/server/**/*.tsx',
     ],
     plugins: {
       '@next/internal': nextEslintPluginInternal,
     },
     rules: {
-      '@next/internal/no-jsx-in-app-router': 'error',
+      '@next/internal/no-ambiguous-jsx': 'error',
     },
   },
   {

--- a/packages/eslint-plugin-internal/src/eslint-no-ambiguous-jsx.js
+++ b/packages/eslint-plugin-internal/src/eslint-no-ambiguous-jsx.js
@@ -1,19 +1,14 @@
 /**
- * ESLint rule: typechecked-require
- */
-
-/**
  * @type {import('eslint').Rule.RuleModule}
  */
 const plugin = {
-  name: 'no-jsx-in-app-router',
+  name: 'no-ambiguous-jsx',
   meta: {
     type: 'problem',
     docs: {
       description:
-        'JSX in app-render will default to React Client if it is not bundled in next-server. ' +
-        "If you're creating JSX for React Server, use createElement from ComponentMod instead.",
-      category: 'TypeScript',
+        'Unbundled JSX will default to React Client if it is not bundled in next-server. ' +
+        "If you're creating JSX for React Server, use createElement from componentMod instead.",
       recommended: true,
     },
     fixable: 'code',

--- a/packages/eslint-plugin-internal/src/eslint-no-jsx-in-app-router.js
+++ b/packages/eslint-plugin-internal/src/eslint-no-jsx-in-app-router.js
@@ -1,0 +1,39 @@
+/**
+ * ESLint rule: typechecked-require
+ */
+
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+const plugin = {
+  name: 'no-jsx-in-app-router',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'JSX in app-render will default to React Client if it is not bundled in next-server. ' +
+        "If you're creating JSX for React Server, use createElement from ComponentMod instead.",
+      category: 'TypeScript',
+      recommended: true,
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {},
+  },
+
+  create(context) {
+    function reportJSX(node) {
+      context.report({
+        message: 'Ambiguous JSX usage.',
+        node: node.openingFragment ?? node.name,
+      })
+    }
+
+    return {
+      JSXOpeningElement: reportJSX,
+      JSXFragment: reportJSX,
+    }
+  },
+}
+
+module.exports = plugin

--- a/packages/eslint-plugin-internal/src/eslint-plugin-internal.js
+++ b/packages/eslint-plugin-internal/src/eslint-plugin-internal.js
@@ -1,7 +1,9 @@
 const typecheckedRequire = require('./eslint-typechecked-require')
+const noJsxInAppRouter = require('./eslint-no-jsx-in-app-router')
 
 module.exports = {
   rules: {
+    'no-jsx-in-app-router': noJsxInAppRouter,
     'typechecked-require': typecheckedRequire,
   },
 }

--- a/packages/eslint-plugin-internal/src/eslint-plugin-internal.js
+++ b/packages/eslint-plugin-internal/src/eslint-plugin-internal.js
@@ -1,9 +1,9 @@
 const typecheckedRequire = require('./eslint-typechecked-require')
-const noJsxInAppRouter = require('./eslint-no-jsx-in-app-router')
+const noAmbiguousJSX = require('./eslint-no-ambiguous-jsx')
 
 module.exports = {
   rules: {
-    'no-jsx-in-app-router': noJsxInAppRouter,
+    'no-ambiguous-jsx': noAmbiguousJSX,
     'typechecked-require': typecheckedRequire,
   },
 }

--- a/packages/next/src/client/components/http-access-fallback/error-boundary.tsx
+++ b/packages/next/src/client/components/http-access-fallback/error-boundary.tsx
@@ -26,7 +26,8 @@ interface HTTPAccessFallbackBoundaryProps {
   notFound?: React.ReactNode
   forbidden?: React.ReactNode
   unauthorized?: React.ReactNode
-  children: React.ReactNode
+  // TODO: Make this required once `React.createElement` understands that positional args go into children
+  children?: React.ReactNode
   missingSlots?: Set<string>
 }
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1320,7 +1320,7 @@ function App<T>({
   nonce,
   images,
 }: {
-  /* eslint-disable @next/internal/no-jsx-in-app-router -- React Client */
+  /* eslint-disable @next/internal/no-ambiguous-jsx -- React Client */
   reactServerStream: BinaryStreamOf<T>
   reactDebugStream: ReadableStream<Uint8Array> | undefined
   preinitScripts: () => void
@@ -1375,7 +1375,7 @@ function App<T>({
       </ImageConfigContext.Provider>
     </HeadManagerContext.Provider>
   )
-  /* eslint-enable @next/internal/no-jsx-in-app-router -- React Client */
+  /* eslint-enable @next/internal/no-ambiguous-jsx -- React Client */
 }
 
 // @TODO our error stream should be probably just use the same root component. But it was previously
@@ -1400,7 +1400,7 @@ function ErrorApp<T>({
   nonce?: string
   images: RenderOpts['images']
 }): JSX.Element {
-  /* eslint-disable @next/internal/no-jsx-in-app-router -- React Client */
+  /* eslint-disable @next/internal/no-ambiguous-jsx -- React Client */
   preinitScripts()
   const response = ReactClient.use(
     useFlightStream<InitialRSCPayload>(
@@ -1435,7 +1435,7 @@ function ErrorApp<T>({
       </ServerInsertedHTMLProvider>
     </ImageConfigContext.Provider>
   )
-  /* eslint-enable @next/internal/no-jsx-in-app-router -- React Client */
+  /* eslint-enable @next/internal/no-ambiguous-jsx -- React Client */
 }
 
 // We use a trick with TS Generics to branch streams with a type so we can
@@ -2155,7 +2155,7 @@ async function renderToStream(
   createRequestStore: (() => RequestStore) | undefined,
   devValidatingFallbackParams: OpaqueFallbackRouteParams | null
 ): Promise<ReadableStream<Uint8Array>> {
-  /* eslint-disable @next/internal/no-jsx-in-app-router -- React Client */
+  /* eslint-disable @next/internal/no-ambiguous-jsx -- React Client */
   const { assetPrefix, htmlRequestId, nonce, pagePath, renderOpts, requestId } =
     ctx
 
@@ -2700,7 +2700,7 @@ async function renderToStream(
       throw finalErr
     }
   }
-  /* eslint-enable @next/internal/no-jsx-in-app-router */
+  /* eslint-enable @next/internal/no-ambiguous-jsx */
 }
 
 async function renderWithRestartOnCacheMissInDev(
@@ -3182,7 +3182,7 @@ async function spawnDynamicValidationInDev(
     const pendingInitialClientResult = workUnitAsyncStorage.run(
       initialClientPrerenderStore,
       prerender,
-      // eslint-disable-next-line @next/internal/no-jsx-in-app-router -- React Client
+      // eslint-disable-next-line @next/internal/no-ambiguous-jsx -- React Client
       <App
         reactServerStream={initialServerResult.asUnclosingStream()}
         reactDebugStream={undefined}
@@ -3413,7 +3413,7 @@ async function spawnDynamicValidationInDev(
           const pendingFinalClientResult = workUnitAsyncStorage.run(
             finalClientPrerenderStore,
             prerender,
-            // eslint-disable-next-line @next/internal/no-jsx-in-app-router -- React Client
+            // eslint-disable-next-line @next/internal/no-ambiguous-jsx -- React Client
             <App
               reactServerStream={reactServerResult.asUnclosingStream()}
               reactDebugStream={undefined}
@@ -3933,7 +3933,7 @@ async function prerenderToStream(
         const pendingInitialClientResult = workUnitAsyncStorage.run(
           initialClientPrerenderStore,
           prerender,
-          // eslint-disable-next-line @next/internal/no-jsx-in-app-router
+          // eslint-disable-next-line @next/internal/no-ambiguous-jsx
           <App
             reactServerStream={initialServerResult.asUnclosingStream()}
             reactDebugStream={undefined}
@@ -4169,7 +4169,7 @@ async function prerenderToStream(
             const pendingFinalClientResult = workUnitAsyncStorage.run(
               finalClientPrerenderStore,
               prerender,
-              // eslint-disable-next-line @next/internal/no-jsx-in-app-router
+              // eslint-disable-next-line @next/internal/no-ambiguous-jsx
               <App
                 reactServerStream={reactServerResult.asUnclosingStream()}
                 reactDebugStream={undefined}
@@ -4335,7 +4335,7 @@ async function prerenderToStream(
           const foreverStream = new ReadableStream<Uint8Array>()
 
           const resumeStream = await resume(
-            // eslint-disable-next-line @next/internal/no-jsx-in-app-router
+            // eslint-disable-next-line @next/internal/no-ambiguous-jsx
             <App
               reactServerStream={foreverStream}
               reactDebugStream={undefined}
@@ -4444,7 +4444,7 @@ async function prerenderToStream(
         await workUnitAsyncStorage.run(
           ssrPrerenderStore,
           prerender,
-          // eslint-disable-next-line @next/internal/no-jsx-in-app-router
+          // eslint-disable-next-line @next/internal/no-ambiguous-jsx
           <App
             reactServerStream={reactServerResult.asUnclosingStream()}
             reactDebugStream={undefined}
@@ -4587,7 +4587,7 @@ async function prerenderToStream(
           const foreverStream = new ReadableStream<Uint8Array>()
 
           const resumeStream = await resume(
-            // eslint-disable-next-line @next/internal/no-jsx-in-app-router
+            // eslint-disable-next-line @next/internal/no-ambiguous-jsx
             <App
               reactServerStream={foreverStream}
               reactDebugStream={undefined}
@@ -4673,7 +4673,7 @@ async function prerenderToStream(
       const htmlStream = await workUnitAsyncStorage.run(
         prerenderLegacyStore,
         renderToReadableStream,
-        // eslint-disable-next-line @next/internal/no-jsx-in-app-router
+        // eslint-disable-next-line @next/internal/no-ambiguous-jsx
         <App
           reactServerStream={reactServerResult.asUnclosingStream()}
           reactDebugStream={undefined}
@@ -4849,7 +4849,7 @@ async function prerenderToStream(
           ReactDOMServer:
             require('react-dom/server') as typeof import('react-dom/server'),
           element: (
-            // eslint-disable-next-line @next/internal/no-jsx-in-app-router
+            // eslint-disable-next-line @next/internal/no-ambiguous-jsx
             <ErrorApp
               reactServerStream={errorServerStream}
               reactDebugStream={undefined}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1,3 +1,4 @@
+import type { ComponentType, ErrorInfo, JSX, ReactNode } from 'react'
 import type { RenderOpts, PreloadCallbacks } from './types'
 import type {
   ActionResult,
@@ -28,8 +29,7 @@ import type {
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
 import type { BaseNextRequest, BaseNextResponse } from '../base-http'
 import type { IncomingHttpHeaders } from 'http'
-
-import React, { type ErrorInfo, type JSX } from 'react'
+import * as ReactClient from 'react'
 
 import RenderResult, {
   type AppPageRenderResultMetadata,
@@ -417,10 +417,12 @@ function makeGetDynamicParamFromSegment(
 }
 
 function NonIndex({
+  createElement,
   pagePath,
   statusCode,
   isPossibleServerAction,
 }: {
+  createElement: typeof ReactClient.createElement
   pagePath: string
   statusCode: number | undefined
   isPossibleServerAction: boolean
@@ -431,7 +433,10 @@ function NonIndex({
   // Only render noindex for page request, skip for server actions
   // TODO: is this correct if `isPossibleServerAction` is a false positive?
   if (!isPossibleServerAction && (is404Page || isInvalidStatusCode)) {
-    return <meta name="robots" content="noindex" />
+    return createElement('meta', {
+      name: 'robots',
+      content: 'noindex',
+    })
   }
   return null
 }
@@ -462,7 +467,9 @@ async function generateDynamicRSCPayload(
       routeModule: {
         userland: { loaderTree },
       },
+      createElement,
       createMetadataComponents,
+      Fragment,
     },
     getDynamicParamFromSegment,
     query,
@@ -494,18 +501,23 @@ async function generateDynamicRSCPayload(
         parentParams: {},
         flightRouterState,
         // For flight, render metadata inside leaf page
-        rscHead: (
-          <React.Fragment key={flightDataPathHeadKey}>
-            {/* noindex needs to be blocking */}
-            <NonIndex
-              pagePath={ctx.pagePath}
-              statusCode={ctx.res.statusCode}
-              isPossibleServerAction={ctx.isPossibleServerAction}
-            />
-            {/* Adding requestId as react key to make metadata remount for each render */}
-            <Viewport key={getFlightViewportKey(requestId)} />
-            <Metadata key={getFlightMetadataKey(requestId)} />
-          </React.Fragment>
+        rscHead: createElement(
+          Fragment,
+          {
+            key: flightDataPathHeadKey,
+          },
+          createElement(NonIndex, {
+            createElement,
+            pagePath: ctx.pagePath,
+            statusCode: ctx.res.statusCode,
+            isPossibleServerAction: ctx.isPossibleServerAction,
+          }),
+          createElement(Viewport, {
+            key: getFlightViewportKey(requestId),
+          }),
+          createElement(Metadata, {
+            key: getFlightMetadataKey(requestId),
+          })
         ),
         injectedCSS: new Set(),
         injectedJS: new Set(),
@@ -595,7 +607,7 @@ async function generateDynamicFlightRenderResult(
 
   const RSCPayload: RSCPayload & {
     /** Only available during cacheComponents development builds. Used for logging errors. */
-    _validation?: Promise<React.ReactNode>
+    _validation?: Promise<ReactNode>
   } = await workUnitAsyncStorage.run(
     requestStore,
     generateDynamicRSCPayload,
@@ -1037,7 +1049,7 @@ async function getRSCPayload(
   tree: LoaderTree,
   ctx: AppRenderContext,
   is404: boolean
-): Promise<InitialRSCPayload & { P: React.ReactNode }> {
+): Promise<InitialRSCPayload & { P: ReactNode }> {
   const injectedCSS = new Set<string>()
   const injectedJS = new Set<string>()
   const injectedFontPreloadTags = new Set<string>()
@@ -1052,7 +1064,7 @@ async function getRSCPayload(
     getDynamicParamFromSegment,
     query,
     appUsingSizeAdjustment,
-    componentMod: { createMetadataComponents },
+    componentMod: { createMetadataComponents, createElement, Fragment },
     url,
     workStore,
   } = ctx
@@ -1104,20 +1116,25 @@ async function getRSCPayload(
   const couldBeIntercepted =
     typeof varyHeader === 'string' && varyHeader.includes(NEXT_URL)
 
-  const initialHead = (
-    <React.Fragment key={flightDataPathHeadKey}>
-      <NonIndex
-        pagePath={ctx.pagePath}
-        statusCode={ctx.res.statusCode}
-        isPossibleServerAction={ctx.isPossibleServerAction}
-      />
-      <Viewport />
-      <Metadata />
-      {/* This meta tag is for next/font which is still required to be blocking. */}
-      {appUsingSizeAdjustment ? (
-        <meta name="next-size-adjust" content="" />
-      ) : null}
-    </React.Fragment>
+  const initialHead = createElement(
+    Fragment,
+    {
+      key: flightDataPathHeadKey,
+    },
+    createElement(NonIndex, {
+      createElement,
+      pagePath: ctx.pagePath,
+      statusCode: ctx.res.statusCode,
+      isPossibleServerAction: ctx.isPossibleServerAction,
+    }),
+    createElement(Viewport, null),
+    createElement(Metadata, null),
+    appUsingSizeAdjustment
+      ? createElement('meta', {
+          name: 'next-size-adjust',
+          content: '',
+        })
+      : null
   )
 
   const { GlobalError, styles: globalErrorStyles } = await getGlobalErrorStyles(
@@ -1137,7 +1154,9 @@ async function getRSCPayload(
 
   return {
     // See the comment above the `Preloads` component (below) for why this is part of the payload
-    P: <Preloads preloadCallbacks={preloadCallbacks} />,
+    P: createElement(Preloads, {
+      preloadCallbacks: preloadCallbacks,
+    }),
     b: ctx.sharedContext.buildId,
     c: prepareInitialCanonicalUrl(url),
     i: !!couldBeIntercepted,
@@ -1177,7 +1196,7 @@ async function getErrorRSCPayload(
   const {
     getDynamicParamFromSegment,
     query,
-    componentMod: { createMetadataComponents },
+    componentMod: { createMetadataComponents, createElement, Fragment },
     url,
     workStore,
   } = ctx
@@ -1194,19 +1213,24 @@ async function getErrorRSCPayload(
     serveStreamingMetadata: serveStreamingMetadata,
   })
 
-  const initialHead = (
-    <React.Fragment key={flightDataPathHeadKey}>
-      <NonIndex
-        pagePath={ctx.pagePath}
-        statusCode={ctx.res.statusCode}
-        isPossibleServerAction={ctx.isPossibleServerAction}
-      />
-      <Viewport />
-      {process.env.NODE_ENV === 'development' && (
-        <meta name="next-error" content="not-found" />
-      )}
-      <Metadata />
-    </React.Fragment>
+  const initialHead = createElement(
+    Fragment,
+    {
+      key: flightDataPathHeadKey,
+    },
+    createElement(NonIndex, {
+      createElement,
+      pagePath: ctx.pagePath,
+      statusCode: ctx.res.statusCode,
+      isPossibleServerAction: ctx.isPossibleServerAction,
+    }),
+    createElement(Viewport, null),
+    process.env.NODE_ENV === 'development' &&
+      createElement('meta', {
+        name: 'next-error',
+        content: 'not-found',
+      }),
+    createElement(Metadata, null)
   )
 
   const initialTree = createFlightRouterStateFromLoaderTree(
@@ -1224,18 +1248,24 @@ async function getErrorRSCPayload(
   // so we create a not found page with AppRouter
   const seedData: CacheNodeSeedData = [
     initialTree[0],
-    <html id="__next_error__">
-      <head></head>
-      <body>
-        {process.env.NODE_ENV !== 'production' && err ? (
-          <template
-            data-next-error-message={err.message}
-            data-next-error-digest={'digest' in err ? err.digest : ''}
-            data-next-error-stack={err.stack}
-          />
-        ) : null}
-      </body>
-    </html>,
+    createElement(
+      'html',
+      {
+        id: '__next_error__',
+      },
+      createElement('head', null),
+      createElement(
+        'body',
+        null,
+        process.env.NODE_ENV !== 'production' && err
+          ? createElement('template', {
+              'data-next-error-message': err.message,
+              'data-next-error-digest': 'digest' in err ? err.digest : '',
+              'data-next-error-stack': err.stack,
+            })
+          : null
+      )
+    ),
     {},
     null,
     false,
@@ -1290,16 +1320,19 @@ function App<T>({
   nonce,
   images,
 }: {
+  /* eslint-disable @next/internal/no-jsx-in-app-router -- React Client */
   reactServerStream: BinaryStreamOf<T>
   reactDebugStream: ReadableStream<Uint8Array> | undefined
   preinitScripts: () => void
   clientReferenceManifest: NonNullable<RenderOpts['clientReferenceManifest']>
-  ServerInsertedHTMLProvider: React.ComponentType<{ children: JSX.Element }>
+  ServerInsertedHTMLProvider: ComponentType<{
+    children: JSX.Element
+  }>
   images: RenderOpts['images']
   nonce?: string
 }): JSX.Element {
   preinitScripts()
-  const response = React.use(
+  const response = ReactClient.use(
     useFlightStream<InitialRSCPayload>(
       reactServerStream,
       reactDebugStream,
@@ -1342,6 +1375,7 @@ function App<T>({
       </ImageConfigContext.Provider>
     </HeadManagerContext.Provider>
   )
+  /* eslint-enable @next/internal/no-jsx-in-app-router -- React Client */
 }
 
 // @TODO our error stream should be probably just use the same root component. But it was previously
@@ -1360,12 +1394,15 @@ function ErrorApp<T>({
   reactDebugStream: ReadableStream<Uint8Array> | undefined
   preinitScripts: () => void
   clientReferenceManifest: NonNullable<RenderOpts['clientReferenceManifest']>
-  ServerInsertedHTMLProvider: React.ComponentType<{ children: JSX.Element }>
+  ServerInsertedHTMLProvider: ComponentType<{
+    children: JSX.Element
+  }>
   nonce?: string
   images: RenderOpts['images']
 }): JSX.Element {
+  /* eslint-disable @next/internal/no-jsx-in-app-router -- React Client */
   preinitScripts()
-  const response = React.use(
+  const response = ReactClient.use(
     useFlightStream<InitialRSCPayload>(
       reactServerStream,
       reactDebugStream,
@@ -1398,6 +1435,7 @@ function ErrorApp<T>({
       </ServerInsertedHTMLProvider>
     </ImageConfigContext.Provider>
   )
+  /* eslint-enable @next/internal/no-jsx-in-app-router -- React Client */
 }
 
 // We use a trick with TS Generics to branch streams with a type so we can
@@ -2117,6 +2155,7 @@ async function renderToStream(
   createRequestStore: (() => RequestStore) | undefined,
   devValidatingFallbackParams: OpaqueFallbackRouteParams | null
 ): Promise<ReadableStream<Uint8Array>> {
+  /* eslint-disable @next/internal/no-jsx-in-app-router -- React Client */
   const { assetPrefix, htmlRequestId, nonce, pagePath, renderOpts, requestId } =
     ctx
 
@@ -2242,7 +2281,7 @@ async function renderToStream(
     ) {
       type RSCPayloadWithValidation = InitialRSCPayload & {
         /** Only available during cacheComponents development builds. Used for logging errors. */
-        _validation?: Promise<React.ReactNode>
+        _validation?: Promise<ReactNode>
       }
 
       const [resolveValidation, validationOutlet] = createValidationOutlet()
@@ -2661,6 +2700,7 @@ async function renderToStream(
       throw finalErr
     }
   }
+  /* eslint-enable @next/internal/no-jsx-in-app-router */
 }
 
 async function renderWithRestartOnCacheMissInDev(
@@ -2870,8 +2910,8 @@ function createDebugChannel(): DebugChannelPair | undefined {
 }
 
 function createValidationOutlet() {
-  let resolveValidation: (value: React.ReactNode) => void
-  let outlet = new Promise<React.ReactNode>((resolve) => {
+  let resolveValidation: (value: ReactNode) => void
+  let outlet = new Promise<ReactNode>((resolve) => {
     resolveValidation = resolve
   })
   return [resolveValidation!, outlet] as const
@@ -2884,7 +2924,7 @@ function createValidationOutlet() {
  * in conjunction with any changes to that function.
  */
 async function spawnDynamicValidationInDev(
-  resolveValidation: (validatingElement: React.ReactNode) => void,
+  resolveValidation: (validatingElement: ReactNode) => void,
   tree: LoaderTree,
   ctx: AppRenderContext,
   isNotFound: boolean,
@@ -2943,8 +2983,9 @@ async function spawnDynamicValidationInDev(
   // ready to cut the render off.
   const cacheSignal = new CacheSignal()
 
-  const captureOwnerStackClient = React.captureOwnerStack
-  const captureOwnerStackServer = ComponentMod.captureOwnerStack
+  const captureOwnerStackClient = ReactClient.captureOwnerStack
+  const { captureOwnerStack: captureOwnerStackServer, createElement } =
+    ComponentMod
 
   // The resume data cache here should use a fresh instance as it's
   // performing a fresh prerender. If we get to implementing the
@@ -3077,11 +3118,11 @@ async function spawnDynamicValidationInDev(
   const { invalidDynamicUsageError } = workStore
   if (invalidDynamicUsageError) {
     resolveValidation(
-      <LogSafely
-        fn={() => {
+      createElement(LogSafely, {
+        fn: () => {
           console.error(invalidDynamicUsageError)
-        }}
-      />
+        },
+      })
     )
     return
   }
@@ -3141,6 +3182,7 @@ async function spawnDynamicValidationInDev(
     const pendingInitialClientResult = workUnitAsyncStorage.run(
       initialClientPrerenderStore,
       prerender,
+      // eslint-disable-next-line @next/internal/no-jsx-in-app-router -- React Client
       <App
         reactServerStream={initialServerResult.asUnclosingStream()}
         reactDebugStream={undefined}
@@ -3371,6 +3413,7 @@ async function spawnDynamicValidationInDev(
           const pendingFinalClientResult = workUnitAsyncStorage.run(
             finalClientPrerenderStore,
             prerender,
+            // eslint-disable-next-line @next/internal/no-jsx-in-app-router -- React Client
             <App
               reactServerStream={reactServerResult.asUnclosingStream()}
               reactDebugStream={undefined}
@@ -3432,15 +3475,15 @@ async function spawnDynamicValidationInDev(
 
     const { preludeIsEmpty } = await processPrelude(unprocessedPrelude)
     resolveValidation(
-      <LogSafely
-        fn={throwIfDisallowedDynamic.bind(
+      createElement(LogSafely, {
+        fn: throwIfDisallowedDynamic.bind(
           null,
           workStore,
           preludeIsEmpty ? PreludeState.Empty : PreludeState.Full,
           dynamicValidation,
           serverDynamicTracking
-        )}
-      />
+        ),
+      })
     )
   } catch (thrownValue) {
     // Even if the root errors we still want to report any cache components errors
@@ -3467,7 +3510,11 @@ async function spawnDynamicValidationInDev(
       }
     }
 
-    resolveValidation(<LogSafely fn={loggingFunction} />)
+    resolveValidation(
+      createElement(LogSafely, {
+        fn: loggingFunction,
+      })
+    )
   }
 }
 
@@ -3886,6 +3933,7 @@ async function prerenderToStream(
         const pendingInitialClientResult = workUnitAsyncStorage.run(
           initialClientPrerenderStore,
           prerender,
+          // eslint-disable-next-line @next/internal/no-jsx-in-app-router
           <App
             reactServerStream={initialServerResult.asUnclosingStream()}
             reactDebugStream={undefined}
@@ -4121,6 +4169,7 @@ async function prerenderToStream(
             const pendingFinalClientResult = workUnitAsyncStorage.run(
               finalClientPrerenderStore,
               prerender,
+              // eslint-disable-next-line @next/internal/no-jsx-in-app-router
               <App
                 reactServerStream={reactServerResult.asUnclosingStream()}
                 reactDebugStream={undefined}
@@ -4286,6 +4335,7 @@ async function prerenderToStream(
           const foreverStream = new ReadableStream<Uint8Array>()
 
           const resumeStream = await resume(
+            // eslint-disable-next-line @next/internal/no-jsx-in-app-router
             <App
               reactServerStream={foreverStream}
               reactDebugStream={undefined}
@@ -4394,6 +4444,7 @@ async function prerenderToStream(
         await workUnitAsyncStorage.run(
           ssrPrerenderStore,
           prerender,
+          // eslint-disable-next-line @next/internal/no-jsx-in-app-router
           <App
             reactServerStream={reactServerResult.asUnclosingStream()}
             reactDebugStream={undefined}
@@ -4536,6 +4587,7 @@ async function prerenderToStream(
           const foreverStream = new ReadableStream<Uint8Array>()
 
           const resumeStream = await resume(
+            // eslint-disable-next-line @next/internal/no-jsx-in-app-router
             <App
               reactServerStream={foreverStream}
               reactDebugStream={undefined}
@@ -4621,6 +4673,7 @@ async function prerenderToStream(
       const htmlStream = await workUnitAsyncStorage.run(
         prerenderLegacyStore,
         renderToReadableStream,
+        // eslint-disable-next-line @next/internal/no-jsx-in-app-router
         <App
           reactServerStream={reactServerResult.asUnclosingStream()}
           reactDebugStream={undefined}
@@ -4796,6 +4849,7 @@ async function prerenderToStream(
           ReactDOMServer:
             require('react-dom/server') as typeof import('react-dom/server'),
           element: (
+            // eslint-disable-next-line @next/internal/no-jsx-in-app-router
             <ErrorApp
               reactServerStream={errorServerStream}
               reactDebugStream={undefined}
@@ -4886,12 +4940,15 @@ const getGlobalErrorStyles = async (
   ctx: AppRenderContext
 ): Promise<{
   GlobalError: GlobalErrorComponent
-  styles: React.ReactNode | undefined
+  styles: ReactNode | undefined
 }> => {
   const {
     modules: { 'global-error': globalErrorModule },
   } = parseLoaderTree(tree)
 
+  const {
+    componentMod: { createElement },
+  } = ctx
   const GlobalErrorComponent: GlobalErrorComponent =
     ctx.componentMod.GlobalError
   let globalErrorStyles
@@ -4917,17 +4974,18 @@ const getGlobalErrorStyles = async (
     )
     if (globalErrorModulePath) {
       const SegmentViewNode = ctx.componentMod.SegmentViewNode
-      globalErrorStyles = (
+      globalErrorStyles =
         // This will be rendered next to GlobalError component under ErrorBoundary,
         // it requires a key to avoid React warning about duplicate keys.
-        <SegmentViewNode
-          key="ge-svn"
-          type="global-error"
-          pagePath={globalErrorModulePath}
-        >
-          {globalErrorStyles}
-        </SegmentViewNode>
-      )
+        createElement(
+          SegmentViewNode,
+          {
+            key: 'ge-svn',
+            type: 'global-error',
+            pagePath: globalErrorModulePath,
+          },
+          globalErrorStyles
+        )
     }
   }
 

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/internal/no-jsx-in-app-router -- Bundled in entry-base so it gets the right JSX runtime. */
 import type {
   CacheNodeSeedData,
   FlightRouterState,

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @next/internal/no-jsx-in-app-router -- Bundled in entry-base so it gets the right JSX runtime. */
+/* eslint-disable @next/internal/no-ambiguous-jsx -- Bundled in entry-base so it gets the right JSX runtime. */
 import type {
   CacheNodeSeedData,
   FlightRouterState,

--- a/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
+++ b/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { interopDefault } from './interop-default'
 import { getLinkAndScriptTags } from './get-css-inlined-link-tags'
 import type { AppRenderContext } from './app-render'
@@ -19,6 +18,9 @@ export async function createComponentStylesAndScripts({
   injectedJS: Set<string>
   ctx: AppRenderContext
 }): Promise<[React.ComponentType<any>, React.ReactNode, React.ReactNode]> {
+  const {
+    componentMod: { createElement },
+  } = ctx
   const { styles: entryCssFiles, scripts: jsHrefs } = getLinkAndScriptTags(
     ctx.clientReferenceManifest,
     filePath,
@@ -29,15 +31,13 @@ export async function createComponentStylesAndScripts({
   const styles = renderCssResource(entryCssFiles, ctx)
 
   const scripts = jsHrefs
-    ? jsHrefs.map((href, index) => (
-        <script
-          src={`${ctx.assetPrefix}/_next/${encodeURIPath(
-            href
-          )}${getAssetQueryString(ctx, true)}`}
-          async={true}
-          key={`script-${index}`}
-        />
-      ))
+    ? jsHrefs.map((href, index) =>
+        createElement('script', {
+          src: `${ctx.assetPrefix}/_next/${encodeURIPath(href)}${getAssetQueryString(ctx, true)}`,
+          async: true,
+          key: `script-${index}`,
+        })
+      )
     : null
 
   const Comp = interopDefault(await getComponent())

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -941,16 +941,28 @@ async function createComponentTreeInternal(
         const UseCacheLayoutComponent: ComponentType<UseCacheLayoutProps> =
           SegmentComponent
 
-        serverSegment = createElement(UseCacheLayoutComponent, {
-          ...parallelRouteProps,
-          params: params,
-          $$isLayout: true,
-        })
+        serverSegment = createElement(
+          UseCacheLayoutComponent,
+          {
+            ...parallelRouteProps,
+            params: params,
+            $$isLayout: true,
+          },
+          // Force static children here so that they're validated.
+          // See https://github.com/facebook/react/pull/34846
+          parallelRouteProps.children
+        )
       } else {
-        serverSegment = createElement(SegmentComponent, {
-          ...parallelRouteProps,
-          params: params,
-        })
+        serverSegment = createElement(
+          SegmentComponent,
+          {
+            ...parallelRouteProps,
+            params: params,
+          },
+          // Force static children here so that they're validated.
+          // See https://github.com/facebook/react/pull/34846
+          parallelRouteProps.children
+        )
       }
 
       if (isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot) {

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -1,9 +1,9 @@
+import type { ComponentType } from 'react'
 import type {
   CacheNodeSeedData,
   LoadingModuleData,
 } from '../../shared/lib/app-router-types'
 import type { PreloadCallbacks } from './types'
-import React from 'react'
 import {
   isClientReference,
   isUseCacheFunction,
@@ -51,7 +51,7 @@ export function createComponentTree(props: {
   missingSlots?: Set<string>
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
-  MetadataOutlet: React.ComponentType
+  MetadataOutlet: ComponentType
 }): Promise<CacheNodeSeedData> {
   return getTracer().trace(
     NextNodeServerSpan.createComponentTree,
@@ -98,7 +98,7 @@ async function createComponentTreeInternal(
     missingSlots?: Set<string>
     preloadCallbacks: PreloadCallbacks
     authInterrupts: boolean
-    MetadataOutlet: React.ComponentType | null
+    MetadataOutlet: ComponentType | null
   },
   isRoot: boolean
 ): Promise<CacheNodeSeedData> {
@@ -106,6 +106,8 @@ async function createComponentTreeInternal(
     renderOpts: { nextConfigOutput, experimental },
     workStore,
     componentMod: {
+      createElement,
+      Fragment,
       SegmentViewNode,
       HTTPAccessFallbackBoundary,
       LayoutRouter,
@@ -161,7 +163,7 @@ async function createComponentTreeInternal(
         injectedCSS: injectedCSSWithCurrentLayout,
         injectedJS: injectedJSWithCurrentLayout,
       })
-    : [React.Fragment]
+    : [Fragment]
 
   const [ErrorComponent, errorStyles, errorScripts] = error
     ? await createComponentStylesAndScripts({
@@ -354,7 +356,7 @@ async function createComponentTreeInternal(
   const isPossiblyPartialResponse =
     isStaticGeneration && experimental.isRoutePPREnabled === true
 
-  const LayoutOrPage: React.ComponentType<any> | undefined = layoutOrPageMod
+  const LayoutOrPage: ComponentType<any> | undefined = layoutOrPageMod
     ? interopDefault(layoutOrPageMod)
     : undefined
 
@@ -543,10 +545,10 @@ async function createComponentTreeInternal(
           childCacheNodeSeedData = seedData
         }
 
-        const templateNode = (
-          <Template>
-            <RenderFromTemplateContext />
-          </Template>
+        const templateNode = createElement(
+          Template,
+          null,
+          createElement(RenderFromTemplateContext, null)
         )
 
         const templateFilePath = getConventionPathByType(tree, dir, 'template')
@@ -557,78 +559,77 @@ async function createComponentTreeInternal(
           : undefined
 
         const wrappedErrorStyles =
-          isSegmentViewEnabled && errorFilePath ? (
-            <SegmentViewNode type="error" pagePath={errorFilePath}>
-              {errorStyles}
-            </SegmentViewNode>
-          ) : (
-            errorStyles
-          )
+          isSegmentViewEnabled && errorFilePath
+            ? createElement(
+                SegmentViewNode,
+                {
+                  type: 'error',
+                  pagePath: errorFilePath,
+                },
+                errorStyles
+              )
+            : errorStyles
 
         // Add a suffix to avoid conflict with the segment view node representing rendered file.
         // existence: not-found.tsx@boundary
         // rendered: not-found.tsx
         const fileNameSuffix = BOUNDARY_SUFFIX
-        const segmentViewBoundaries = isSegmentViewEnabled ? (
-          <>
-            {notFoundFilePath && (
-              <SegmentViewNode
-                type={`${BOUNDARY_PREFIX}not-found`}
-                pagePath={notFoundFilePath + fileNameSuffix}
-              />
-            )}
-            {loadingFilePath && (
-              <SegmentViewNode
-                type={`${BOUNDARY_PREFIX}loading`}
-                pagePath={loadingFilePath + fileNameSuffix}
-              />
-            )}
-            {errorFilePath && (
-              <SegmentViewNode
-                type={`${BOUNDARY_PREFIX}error`}
-                pagePath={errorFilePath + fileNameSuffix}
-              />
-            )}
-            {/* Only show global-error when it's the builtin one */}
-            {globalErrorFilePath && (
-              <SegmentViewNode
-                type={`${BOUNDARY_PREFIX}global-error`}
-                pagePath={
-                  isNextjsBuiltinFilePath(globalErrorFilePath)
+        const segmentViewBoundaries = isSegmentViewEnabled
+          ? createElement(
+              Fragment,
+              null,
+              notFoundFilePath &&
+                createElement(SegmentViewNode, {
+                  type: `${BOUNDARY_PREFIX}not-found`,
+                  pagePath: notFoundFilePath + fileNameSuffix,
+                }),
+              loadingFilePath &&
+                createElement(SegmentViewNode, {
+                  type: `${BOUNDARY_PREFIX}loading`,
+                  pagePath: loadingFilePath + fileNameSuffix,
+                }),
+              errorFilePath &&
+                createElement(SegmentViewNode, {
+                  type: `${BOUNDARY_PREFIX}error`,
+                  pagePath: errorFilePath + fileNameSuffix,
+                }),
+              globalErrorFilePath &&
+                createElement(SegmentViewNode, {
+                  type: `${BOUNDARY_PREFIX}global-error`,
+                  pagePath: isNextjsBuiltinFilePath(globalErrorFilePath)
                     ? `${BUILTIN_PREFIX}global-error.js${fileNameSuffix}`
-                    : globalErrorFilePath
-                }
-              />
-            )}
-            {/* do not surface forbidden and unauthorized boundaries yet as they're unstable */}
-          </>
-        ) : null
+                    : globalErrorFilePath,
+                })
+            )
+          : null
 
         return [
           parallelRouteKey,
-          <LayoutRouter
-            parallelRouterKey={parallelRouteKey}
-            // TODO-APP: Add test for loading returning `undefined`. This currently can't be tested as the `webdriver()` tab will wait for the full page to load before returning.
-            error={ErrorComponent}
-            errorStyles={wrappedErrorStyles}
-            errorScripts={errorScripts}
-            template={
-              // Only render SegmentViewNode when there's an actual template
-              isSegmentViewEnabled && templateFilePath ? (
-                <SegmentViewNode type="template" pagePath={templateFilePath}>
-                  {templateNode}
-                </SegmentViewNode>
-              ) : (
-                templateNode
-              )
-            }
-            templateStyles={templateStyles}
-            templateScripts={templateScripts}
-            notFound={notFoundComponent}
-            forbidden={forbiddenComponent}
-            unauthorized={unauthorizedComponent}
-            {...(isSegmentViewEnabled && { segmentViewBoundaries })}
-          />,
+          createElement(LayoutRouter, {
+            parallelRouterKey: parallelRouteKey,
+            error: ErrorComponent,
+            errorStyles: wrappedErrorStyles,
+            errorScripts: errorScripts,
+            template:
+              isSegmentViewEnabled && templateFilePath
+                ? createElement(
+                    SegmentViewNode,
+                    {
+                      type: 'template',
+                      pagePath: templateFilePath,
+                    },
+                    templateNode
+                  )
+                : templateNode,
+            templateStyles: templateStyles,
+            templateScripts: templateScripts,
+            notFound: notFoundComponent,
+            forbidden: forbiddenComponent,
+            unauthorized: unauthorizedComponent,
+            ...(isSegmentViewEnabled && {
+              segmentViewBoundaries,
+            }),
+          }),
           childCacheNodeSeedData,
         ]
       }
@@ -646,18 +647,22 @@ async function createComponentTreeInternal(
     parallelRouteCacheNodeSeedData[parallelRouteKey] = flightData
   }
 
-  let loadingElement = Loading ? <Loading key="l" /> : null
+  let loadingElement = Loading
+    ? createElement(Loading, {
+        key: 'l',
+      })
+    : null
   const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
   if (isSegmentViewEnabled && loadingElement) {
     if (loadingFilePath) {
-      loadingElement = (
-        <SegmentViewNode
-          key={cacheNodeKey + '-loading'}
-          type="loading"
-          pagePath={loadingFilePath}
-        >
-          {loadingElement}
-        </SegmentViewNode>
+      loadingElement = createElement(
+        SegmentViewNode,
+        {
+          key: cacheNodeKey + '-loading',
+          type: 'loading',
+          pagePath: loadingFilePath,
+        },
+        loadingElement
       )
     }
   }
@@ -670,10 +675,14 @@ async function createComponentTreeInternal(
   if (!MaybeComponent) {
     return [
       actualSegment,
-      <React.Fragment key={cacheNodeKey}>
-        {layerAssets}
-        {parallelRouteProps.children}
-      </React.Fragment>,
+      createElement(
+        Fragment,
+        {
+          key: cacheNodeKey,
+        },
+        layerAssets,
+        parallelRouteProps.children
+      ),
       parallelRouteCacheNodeSeedData,
       loadingData,
       isPossiblyPartialResponse,
@@ -700,13 +709,17 @@ async function createComponentTreeInternal(
   ) {
     return [
       actualSegment,
-      <React.Fragment key={cacheNodeKey}>
-        <Postpone
-          reason='dynamic = "force-dynamic" was used'
-          route={workStore.route}
-        />
-        {layerAssets}
-      </React.Fragment>,
+      createElement(
+        Fragment,
+        {
+          key: cacheNodeKey,
+        },
+        createElement(Postpone, {
+          reason: 'dynamic = "force-dynamic" was used',
+          route: workStore.route,
+        }),
+        layerAssets
+      ),
       parallelRouteCacheNodeSeedData,
       loadingData,
       true,
@@ -737,22 +750,18 @@ async function createComponentTreeInternal(
           createPrerenderParamsForClientSegment(currentParams)
         const promiseOfSearchParams =
           createPrerenderSearchParamsForClientPage(workStore)
-        pageElement = (
-          <ClientPageRoot
-            Component={PageComponent}
-            searchParams={query}
-            params={currentParams}
-            promises={[promiseOfSearchParams, promiseOfParams]}
-          />
-        )
+        pageElement = createElement(ClientPageRoot, {
+          Component: PageComponent,
+          searchParams: query,
+          params: currentParams,
+          promises: [promiseOfSearchParams, promiseOfParams],
+        })
       } else {
-        pageElement = (
-          <ClientPageRoot
-            Component={PageComponent}
-            searchParams={query}
-            params={currentParams}
-          />
-        )
+        pageElement = createElement(ClientPageRoot, {
+          Component: PageComponent,
+          searchParams: query,
+          params: currentParams,
+        })
       }
     } else {
       // If we are passing params to a server component Page we need to track
@@ -768,20 +777,19 @@ async function createComponentTreeInternal(
       let searchParams = createServerSearchParamsForServerPage(query, workStore)
 
       if (isUseCacheFunction(PageComponent)) {
-        const UseCachePageComponent: React.ComponentType<UseCachePageProps> =
+        const UseCachePageComponent: ComponentType<UseCachePageProps> =
           PageComponent
 
-        pageElement = (
-          <UseCachePageComponent
-            params={params}
-            searchParams={searchParams}
-            $$isPage
-          />
-        )
+        pageElement = createElement(UseCachePageComponent, {
+          params: params,
+          searchParams: searchParams,
+          $$isPage: true,
+        })
       } else {
-        pageElement = (
-          <PageComponent params={params} searchParams={searchParams} />
-        )
+        pageElement = createElement(PageComponent, {
+          params: params,
+          searchParams: searchParams,
+        })
       }
     }
 
@@ -791,25 +799,29 @@ async function createComponentTreeInternal(
       getConventionPathByType(tree, dir, 'defaultPage')
     const segmentType = isDefaultSegment ? 'default' : 'page'
     const wrappedPageElement =
-      isSegmentViewEnabled && pageFilePath ? (
-        <SegmentViewNode
-          key={cacheNodeKey + '-' + segmentType}
-          type={segmentType}
-          pagePath={pageFilePath}
-        >
-          {pageElement}
-        </SegmentViewNode>
-      ) : (
-        pageElement
-      )
+      isSegmentViewEnabled && pageFilePath
+        ? createElement(
+            SegmentViewNode,
+            {
+              key: cacheNodeKey + '-' + segmentType,
+              type: segmentType,
+              pagePath: pageFilePath,
+            },
+            pageElement
+          )
+        : pageElement
 
     return [
       actualSegment,
-      <React.Fragment key={cacheNodeKey}>
-        {wrappedPageElement}
-        {layerAssets}
-        {MetadataOutlet ? <MetadataOutlet /> : null}
-      </React.Fragment>,
+      createElement(
+        Fragment,
+        {
+          key: cacheNodeKey,
+        },
+        wrappedPageElement,
+        layerAssets,
+        MetadataOutlet ? createElement(MetadataOutlet, null) : null
+      ),
       parallelRouteCacheNodeSeedData,
       loadingData,
       isPossiblyPartialResponse,
@@ -831,22 +843,18 @@ async function createComponentTreeInternal(
         const promiseOfParams =
           createPrerenderParamsForClientSegment(currentParams)
 
-        clientSegment = (
-          <ClientSegmentRoot
-            Component={SegmentComponent}
-            slots={parallelRouteProps}
-            params={currentParams}
-            promise={promiseOfParams}
-          />
-        )
+        clientSegment = createElement(ClientSegmentRoot, {
+          Component: SegmentComponent,
+          slots: parallelRouteProps,
+          params: currentParams,
+          promise: promiseOfParams,
+        })
       } else {
-        clientSegment = (
-          <ClientSegmentRoot
-            Component={SegmentComponent}
-            slots={parallelRouteProps}
-            params={currentParams}
-          />
-        )
+        clientSegment = createElement(ClientSegmentRoot, {
+          Component: SegmentComponent,
+          slots: parallelRouteProps,
+          params: currentParams,
+        })
       }
 
       if (isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot) {
@@ -859,6 +867,7 @@ async function createComponentTreeInternal(
         // We should instead look into handling the fallback behavior differently in development mode so that it doesn't
         // rely on the `NotFound` behavior.
         notfoundClientSegment = createErrorBoundaryClientSegmentRoot({
+          ctx,
           ErrorBoundaryComponent: NotFound,
           errorElement: notFoundElement,
           ClientSegmentRoot,
@@ -867,6 +876,7 @@ async function createComponentTreeInternal(
           currentParams,
         })
         forbiddenClientSegment = createErrorBoundaryClientSegmentRoot({
+          ctx,
           ErrorBoundaryComponent: Forbidden,
           errorElement: forbiddenElement,
           ClientSegmentRoot,
@@ -875,6 +885,7 @@ async function createComponentTreeInternal(
           currentParams,
         })
         unauthorizedClientSegment = createErrorBoundaryClientSegmentRoot({
+          ctx,
           ErrorBoundaryComponent: Unauthorized,
           errorElement: unauthorizedElement,
           ClientSegmentRoot,
@@ -887,31 +898,35 @@ async function createComponentTreeInternal(
           forbiddenClientSegment ||
           unauthorizedClientSegment
         ) {
-          segmentNode = (
-            <HTTPAccessFallbackBoundary
-              key={cacheNodeKey}
-              notFound={notfoundClientSegment}
-              forbidden={forbiddenClientSegment}
-              unauthorized={unauthorizedClientSegment}
-            >
-              {layerAssets}
-              {clientSegment}
-            </HTTPAccessFallbackBoundary>
+          segmentNode = createElement(
+            HTTPAccessFallbackBoundary,
+            {
+              key: cacheNodeKey,
+              notFound: notfoundClientSegment,
+              forbidden: forbiddenClientSegment,
+              unauthorized: unauthorizedClientSegment,
+            },
+            layerAssets,
+            clientSegment
           )
         } else {
-          segmentNode = (
-            <React.Fragment key={cacheNodeKey}>
-              {layerAssets}
-              {clientSegment}
-            </React.Fragment>
+          segmentNode = createElement(
+            Fragment,
+            {
+              key: cacheNodeKey,
+            },
+            layerAssets,
+            clientSegment
           )
         }
       } else {
-        segmentNode = (
-          <React.Fragment key={cacheNodeKey}>
-            {layerAssets}
-            {clientSegment}
-          </React.Fragment>
+        segmentNode = createElement(
+          Fragment,
+          {
+            key: cacheNodeKey,
+          },
+          layerAssets,
+          clientSegment
         )
       }
     } else {
@@ -923,20 +938,19 @@ async function createComponentTreeInternal(
       let serverSegment: React.ReactNode
 
       if (isUseCacheFunction(SegmentComponent)) {
-        const UseCacheLayoutComponent: React.ComponentType<UseCacheLayoutProps> =
+        const UseCacheLayoutComponent: ComponentType<UseCacheLayoutProps> =
           SegmentComponent
 
-        serverSegment = (
-          <UseCacheLayoutComponent
-            {...parallelRouteProps}
-            params={params}
-            $$isLayout
-          />
-        )
+        serverSegment = createElement(UseCacheLayoutComponent, {
+          ...parallelRouteProps,
+          params: params,
+          $$isLayout: true,
+        })
       } else {
-        serverSegment = (
-          <SegmentComponent {...parallelRouteProps} params={params} />
-        )
+        serverSegment = createElement(SegmentComponent, {
+          ...parallelRouteProps,
+          params: params,
+        })
       }
 
       if (isRootLayoutWithChildrenSlotAndAtLeastOneMoreSlot) {
@@ -945,44 +959,54 @@ async function createComponentTreeInternal(
         // but it's not ideal, as it needlessly invokes the `NotFound` component and renders the `RootLayout` twice.
         // We should instead look into handling the fallback behavior differently in development mode so that it doesn't
         // rely on the `NotFound` behavior.
-        segmentNode = (
-          <HTTPAccessFallbackBoundary
-            key={cacheNodeKey}
-            notFound={
-              notFoundElement ? (
-                <>
-                  {layerAssets}
-                  <SegmentComponent params={params}>
-                    {notFoundStyles}
-                    {notFoundElement}
-                  </SegmentComponent>
-                </>
-              ) : undefined
-            }
-          >
-            {layerAssets}
-            {serverSegment}
-          </HTTPAccessFallbackBoundary>
+        segmentNode = createElement(
+          HTTPAccessFallbackBoundary,
+          {
+            key: cacheNodeKey,
+            notFound: notFoundElement
+              ? createElement(
+                  Fragment,
+                  null,
+                  layerAssets,
+                  createElement(
+                    SegmentComponent,
+                    {
+                      params: params,
+                    },
+                    notFoundStyles,
+                    notFoundElement
+                  )
+                )
+              : undefined,
+          },
+          layerAssets,
+          serverSegment
         )
       } else {
-        segmentNode = (
-          <React.Fragment key={cacheNodeKey}>
-            {layerAssets}
-            {serverSegment}
-          </React.Fragment>
+        segmentNode = createElement(
+          Fragment,
+          {
+            key: cacheNodeKey,
+          },
+          layerAssets,
+          serverSegment
         )
       }
     }
 
     const layoutFilePath = getConventionPathByType(tree, dir, 'layout')
     const wrappedSegmentNode =
-      isSegmentViewEnabled && layoutFilePath ? (
-        <SegmentViewNode key="layout" type="layout" pagePath={layoutFilePath}>
-          {segmentNode}
-        </SegmentViewNode>
-      ) : (
-        segmentNode
-      )
+      isSegmentViewEnabled && layoutFilePath
+        ? createElement(
+            SegmentViewNode,
+            {
+              key: 'layout',
+              type: 'layout',
+              pagePath: layoutFilePath,
+            },
+            segmentNode
+          )
+        : segmentNode
 
     // For layouts we just render the component
     return [
@@ -997,6 +1021,7 @@ async function createComponentTreeInternal(
 }
 
 function createErrorBoundaryClientSegmentRoot({
+  ctx,
   ErrorBoundaryComponent,
   errorElement,
   ClientSegmentRoot,
@@ -1004,26 +1029,30 @@ function createErrorBoundaryClientSegmentRoot({
   SegmentComponent,
   currentParams,
 }: {
-  ErrorBoundaryComponent: React.ComponentType<any> | undefined
+  ctx: AppRenderContext
+  ErrorBoundaryComponent: ComponentType<any> | undefined
   errorElement: React.ReactNode
-  ClientSegmentRoot: React.ComponentType<any>
+  ClientSegmentRoot: ComponentType<any>
   layerAssets: React.ReactNode
-  SegmentComponent: React.ComponentType<any>
+  SegmentComponent: ComponentType<any>
   currentParams: Params
 }) {
+  const {
+    componentMod: { createElement, Fragment },
+  } = ctx
   if (ErrorBoundaryComponent) {
     const notFoundParallelRouteProps = {
       children: errorElement,
     }
-    return (
-      <>
-        {layerAssets}
-        <ClientSegmentRoot
-          Component={SegmentComponent}
-          slots={notFoundParallelRouteProps}
-          params={currentParams}
-        />
-      </>
+    return createElement(
+      Fragment,
+      null,
+      layerAssets,
+      createElement(ClientSegmentRoot, {
+        Component: SegmentComponent,
+        slots: notFoundParallelRouteProps,
+        params: currentParams,
+      })
     )
   }
   return null
@@ -1095,37 +1124,39 @@ async function createBoundaryConventionElement({
     | 'loading'
     | 'forbidden'
     | 'unauthorized'
-  Component: React.ComponentType<any> | undefined
+  Component: ComponentType<any> | undefined
   styles: React.ReactNode | undefined
   tree: LoaderTree
 }) {
+  const {
+    componentMod: { createElement, Fragment },
+  } = ctx
   const isSegmentViewEnabled = !!ctx.renderOpts.dev
   const dir =
     (process.env.NEXT_RUNTIME === 'edge'
       ? process.env.__NEXT_EDGE_PROJECT_DIR
       : ctx.renderOpts.dir) || ''
   const { SegmentViewNode } = ctx.componentMod
-  const element = Component ? (
-    <>
-      <Component />
-      {styles}
-    </>
-  ) : undefined
+  const element = Component
+    ? createElement(Fragment, null, createElement(Component, null), styles)
+    : undefined
 
   const pagePath = getConventionPathByType(tree, dir, conventionName)
 
   const wrappedElement =
-    isSegmentViewEnabled && element ? (
-      <SegmentViewNode
-        key={cacheNodeKey + '-' + conventionName}
-        type={conventionName}
-        pagePath={pagePath!}
-      >
-        {element}
-      </SegmentViewNode>
-    ) : (
-      element
-    )
+    isSegmentViewEnabled && element
+      ? createElement(
+          SegmentViewNode,
+          {
+            key: cacheNodeKey + '-' + conventionName,
+            type: conventionName,
+            // TODO: Discovered when moving to `createElement`.
+            // `SegmentViewNode` doesn't support undefined `pagePath`
+            pagePath: pagePath!,
+          },
+          element
+        )
+      : element
 
   return [wrappedElement, pagePath] as const
 }

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -10,7 +10,8 @@ export {
 // eslint-disable-next-line import/no-extraneous-dependencies
 export { prerender } from 'react-server-dom-webpack/static'
 
-export { captureOwnerStack } from 'react'
+// TODO: Just re-export `* as ReactServer`
+export { captureOwnerStack, createElement, Fragment } from 'react'
 
 export { default as LayoutRouter } from '../../client/components/layout-router'
 export { default as RenderFromTemplateContext } from '../../client/components/render-from-template-context'

--- a/packages/next/src/server/app-render/get-layer-assets.tsx
+++ b/packages/next/src/server/app-render/get-layer-assets.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { getLinkAndScriptTags } from './get-css-inlined-link-tags'
 import { getPreloadableFonts } from './get-preloadable-fonts'
 import type { AppRenderContext } from './app-render'
@@ -22,6 +21,9 @@ export function getLayerAssets({
   ctx: AppRenderContext
   preloadCallbacks: PreloadCallbacks
 }): React.ReactNode {
+  const {
+    componentMod: { createElement },
+  } = ctx
   const { styles: styleTags, scripts: scriptTags } = layoutOrPagePath
     ? getLinkAndScriptTags(
         ctx.clientReferenceManifest,
@@ -81,14 +83,12 @@ export function getLayerAssets({
           href
         )}${getAssetQueryString(ctx, true)}`
 
-        return (
-          <script
-            src={fullSrc}
-            async={true}
-            key={`script-${index}`}
-            nonce={ctx.nonce}
-          />
-        )
+        return createElement('script', {
+          src: fullSrc,
+          async: true,
+          key: `script-${index}`,
+          nonce: ctx.nonce,
+        })
       })
     : []
 

--- a/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
+++ b/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @next/internal/no-jsx-in-app-router -- whole module is used in React Client */
+/* eslint-disable @next/internal/no-ambiguous-jsx -- whole module is used in React Client */
 import React, { type JSX } from 'react'
 import { isHTTPAccessFallbackError } from '../../client/components/http-access-fallback/http-access-fallback'
 import {

--- a/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
+++ b/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/internal/no-jsx-in-app-router -- whole module is used in React Client */
 import React, { type JSX } from 'react'
 import { isHTTPAccessFallbackError } from '../../client/components/http-access-fallback/http-access-fallback'
 import {

--- a/packages/next/src/server/app-render/render-css-resource.tsx
+++ b/packages/next/src/server/app-render/render-css-resource.tsx
@@ -14,6 +14,9 @@ export function renderCssResource(
   ctx: AppRenderContext,
   preloadCallbacks?: PreloadCallbacks
 ) {
+  const {
+    componentMod: { createElement },
+  } = ctx
   return entryCssFiles.map((entryCssFile, index) => {
     // `Precedence` is an opt-in signal for React to handle resource
     // loading and deduplication, etc. It's also used as the key to sort
@@ -37,16 +40,15 @@ export function renderCssResource(
     )}${getAssetQueryString(ctx, true)}`
 
     if (entryCssFile.inlined && !ctx.parsedRequestHeaders.isRSCRequest) {
-      return (
-        <style
-          key={index}
-          nonce={ctx.nonce}
-          // @ts-ignore
-          precedence={precedence}
-          href={fullHref}
-        >
-          {entryCssFile.content}
-        </style>
+      return createElement(
+        'style',
+        {
+          key: index,
+          nonce: ctx.nonce,
+          precedence: precedence,
+          href: fullHref,
+        },
+        entryCssFile.content
       )
     }
 
@@ -58,16 +60,13 @@ export function renderCssResource(
       )
     })
 
-    return (
-      <link
-        key={index}
-        rel="stylesheet"
-        href={fullHref}
-        // @ts-ignore
-        precedence={precedence}
-        crossOrigin={ctx.renderOpts.crossOrigin}
-        nonce={ctx.nonce}
-      />
-    )
+    return createElement('link', {
+      key: index,
+      rel: 'stylesheet',
+      href: fullHref,
+      precedence: precedence,
+      crossOrigin: ctx.renderOpts.crossOrigin,
+      nonce: ctx.nonce,
+    })
   })
 }

--- a/packages/next/src/server/app-render/server-inserted-html.tsx
+++ b/packages/next/src/server/app-render/server-inserted-html.tsx
@@ -1,12 +1,14 @@
+/* eslint-disable @next/internal/no-jsx-in-app-router -- whole module is used in React Client */
 // Provider for the `useServerInsertedHTML` API to register callbacks to insert
 // elements into the HTML stream.
 
-import React, { type JSX } from 'react'
+import type { JSX, ReactNode } from 'react'
+import * as ReactClient from 'react'
 import { ServerInsertedHTMLContext } from '../../shared/lib/server-inserted-html.shared-runtime'
 
 export function createServerInsertedHTML() {
-  const serverInsertedHTMLCallbacks: (() => React.ReactNode)[] = []
-  const addInsertedHtml = (handler: () => React.ReactNode) => {
+  const serverInsertedHTMLCallbacks: (() => ReactNode)[] = []
+  const addInsertedHtml = (handler: () => ReactNode) => {
     serverInsertedHTMLCallbacks.push(handler)
   }
 
@@ -20,9 +22,9 @@ export function createServerInsertedHTML() {
     },
     renderServerInsertedHTML() {
       return serverInsertedHTMLCallbacks.map((callback, index) => (
-        <React.Fragment key={'__next_server_inserted__' + index}>
+        <ReactClient.Fragment key={'__next_server_inserted__' + index}>
           {callback()}
-        </React.Fragment>
+        </ReactClient.Fragment>
       ))
     },
   }

--- a/packages/next/src/server/app-render/server-inserted-html.tsx
+++ b/packages/next/src/server/app-render/server-inserted-html.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @next/internal/no-jsx-in-app-router -- whole module is used in React Client */
+/* eslint-disable @next/internal/no-ambiguous-jsx -- whole module is used in React Client */
 // Provider for the `useServerInsertedHTML` API to register callbacks to insert
 // elements into the HTML stream.
 

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/internal/no-ambiguous-jsx -- Pages router doesn't use react-server */
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { ParsedUrlQuery } from 'querystring'
 import type { ReactDOMServerReadableStream } from 'react-dom/server'


### PR DESCRIPTION
We're using JSX throughout library code which will be transpiled to `react/jsx-runtime`. However, some modules are not bundled and instead get the React Server module injected (via `ctx.componentMod`). These modules need to be careful with using JSX since they might create elements that are designated for rendering in React Server. If they're unbundled and use JSX, they'd be using React Client JSX.

Now we lint against any JSX usage in `packages/next/src/server`. The idea is to disable the rule for code that's definitely React Client. Mostly to keep the diff minimal and to not hurt DX too much. Code that produces JSX for React Server, must use `createElement` and `Fragment` from `ctx.componentMod` (i.e. React Server). Technically all React built-ins but Components we get away with at the moment since they're all just global Symbols.

The lint rule is mostly a stop-gap. We should warn about Client elements passed to the Server in React but that's more disruptive and not the right time.
