### PR TITLE
remove rdcForNavigations configuration & bundle with cacheComponents

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1586,9 +1586,7 @@ export default async function build(
               clientParamParsingOrigins:
                 config.experimental.clientParamParsingOrigins,
               dynamicRSCPrerender:
-                isAppPPREnabled &&
-                config.experimental.rdcForNavigations === true &&
-                config.experimental.cacheComponents === true,
+                isAppPPREnabled && config.experimental.cacheComponents === true,
             },
             rewriteHeaders: {
               pathHeader: NEXT_REWRITTEN_PATH_HEADER,

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -291,12 +291,9 @@ export async function handler(
       !(isHtmlBot && isRoutePPREnabled)
   )
 
-  // When a page supports PPR, we can support RSC for Navigations so long as the
-  // feature is not disabled.
-  const supportsRSCForNavigations =
-    isRoutePPREnabled &&
-    nextConfig.experimental.rdcForNavigations === true &&
-    nextConfig.experimental.cacheComponents === true
+  // When a page supports cacheComponents, we can support RDC for Navigations
+  const supportsRDCForNavigations =
+    isRoutePPREnabled && nextConfig.experimental.cacheComponents === true
 
   // In development, we always want to generate dynamic HTML.
   const supportsDynamicResponse: boolean =
@@ -312,7 +309,7 @@ export async function handler(
     // If this handler supports onCacheEntryV2, then we can only support
     // dynamic responses if it's a dynamic RSC request and not in minimal mode. If it
     // doesn't support it we must fallback to the default behavior.
-    (supportsRSCForNavigations && getRequestMeta(req, 'onCacheEntryV2')
+    (supportsRDCForNavigations && getRequestMeta(req, 'onCacheEntryV2')
       ? // In minimal mode, we'll always want to generate a static response
         // which will generate the RDC for the route. When resuming a Dynamic
         // RSC request, we'll pass the minimal postponed data to the render
@@ -810,7 +807,7 @@ export async function handler(
       // is consistent between the static and dynamic renders.
       if (
         // Only enable RDC for Navigations if the feature is enabled.
-        supportsRSCForNavigations &&
+        supportsRDCForNavigations &&
         process.env.NEXT_RUNTIME !== 'edge' &&
         !minimalMode &&
         incrementalCache &&
@@ -1124,7 +1121,7 @@ export async function handler(
       // prefer the `onCacheEntryV2` callback. Once RDC for Navigations is the
       // default, we can remove the fallback to `onCacheEntry` as
       // `onCacheEntryV2` is now fully supported.
-      const onCacheEntry = supportsRSCForNavigations
+      const onCacheEntry = supportsRDCForNavigations
         ? (getRequestMeta(req, 'onCacheEntryV2') ??
           getRequestMeta(req, 'onCacheEntry'))
         : getRequestMeta(req, 'onCacheEntry')

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -195,7 +195,6 @@ export const experimentalSchema = {
   clientSegmentCache: z
     .union([z.boolean(), z.literal('client-only')])
     .optional(),
-  rdcForNavigations: z.boolean().optional(),
   clientParamParsingOrigins: z.array(z.string()).optional(),
   dynamicOnHover: z.boolean().optional(),
   disableOptimizedLoading: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -282,13 +282,6 @@ export interface ExperimentalConfig {
   clientSegmentCache?: boolean | 'client-only'
 
   /**
-   * Enables RDC for Dynamic Navigations. This is only supported for App Router
-   * when Partial Prerendering is also enabled. This is enabled by default when
-   * Partial Prerendering is enabled.
-   */
-  rdcForNavigations?: boolean
-
-  /**
    * The origins that are allowed to write the rewritten headers when
    * performing a non-relative rewrite. When undefined, no non-relative
    * rewrites will get the rewrite headers.
@@ -1448,7 +1441,6 @@ export const defaultConfig = Object.freeze({
     linkNoTouchStart: false,
     caseSensitiveRoutes: false,
     clientSegmentCache: true,
-    rdcForNavigations: false,
     clientParamParsingOrigins: undefined,
     dynamicOnHover: false,
     preloadEntriesOnStart: true,

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -157,21 +157,6 @@ describe('loadConfig', () => {
       delete process.env.__NEXT_VERSION
     })
 
-    it('errors when rdcForNavigations is enabled but cacheComponents is disabled', async () => {
-      await expect(
-        loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
-          customConfig: {
-            experimental: {
-              rdcForNavigations: true,
-              ppr: false,
-            },
-          },
-        })
-      ).rejects.toThrow(
-        '`experimental.rdcForNavigations` is enabled, but `experimental.cacheComponents` is not.'
-      )
-    })
-
     it('errors when ppr is set to incremental', async () => {
       await expect(
         loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
@@ -184,18 +169,6 @@ describe('loadConfig', () => {
       ).rejects.toThrow(
         /`experimental\.ppr` has been merged into `experimental\.cacheComponents`/
       )
-    })
-
-    it('defaults rdcForNavigations to true when cacheComponents is enabled', async () => {
-      const result = await loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
-        customConfig: {
-          experimental: {
-            cacheComponents: true,
-          },
-        },
-      })
-
-      expect(result.experimental.rdcForNavigations).toBe(true)
     })
   })
 })

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -260,7 +260,6 @@ function assignDefaultsAndValidate(
   dir: string,
   userConfig: NextConfig & { configFileName: string },
   silent: boolean,
-  configuredExperimentalFeatures: ConfiguredExperimentalFeature[],
   phase: PHASE_TYPE
 ): NextConfigComplete {
   const configFileName = userConfig.configFileName
@@ -1282,34 +1281,6 @@ function assignDefaultsAndValidate(
     result.experimental.useCache = result.experimental.cacheComponents
   }
 
-  // If cacheComponents is enabled and the user hasn't configured
-  // rdcForNavigations, we enable it by default.
-  if (
-    result.experimental.cacheComponents &&
-    userConfig.experimental?.rdcForNavigations === undefined
-  ) {
-    result.experimental.rdcForNavigations = true
-
-    if (configuredExperimentalFeatures) {
-      addConfiguredExperimentalFeature(
-        configuredExperimentalFeatures,
-        'rdcForNavigations',
-        true,
-        'enabled by `experimental.cacheComponents`'
-      )
-    }
-  }
-
-  // If rdcForNavigations is enabled, but cacheComponents is not, we throw an error.
-  if (
-    result.experimental.rdcForNavigations &&
-    !result.experimental.cacheComponents
-  ) {
-    throw new Error(
-      '`experimental.rdcForNavigations` is enabled, but `experimental.cacheComponents` is not.'
-    )
-  }
-
   if (
     phase === PHASE_DEVELOPMENT_SERVER &&
     result.experimental?.isolatedDevBuild
@@ -1488,7 +1459,6 @@ export default async function loadConfig(
           ...customConfig,
         },
         silent,
-        configuredExperimentalFeatures,
         phase
       ),
       phase,
@@ -1660,7 +1630,6 @@ export default async function loadConfig(
         ...userConfig,
       },
       silent,
-      configuredExperimentalFeatures,
       phase
     )
 
@@ -1716,7 +1685,6 @@ export default async function loadConfig(
     dir,
     { ...clonedDefaultConfig, configFileName },
     silent,
-    configuredExperimentalFeatures,
     phase
   ) as NextConfigComplete
 
@@ -1808,25 +1776,6 @@ function enforceExperimentalFeatures(
       addConfiguredExperimentalFeature(
         configuredExperimentalFeatures,
         'cacheComponents',
-        true,
-        'enabled by `__NEXT_EXPERIMENTAL_CACHE_COMPONENTS`'
-      )
-    }
-  }
-
-  // TODO: Remove this once we've made RDC for Navigations the default for cache components.
-  if (
-    process.env.__NEXT_EXPERIMENTAL_CACHE_COMPONENTS === 'true' &&
-    // We do respect an explicit value in the user config.
-    (config.experimental.rdcForNavigations === undefined ||
-      (isDefaultConfig && !config.experimental.rdcForNavigations))
-  ) {
-    config.experimental.rdcForNavigations = true
-
-    if (configuredExperimentalFeatures) {
-      addConfiguredExperimentalFeature(
-        configuredExperimentalFeatures,
-        'rdcForNavigations',
         true,
         'enabled by `__NEXT_EXPERIMENTAL_CACHE_COMPONENTS`'
       )

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -27,7 +27,6 @@ describe('build-output-prerender', () => {
                 - Experiments (use with caution):
                   ✓ cacheComponents
                   ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
             `)
           } else {
@@ -36,7 +35,6 @@ describe('build-output-prerender', () => {
                 - Experiments (use with caution):
                   ✓ cacheComponents
                   ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
             `)
           }
@@ -47,8 +45,7 @@ describe('build-output-prerender', () => {
                 - Experiments (use with caution):
                   ✓ cacheComponents
                   ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
-                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
@@ -56,8 +53,7 @@ describe('build-output-prerender', () => {
                 - Experiments (use with caution):
                   ✓ cacheComponents
                   ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
-                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
             `)
           }
         } else {
@@ -66,24 +62,21 @@ describe('build-output-prerender', () => {
              "▲ Next.js x.y.z (Turbopack)
                 - Experiments (use with caution):
                   ✓ cacheComponents
-                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
-                  ✓ rdcForNavigations (enabled by \`experimental.cacheComponents\`)"
+                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)"
             `)
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (Rspack)
                 - Experiments (use with caution):
                   ✓ cacheComponents
-                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
-                  ✓ rdcForNavigations (enabled by \`experimental.cacheComponents\`)"
+                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (webpack)
                 - Experiments (use with caution):
                   ✓ cacheComponents
-                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
-                  ✓ rdcForNavigations (enabled by \`experimental.cacheComponents\`)"
+                  ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)"
             `)
           }
         }
@@ -140,7 +133,6 @@ describe('build-output-prerender', () => {
                   ✓ cacheComponents
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
                   ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
@@ -153,7 +145,6 @@ describe('build-output-prerender', () => {
                   ✓ cacheComponents
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
                   ⨯ serverMinification (disabled by \`--debug-prerender\`)
                   ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
@@ -169,7 +160,6 @@ describe('build-output-prerender', () => {
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
             `)
@@ -182,7 +172,6 @@ describe('build-output-prerender', () => {
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ⨯ serverMinification (disabled by \`--debug-prerender\`)
                   ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
@@ -196,7 +185,6 @@ describe('build-output-prerender', () => {
                   ✓ cacheComponents
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ rdcForNavigations (enabled by \`experimental.cacheComponents\`)
                   ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
             `)
@@ -208,7 +196,6 @@ describe('build-output-prerender', () => {
                   ✓ cacheComponents
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ rdcForNavigations (enabled by \`experimental.cacheComponents\`)
                   ⨯ serverMinification (disabled by \`--debug-prerender\`)
                   ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
@@ -220,7 +207,6 @@ describe('build-output-prerender', () => {
                   ✓ cacheComponents
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ rdcForNavigations (enabled by \`experimental.cacheComponents\`)
                   ⨯ serverMinification (disabled by \`--debug-prerender\`)
                   ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
@@ -276,7 +262,6 @@ describe('build-output-prerender', () => {
                 - Experiments (use with caution):
                   ✓ cacheComponents (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
             `)
           } else {
@@ -285,7 +270,6 @@ describe('build-output-prerender', () => {
                 - Experiments (use with caution):
                   ✓ cacheComponents (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`experimental.cacheComponents\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
             `)
           }
@@ -294,15 +278,13 @@ describe('build-output-prerender', () => {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (Turbopack)
                 - Experiments (use with caution):
-                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (webpack)
                 - Experiments (use with caution):
-                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
             `)
           }
         } else {
@@ -342,7 +324,6 @@ describe('build-output-prerender', () => {
                   ✓ cacheComponents (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
                   ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
@@ -355,7 +336,6 @@ describe('build-output-prerender', () => {
                   ✓ cacheComponents (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_CACHE_COMPONENTS\`)
                   ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
                   ⨯ serverMinification (disabled by \`--debug-prerender\`)
                   ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
@@ -370,7 +350,6 @@ describe('build-output-prerender', () => {
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
                   ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
             `)
@@ -382,7 +361,6 @@ describe('build-output-prerender', () => {
                   ✓ enablePrerenderSourceMaps (enabled by \`--debug-prerender\`)
                   ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ rdcForNavigations (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
                   ⨯ serverMinification (disabled by \`--debug-prerender\`)
                   ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)


### PR DESCRIPTION
Removes the `experimental.rdcForNavigations` flag and enables it behind `experimental.cacheComponents`. This is another flag that should not be configurable and will be part of the complete cache components story. 