### PR TITLE
Remove deprecated experimental_ppr route-level configuration

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -11,19 +11,19 @@ use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use swc_core::{
-    atoms::{Atom, atom},
+    atoms::{atom, Atom},
     common::{
-        DUMMY_SP, FileName, Span, Spanned,
         comments::{Comment, CommentKind, Comments},
         errors::HANDLER,
         util::take::Take,
+        FileName, Span, Spanned, DUMMY_SP,
     },
     ecma::{
         ast::*,
-        utils::{ExprFactory, prepend_stmts, quote_ident, quote_str},
+        utils::{prepend_stmts, quote_ident, quote_str, ExprFactory},
         visit::{
-            Visit, VisitMut, VisitMutWith, VisitWith, noop_visit_mut_type, noop_visit_type,
-            visit_mut_pass,
+            noop_visit_mut_type, noop_visit_type, visit_mut_pass, Visit, VisitMut, VisitMutWith,
+            VisitWith,
         },
     },
 };

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -11,19 +11,19 @@ use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use swc_core::{
-    atoms::{atom, Atom},
+    atoms::{Atom, atom},
     common::{
+        DUMMY_SP, FileName, Span, Spanned,
         comments::{Comment, CommentKind, Comments},
         errors::HANDLER,
         util::take::Take,
-        FileName, Span, Spanned, DUMMY_SP,
     },
     ecma::{
         ast::*,
-        utils::{prepend_stmts, quote_ident, quote_str, ExprFactory},
+        utils::{ExprFactory, prepend_stmts, quote_ident, quote_str},
         visit::{
-            noop_visit_mut_type, noop_visit_type, visit_mut_pass, Visit, VisitMut, VisitMutWith,
-            VisitWith,
+            Visit, VisitMut, VisitMutWith, VisitWith, noop_visit_mut_type, noop_visit_type,
+            visit_mut_pass,
         },
     },
 };
@@ -843,7 +843,8 @@ impl ReactServerComponentValidator {
                             );
                         }
                     }
-                    "dynamicParams" | "dynamic" | "fetchCache" | "revalidate" => {
+                    "dynamicParams" | "dynamic" | "fetchCache" | "revalidate"
+                    | "experimental_ppr" => {
                         if self.cache_components_enabled {
                             possibly_invalid_exports.insert(
                                 export_name.clone(),

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2914,7 +2914,7 @@ export default async function build(
                 const isDynamicError = appConfig?.dynamic === 'error'
 
                 const isRoutePPREnabled: boolean = appConfig
-                  ? checkIsRoutePPREnabled(config.experimental.ppr, appConfig)
+                  ? checkIsRoutePPREnabled(config.experimental.ppr)
                   : false
 
                 routes.forEach((route) => {
@@ -3107,7 +3107,7 @@ export default async function build(
             // partial pre-rendering.
             const isRoutePPREnabled: true | undefined =
               !isAppRouteHandler &&
-              checkIsRoutePPREnabled(config.experimental.ppr, appConfig)
+              checkIsRoutePPREnabled(config.experimental.ppr)
                 ? true
                 : undefined
 

--- a/packages/next/src/build/segment-config/app/app-segment-config.ts
+++ b/packages/next/src/build/segment-config/app/app-segment-config.ts
@@ -136,13 +136,6 @@ const AppSegmentConfigSchema = z.object({
   preferredRegion: z.union([z.string(), z.array(z.string())]).optional(),
 
   /**
-   * Whether the page supports partial prerendering. When true, the page will be
-   * served using partial prerendering. This setting will only take affect if
-   * it's enabled via the `experimental.ppr = "incremental"` option.
-   */
-  experimental_ppr: z.boolean().optional(),
-
-  /**
    * The runtime to use for the page.
    */
   runtime: z.enum(['edge', 'nodejs']).optional(),
@@ -239,13 +232,6 @@ export type AppSegmentConfig = {
    * The preferred region for the page.
    */
   preferredRegion?: string | string[]
-
-  /**
-   * Whether the page supports partial prerendering. When true, the page will be
-   * served using partial prerendering. This setting will only take affect if
-   * it's enabled via the `experimental.ppr = "incremental"` option.
-   */
-  experimental_ppr?: boolean
 
   /**
    * The runtime to use for the page.

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -823,7 +823,7 @@ export async function isPageStatic({
         // in incremental mode.
         isRoutePPREnabled =
           routeModule.definition.kind === RouteKind.APP_PAGE &&
-          checkIsRoutePPREnabled(pprConfig, appConfig)
+          checkIsRoutePPREnabled(pprConfig)
 
         // If force dynamic was set and we don't have PPR enabled, then set the
         // revalidate to 0.
@@ -948,7 +948,6 @@ type ReducedAppConfig = Pick<
   | 'dynamic'
   | 'fetchCache'
   | 'preferredRegion'
-  | 'experimental_ppr'
   | 'runtime'
   | 'maxDuration'
 >
@@ -971,7 +970,6 @@ export function reduceAppConfig(
       fetchCache,
       preferredRegion,
       revalidate,
-      experimental_ppr,
       runtime,
       maxDuration,
     } = segment.config || {}
@@ -1002,12 +1000,6 @@ export function reduceAppConfig(
       (typeof config.revalidate !== 'number' || revalidate < config.revalidate)
     ) {
       config.revalidate = revalidate
-    }
-
-    // If partial prerendering has been set, only override it if the current
-    // value is provided as it's resolved from root layout to leaf page.
-    if (typeof experimental_ppr !== 'undefined') {
-      config.experimental_ppr = experimental_ppr
     }
 
     if (typeof runtime !== 'undefined') {

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -85,7 +85,6 @@ checkFields<Diff<{
   generateMetadata?: Function
   viewport?: any
   generateViewport?: Function
-  experimental_ppr?: boolean
   `
   }
 }, TEntry, ''>>()

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -3,7 +3,6 @@ import type { NextConfigComplete } from '../config-shared'
 import '../require-hook'
 import '../node-environment'
 
-import { reduceAppConfig } from '../../build/utils'
 import { collectSegments } from '../../build/segment-config/app/app-segments'
 import type { StaticPathsResult } from '../../build/static-paths/types'
 import { loadComponents } from '../load-components'
@@ -114,7 +113,7 @@ export async function loadStaticPaths({
 
     const isRoutePPREnabled =
       isAppPageRouteModule(routeModule) &&
-      checkIsRoutePPREnabled(config.pprConfig, reduceAppConfig(segments))
+      checkIsRoutePPREnabled(config.pprConfig)
 
     const rootParamKeys = collectRootParamKeys(routeModule)
 

--- a/packages/next/src/server/lib/experimental/ppr.ts
+++ b/packages/next/src/server/lib/experimental/ppr.ts
@@ -40,22 +40,13 @@ export function checkIsAppPPREnabled(
  * @see {@link checkIsAppPPREnabled} for checking if the application has PPR enabled.
  */
 export function checkIsRoutePPREnabled(
-  config: ExperimentalPPRConfig | undefined,
-  appConfig: {
-    experimental_ppr?: boolean
-  }
+  config: ExperimentalPPRConfig | undefined
 ): boolean {
   // If the config is undefined, partial prerendering is disabled.
   if (typeof config === 'undefined') return false
 
   // If the config is a boolean, use it directly.
   if (typeof config === 'boolean') return config
-
-  // If the config is a string, it must be 'incremental' to enable partial
-  // prerendering.
-  if (config === 'incremental' && appConfig.experimental_ppr === true) {
-    return true
-  }
 
   return false
 }

--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -145,17 +145,6 @@ const API_DOCS: Record<
       '`maxDuration` allows you to set max default execution time for your function. If it is not specified, the default value is dependent on your deployment platform and plan.',
     link: 'https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#maxduration',
   },
-  experimental_ppr: {
-    description: `Enables experimental Partial Prerendering (PPR) for this page / layout, when PPR is set to "incremental" mode.`,
-    link: 'https://nextjs.org/docs/app/api-reference/next-config-js/ppr',
-    options: {
-      true: 'Enable PPR for this route',
-      false: 'Disable PPR for this route',
-    } satisfies DocsOptionsObject<FullAppSegmentConfig['experimental_ppr']>,
-    isValid: (value: string) => {
-      return value === 'true' || value === 'false'
-    },
-  },
   unstable_prefetch: {
     description: `Specifies the default prefetching behavior for this segment. This configuration is currently under development and will change.`,
     link: '(docs coming soon)',

--- a/test/e2e/app-dir/metadata/app/large-shell/[slug]/page.tsx
+++ b/test/e2e/app-dir/metadata/app/large-shell/[slug]/page.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from 'next'
 
-export const experimental_ppr = true
-
 export const generateMetadata = async ({ params }): Promise<Metadata> => {
   const { slug } = await params
   return { title: `${slug}` }


### PR DESCRIPTION
### What?

Removes the deprecated `experimental_ppr` route-level configuration option from Next.js.

### Why?

The PPR configuration feature has been deprecated in favor of the cache components feature flag. The `experimental_ppr` route-level option no longer has any effect since incremental PPR is not supported with cache components. 

Rather than silently ignoring this configuration, this change ensures that users receive an explicit error when they attempt to export `experimental_ppr` from their routes. This provides clear feedback that the configuration needs to be removed when migrating to the cache components approach.

### How?

- Removed `experimental_ppr` from the segment config schema and types (both Rust and TypeScript)
- Updated `checkIsRoutePPREnabled` to no longer accept the `appConfig` parameter since route-level config is removed
- Added `experimental_ppr` to the list of possibly invalid exports when cache components are enabled, ensuring users get an error instead of silent failure
- Removed unused `reduceAppConfig` import that was no longer needed after these changes