### PR TITLE
[turbopack] fix build of empty entries of pages

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -552,6 +552,12 @@ export async function createPagesMapping({
       // added or removed.
       const root = isDev && pagesDir ? PAGES_DIR_ALIAS : 'next/dist/pages'
 
+      // If there are no user pages routes, treat this as app-dir-only mode.
+      // The pages/ folder could be present and the initial appDirOnly is treated as false, but no valid routes are found.
+      if (Object.keys(pages).length === 0 && !appDirOnly) {
+        appDirOnly = true
+      }
+
       return {
         // Don't add default pages entries if this is an app-router-only build
         ...((isDev || !appDirOnly) && {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1276,6 +1276,10 @@ export default async function build(
         )
       NextBuildContext.mappedPages = mappedPages
 
+      if (Object.keys(mappedPages).length === 0 && !appDirOnly) {
+        appDirOnly = true
+      }
+
       let mappedAppPages: MappedPages | undefined
       let mappedAppLayouts: MappedPages | undefined
       let denormalizedAppPages: string[] | undefined

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1276,8 +1276,9 @@ export default async function build(
         )
       NextBuildContext.mappedPages = mappedPages
 
+      // Update appDirOnly if no user pages routes are found
       if (Object.keys(mappedPages).length === 0 && !appDirOnly) {
-        appDirOnly = true
+        NextBuildContext.appDirOnly = appDirOnly = true
       }
 
       let mappedAppPages: MappedPages | undefined


### PR DESCRIPTION
Initially in #82444 we treat the app router only flag when `pages/` conventional folder doesn't exist. But actually it's not the only critical condition. Cause you might have a pages folder but there's no actual routes but contain some other random files.

When traversing the entries from `pages/` folder, if the app router folder is set to false before, after no routes found we can flag it to `true` to avoid adding unnessary pages routes there