### PR TITLE
test: Fix and update recursive-delete benchmarks

### DIFF
--- a/bench/recursive-delete/README.md
+++ b/bench/recursive-delete/README.md
@@ -1,0 +1,7 @@
+# Recursive Delete Benchmark
+
+```bash
+pnpm bench
+```
+
+Run `pnpm bench --help` for options.

--- a/bench/recursive-delete/nodejs-rm.js
+++ b/bench/recursive-delete/nodejs-rm.js
@@ -1,0 +1,27 @@
+import { rm as rmPromises } from 'fs/promises'
+import { rm as rmCallback, rmSync } from 'fs'
+import { promisify } from 'util'
+
+const rmCallbackPromise = promisify(rmCallback)
+
+const targetDir = process.argv[2]
+const method = process.argv[3] // 'promises', 'callback', or 'sync'
+
+async function test() {
+  const time = process.hrtime()
+
+  if (method === 'promises') {
+    await rmPromises(targetDir, { recursive: true, force: true })
+  } else if (method === 'callback') {
+    await rmCallbackPromise(targetDir, { recursive: true, force: true })
+  } else if (method === 'sync') {
+    rmSync(targetDir, { recursive: true, force: true })
+  }
+
+  const hrtime = process.hrtime(time)
+  const nanoseconds = hrtime[0] * 1e9 + hrtime[1]
+  const milliseconds = nanoseconds / 1e6
+  console.log(milliseconds)
+}
+
+test()

--- a/bench/recursive-delete/package.json
+++ b/bench/recursive-delete/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bench-recursive-delete",
+  "type": "module",
+  "scripts": {
+    "bench": "bash run.sh"
+  },
+  "devDependencies": {
+    "fuzzponent": "workspace:*",
+    "next": "workspace:*",
+    "rimraf": "6.0.1"
+  }
+}

--- a/bench/recursive-delete/recursive-delete.js
+++ b/bench/recursive-delete/recursive-delete.js
@@ -1,10 +1,10 @@
-import { join } from 'path'
-import { recursiveDelete } from 'next/dist/lib/recursive-delete'
-const resolveDataDir = join(__dirname, `fixtures-${process.argv[2]}`)
+import { recursiveDeleteSyncWithAsyncRetries } from 'next/dist/lib/recursive-delete.js'
+
+const targetDir = process.argv[2]
 
 async function test() {
   const time = process.hrtime()
-  await recursiveDelete(resolveDataDir)
+  await recursiveDeleteSyncWithAsyncRetries(targetDir)
 
   const hrtime = process.hrtime(time)
   const nanoseconds = hrtime[0] * 1e9 + hrtime[1]

--- a/bench/recursive-delete/rimraf.js
+++ b/bench/recursive-delete/rimraf.js
@@ -1,13 +1,16 @@
-import { join } from 'path'
-import { promisify } from 'util'
-import rimrafMod from 'rimraf'
+import { manual, manualSync } from 'rimraf'
 
-const rimraf = promisify(rimrafMod)
-const resolveDataDir = join(__dirname, `fixtures-${process.argv[2]}`, '**/*')
+const targetDir = process.argv[2]
+const method = process.argv[3]
 
 async function test() {
   const time = process.hrtime()
-  await rimraf(resolveDataDir)
+
+  if (method === 'sync') {
+    manualSync(targetDir)
+  } else {
+    await manual(targetDir)
+  }
 
   const hrtime = process.hrtime(time)
   const nanoseconds = hrtime[0] * 1e9 + hrtime[1]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -794,6 +794,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/next
 
+  bench/recursive-delete:
+    devDependencies:
+      fuzzponent:
+        specifier: workspace:*
+        version: link:../fuzzponent
+      next:
+        specifier: workspace:*
+        version: link:../../packages/next
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+
   bench/rendering:
     dependencies:
       fs-extra:
@@ -12221,10 +12233,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@11.1.0:
-    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
-    engines: {node: 20 || >=22}
 
   lru-cache@11.2.1:
     resolution: {integrity: sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==}
@@ -30665,8 +30673,6 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.1.0: {}
-
   lru-cache@11.2.1: {}
 
   lru-cache@4.1.5:
@@ -32920,7 +32926,7 @@ snapshots:
 
   path-scurry@2.0.0:
     dependencies:
-      lru-cache: 11.1.0
+      lru-cache: 11.2.1
       minipass: 7.1.2
 
   path-to-regexp@0.1.12: {}


### PR DESCRIPTION
PR created with claude code, with some manual review.

- Update benchmark scripts to work, given my recent code changes
- Include a native nodejs benchmark
- Use rimraf's `manual` implementation (tries to use node's native version)
- Tried to clean up the code a bit
- Use a trap to always clean up
- Use getopt and add an `--iterations` option
- `set -euo pipefail` to avoid swallowing errors

Example output:

```
pnpm bench

> bench-recursive-delete@ bench /home/bgw.linux/next.js/bench/recursive-delete
> bash run.sh

-----------
rimraf (async) 1
62.443657
rimraf (async) 2
52.953482
rimraf (async) 3
52.029235
rimraf (async) 4
50.709822
rimraf (async) 5
54.204893
-----------
rimraf (sync) 1
35.034669
rimraf (sync) 2
35.663417
rimraf (sync) 3
46.360754
rimraf (sync) 4
36.859329
rimraf (sync) 5
34.368796
-----------
recursive delete 1
37.851534
recursive delete 2
35.98904
recursive delete 3
36.620913
recursive delete 4
38.059992
recursive delete 5
43.880346
-----------
nodejs rm (promises) 1
71.301125
nodejs rm (promises) 2
89.78331
nodejs rm (promises) 3
68.073553
nodejs rm (promises) 4
70.787543
nodejs rm (promises) 5
73.727616
-----------
nodejs rm (callback) 1
92.698258
nodejs rm (callback) 2
73.043993
nodejs rm (callback) 3
70.869584
nodejs rm (callback) 4
69.196757
nodejs rm (callback) 5
75.715526
-----------
nodejs rm (sync) 1
41.71002
nodejs rm (sync) 2
41.742395
nodejs rm (sync) 3
38.894571
nodejs rm (sync) 4
41.326271
nodejs rm (sync) 5
48.152122
```

Closes PACK-5721