### PR TITLE
fix: throw error during build when invalid export for Proxy

### DIFF
--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
@@ -142,10 +140,7 @@ impl Issue for MiddlewareMissingExportIssue {
 
     #[turbo_tasks::function]
     fn title(&self) -> Vc<StyledString> {
-        let file_name = Path::new(&self.file_path.path)
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or(&self.file_path.path);
+        let file_name = self.file_path.file_name();
 
         StyledString::Line(vec![
             StyledString::Text(rcstr!("The ")),

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -1,8 +1,15 @@
-use anyhow::{Result, bail};
+use std::path::Path;
+
+use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
-use turbopack_core::{context::AssetContext, module::Module, reference_type::ReferenceType};
+use turbopack_core::{
+    context::AssetContext,
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    module::Module,
+    reference_type::ReferenceType,
+};
 use turbopack_ecmascript::chunk::{EcmascriptChunkPlaceable, EcmascriptExports};
 
 use crate::util::load_next_js_template;
@@ -33,7 +40,11 @@ pub async fn get_middleware_module(
     // Determine if this is a proxy file by checking the module path
     let userland_path = userland_module.ident().path().await?;
     let is_proxy = userland_path.file_stem() == Some("proxy");
-    let page_path = if is_proxy { "/proxy" } else { "/middleware" };
+    let (file_type, function_name, page_path) = if is_proxy {
+        ("Proxy", "proxy", "/proxy")
+    } else {
+        ("Middleware", "middleware", "/middleware")
+    };
 
     // Validate that the module has the required exports
     if let Some(ecma_module) =
@@ -46,13 +57,9 @@ pub async fn get_middleware_module(
             // ESM modules - check for named or default export
             EcmascriptExports::EsmExports(esm_exports) => {
                 let esm_exports = esm_exports.await?;
-                let has_default = esm_exports.exports.contains_key(&rcstr!("default"));
-                let expected_named = if is_proxy {
-                    rcstr!("proxy")
-                } else {
-                    rcstr!("middleware")
-                };
-                let has_named = esm_exports.exports.contains_key(&expected_named);
+                let has_default = esm_exports.exports.contains_key("default");
+                let expected_named = function_name;
+                let has_named = esm_exports.exports.contains_key(expected_named);
                 has_default || has_named
             }
             // CommonJS modules are valid (they can have module.exports or exports.default)
@@ -67,21 +74,16 @@ pub async fn get_middleware_module(
         };
 
         if !has_valid_export {
-            let file_type = if is_proxy { "Proxy" } else { "Middleware" };
-            let function_name = if is_proxy { "proxy" } else { "middleware" };
-            // Extract just the filename for the error message
-            let file_name = userland_path
-                .path
-                .split('/')
-                .next_back()
-                .unwrap_or(&userland_path.path);
-            // Use the same error message format as the runtime check
-            bail!(
-                "The {} file \"./{}\" must export a function named `{}` or a default function.",
-                file_type,
-                file_name,
-                function_name
-            );
+            MiddlewareMissingExportIssue {
+                file_type: file_type.into(),
+                function_name: function_name.into(),
+                file_path: (*userland_path).clone(),
+            }
+            .resolved_cell()
+            .emit();
+
+            // Continue execution instead of bailing - let the module be processed anyway
+            // The runtime template will still catch this at runtime
         }
     }
     // If we can't cast to EcmascriptChunkPlaceable, continue without validation
@@ -113,4 +115,52 @@ pub async fn get_middleware_module(
         .module();
 
     Ok(module)
+}
+
+#[turbo_tasks::value]
+struct MiddlewareMissingExportIssue {
+    file_type: RcStr,     // "Proxy" or "Middleware"
+    function_name: RcStr, // "proxy" or "middleware"
+    file_path: FileSystemPath,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for MiddlewareMissingExportIssue {
+    #[turbo_tasks::function]
+    fn stage(&self) -> Vc<IssueStage> {
+        IssueStage::Transform.into()
+    }
+
+    fn severity(&self) -> IssueSeverity {
+        IssueSeverity::Error
+    }
+
+    #[turbo_tasks::function]
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        self.file_path.clone().cell()
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> Vc<StyledString> {
+        let file_name = Path::new(&self.file_path.path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(&self.file_path.path);
+
+        StyledString::Line(vec![
+            StyledString::Text(rcstr!("The ")),
+            StyledString::Code(self.file_type.clone()),
+            StyledString::Text(rcstr!(" file \"")),
+            StyledString::Code(format!("./{}", file_name).into()),
+            StyledString::Text(rcstr!("\" must export a function named ")),
+            StyledString::Code(format!("`{}`", self.function_name).into()),
+            StyledString::Text(rcstr!(" or a default function.")),
+        ])
+        .cell()
+    }
+
+    #[turbo_tasks::function]
+    fn description(&self) -> Vc<OptionStyledString> {
+        Vc::cell(None)
+    }
 }

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -1,8 +1,9 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{context::AssetContext, module::Module, reference_type::ReferenceType};
+use turbopack_ecmascript::chunk::{EcmascriptChunkPlaceable, EcmascriptExports};
 
 use crate::util::load_next_js_template;
 
@@ -34,11 +35,67 @@ pub async fn get_middleware_module(
     let is_proxy = userland_path.file_stem() == Some("proxy");
     let page_path = if is_proxy { "/proxy" } else { "/middleware" };
 
+    // Validate that the module has the required exports
+    if let Some(ecma_module) =
+        Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*userland_module).await?
+    {
+        let exports = ecma_module.get_exports().await?;
+
+        // Check if the module has the required exports
+        let has_valid_export = match &*exports {
+            // ESM modules - check for named or default export
+            EcmascriptExports::EsmExports(esm_exports) => {
+                let esm_exports = esm_exports.await?;
+                let has_default = esm_exports.exports.contains_key(&rcstr!("default"));
+                let expected_named = if is_proxy {
+                    rcstr!("proxy")
+                } else {
+                    rcstr!("middleware")
+                };
+                let has_named = esm_exports.exports.contains_key(&expected_named);
+                has_default || has_named
+            }
+            // CommonJS modules are valid (they can have module.exports or exports.default)
+            EcmascriptExports::CommonJs | EcmascriptExports::Value => true,
+            // DynamicNamespace might be valid for certain module types
+            EcmascriptExports::DynamicNamespace => true,
+            // None/Unknown likely indicate parsing errors - skip validation
+            // The parsing error will be emitted separately by Turbopack
+            EcmascriptExports::None | EcmascriptExports::Unknown => true,
+            // EmptyCommonJs is a legitimate case of missing exports
+            EcmascriptExports::EmptyCommonJs => false,
+        };
+
+        if !has_valid_export {
+            let file_type = if is_proxy { "Proxy" } else { "Middleware" };
+            let function_name = if is_proxy { "proxy" } else { "middleware" };
+            // Extract just the filename for the error message
+            let file_name = userland_path
+                .path
+                .split('/')
+                .next_back()
+                .unwrap_or(&userland_path.path);
+            // Use the same error message format as the runtime check
+            bail!(
+                "The {} file \"./{}\" must export a function named `{}` or a default function.",
+                file_type,
+                file_name,
+                function_name
+            );
+        }
+    }
+    // If we can't cast to EcmascriptChunkPlaceable, continue without validation
+    // (might be a special module type that doesn't support export checking)
+
     // Load the file from the next.js codebase.
     let source = load_next_js_template(
         "middleware.js",
         project_root,
-        &[("VAR_USERLAND", INNER), ("VAR_DEFINITION_PAGE", page_path)],
+        &[
+            ("VAR_USERLAND", INNER),
+            ("VAR_DEFINITION_PAGE", page_path),
+            ("VAR_MODULE_RELATIVE_PATH", userland_path.path.as_str()),
+        ],
         &[],
         &[],
     )

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -879,5 +879,7 @@
   "878": "Config options `skipProxyUrlNormalize` and `skipMiddlewareUrlNormalize` cannot be set at the same time. Please use `skipProxyUrlNormalize` instead.",
   "879": "Config options `experimental.proxyClientMaxBodySize` and `experimental.middlewareClientMaxBodySize` cannot be set at the same time. Please use `experimental.proxyClientMaxBodySize` instead.",
   "880": "Config options `experimental.proxyPrefetch` and `experimental.middlewarePrefetch` cannot be set at the same time. Please use `experimental.proxyPrefetch` instead.",
-  "881": "Invalid render stage: %s"
+  "881": "Invalid render stage: %s",
+  "882": "The %s file \"./%s\" must export a function named \\`%s\\` or a default function.",
+  "883": "The %s file \"%s\" must export a function named \\`%s\\` or a default function."
 }

--- a/packages/next/src/build/templates/middleware.ts
+++ b/packages/next/src/build/templates/middleware.ts
@@ -12,13 +12,15 @@ import { isNextRouterError } from '../../client/components/is-next-router-error'
 const mod = { ..._mod }
 
 const page = 'VAR_DEFINITION_PAGE'
+// Turbopack does not add a `./` prefix to the relative file path, but Webpack does.
+const relativeFilePath = 'VAR_MODULE_RELATIVE_PATH'
 // @ts-expect-error `page` will be replaced during build
 const isProxy = page === '/proxy' || page === '/src/proxy'
 const handler = (isProxy ? mod.proxy : mod.middleware) || mod.default
 
 if (typeof handler !== 'function') {
   throw new Error(
-    `The ${isProxy ? 'Proxy' : 'Middleware'} "${page}" must export a ${isProxy ? '`proxy`' : '`middleware`'} or a \`default\` function`
+    `The ${isProxy ? 'Proxy' : 'Middleware'} file "${relativeFilePath.startsWith('.') ? relativeFilePath : `./${relativeFilePath}`}" must export a function named \`${isProxy ? 'proxy' : 'middleware'}\` or a default function.`
   )
 }
 

--- a/packages/next/src/build/webpack/loaders/next-middleware-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-middleware-loader.ts
@@ -70,5 +70,8 @@ export default async function middlewareLoader(this: any) {
   return await loadEntrypoint('middleware', {
     VAR_USERLAND: pagePath,
     VAR_DEFINITION_PAGE: page,
+    // Turbopack sets `VAR_USERLAND` to `INNER_MIDDLEWARE_MODULE`, so use
+    // `VAR_MODULE_RELATIVE_PATH` for error messages.
+    VAR_MODULE_RELATIVE_PATH: pagePath,
   })
 }

--- a/test/e2e/app-dir/proxy-missing-export/app/layout.tsx
+++ b/test/e2e/app-dir/proxy-missing-export/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/proxy-missing-export/app/page.tsx
+++ b/test/e2e/app-dir/proxy-missing-export/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/proxy-missing-export/next.config.js
+++ b/test/e2e/app-dir/proxy-missing-export/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/proxy-missing-export/proxy-missing-export.test.ts
+++ b/test/e2e/app-dir/proxy-missing-export/proxy-missing-export.test.ts
@@ -1,0 +1,109 @@
+import { nextTestSetup } from 'e2e-utils'
+import { join } from 'node:path'
+import { writeFile } from 'node:fs/promises'
+
+const errorMessage =
+  'The Proxy file "./proxy.ts" must export a function named `proxy` or a default function.'
+
+describe('proxy-missing-export', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should error when proxy file has invalid export named middleware', async () => {
+    await writeFile(
+      join(next.testDir, 'proxy.ts'),
+      'export function middleware() {}'
+    )
+
+    if (isNextDev) {
+      await next.start().catch(() => {})
+      // Use .catch() because Turbopack errors during compile and exits before runtime.
+      await next.browser('/').catch(() => {})
+      expect(next.cliOutput).toContain(errorMessage)
+    } else {
+      const { cliOutput } = await next.build()
+      expect(cliOutput).toContain(errorMessage)
+    }
+
+    await next.stop()
+  })
+
+  it('should NOT error when proxy file has a default function export', async () => {
+    await writeFile(
+      join(next.testDir, 'proxy.ts'),
+      'export default function handler() {}'
+    )
+
+    await next.start()
+
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+
+    await next.stop()
+  })
+
+  it('should NOT error when proxy file has a default arrow function export', async () => {
+    await writeFile(join(next.testDir, 'proxy.ts'), 'export default () => {}')
+
+    await next.start()
+
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+
+    await next.stop()
+  })
+
+  it('should NOT error when proxy file has a named declaration function export', async () => {
+    await writeFile(
+      join(next.testDir, 'proxy.ts'),
+      'const proxy = function() {}; export { proxy };'
+    )
+
+    await next.start()
+
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+
+    await next.stop()
+  })
+
+  it('should NOT error when proxy file has a named declaration arrow function export', async () => {
+    await writeFile(
+      join(next.testDir, 'proxy.ts'),
+      'const proxy = () => {}; export { proxy };'
+    )
+
+    await next.start()
+
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+
+    await next.stop()
+  })
+
+  it('should error when proxy file has a named export with different name alias', async () => {
+    await writeFile(
+      join(next.testDir, 'proxy.ts'),
+      'const proxy = () => {}; export { proxy as handler };'
+    )
+
+    if (isNextDev) {
+      await next.start().catch(() => {})
+      // Use .catch() because Turbopack errors during compile and exits before runtime.
+      await next.browser('/').catch(() => {})
+      expect(next.cliOutput).toContain(errorMessage)
+    } else {
+      const { cliOutput } = await next.build()
+      expect(cliOutput).toContain(errorMessage)
+    }
+
+    await next.stop()
+  })
+})

--- a/test/production/exported-runtimes-value-validation/invalid-middleware/middleware.js
+++ b/test/production/exported-runtimes-value-validation/invalid-middleware/middleware.js
@@ -1,3 +1,5 @@
+export default function () {}
+
 const dynamicPath = `/:foobar`
 
 export const config = {


### PR DESCRIPTION
### Why?

When Proxy/Middleware had invalid exports (valid: named function `proxy` for `proxy.js`, named function `middleware` for `middleware.js`, or default function), it errored during runtime but not during build.

This error can sneak into production as it only throws during runtime.

### How?

Walk AST of the Proxy/Middleware file, and if a valid export is not found, throw during build.