### PR TITLE
Turbopack: lower level drop collectibles

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -842,7 +842,7 @@ pub async fn get_global_information_for_endpoint(
         get_global_information_for_endpoint_inner_operation(module_graph, is_single_page);
     let result_vc = if !is_single_page {
         let result_vc = result_op.resolve_strongly_consistent().await?;
-        let _issues = result_op.take_collectibles::<Box<dyn Issue>>();
+        result_op.drop_collectibles::<Box<dyn Issue>>();
         *result_vc
     } else {
         result_op.connect()

--- a/crates/next-api/src/operation.rs
+++ b/crates/next-api/src/operation.rs
@@ -37,7 +37,7 @@ async fn entrypoints_without_collectibles_operation(
     entrypoints: OperationVc<Entrypoints>,
 ) -> Result<Vc<Entrypoints>> {
     let _ = entrypoints.resolve_strongly_consistent().await?;
-    let _ = entrypoints.take_collectibles::<Box<dyn Diagnostic>>();
+    entrypoints.drop_collectibles::<Box<dyn Diagnostic>>();
     entrypoints.drop_issues();
     let _ = get_effects(entrypoints).await?;
     Ok(entrypoints.connect())

--- a/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
@@ -164,7 +164,7 @@ async fn my_collecting_function() -> Result<Vc<Thing>> {
     let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
     let result_vc = result_op.connect();
     result_vc.await?;
-    result_op.take_collectibles::<Box<dyn ValueToString>>();
+    result_op.drop_collectibles::<Box<dyn ValueToString>>();
     Ok(result_vc)
 }
 

--- a/turbopack/crates/turbo-tasks/src/collectibles.rs
+++ b/turbopack/crates/turbo-tasks/src/collectibles.rs
@@ -4,6 +4,7 @@ use crate::{ResolvedVc, VcValueTrait};
 
 /// Implemented on `OperationVc` and `RawVc`.
 pub trait CollectiblesSource {
+    fn drop_collectibles<T: VcValueTrait>(self);
     fn take_collectibles<T: VcValueTrait>(self) -> AutoSet<ResolvedVc<T>>;
     fn peek_collectibles<T: VcValueTrait>(self) -> AutoSet<ResolvedVc<T>>;
 }

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -316,6 +316,18 @@ impl CollectiblesSource for RawVc {
             .filter_map(|(raw, count)| (count > 0).then_some(raw.try_into().unwrap()))
             .collect()
     }
+
+    fn drop_collectibles<T: VcValueTrait + ?Sized>(self) {
+        let RawVc::TaskOutput(task_id) = self else {
+            panic!(
+                "<RawVc as CollectiblesSource>::drop_collectibles() must only be called on a \
+                 RawVc::TaskOutput"
+            );
+        };
+        let tt = turbo_tasks();
+        let map = tt.read_task_collectibles(task_id, T::get_trait_type_id());
+        tt.unemit_collectibles(T::get_trait_type_id(), &map);
+    }
 }
 
 pub struct ReadRawVcFuture {

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -236,6 +236,10 @@ impl<T> CollectiblesSource for OperationVc<T>
 where
     T: ?Sized,
 {
+    fn drop_collectibles<Vt: VcValueTrait>(self) {
+        self.node.node.drop_collectibles::<Vt>();
+    }
+
     fn take_collectibles<Vt: VcValueTrait>(self) -> AutoSet<ResolvedVc<Vt>> {
         self.node.node.take_collectibles()
     }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -840,7 +840,7 @@ where
     }
 
     fn drop_issues(self) {
-        let _ = self.take_collectibles::<Box<dyn Issue>>();
+        self.drop_collectibles::<Box<dyn Issue>>();
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1093,7 +1093,7 @@ impl ModuleGraph {
         async move {
             let result_op = compute_async_module_info(self.to_resolved().await?);
             let result_vc = result_op.resolve_strongly_consistent().await?;
-            let _issues = result_op.take_collectibles::<Box<dyn Issue>>();
+            result_op.drop_collectibles::<Box<dyn Issue>>();
             anyhow::Ok(*result_vc)
         }
         .instrument(tracing::info_span!("compute async module info"))


### PR DESCRIPTION
### What?

also implement drop_collectibles on the CollectiblesSource to avoid an allocation

Closes PACK-5684