### PR TITLE
Development: Use process.hrtime for request time calculation

### DIFF
--- a/packages/next/src/build/duration-to-string.ts
+++ b/packages/next/src/build/duration-to-string.ts
@@ -17,6 +17,18 @@ export function hrtimeToSeconds(hrtime: [number, number]): number {
   return hrtime[0] + hrtime[1] / 1e9
 }
 
+function nanosecondsBigIntToSeconds(nanoseconds: bigint): number {
+  return Number(nanoseconds) / 1000000000
+}
+
+function hrtimeBigIntToSeconds(hrtime: bigint): number {
+  return nanosecondsBigIntToSeconds(hrtime)
+}
+
+export function hrtimeBigIntDurationToString(hrtime: bigint) {
+  return durationToString(hrtimeBigIntToSeconds(hrtime))
+}
+
 export function hrtimeDurationToString(hrtime: [number, number]): string {
   return durationToString(hrtimeToSeconds(hrtime))
 }

--- a/packages/next/src/server/dev/log-requests.ts
+++ b/packages/next/src/server/dev/log-requests.ts
@@ -1,4 +1,4 @@
-import { hrtimeDurationToString } from '../../build/duration-to-string'
+import { hrtimeBigIntDurationToString } from '../../build/duration-to-string'
 import {
   blue,
   bold,
@@ -42,10 +42,16 @@ export function logRequests(
   request: NodeNextRequest,
   response: NodeNextResponse,
   loggingConfig: LoggingConfig,
-  requestEndTime: ReturnType<typeof process.hrtime>
+  requestStartTime: bigint,
+  requestEndTime: bigint
 ): void {
   if (!ignoreLoggingIncomingRequests(request, loggingConfig)) {
-    logIncomingRequests(request, requestEndTime, response.statusCode)
+    logIncomingRequests(
+      request,
+      requestStartTime,
+      requestEndTime,
+      response.statusCode
+    )
   }
 
   if (request.fetchMetrics) {
@@ -57,7 +63,8 @@ export function logRequests(
 
 function logIncomingRequests(
   request: NodeNextRequest,
-  requestEndTime: ReturnType<typeof process.hrtime>,
+  requestStartTime: bigint,
+  requestEndTime: bigint,
   statusCode: number
 ): void {
   const isRSC = getRequestMeta(request, 'isRSCRequest')
@@ -77,7 +84,7 @@ function logIncomingRequests(
   const coloredStatus = statusCodeColor(statusCode.toString())
 
   return writeLine(
-    `${request.method} ${url} ${coloredStatus} in ${hrtimeDurationToString(requestEndTime)}`
+    `${request.method} ${url} ${coloredStatus} in ${hrtimeBigIntDurationToString(requestEndTime - requestStartTime)}`
   )
 }
 

--- a/packages/next/src/server/dev/log-requests.ts
+++ b/packages/next/src/server/dev/log-requests.ts
@@ -1,3 +1,4 @@
+import { hrtimeDurationToString } from '../../build/duration-to-string'
 import {
   blue,
   bold,
@@ -12,13 +13,6 @@ import type { FetchMetric } from '../base-http'
 import type { NodeNextRequest, NodeNextResponse } from '../base-http/node'
 import type { LoggingConfig } from '../config-shared'
 import { getRequestMeta } from '../request-meta'
-
-export interface RequestLoggingOptions {
-  readonly request: NodeNextRequest
-  readonly response: NodeNextResponse
-  readonly loggingConfig: LoggingConfig | undefined
-  readonly requestDurationInMs: number
-}
 
 /**
  * Returns true if the incoming request should be ignored for logging.
@@ -44,15 +38,14 @@ export function ignoreLoggingIncomingRequests(
   return ignore.some((pattern) => pattern.test(request.url))
 }
 
-export function logRequests(options: RequestLoggingOptions): void {
-  const { request, response, loggingConfig, requestDurationInMs } = options
-
+export function logRequests(
+  request: NodeNextRequest,
+  response: NodeNextResponse,
+  loggingConfig: LoggingConfig,
+  requestEndTime: ReturnType<typeof process.hrtime>
+): void {
   if (!ignoreLoggingIncomingRequests(request, loggingConfig)) {
-    logIncomingRequests({
-      request,
-      requestDurationInMs,
-      statusCode: response.statusCode,
-    })
+    logIncomingRequests(request, requestEndTime, response.statusCode)
   }
 
   if (request.fetchMetrics) {
@@ -62,14 +55,11 @@ export function logRequests(options: RequestLoggingOptions): void {
   }
 }
 
-interface IncomingRequestOptions {
-  readonly request: NodeNextRequest
-  readonly requestDurationInMs: number
-  readonly statusCode: number
-}
-
-function logIncomingRequests(options: IncomingRequestOptions): void {
-  const { request, requestDurationInMs, statusCode } = options
+function logIncomingRequests(
+  request: NodeNextRequest,
+  requestEndTime: ReturnType<typeof process.hrtime>,
+  statusCode: number
+): void {
   const isRSC = getRequestMeta(request, 'isRSCRequest')
   const url = isRSC ? stripNextRscUnionQuery(request.url) : request.url
 
@@ -87,7 +77,7 @@ function logIncomingRequests(options: IncomingRequestOptions): void {
   const coloredStatus = statusCodeColor(statusCode.toString())
 
   return writeLine(
-    `${request.method} ${url} ${coloredStatus} in ${requestDurationInMs}ms`
+    `${request.method} ${url} ${coloredStatus} in ${hrtimeDurationToString(requestEndTime)}`
   )
 }
 

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -466,7 +466,7 @@ export default class DevServer extends Server {
       const loggingConfig = this.nextConfig.logging
 
       if (loggingConfig !== false) {
-        const requestStart = process.hrtime()
+        const requestStart = process.hrtime.bigint()
         const isMiddlewareRequest = getRequestMeta(req, 'middlewareInvoke')
 
         if (!isMiddlewareRequest) {
@@ -480,8 +480,14 @@ export default class DevServer extends Server {
               return
             }
 
-            const requestEnd = process.hrtime(requestStart)
-            logRequests(request, response, loggingConfig, requestEnd)
+            const requestEnd = process.hrtime.bigint()
+            logRequests(
+              request,
+              response,
+              loggingConfig,
+              requestStart,
+              requestEnd
+            )
           })
         }
       }

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -466,7 +466,7 @@ export default class DevServer extends Server {
       const loggingConfig = this.nextConfig.logging
 
       if (loggingConfig !== false) {
-        const start = Date.now()
+        const requestStart = process.hrtime()
         const isMiddlewareRequest = getRequestMeta(req, 'middlewareInvoke')
 
         if (!isMiddlewareRequest) {
@@ -480,12 +480,8 @@ export default class DevServer extends Server {
               return
             }
 
-            logRequests({
-              request,
-              response,
-              loggingConfig,
-              requestDurationInMs: Date.now() - start,
-            })
+            const requestEnd = process.hrtime(requestStart)
+            logRequests(request, response, loggingConfig, requestEnd)
           })
         }
       }


### PR DESCRIPTION
## What?

Instead of using `Date.now()` to compare timing uses the more appropriate `process.hrtime.bigint()` 

Closes PACK-5689