### PR TITLE
Development: Implement request log time details

### DIFF
--- a/packages/next/src/build/duration-to-string.ts
+++ b/packages/next/src/build/duration-to-string.ts
@@ -16,34 +16,30 @@ const SECONDS_THRESHOLD_LOW_NANOSECONDS = 2_000_000_000 // 2 seconds in nanoseco
 const MILLISECONDS_THRESHOLD_NANOSECONDS = 1_000_000 // 1 millisecond in nanoseconds
 
 export function durationToString(compilerDuration: number) {
-  let durationString
   if (compilerDuration > MINUTES_THRESHOLD_SECONDS) {
-    durationString = `${(compilerDuration / SECONDS_IN_MINUTE).toFixed(1)}min`
+    return `${(compilerDuration / SECONDS_IN_MINUTE).toFixed(1)}min`
   } else if (compilerDuration > SECONDS_THRESHOLD_HIGH) {
-    durationString = `${compilerDuration.toFixed(0)}s`
+    return `${compilerDuration.toFixed(0)}s`
   } else if (compilerDuration > SECONDS_THRESHOLD_LOW) {
-    durationString = `${compilerDuration.toFixed(1)}s`
+    return `${compilerDuration.toFixed(1)}s`
   } else {
-    durationString = `${(compilerDuration * MILLISECONDS_PER_SECOND).toFixed(1)}ms`
+    return `${(compilerDuration * MILLISECONDS_PER_SECOND).toFixed(1)}ms`
   }
-  return durationString
 }
 
 function durationToStringWithNanoseconds(durationBigInt: bigint): string {
-  let durationString
   const duration = Number(durationBigInt)
   if (duration > MINUTES_THRESHOLD_NANOSECONDS) {
-    durationString = `${(duration / NANOSECONDS_IN_MINUTE).toFixed(1)}min`
+    return `${(duration / NANOSECONDS_IN_MINUTE).toFixed(1)}min`
   } else if (duration > SECONDS_THRESHOLD_HIGH_NANOSECONDS) {
-    durationString = `${(duration / NANOSECONDS_PER_SECOND).toFixed(0)}s`
+    return `${(duration / NANOSECONDS_PER_SECOND).toFixed(0)}s`
   } else if (duration > SECONDS_THRESHOLD_LOW_NANOSECONDS) {
-    durationString = `${(duration / NANOSECONDS_PER_SECOND).toFixed(1)}s`
+    return `${(duration / NANOSECONDS_PER_SECOND).toFixed(1)}s`
   } else if (duration > MILLISECONDS_THRESHOLD_NANOSECONDS) {
-    durationString = `${(duration / NANOSECONDS_PER_MILLISECOND).toFixed(0)}ms`
+    return `${(duration / NANOSECONDS_PER_MILLISECOND).toFixed(0)}ms`
   } else {
-    durationString = `${(duration / NANOSECONDS_PER_MICROSECOND).toFixed(0)}µs`
+    return `${(duration / NANOSECONDS_PER_MICROSECOND).toFixed(0)}µs`
   }
-  return durationString
 }
 
 export function hrtimeToSeconds(hrtime: [number, number]): number {

--- a/packages/next/src/build/duration-to-string.ts
+++ b/packages/next/src/build/duration-to-string.ts
@@ -1,13 +1,30 @@
+// Time thresholds in seconds
+const SECONDS_IN_MINUTE = 60
+const MINUTES_THRESHOLD_SECONDS = 120 // 2 minutes
+const SECONDS_THRESHOLD_HIGH = 40
+const SECONDS_THRESHOLD_LOW = 2
+const MILLISECONDS_PER_SECOND = 1000
+
+// Time thresholds and conversion factors for nanoseconds
+const NANOSECONDS_PER_SECOND = 1_000_000_000
+const NANOSECONDS_PER_MILLISECOND = 1_000_000
+const NANOSECONDS_PER_MICROSECOND = 1_000
+const NANOSECONDS_IN_MINUTE = 60_000_000_000 // 60 * 1_000_000_000
+const MINUTES_THRESHOLD_NANOSECONDS = 120_000_000_000 // 2 minutes in nanoseconds
+const SECONDS_THRESHOLD_HIGH_NANOSECONDS = 40_000_000_000 // 40 seconds in nanoseconds
+const SECONDS_THRESHOLD_LOW_NANOSECONDS = 2_000_000_000 // 2 seconds in nanoseconds
+const MILLISECONDS_THRESHOLD_NANOSECONDS = 1_000_000 // 1 millisecond in nanoseconds
+
 export function durationToString(compilerDuration: number) {
   let durationString
-  if (compilerDuration > 120) {
-    durationString = `${(compilerDuration / 60).toFixed(1)}min`
-  } else if (compilerDuration > 40) {
+  if (compilerDuration > MINUTES_THRESHOLD_SECONDS) {
+    durationString = `${(compilerDuration / SECONDS_IN_MINUTE).toFixed(1)}min`
+  } else if (compilerDuration > SECONDS_THRESHOLD_HIGH) {
     durationString = `${compilerDuration.toFixed(0)}s`
-  } else if (compilerDuration > 2) {
+  } else if (compilerDuration > SECONDS_THRESHOLD_LOW) {
     durationString = `${compilerDuration.toFixed(1)}s`
   } else {
-    durationString = `${(compilerDuration * 1000).toFixed(1)}ms`
+    durationString = `${(compilerDuration * MILLISECONDS_PER_SECOND).toFixed(1)}ms`
   }
   return durationString
 }
@@ -15,23 +32,23 @@ export function durationToString(compilerDuration: number) {
 function durationToStringWithNanoseconds(durationBigInt: bigint): string {
   let durationString
   const duration = Number(durationBigInt)
-  if (duration > 120000000000) {
-    durationString = `${(duration / 60000000000).toFixed(1)}min`
-  } else if (duration > 40000000000) {
-    durationString = `${(duration / 1000000000).toFixed(0)}s`
-  } else if (duration > 2000000000) {
-    durationString = `${(duration / 1000000000).toFixed(1)}s`
-  } else if (duration > 1000000) {
-    durationString = `${(duration / 1000000).toFixed(0)}ms`
+  if (duration > MINUTES_THRESHOLD_NANOSECONDS) {
+    durationString = `${(duration / NANOSECONDS_IN_MINUTE).toFixed(1)}min`
+  } else if (duration > SECONDS_THRESHOLD_HIGH_NANOSECONDS) {
+    durationString = `${(duration / NANOSECONDS_PER_SECOND).toFixed(0)}s`
+  } else if (duration > SECONDS_THRESHOLD_LOW_NANOSECONDS) {
+    durationString = `${(duration / NANOSECONDS_PER_SECOND).toFixed(1)}s`
+  } else if (duration > MILLISECONDS_THRESHOLD_NANOSECONDS) {
+    durationString = `${(duration / NANOSECONDS_PER_MILLISECOND).toFixed(0)}ms`
   } else {
-    durationString = `${(duration / 1000).toFixed(0)}µs`
+    durationString = `${(duration / NANOSECONDS_PER_MICROSECOND).toFixed(0)}µs`
   }
   return durationString
 }
 
 export function hrtimeToSeconds(hrtime: [number, number]): number {
   // hrtime is a tuple of [seconds, nanoseconds]
-  return hrtime[0] + hrtime[1] / 1e9
+  return hrtime[0] + hrtime[1] / NANOSECONDS_PER_SECOND
 }
 
 export function hrtimeBigIntDurationToString(hrtime: bigint) {

--- a/packages/next/src/build/duration-to-string.ts
+++ b/packages/next/src/build/duration-to-string.ts
@@ -7,7 +7,24 @@ export function durationToString(compilerDuration: number) {
   } else if (compilerDuration > 2) {
     durationString = `${compilerDuration.toFixed(1)}s`
   } else {
-    durationString = `${(compilerDuration * 1000).toFixed(0)}ms`
+    durationString = `${(compilerDuration * 1000).toFixed(1)}ms`
+  }
+  return durationString
+}
+
+function durationToStringWithNanoseconds(durationBigInt: bigint): string {
+  let durationString
+  const duration = Number(durationBigInt)
+  if (duration > 120000000000) {
+    durationString = `${(duration / 60000000000).toFixed(1)}min`
+  } else if (duration > 40000000000) {
+    durationString = `${(duration / 1000000000).toFixed(0)}s`
+  } else if (duration > 2000000000) {
+    durationString = `${(duration / 1000000000).toFixed(1)}s`
+  } else if (duration > 1000000) {
+    durationString = `${(duration / 1000000).toFixed(0)}ms`
+  } else {
+    durationString = `${(duration / 1000).toFixed(0)}µs`
   }
   return durationString
 }
@@ -17,16 +34,8 @@ export function hrtimeToSeconds(hrtime: [number, number]): number {
   return hrtime[0] + hrtime[1] / 1e9
 }
 
-function nanosecondsBigIntToSeconds(nanoseconds: bigint): number {
-  return Number(nanoseconds) / 1000000000
-}
-
-function hrtimeBigIntToSeconds(hrtime: bigint): number {
-  return nanosecondsBigIntToSeconds(hrtime)
-}
-
 export function hrtimeBigIntDurationToString(hrtime: bigint) {
-  return durationToString(hrtimeBigIntToSeconds(hrtime))
+  return durationToStringWithNanoseconds(hrtime)
 }
 
 export function hrtimeDurationToString(hrtime: [number, number]): string {

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -10,7 +10,7 @@ import { RouteKind } from '../../server/route-kind' with { 'turbopack-transition
 
 import { getRevalidateReason } from '../../server/instrumentation/utils'
 import { getTracer, SpanKind, type Span } from '../../server/lib/trace/tracer'
-import { getRequestMeta } from '../../server/request-meta'
+import { addRequestMeta, getRequestMeta } from '../../server/request-meta'
 import { BaseServerSpan } from '../../server/lib/trace/constants'
 import { interopDefault } from '../../server/app-render/interop-default'
 import { stripFlightHeaders } from '../../server/app-render/strip-flight-headers'
@@ -118,6 +118,9 @@ export async function handler(
     waitUntil: (prom: Promise<void>) => void
   }
 ) {
+  if (routeModule.isDev) {
+    addRequestMeta(req, 'devRequestTimingInternalsEnd', process.hrtime.bigint())
+  }
   let srcPage = 'VAR_DEFINITION_PAGE'
 
   // turbopack doesn't normalize `/index` in the page name

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -6,7 +6,7 @@ import {
 import { RouteKind } from '../../server/route-kind'
 import { patchFetch as _patchFetch } from '../../server/lib/patch-fetch'
 import type { IncomingMessage, ServerResponse } from 'node:http'
-import { getRequestMeta } from '../../server/request-meta'
+import { addRequestMeta, getRequestMeta } from '../../server/request-meta'
 import { getTracer, type Span, SpanKind } from '../../server/lib/trace/tracer'
 import { setReferenceManifestsSingleton } from '../../server/app-render/encryption-utils'
 import { createServerModuleMap } from '../../server/app-render/action-utils'
@@ -85,6 +85,9 @@ export async function handler(
     waitUntil: (prom: Promise<void>) => void
   }
 ) {
+  if (routeModule.isDev) {
+    addRequestMeta(req, 'devRequestTimingInternalsEnd', process.hrtime.bigint())
+  }
   let srcPage = 'VAR_DEFINITION_PAGE'
 
   // turbopack doesn't normalize `/index` in the page name

--- a/packages/next/src/server/dev/log-requests.ts
+++ b/packages/next/src/server/dev/log-requests.ts
@@ -43,14 +43,18 @@ export function logRequests(
   response: NodeNextResponse,
   loggingConfig: LoggingConfig,
   requestStartTime: bigint,
-  requestEndTime: bigint
+  requestEndTime: bigint,
+  devRequestTimingMiddlewareStart: bigint | undefined,
+  devRequestTimingMiddlewareEnd: bigint | undefined
 ): void {
   if (!ignoreLoggingIncomingRequests(request, loggingConfig)) {
     logIncomingRequests(
       request,
       requestStartTime,
       requestEndTime,
-      response.statusCode
+      response.statusCode,
+      devRequestTimingMiddlewareStart,
+      devRequestTimingMiddlewareEnd
     )
   }
 
@@ -65,9 +69,15 @@ function logIncomingRequests(
   request: NodeNextRequest,
   requestStartTime: bigint,
   requestEndTime: bigint,
-  statusCode: number
+  statusCode: number,
+  devRequestTimingMiddlewareStart: bigint | undefined,
+  devRequestTimingMiddlewareEnd: bigint | undefined
 ): void {
   const isRSC = getRequestMeta(request, 'isRSCRequest')
+  const devRequestTimingInternalsEnd = getRequestMeta(
+    request,
+    'devRequestTimingInternalsEnd'
+  )
   const url = isRSC ? stripNextRscUnionQuery(request.url) : request.url
 
   const statusCodeColor =
@@ -83,8 +93,31 @@ function logIncomingRequests(
 
   const coloredStatus = statusCodeColor(statusCode.toString())
 
+  const totalRequestTime = requestEndTime - requestStartTime
+
+  const times: Array<[label: string, time: bigint]> = []
+
+  let middlewareTime: bigint | undefined
+  if (devRequestTimingMiddlewareStart && devRequestTimingMiddlewareEnd) {
+    middlewareTime =
+      devRequestTimingMiddlewareEnd - devRequestTimingMiddlewareStart
+    times.push(['user-proxy', middlewareTime])
+  }
+
+  if (devRequestTimingInternalsEnd) {
+    let frameworkTime = devRequestTimingInternalsEnd - requestStartTime
+
+    /* Middleware runs during the internals so we have to subtract it from the framework time */
+    if (middlewareTime) {
+      frameworkTime -= middlewareTime
+    }
+    // Insert as the first item to be rendered in the list
+    times.unshift(['framework', frameworkTime])
+    times.push(['user', requestEndTime - devRequestTimingInternalsEnd])
+  }
+
   return writeLine(
-    `${request.method} ${url} ${coloredStatus} in ${hrtimeBigIntDurationToString(requestEndTime - requestStartTime)}`
+    `${request.method} ${url} ${coloredStatus} in ${hrtimeBigIntDurationToString(totalRequestTime)}${times.length > 0 ? ` (${times.map(([label, time]) => `${label}: ${hrtimeBigIntDurationToString(time)}`).join(', ')})` : ''}`
   )
 }
 

--- a/packages/next/src/server/dev/log-requests.ts
+++ b/packages/next/src/server/dev/log-requests.ts
@@ -7,6 +7,7 @@ import {
   red,
   white,
   yellow,
+  dim,
 } from '../../lib/picocolors'
 import { stripNextRscUnionQuery } from '../../lib/url'
 import type { FetchMetric } from '../base-http'
@@ -101,7 +102,7 @@ function logIncomingRequests(
   if (devRequestTimingMiddlewareStart && devRequestTimingMiddlewareEnd) {
     middlewareTime =
       devRequestTimingMiddlewareEnd - devRequestTimingMiddlewareStart
-    times.push(['user-proxy', middlewareTime])
+    times.push(['proxy.ts', middlewareTime])
   }
 
   if (devRequestTimingInternalsEnd) {
@@ -112,12 +113,12 @@ function logIncomingRequests(
       frameworkTime -= middlewareTime
     }
     // Insert as the first item to be rendered in the list
-    times.unshift(['framework', frameworkTime])
-    times.push(['user', requestEndTime - devRequestTimingInternalsEnd])
+    times.unshift(['compile', frameworkTime])
+    times.push(['render', requestEndTime - devRequestTimingInternalsEnd])
   }
 
   return writeLine(
-    `${request.method} ${url} ${coloredStatus} in ${hrtimeBigIntDurationToString(totalRequestTime)}${times.length > 0 ? ` (${times.map(([label, time]) => `${label}: ${hrtimeBigIntDurationToString(time)}`).join(', ')})` : ''}`
+    `${request.method} ${url} ${coloredStatus} in ${hrtimeBigIntDurationToString(totalRequestTime)}${times.length > 0 ? dim(` (${times.map(([label, time]) => `${label}: ${hrtimeBigIntDurationToString(time)}`).join(', ')})`) : ''}`
   )
 }
 

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -519,6 +519,13 @@ export function getResolveRoutes(
             addRequestMeta(req, 'invokeOutput', '')
             addRequestMeta(req, 'invokeQuery', {})
             addRequestMeta(req, 'middlewareInvoke', true)
+            if (opts.dev) {
+              addRequestMeta(
+                req,
+                'devRequestTimingMiddlewareStart',
+                process.hrtime.bigint()
+              )
+            }
             debug('invoking middleware', req.url, req.headers)
 
             let middlewareRes: Response | undefined = undefined
@@ -542,6 +549,14 @@ export function getResolveRoutes(
                       controller.close()
                     },
                   })
+                }
+              } finally {
+                if (opts.dev) {
+                  addRequestMeta(
+                    req,
+                    'devRequestTimingMiddlewareEnd',
+                    process.hrtime.bigint()
+                  )
                 }
               }
             } catch (e) {

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -262,6 +262,14 @@ export interface RequestMeta {
    * DEV only: The fallback params that should be used when validating prerenders during dev
    */
   devValidatingFallbackParams?: OpaqueFallbackRouteParams
+
+  /**
+   * DEV only: Request timings in process.hrtime.bigint()
+   */
+  devRequestTimingStart?: bigint
+  devRequestTimingMiddlewareStart?: bigint
+  devRequestTimingMiddlewareEnd?: bigint
+  devRequestTimingInternalsEnd?: bigint
 }
 
 /**


### PR DESCRIPTION
## What?

Adds more detailed time for each request, showing what time is spent in Next.js (i.e. routing, Turbopack compilation, etc.) and what time is spent executing the application code which includes time spent in React / React rendering, requiring the application code, etc.

The additional info is dimmed:

<img width="744" height="124" alt="CleanShot 2025-10-15 at 19 27 01@2x" src="https://github.com/user-attachments/assets/b6ce973e-4687-4865-9ebb-be54865331b1" />


Text:

```
 GET / 200 in 626ms (compile: 500ms, render: 125ms)
 GET / 200 in 24ms (compile: 2ms, render: 22ms)
 GET / 200 in 20ms (compile: 2ms, render: 18ms)
 GET / 200 in 16ms (compile: 1ms, render: 15ms)
 GET / 200 in 16ms (compile: 1ms, render: 14ms)
```

While working on this I found that the existing time (the `in 22ms` part) did not include time spent in proxy.ts, which is unexpected as you'd want to see the total time spent on a request, including running proxy.ts. I've fixed that bug in this PR, as well as added tracking of the time spent in proxy:

To test I added a middleware that adds 1 second delay on all requests:

Before (note: request took more than 1 second):

```
 GET / 200 in 16ms
 GET / 200 in 20ms
```

After (note: request still takes the same time, but now correctly logs it):

```
 GET / 200 in 1610ms (compile: 450ms, proxy.ts: 1039ms, render: 121ms)
 GET / 200 in 1038ms (compile: 5ms, proxy.ts: 1007ms, render: 27ms)
 GET / 200 in 1034ms (compile: 5ms, proxy.ts: 1004ms, render: 25ms)
```

Closes PACK-5690