### PR TITLE
[dev-overlay] Never dedupe errors with different names or messages

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/shared.ts
+++ b/packages/next/src/next-devtools/dev-overlay/shared.ts
@@ -324,6 +324,9 @@ export function useErrorOverlayReducer(
     const pendingEvents = events.filter((event) => {
       // Filter out duplicate errors
       return (
+        // SpiderMonkey and JavaScriptCore don't include the error message in the stack.
+        // We don't want to dedupe errors with different messages for which we don't have a good stack
+        '' + event.error !== '' + pendingEvent.error ||
         (event.error.stack !== pendingEvent.error.stack &&
           // TODO: Let ReactDevTools control deduping instead?
           getStackIgnoringStrictMode(event.error.stack) !==


### PR DESCRIPTION
Can happen when non-error objects are logged/thrown. SpiderMonkey (FF) and JSC (Safari) don't include name and message in `.stack` so different issues would be deduped.

Closes https://linear.app/vercel/issue/NAR-376/