### PR TITLE
[turbopack] Don't warn on the lightning css experimental option

### DIFF
--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -40,9 +40,6 @@ const unsupportedTurbopackNextConfigOptions = [
   'experimental.fullySpecified',
   'experimental.urlImports',
   'experimental.slowModuleDetection',
-
-  // We always use lightningcss
-  'experimental.useLightningcss',
 ]
 
 /**  */


### PR DESCRIPTION
This is ignored by turbopack but we also always run with useLightningCss so it isn't harmful to set this.  If people are using both webpack and turbopack then setting this is reasonable.

Closes PACK-5727