### PR TITLE
Turbopack: Track errored tasks as dependency when using untracked()

### DIFF
--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -17,7 +17,7 @@ use rustc_hash::FxHashMap;
 use tokio::sync::mpsc::Receiver;
 use turbo_tasks::{
     CellId, ExecutionId, InvalidationReason, LocalTaskId, MagicAny, RawVc, ReadCellOptions,
-    ReadConsistency, TaskId, TaskPersistence, TraitTypeId, TurboTasksApi, TurboTasksCallApi,
+    ReadOutputOptions, TaskId, TaskPersistence, TraitTypeId, TurboTasksApi, TurboTasksCallApi,
     backend::{CellContent, TaskCollectiblesMap, TypedCellContent},
     event::{Event, EventListener},
     message_queue::CompilationEvent,
@@ -176,7 +176,7 @@ impl TurboTasksApi for VcStorage {
     fn try_read_task_output(
         &self,
         id: TaskId,
-        _consistency: ReadConsistency,
+        _options: ReadOutputOptions,
     ) -> Result<Result<RawVc, EventListener>> {
         let tasks = self.tasks.lock().unwrap();
         let i = *id - 1;
@@ -188,14 +188,6 @@ impl TurboTasksApi for VcStorage {
                 Err(err) => Err(anyhow!(err.clone())),
             },
         }
-    }
-
-    fn try_read_task_output_untracked(
-        &self,
-        task: TaskId,
-        consistency: ReadConsistency,
-    ) -> Result<Result<RawVc, EventListener>> {
-        self.try_read_task_output(task, consistency)
     }
 
     fn try_read_task_cell(
@@ -212,23 +204,7 @@ impl TurboTasksApi for VcStorage {
         }
         .into_typed(index.type_id)))
     }
-
-    fn try_read_task_cell_untracked(
-        &self,
-        task: TaskId,
-        index: CellId,
-        _options: ReadCellOptions,
-    ) -> Result<Result<TypedCellContent, EventListener>> {
-        let map = self.cells.lock().unwrap();
-        Ok(Ok(if let Some(cell) = map.get(&(task, index)) {
-            cell.to_owned()
-        } else {
-            Default::default()
-        }
-        .into_typed(index.type_id)))
-    }
-
-    fn try_read_own_task_cell_untracked(
+    fn try_read_own_task_cell(
         &self,
         current_task: TaskId,
         index: CellId,

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -17,16 +17,11 @@ use tracing::Span;
 use turbo_rcstr::RcStr;
 
 use crate::{
-    RawVc, ReadCellOptions, ReadRef, SharedReference, TaskId, TaskIdSet, TraitRef, TraitTypeId,
-    TurboTasksPanic, ValueTypeId, VcRead, VcValueTrait, VcValueType,
-    event::EventListener,
-    macro_helpers::NativeFunction,
-    magic_any::MagicAny,
-    manager::{ReadConsistency, TurboTasksBackendApi},
-    raw_vc::CellId,
-    registry,
-    task::shared_reference::TypedSharedReference,
-    task_statistics::TaskStatisticsApi,
+    RawVc, ReadCellOptions, ReadOutputOptions, ReadRef, SharedReference, TaskId, TaskIdSet,
+    TraitRef, TraitTypeId, TurboTasksPanic, ValueTypeId, VcRead, VcValueTrait, VcValueType,
+    event::EventListener, macro_helpers::NativeFunction, magic_any::MagicAny,
+    manager::TurboTasksBackendApi, raw_vc::CellId, registry,
+    task::shared_reference::TypedSharedReference, task_statistics::TaskStatisticsApi,
     triomphe_utils::unchecked_sidecast_triomphe_arc,
 };
 
@@ -564,7 +559,7 @@ pub trait Backend: Sync + Send {
         &self,
         task: TaskId,
         reader: Option<TaskId>,
-        consistency: ReadConsistency,
+        options: ReadOutputOptions,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) -> Result<Result<RawVc, EventListener>>;
 
@@ -581,7 +576,7 @@ pub trait Backend: Sync + Send {
 
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
     /// using it could break cache invalidation.
-    fn try_read_own_task_cell_untracked(
+    fn try_read_own_task_cell(
         &self,
         current_task: TaskId,
         index: CellId,

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -108,14 +108,14 @@ pub use join_iter_ext::{JoinIterExt, TryFlatJoinIterExt, TryJoinIterExt};
 pub use key_value_pair::KeyValuePair;
 pub use magic_any::MagicAny;
 pub use manager::{
-    CurrentCellRef, ReadConsistency, TaskPersistence, TurboTasks, TurboTasksApi,
+    CurrentCellRef, ReadConsistency, ReadTracking, TaskPersistence, TurboTasks, TurboTasksApi,
     TurboTasksBackendApi, TurboTasksCallApi, Unused, UpdateInfo, dynamic_call, emit, mark_finished,
     mark_root, mark_session_dependent, mark_stateful, prevent_gc, run, run_once,
     run_once_with_reason, trait_call, turbo_tasks, turbo_tasks_scope,
 };
 pub use output::OutputContent;
 pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};
-pub use read_options::ReadCellOptions;
+pub use read_options::{ReadCellOptions, ReadOutputOptions};
 pub use read_ref::ReadRef;
 use rustc_hash::FxHasher;
 pub use serialization_invalidation::SerializationInvalidator;

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -369,6 +369,7 @@ impl ReadRawVcFuture {
     /// using it could break cache invalidation.
     pub fn untracked(mut self) -> Self {
         self.read_output_options.tracking = ReadTracking::TrackOnlyError;
+        self.read_cell_options.tracking = ReadTracking::TrackOnlyError;
         self
     }
 
@@ -379,6 +380,7 @@ impl ReadRawVcFuture {
     /// using it could break cache invalidation.
     pub fn untracked_including_errors(mut self) -> Self {
         self.read_output_options.tracking = ReadTracking::Untracked;
+        self.read_cell_options.tracking = ReadTracking::Untracked;
         self
     }
 

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -11,12 +11,14 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    CollectiblesSource, ReadCellOptions, ReadConsistency, ResolvedVc, TaskId, TaskPersistence,
-    TraitTypeId, ValueType, ValueTypeId, VcValueTrait,
+    CollectiblesSource, ReadCellOptions, ReadConsistency, ReadOutputOptions, ResolvedVc, TaskId,
+    TaskPersistence, TraitTypeId, ValueType, ValueTypeId, VcValueTrait,
     backend::{CellContent, TypedCellContent},
     event::EventListener,
     id::{ExecutionId, LocalTaskId},
-    manager::{read_local_output, read_task_cell, read_task_output, with_turbo_tasks},
+    manager::{
+        ReadTracking, read_local_output, read_task_cell, read_task_output, with_turbo_tasks,
+    },
     registry::{self, get_value_type},
     turbo_tasks,
 };
@@ -170,7 +172,7 @@ impl RawVc {
         loop {
             match current {
                 RawVc::TaskOutput(task) => {
-                    current = read_task_output(&*tt, task, ReadConsistency::Eventual)
+                    current = read_task_output(&*tt, task, ReadOutputOptions::default())
                         .await
                         .map_err(|source| ResolveTypeError::TaskError { source })?;
                 }
@@ -199,29 +201,37 @@ impl RawVc {
 
     /// See [`crate::Vc::resolve`].
     pub(crate) async fn resolve(self) -> Result<RawVc> {
-        self.resolve_inner(ReadConsistency::Eventual).await
+        self.resolve_inner(ReadOutputOptions {
+            tracking: ReadTracking::default(),
+            consistency: ReadConsistency::Eventual,
+        })
+        .await
     }
 
     /// See [`crate::Vc::resolve_strongly_consistent`].
     pub(crate) async fn resolve_strongly_consistent(self) -> Result<RawVc> {
-        self.resolve_inner(ReadConsistency::Strong).await
+        self.resolve_inner(ReadOutputOptions {
+            tracking: ReadTracking::default(),
+            consistency: ReadConsistency::Strong,
+        })
+        .await
     }
 
-    async fn resolve_inner(self, mut consistency: ReadConsistency) -> Result<RawVc> {
+    async fn resolve_inner(self, mut options: ReadOutputOptions) -> Result<RawVc> {
         let tt = turbo_tasks();
         let mut current = self;
         loop {
             match current {
                 RawVc::TaskOutput(task) => {
-                    current = read_task_output(&*tt, task, consistency).await?;
+                    current = read_task_output(&*tt, task, options).await?;
                     // We no longer need to read strongly consistent, as any Vc returned
                     // from the first task will be inside of the scope of the first
                     // task. So it's already strongly consistent.
-                    consistency = ReadConsistency::Eventual;
+                    options.consistency = ReadConsistency::Eventual;
                 }
                 RawVc::TaskCell(_, _) => return Ok(current),
                 RawVc::LocalOutput(execution_id, local_task_id, ..) => {
-                    debug_assert_eq!(consistency, ReadConsistency::Eventual);
+                    debug_assert_eq!(options.consistency, ReadConsistency::Eventual);
                     current = read_local_output(&*tt, execution_id, local_task_id).await?;
                 }
             }
@@ -331,9 +341,8 @@ impl CollectiblesSource for RawVc {
 }
 
 pub struct ReadRawVcFuture {
-    consistency: ReadConsistency,
     current: RawVc,
-    untracked: bool,
+    read_output_options: ReadOutputOptions,
     read_cell_options: ReadCellOptions,
     listener: Option<EventListener>,
 }
@@ -341,23 +350,35 @@ pub struct ReadRawVcFuture {
 impl ReadRawVcFuture {
     pub(crate) fn new(vc: RawVc) -> Self {
         ReadRawVcFuture {
-            consistency: ReadConsistency::Eventual,
             current: vc,
-            untracked: false,
+            read_output_options: ReadOutputOptions::default(),
             read_cell_options: ReadCellOptions::default(),
             listener: None,
         }
     }
 
     pub fn strongly_consistent(mut self) -> Self {
-        self.consistency = ReadConsistency::Strong;
+        self.read_output_options.consistency = ReadConsistency::Strong;
         self
     }
 
+    /// This will not track the value as dependency, but will still track the error as dependency,
+    /// if there is an error.
+    ///
     /// INVALIDATION: Be careful with this, it will not track dependencies, so
     /// using it could break cache invalidation.
     pub fn untracked(mut self) -> Self {
-        self.untracked = true;
+        self.read_output_options.tracking = ReadTracking::TrackOnlyError;
+        self
+    }
+
+    /// This will not track the value or the error as dependency.
+    /// Make sure to handle eventual consistency errors.
+    ///
+    /// INVALIDATION: Be careful with this, it will not track dependencies, so
+    /// using it could break cache invalidation.
+    pub fn untracked_including_errors(mut self) -> Self {
+        self.read_output_options.tracking = ReadTracking::Untracked;
         self
     }
 
@@ -385,17 +406,13 @@ impl Future for ReadRawVcFuture {
                 }
                 let mut listener = match this.current {
                     RawVc::TaskOutput(task) => {
-                        let read_result = if this.untracked {
-                            tt.try_read_task_output_untracked(task, this.consistency)
-                        } else {
-                            tt.try_read_task_output(task, this.consistency)
-                        };
+                        let read_result = tt.try_read_task_output(task, this.read_output_options);
                         match read_result {
                             Ok(Ok(vc)) => {
                                 // We no longer need to read strongly consistent, as any Vc returned
                                 // from the first task will be inside of the scope of the first
                                 // task. So it's already strongly consistent.
-                                this.consistency = ReadConsistency::Eventual;
+                                this.read_output_options.consistency = ReadConsistency::Eventual;
                                 this.current = vc;
                                 continue 'outer;
                             }
@@ -404,11 +421,8 @@ impl Future for ReadRawVcFuture {
                         }
                     }
                     RawVc::TaskCell(task, index) => {
-                        let read_result = if this.untracked {
-                            tt.try_read_task_cell_untracked(task, index, this.read_cell_options)
-                        } else {
-                            tt.try_read_task_cell(task, index, this.read_cell_options)
-                        };
+                        let read_result =
+                            tt.try_read_task_cell(task, index, this.read_cell_options);
                         match read_result {
                             Ok(Ok(content)) => {
                                 // SAFETY: Constructor ensures that T and U are binary identical
@@ -419,7 +433,10 @@ impl Future for ReadRawVcFuture {
                         }
                     }
                     RawVc::LocalOutput(execution_id, local_output_id, ..) => {
-                        debug_assert_eq!(this.consistency, ReadConsistency::Eventual);
+                        debug_assert_eq!(
+                            this.read_output_options.consistency,
+                            ReadConsistency::Eventual
+                        );
                         let read_result = tt.try_read_local_output(execution_id, local_output_id);
                         match read_result {
                             Ok(Ok(vc)) => {

--- a/turbopack/crates/turbo-tasks/src/read_options.rs
+++ b/turbopack/crates/turbo-tasks/src/read_options.rs
@@ -1,4 +1,13 @@
+use crate::{ReadConsistency, ReadTracking};
+
 #[derive(Clone, Copy, Debug, Default)]
 pub struct ReadCellOptions {
+    pub tracking: ReadTracking,
     pub final_read_hint: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ReadOutputOptions {
+    pub tracking: ReadTracking,
+    pub consistency: ReadConsistency,
 }


### PR DESCRIPTION
### What?

The pattern `some_operation().untracked().await?` is dangerous as it propages the error to the parent task.

An untracked read accepts an incorrectness due to eventual consistency during an update. This might also cause eventual consistent errors.

If these errors are propagates to the parent task, these error will not easily go away, as the read was untrack and therefore the error doesn't resolve automatically when the `some_operation` task computes again.

This change changes to the default of untracked read to be only untracked for the value, but track the dependency in case of an error.

Closes PACK-5705