### PR TITLE
Turbopack: fix pageExtensions precedence

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1388,7 +1388,12 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub fn page_extensions(&self) -> Vc<Vec<RcStr>> {
-        Vc::cell(self.page_extensions.clone())
+        // Sort page extensions by length descending. This mirrors the Webpack behavior in Next.js,
+        // which just builds a regex alternative, which greedily matches the longest
+        // extension: https://github.com/vercel/next.js/blob/32476071fe331948d89a35c391eb578aed8de979/packages/next/src/build/entries.ts#L409
+        let mut extensions = self.page_extensions.clone();
+        extensions.sort_by_key(|ext| std::cmp::Reverse(ext.len()));
+        Vc::cell(extensions)
     }
 
     #[turbo_tasks::function]

--- a/test/integration/custom-page-extension/next.config.js
+++ b/test/integration/custom-page-extension/next.config.js
@@ -1,3 +1,5 @@
-module.exports = {
-  pageExtensions: ['page.js'],
-}
+module.exports = (phase, { defaultConfig }) => ({
+  // Append the custom extension to the default page extensions, to ensure that matching precedence
+  // is by length.
+  pageExtensions: [...defaultConfig.pageExtensions, 'page.js'],
+})


### PR DESCRIPTION
Webpack doesn't use the specified order, it's by length.

Closes PACK-5691