### PR TITLE
[Cache Components] correctly label IO promises in devtools

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -888,5 +888,5 @@
   "887": "`cacheLife()` is only available with the `cacheComponents` config.",
   "888": "Unknown \\`cacheLife()\\` profile \"%s\" is not configured in next.config.js\\nmodule.exports = {\n  cacheLife: {\n    \"%s\": ...\\n  }\n}",
   "889": "Unknown \\`cacheLife()\\` profile \"%s\" is not configured in next.config.js\\nmodule.exports = {\n  cacheLife: {\n      \"%s\": ...\\n    }\n}",
-  "890": "Received a underlying cookies object that does not match either `cookies` or `mutableCookies`"
+  "890": "Received an underlying cookies object that does not match either `cookies` or `mutableCookies`"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -887,5 +887,6 @@
   "886": "`cacheTag()` is only available with the `cacheComponents` config.",
   "887": "`cacheLife()` is only available with the `cacheComponents` config.",
   "888": "Unknown \\`cacheLife()\\` profile \"%s\" is not configured in next.config.js\\nmodule.exports = {\n  cacheLife: {\n    \"%s\": ...\\n  }\n}",
-  "889": "Unknown \\`cacheLife()\\` profile \"%s\" is not configured in next.config.js\\nmodule.exports = {\n  cacheLife: {\n      \"%s\": ...\\n    }\n}"
+  "889": "Unknown \\`cacheLife()\\` profile \"%s\" is not configured in next.config.js\\nmodule.exports = {\n  cacheLife: {\n      \"%s\": ...\\n    }\n}",
+  "890": "Received a underlying cookies object that does not match either `cookies` or `mutableCookies`"
 }

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -70,8 +70,20 @@ export interface RequestStore extends CommonWorkUnitStore {
   usedDynamic?: boolean
   devFallbackParams?: OpaqueFallbackRouteParams | null
   stagedRendering?: StagedRenderingController | null
+  asyncApiPromises?: DevAsyncApiPromises
   cacheSignal?: CacheSignal | null
   prerenderResumeDataCache?: PrerenderResumeDataCache | null
+}
+
+type DevAsyncApiPromises = {
+  cookies: Promise<ReadonlyRequestCookies>
+  mutableCookies: Promise<ReadonlyRequestCookies>
+  headers: Promise<ReadonlyHeaders>
+
+  sharedParamsParent: Promise<string>
+  sharedSearchParamsParent: Promise<string>
+
+  connection: Promise<undefined>
 }
 
 /**

--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -83,7 +83,11 @@ export function makeDevtoolsIOAwarePromise<T>(
 ): Promise<T> {
   if (requestStore.stagedRendering) {
     // We resolve each stage in a timeout, so React DevTools will pick this up as IO.
-    return requestStore.stagedRendering.delayUntilStage(stage, underlying)
+    return requestStore.stagedRendering.delayUntilStage(
+      stage,
+      undefined,
+      underlying
+    )
   }
   // in React DevTools if we resolve in a setTimeout we will observe
   // the promise resolution as something that can suspend a boundary or root.

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -562,10 +562,8 @@ export function createPatchedFetcher(
                   cacheSignal.endRead()
                   cacheSignal = null
                 }
-                await workUnitStore.stagedRendering.delayUntilStage(
-                  RenderStage.Dynamic,
-                  undefined,
-                  undefined
+                await workUnitStore.stagedRendering.waitForStage(
+                  RenderStage.Dynamic
                 )
               }
               break
@@ -690,10 +688,8 @@ export function createPatchedFetcher(
                       cacheSignal.endRead()
                       cacheSignal = null
                     }
-                    await workUnitStore.stagedRendering.delayUntilStage(
-                      RenderStage.Dynamic,
-                      undefined,
-                      undefined
+                    await workUnitStore.stagedRendering.waitForStage(
+                      RenderStage.Dynamic
                     )
                   }
                   break
@@ -964,10 +960,8 @@ export function createPatchedFetcher(
                     process.env.NODE_ENV === 'development' &&
                     workUnitStore.stagedRendering
                   ) {
-                    await workUnitStore.stagedRendering.delayUntilStage(
-                      RenderStage.Dynamic,
-                      undefined,
-                      undefined
+                    await workUnitStore.stagedRendering.waitForStage(
+                      RenderStage.Dynamic
                     )
                   }
                   break
@@ -1094,10 +1088,8 @@ export function createPatchedFetcher(
                       cacheSignal.endRead()
                       cacheSignal = null
                     }
-                    await workUnitStore.stagedRendering.delayUntilStage(
-                      RenderStage.Dynamic,
-                      undefined,
-                      undefined
+                    await workUnitStore.stagedRendering.waitForStage(
+                      RenderStage.Dynamic
                     )
                   }
                   break
@@ -1142,10 +1134,8 @@ export function createPatchedFetcher(
                       process.env.NODE_ENV === 'development' &&
                       workUnitStore.stagedRendering
                     ) {
-                      await workUnitStore.stagedRendering.delayUntilStage(
-                        RenderStage.Dynamic,
-                        undefined,
-                        undefined
+                      await workUnitStore.stagedRendering.waitForStage(
+                        RenderStage.Dynamic
                       )
                     }
                     break

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -564,6 +564,7 @@ export function createPatchedFetcher(
                 }
                 await workUnitStore.stagedRendering.delayUntilStage(
                   RenderStage.Dynamic,
+                  undefined,
                   undefined
                 )
               }
@@ -691,6 +692,7 @@ export function createPatchedFetcher(
                     }
                     await workUnitStore.stagedRendering.delayUntilStage(
                       RenderStage.Dynamic,
+                      undefined,
                       undefined
                     )
                   }
@@ -964,6 +966,7 @@ export function createPatchedFetcher(
                   ) {
                     await workUnitStore.stagedRendering.delayUntilStage(
                       RenderStage.Dynamic,
+                      undefined,
                       undefined
                     )
                   }
@@ -1093,6 +1096,7 @@ export function createPatchedFetcher(
                     }
                     await workUnitStore.stagedRendering.delayUntilStage(
                       RenderStage.Dynamic,
+                      undefined,
                       undefined
                     )
                   }
@@ -1140,6 +1144,7 @@ export function createPatchedFetcher(
                     ) {
                       await workUnitStore.stagedRendering.delayUntilStage(
                         RenderStage.Dynamic,
+                        undefined,
                         undefined
                       )
                     }

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -106,6 +106,9 @@ export function connection(): Promise<void> {
             // Semantically we only need the dev tracking when running in `next dev`
             // but since you would never use next dev with production NODE_ENV we use this
             // as a proxy so we can statically exclude this code from production builds.
+            if (workUnitStore.asyncApiPromises) {
+              return workUnitStore.asyncApiPromises.connection
+            }
             return makeDevtoolsIOAwarePromise(
               undefined,
               workUnitStore,

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -28,7 +28,6 @@ import {
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
 import { isRequestAPICallableInsideAfter } from './utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
-import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
 import { RenderStage } from '../app-render/staged-rendering'
 
 export function cookies(): Promise<ReadonlyRequestCookies> {
@@ -198,7 +197,7 @@ function makeUntrackedCookiesWithDevWarnings(
       promise = requestStore.asyncApiPromises.cookies
     } else {
       throw new InvariantError(
-        'Received a underlying cookies object that does not match either `cookies` or `mutableCookies`'
+        'Received an underlying cookies object that does not match either `cookies` or `mutableCookies`'
       )
     }
     return instrumentCookiesPromiseWithDevWarnings(promise, route)
@@ -230,35 +229,65 @@ function instrumentCookiesPromiseWithDevWarnings(
   promise: Promise<ReadonlyRequestCookies>,
   route: string | undefined
 ) {
-  return new Proxy(promise, {
-    get(target, prop, receiver) {
-      switch (prop) {
-        case Symbol.iterator: {
-          warnForSyncAccess(route, '`...cookies()` or similar iteration')
-          break
-        }
-        case 'size':
-        case 'get':
-        case 'getAll':
-        case 'has':
-        case 'set':
-        case 'delete':
-        case 'clear':
-        case 'toString': {
-          warnForSyncAccess(route, `\`cookies().${prop}\``)
-          break
-        }
-        default: {
-          // We only warn for well-defined properties of the cookies object.
-        }
-      }
-
-      return ReflectAdapter.get(target, prop, receiver)
-    },
-    set(target, prop, newValue, receiver) {
-      return ReflectAdapter.set(target, prop, newValue, receiver)
-    },
+  Object.defineProperties(promise, {
+    [Symbol.iterator]: replaceableWarningDescriptorForSymbolIterator(
+      promise,
+      route
+    ),
+    size: replaceableWarningDescriptor(promise, 'size', route),
+    get: replaceableWarningDescriptor(promise, 'get', route),
+    getAll: replaceableWarningDescriptor(promise, 'getAll', route),
+    has: replaceableWarningDescriptor(promise, 'has', route),
+    set: replaceableWarningDescriptor(promise, 'set', route),
+    delete: replaceableWarningDescriptor(promise, 'delete', route),
+    clear: replaceableWarningDescriptor(promise, 'clear', route),
+    toString: replaceableWarningDescriptor(promise, 'toString', route),
   })
+  return promise
+}
+
+function replaceableWarningDescriptor(
+  target: unknown,
+  prop: string,
+  route: string | undefined
+) {
+  return {
+    enumerable: false,
+    get() {
+      warnForSyncAccess(route, `\`cookies().${prop}\``)
+      return undefined
+    },
+    set(value: unknown) {
+      Object.defineProperty(target, prop, {
+        value,
+        writable: true,
+        configurable: true,
+      })
+    },
+    configurable: true,
+  }
+}
+
+function replaceableWarningDescriptorForSymbolIterator(
+  target: unknown,
+  route: string | undefined
+) {
+  return {
+    enumerable: false,
+    get() {
+      warnForSyncAccess(route, '`...cookies()` or similar iteration')
+      return undefined
+    },
+    set(value: unknown) {
+      Object.defineProperty(target, Symbol.iterator, {
+        value,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      })
+    },
+    configurable: true,
+  }
 }
 
 function createCookiesAccessError(

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -201,9 +201,7 @@ function makeUntrackedCookiesWithDevWarnings(
         'Received a underlying cookies object that does not match either `cookies` or `mutableCookies`'
       )
     }
-    // TODO(restart-on-cache-miss): Instrument with warnings
-    // return instrumentCookiesPromiseWithDevWarnings(promise, route)
-    return promise
+    return instrumentCookiesPromiseWithDevWarnings(promise, route)
   }
 
   const cachedCookies = CachedCookies.get(underlyingCookies)

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -190,6 +190,22 @@ function makeUntrackedCookiesWithDevWarnings(
   underlyingCookies: ReadonlyRequestCookies,
   route?: string
 ): Promise<ReadonlyRequestCookies> {
+  if (requestStore.asyncApiPromises) {
+    let promise: Promise<ReadonlyRequestCookies>
+    if (underlyingCookies === requestStore.mutableCookies) {
+      promise = requestStore.asyncApiPromises.mutableCookies
+    } else if (underlyingCookies === requestStore.cookies) {
+      promise = requestStore.asyncApiPromises.cookies
+    } else {
+      throw new InvariantError(
+        'Received a underlying cookies object that does not match either `cookies` or `mutableCookies`'
+      )
+    }
+    // TODO(restart-on-cache-miss): Instrument with warnings
+    // return instrumentCookiesPromiseWithDevWarnings(promise, route)
+    return promise
+  }
+
   const cachedCookies = CachedCookies.get(underlyingCookies)
   if (cachedCookies) {
     return cachedCookies
@@ -201,7 +217,22 @@ function makeUntrackedCookiesWithDevWarnings(
     RenderStage.Runtime
   )
 
-  const proxiedPromise = new Proxy(promise, {
+  const proxiedPromise = instrumentCookiesPromiseWithDevWarnings(promise, route)
+
+  CachedCookies.set(underlyingCookies, proxiedPromise)
+
+  return proxiedPromise
+}
+
+const warnForSyncAccess = createDedupedByCallsiteServerErrorLoggerDev(
+  createCookiesAccessError
+)
+
+function instrumentCookiesPromiseWithDevWarnings(
+  promise: Promise<ReadonlyRequestCookies>,
+  route: string | undefined
+) {
+  return new Proxy(promise, {
     get(target, prop, receiver) {
       switch (prop) {
         case Symbol.iterator: {
@@ -226,16 +257,11 @@ function makeUntrackedCookiesWithDevWarnings(
 
       return ReflectAdapter.get(target, prop, receiver)
     },
+    set(target, prop, newValue, receiver) {
+      return ReflectAdapter.set(target, prop, newValue, receiver)
+    },
   })
-
-  CachedCookies.set(underlyingCookies, proxiedPromise)
-
-  return proxiedPromise
 }
-
-const warnForSyncAccess = createDedupedByCallsiteServerErrorLoggerDev(
-  createCookiesAccessError
-)
 
 function createCookiesAccessError(
   route: string | undefined,

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -26,7 +26,6 @@ import {
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
 import { isRequestAPICallableInsideAfter } from './utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
-import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
 import { RenderStage } from '../app-render/staged-rendering'
 
 /**
@@ -230,37 +229,67 @@ function instrumentHeadersPromiseWithDevWarnings(
   promise: Promise<ReadonlyHeaders>,
   route: string | undefined
 ) {
-  return new Proxy(promise, {
-    get(target, prop, receiver) {
-      switch (prop) {
-        case Symbol.iterator: {
-          warnForSyncAccess(route, '`...headers()` or similar iteration')
-          break
-        }
-        case 'append':
-        case 'delete':
-        case 'get':
-        case 'has':
-        case 'set':
-        case 'getSetCookie':
-        case 'forEach':
-        case 'keys':
-        case 'values':
-        case 'entries': {
-          warnForSyncAccess(route, `\`headers().${prop}\``)
-          break
-        }
-        default: {
-          // We only warn for well-defined properties of the headers object.
-        }
-      }
-
-      return ReflectAdapter.get(target, prop, receiver)
-    },
-    set(target, prop, newValue, receiver) {
-      return ReflectAdapter.set(target, prop, newValue, receiver)
-    },
+  Object.defineProperties(promise, {
+    [Symbol.iterator]: replaceableWarningDescriptorForSymbolIterator(
+      promise,
+      route
+    ),
+    append: replaceableWarningDescriptor(promise, 'append', route),
+    delete: replaceableWarningDescriptor(promise, 'delete', route),
+    get: replaceableWarningDescriptor(promise, 'get', route),
+    has: replaceableWarningDescriptor(promise, 'has', route),
+    set: replaceableWarningDescriptor(promise, 'set', route),
+    getSetCookie: replaceableWarningDescriptor(promise, 'getSetCookie', route),
+    forEach: replaceableWarningDescriptor(promise, 'forEach', route),
+    keys: replaceableWarningDescriptor(promise, 'keys', route),
+    values: replaceableWarningDescriptor(promise, 'values', route),
+    entries: replaceableWarningDescriptor(promise, 'entries', route),
   })
+  return promise
+}
+
+function replaceableWarningDescriptor(
+  target: unknown,
+  prop: string,
+  route: string | undefined
+) {
+  return {
+    enumerable: false,
+    get() {
+      warnForSyncAccess(route, `\`headers().${prop}\``)
+      return undefined
+    },
+    set(value: unknown) {
+      Object.defineProperty(target, prop, {
+        value,
+        writable: true,
+        configurable: true,
+      })
+    },
+    configurable: true,
+  }
+}
+
+function replaceableWarningDescriptorForSymbolIterator(
+  target: unknown,
+  route: string | undefined
+) {
+  return {
+    enumerable: false,
+    get() {
+      warnForSyncAccess(route, '`...headers()` or similar iteration')
+      return undefined
+    },
+    set(value: unknown) {
+      Object.defineProperty(target, Symbol.iterator, {
+        value,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      })
+    },
+    configurable: true,
+  }
 }
 
 function createHeadersAccessError(

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -201,9 +201,7 @@ function makeUntrackedHeadersWithDevWarnings(
 ): Promise<ReadonlyHeaders> {
   if (requestStore.asyncApiPromises) {
     const promise = requestStore.asyncApiPromises.headers
-    // TODO(restart-on-cache-miss): Instrument with warnings
-    // return instrumentHeadersPromiseWithDevWarnings(promise, route)
-    return promise
+    return instrumentHeadersPromiseWithDevWarnings(promise, route)
   }
 
   const cachedHeaders = CachedHeaders.get(underlyingHeaders)

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -199,6 +199,13 @@ function makeUntrackedHeadersWithDevWarnings(
   route: string | undefined,
   requestStore: RequestStore
 ): Promise<ReadonlyHeaders> {
+  if (requestStore.asyncApiPromises) {
+    const promise = requestStore.asyncApiPromises.headers
+    // TODO(restart-on-cache-miss): Instrument with warnings
+    // return instrumentHeadersPromiseWithDevWarnings(promise, route)
+    return promise
+  }
+
   const cachedHeaders = CachedHeaders.get(underlyingHeaders)
   if (cachedHeaders) {
     return cachedHeaders
@@ -210,7 +217,22 @@ function makeUntrackedHeadersWithDevWarnings(
     RenderStage.Runtime
   )
 
-  const proxiedPromise = new Proxy(promise, {
+  const proxiedPromise = instrumentHeadersPromiseWithDevWarnings(promise, route)
+
+  CachedHeaders.set(underlyingHeaders, proxiedPromise)
+
+  return proxiedPromise
+}
+
+const warnForSyncAccess = createDedupedByCallsiteServerErrorLoggerDev(
+  createHeadersAccessError
+)
+
+function instrumentHeadersPromiseWithDevWarnings(
+  promise: Promise<ReadonlyHeaders>,
+  route: string | undefined
+) {
+  return new Proxy(promise, {
     get(target, prop, receiver) {
       switch (prop) {
         case Symbol.iterator: {
@@ -237,16 +259,11 @@ function makeUntrackedHeadersWithDevWarnings(
 
       return ReflectAdapter.get(target, prop, receiver)
     },
+    set(target, prop, newValue, receiver) {
+      return ReflectAdapter.set(target, prop, newValue, receiver)
+    },
   })
-
-  CachedHeaders.set(underlyingHeaders, proxiedPromise)
-
-  return proxiedPromise
 }
-
-const warnForSyncAccess = createDedupedByCallsiteServerErrorLoggerDev(
-  createHeadersAccessError
-)
 
 function createHeadersAccessError(
   route: string | undefined,

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -455,6 +455,19 @@ function makeDynamicallyTrackedParamsWithDevWarnings(
   workStore: WorkStore,
   requestStore: RequestStore
 ): Promise<Params> {
+  if (requestStore.asyncApiPromises && hasFallbackParams) {
+    const promise = requestStore.asyncApiPromises.sharedParamsParent.then(
+      () => underlyingParams
+    )
+    // TODO(restart-on-cache-miss): Instrument with warnings
+    // return instrumentParamsPromiseWithDevWarnings(
+    //   underlyingParams,
+    //   promise,
+    //   workStore
+    // )
+    return promise
+  }
+
   const cachedParams = CachedParams.get(underlyingParams)
   if (cachedParams) {
     return cachedParams
@@ -472,6 +485,20 @@ function makeDynamicallyTrackedParamsWithDevWarnings(
     : // We don't want to force an environment transition when this params is not part of the fallback params set
       Promise.resolve(underlyingParams)
 
+  const proxiedPromise = instrumentParamsPromiseWithDevWarnings(
+    underlyingParams,
+    promise,
+    workStore
+  )
+  CachedParams.set(underlyingParams, proxiedPromise)
+  return proxiedPromise
+}
+
+function instrumentParamsPromiseWithDevWarnings(
+  underlyingParams: Params,
+  promise: Promise<Params>,
+  workStore: WorkStore
+): Promise<Params> {
   // Track which properties we should warn for.
   const proxiedProperties = new Set<string>()
 
@@ -484,7 +511,7 @@ function makeDynamicallyTrackedParamsWithDevWarnings(
     }
   })
 
-  const proxiedPromise = new Proxy(promise, {
+  return new Proxy(promise, {
     get(target, prop, receiver) {
       if (typeof prop === 'string') {
         if (
@@ -509,9 +536,6 @@ function makeDynamicallyTrackedParamsWithDevWarnings(
       return Reflect.ownKeys(target)
     },
   })
-
-  CachedParams.set(underlyingParams, proxiedPromise)
-  return proxiedPromise
 }
 
 const warnForSyncAccess = createDedupedByCallsiteServerErrorLoggerDev(

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -456,16 +456,20 @@ function makeDynamicallyTrackedParamsWithDevWarnings(
   requestStore: RequestStore
 ): Promise<Params> {
   if (requestStore.asyncApiPromises && hasFallbackParams) {
+    // Deliberately don't wrap each instance of params in a `new Promise()`.
+    // We want React Devtools to consider all the separate `params` promises
+    // that we create for each segment to be triggered by one IO operation --
+    // the resolving of the underlying `sharedParamsParent` promise.
+    // It's created above any userspace code and has a `displayName`,
+    // so it should show up in "suspended by".
     const promise = requestStore.asyncApiPromises.sharedParamsParent.then(
       () => underlyingParams
     )
-    // TODO(restart-on-cache-miss): Instrument with warnings
-    // return instrumentParamsPromiseWithDevWarnings(
-    //   underlyingParams,
-    //   promise,
-    //   workStore
-    // )
-    return promise
+    return instrumentParamsPromiseWithDevWarnings(
+      underlyingParams,
+      promise,
+      workStore
+    )
   }
 
   const cachedParams = CachedParams.get(underlyingParams)

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -386,18 +386,34 @@ function makeUntrackedSearchParamsWithDevWarnings(
   workStore: WorkStore,
   requestStore: RequestStore
 ): Promise<SearchParams> {
-  const shouldCachePromise = !!requestStore.asyncApiPromises
-  if (shouldCachePromise) {
-    // Note: unlike some of the other functions here, we tie the lifetime of the cached search params
-    // to the request store, not `underlyingSearchParams`.
-    // If we didn't do that we'd end up re-using the same object across both renders in the restart-on-cache-miss flow,
-    // meaning that the `searchParams` promise would (incorrectly) be already resolved in the restarted render.
-    const cachedSearchParams = CachedSearchParams.get(requestStore)
+  if (requestStore.asyncApiPromises) {
+    // Do not cache the resulting promise. If we do, we'll only show the first "awaited at"
+    // across all segments that receive searchParams.
+    return makeUntrackedSearchParamsWithDevWarningsImpl(
+      underlyingSearchParams,
+      workStore,
+      requestStore
+    )
+  } else {
+    const cachedSearchParams = CachedSearchParams.get(underlyingSearchParams)
     if (cachedSearchParams) {
       return cachedSearchParams
     }
+    const promise = makeUntrackedSearchParamsWithDevWarningsImpl(
+      underlyingSearchParams,
+      workStore,
+      requestStore
+    )
+    CachedSearchParams.set(requestStore, promise)
+    return promise
   }
+}
 
+function makeUntrackedSearchParamsWithDevWarningsImpl(
+  underlyingSearchParams: SearchParams,
+  workStore: WorkStore,
+  requestStore: RequestStore
+): Promise<SearchParams> {
   const promiseInitialized = { current: false }
   const proxiedUnderlying = instrumentSearchParamsObjectWithDevWarnings(
     underlyingSearchParams,
@@ -407,6 +423,12 @@ function makeUntrackedSearchParamsWithDevWarnings(
 
   let promise: Promise<SearchParams>
   if (requestStore.asyncApiPromises) {
+    // Deliberately don't wrap each instance of params in a `new Promise()`.
+    // We want React Devtools to consider all the separate `searchParams` promises
+    // that we create for each segment to be triggered by one IO operation --
+    // the resolving of the underlying `sharedParamsParent` promise.
+    // It's created above any userspace code and has a `displayName`,
+    // so it should show up in "suspended by".
     promise = requestStore.asyncApiPromises.sharedSearchParamsParent.then(
       () => proxiedUnderlying
     )
@@ -432,22 +454,11 @@ function makeUntrackedSearchParamsWithDevWarnings(
     ignoreReject
   )
 
-  if (requestStore.asyncApiPromises) {
-    // TODO(restart-on-cache-miss): Instrument with warnings
-    return promise
-  }
-
-  const proxiedPromise = instrumentSearchParamsPromiseWithDevWarnings(
+  return instrumentSearchParamsPromiseWithDevWarnings(
     underlyingSearchParams,
     promise,
     workStore
   )
-
-  if (shouldCachePromise) {
-    CachedSearchParams.set(requestStore, proxiedPromise)
-  }
-
-  return proxiedPromise
 }
 
 function ignoreReject() {}

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -386,28 +386,86 @@ function makeUntrackedSearchParamsWithDevWarnings(
   workStore: WorkStore,
   requestStore: RequestStore
 ): Promise<SearchParams> {
-  // Note: unlike some of the other functions here, we tie the lifetime of the cached search params
-  // to the request store, not `underlyingSearchParams`.
-  // If we didn't do that we'd end up re-using the same object across both renders in the restart-on-cache-miss flow,
-  // meaning that the `searchParams` promise would (incorrectly) be already resolved in the restarted render.
-  const cachedSearchParams = CachedSearchParams.get(requestStore)
-  if (cachedSearchParams) {
-    return cachedSearchParams
+  const shouldCachePromise = !!requestStore.asyncApiPromises
+  if (shouldCachePromise) {
+    // Note: unlike some of the other functions here, we tie the lifetime of the cached search params
+    // to the request store, not `underlyingSearchParams`.
+    // If we didn't do that we'd end up re-using the same object across both renders in the restart-on-cache-miss flow,
+    // meaning that the `searchParams` promise would (incorrectly) be already resolved in the restarted render.
+    const cachedSearchParams = CachedSearchParams.get(requestStore)
+    if (cachedSearchParams) {
+      return cachedSearchParams
+    }
   }
 
-  // Track which properties we should warn for.
-  const proxiedProperties = new Set<string>()
+  const promiseInitialized = { current: false }
+  const proxiedUnderlying = instrumentSearchParamsObjectWithDevWarnings(
+    underlyingSearchParams,
+    workStore,
+    promiseInitialized
+  )
 
+  let promise: Promise<SearchParams>
+  if (requestStore.asyncApiPromises) {
+    promise = requestStore.asyncApiPromises.sharedSearchParamsParent.then(
+      () => proxiedUnderlying
+    )
+  } else {
+    promise = makeDevtoolsIOAwarePromise(
+      proxiedUnderlying,
+      requestStore,
+      RenderStage.Runtime
+    )
+  }
+  promise.then(
+    () => {
+      promiseInitialized.current = true
+    },
+    // If we're in staged rendering, this promise will reject if the render
+    // is aborted before it can reach the runtime stage.
+    // In that case, we have to prevent an unhandled rejection from the promise
+    // created by this `.then()` call.
+    // This does not affect the `promiseInitialized` logic above,
+    // because `proxiedUnderlying` will not be used to resolve the promise,
+    // so there's no risk of any of its properties being accessed and triggering
+    // an undesireable warning.
+    ignoreReject
+  )
+
+  if (requestStore.asyncApiPromises) {
+    // TODO(restart-on-cache-miss): Instrument with warnings
+    return promise
+  }
+
+  const proxiedPromise = instrumentSearchParamsPromiseWithDevWarnings(
+    underlyingSearchParams,
+    promise,
+    workStore
+  )
+
+  if (shouldCachePromise) {
+    CachedSearchParams.set(requestStore, proxiedPromise)
+  }
+
+  return proxiedPromise
+}
+
+function ignoreReject() {}
+
+function instrumentSearchParamsObjectWithDevWarnings(
+  underlyingSearchParams: SearchParams,
+  workStore: WorkStore,
+  promiseInitialized: { current: boolean }
+) {
   // We have an unfortunate sequence of events that requires this initialization logic. We want to instrument the underlying
   // searchParams object to detect if you are accessing values in dev. This is used for warnings and for things like the static prerender
   // indicator. However when we pass this proxy to our Promise.resolve() below the VM checks if the resolved value is a promise by looking
   // at the `.then` property. To our dynamic tracking logic this is indistinguishable from a `then` searchParam and so we would normally trigger
   // dynamic tracking. However we know that this .then is not real dynamic access, it's just how thenables resolve in sequence. So we introduce
   // this initialization concept so we omit the dynamic check until after we've constructed our resolved promise.
-  let promiseInitialized = false
-  const proxiedUnderlying = new Proxy(underlyingSearchParams, {
+  return new Proxy(underlyingSearchParams, {
     get(target, prop, receiver) {
-      if (typeof prop === 'string' && promiseInitialized) {
+      if (typeof prop === 'string' && promiseInitialized.current) {
         if (workStore.dynamicShouldError) {
           const expression = describeStringPropertyAccess('searchParams', prop)
           throwWithStaticGenerationBailoutErrorWithDynamicError(
@@ -445,18 +503,15 @@ function makeUntrackedSearchParamsWithDevWarnings(
       return Reflect.ownKeys(target)
     },
   })
+}
 
-  // We don't use makeResolvedReactPromise here because searchParams
-  // supports copying with spread and we don't want to unnecessarily
-  // instrument the promise with spreadable properties of ReactPromise.
-  const promise = makeDevtoolsIOAwarePromise(
-    proxiedUnderlying,
-    requestStore,
-    RenderStage.Runtime
-  )
-  promise.then(() => {
-    promiseInitialized = true
-  })
+function instrumentSearchParamsPromiseWithDevWarnings(
+  underlyingSearchParams: SearchParams,
+  promise: Promise<SearchParams>,
+  workStore: WorkStore
+) {
+  // Track which properties we should warn for.
+  const proxiedProperties = new Set<string>()
 
   Object.keys(underlyingSearchParams).forEach((prop) => {
     if (wellKnownProperties.has(prop)) {
@@ -467,7 +522,7 @@ function makeUntrackedSearchParamsWithDevWarnings(
     }
   })
 
-  const proxiedPromise = new Proxy(promise, {
+  return new Proxy(promise, {
     get(target, prop, receiver) {
       if (prop === 'then' && workStore.dynamicShouldError) {
         const expression = '`searchParams.then`'
@@ -520,9 +575,6 @@ function makeUntrackedSearchParamsWithDevWarnings(
       return Reflect.ownKeys(target)
     },
   })
-
-  CachedSearchParams.set(requestStore, proxiedPromise)
-  return proxiedPromise
 }
 
 const warnForSyncAccess = createDedupedByCallsiteServerErrorLoggerDev(

--- a/packages/next/src/shared/lib/utils/reflect-utils.ts
+++ b/packages/next/src/shared/lib/utils/reflect-utils.ts
@@ -29,21 +29,20 @@ export const wellKnownProperties = new Set([
   'toLocaleString',
 
   // Promise prototype
-  // fallthrough
   'then',
   'catch',
   'finally',
 
   // React Promise extension
-  // fallthrough
   'status',
+  // 'value',
+  // 'error',
 
   // React introspection
   'displayName',
   '_debugInfo',
 
   // Common tested properties
-  // fallthrough
   'toJSON',
   '$$typeof',
   '__esModule',


### PR DESCRIPTION
Updates to staged rendering (cacheComponents dev) to support "suspended by" in Suspense Devtools

- promises for `cookies()` and other user-callable APIs are now created before we start the render. Each call to `cookies()` will return the same promise (although currently it's wrapped in a fresh proxy). The promise is created via `new Promise`, triggered by a timeout (for the relevant stage) and has `displayName`. This marks it as an IO operation. By re-using the same promise, we make sure that all callsites that await it are considered to be suspended by the same IO operation.
- promises for `params` and `searchParams` use a similar trick. All instances of `params` and will be derived from one shared IO promise `sharedParamsParent`. When determining "suspended by", React will walk up the promise chain, find this parent, and use its `displayName`, which we set to `"params"`. `searchParams` work analogously

Closes https://linear.app/vercel/issue/NAR-417