### PR TITLE
fix types of eslint-config-next

### DIFF
--- a/packages/eslint-config-next/tsconfig.json
+++ b/packages/eslint-config-next/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "rootDir": "src",
     "module": "commonjs",
     "target": "es2019",
     "esModuleInterop": true,


### PR DESCRIPTION
The types were published on `dist/src/*.d.ts` but on `package.json` `exports` points to `dist/*.d.ts`

<img width="250" height="284" alt="image" src="https://github.com/user-attachments/assets/7884935f-4ad6-42e7-94ca-17e9eb07df8a" />

<img width="327" height="282" alt="image" src="https://github.com/user-attachments/assets/74e03c2f-4eff-450c-b74d-609c084f3186" />

---

This PR adds `"roorDir": "src"` to `tsconfig.json` so it builds with the right file structure:

<img width="246" height="328" alt="image" src="https://github.com/user-attachments/assets/b4048143-7338-4727-9a19-2401529cfcb7" />
 
