### PR TITLE
fix: Handle non-directory files in cache folder when performing cleanup

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/database/db_invalidation.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/db_invalidation.rs
@@ -166,7 +166,11 @@ fn cleanup_db_inner(base_path: &Path) -> io::Result<()> {
     for entry in contents {
         let entry = entry?;
         if entry.file_name() != INVALIDATION_MARKER {
-            fs::remove_dir_all(entry.path())?;
+            if entry.file_type()?.is_dir() {
+                fs::remove_dir_all(entry.path())?;
+            } else {
+                fs::remove_file(entry.path())?;
+            }
         }
     }
 


### PR DESCRIPTION
https://vercel.slack.com/archives/C046HAU4H7F/p1760563400531829

Repro this by creating a non-directory file in `cache/turbopack`, and then invalidating it:

```
touch .next/dev/cache/turbopack/notadirectory
touch .next/dev/cache/turbopack/__turbo_tasks_invalidated_db
```

Before:
![Screenshot 2025-10-15 at 4.13.33 PM.png](https://app.graphite.dev/user-attachments/assets/670eba50-d87d-4d2a-a28d-d338cfd3863c.png)

After:

![Screenshot 2025-10-15 at 4.14.09 PM.png](https://app.graphite.dev/user-attachments/assets/30ba99ab-7859-475c-954a-77c1a0cd45a9.png)

See that the directory was cleaned up.

Closes PACK-5716