### PR TITLE
[Cache Components] Allow unstable prefix for cacheLife and cacheTag

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -653,7 +653,9 @@ impl ReactServerComponentValidator {
                         "revalidateTag",
                         // "unstable_cache", // useless in client, but doesn't technically error
                         "cacheLife",
+                        "unstable_cacheLife",
                         "cacheTag",
+                        "unstable_cacheTag",
                         // "unstable_noStore" // no-op in client, but allowed for legacy reasons
                     ],
                 ),

--- a/packages/next/cache.d.ts
+++ b/packages/next/cache.d.ts
@@ -9,7 +9,9 @@ export {
 
 export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
 
-export { cacheTag } from 'next/dist/server/use-cache/cache-tag'
+import { cacheTag } from 'next/dist/server/use-cache/cache-tag'
+
+export { cacheTag }
 
 /**
  * Cache this `"use cache"` for a timespan defined by the `"default"` profile.
@@ -147,3 +149,6 @@ export function cacheLife(profile: {
    */
   expire?: number
 }): void
+
+export const unstable_cacheLife: typeof cacheLife
+export const unstable_cacheTag: typeof cacheTag

--- a/packages/next/cache.js
+++ b/packages/next/cache.js
@@ -19,6 +19,33 @@ const cacheExports = {
   cacheTag: require('next/dist/server/use-cache/cache-tag').cacheTag,
 }
 
+let didWarnCacheLife = false
+function unstable_cacheLife() {
+  if (!didWarnCacheLife) {
+    didWarnCacheLife = true
+    const error = new Error(
+      '`unstable_cacheLife` was recently stabilized and should be imported as `cacheLife`. The `unstable` prefixed form will be removed in a future version of Next.js.'
+    )
+    console.error(error)
+  }
+  return cacheExports.cacheLife.apply(this, arguments)
+}
+
+let didWarnCacheTag = false
+function unstable_cacheTag() {
+  if (!didWarnCacheTag) {
+    didWarnCacheTag = true
+    const error = new Error(
+      '`unstable_cacheTag` was recently stabilized and should be imported as `cacheTag`. The `unstable` prefixed form will be removed in a future version of Next.js.'
+    )
+    console.error(error)
+  }
+  return cacheExports.cacheTag.apply(this, arguments)
+}
+
+cacheExports.unstable_cacheLife = unstable_cacheLife
+cacheExports.unstable_cacheTag = unstable_cacheTag
+
 // https://nodejs.org/api/esm.html#commonjs-namespaces
 // When importing CommonJS modules, the module.exports object is provided as the default export
 module.exports = cacheExports
@@ -30,5 +57,7 @@ exports.revalidateTag = cacheExports.revalidateTag
 exports.updateTag = cacheExports.updateTag
 exports.unstable_noStore = cacheExports.unstable_noStore
 exports.cacheLife = cacheExports.cacheLife
+exports.unstable_cacheLife = cacheExports.unstable_cacheLife
 exports.cacheTag = cacheExports.cacheTag
+exports.unstable_cacheTag = cacheExports.unstable_cacheTag
 exports.refresh = cacheExports.refresh

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -538,7 +538,11 @@ declare module 'next/cache' {
 
   ${overloads}
 
-  export { cacheTag } from 'next/dist/server/use-cache/cache-tag'
+  import { cacheTag } from 'next/dist/server/use-cache/cache-tag'
+  export { cacheTag }
+
+  export const unstable_cacheTag: typeof cacheTag
+  export const unstable_cacheLife: typeof cacheLife
 }
 `
 }

--- a/test/e2e/app-dir/cache-components-errors/cache-components-unstable-deprecations.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-unstable-deprecations.test.ts
@@ -1,0 +1,40 @@
+import { isNextDev, nextTestSetup } from 'e2e-utils'
+
+describe('Cache Components Errors', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname + '/fixtures/unstable-deprecations',
+  })
+
+  if (skipped) {
+    return
+  }
+
+  describe('Deprecating `unstable` prefix for `cacheLife` and `cacheTag`', () => {
+    it('warns if you use `cacheLife` through `unstable_cacheLife`', async () => {
+      if (isNextDev) {
+        await next.browser('/life')
+
+        expect(next.cliOutput).toContain(
+          'Error: `unstable_cacheLife` was recently stabilized'
+        )
+      } else {
+        expect(next.cliOutput).toContain(
+          'Error: `unstable_cacheLife` was recently stabilized'
+        )
+      }
+    })
+    it('warns if you use `cacheTag` through `unstable_cacheTag`', async () => {
+      if (isNextDev) {
+        await next.browser('/tag')
+
+        expect(next.cliOutput).toContain(
+          'Error: `unstable_cacheTag` was recently stabilized'
+        )
+      } else {
+        expect(next.cliOutput).toContain(
+          'Error: `unstable_cacheTag` was recently stabilized'
+        )
+      }
+    })
+  })
+})

--- a/test/e2e/app-dir/cache-components-errors/fixtures/unstable-deprecations/app/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/unstable-deprecations/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/unstable-deprecations/app/life/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/unstable-deprecations/app/life/page.tsx
@@ -1,0 +1,37 @@
+import { unstable_cacheLife, cacheLife } from 'next/cache'
+
+export default async function Page() {
+  const stable = await stableLife()
+  const unstable1 = await unstableLife1()
+  const unstable2 = await unstableLife2()
+  return (
+    <>
+      <div>
+        This page calls a "use cache" function that uses the unstable_cacheLife
+        API twice. We expect to see a warning once per server lifetime when
+        using unstable_cacheLife.
+      </div>
+      <div>{stable}</div>
+      <div>{unstable1}</div>
+      <div>{unstable2}</div>
+    </>
+  )
+}
+
+async function unstableLife1() {
+  'use cache'
+  unstable_cacheLife('minutes')
+  return Math.random()
+}
+
+async function unstableLife2() {
+  'use cache'
+  unstable_cacheLife('minutes')
+  return Math.random()
+}
+
+async function stableLife() {
+  'use cache'
+  cacheLife('minutes')
+  return Math.random()
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/unstable-deprecations/app/tag/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/unstable-deprecations/app/tag/page.tsx
@@ -1,0 +1,37 @@
+import { unstable_cacheTag, cacheTag } from 'next/cache'
+
+export default async function Page() {
+  const stable = await stableTag()
+  const unstable1 = await unstableTag1()
+  const unstable2 = await unstableTag2()
+  return (
+    <>
+      <div>
+        This page calls a "use cache" function that uses the unstable_cacheTag
+        API twice. We expect to see a warning once per server lifetime when
+        using unstable_cacheTag.
+      </div>
+      <div>{stable}</div>
+      <div>{unstable1}</div>
+      <div>{unstable2}</div>
+    </>
+  )
+}
+
+async function unstableTag1() {
+  'use cache'
+  unstable_cacheTag('tag')
+  return Math.random()
+}
+
+async function unstableTag2() {
+  'use cache'
+  unstable_cacheTag('tag')
+  return Math.random()
+}
+
+async function stableTag() {
+  'use cache'
+  cacheTag('tag')
+  return Math.random()
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/unstable-deprecations/next.config.js
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/unstable-deprecations/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    cacheComponents: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/cache-components-errors/fixtures/unstable-deprecations/patch-console.js
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/unstable-deprecations/patch-console.js
@@ -1,0 +1,12 @@
+const originalLog = console.log.bind(console)
+
+console.log = (...args) => {
+  new Date()
+  Math.random()
+  if (typeof args[0] === 'string') {
+    const firstArg = '[<timestamp>] ' + args[0]
+    originalLog(firstArg, ...args.slice(1))
+  } else {
+    originalLog('[<timestamp>] ', ...args)
+  }
+}


### PR DESCRIPTION
These are now stable but to allow for graceful upgrading we still export unstable versions. The unstable version includes a once-warning that indicates you should upgrade to the stable name.