### PR TITLE
Reland "Include server latency in debug info"

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -34,6 +34,7 @@ import type { NextConfigComplete } from '../server/config-shared'
 import { finalizeEntrypoint } from './entries'
 import * as Log from './output/log'
 import { buildConfiguration } from './webpack/config'
+import ForceCompleteRuntimePlugin from './webpack/plugins/force-complete-runtime'
 import MiddlewarePlugin, {
   getEdgePolyfilledModules,
   handleWebpackExternalForEdgeRuntime,
@@ -1952,6 +1953,9 @@ export default async function getBaseWebpackConfig(
       ],
     },
     plugins: [
+      // In prod Webpack will already have a runtime for all reachable chunks.
+      // During dev, it will update the runtime as chunks come in which may be too late for Flight.
+      dev && new ForceCompleteRuntimePlugin(),
       isNodeServer &&
         new bundler.NormalModuleReplacementPlugin(
           /\.\/(.+)\.shared-runtime$/,

--- a/packages/next/src/build/webpack/plugins/force-complete-runtime.ts
+++ b/packages/next/src/build/webpack/plugins/force-complete-runtime.ts
@@ -1,0 +1,39 @@
+import { webpack } from 'next/dist/compiled/webpack/webpack'
+
+export default class ForceCompleteRuntimePlugin {
+  allSharedRuntimeGlobals = new Set([
+    // List is incomplete. These are the globals that are not commonly in the
+    // Webpack runtime but may show up during after Client navs.
+    // If you ever get "__webpack_require__.X is not a function" or similar,
+    // check https://github.com/webpack/webpack/blob/0f84d1e3bf69915dc060f23ced9dfa468a884a42/lib/RuntimeGlobals.js
+    // for which one it is and add it here.
+    webpack.RuntimeGlobals.compatGetDefaultExport,
+  ])
+
+  apply(compiler: webpack.Compiler) {
+    compiler.hooks.thisCompilation.tap(
+      'ForceCompleteRuntimePlugin',
+      (compilation) => {
+        // Ensure that each chunk uses the complete Webpack runtime.
+        // That way soft nav to a new page has the full runtime available
+        // by the time the chunk loads.
+        // This is a workaround until we can get Webpack to include runtime updates
+        // in the Flight response or the Flight Client to wait for HMR updates.
+        compilation.hooks.afterChunks.tap(
+          { name: 'ForceCompleteRuntimePlugin' },
+          (chunks) => {
+            for (const chunk of chunks) {
+              compilation.chunkGraph.addChunkRuntimeRequirements(
+                chunk,
+                this.allSharedRuntimeGlobals
+              )
+              // Just need to add runtime requirements to one chunk since we only
+              // have one runtime chunk for all other chunks.
+              break
+            }
+          }
+        )
+      }
+    )
+  }
+}

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -139,6 +139,7 @@ describe('createInitialRouterState', () => {
       cache: expectedCache,
       nextUrl: '/linking',
       previousNextUrl: null,
+      debugInfo: null,
     }
 
     expect(state).toMatchObject(expected)

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -111,6 +111,7 @@ export function createInitialRouterState({
       (extractPathFromFlightRouterState(initialTree) || location?.pathname) ??
       null,
     previousNextUrl: null,
+    debugInfo: null,
   }
 
   if (process.env.NODE_ENV !== 'development' && location) {
@@ -146,6 +147,7 @@ export function createInitialRouterState({
           prerendered && !process.env.__NEXT_CLIENT_SEGMENT_CACHE
             ? STATIC_STALETIME_MS
             : -1,
+        debugInfo: null,
       },
       tree: initialState.tree,
       prefetchCache: initialState.prefetchCache,

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -2,7 +2,10 @@
 
 // TODO: Explicitly import from client.browser
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { createFromReadableStream as createFromReadableStreamBrowser } from 'react-server-dom-webpack/client'
+import {
+  createFromReadableStream as createFromReadableStreamBrowser,
+  createFromFetch as createFromFetchBrowser,
+} from 'react-server-dom-webpack/client'
 
 import type {
   FlightRouterState,
@@ -37,6 +40,8 @@ import { urlToUrlWithoutFlightMarker } from '../../route-params'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
+const createFromFetch =
+  createFromFetchBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromFetch']
 
 let createDebugChannel:
   | typeof import('../../dev/debug-channel').createDebugChannel
@@ -65,6 +70,7 @@ export type FetchServerResponseResult = {
   prerendered: boolean
   postponed: boolean
   staleTime: number
+  debugInfo: Array<any> | null
 }
 
 export type RequestHeaders = {
@@ -91,6 +97,7 @@ function doMpaNavigation(url: string): FetchServerResponseResult {
     prerendered: false,
     postponed: false,
     staleTime: -1,
+    debugInfo: null,
   }
 }
 
@@ -175,10 +182,17 @@ export async function fetchServerResponse(
       }
     }
 
-    const res = await createFetch(
+    // Typically, during a navigation, we decode the response using Flight's
+    // `createFromFetch` API, which accepts a `fetch` promise.
+    // TODO: Remove this check once the old PPR flag is removed
+    const isLegacyPPR =
+      process.env.__NEXT_PPR && !process.env.__NEXT_CACHE_COMPONENTS
+    const shouldImmediatelyDecode = !isLegacyPPR
+    const res = await createFetch<NavigationFlightResponse>(
       url,
       headers,
       fetchPriority,
+      shouldImmediatelyDecode,
       abortController.signal
     )
 
@@ -226,26 +240,37 @@ export async function fetchServerResponse(
       ).waitForWebpackRuntimeHotUpdate()
     }
 
-    // Handle the `fetch` readable stream that can be unwrapped by `React.use`.
-    const flightStream = postponed
-      ? createUnclosingPrefetchStream(res.body)
-      : res.body
-    const response = await (createFromNextReadableStream(
-      flightStream,
-      headers
-    ) as Promise<NavigationFlightResponse>)
+    let flightResponsePromise = res.flightResponse
+    if (flightResponsePromise === null) {
+      // Typically, `createFetch` would have already started decoding the
+      // Flight response. If it hasn't, though, we need to decode it now.
+      // TODO: This should only be reachable if legacy PPR is enabled (i.e. PPR
+      // without Cache Components). Remove this branch once legacy PPR
+      // is deleted.
+      const flightStream = postponed
+        ? createUnclosingPrefetchStream(res.body)
+        : res.body
+      flightResponsePromise =
+        createFromNextReadableStream<NavigationFlightResponse>(
+          flightStream,
+          headers
+        )
+    }
 
-    if (getAppBuildId() !== response.b) {
+    const flightResponse = await flightResponsePromise
+
+    if (getAppBuildId() !== flightResponse.b) {
       return doMpaNavigation(res.url)
     }
 
     return {
-      flightData: normalizeFlightData(response.f),
+      flightData: normalizeFlightData(flightResponse.f),
       canonicalUrl: canonicalUrl,
       couldBeIntercepted: interception,
-      prerendered: response.S,
+      prerendered: flightResponse.S,
       postponed,
       staleTime,
+      debugInfo: flightResponsePromise._debugInfo ?? null,
     }
   } catch (err) {
     if (!abortController.signal.aborted) {
@@ -265,6 +290,7 @@ export async function fetchServerResponse(
       prerendered: false,
       postponed: false,
       staleTime: -1,
+      debugInfo: null,
     }
   }
 }
@@ -274,21 +300,23 @@ export async function fetchServerResponse(
 // the codebase. For example, there's some custom logic for manually following
 // redirects, so "redirected" in this type could be a composite of multiple
 // browser fetch calls; however, this fact should not leak to the caller.
-export type RSCResponse = {
+export type RSCResponse<T> = {
   ok: boolean
   redirected: boolean
   headers: Headers
   body: ReadableStream<Uint8Array> | null
   status: number
   url: string
+  flightResponse: (Promise<T> & { _debugInfo?: Array<any> }) | null
 }
 
-export async function createFetch(
+export async function createFetch<T>(
   url: URL,
   headers: RequestHeaders,
   fetchPriority: 'auto' | 'high' | 'low' | null,
+  shouldImmediatelyDecode: boolean,
   signal?: AbortSignal
-): Promise<RSCResponse> {
+): Promise<RSCResponse<T>> {
   // TODO: In output: "export" mode, the headers do nothing. Omit them (and the
   // cache busting search param) from the request so they're
   // maximally cacheable.
@@ -326,7 +354,21 @@ export async function createFetch(
   // track them separately.
   let fetchUrl = new URL(url)
   setCacheBustingSearchParam(fetchUrl, headers)
-  let browserResponse = await fetch(fetchUrl, fetchOptions)
+  let fetchPromise = fetch(fetchUrl, fetchOptions)
+  // Immediately pass the fetch promise to the Flight client so that the debug
+  // info includes the latency from the client to the server. The internal timer
+  // in React starts as soon as `createFromFetch` is called.
+  //
+  // The only case where we don't do this is during a prefetch, because we have
+  // to do some extra processing of the response stream (see
+  // `createUnclosingPrefetchStream`). But this is fine, because a top-level
+  // prefetch response never blocks a navigation; if it hasn't already been
+  // written into the cache by the time the navigation happens, the router will
+  // go straight to a dynamic request.
+  let flightResponsePromise = shouldImmediatelyDecode
+    ? createFromNextFetch<T>(fetchPromise, headers)
+    : null
+  let browserResponse = await fetchPromise
 
   // If the server responds with a redirect (e.g. 307), and the redirected
   // location does not contain the cache busting search param set in the
@@ -379,9 +421,14 @@ export async function createFetch(
       //
       // Append the cache busting search param to the redirected URL and
       // fetch again.
+      // TODO: We should abort the previous request.
       fetchUrl = new URL(responseUrl)
       setCacheBustingSearchParam(fetchUrl, headers)
-      browserResponse = await fetch(fetchUrl, fetchOptions)
+      fetchPromise = fetch(fetchUrl, fetchOptions)
+      flightResponsePromise = shouldImmediatelyDecode
+        ? createFromNextFetch<T>(fetchPromise, headers)
+        : null
+      browserResponse = await fetchPromise
       // We just performed a manual redirect, so this is now true.
       redirected = true
     }
@@ -392,7 +439,7 @@ export async function createFetch(
   const responseUrl = new URL(browserResponse.url, fetchUrl)
   responseUrl.searchParams.delete(NEXT_RSC_UNION_QUERY)
 
-  const rscResponse: RSCResponse = {
+  const rscResponse: RSCResponse<T> = {
     url: responseUrl.href,
 
     // This is true if any redirects occurred, either automatically by the
@@ -408,16 +455,32 @@ export async function createFetch(
     headers: browserResponse.headers,
     body: browserResponse.body,
     status: browserResponse.status,
+
+    // This is the exact promise returned by `createFromFetch`. It contains
+    // debug information that we need to transfer to any derived promises that
+    // are later rendered by React.
+    flightResponse: flightResponsePromise,
   }
 
   return rscResponse
 }
 
-export function createFromNextReadableStream(
+export function createFromNextReadableStream<T>(
   flightStream: ReadableStream<Uint8Array>,
   requestHeaders: RequestHeaders
-): Promise<unknown> {
+): Promise<T> {
   return createFromReadableStream(flightStream, {
+    callServer,
+    findSourceMapURL,
+    debugChannel: createDebugChannel && createDebugChannel(requestHeaders),
+  })
+}
+
+function createFromNextFetch<T>(
+  promiseForResponse: Promise<Response>,
+  requestHeaders: RequestHeaders
+): Promise<T> & { _debugInfo?: Array<any> } {
+  return createFromFetch(promiseForResponse, {
     callServer,
     findSourceMapURL,
     debugChannel: createDebugChannel && createDebugChannel(requestHeaders),

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -234,6 +234,9 @@ export async function fetchServerResponse(
     // In prod, every page will have the same Webpack runtime.
     // In dev, the Webpack runtime is minimal for each page.
     // We need to ensure the Webpack runtime is updated before executing client-side JS of the new page.
+    // TODO: This needs to happen in the Flight Client.
+    // Or Webpack needs to include the runtime update in the Flight response as
+    // a blocking script.
     if (process.env.NODE_ENV !== 'production' && !process.env.TURBOPACK) {
       await (
         require('../../dev/hot-reloader/app/hot-reloader-app') as typeof import('../../dev/hot-reloader/app/hot-reloader-app')

--- a/packages/next/src/client/components/router-reducer/handle-mutable.ts
+++ b/packages/next/src/client/components/router-reducer/handle-mutable.ts
@@ -87,5 +87,6 @@ export function handleMutable(
       : state.tree,
     nextUrl,
     previousNextUrl: previousNextUrl,
+    debugInfo: mutable.collectedDebugInfo ?? null,
   }
 }

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -210,7 +210,8 @@ export function navigateReducer(
       state.cache,
       state.tree,
       state.nextUrl,
-      shouldScroll
+      shouldScroll,
+      mutable
     )
     return handleNavigationResult(url, state, mutable, pendingPush, result)
   }

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -46,5 +46,6 @@ export function restoreReducer(
     tree: treeToRestore,
     nextUrl: extractPathFromFlightRouterState(treeToRestore) ?? url.pathname,
     previousNextUrl: null,
+    debugInfo: null,
   }
 }

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -439,6 +439,7 @@ export function serverActionReducer(
               // TODO: We should be able to set this if the server action
               // returned a fully static response.
               staleTime: -1,
+              debugInfo: null,
             },
             tree: state.tree,
             prefetchCache: state.prefetchCache,

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -35,6 +35,7 @@ export interface Mutable {
   shouldScroll?: boolean
   preserveCustomHistoryState?: boolean
   onlyHashChange?: boolean
+  collectedDebugInfo?: Array<unknown>
 }
 
 export interface ServerActionMutable extends Mutable {
@@ -259,10 +260,14 @@ export type AppRouterState = {
    * The previous next-url that was used previous to a dynamic navigation.
    */
   previousNextUrl: string | null
+
+  debugInfo: Array<unknown> | null
 }
 
 export type ReadonlyReducerState = Readonly<AppRouterState>
-export type ReducerState = Promise<AppRouterState> | AppRouterState
+export type ReducerState =
+  | (Promise<AppRouterState> & { _debugInfo?: Array<unknown> })
+  | AppRouterState
 export type ReducerActions = Readonly<
   | RefreshAction
   | NavigateAction

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -21,7 +21,9 @@ export type RouteParam = {
   type: DynamicParamTypesShort
 }
 
-export function getRenderedSearch(response: RSCResponse): NormalizedSearch {
+export function getRenderedSearch(
+  response: RSCResponse<unknown>
+): NormalizedSearch {
   // If the server performed a rewrite, the search params used to render the
   // page will be different from the params in the request URL. In this case,
   // the response will include a header that gives the rewritten search query.
@@ -37,7 +39,7 @@ export function getRenderedSearch(response: RSCResponse): NormalizedSearch {
     .search as NormalizedSearch
 }
 
-export function getRenderedPathname(response: RSCResponse): string {
+export function getRenderedPathname(response: RSCResponse<unknown>): string {
   // If the server performed a rewrite, the pathname used to render the
   // page will be different from the pathname in the request URL. In this case,
   // the response will include a header that gives the rewritten pathname.


### PR DESCRIPTION
Relands https://github.com/vercel/next.js/pull/84580

We hit the scenario again that https://github.com/vercel/next.js/pull/67673 was supposed to fix. It's not enough to wait for HMR of the Webpack runtime in Next.js. This needs to happen in the Flight Client. Either in the bundler integration layer or Webpack sending the update as a blocking script.