### PR TITLE
[test] Disable CTA from React DevTools

### DIFF
--- a/packages/next/src/client/app-next-dev.ts
+++ b/packages/next/src/client/app-next-dev.ts
@@ -1,5 +1,6 @@
 // TODO-APP: hydration warning
 
+import './next-test'
 import './app-webpack'
 
 import { renderAppDevOverlay } from 'next/dist/compiled/next-devtools'

--- a/packages/next/src/client/app-next-turbopack.ts
+++ b/packages/next/src/client/app-next-turbopack.ts
@@ -1,3 +1,4 @@
+import './next-test'
 import { appBootstrap } from './app-bootstrap'
 import { isRecoverableError } from './react-client-callbacks/on-recoverable-error'
 

--- a/packages/next/src/client/next-dev-turbopack.ts
+++ b/packages/next/src/client/next-dev-turbopack.ts
@@ -1,4 +1,5 @@
 // TODO: Remove use of `any` type.
+import './next-test'
 import { initialize, version, router, emitter } from './'
 import initHMR from './dev/hot-middleware-client'
 

--- a/packages/next/src/client/next-dev.ts
+++ b/packages/next/src/client/next-dev.ts
@@ -1,4 +1,5 @@
 // TODO: Remove use of `any` type.
+import './next-test'
 import './webpack'
 import { initialize, version, router, emitter } from './'
 import initHMR from './dev/hot-middleware-client'

--- a/packages/next/src/client/next-test.ts
+++ b/packages/next/src/client/next-test.ts
@@ -1,0 +1,6 @@
+// For App and Pages Router
+if (process.env.NODE_ENV !== 'production' && process.env.__NEXT_TEST_MODE) {
+  // Our tests don't run with React DevTools attached so the CTA is noisy.
+  // See https://github.com/facebook/react/pull/11448
+  ;(window as any).__REACT_DEVTOOLS_GLOBAL_HOOK__ = { isDisabled: true }
+}


### PR DESCRIPTION
No more double "Download the React DevTools for a better development experience: https://react.dev/link/react-devtools" in tests.

The browser we test with has no React DevTools installed (though that'd be nice for integration testing). The CTA to download RDT is just noise for our test logs. This became twice as bad once we separated Next DevTools because each React bundle logs the CTA separately.