### PR TITLE
[dev] Fix Middleware and Proxy file conflict

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -393,26 +393,6 @@ async function startWatcher(
 
       let hasMiddlewareFile = false
       let hasProxyFile = false
-      for (const fileName of sortedKnownFiles) {
-        const { name } = path.parse(fileName)
-        if (name === MIDDLEWARE_FILENAME) {
-          hasMiddlewareFile = true
-        }
-        if (name === PROXY_FILENAME) {
-          hasProxyFile = true
-        }
-      }
-
-      if (hasMiddlewareFile) {
-        if (hasProxyFile) {
-          throw new Error(
-            `Both "${MIDDLEWARE_FILENAME}" and "${PROXY_FILENAME}" files are detected. Please use "${PROXY_FILENAME}" instead.`
-          )
-        }
-        Log.warnOnce(
-          `The "${MIDDLEWARE_FILENAME}" file convention is deprecated. Please use "${PROXY_FILENAME}" instead.`
-        )
-      }
 
       for (const fileName of sortedKnownFiles) {
         if (
@@ -421,6 +401,30 @@ async function startWatcher(
         ) {
           continue
         }
+
+        const { name: fileBaseName, dir: fileDir } = path.parse(fileName)
+
+        const isAtConventionLevel =
+          fileDir === dir || fileDir === path.join(dir, 'src')
+
+        if (isAtConventionLevel && fileBaseName === MIDDLEWARE_FILENAME) {
+          hasMiddlewareFile = true
+        }
+        if (isAtConventionLevel && fileBaseName === PROXY_FILENAME) {
+          hasProxyFile = true
+        }
+
+        if (hasMiddlewareFile) {
+          if (hasProxyFile) {
+            throw new Error(
+              `Both "${MIDDLEWARE_FILENAME}" and "${PROXY_FILENAME}" files are detected. Please use "${PROXY_FILENAME}" instead.`
+            )
+          }
+          Log.warnOnce(
+            `The "${MIDDLEWARE_FILENAME}" file convention is deprecated. Please use "${PROXY_FILENAME}" instead.`
+          )
+        }
+
         const meta = knownFiles.get(fileName)
 
         const watchTime = fileWatchTimes.get(fileName)

--- a/test/e2e/app-dir/app-middleware/app/middleware.js
+++ b/test/e2e/app-dir/app-middleware/app/middleware.js
@@ -1,0 +1,1 @@
+// noop, this file should not picked up as Middleware file and throw error.

--- a/test/e2e/app-dir/app-middleware/app/proxy.js
+++ b/test/e2e/app-dir/app-middleware/app/proxy.js
@@ -1,0 +1,1 @@
+// noop, this file should not picked up as Proxy file and throw error.


### PR DESCRIPTION
Since the conflict check looked only at the file name 💀, when there's a `proxy` or `middleware` file inside the app, it also detected a conflict:

```
Unhandled Rejection: Error: Both "middleware" and "proxy" files are detected. Please use "proxy" instead.
```

CI: https://github.com/vercel/next.js/actions/runs/18568804746/job/52937138783?pr=84965#step:34:326

Therefore, check for the actual file path of the middleware/proxy file.