### PR TITLE
Stop manually setting stacktrace limit

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1979,18 +1979,7 @@ async function validateConfigSchema(
       }
 
       const fullErrorMessage = errorMessages.join('\n')
-
-      let err: Error
-      // Hide the stack trace for this error as the trace is not useful here.
-      const stackTraceLimit = Error.stackTraceLimit
-      Error.stackTraceLimit = 0
-      try {
-        err = new Error(fullErrorMessage)
-      } finally {
-        Error.stackTraceLimit = stackTraceLimit
-      }
-
-      throw err
+      throw new Error(fullErrorMessage)
     }
   }
 }


### PR DESCRIPTION
Ignore-listing will take care of removing irrelevant stacks. And if you do need the stacks, you can just disable them in a debugger (or upcoming CLI flag). It's also future proof in case this code ever gets refactored to something callable from user code. Forcing no stacks helps nobody since it adds square brackets around logged errors.

Before:
```
[Error: Fatal next config errors found in next.config.js that must be fixed:
    Unrecognized key(s) in object: 'turbopackPersistentCachingForDev', 'devtoolSegmentExplorer' at "experimental"
    Use 'experimental.turbopackFileSystemCacheForDev' instead.
    Learn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache
These configuration options are required or have been migrated. Please update your configuration.
See more info here: https://nextjs.org/docs/messages/invalid-next-config]
```

After:
```
Error: Fatal next config errors found in next.config.js that must be fixed:
    Unrecognized key(s) in object: 'turbopackPersistentCachingForDev', 'devtoolSegmentExplorer' at "experimental"
    Use 'experimental.turbopackFileSystemCacheForDev' instead.
    Learn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache
These configuration options are required or have been migrated. Please update your configuration.
See more info here: https://nextjs.org/docs/messages/invalid-next-config
    at ignore-listed frames
```
