### PR TITLE
Turbopack: fix `strip_prefix prefix is too long`

### DIFF
--- a/bench/app-router-server/app/page.js
+++ b/bench/app-router-server/app/page.js
@@ -1,4 +1,10 @@
-import(`@/${globalThis.type}/zh-Hant/${globalThis.processedSlugPath}/page.ts`)
+import(`@/${globalThis.type}/${globalThis.processedSlugPath}`)
+
+// globalThis.docs = 'docs'
+// console.trace(require(`@/${globalThis.docs}/foo`))
+
+// globalThis.foo = 'foo'
+// console.trace(require(`@/docs/${globalThis.foo}`))
 
 export default function page() {
   return <div>hello</div>

--- a/bench/app-router-server/app/page.js
+++ b/bench/app-router-server/app/page.js
@@ -1,0 +1,5 @@
+import(`@/${globalThis.type}/zh-Hant/${globalThis.processedSlugPath}/page.ts`)
+
+export default function page() {
+  return <div>hello</div>
+}

--- a/bench/app-router-server/app/rsc/page.js
+++ b/bench/app-router-server/app/rsc/page.js
@@ -1,5 +1,0 @@
-import * as React from 'react'
-
-export default function page() {
-  return <div>hello</div>
-}

--- a/bench/app-router-server/docs/foo.ts
+++ b/bench/app-router-server/docs/foo.ts
@@ -1,0 +1,1 @@
+export default 'docs'

--- a/bench/app-router-server/docs2/foo.ts
+++ b/bench/app-router-server/docs2/foo.ts
@@ -1,0 +1,1 @@
+export default 'docs2'

--- a/bench/app-router-server/next-env.d.ts
+++ b/bench/app-router-server/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import './.next/types/routes.d.ts'
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/bench/app-router-server/pages/index.js
+++ b/bench/app-router-server/pages/index.js
@@ -1,9 +1,0 @@
-import * as React from 'react'
-
-export default function page() {
-  return <div> hello world </div>
-}
-
-export async function getServerSideProps() {
-  return {}
-}

--- a/bench/app-router-server/tsconfig.json
+++ b/bench/app-router-server/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"],
+      "@/docs/*": ["./docs/*"],
+      "@/learn/*": ["./learn/*"]
+    },
+    "strictNullChecks": true
+  },
+  "include": [
+    "**/*.mts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "next-env.d.ts",
+    "next.config.mjs"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/bench/app-router-server/tsconfig.json
+++ b/bench/app-router-server/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -20,8 +20,7 @@
     ],
     "paths": {
       "@/*": ["./*"],
-      "@/docs/*": ["./docs/*"],
-      "@/learn/*": ["./learn/*"]
+      "@/docs/*": ["./docs2/*"]
     },
     "strictNullChecks": true
   },
@@ -31,7 +30,8 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     "next-env.d.ts",
-    "next.config.mjs"
+    "next.config.mjs",
+    ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -426,7 +426,7 @@ pub async fn type_resolve(
         fragment: _,
     } = &*request.await?
     {
-        let mut m = if let Some(mut stripped) = m.strip_prefix("@")? {
+        let mut m = if let Some(mut stripped) = m.strip_constant_prefix("@")? {
             stripped.replace_constants(&|c| Some(Pattern::Constant(c.replace("/", "__").into())));
             stripped
         } else {

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/index.js
@@ -1,11 +1,19 @@
-import { loadSub, loadSubNested, loadSubFallback } from './src/foo'
+import {
+  load,
+  loadComplex,
+  loadSub,
+  loadSubNested,
+  loadSubFallback,
+} from './src/foo'
 
 it('should support dynamic requests with tsconfig.paths', () => {
-  expect(loadSub('file2.js').default).toBe('file2')
+  expect(load('sub/file2.js').default).toBe('file2')
+  expect(loadSub('file2.js').default).toBe('file2-override')
+  expect(loadComplex('sub', 'file2', 'js').default).toBe('file2')
 })
 
 it('should support dynamic requests with tsconfig.paths and without extension', () => {
-  expect(loadSub('file2').default).toBe('file2')
+  expect(loadSub('file2').default).toBe('file2-override')
 })
 
 it('should support dynamic requests with tsconfig.paths and multiple dynamic parts', () => {

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/src/foo.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/src/foo.ts
@@ -1,3 +1,11 @@
+export function load(v: string) {
+  return require(`@/${v}`)
+}
+
+export function loadComplex(dir: string, name: string, ext: string) {
+  return require(`@/${dir}/${name}/${ext}`)
+}
+
 export function loadSub(v: string) {
   return require(`@/sub/${v}`)
 }

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/sub-override/file1.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/sub-override/file1.js
@@ -1,0 +1,1 @@
+export default 'file1-override'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/sub-override/file2.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/sub-override/file2.js
@@ -1,0 +1,1 @@
+export default 'file2-override'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/sub-override/file3.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/sub-override/file3.js
@@ -1,0 +1,1 @@
+export default 'file3-override'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/tsconfig.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/tsconfig-paths-dynamic/input/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "paths": {
       "@/*": ["./*"],
+      "@/sub/*": ["./sub-override/*"],
       "@sub/*": ["./sub/*", "./sub-fallback/*"]
     }
   }


### PR DESCRIPTION
Related to https://github.com/vercel/next.js/pull/84178

With overlapping tsconfig paths/exports fields, Turbopack currently fails:
```
Error: Turbopack build failed with 1 errors:
./bench/app-router-server/app/page.js:1:1
Module not found: Can't resolve '@/' <dynamic> '/' <dynamic>
> 1 | import(`@/${globalThis.type}/${globalThis.processedSlugPath}`)
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  2 |
  3 | // globalThis.docs = 'docs'
  4 | // console.trace(require(`@/${globalThis.docs}/foo`))

'@/' <dynamic> '/' <dynamic>.strip_constant_prefix_len("@/docs/".len())

Caused by:
- strip_constant_prefix_len prefix is too long

Debug info:
- Execution of <ModuleAssetContext as AssetContext>::resolve_asset failed
- Execution of resolve failed
- Execution of resolve_internal failed
- '@/' <dynamic> '/' <dynamic>.strip_constant_prefix_len("@/docs/".len())
- strip_constant_prefix_len prefix is too long
Error while looking up import map: '@/' <dynamic> '/' <dynamic>.strip_constant_prefix_len("@/docs/".len())

Caused by:
- strip_constant_prefix_len prefix is too long
```