### PR TITLE
Add codemod for removing `unstable_` prefix

### DIFF
--- a/packages/next-codemod/lib/utils.ts
+++ b/packages/next-codemod/lib/utils.ts
@@ -132,4 +132,9 @@ export const TRANSFORMER_INQUIRER_CHOICES = [
     value: 'middleware-to-proxy',
     version: '15.6.0-canary.54',
   },
+  {
+    title: 'Remove `unstable_` prefix from stabilized API',
+    value: 'remove-unstable-prefix',
+    version: '16.0.0-canary.10',
+  },
 ]

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/alias.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/alias.input.tsx
@@ -1,0 +1,26 @@
+// @ts-nocheck
+import { unstable_cacheTag as cacheTagImport, unstable_cacheLife as cacheLifeImport } from 'next/cache'
+const { unstable_cacheTag: cacheTagRequire, unstable_cacheLife: cacheLifeRequire } = require('next/cache')
+// Alias with same API name, alias should be removed.
+import { unstable_cacheTag as cacheTag, unstable_cacheLife as cacheLife } from 'next/cache'
+const { unstable_cacheTag: cacheTag, unstable_cacheLife: cacheLife } = require('next/cache')
+
+export function MyComponent() {
+  const cacheTagImportTag = cacheTagImport('foo')
+  const cacheLifeImportLife = cacheLifeImport('1 hour')
+  const cacheTagRequireTag = cacheTagRequire('bar')
+  const cacheLifeRequireLife = cacheLifeRequire('2 hours')
+  const cacheTagAlias = cacheTag('redundant')
+  const cacheLifeAlias = cacheLife('redundant-time')
+
+  return (
+    <div>
+      <p>Using cache tag: {cacheTagImportTag}</p>
+      <p>Using cache life: {cacheLifeImportLife}</p>
+      <p>Using another tag: {cacheTagRequireTag}</p>
+      <p>Using another life: {cacheLifeRequireLife}</p>
+      <p>Using same alias tag: {cacheTagAlias}</p>
+      <p>Using same alias life: {cacheLifeAlias}</p>
+    </div>
+  )
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/alias.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/alias.output.tsx
@@ -1,0 +1,26 @@
+// @ts-nocheck
+import { cacheTag as cacheTagImport, cacheLife as cacheLifeImport } from 'next/cache'
+const { cacheTag: cacheTagRequire, cacheLife: cacheLifeRequire } = require('next/cache')
+// Alias with same API name, alias should be removed.
+import { cacheTag, cacheLife } from 'next/cache'
+const { cacheTag, cacheLife } = require('next/cache')
+
+export function MyComponent() {
+  const cacheTagImportTag = cacheTagImport('foo')
+  const cacheLifeImportLife = cacheLifeImport('1 hour')
+  const cacheTagRequireTag = cacheTagRequire('bar')
+  const cacheLifeRequireLife = cacheLifeRequire('2 hours')
+  const cacheTagAlias = cacheTag('redundant')
+  const cacheLifeAlias = cacheLife('redundant-time')
+
+  return (
+    <div>
+      <p>Using cache tag: {cacheTagImportTag}</p>
+      <p>Using cache life: {cacheLifeImportLife}</p>
+      <p>Using another tag: {cacheTagRequireTag}</p>
+      <p>Using another life: {cacheLifeRequireLife}</p>
+      <p>Using same alias tag: {cacheTagAlias}</p>
+      <p>Using same alias life: {cacheLifeAlias}</p>
+    </div>
+  )
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/bracket-notation.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/bracket-notation.input.tsx
@@ -1,0 +1,19 @@
+// @ts-nocheck
+/* eslint-disable */
+const cache = require('next/cache')
+const dynamicCache = await import('next/cache')
+
+// Bracket notation property access with string literals
+const tag = cache['unstable_cacheTag']('my-tag')
+const life = dynamicCache['unstable_cacheLife']('2 hours')
+
+// Direct bracket notation access on require
+const directTag = require('next/cache')['unstable_cacheTag']
+
+// Bracket notation property access inside a function
+function testCache() {
+  const tag2 = cache['unstable_cacheTag']('tag2')
+  const life2 = dynamicCache['unstable_cacheLife']('life2')
+
+  return { tag2, life2 }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/bracket-notation.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/bracket-notation.output.tsx
@@ -1,0 +1,19 @@
+// @ts-nocheck
+/* eslint-disable */
+const cache = require('next/cache')
+const dynamicCache = await import('next/cache')
+
+// Bracket notation property access with string literals
+const tag = cache["cacheTag"]('my-tag')
+const life = dynamicCache["cacheLife"]('2 hours')
+
+// Direct bracket notation access on require
+const directTag = require('next/cache')["cacheTag"]
+
+// Bracket notation property access inside a function
+function testCache() {
+  const tag2 = cache["cacheTag"]('tag2')
+  const life2 = dynamicCache["cacheLife"]('life2')
+
+  return { tag2, life2 }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/dynamic-import.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/dynamic-import.input.tsx
@@ -1,0 +1,20 @@
+// @ts-nocheck
+/* eslint-disable */
+async function loadCache() {
+  // Dynamic import with destructuring
+  const { unstable_cacheTag, unstable_cacheLife } = await import('next/cache')
+
+  // Dynamic import with property access
+  const cache = await import('next/cache')
+  const directTag = cache.unstable_cacheTag
+  const directLife = cache.unstable_cacheLife
+
+  return { directTag, directLife }
+}
+
+// Dynamic import without await
+const cachePromise = import('next/cache').then(({ unstable_cacheTag, unstable_cacheLife }) => {
+  const tag = unstable_cacheTag('async-tag')
+  const life = unstable_cacheLife('3 hours')
+  return { tag, life }
+})

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/dynamic-import.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/dynamic-import.output.tsx
@@ -1,0 +1,20 @@
+// @ts-nocheck
+/* eslint-disable */
+async function loadCache() {
+  // Dynamic import with destructuring
+  const { cacheTag, cacheLife } = await import('next/cache')
+
+  // Dynamic import with property access
+  const cache = await import('next/cache')
+  const directTag = cache.cacheTag
+  const directLife = cache.cacheLife
+
+  return { directTag, directLife }
+}
+
+// Dynamic import without await
+const cachePromise = import('next/cache').then(({ cacheTag, cacheLife }) => {
+  const tag = cacheTag('async-tag')
+  const life = cacheLife('3 hours')
+  return { tag, life }
+})

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/dynamic-require.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/dynamic-require.input.tsx
@@ -1,0 +1,17 @@
+// @ts-nocheck
+/* eslint-disable */
+function loadCache() {
+  // Dynamic require with destructuring
+  const { unstable_cacheTag, unstable_cacheLife } = require('next/cache')
+
+  // Dynamic require with property access
+  const cache = require('next/cache')
+  const directTag = cache.unstable_cacheTag
+  const directLife = cache.unstable_cacheLife
+
+  // Direct property access on require
+  const tag = require('next/cache').unstable_cacheTag('my-tag')
+  const life = require('next/cache').unstable_cacheLife('2 hours')
+
+  return { tag, life, directTag, directLife }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/dynamic-require.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/dynamic-require.output.tsx
@@ -1,0 +1,17 @@
+// @ts-nocheck
+/* eslint-disable */
+function loadCache() {
+  // Dynamic require with destructuring
+  const { cacheTag, cacheLife } = require('next/cache')
+
+  // Dynamic require with property access
+  const cache = require('next/cache')
+  const directTag = cache.cacheTag
+  const directLife = cache.cacheLife
+
+  // Direct property access on require
+  const tag = require('next/cache').cacheTag('my-tag')
+  const life = require('next/cache').cacheLife('2 hours')
+
+  return { tag, life, directTag, directLife }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/export-statements.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/export-statements.input.tsx
@@ -1,0 +1,11 @@
+// @ts-nocheck
+/* eslint-disable */
+
+// Re-export unstable APIs from next/cache
+export { unstable_cacheTag, unstable_cacheLife, revalidatePath} from 'next/cache'
+
+// Re-export with aliases
+export { unstable_cacheTag as createTag, unstable_cacheLife as createLife } from 'next/cache'
+
+// Default export should not be affected
+export { default as cache } from 'next/cache'

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/export-statements.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/export-statements.output.tsx
@@ -1,0 +1,11 @@
+// @ts-nocheck
+/* eslint-disable */
+
+// Re-export unstable APIs from next/cache
+export { cacheTag, cacheLife, revalidatePath} from 'next/cache'
+
+// Re-export with aliases
+export { cacheTag as createTag, cacheLife as createLife } from 'next/cache'
+
+// Default export should not be affected
+export { default as cache } from 'next/cache'

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/import.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/import.input.tsx
@@ -1,0 +1,18 @@
+// @ts-nocheck
+/* eslint-disable */
+import { unstable_cacheTag, revalidatePath, unstable_cacheLife } from 'next/cache'
+
+export function MyComponent() {
+  const tag = unstable_cacheTag('my-tag')
+  const life = unstable_cacheLife('2 hours')
+
+  // This should remain unchanged
+  revalidatePath('/app')
+
+  return (
+    <div>
+      <p>Using cache tag: {tag}</p>
+      <p>Using cache life: {life}</p>
+    </div>
+  )
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/import.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/import.output.tsx
@@ -1,0 +1,18 @@
+// @ts-nocheck
+/* eslint-disable */
+import { cacheTag, revalidatePath, cacheLife } from 'next/cache'
+
+export function MyComponent() {
+  const tag = cacheTag('my-tag')
+  const life = cacheLife('2 hours')
+
+  // This should remain unchanged
+  revalidatePath('/app')
+
+  return (
+    <div>
+      <p>Using cache tag: {tag}</p>
+      <p>Using cache life: {life}</p>
+    </div>
+  )
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/namespace-import.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/namespace-import.input.tsx
@@ -1,0 +1,14 @@
+// @ts-nocheck
+/* eslint-disable */
+import * as cache from 'next/cache'
+
+export function testNamespaceAccess() {
+  // Namespace property access
+  const tag = cache.unstable_cacheTag('tag')
+  const life = cache.unstable_cacheLife('1 hour')
+
+  // This should remain unchanged
+  const path = cache.revalidatePath('/app')
+
+  return { tag, life, path }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/namespace-import.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/namespace-import.output.tsx
@@ -1,0 +1,14 @@
+// @ts-nocheck
+/* eslint-disable */
+import * as cache from 'next/cache'
+
+export function testNamespaceAccess() {
+  // Namespace property access
+  const tag = cache.cacheTag('tag')
+  const life = cache.cacheLife('1 hour')
+
+  // This should remain unchanged
+  const path = cache.revalidatePath('/app')
+
+  return { tag, life, path }
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/require.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/require.input.tsx
@@ -1,0 +1,18 @@
+// @ts-nocheck
+/* eslint-disable */
+const { unstable_cacheTag, unstable_cacheLife, revalidatePath } = require('next/cache')
+
+export function MyComponent() {
+  const tag = unstable_cacheTag('my-tag')
+  const life = unstable_cacheLife('2 hours')
+
+  // This should remain unchanged
+  revalidatePath('/app')
+
+  return (
+    <div>
+      <p>Using cache tag: {tag}</p>
+      <p>Using cache life: {life}</p>
+    </div>
+  )
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/require.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/require.output.tsx
@@ -1,0 +1,18 @@
+// @ts-nocheck
+/* eslint-disable */
+const { cacheTag, cacheLife, revalidatePath } = require('next/cache')
+
+export function MyComponent() {
+  const tag = cacheTag('my-tag')
+  const life = cacheLife('2 hours')
+
+  // This should remain unchanged
+  revalidatePath('/app')
+
+  return (
+    <div>
+      <p>Using cache tag: {tag}</p>
+      <p>Using cache life: {life}</p>
+    </div>
+  )
+}

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/type-imports.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/type-imports.input.tsx
@@ -1,0 +1,7 @@
+// @ts-nocheck
+
+// Type imports
+import type { unstable_cacheTag, unstable_cacheLife } from 'next/cache'
+
+// Type imports as alias
+import type { unstable_cacheTag as regularTag, unstable_cacheLife as regularLife } from 'next/cache'

--- a/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/type-imports.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-unstable-prefix/type-imports.output.tsx
@@ -1,0 +1,7 @@
+// @ts-nocheck
+
+// Type imports
+import type { cacheTag, cacheLife } from 'next/cache'
+
+// Type imports as alias
+import type { cacheTag as regularTag, cacheLife as regularLife } from 'next/cache'

--- a/packages/next-codemod/transforms/__tests__/remove-unstable-prefix.test.js
+++ b/packages/next-codemod/transforms/__tests__/remove-unstable-prefix.test.js
@@ -1,0 +1,16 @@
+/* global jest */
+jest.autoMockOff()
+const defineTest = require('jscodeshift/dist/testUtils').defineTest
+const { readdirSync } = require('fs')
+const { join } = require('path')
+
+const fixtureDir = 'remove-unstable-prefix'
+const fixtureDirPath = join(__dirname, '..', '__testfixtures__', fixtureDir)
+const fixtures = readdirSync(fixtureDirPath)
+  .filter(file => file.endsWith('.input.tsx'))
+  .map(file => file.replace('.input.tsx', ''))
+
+for (const fixture of fixtures) {
+  const prefix = `${fixtureDir}/${fixture}`;
+  defineTest(__dirname, fixtureDir, null, prefix, { parser: 'tsx' });
+}

--- a/packages/next-codemod/transforms/remove-unstable-prefix.ts
+++ b/packages/next-codemod/transforms/remove-unstable-prefix.ts
@@ -1,0 +1,357 @@
+import type { API, FileInfo, Options } from 'jscodeshift'
+import { createParserFromPath } from '../lib/parser'
+
+// Mapping of unstable APIs to their stable counterparts
+// This can be easily extended when new APIs are stabilized
+const UNSTABLE_TO_STABLE_MAPPING: Record<string, string> = {
+  unstable_cacheTag: 'cacheTag',
+  unstable_cacheLife: 'cacheLife',
+}
+
+// Helper function to check if a property name should be renamed
+function shouldRenameProperty(propertyName: string): boolean {
+  return propertyName in UNSTABLE_TO_STABLE_MAPPING
+}
+
+export default function transformer(
+  file: FileInfo,
+  _api: API,
+  options: Options
+) {
+  const j = createParserFromPath(file.path)
+  const root = j(file.source)
+  let hasChanges = false
+
+  try {
+    // Track identifier renames that need to be applied
+    const identifierRenames: Array<{ oldName: string; newName: string }> = []
+    // Track variables assigned from next/cache imports/requires
+    const cacheVariables = new Set<string>()
+
+    // Handle ES6 imports: import { unstable_cacheTag } from 'next/cache'
+    root
+      .find(j.ImportDeclaration, { source: { value: 'next/cache' } })
+      .forEach((path) => {
+        path.node.specifiers?.forEach((specifier) => {
+          if (
+            specifier.type === 'ImportSpecifier' &&
+            specifier.imported?.type === 'Identifier' &&
+            shouldRenameProperty(specifier.imported.name)
+          ) {
+            const oldName = specifier.imported.name
+            const newName = UNSTABLE_TO_STABLE_MAPPING[oldName]
+
+            // Handle alias scenarios
+            if (specifier.local && specifier.local.name === newName) {
+              // Same alias name: { unstable_cacheTag as cacheTag } -> { cacheTag }
+              const newSpecifier = j.importSpecifier(j.identifier(newName))
+              const specifierIndex = path.node.specifiers.indexOf(specifier)
+              path.node.specifiers[specifierIndex] = newSpecifier
+              identifierRenames.push({ oldName, newName })
+            } else {
+              // Normal case: just update the imported name
+              specifier.imported = j.identifier(newName)
+              if (!specifier.local || specifier.local.name === oldName) {
+                // Not aliased or aliased with old name: add to identifier renames
+                identifierRenames.push({ oldName, newName })
+              }
+            }
+
+            hasChanges = true
+          } else if (specifier.type === 'ImportNamespaceSpecifier') {
+            // Handle namespace imports: import * as cache from 'next/cache'
+            cacheVariables.add(specifier.local.name)
+          }
+        })
+      })
+
+    // Handle export statements: export { unstable_cacheTag } from 'next/cache'
+    root
+      .find(j.ExportNamedDeclaration, { source: { value: 'next/cache' } })
+      .forEach((path) => {
+        path.node.specifiers?.forEach((specifier) => {
+          if (
+            specifier.type === 'ExportSpecifier' &&
+            specifier.local?.type === 'Identifier' &&
+            shouldRenameProperty(specifier.local.name)
+          ) {
+            const oldName = specifier.local.name
+            const newName = UNSTABLE_TO_STABLE_MAPPING[oldName]
+
+            specifier.local = j.identifier(newName)
+
+            // Handle export alias scenarios
+            if (specifier.exported && specifier.exported.name === newName) {
+              // Same alias name: { unstable_cacheTag as cacheTag } -> { cacheTag }
+              specifier.exported = specifier.local
+            } else if (
+              !specifier.exported ||
+              specifier.exported.name === oldName
+            ) {
+              // Not aliased or aliased with old name
+              specifier.exported = j.identifier(newName)
+            }
+
+            hasChanges = true
+          }
+        })
+      })
+
+    // Handle require('next/cache') calls and destructuring
+    root
+      .find(j.CallExpression, { callee: { name: 'require' } })
+      .forEach((path) => {
+        if (
+          path.node.arguments[0]?.type === 'StringLiteral' &&
+          path.node.arguments[0].value === 'next/cache'
+        ) {
+          // Track variable assignments: const cache = require('next/cache')
+          const parent = path.parent?.node
+          if (
+            parent?.type === 'VariableDeclarator' &&
+            parent.id?.type === 'Identifier'
+          ) {
+            cacheVariables.add(parent.id.name)
+          }
+
+          // Handle destructuring: const { unstable_cacheTag } = require('next/cache')
+          if (
+            parent?.type === 'VariableDeclarator' &&
+            parent.id?.type === 'ObjectPattern'
+          ) {
+            parent.id.properties?.forEach((property) => {
+              if (
+                property.type === 'ObjectProperty' &&
+                property.key?.type === 'Identifier' &&
+                shouldRenameProperty(property.key.name)
+              ) {
+                const oldName = property.key.name
+                const newName = UNSTABLE_TO_STABLE_MAPPING[oldName]
+
+                property.key = j.identifier(newName)
+
+                // Handle both shorthand and explicit destructuring
+                if (!property.value) {
+                  property.value = j.identifier(newName)
+                  identifierRenames.push({ oldName, newName })
+                } else if (property.value.type === 'Identifier') {
+                  const localName = property.value.name
+                  if (localName === oldName) {
+                    property.value = j.identifier(newName)
+                    identifierRenames.push({ oldName, newName })
+                  } else if (localName === newName) {
+                    // Same alias name: { unstable_cacheTag: cacheTag } -> { cacheTag }
+                    property.value = j.identifier(newName)
+                    property.shorthand = true
+                    identifierRenames.push({ oldName, newName })
+                  }
+                }
+
+                hasChanges = true
+              }
+            })
+          }
+        }
+      })
+
+    // Handle await import('next/cache') calls and destructuring
+    root.find(j.AwaitExpression).forEach((path) => {
+      const arg = path.node.argument
+      if (
+        arg?.type === 'CallExpression' &&
+        arg.callee?.type === 'Import' &&
+        arg.arguments[0]?.type === 'StringLiteral' &&
+        arg.arguments[0].value === 'next/cache'
+      ) {
+        // Track variable assignments: const cache = await import('next/cache')
+        const parent = path.parent?.node
+        if (
+          parent?.type === 'VariableDeclarator' &&
+          parent.id?.type === 'Identifier'
+        ) {
+          cacheVariables.add(parent.id.name)
+        }
+
+        // Handle destructuring: const { unstable_cacheTag } = await import('next/cache')
+        if (
+          parent?.type === 'VariableDeclarator' &&
+          parent.id?.type === 'ObjectPattern'
+        ) {
+          parent.id.properties?.forEach((property) => {
+            if (
+              property.type === 'ObjectProperty' &&
+              property.key?.type === 'Identifier' &&
+              shouldRenameProperty(property.key.name)
+            ) {
+              const oldName = property.key.name
+              const newName = UNSTABLE_TO_STABLE_MAPPING[oldName]
+
+              property.key = j.identifier(newName)
+
+              if (!property.value) {
+                property.value = j.identifier(newName)
+                identifierRenames.push({ oldName, newName })
+              } else if (property.value.type === 'Identifier') {
+                const localName = property.value.name
+                if (localName === oldName) {
+                  property.value = j.identifier(newName)
+                  identifierRenames.push({ oldName, newName })
+                } else if (localName === newName) {
+                  // Same alias name: { unstable_cacheTag: cacheTag } -> { cacheTag }
+                  property.value = j.identifier(newName)
+                  property.shorthand = true
+                  identifierRenames.push({ oldName, newName })
+                }
+              }
+
+              hasChanges = true
+            }
+          })
+        }
+      }
+    })
+
+    // Handle .then() chains: import('next/cache').then(({ unstable_cacheTag }) => ...)
+    root.find(j.CallExpression).forEach((path) => {
+      if (
+        path.node.callee?.type === 'MemberExpression' &&
+        path.node.callee.property?.type === 'Identifier' &&
+        path.node.callee.property.name === 'then' &&
+        path.node.callee.object?.type === 'CallExpression' &&
+        path.node.callee.object.callee?.type === 'Import' &&
+        path.node.callee.object.arguments[0]?.type === 'StringLiteral' &&
+        path.node.callee.object.arguments[0].value === 'next/cache' &&
+        path.node.arguments.length > 0
+      ) {
+        const callback = path.node.arguments[0]
+        let params = null
+
+        if (callback.type === 'ArrowFunctionExpression') {
+          params = callback.params
+        } else if (callback.type === 'FunctionExpression') {
+          params = callback.params
+        }
+
+        if (params && params.length > 0 && params[0].type === 'ObjectPattern') {
+          params[0].properties?.forEach((property) => {
+            if (
+              property.type === 'ObjectProperty' &&
+              property.key?.type === 'Identifier' &&
+              shouldRenameProperty(property.key.name)
+            ) {
+              const oldName = property.key.name
+              const newName = UNSTABLE_TO_STABLE_MAPPING[oldName]
+
+              property.key = j.identifier(newName)
+
+              if (!property.value) {
+                property.value = j.identifier(newName)
+                identifierRenames.push({ oldName, newName })
+              } else if (property.value.type === 'Identifier') {
+                const localName = property.value.name
+                if (localName === oldName) {
+                  property.value = j.identifier(newName)
+                  identifierRenames.push({ oldName, newName })
+                } else if (localName === newName) {
+                  // Same alias name: { unstable_cacheTag: cacheTag } -> { cacheTag }
+                  property.value = j.identifier(newName)
+                  property.shorthand = true
+                  identifierRenames.push({ oldName, newName })
+                }
+              }
+
+              hasChanges = true
+            }
+          })
+        }
+      }
+    })
+
+    // Handle member expressions
+    root.find(j.MemberExpression).forEach((path) => {
+      const node = path.node
+
+      // Handle direct property access: require('next/cache').unstable_cacheTag
+      if (
+        node.object?.type === 'CallExpression' &&
+        node.object.callee?.type === 'Identifier' &&
+        node.object.callee.name === 'require' &&
+        node.object.arguments[0]?.type === 'StringLiteral' &&
+        node.object.arguments[0].value === 'next/cache'
+      ) {
+        if (
+          node.computed &&
+          node.property?.type === 'StringLiteral' &&
+          shouldRenameProperty(node.property.value)
+        ) {
+          const newName = UNSTABLE_TO_STABLE_MAPPING[node.property.value]
+          node.property = j.stringLiteral(newName)
+          hasChanges = true
+        } else if (
+          !node.computed &&
+          node.property?.type === 'Identifier' &&
+          shouldRenameProperty(node.property.name)
+        ) {
+          const newName = UNSTABLE_TO_STABLE_MAPPING[node.property.name]
+          node.property = j.identifier(newName)
+          hasChanges = true
+        }
+      }
+
+      // Handle property access on cache variables: cache.unstable_cacheTag or cache['unstable_cacheTag']
+      if (
+        node.object?.type === 'Identifier' &&
+        cacheVariables.has(node.object.name)
+      ) {
+        if (
+          node.computed &&
+          node.property?.type === 'StringLiteral' &&
+          shouldRenameProperty(node.property.value)
+        ) {
+          const newName = UNSTABLE_TO_STABLE_MAPPING[node.property.value]
+          node.property = j.stringLiteral(newName)
+          hasChanges = true
+        } else if (
+          !node.computed &&
+          node.property?.type === 'Identifier' &&
+          shouldRenameProperty(node.property.name)
+        ) {
+          const newName = UNSTABLE_TO_STABLE_MAPPING[node.property.name]
+          node.property = j.identifier(newName)
+          hasChanges = true
+        }
+      }
+    })
+
+    // Apply all identifier renames with better scope awareness
+    identifierRenames.forEach(({ oldName, newName }) => {
+      root
+        .find(j.Identifier, { name: oldName })
+        .filter((identifierPath) => {
+          // Skip renaming declarations themselves
+          const parent = identifierPath.parent
+          return !(
+            parent.node.type === 'ImportSpecifier' ||
+            parent.node.type === 'ExportSpecifier' ||
+            (parent.node.type === 'ObjectProperty' &&
+              parent.node.key === identifierPath.node) ||
+            (parent.node.type === 'VariableDeclarator' &&
+              parent.node.id === identifierPath.node) ||
+            (parent.node.type === 'FunctionDeclaration' &&
+              parent.node.id === identifierPath.node) ||
+            (parent.node.type === 'Property' &&
+              parent.node.key === identifierPath.node &&
+              !parent.node.computed)
+          )
+        })
+        .forEach((identifierPath) => {
+          identifierPath.node.name = newName
+        })
+    })
+
+    return hasChanges ? root.toSource(options) : file.source
+  } catch (error) {
+    console.warn(`Failed to transform ${file.path}: ${error.message}`)
+    return file.source
+  }
+}


### PR DESCRIPTION
Stacked on https://github.com/vercel/next.js/pull/84877, https://github.com/vercel/next.js/pull/84880

This PR adds a codemod for removing the `unstable_` prefix for stabilized APIs. It is considered to scale by adding more APIs to the `UNSTABLE_TO_STABLE_MAPPING` map in the future to this codemod.

Closes NEXT-4739