### PR TITLE
[cache components]: prevent expired entries from being served

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -828,10 +828,6 @@ export async function handler(
             kind: IncrementalCacheKind.APP_PAGE,
             isRoutePPREnabled: true,
             isFallback: false,
-            // CRITICAL: we need to allow stale here as we'll revalidate in the
-            // background if it's stale. We _want_ to possibly serve a stale
-            // response here as it'll be consistent with the static render.
-            allowStale: true,
           }
         )
 

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -293,16 +293,6 @@ export default class FileSystemCache implements CacheHandler {
       }
     }
 
-    // If enabled, this will return the possibly stale data without validating
-    // that the tags have expired or not yet been revalidated.
-    if ('allowStale' in ctx && ctx.allowStale) {
-      if (FileSystemCache.debug) {
-        console.log('FileSystemCache: allow stale', ctx.allowStale)
-      }
-
-      return data ?? null
-    }
-
     if (
       data?.value?.kind === CachedRouteKind.APP_PAGE ||
       data?.value?.kind === CachedRouteKind.APP_ROUTE ||

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -228,11 +228,6 @@ export interface GetIncrementalResponseCacheContext {
    * True if this is a fallback request.
    */
   isFallback: boolean
-
-  /**
-   * True if stale data is allowed to be returned.
-   */
-  allowStale?: boolean
 }
 
 export interface SetIncrementalFetchCacheContext {

--- a/test/production/app-dir/resume-data-cache/app/revalidate/route.ts
+++ b/test/production/app-dir/resume-data-cache/app/revalidate/route.ts
@@ -1,6 +1,6 @@
 import { revalidateTag } from 'next/cache'
 
 export function POST() {
-  revalidateTag('test', 'expireNow')
+  revalidateTag('test', 'seconds')
   return new Response(null, { status: 200 })
 }

--- a/test/production/app-dir/resume-data-cache/next.config.js
+++ b/test/production/app-dir/resume-data-cache/next.config.js
@@ -5,13 +5,6 @@ const nextConfig = {
   experimental: {
     cacheComponents: true,
     clientSegmentCache: true,
-    cacheLife: {
-      expireNow: {
-        stale: 0,
-        expire: 0,
-        revalidate: 0,
-      },
-    },
   },
 }
 


### PR DESCRIPTION
The `allowStale` value is currently erroneously also allowing expired values to be served, because it's happening in the `file-system-cache`, before expiration values are checked.

This removes the handling all together to prevent the possibility of serving data that has been expired (eg via`updateTag`). 