### PR TITLE
Add codemod for removing `experimental_ppr`

### DIFF
--- a/docs/01-app/02-guides/upgrading/codemods.mdx
+++ b/docs/01-app/02-guides/upgrading/codemods.mdx
@@ -26,6 +26,20 @@ Replacing `<transform>` and `<path>` with appropriate values.
 
 ### 16.0
 
+#### Remove `experimental_ppr` Route Segment Config from App Router pages and layouts
+
+##### `remove-experimental-ppr`
+
+```bash filename="Terminal"
+npx @next/codemod@latest remove-experimental-ppr .
+```
+
+This codemod removes the `experimental_ppr` Route Segment Config from App Router pages and layouts.
+
+```diff filename="app/page.tsx"
+- export const experimental_ppr = true;
+```
+
 #### Migrate from `next lint` to ESLint CLI
 
 ##### `next-lint-to-eslint-cli`

--- a/packages/next-codemod/lib/utils.ts
+++ b/packages/next-codemod/lib/utils.ts
@@ -137,4 +137,10 @@ export const TRANSFORMER_INQUIRER_CHOICES = [
     value: 'remove-unstable-prefix',
     version: '16.0.0-canary.10',
   },
+  {
+    title:
+      'Remove `experimental_ppr` Route Segment Config from App Router pages and layouts',
+    value: 'remove-experimental-ppr',
+    version: '16.0.0-canary.11',
+  },
 ]

--- a/packages/next-codemod/transforms/__testfixtures__/remove-experimental-ppr/basic.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-experimental-ppr/basic.input.tsx
@@ -1,0 +1,7 @@
+// @ts-nocheck
+export default function Page() {
+  return <p>hello world</p>;
+}
+
+export const experimental_ppr = true;
+export const runtime = 'nodejs';

--- a/packages/next-codemod/transforms/__testfixtures__/remove-experimental-ppr/basic.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-experimental-ppr/basic.output.tsx
@@ -1,0 +1,6 @@
+// @ts-nocheck
+export default function Page() {
+  return <p>hello world</p>;
+}
+
+export const runtime = 'nodejs';

--- a/packages/next-codemod/transforms/__testfixtures__/remove-experimental-ppr/separate-export.input.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-experimental-ppr/separate-export.input.tsx
@@ -1,0 +1,9 @@
+// @ts-nocheck
+export default function Page() {
+  return <p>hello world</p>;
+}
+
+const experimental_ppr = true;
+const runtime = 'nodejs';
+
+export { experimental_ppr, runtime };

--- a/packages/next-codemod/transforms/__testfixtures__/remove-experimental-ppr/separate-export.output.tsx
+++ b/packages/next-codemod/transforms/__testfixtures__/remove-experimental-ppr/separate-export.output.tsx
@@ -1,0 +1,8 @@
+// @ts-nocheck
+export default function Page() {
+  return <p>hello world</p>;
+}
+
+const runtime = 'nodejs';
+
+export { runtime };

--- a/packages/next-codemod/transforms/__tests__/remove-experimental-ppr.test.js
+++ b/packages/next-codemod/transforms/__tests__/remove-experimental-ppr.test.js
@@ -1,0 +1,16 @@
+/* global jest */
+jest.autoMockOff()
+const defineTest = require('jscodeshift/dist/testUtils').defineTest
+const { readdirSync } = require('fs')
+const { join } = require('path')
+
+const fixtureDir = 'remove-experimental-ppr'
+const fixtureDirPath = join(__dirname, '..', '__testfixtures__', fixtureDir)
+const fixtures = readdirSync(fixtureDirPath)
+  .filter(file => file.endsWith('.input.tsx'))
+  .map(file => file.replace('.input.tsx', ''))
+
+for (const fixture of fixtures) {
+  const prefix = `${fixtureDir}/${fixture}`;
+  defineTest(__dirname, fixtureDir, null, prefix, { parser: 'tsx' });
+}

--- a/packages/next-codemod/transforms/remove-experimental-ppr.ts
+++ b/packages/next-codemod/transforms/remove-experimental-ppr.ts
@@ -1,0 +1,85 @@
+import type { API, FileInfo } from 'jscodeshift'
+import { createParserFromPath } from '../lib/parser'
+
+export default function transformer(file: FileInfo, _api: API) {
+  // Run on App Router page/layout/route files, except for test environment.
+  if (
+    process.env.NODE_ENV !== 'test' &&
+    !/[/\\]app[/\\](?:.*[/\\])?(page|layout|route)(\.[^/\\]*)?$/.test(file.path)
+  ) {
+    return file.source
+  }
+
+  const j = createParserFromPath(file.path)
+  const root = j(file.source)
+
+  let hasChanges = false
+
+  // Remove export const experimental_ppr = boolean
+  const directExports = root.find(j.ExportNamedDeclaration, {
+    declaration: {
+      type: 'VariableDeclaration',
+      declarations: [
+        {
+          id: { name: 'experimental_ppr' },
+        },
+      ],
+    },
+  })
+
+  if (directExports.size() > 0) {
+    directExports.remove()
+    hasChanges = true
+  }
+
+  // Remove const experimental_ppr = boolean declarations
+  const variableDeclarations = root.find(j.VariableDeclaration).filter((path) =>
+    path.node.declarations.some((decl) => {
+      if (j.VariableDeclarator.check(decl) && j.Identifier.check(decl.id)) {
+        return decl.id.name === 'experimental_ppr'
+      }
+      return false
+    })
+  )
+
+  if (variableDeclarations.size() > 0) {
+    variableDeclarations.remove()
+    hasChanges = true
+  }
+
+  // Handle export { experimental_ppr } and export { experimental_ppr, other }
+  const namedExports = root
+    .find(j.ExportNamedDeclaration)
+    .filter((path) => path.node.specifiers && path.node.specifiers.length > 0)
+
+  namedExports.forEach((path) => {
+    const specifiers = path.node.specifiers
+    if (!specifiers) return
+
+    const filteredSpecifiers = specifiers.filter((spec) => {
+      if (j.ExportSpecifier.check(spec) && j.Identifier.check(spec.local)) {
+        return spec.local.name !== 'experimental_ppr'
+      }
+      return true
+    })
+
+    // If we removed any specifiers
+    if (filteredSpecifiers.length !== specifiers.length) {
+      hasChanges = true
+
+      // If no specifiers left, remove the entire export statement
+      if (filteredSpecifiers.length === 0) {
+        j(path).remove()
+      } else {
+        // Update the specifiers array
+        path.node.specifiers = filteredSpecifiers
+      }
+    }
+  })
+
+  if (hasChanges) {
+    return root.toSource()
+  }
+
+  return file.source
+}


### PR DESCRIPTION
`experimental_ppr` is removed by https://github.com/vercel/next.js/pull/84871, so add codemod for it.