### PR TITLE
[segment cache]: delay revalidation prefetch pings 300ms

### DIFF
--- a/packages/next/src/client/components/segment-cache-impl/cache.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache.ts
@@ -34,6 +34,7 @@ import {
   isPrefetchTaskDirty,
   type PrefetchTask,
   type PrefetchSubtaskResult,
+  startRevalidationCooldown,
 } from './scheduler'
 import { getAppBuildId } from '../../app-build-id'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
@@ -315,14 +316,6 @@ export function getCurrentCacheVersion(): number {
   return currentCacheVersion
 }
 
-// Timestamp of the last cache revalidation. Used to implement a delay before
-// re-prefetching visible links, to allow CDN propagation.
-let lastRevalidationTimestamp: number | null = null
-
-export function getLastRevalidationTimestamp(): number | null {
-  return lastRevalidationTimestamp
-}
-
 /**
  * Used to clear the client prefetch cache when a server action calls
  * revalidatePath or revalidateTag. Eventually we will support only clearing the
@@ -335,9 +328,8 @@ export function revalidateEntireCache(
 ) {
   currentCacheVersion++
 
-  // Record the timestamp of this revalidation so we can delay re-prefetching
-  // to allow CDN cache propagation.
-  lastRevalidationTimestamp = Date.now()
+  // Start a cooldown before re-prefetching to allow CDN cache propagation.
+  startRevalidationCooldown()
 
   // Clearing the cache also effectively rejects any pending requests, because
   // when the response is received, it gets written into a cache entry that is

--- a/packages/next/src/client/components/segment-cache-impl/cache.ts
+++ b/packages/next/src/client/components/segment-cache-impl/cache.ts
@@ -315,6 +315,14 @@ export function getCurrentCacheVersion(): number {
   return currentCacheVersion
 }
 
+// Timestamp of the last cache revalidation. Used to implement a delay before
+// re-prefetching visible links, to allow CDN propagation.
+let lastRevalidationTimestamp: number | null = null
+
+export function getLastRevalidationTimestamp(): number | null {
+  return lastRevalidationTimestamp
+}
+
 /**
  * Used to clear the client prefetch cache when a server action calls
  * revalidatePath or revalidateTag. Eventually we will support only clearing the
@@ -326,6 +334,10 @@ export function revalidateEntireCache(
   tree: FlightRouterState
 ) {
   currentCacheVersion++
+
+  // Record the timestamp of this revalidation so we can delay re-prefetching
+  // to allow CDN cache propagation.
+  lastRevalidationTimestamp = Date.now()
 
   // Clearing the cache also effectively rejects any pending requests, because
   // when the response is received, it gets written into a cache entry that is

--- a/packages/next/src/client/components/segment-cache-impl/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache-impl/scheduler.ts
@@ -26,6 +26,7 @@ import {
   resetRevalidatingSegmentEntry,
   getSegmentKeypath,
   canNewFetchStrategyProvideMoreContent,
+  getLastRevalidationTimestamp,
 } from './cache'
 import type { RouteCacheKey } from './cache-key'
 import { createCacheKey } from './cache-key'
@@ -196,6 +197,12 @@ let didScheduleMicrotask = false
 // priority at a time. We reserve special network bandwidth for this task only.
 let mostRecentlyHoveredLink: PrefetchTask | null = null
 
+// CDN cache propagation delay after revalidation (in milliseconds)
+const REVALIDATION_COOLDOWN_MS = 300
+
+// Flag to prevent scheduling multiple cooldown timeouts
+let didScheduleCooldownTimeout = false
+
 export type IncludeDynamicData = null | 'full' | 'dynamic'
 
 /**
@@ -344,12 +351,45 @@ function ensureWorkIsScheduled() {
 }
 
 /**
+ * Schedules a retry of the task queue after the revalidation cooldown expires.
+ * This ensures we don't prefetch stale data from CDN caches that haven't
+ * propagated yet.
+ */
+function scheduleRetryAfterRevalidationCooldown(
+  remainingCooldown: number
+): void {
+  if (!didScheduleCooldownTimeout) {
+    didScheduleCooldownTimeout = true
+    setTimeout(() => {
+      didScheduleCooldownTimeout = false
+      ensureWorkIsScheduled()
+    }, remainingCooldown)
+  }
+}
+
+/**
  * Checks if we've exceeded the maximum number of concurrent prefetch requests,
  * to avoid saturating the browser's internal network queue. This is a
  * cooperative limit — prefetch tasks should check this before issuing
  * new requests.
+ *
+ * Also checks if we're within the revalidation cooldown window, during which
+ * prefetch requests are delayed to allow CDN cache propagation.
  */
-function hasNetworkBandwidth(task: PrefetchTask): boolean {
+function hasNetworkBandwidth(now: number, task: PrefetchTask): boolean {
+  // Check if we're within the revalidation cooldown window
+  const lastRevalidation = getLastRevalidationTimestamp()
+  if (lastRevalidation !== null) {
+    const timeSinceRevalidation = now - lastRevalidation
+    if (timeSinceRevalidation < REVALIDATION_COOLDOWN_MS) {
+      // We're within the cooldown window. Schedule a retry after the cooldown
+      // expires, then return false to prevent prefetching.
+      const remainingCooldown = REVALIDATION_COOLDOWN_MS - timeSinceRevalidation
+      scheduleRetryAfterRevalidationCooldown(remainingCooldown)
+      return false
+    }
+  }
+
   // TODO: Also check if there's an in-progress navigation. We should never
   // add prefetch requests to the network queue if an actual navigation is
   // taking place, to ensure there's sufficient bandwidth for render-blocking
@@ -437,7 +477,7 @@ function processQueueInMicrotask() {
 
   // Process the task queue until we run out of network bandwidth.
   let task = heapPeek(taskHeap)
-  while (task !== null && hasNetworkBandwidth(task)) {
+  while (task !== null && hasNetworkBandwidth(now, task)) {
     task.cacheVersion = getCurrentCacheVersion()
 
     const exitStatus = pingRoute(now, task)
@@ -610,7 +650,7 @@ function pingRootRouteTree(
         return PrefetchTaskExitStatus.Done
       }
       // Recursively fill in the segment tree.
-      if (!hasNetworkBandwidth(task)) {
+      if (!hasNetworkBandwidth(now, task)) {
         // Stop prefetching segments until there's more bandwidth.
         return PrefetchTaskExitStatus.InProgress
       }
@@ -794,7 +834,7 @@ function pingSharedPartOfCacheComponentsTree(
   const newTreeChildren = newTree.slots
   if (newTreeChildren !== null) {
     for (const parallelRouteKey in newTreeChildren) {
-      if (!hasNetworkBandwidth(task)) {
+      if (!hasNetworkBandwidth(now, task)) {
         // Stop prefetching segments until there's more bandwidth.
         return PrefetchTaskExitStatus.InProgress
       }
@@ -890,7 +930,7 @@ function pingNewPartOfCacheComponentsTree(
   )
   pingStaticSegmentData(now, task, route, segment, task.key, tree)
   if (tree.slots !== null) {
-    if (!hasNetworkBandwidth(task)) {
+    if (!hasNetworkBandwidth(now, task)) {
       // Stop prefetching segments until there's more bandwidth.
       return PrefetchTaskExitStatus.InProgress
     }

--- a/packages/next/src/client/components/segment-cache-impl/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache-impl/scheduler.ts
@@ -26,7 +26,6 @@ import {
   resetRevalidatingSegmentEntry,
   getSegmentKeypath,
   canNewFetchStrategyProvideMoreContent,
-  getLastRevalidationTimestamp,
 } from './cache'
 import type { RouteCacheKey } from './cache-key'
 import { createCacheKey } from './cache-key'
@@ -200,8 +199,29 @@ let mostRecentlyHoveredLink: PrefetchTask | null = null
 // CDN cache propagation delay after revalidation (in milliseconds)
 const REVALIDATION_COOLDOWN_MS = 300
 
-// Flag to prevent scheduling multiple cooldown timeouts
-let didScheduleCooldownTimeout = false
+// Timeout handle for the revalidation cooldown. When non-null, prefetch
+// requests are blocked to allow CDN cache propagation.
+let revalidationCooldownTimeoutHandle: ReturnType<typeof setTimeout> | null =
+  null
+
+/**
+ * Called by the cache when revalidation occurs. Starts a cooldown period
+ * during which prefetch requests are blocked to allow CDN cache propagation.
+ */
+export function startRevalidationCooldown(): void {
+  // Clear any existing timeout in case multiple revalidations happen
+  // in quick succession.
+  if (revalidationCooldownTimeoutHandle !== null) {
+    clearTimeout(revalidationCooldownTimeoutHandle)
+  }
+
+  // Schedule the cooldown to expire after the delay.
+  revalidationCooldownTimeoutHandle = setTimeout(() => {
+    revalidationCooldownTimeoutHandle = null
+    // Retry the prefetch queue now that the cooldown has expired.
+    ensureWorkIsScheduled()
+  }, REVALIDATION_COOLDOWN_MS)
+}
 
 export type IncludeDynamicData = null | 'full' | 'dynamic'
 
@@ -351,23 +371,6 @@ function ensureWorkIsScheduled() {
 }
 
 /**
- * Schedules a retry of the task queue after the revalidation cooldown expires.
- * This ensures we don't prefetch stale data from CDN caches that haven't
- * propagated yet.
- */
-function scheduleRetryAfterRevalidationCooldown(
-  remainingCooldown: number
-): void {
-  if (!didScheduleCooldownTimeout) {
-    didScheduleCooldownTimeout = true
-    setTimeout(() => {
-      didScheduleCooldownTimeout = false
-      ensureWorkIsScheduled()
-    }, remainingCooldown)
-  }
-}
-
-/**
  * Checks if we've exceeded the maximum number of concurrent prefetch requests,
  * to avoid saturating the browser's internal network queue. This is a
  * cooperative limit — prefetch tasks should check this before issuing
@@ -376,18 +379,13 @@ function scheduleRetryAfterRevalidationCooldown(
  * Also checks if we're within the revalidation cooldown window, during which
  * prefetch requests are delayed to allow CDN cache propagation.
  */
-function hasNetworkBandwidth(now: number, task: PrefetchTask): boolean {
+function hasNetworkBandwidth(task: PrefetchTask): boolean {
   // Check if we're within the revalidation cooldown window
-  const lastRevalidation = getLastRevalidationTimestamp()
-  if (lastRevalidation !== null) {
-    const timeSinceRevalidation = now - lastRevalidation
-    if (timeSinceRevalidation < REVALIDATION_COOLDOWN_MS) {
-      // We're within the cooldown window. Schedule a retry after the cooldown
-      // expires, then return false to prevent prefetching.
-      const remainingCooldown = REVALIDATION_COOLDOWN_MS - timeSinceRevalidation
-      scheduleRetryAfterRevalidationCooldown(remainingCooldown)
-      return false
-    }
+  if (revalidationCooldownTimeoutHandle !== null) {
+    // We're within the cooldown window. Return false to prevent prefetching.
+    // When the cooldown expires, the timeout will call ensureWorkIsScheduled()
+    // to retry the queue.
+    return false
   }
 
   // TODO: Also check if there's an in-progress navigation. We should never
@@ -477,7 +475,7 @@ function processQueueInMicrotask() {
 
   // Process the task queue until we run out of network bandwidth.
   let task = heapPeek(taskHeap)
-  while (task !== null && hasNetworkBandwidth(now, task)) {
+  while (task !== null && hasNetworkBandwidth(task)) {
     task.cacheVersion = getCurrentCacheVersion()
 
     const exitStatus = pingRoute(now, task)
@@ -650,7 +648,7 @@ function pingRootRouteTree(
         return PrefetchTaskExitStatus.Done
       }
       // Recursively fill in the segment tree.
-      if (!hasNetworkBandwidth(now, task)) {
+      if (!hasNetworkBandwidth(task)) {
         // Stop prefetching segments until there's more bandwidth.
         return PrefetchTaskExitStatus.InProgress
       }
@@ -834,7 +832,7 @@ function pingSharedPartOfCacheComponentsTree(
   const newTreeChildren = newTree.slots
   if (newTreeChildren !== null) {
     for (const parallelRouteKey in newTreeChildren) {
-      if (!hasNetworkBandwidth(now, task)) {
+      if (!hasNetworkBandwidth(task)) {
         // Stop prefetching segments until there's more bandwidth.
         return PrefetchTaskExitStatus.InProgress
       }
@@ -930,7 +928,7 @@ function pingNewPartOfCacheComponentsTree(
   )
   pingStaticSegmentData(now, task, route, segment, task.key, tree)
   if (tree.slots !== null) {
-    if (!hasNetworkBandwidth(now, task)) {
+    if (!hasNetworkBandwidth(task)) {
       // Stop prefetching segments until there's more bandwidth.
       return PrefetchTaskExitStatus.InProgress
     }


### PR DESCRIPTION
After performing a router revalidation (ie in a server action, or calling router.refresh()), we currently immediately re-prefetch any links on the page to ensure that subsequent navigations will be able to see any changed data. This generally works fine when self-hosting/via `next start` because the same server that is responsible for writing to the cache also handles serving it. However, when Next.js deployed and fronted by an external cache handler/CDN (eg deployed to Vercel), it can take some time to propagate. On Vercel, the documented max amount of time is 300ms. To alleviate stale data that could come about as a result of this, we will wait 300ms before triggering the prefetch again. 