### PR TITLE
Add rendered search to router state

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -284,6 +284,7 @@ export function hydrate(
                 navigatedAt: initialTimestamp,
                 initialFlightData: initialRSCPayload.f,
                 initialCanonicalUrlParts: initialRSCPayload.c,
+                initialRenderedSearch: initialRSCPayload.q,
                 initialParallelRoutes: new Map(),
                 location: window.location,
               }),

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -9,6 +9,7 @@ import {
   type NavigateAction,
   ACTION_HMR_REFRESH,
   PrefetchKind,
+  type AppHistoryState,
 } from './router-reducer/router-reducer-types'
 import { reducer } from './router-reducer/router-reducer'
 import { startTransition } from 'react'
@@ -27,7 +28,6 @@ import type {
   PrefetchOptions,
 } from '../../shared/lib/app-router-context.shared-runtime'
 import { setLinkForCurrentNavigation, type LinkInstance } from './links'
-import type { FlightRouterState } from '../../shared/lib/app-router-types'
 import type { ClientInstrumentationHooks } from '../app-index'
 import type { GlobalErrorComponent } from './builtin/global-error'
 
@@ -305,7 +305,7 @@ export function dispatchNavigateAction(
 
 export function dispatchTraverseAction(
   href: string,
-  tree: FlightRouterState | undefined
+  historyState: AppHistoryState | undefined
 ) {
   const onRouterTransitionStart = getProfilingHookForOnNavigationStart()
   if (onRouterTransitionStart !== null) {
@@ -314,7 +314,7 @@ export function dispatchTraverseAction(
   dispatchAppRouterAction({
     type: ACTION_RESTORE,
     url: new URL(href),
-    tree,
+    historyState,
   })
 }
 

--- a/packages/next/src/client/components/router-reducer/aliased-prefetch-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/aliased-prefetch-navigations.ts
@@ -31,6 +31,7 @@ export function handleAliasedPrefetchEntry(
   state: ReadonlyReducerState,
   flightData: string | NormalizedFlightData[],
   url: URL,
+  renderedSearch: string,
   mutable: Mutable
 ) {
   let currentTree = state.tree
@@ -140,6 +141,7 @@ export function handleAliasedPrefetchEntry(
   }
 
   mutable.patchedTree = currentTree
+  mutable.renderedSearch = renderedSearch
   mutable.cache = currentCache
   mutable.canonicalUrl = href
   mutable.hashFragment = url.hash

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.test.tsx
@@ -38,6 +38,7 @@ describe('createInitialRouterState', () => {
       navigatedAt,
       initialFlightData: [[initialTree, ['', children, {}, null]]],
       initialCanonicalUrlParts: initialCanonicalUrl.split('/'),
+      initialRenderedSearch: '',
       initialParallelRoutes,
       location: new URL('/linking', 'https://localhost') as any,
     })
@@ -46,6 +47,7 @@ describe('createInitialRouterState', () => {
       navigatedAt,
       initialFlightData: [[initialTree, ['', children, {}, null]]],
       initialCanonicalUrlParts: initialCanonicalUrl.split('/'),
+      initialRenderedSearch: '',
       initialParallelRoutes,
       location: new URL('/linking', 'https://localhost') as any,
     })
@@ -102,6 +104,7 @@ describe('createInitialRouterState', () => {
     const expected: ReturnType<typeof createInitialRouterState> = {
       tree: initialTree,
       canonicalUrl: initialCanonicalUrl,
+      renderedSearch: '',
       pushRef: {
         pendingPush: false,
         mpaNavigation: false,

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -6,12 +6,15 @@ import type {
 import { createHrefFromUrl } from './create-href-from-url'
 import { fillLazyItemsTillLeafWithHead } from './fill-lazy-items-till-leaf-with-head'
 import { extractPathFromFlightRouterState } from './compute-changed-path'
+
+import type { AppRouterState } from './router-reducer-types'
 import { addRefreshMarkerToActiveParallelSegments } from './refetch-inactive-parallel-segments'
 import { getFlightDataPartsFromPath } from '../../flight-data-helpers'
 
 export interface InitialRouterStateParameters {
   navigatedAt: number
   initialCanonicalUrlParts: string[]
+  initialRenderedSearch: string
   initialParallelRoutes: CacheNode['parallelRoutes']
   initialFlightData: FlightDataPath[]
   location: Location | null
@@ -21,9 +24,10 @@ export function createInitialRouterState({
   navigatedAt,
   initialFlightData,
   initialCanonicalUrlParts,
+  initialRenderedSearch,
   initialParallelRoutes,
   location,
-}: InitialRouterStateParameters) {
+}: InitialRouterStateParameters): AppRouterState {
   // When initialized on the server, the canonical URL is provided as an array of parts.
   // This is to ensure that when the RSC payload streamed to the client, crawlers don't interpret it
   // as a URL that should be crawled.
@@ -91,6 +95,7 @@ export function createInitialRouterState({
       segmentPaths: [],
     },
     canonicalUrl,
+    renderedSearch: initialRenderedSearch,
     nextUrl:
       // the || operator is intentional, the pathname can be an empty string
       (extractPathFromFlightRouterState(initialTree) || location?.pathname) ??

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -63,15 +63,21 @@ export interface FetchServerResponseOptions {
   readonly isHmrRefresh?: boolean
 }
 
-export type FetchServerResponseResult = {
-  flightData: NormalizedFlightData[] | string
-  canonicalUrl: URL | undefined
+type SpaFetchServerResponseResult = {
+  flightData: NormalizedFlightData[]
+  canonicalUrl: URL
   couldBeIntercepted: boolean
   prerendered: boolean
   postponed: boolean
   staleTime: number
   debugInfo: Array<any> | null
 }
+
+type MpaFetchServerResponseResult = string
+
+export type FetchServerResponseResult =
+  | MpaFetchServerResponseResult
+  | SpaFetchServerResponseResult
 
 export type RequestHeaders = {
   [RSC_HEADER]?: '1'
@@ -88,17 +94,7 @@ export type RequestHeaders = {
 }
 
 function doMpaNavigation(url: string): FetchServerResponseResult {
-  return {
-    flightData: urlToUrlWithoutFlightMarker(
-      new URL(url, location.origin)
-    ).toString(),
-    canonicalUrl: undefined,
-    couldBeIntercepted: false,
-    prerendered: false,
-    postponed: false,
-    staleTime: -1,
-    debugInfo: null,
-  }
+  return urlToUrlWithoutFlightMarker(new URL(url, location.origin)).toString()
 }
 
 let abortController = new AbortController()
@@ -197,7 +193,7 @@ export async function fetchServerResponse(
     )
 
     const responseUrl = urlToUrlWithoutFlightMarker(new URL(res.url))
-    const canonicalUrl = res.redirected ? responseUrl : undefined
+    const canonicalUrl = res.redirected ? responseUrl : url
 
     const contentType = res.headers.get('content-type') || ''
     const interception = !!res.headers.get('vary')?.includes(NEXT_URL)
@@ -266,8 +262,13 @@ export async function fetchServerResponse(
       return doMpaNavigation(res.url)
     }
 
+    const normalizedFlightData = normalizeFlightData(flightResponse.f)
+    if (typeof normalizedFlightData === 'string') {
+      return doMpaNavigation(normalizedFlightData)
+    }
+
     return {
-      flightData: normalizeFlightData(flightResponse.f),
+      flightData: normalizedFlightData,
       canonicalUrl: canonicalUrl,
       couldBeIntercepted: interception,
       prerendered: flightResponse.S,
@@ -286,15 +287,7 @@ export async function fetchServerResponse(
     // If fetch fails handle it like a mpa navigation
     // TODO-APP: Add a test for the case where a CORS request fails, e.g. external url redirect coming from the response.
     // See https://github.com/vercel/next.js/issues/43605#issuecomment-1451617521 for a reproduction.
-    return {
-      flightData: url.toString(),
-      canonicalUrl: undefined,
-      couldBeIntercepted: false,
-      prerendered: false,
-      postponed: false,
-      staleTime: -1,
-      debugInfo: null,
-    }
+    return url.toString()
   }
 }
 

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -36,7 +36,11 @@ import {
 } from '../../flight-data-helpers'
 import { getAppBuildId } from '../../app-build-id'
 import { setCacheBustingSearchParam } from './set-cache-busting-search-param'
-import { urlToUrlWithoutFlightMarker } from '../../route-params'
+import {
+  getRenderedSearch,
+  urlToUrlWithoutFlightMarker,
+} from '../../route-params'
+import type { NormalizedSearch } from '../segment-cache'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
@@ -66,6 +70,7 @@ export interface FetchServerResponseOptions {
 type SpaFetchServerResponseResult = {
   flightData: NormalizedFlightData[]
   canonicalUrl: URL
+  renderedSearch: NormalizedSearch
   couldBeIntercepted: boolean
   prerendered: boolean
   postponed: boolean
@@ -270,6 +275,7 @@ export async function fetchServerResponse(
     return {
       flightData: normalizedFlightData,
       canonicalUrl: canonicalUrl,
+      renderedSearch: getRenderedSearch(res),
       couldBeIntercepted: interception,
       prerendered: flightResponse.S,
       postponed,

--- a/packages/next/src/client/components/router-reducer/handle-mutable.ts
+++ b/packages/next/src/client/components/router-reducer/handle-mutable.ts
@@ -35,11 +35,8 @@ export function handleMutable(
 
   return {
     // Set href.
-    canonicalUrl: isNotUndefined(mutable.canonicalUrl)
-      ? mutable.canonicalUrl === state.canonicalUrl
-        ? state.canonicalUrl
-        : mutable.canonicalUrl
-      : state.canonicalUrl,
+    canonicalUrl: mutable.canonicalUrl ?? state.canonicalUrl,
+    renderedSearch: mutable.renderedSearch ?? state.renderedSearch,
     pushRef: {
       pendingPush: isNotUndefined(mutable.pendingPush)
         ? mutable.pendingPush

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -790,13 +790,14 @@ export function listenForDynamicRequest(
   responsePromise: Promise<FetchServerResponseResult>
 ) {
   responsePromise.then(
-    ({ flightData, debugInfo }: FetchServerResponseResult) => {
-      if (typeof flightData === 'string') {
+    (result: FetchServerResponseResult) => {
+      if (typeof result === 'string') {
         // Happens when navigating to page in `pages` from `app`. We shouldn't
         // get here because should have already handled this during
         // the prefetch.
         return
       }
+      const { flightData, debugInfo } = result
       for (const normalizedFlightData of flightData) {
         const {
           segmentPath,

--- a/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
@@ -1,4 +1,7 @@
-import { fetchServerResponse } from '../fetch-server-response'
+import {
+  fetchServerResponse,
+  type FetchServerResponseResult,
+} from '../fetch-server-response'
 import { createHrefFromUrl } from '../create-href-from-url'
 import { applyRouterStatePatchToTree } from '../apply-router-state-patch-to-tree'
 import { isNavigatingToNewRootLayout } from '../is-navigating-to-new-root-layout'
@@ -42,16 +45,18 @@ function hmrRefreshReducerImpl(
   })
 
   return cache.lazyData.then(
-    ({ flightData, canonicalUrl: canonicalUrlOverride }) => {
+    (result: FetchServerResponseResult) => {
       // Handle case when navigating to page in `pages` from `app`
-      if (typeof flightData === 'string') {
+      if (typeof result === 'string') {
         return handleExternalUrl(
           state,
           mutable,
-          flightData,
+          result,
           state.pushRef.pendingPush
         )
       }
+
+      const { flightData, canonicalUrl } = result
 
       // Remove cache.lazyData as it has been resolved at this point.
       cache.lazyData = null
@@ -88,13 +93,6 @@ function hmrRefreshReducerImpl(
           )
         }
 
-        const canonicalUrlOverrideHref = canonicalUrlOverride
-          ? createHrefFromUrl(canonicalUrlOverride)
-          : undefined
-
-        if (canonicalUrlOverride) {
-          mutable.canonicalUrl = canonicalUrlOverrideHref
-        }
         const applied = applyFlightData(
           navigatedAt,
           currentCache,
@@ -108,7 +106,7 @@ function hmrRefreshReducerImpl(
         }
 
         mutable.patchedTree = newTree
-        mutable.canonicalUrl = href
+        mutable.canonicalUrl = createHrefFromUrl(canonicalUrl)
 
         currentTree = newTree
       }

--- a/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/hmr-refresh-reducer.ts
@@ -56,7 +56,7 @@ function hmrRefreshReducerImpl(
         )
       }
 
-      const { flightData, canonicalUrl } = result
+      const { flightData, canonicalUrl, renderedSearch } = result
 
       // Remove cache.lazyData as it has been resolved at this point.
       cache.lazyData = null
@@ -106,6 +106,7 @@ function hmrRefreshReducerImpl(
         }
 
         mutable.patchedTree = newTree
+        mutable.renderedSearch = renderedSearch
         mutable.canonicalUrl = createHrefFromUrl(canonicalUrl)
 
         currentTree = newTree

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -108,6 +108,7 @@ function handleNavigationResult(
       // Received a new result.
       mutable.cache = result.data.cacheNode
       mutable.patchedTree = result.data.flightRouterState
+      mutable.renderedSearch = result.data.renderedSearch
       mutable.canonicalUrl = result.data.canonicalUrl
       mutable.scrollableSegments = result.data.scrollableSegments
       mutable.shouldScroll = result.data.shouldScroll

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -1,4 +1,7 @@
-import { fetchServerResponse } from '../fetch-server-response'
+import {
+  fetchServerResponse,
+  type FetchServerResponseResult,
+} from '../fetch-server-response'
 import { createHrefFromUrl } from '../create-href-from-url'
 import { applyRouterStatePatchToTree } from '../apply-router-state-patch-to-tree'
 import { isNavigatingToNewRootLayout } from '../is-navigating-to-new-root-layout'
@@ -50,16 +53,18 @@ export function refreshReducer(
 
   const navigatedAt = Date.now()
   return cache.lazyData.then(
-    async ({ flightData, canonicalUrl: canonicalUrlOverride }) => {
+    async (result: FetchServerResponseResult) => {
       // Handle case when navigating to page in `pages` from `app`
-      if (typeof flightData === 'string') {
+      if (typeof result === 'string') {
         return handleExternalUrl(
           state,
           mutable,
-          flightData,
+          result,
           state.pushRef.pendingPush
         )
       }
+
+      const { flightData, canonicalUrl } = result
 
       // Remove cache.lazyData as it has been resolved at this point.
       cache.lazyData = null
@@ -99,13 +104,7 @@ export function refreshReducer(
           )
         }
 
-        const canonicalUrlOverrideHref = canonicalUrlOverride
-          ? createHrefFromUrl(canonicalUrlOverride)
-          : undefined
-
-        if (canonicalUrlOverride) {
-          mutable.canonicalUrl = canonicalUrlOverrideHref
-        }
+        mutable.canonicalUrl = createHrefFromUrl(canonicalUrl)
 
         // Handles case where prefetch only returns the router tree patch without rendered components.
         if (cacheNodeSeedData !== null) {

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -64,7 +64,7 @@ export function refreshReducer(
         )
       }
 
-      const { flightData, canonicalUrl } = result
+      const { flightData, canonicalUrl, renderedSearch } = result
 
       // Remove cache.lazyData as it has been resolved at this point.
       cache.lazyData = null
@@ -136,6 +136,7 @@ export function refreshReducer(
 
         mutable.cache = cache
         mutable.patchedTree = newTree
+        mutable.renderedSearch = renderedSearch
 
         currentTree = newTree
       }

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -6,12 +6,13 @@ import type {
 } from '../router-reducer-types'
 import { extractPathFromFlightRouterState } from '../compute-changed-path'
 import { updateCacheNodeOnPopstateRestoration } from '../ppr-navigations'
+import type { FlightRouterState } from '../../../../shared/lib/app-router-types'
 
 export function restoreReducer(
   state: ReadonlyReducerState,
   action: RestoreAction
 ): ReducerState {
-  const { url, tree } = action
+  const { url, historyState } = action
   const href = createHrefFromUrl(url)
   // This action is used to restore the router state from the history state.
   // However, it's possible that the history state no longer contains the `FlightRouterState`.
@@ -19,7 +20,15 @@ export function restoreReducer(
   // occurred before hydration, or if the user navigated to a hash using a regular anchor link,
   // the history state will not contain the `FlightRouterState`.
   // In this case, we'll continue to use the existing tree so the router doesn't get into an invalid state.
-  const treeToRestore = tree || state.tree
+  let treeToRestore: FlightRouterState | undefined
+  let renderedSearch: string | undefined
+  if (historyState) {
+    treeToRestore = historyState.tree
+    renderedSearch = historyState.renderedSearch
+  } else {
+    treeToRestore = state.tree
+    renderedSearch = state.renderedSearch
+  }
 
   const oldCache = state.cache
   const newCache = process.env.__NEXT_PPR
@@ -33,6 +42,7 @@ export function restoreReducer(
   return {
     // Set canonical url
     canonicalUrl: href,
+    renderedSearch,
     pushRef: {
       pendingPush: false,
       mpaNavigation: false,

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -33,7 +33,7 @@ export function serverPatchReducer(
     )
   }
 
-  const { flightData, canonicalUrl } = serverResponse
+  const { flightData, canonicalUrl, renderedSearch } = serverResponse
 
   let currentTree = state.tree
   let currentCache = state.cache
@@ -74,6 +74,7 @@ export function serverPatchReducer(
     applyFlightData(navigatedAt, currentCache, cache, normalizedFlightData)
 
     mutable.patchedTree = newTree
+    mutable.renderedSearch = renderedSearch
     mutable.cache = cache
 
     currentCache = cache

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -17,24 +17,23 @@ export function serverPatchReducer(
   state: ReadonlyReducerState,
   action: ServerPatchAction
 ): ReducerState {
-  const {
-    serverResponse: { flightData, canonicalUrl: canonicalUrlOverride },
-    navigatedAt,
-  } = action
+  const { serverResponse, navigatedAt } = action
 
   const mutable: Mutable = {}
 
   mutable.preserveCustomHistoryState = false
 
   // Handle case when navigating to page in `pages` from `app`
-  if (typeof flightData === 'string') {
+  if (typeof serverResponse === 'string') {
     return handleExternalUrl(
       state,
       mutable,
-      flightData,
+      serverResponse,
       state.pushRef.pendingPush
     )
   }
+
+  const { flightData, canonicalUrl } = serverResponse
 
   let currentTree = state.tree
   let currentCache = state.cache
@@ -69,13 +68,7 @@ export function serverPatchReducer(
       )
     }
 
-    const canonicalUrlOverrideHref = canonicalUrlOverride
-      ? createHrefFromUrl(canonicalUrlOverride)
-      : undefined
-
-    if (canonicalUrlOverrideHref) {
-      mutable.canonicalUrl = canonicalUrlOverrideHref
-    }
+    mutable.canonicalUrl = createHrefFromUrl(canonicalUrl)
 
     const cache: CacheNode = createEmptyCacheNode()
     applyFlightData(navigatedAt, currentCache, cache, normalizedFlightData)

--- a/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
+++ b/packages/next/src/client/components/router-reducer/refetch-inactive-parallel-segments.ts
@@ -74,8 +74,9 @@ async function refreshInactiveParallelSegmentsImpl({
         flightRouterState: [rootTree[0], rootTree[1], rootTree[2], 'refetch'],
         nextUrl: includeNextUrl ? state.nextUrl : null,
       }
-    ).then(({ flightData }) => {
-      if (typeof flightData !== 'string') {
+    ).then((result) => {
+      if (typeof result !== 'string') {
+        const { flightData } = result
         for (const flightDataPath of flightData) {
           // we only pass the new cache as this function is called after clearing the router cache
           // and filling in the new page data from the server. Meaning the existing cache is actually the cache that's
@@ -88,7 +89,7 @@ async function refreshInactiveParallelSegmentsImpl({
           )
         }
       } else {
-        // When flightData is a string, it suggests that the server response should have triggered an MPA navigation
+        // When result is a string, it suggests that the server response should have triggered an MPA navigation
         // I'm not 100% sure of this decision, but it seems unlikely that we'd want to introduce a redirect side effect
         // when refreshing on-screen data, so handling this has been ommitted.
       }

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -25,6 +25,7 @@ export type RouterChangeByServerResponse = ({
 export interface Mutable {
   mpaNavigation?: boolean
   patchedTree?: FlightRouterState
+  renderedSearch?: string
   canonicalUrl?: string
   scrollableSegments?: FlightSegmentPath[]
   pendingPush?: boolean
@@ -122,7 +123,12 @@ export interface NavigateAction {
 export interface RestoreAction {
   type: typeof ACTION_RESTORE
   url: URL
-  tree: FlightRouterState | undefined
+  historyState: AppHistoryState | undefined
+}
+
+export type AppHistoryState = {
+  tree: FlightRouterState
+  renderedSearch: string
 }
 
 /**
@@ -219,6 +225,7 @@ export type AppRouterState = {
    * - This is the url you see in the browser.
    */
   canonicalUrl: string
+  renderedSearch: string
   /**
    * The underlying "url" representing the UI state, which is used for intercepting routes.
    */

--- a/packages/next/src/client/components/segment-cache-impl/navigation.ts
+++ b/packages/next/src/client/components/segment-cache-impl/navigation.ts
@@ -15,7 +15,7 @@ import {
   listenForDynamicRequest,
   type Task as PPRNavigationTask,
 } from '../router-reducer/ppr-navigations'
-import { createHrefFromUrl as createCanonicalUrl } from '../router-reducer/create-href-from-url'
+import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
 import {
   EntryStatus,
   readRouteCacheEntry,
@@ -431,23 +431,19 @@ async function navigateDynamicallyWithNoPrefetch(
     flightRouterState: currentFlightRouterState,
     nextUrl,
   })
-  const {
-    flightData,
-    canonicalUrl: canonicalUrlOverride,
-    debugInfo: debugInfoFromResponse,
-  } = await promiseForDynamicServerResponse
-
-  if (debugInfoFromResponse !== null) {
-    collectedDebugInfo.push(...debugInfoFromResponse)
-  }
-
-  if (typeof flightData === 'string') {
+  const result = await promiseForDynamicServerResponse
+  if (typeof result === 'string') {
     // This is an MPA navigation.
-    const newUrl = flightData
+    const newUrl = result
     return {
       tag: NavigationResultTag.MPA,
       data: newUrl,
     }
+  }
+
+  const { flightData, canonicalUrl, debugInfo: debugInfoFromResponse } = result
+  if (debugInfoFromResponse !== null) {
+    collectedDebugInfo.push(...debugInfoFromResponse)
   }
 
   // Since the response format of dynamic requests and prefetches is slightly
@@ -463,10 +459,6 @@ async function navigateDynamicallyWithNoPrefetch(
   const prefetchSeedData = null
   const prefetchHead = null
   const isPrefetchHeadPartial = true
-
-  const canonicalUrl = createCanonicalUrl(
-    canonicalUrlOverride ? canonicalUrlOverride : url
-  )
 
   // Now we proceed exactly as we would for normal navigation.
   const scrollableSegments: Array<FlightSegmentPath> = []
@@ -501,7 +493,7 @@ async function navigateDynamicallyWithNoPrefetch(
     return navigationTaskToResult(
       task,
       currentCacheNode,
-      canonicalUrl,
+      createHrefFromUrl(canonicalUrl),
       scrollableSegments,
       shouldScroll,
       hash
@@ -512,7 +504,7 @@ async function navigateDynamicallyWithNoPrefetch(
   return {
     tag: NavigationResultTag.NoOp,
     data: {
-      canonicalUrl,
+      canonicalUrl: createHrefFromUrl(canonicalUrl),
       shouldScroll,
     },
   }

--- a/packages/next/src/client/components/segment-cache-impl/navigation.ts
+++ b/packages/next/src/client/components/segment-cache-impl/navigation.ts
@@ -48,6 +48,7 @@ type SuccessfulNavigationResult = {
     flightRouterState: FlightRouterState
     cacheNode: CacheNode
     canonicalUrl: string
+    renderedSearch: string
     scrollableSegments: Array<FlightSegmentPath>
     shouldScroll: boolean
     hash: string
@@ -123,6 +124,7 @@ export function navigate(
     const prefetchHead = route.head
     const isPrefetchHeadPartial = route.isHeadPartial
     const newCanonicalUrl = route.canonicalUrl
+    const renderedSearch = route.renderedSearch
     return navigateUsingPrefetchedRouteTree(
       now,
       url,
@@ -136,6 +138,7 @@ export function navigate(
       prefetchHead,
       isPrefetchHeadPartial,
       newCanonicalUrl,
+      renderedSearch,
       shouldScroll,
       url.hash
     )
@@ -164,6 +167,7 @@ export function navigate(
       const prefetchHead = optimisticRoute.head
       const isPrefetchHeadPartial = optimisticRoute.isHeadPartial
       const newCanonicalUrl = optimisticRoute.canonicalUrl
+      const newRenderedSearch = optimisticRoute.renderedSearch
       return navigateUsingPrefetchedRouteTree(
         now,
         url,
@@ -177,6 +181,7 @@ export function navigate(
         prefetchHead,
         isPrefetchHeadPartial,
         newCanonicalUrl,
+        newRenderedSearch,
         shouldScroll,
         url.hash
       )
@@ -218,6 +223,7 @@ function navigateUsingPrefetchedRouteTree(
   prefetchHead: HeadData | null,
   isPrefetchHeadPartial: boolean,
   canonicalUrl: string,
+  renderedSearch: string,
   shouldScroll: boolean,
   hash: string
 ): SuccessfulNavigationResult | NoOpNavigationResult | MPANavigationResult {
@@ -259,6 +265,7 @@ function navigateUsingPrefetchedRouteTree(
       task,
       currentCacheNode,
       canonicalUrl,
+      renderedSearch,
       scrollableSegments,
       shouldScroll,
       hash
@@ -279,6 +286,7 @@ function navigationTaskToResult(
   task: PPRNavigationTask,
   currentCacheNode: CacheNode,
   canonicalUrl: string,
+  renderedSearch: string,
   scrollableSegments: Array<FlightSegmentPath>,
   shouldScroll: boolean,
   hash: string
@@ -299,6 +307,7 @@ function navigationTaskToResult(
       flightRouterState,
       cacheNode: newCacheNode !== null ? newCacheNode : currentCacheNode,
       canonicalUrl,
+      renderedSearch,
       scrollableSegments,
       shouldScroll,
       hash,
@@ -441,7 +450,12 @@ async function navigateDynamicallyWithNoPrefetch(
     }
   }
 
-  const { flightData, canonicalUrl, debugInfo: debugInfoFromResponse } = result
+  const {
+    flightData,
+    canonicalUrl,
+    renderedSearch,
+    debugInfo: debugInfoFromResponse,
+  } = result
   if (debugInfoFromResponse !== null) {
     collectedDebugInfo.push(...debugInfoFromResponse)
   }
@@ -494,6 +508,7 @@ async function navigateDynamicallyWithNoPrefetch(
       task,
       currentCacheNode,
       createHrefFromUrl(canonicalUrl),
+      renderedSearch,
       scrollableSegments,
       shouldScroll,
       hash

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -262,6 +262,8 @@ export type InitialRSCPayload = {
   b: string
   /** initialCanonicalUrlParts */
   c: string[]
+  /** initialRenderedSearch */
+  q: string
   /** couldBeIntercepted */
   i: boolean
   /** initialFlightData */


### PR DESCRIPTION
The "rendered search" represents the search params that are observed on the server, i.e. the ones passed as the `searchParams` prop to page segments. They may differ from the search params in the browser's URL bar, if the server performed a rewrite. This case corresponds to the x-nextjs-rewritten-query header.

If a page segment is marked with `"use client"`, we can use this value to compute the search params on the client instead of having to fetch them from the server. This part is implemented in #84883.