### PR TITLE
[turbopack] Allow withRspack to work even if you already have NEXT_RSPACK set

### DIFF
--- a/packages/next-rspack/index.js
+++ b/packages/next-rspack/index.js
@@ -1,10 +1,10 @@
 Error.stackTraceLimit = 100
 module.exports = function withRspack(config) {
-  if (process.env.NEXT_RSPACK === 'true') {
+  if (process.env.NEXT_RSPACK) {
     // we have already been called.  This can happen when using build workers.
     return config
   }
-  if (!process.env.TURBOPACK || process.env.TURBOPACK === 'auto') {
+  if (process.env.TURBOPACK === 'auto') {
     delete process.env.TURBOPACK
     process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent'
     process.env.NEXT_RSPACK = 'true'


### PR DESCRIPTION
Fix an issue where if a user set `NEXT_RSPACK` as an environment variable then `next` would think it was using rspack but `withRspack` would think it was using `--webpack`.   The issue is that the idempotency check was too strict.

This partially reverts https://github.com/vercel/next.js/pull/84885 


Closes PACK-5704