### PR TITLE
Show relative path from cwd for Proxy Middleware file conflict error

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -881,5 +881,6 @@
   "880": "Config options `experimental.proxyPrefetch` and `experimental.middlewarePrefetch` cannot be set at the same time. Please use `experimental.proxyPrefetch` instead.",
   "881": "Invalid render stage: %s",
   "882": "The %s file \"./%s\" must export a function named \\`%s\\` or a default function.",
-  "883": "The %s file \"%s\" must export a function named \\`%s\\` or a default function."
+  "883": "The %s file \"%s\" must export a function named \\`%s\\` or a default function.",
+  "884": "Both %s file \"./%s\" and %s file \"./%s\" are detected. Please use \"./%s\" only."
 }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -391,8 +391,8 @@ async function startWatcher(
         sortByPageExts(nextConfig.pageExtensions)
       )
 
-      let hasMiddlewareFile = false
-      let hasProxyFile = false
+      let proxyFilePath: string | undefined
+      let middlewareFilePath: string | undefined
 
       for (const fileName of sortedKnownFiles) {
         if (
@@ -408,16 +408,18 @@ async function startWatcher(
           fileDir === dir || fileDir === path.join(dir, 'src')
 
         if (isAtConventionLevel && fileBaseName === MIDDLEWARE_FILENAME) {
-          hasMiddlewareFile = true
+          middlewareFilePath = fileName
         }
         if (isAtConventionLevel && fileBaseName === PROXY_FILENAME) {
-          hasProxyFile = true
+          proxyFilePath = fileName
         }
 
-        if (hasMiddlewareFile) {
-          if (hasProxyFile) {
+        if (middlewareFilePath) {
+          if (proxyFilePath) {
+            const cwd = process.cwd()
+
             throw new Error(
-              `Both "${MIDDLEWARE_FILENAME}" and "${PROXY_FILENAME}" files are detected. Please use "${PROXY_FILENAME}" instead.`
+              `Both ${MIDDLEWARE_FILENAME} file "./${path.relative(cwd, middlewareFilePath)}" and ${PROXY_FILENAME} file "./${path.relative(cwd, proxyFilePath)}" are detected. Please use "./${path.relative(cwd, proxyFilePath)}" only.`
             )
           }
           Log.warnOnce(

--- a/test/e2e/app-dir/proxy-with-middleware/proxy-with-middleware.test.ts
+++ b/test/e2e/app-dir/proxy-with-middleware/proxy-with-middleware.test.ts
@@ -12,16 +12,15 @@ describe('proxy-with-middleware', () => {
   }
 
   it('should error when both middleware and proxy files are detected', async () => {
+    const message =
+      'Both middleware file "./middleware.ts" and proxy file "./proxy.ts" are detected. Please use "./proxy.ts" only.'
+
     if (isNextDev) {
       await next.start().catch(() => {})
-      expect(next.cliOutput).toContain(
-        'Both "middleware" and "proxy" files are detected. Please use "proxy" instead.'
-      )
+      expect(next.cliOutput).toContain(message)
     } else {
       const { cliOutput } = await next.build()
-      expect(cliOutput).toContain(
-        'Both "middleware" and "proxy" files are detected. Please use "proxy" instead.'
-      )
+      expect(cliOutput).toContain(message)
     }
   })
 })


### PR DESCRIPTION
Show the relative path from cwd when a Proxy Middleware file conflict error occurs to better inform the users. Also, good for double-checking the detection logic.

Closes NEXT-4740