### PR TITLE
Fix printing phase durations for non-tty terminals

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -210,7 +210,7 @@ import { turbopackBuild } from './turbopack-build'
 import { isFileSystemCacheEnabledForBuild } from '../shared/lib/turbopack/utils'
 import { inlineStaticEnv } from '../lib/inline-static-env'
 import { populateStaticEnv } from '../lib/static-env'
-import { durationToString, hrtimeDurationToString } from './duration-to-string'
+import { durationToString } from './duration-to-string'
 import { traceGlobals } from '../trace/shared'
 import { extractNextErrorCode } from '../lib/error-telemetry-utils'
 import { runAfterProductionCompile } from './after-production-compile'
@@ -1876,7 +1876,6 @@ export default async function build(
         traceMemoryUsage('Finished type checking', nextBuildSpan)
       }
 
-      const collectingPageDataStart = process.hrtime()
       const postCompileSpinner = createSpinner('Collecting page data')
 
       const buildManifestPath = path.join(distDir, BUILD_MANIFEST)
@@ -2438,10 +2437,6 @@ export default async function build(
       })
 
       if (postCompileSpinner) {
-        const collectingPageDataEnd = process.hrtime(collectingPageDataStart)
-        postCompileSpinner.setText(
-          `Collecting page data in ${hrtimeDurationToString(collectingPageDataEnd)}`
-        )
         postCompileSpinner.stopAndPersist()
       }
       traceMemoryUsage('Finished collecting page data', nextBuildSpan)
@@ -3950,12 +3945,9 @@ export default async function build(
           .traceAsyncFn(() => writeManifest(routesManifestPath, routesManifest))
       }
 
-      const finalizingPageOptimizationStart = process.hrtime()
       const postBuildSpinner = createSpinner('Finalizing page optimization')
       let buildTracesSpinner
-      let buildTracesStart
       if (buildTracesPromise) {
-        buildTracesStart = process.hrtime()
         buildTracesSpinner = createSpinner('Collecting build traces')
       }
 
@@ -4107,14 +4099,7 @@ export default async function build(
       await buildTracesPromise
 
       if (buildTracesSpinner) {
-        if (buildTracesStart) {
-          const buildTracesEnd = process.hrtime(buildTracesStart)
-          buildTracesSpinner.setText(
-            `Collecting build traces in ${hrtimeDurationToString(buildTracesEnd)}`
-          )
-        }
         buildTracesSpinner.stopAndPersist()
-        buildTracesSpinner = undefined
       }
 
       if (isCompileMode) {
@@ -4191,12 +4176,6 @@ export default async function build(
       }
 
       if (postBuildSpinner) {
-        const finalizingPageOptimizationEnd = process.hrtime(
-          finalizingPageOptimizationStart
-        )
-        postBuildSpinner.setText(
-          `Finalizing page optimization in ${hrtimeDurationToString(finalizingPageOptimizationEnd)}`
-        )
         postBuildSpinner.stopAndPersist()
       }
       console.log()

--- a/packages/next/src/build/progress.ts
+++ b/packages/next/src/build/progress.ts
@@ -53,7 +53,7 @@ export const createProgress = (total: number, label: string) => {
     // - per fully generated segment, or
     // - per minute
     // when not showing the spinner
-    if (!process.env.IS_TTY) {
+    if (!process.stdout.isTTY) {
       currentSegmentCount++
 
       if (currentSegmentCount === currentSegmentTotal) {

--- a/packages/next/src/build/progress.ts
+++ b/packages/next/src/build/progress.ts
@@ -68,17 +68,15 @@ export const createProgress = (total: number, label: string) => {
 
     const isFinished = curProgress === total
     const message = `${label} (${curProgress}/${total})`
-    if (progressSpinner && !isFinished) {
-      progressSpinner.setText(message)
-    } else {
-      progressSpinner.setText(message)
-      progressSpinner?.stopAndPersist()
+    progressSpinner.setText(message)
+    if (isFinished) {
+      progressSpinner.stopAndPersist()
     }
   }
 
   const clear = () => {
     if (
-      progressSpinner &&
+      process.stdout.isTTY &&
       // Ensure only reset and clear once to avoid set operation overflow in ora
       progressSpinner.isSpinning
     ) {

--- a/packages/next/src/build/progress.ts
+++ b/packages/next/src/build/progress.ts
@@ -53,7 +53,7 @@ export const createProgress = (total: number, label: string) => {
     // - per fully generated segment, or
     // - per minute
     // when not showing the spinner
-    if (!progressSpinner) {
+    if (!process.env.IS_TTY) {
       currentSegmentCount++
 
       if (currentSegmentCount === currentSegmentTotal) {

--- a/packages/next/src/build/progress.ts
+++ b/packages/next/src/build/progress.ts
@@ -49,6 +49,10 @@ export const createProgress = (total: number, label: string) => {
       interval: 200,
     },
   })
+  if (process.stdout.isTTY) {
+    // createSpinner logs the initial state, but doesn't do anything afterwards anyway.
+    progressSpinner = undefined
+  }
 
   const run = () => {
     curProgress++
@@ -72,7 +76,7 @@ export const createProgress = (total: number, label: string) => {
 
     const isFinished = curProgress === total
     const message = `${label} (${curProgress}/${total})`
-    if (process.stdout.isTTY && progressSpinner && !isFinished) {
+    if (progressSpinner && !isFinished) {
       progressSpinner.setText(message)
     } else {
       progressSpinner?.stop()
@@ -87,7 +91,6 @@ export const createProgress = (total: number, label: string) => {
 
   const clear = () => {
     if (
-      process.stdout.isTTY &&
       progressSpinner &&
       // Ensure only reset and clear once to avoid set operation overflow in ora
       progressSpinner.isSpinning

--- a/packages/next/src/build/progress.ts
+++ b/packages/next/src/build/progress.ts
@@ -72,7 +72,7 @@ export const createProgress = (total: number, label: string) => {
 
     const isFinished = curProgress === total
     const message = `${label} (${curProgress}/${total})`
-    if (progressSpinner && !isFinished) {
+    if (process.stdout.isTTY && progressSpinner && !isFinished) {
       progressSpinner.setText(message)
     } else {
       progressSpinner?.stop()
@@ -87,6 +87,7 @@ export const createProgress = (total: number, label: string) => {
 
   const clear = () => {
     if (
+      process.stdout.isTTY &&
       progressSpinner &&
       // Ensure only reset and clear once to avoid set operation overflow in ora
       progressSpinner.isSpinning

--- a/packages/next/src/build/progress.ts
+++ b/packages/next/src/build/progress.ts
@@ -1,5 +1,3 @@
-import * as Log from '../build/output/log'
-import { hrtimeDurationToString } from './duration-to-string'
 import createSpinner from './spinner'
 
 function divideSegments(number: number, segments: number): number[] {
@@ -16,8 +14,6 @@ function divideSegments(number: number, segments: number): number[] {
 }
 
 export const createProgress = (total: number, label: string) => {
-  const progressStart = process.hrtime()
-
   const segments = divideSegments(total, 4)
 
   if (total === 0) {
@@ -49,10 +45,6 @@ export const createProgress = (total: number, label: string) => {
       interval: 200,
     },
   })
-  if (process.stdout.isTTY) {
-    // createSpinner logs the initial state, but doesn't do anything afterwards anyway.
-    progressSpinner = undefined
-  }
 
   const run = () => {
     curProgress++
@@ -79,13 +71,8 @@ export const createProgress = (total: number, label: string) => {
     if (progressSpinner && !isFinished) {
       progressSpinner.setText(message)
     } else {
-      progressSpinner?.stop()
-      if (isFinished) {
-        const progressEnd = process.hrtime(progressStart)
-        Log.event(`${message} in ${hrtimeDurationToString(progressEnd)}`)
-      } else {
-        Log.info(`${message} ${process.stdout.isTTY ? '\n' : '\r'}`)
-      }
+      progressSpinner.setText(message)
+      progressSpinner?.stopAndPersist()
     }
   }
 

--- a/packages/next/src/build/spinner.ts
+++ b/packages/next/src/build/spinner.ts
@@ -80,7 +80,8 @@ export default function createSpinner(
     }
     return spinner
   } else {
-    logFn(prefixText ? prefixText + '...' : text)
+    text = ` ${Log.prefixes.info} ${text} `
+    logFn(text)
 
     // @ts-ignore
     let spinner = {
@@ -89,14 +90,13 @@ export default function createSpinner(
       text: '',
       clear: '',
       setText(newText: string) {
-        logFn(` ${Log.prefixes.info} ${newText} `)
+        text = ` ${Log.prefixes.info} ${newText}`
+        logFn(text)
       },
       stop: () => spinner,
       stopAndPersist: () => {
         const duration = process.hrtime.bigint() - progressStart
-        logFn(
-          ` ${Log.prefixes.event} ${text} in ${hrtimeBigIntDurationToString(duration)}`
-        )
+        logFn(`${text} in ${hrtimeBigIntDurationToString(duration)}`)
         return spinner!
       },
     } as ora.Ora & { setText: (text: string) => void }

--- a/packages/next/src/build/spinner.ts
+++ b/packages/next/src/build/spinner.ts
@@ -1,6 +1,6 @@
 import ora from 'next/dist/compiled/ora'
 import * as Log from './output/log'
-import { hrtimeDurationToString } from './duration-to-string'
+import { hrtimeBigIntDurationToString } from './duration-to-string'
 
 const dotsSpinner = {
   frames: ['.', '..', '...'],
@@ -13,7 +13,7 @@ export default function createSpinner(
   logFn: (...data: any[]) => void = console.log
 ) {
   let prefixText = ` ${Log.prefixes.info} ${text} `
-  const progressStart = process.hrtime()
+  const progressStart = process.hrtime.bigint()
 
   if (process.stdout.isTTY) {
     let spinner = ora({
@@ -70,8 +70,8 @@ export default function createSpinner(
       return spinner
     }
     spinner.stopAndPersist = () => {
-      const progressEnd = process.hrtime(progressStart)
-      text = `${text} in ${hrtimeDurationToString(progressEnd)}`
+      const duration = process.hrtime.bigint() - progressStart
+      text = `${text} in ${hrtimeBigIntDurationToString(duration)}`
       prefixText = ` ${Log.prefixes.info} ${text} `
       spinner.prefixText = prefixText
       origStopAndPersist()
@@ -93,9 +93,9 @@ export default function createSpinner(
       },
       stop: () => spinner,
       stopAndPersist: () => {
-        const progressEnd = process.hrtime(progressStart)
+        const duration = process.hrtime.bigint() - progressStart
         logFn(
-          ` ${Log.prefixes.event} ${text} in ${hrtimeDurationToString(progressEnd)}`
+          ` ${Log.prefixes.event} ${text} in ${hrtimeBigIntDurationToString(duration)}`
         )
         return spinner!
       },

--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -7,7 +7,6 @@ import { Worker } from '../lib/worker'
 import createSpinner from './spinner'
 import { eventTypeCheckCompleted } from '../telemetry/events'
 import isError from '../lib/is-error'
-import { hrtimeDurationToString } from './duration-to-string'
 
 /**
  * typescript will be loaded in "next/lib/verify-typescript-setup" and
@@ -127,11 +126,7 @@ export async function startTypeChecking({
       )
 
     if (typeCheckingSpinner) {
-      typeCheckingSpinner.stop()
-
-      createSpinner(
-        `Finished TypeScript${ignoreTypeScriptErrors ? ' config validation' : ''} in ${hrtimeDurationToString(typeCheckEnd)}`
-      )?.stopAndPersist()
+      typeCheckingSpinner.stopAndPersist()
     }
 
     if (!ignoreTypeScriptErrors && verifyResult) {

--- a/test/e2e/app-dir/cache-components-errors/cache-components-console-patch.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-console-patch.test.ts
@@ -62,8 +62,7 @@ describe('Cache Components Errors', () => {
           if (isTurbopack) {
             expect(output).toMatchInlineSnapshot(`
              "[<timestamp>] This is a console log from a server component page
-             [<timestamp>] This is a console log from a server component page
-             [<timestamp>]"
+             [<timestamp>] This is a console log from a server component page"
             `)
           } else {
             expect(output).toMatchInlineSnapshot(`

--- a/test/e2e/app-dir/cache-components-errors/cache-components-console-patch.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-console-patch.test.ts
@@ -67,11 +67,12 @@ describe('Cache Components Errors', () => {
             `)
           } else {
             expect(output).toMatchInlineSnapshot(`
-                        "[<timestamp>] This is a console log from a server component page
-                        [<timestamp>] This is a console log from a server component page
-                        [<timestamp>]    Collecting build traces ...
-                        [<timestamp>]"
-                      `)
+             "[<timestamp>] This is a console log from a server component page
+             [<timestamp>] This is a console log from a server component page
+             [<timestamp>]    Collecting build traces ...
+             [<timestamp>]  ✓ Collecting build traces in 3.1s
+             [<timestamp>]"
+            `)
           }
         })
       }

--- a/test/integration/polyfills/test/index.test.js
+++ b/test/integration/polyfills/test/index.test.js
@@ -51,8 +51,8 @@ describe('Polyfills', () => {
       it('should contain generated page count in output', async () => {
         expect(output).toContain('Generating static pages (0/5)')
         expect(output).toContain('Generating static pages (5/5)')
-        // we should only have 1 segment and the initial message logged out
-        expect(output.match(/Generating static pages/g).length).toBe(5)
+        // we should have 4 segment, the initial message, and the final one with time
+        expect(output.match(/Generating static pages/g).length).toBe(6)
       })
     }
   )

--- a/test/integration/polyfills/test/index.test.js
+++ b/test/integration/polyfills/test/index.test.js
@@ -51,7 +51,7 @@ describe('Polyfills', () => {
       it('should contain generated page count in output', async () => {
         expect(output).toContain('Generating static pages (0/5)')
         expect(output).toContain('Generating static pages (5/5)')
-        // we should have 4 segment, the initial message, and the final one with time
+        // we should have 4 segments, the initial message, and the final one with time
         expect(output.match(/Generating static pages/g).length).toBe(6)
       })
     }

--- a/test/production/app-dir/build-output-debug/index.test.ts
+++ b/test/production/app-dir/build-output-debug/index.test.ts
@@ -12,33 +12,36 @@ describe('next build --debug', () => {
     output = stripAnsi(next.cliOutput)
   })
 
-  const str = `
-
-
-Redirects
-┌ source: /:path+/
-├ destination: /:path+
-└ permanent: true
-
-┌ source: /redirects
-├ destination: /
-└ permanent: true
-
-
-Headers
-┌ source: /
-└ headers:
-  └ x-custom-headers: headers
-
-
-Rewrites
-┌ source: /rewrites
-└ destination: /
-
-
-Route (app)`
-
   it('should log Redirects above Route(app)', async () => {
-    expect(output).toContain(str)
+    let data = output
+      .slice(output.indexOf('Redirects\n'), output.indexOf('○  (Static)'))
+      .trim()
+
+    expect(data).toMatchInlineSnapshot(`
+     "Redirects
+     ┌ source: /:path+/
+     ├ destination: /:path+
+     └ permanent: true
+
+     ┌ source: /redirects
+     ├ destination: /
+     └ permanent: true
+
+
+     Headers
+     ┌ source: /
+     └ headers:
+       └ x-custom-headers: headers
+
+
+     Rewrites
+     ┌ source: /rewrites
+     └ destination: /
+
+
+     Route (app)
+     ┌ ○ /
+     └ ○ /_not-found"
+    `)
   })
 })

--- a/test/production/build-spinners/index.test.ts
+++ b/test/production/build-spinners/index.test.ts
@@ -144,7 +144,6 @@ describe('build-spinners', () => {
     let optimizedBuildIdx = -1
     let collectingPageDataIdx = -1
     let generatingStaticIdx = -1
-    let finalizingOptimization = -1
 
     // order matters so we check output from end to start
     for (let i = output.length - 1; i--; i >= 0) {
@@ -174,24 +173,15 @@ describe('build-spinners', () => {
       ) {
         generatingStaticIdx = i
       }
-
-      if (
-        finalizingOptimization === -1 &&
-        line.includes('Finalizing page optimization')
-      ) {
-        finalizingOptimization = i
-      }
     }
 
     expect(compiledIdx).not.toBe(-1)
     expect(optimizedBuildIdx).not.toBe(-1)
     expect(collectingPageDataIdx).not.toBe(-1)
     expect(generatingStaticIdx).not.toBe(-1)
-    expect(finalizingOptimization).not.toBe(-1)
 
     expect(optimizedBuildIdx).toBeLessThan(compiledIdx)
     expect(compiledIdx).toBeLessThan(collectingPageDataIdx)
     expect(collectingPageDataIdx).toBeLessThan(generatingStaticIdx)
-    expect(generatingStaticIdx).toBeLessThan(finalizingOptimization)
   })
 })

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -116,8 +116,8 @@ describe('Production Usage', () => {
     expect(next.cliOutput).toContain(
       `Generating static pages (${pageCount}/${pageCount})`
     )
-    // we should only have 4 segments and the initial message logged out
-    expect(next.cliOutput.match(/Generating static pages/g).length).toBe(5)
+    // we should have 4 segments, the initial message, and the final one with time
+    expect(next.cliOutput.match(/Generating static pages/g).length).toBe(6)
   })
 
   it('should output traces', async () => {


### PR DESCRIPTION
Previously, `Collecting build traces in 4.6s` wasn't print printed on CI (a non-interactive terminal)

This does slightly change the output, it's now this:

interactive (`pnpm next build bench/basic-app --webpack`):

```
   ▲ Next.js 16.0.0-canary.10 (webpack)

   Creating an optimized production build ...
 ✓ Compiled successfully in 1408.4ms
   Running TypeScript in 50.4ms   
   Collecting page data in 527.6ms   
   Generating static pages (3/3) in 323.2ms   
   Collecting build traces in 5.9s   
```

non-interactive (`pnpm next build bench/basic-app --webpack | cat`):

```
   ▲ Next.js 16.0.0-canary.10 (webpack)

   Creating an optimized production build ...
 ✓ Compiled successfully in 767.1ms
   Running TypeScript ...
 ✓ Running TypeScript in 42.3ms
   Collecting page data ...
 ✓ Collecting page data in 248.4ms
   Generating static pages (0/3) ...
   Generating static pages (1/3) 
   Generating static pages (2/3) 
 ✓ Generating static pages (3/3) in 327.0ms
   Finalizing page optimization ...
   Collecting build traces ...
 ✓ Collecting build traces in 4.6s
 ✓ Finalizing page optimization in 4.6s
```