### PR TITLE
[Cache Components] fix docs for cacheLife("seconds")

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/cacheLife.mdx
+++ b/docs/01-app/03-api-reference/04-functions/cacheLife.mdx
@@ -70,15 +70,15 @@ Next.js provides a set of named cache profiles modeled on various timescales. If
 
 However, we recommend always adding a cache profile when using the `use cache` directive to explicitly define caching behavior.
 
-| **Profile** | `stale`   | `revalidate` | `expire` | **Description**                                                          |
-| ----------- | --------- | ------------ | -------- | ------------------------------------------------------------------------ |
-| `default`   | 5 minutes | 15 minutes   | 1 year   | Default profile, suitable for content that doesn't need frequent updates |
-| `seconds`   | 0         | 1 second     | 1 second | For rapidly changing content requiring near real-time updates            |
-| `minutes`   | 5 minutes | 1 minute     | 1 hour   | For content that updates frequently within an hour                       |
-| `hours`     | 5 minutes | 1 hour       | 1 day    | For content that updates daily but can be slightly stale                 |
-| `days`      | 5 minutes | 1 day        | 1 week   | For content that updates weekly but can be a day old                     |
-| `weeks`     | 5 minutes | 1 week       | 30 days  | For content that updates monthly but can be a week old                   |
-| `max`       | 5 minutes | 30 days      | 1 year   | For very stable content that rarely needs updating                       |
+| **Profile** | `stale`    | `revalidate` | `expire` | **Description**                                                          |
+| ----------- | ---------- | ------------ | -------- | ------------------------------------------------------------------------ |
+| `default`   | 5 minutes  | 15 minutes   | 1 year   | Default profile, suitable for content that doesn't need frequent updates |
+| `seconds`   | 30 seconds | 1 second     | 1 minute | For rapidly changing content requiring near real-time updates            |
+| `minutes`   | 5 minutes  | 1 minute     | 1 hour   | For content that updates frequently within an hour                       |
+| `hours`     | 5 minutes  | 1 hour       | 1 day    | For content that updates daily but can be slightly stale                 |
+| `days`      | 5 minutes  | 1 day        | 1 week   | For content that updates weekly but can be a day old                     |
+| `weeks`     | 5 minutes  | 1 week       | 30 days  | For content that updates monthly but can be a week old                   |
+| `max`       | 5 minutes  | 30 days      | 1 year   | For very stable content that rarely needs updating                       |
 
 The string values used to reference cache profiles don't carry inherent meaning; instead they serve as semantic labels. This allows you to better understand and manage your cached content within your codebase.
 

--- a/packages/next/cache.d.ts
+++ b/packages/next/cache.d.ts
@@ -28,12 +28,12 @@ export function cacheLife(profile: 'default'): void
 /**
  * Cache this `"use cache"` for a timespan defined by the `"seconds"` profile.
  * ```
- *   stale:      0 seconds
+ *   stale:      30 seconds
  *   revalidate: 1 seconds
  *   expire:     1 minute
  * ```
  *
- * This cache may be stale on clients for 0 seconds before checking with the server.
+ * This cache may be stale on clients for 30 seconds before checking with the server.
  * If the server receives a new request after 1 second, start revalidating new values in the background.
  * If this entry has no traffic for 1 minute it will expire. The next request will recompute it.
  */

--- a/packages/next/cache.d.ts
+++ b/packages/next/cache.d.ts
@@ -29,7 +29,7 @@ export function cacheLife(profile: 'default'): void
  * Cache this `"use cache"` for a timespan defined by the `"seconds"` profile.
  * ```
  *   stale:      30 seconds
- *   revalidate: 1 seconds
+ *   revalidate: 1 second
  *   expire:     1 minute
  * ```
  *


### PR DESCRIPTION
Looks like this was missed in #82332, when we bumped the staletime to 30s.