### PR TITLE
Rename MiddlewareMatcher to ProxyMatcher

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -23,9 +23,8 @@ use next_core::{
     next_dynamic::NextDynamicTransition,
     next_edge::route_regex::get_named_middleware_regex,
     next_manifests::{
-        AppPathsManifest, BuildManifest, EdgeFunctionDefinition, MiddlewareMatcher,
-        MiddlewaresManifestV2, PagesManifest, Regions,
-        client_reference_manifest::ClientReferenceManifest,
+        AppPathsManifest, BuildManifest, EdgeFunctionDefinition, MiddlewaresManifestV2,
+        PagesManifest, ProxyMatcher, Regions, client_reference_manifest::ClientReferenceManifest,
     },
     next_server::{
         ServerContextType, get_server_module_options_context, get_server_resolve_options_context,
@@ -1561,7 +1560,7 @@ impl AppEndpoint {
                 if emit_manifests != EmitManifests::None {
                     // create middleware manifest
                     let named_regex = get_named_middleware_regex(&app_entry.pathname);
-                    let matchers = MiddlewareMatcher {
+                    let matchers = ProxyMatcher {
                         regexp: Some(named_regex.into()),
                         original_source: app_entry.pathname.clone(),
                         ..Default::default()

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -5,7 +5,7 @@ use next_core::{
     all_assets_from_entries,
     middleware::get_middleware_module,
     next_edge::entry::wrap_edge_entry,
-    next_manifests::{EdgeFunctionDefinition, MiddlewareMatcher, MiddlewaresManifestV2, Regions},
+    next_manifests::{EdgeFunctionDefinition, MiddlewaresManifestV2, ProxyMatcher, Regions},
     parse_segment_config_from_source,
     segment_config::ParseSegmentMode,
     util::{MiddlewareMatcherKind, NextRuntime},
@@ -171,7 +171,7 @@ impl MiddlewareEndpoint {
                 .iter()
                 .map(|matcher| {
                     let mut matcher = match matcher {
-                        MiddlewareMatcherKind::Str(matcher) => MiddlewareMatcher {
+                        MiddlewareMatcherKind::Str(matcher) => ProxyMatcher {
                             original_source: matcher.as_str().into(),
                             ..Default::default()
                         },
@@ -216,7 +216,7 @@ impl MiddlewareEndpoint {
                 })
                 .collect()
         } else {
-            vec![MiddlewareMatcher {
+            vec![ProxyMatcher {
                 regexp: Some(rcstr!("^/.*$")),
                 original_source: rcstr!("/:path*"),
                 ..Default::default()

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -12,8 +12,8 @@ use next_core::{
     next_dynamic::NextDynamicTransition,
     next_edge::route_regex::get_named_middleware_regex,
     next_manifests::{
-        BuildManifest, ClientBuildManifest, EdgeFunctionDefinition, MiddlewareMatcher,
-        MiddlewaresManifestV2, PagesManifest, Regions,
+        BuildManifest, ClientBuildManifest, EdgeFunctionDefinition, MiddlewaresManifestV2,
+        PagesManifest, ProxyMatcher, Regions,
     },
     next_pages::create_page_ssr_entry_module,
     next_server::{
@@ -1500,7 +1500,7 @@ impl PageEndpoint {
                         };
 
                     let named_regex = get_named_middleware_regex(&this.pathname).into();
-                    let matchers = MiddlewareMatcher {
+                    let matchers = ProxyMatcher {
                         regexp: Some(named_regex),
                         original_source: this.pathname.clone(),
                         ..Default::default()

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -238,7 +238,7 @@ impl Default for MiddlewaresManifest {
     NonLocalValue,
 )]
 #[serde(rename_all = "camelCase", default)]
-pub struct MiddlewareMatcher {
+pub struct ProxyMatcher {
     // When skipped next.js with fill that during merging.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub regexp: Option<RcStr>,
@@ -251,7 +251,7 @@ pub struct MiddlewareMatcher {
     pub original_source: RcStr,
 }
 
-impl Default for MiddlewareMatcher {
+impl Default for ProxyMatcher {
     fn default() -> Self {
         Self {
             regexp: None,
@@ -272,7 +272,7 @@ pub struct EdgeFunctionDefinition {
     pub files: Vec<RcStr>,
     pub name: RcStr,
     pub page: RcStr,
-    pub matchers: Vec<MiddlewareMatcher>,
+    pub matchers: Vec<ProxyMatcher>,
     pub wasm: Vec<AssetBinding>,
     pub assets: Vec<AssetBinding>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -446,14 +446,14 @@ mod tests {
     #[test]
     fn test_middleware_matcher_serialization() {
         let matchers = vec![
-            MiddlewareMatcher {
+            ProxyMatcher {
                 regexp: None,
                 locale: false,
                 has: None,
                 missing: None,
                 original_source: rcstr!(""),
             },
-            MiddlewareMatcher {
+            ProxyMatcher {
                 regexp: Some(rcstr!(".*")),
                 locale: true,
                 has: Some(vec![RouteHas::Query {
@@ -469,7 +469,7 @@ mod tests {
         ];
 
         let serialized = serde_json::to_string(&matchers).unwrap();
-        let deserialized: Vec<MiddlewareMatcher> = serde_json::from_str(&serialized).unwrap();
+        let deserialized: Vec<ProxyMatcher> = serde_json::from_str(&serialized).unwrap();
 
         assert_eq!(matchers, deserialized);
     }

--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -37,7 +37,7 @@ use turbopack_ecmascript::{
 use crate::{
     app_structure::AppPageLoaderTree,
     next_config::RouteHas,
-    next_manifests::MiddlewareMatcher,
+    next_manifests::ProxyMatcher,
     util::{MiddlewareMatcherKind, NextRuntime},
 };
 
@@ -1121,7 +1121,7 @@ async fn parse_route_matcher_from_js_value(
                 if let Some(matcher) = item.as_str() {
                     matchers.push(MiddlewareMatcherKind::Str(matcher.to_string()));
                 } else if let JsValue::Object { parts, .. } = item {
-                    let mut matcher = MiddlewareMatcher::default();
+                    let mut matcher = ProxyMatcher::default();
                     let mut had_source = false;
                     for matcher_part in parts {
                         if let ObjectPart::KeyValue(key, value) = matcher_part {

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -20,7 +20,7 @@ use turbopack_core::{
 
 use crate::{
     embed_js::next_js_fs, next_config::NextConfig, next_import_map::get_next_package,
-    next_manifests::MiddlewareMatcher, next_shared::webpack_rules::WebpackLoaderBuiltinCondition,
+    next_manifests::ProxyMatcher, next_shared::webpack_rules::WebpackLoaderBuiltinCondition,
 };
 
 const NEXT_TEMPLATE_PATH: &str = "dist/esm/build/templates";
@@ -232,7 +232,7 @@ impl NextRuntime {
 #[derive(PartialEq, Eq, Clone, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
 pub enum MiddlewareMatcherKind {
     Str(String),
-    Matcher(MiddlewareMatcher),
+    Matcher(ProxyMatcher),
 }
 
 /// Loads a next.js template, replaces `replacements` and `injections` and makes

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
@@ -264,7 +264,7 @@ Middleware function (if present):
   config: {
     maxDuration?: number
     preferredRegion?: string | string[]
-    matchers?: MiddlewareMatcher[]
+    matchers?: ProxyMatcher[]
   }
 }
 ```

--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -10,7 +10,7 @@ import { recursiveReadDir } from '../../lib/recursive-readdir'
 import { isDynamicRoute } from '../../shared/lib/router/utils'
 import type { Revalidate } from '../../server/lib/cache-control'
 import type { NextConfigComplete } from '../../server/config-shared'
-import type { MiddlewareMatcher } from '../analysis/get-page-static-info'
+import type { ProxyMatcher } from '../analysis/get-page-static-info'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { AdapterOutputType, type PHASE_TYPE } from '../../shared/lib/constants'
 import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
@@ -212,7 +212,7 @@ export interface AdapterOutput {
       /**
        * matchers are the configured matchers for middleware
        */
-      matchers?: MiddlewareMatcher[]
+      matchers?: ProxyMatcher[]
 
       /**
        * bypassToken is the generated token that signals a prerender cache
@@ -246,7 +246,7 @@ export interface AdapterOutput {
       /**
        * matchers are the configured matchers for middleware
        */
-      matchers?: MiddlewareMatcher[]
+      matchers?: ProxyMatcher[]
     }
   }
 }

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -44,7 +44,7 @@ import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-pat
 const PARSE_PATTERN =
   /(?<!(_jsx|jsx-))runtime|preferredRegion|getStaticProps|getServerSideProps|generateStaticParams|export const|generateImageMetadata|generateSitemaps|middleware|proxy/
 
-export type MiddlewareMatcher = {
+export type ProxyMatcher = {
   regexp: string
   locale?: false
   has?: RouteHas[]
@@ -54,13 +54,13 @@ export type MiddlewareMatcher = {
 
 export type ProxyConfig = {
   /**
-   * The matcher for the middleware. Read more: [Next.js Docs: Middleware `matcher`](https://nextjs.org/docs/app/api-reference/file-conventions/proxy#matcher),
-   * [Next.js Docs: Middleware matching paths](https://nextjs.org/docs/app/building-your-application/routing/middleware#matching-paths)
+   * The matcher for the proxy. Read more: [Next.js Docs: Proxy `matcher`](https://nextjs.org/docs/app/api-reference/file-conventions/proxy#matcher),
+   * [Next.js Docs: Proxy matching paths](https://nextjs.org/docs/app/building-your-application/routing/proxy#matching-paths)
    */
-  matchers?: MiddlewareMatcher[]
+  matchers?: ProxyMatcher[]
 
   /**
-   * The regions that the middleware should run in.
+   * The regions that the proxy should run in.
    */
   regions?: string | string[]
 
@@ -422,7 +422,7 @@ async function tryToReadFile(filePath: string, shouldThrow: boolean) {
 export function getMiddlewareMatchers(
   matcherOrMatchers: MiddlewareConfigMatcherInput,
   nextConfig: Pick<NextConfig, 'basePath' | 'i18n'>
-): MiddlewareMatcher[] {
+): ProxyMatcher[] {
   const matchers = Array.isArray(matcherOrMatchers)
     ? matcherOrMatchers
     : [matcherOrMatchers]

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -3,7 +3,7 @@ import type {
   I18NDomains,
   NextConfigComplete,
 } from '../server/config-shared'
-import type { MiddlewareMatcher } from './analysis/get-page-static-info'
+import type { ProxyMatcher } from './analysis/get-page-static-info'
 import type { Rewrite } from '../lib/load-custom-routes'
 import path from 'node:path'
 import { needsExperimentalReact } from '../lib/needs-experimental-react'
@@ -32,7 +32,7 @@ export interface DefineEnvOptions {
   isClient: boolean
   isEdgeServer: boolean
   isNodeServer: boolean
-  middlewareMatchers: MiddlewareMatcher[] | undefined
+  middlewareMatchers: ProxyMatcher[] | undefined
   omitNonDeterministic?: boolean
   rewrites: {
     beforeFiles: Rewrite[]
@@ -46,7 +46,7 @@ interface DefineEnv {
     | string
     | string[]
     | boolean
-    | MiddlewareMatcher[]
+    | ProxyMatcher[]
     | BloomFilter
     | Partial<NextConfigComplete['images']>
     | I18NDomains

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -6,7 +6,7 @@ import type { NextConfigComplete } from '../server/config-shared'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type {
   ProxyConfig,
-  MiddlewareMatcher,
+  ProxyMatcher,
   PageStaticInfo,
 } from './analysis/get-page-static-info'
 import type { LoadedEnvFiles } from '@next/env'
@@ -832,7 +832,7 @@ export async function createEntrypoints(
   const edgeServer: webpack.EntryObject = {}
   const server: webpack.EntryObject = {}
   const client: webpack.EntryObject = {}
-  let middlewareMatchers: MiddlewareMatcher[] | undefined = undefined
+  let middlewareMatchers: ProxyMatcher[] | undefined = undefined
 
   let appPathsPerRoute: Record<string, string[]> = {}
   if (appDir && appPaths) {

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -56,7 +56,7 @@ import type {
   SWC_TARGET_TRIPLE,
 } from './webpack/plugins/telemetry-plugin/telemetry-plugin'
 import type { Span } from '../trace'
-import type { MiddlewareMatcher } from './analysis/get-page-static-info'
+import type { ProxyMatcher } from './analysis/get-page-static-info'
 import loadJsConfig, {
   type JsConfig,
   type ResolvedBaseUrl,
@@ -346,7 +346,7 @@ export default async function getBaseWebpackConfig(
     originalRedirects: CustomRoutes['redirects'] | undefined
     runWebpackSpan: Span
     appDir: string | undefined
-    middlewareMatchers?: MiddlewareMatcher[]
+    middlewareMatchers?: ProxyMatcher[]
     noMangling?: boolean
     jsConfig: any
     jsConfigPath?: string

--- a/packages/next/src/build/webpack/loaders/get-module-build-info.ts
+++ b/packages/next/src/build/webpack/loaders/get-module-build-info.ts
@@ -1,6 +1,6 @@
 import type {
   ProxyConfig,
-  MiddlewareMatcher,
+  ProxyMatcher,
   RSCModuleType,
 } from '../../analysis/get-page-static-info'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
@@ -47,7 +47,7 @@ export interface RouteMeta {
 
 export interface EdgeMiddlewareMeta {
   page: string
-  matchers?: MiddlewareMatcher[]
+  matchers?: ProxyMatcher[]
 }
 
 export interface EdgeSSRMeta {

--- a/packages/next/src/build/webpack/loaders/next-middleware-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-middleware-loader.ts
@@ -1,6 +1,6 @@
 import type {
   ProxyConfig,
-  MiddlewareMatcher,
+  ProxyMatcher,
 } from '../../analysis/get-page-static-info'
 import { getModuleBuildInfo } from './get-module-build-info'
 import {
@@ -20,14 +20,14 @@ export type MiddlewareLoaderOptions = {
 
 // matchers can have special characters that break the loader params
 // parsing so we base64 encode/decode the string
-export function encodeMatchers(matchers: MiddlewareMatcher[]) {
+export function encodeMatchers(matchers: ProxyMatcher[]) {
   return Buffer.from(JSON.stringify(matchers)).toString('base64')
 }
 
 export function decodeMatchers(encodedMatchers: string) {
   return JSON.parse(
     Buffer.from(encodedMatchers, 'base64').toString()
-  ) as MiddlewareMatcher[]
+  ) as ProxyMatcher[]
 }
 
 export default async function middlewareLoader(this: any) {

--- a/packages/next/src/build/webpack/plugins/middleware-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/middleware-plugin.ts
@@ -3,7 +3,7 @@ import type {
   EdgeMiddlewareMeta,
 } from '../loaders/get-module-build-info'
 import type { EdgeSSRMeta } from '../loaders/get-module-build-info'
-import type { MiddlewareMatcher } from '../../analysis/get-page-static-info'
+import type { ProxyMatcher } from '../../analysis/get-page-static-info'
 import { getNamedMiddlewareRegex } from '../../../shared/lib/router/utils/route-regex'
 import { getModuleBuildInfo } from '../loaders/get-module-build-info'
 import { getSortedRoutes } from '../../../shared/lib/router/utils'
@@ -44,7 +44,7 @@ export interface EdgeFunctionDefinition {
   files: string[]
   name: string
   page: string
-  matchers: MiddlewareMatcher[]
+  matchers: ProxyMatcher[]
   env: Record<string, string>
   wasm?: AssetBinding[]
   assets?: AssetBinding[]

--- a/packages/next/src/client/page-loader.ts
+++ b/packages/next/src/client/page-loader.ts
@@ -1,6 +1,6 @@
 import type { ComponentType } from 'react'
 import type { RouteLoader } from './route-loader'
-import type { MiddlewareMatcher } from '../build/analysis/get-page-static-info'
+import type { ProxyMatcher } from '../build/analysis/get-page-static-info'
 import { addBasePath } from './add-base-path'
 import { interpolateAs } from '../shared/lib/router/utils/interpolate-as'
 import getAssetPathFromRoute from '../shared/lib/router/utils/get-asset-path-from-route'
@@ -17,7 +17,7 @@ import {
 
 declare global {
   interface Window {
-    __DEV_MIDDLEWARE_MATCHERS?: MiddlewareMatcher[]
+    __DEV_MIDDLEWARE_MATCHERS?: ProxyMatcher[]
     __DEV_PAGES_MANIFEST?: { pages: string[] }
     __SSG_MANIFEST_CB?: () => void
     __SSG_MANIFEST?: Set<string>
@@ -36,7 +36,7 @@ export default class PageLoader {
   private assetPrefix: string
   private promisedSsgManifest: Promise<Set<string>>
   private promisedDevPagesManifest?: Promise<string[]>
-  private promisedMiddlewareMatchers?: Promise<MiddlewareMatcher[]>
+  private promisedMiddlewareMatchers?: Promise<ProxyMatcher[]>
 
   public routeLoader: RouteLoader
 
@@ -93,7 +93,7 @@ export default class PageLoader {
     ) {
       const middlewareMatchers = process.env.__NEXT_MIDDLEWARE_MATCHERS
       window.__MIDDLEWARE_MATCHERS = middlewareMatchers
-        ? (middlewareMatchers as any as MiddlewareMatcher[])
+        ? (middlewareMatchers as any as ProxyMatcher[])
         : undefined
       return window.__MIDDLEWARE_MATCHERS
       // Turbopack production
@@ -109,7 +109,7 @@ export default class PageLoader {
             { credentials: 'same-origin' }
           )
             .then((res) => res.json())
-            .then((matchers: MiddlewareMatcher[]) => {
+            .then((matchers: ProxyMatcher[]) => {
               window.__MIDDLEWARE_MATCHERS = matchers
               return matchers
             })
@@ -133,7 +133,7 @@ export default class PageLoader {
             { credentials: 'same-origin' }
           )
             .then((res) => res.json())
-            .then((matchers: MiddlewareMatcher[]) => {
+            .then((matchers: ProxyMatcher[]) => {
               window.__DEV_MIDDLEWARE_MATCHERS = matchers
               return matchers
             })

--- a/packages/next/src/client/route-loader.ts
+++ b/packages/next/src/client/route-loader.ts
@@ -1,5 +1,5 @@
 import type { ComponentType } from 'react'
-import type { MiddlewareMatcher } from '../build/analysis/get-page-static-info'
+import type { ProxyMatcher } from '../build/analysis/get-page-static-info'
 import getAssetPathFromRoute from '../shared/lib/router/utils/get-asset-path-from-route'
 import { __unsafeCreateTrustedScriptURL } from './trusted-types'
 import { requestIdleCallback } from './request-idle-callback'
@@ -16,7 +16,7 @@ declare global {
   interface Window {
     __BUILD_MANIFEST?: Record<string, string[]>
     __BUILD_MANIFEST_CB?: Function
-    __MIDDLEWARE_MATCHERS?: MiddlewareMatcher[]
+    __MIDDLEWARE_MATCHERS?: ProxyMatcher[]
     __MIDDLEWARE_MANIFEST_CB?: Function
     __REACT_LOADABLE_MANIFEST?: any
     __DYNAMIC_CSS_MANIFEST?: any

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -40,7 +40,7 @@ import type {
   IncomingMessage,
   ServerResponse as HTTPServerResponse,
 } from 'http'
-import type { MiddlewareMatcher } from '../build/analysis/get-page-static-info'
+import type { ProxyMatcher } from '../build/analysis/get-page-static-info'
 import type { TLSSocket } from 'tls'
 import type { PathnameNormalizer } from './normalizers/request/pathname-normalizer'
 import type { InstrumentationModule } from './instrumentation/types'
@@ -157,7 +157,7 @@ export type FindComponentsResult = {
 export interface MiddlewareRoutingItem {
   page: string
   match: MiddlewareRouteMatch
-  matchers?: MiddlewareMatcher[]
+  matchers?: ProxyMatcher[]
 }
 
 export type RouteHandler<

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1,7 +1,7 @@
 import type { NextConfigComplete } from '../../config-shared'
 import type { FilesystemDynamicRoute } from './filesystem'
 import type { UnwrapPromise } from '../../../lib/coalesced-function'
-import type { MiddlewareMatcher } from '../../../build/analysis/get-page-static-info'
+import type { ProxyMatcher } from '../../../build/analysis/get-page-static-info'
 import type { RoutesManifest } from '../../../build'
 import type { MiddlewareRouteMatch } from '../../../shared/lib/router/utils/middleware-route-matcher'
 import type { PropagateToWorkersField } from './types'
@@ -124,7 +124,7 @@ export type ServerFields = {
     | {
         page: string
         match: MiddlewareRouteMatch
-        matchers?: MiddlewareMatcher[]
+        matchers?: ProxyMatcher[]
       }
     | undefined
   hasAppNotFound?: boolean
@@ -359,7 +359,7 @@ async function startWatcher(
     wp.on('aggregated', async () => {
       let writeEnvDefinitions = false
       let typescriptStatusFromLastAggregation = enabledTypeScript
-      let middlewareMatchers: MiddlewareMatcher[] | undefined
+      let middlewareMatchers: ProxyMatcher[] | undefined
       const routedPages: string[] = []
       const knownFiles = wp.getTimeInfoEntries()
       const appPaths: Record<string, string[]> = {}

--- a/packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts
+++ b/packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts
@@ -1,5 +1,5 @@
 import type { BaseNextRequest } from '../../../../server/base-http'
-import type { MiddlewareMatcher } from '../../../../build/analysis/get-page-static-info'
+import type { ProxyMatcher } from '../../../../build/analysis/get-page-static-info'
 import type { Params } from '../../../../server/request/params'
 import { matchHas } from './prepare-destination'
 
@@ -12,7 +12,7 @@ export interface MiddlewareRouteMatch {
 }
 
 export function getMiddlewareRouteMatcher(
-  matchers: MiddlewareMatcher[]
+  matchers: ProxyMatcher[]
 ): MiddlewareRouteMatch {
   return (
     pathname: string | null | undefined,


### PR DESCRIPTION
Follow up on https://github.com/vercel/next.js/pull/84710, `adapterPath` docs had `MiddlewareMatcher` type, used in `ProxyConfig` type. As it's a user-facing type, update it.