### PR TITLE
[Breaking] Rename instrumentation onRequestError `context.routeType` from `middleware` to `proxy`

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation.mdx
@@ -93,7 +93,7 @@ export function onRequestError(
   context: {
     routerKind: 'Pages Router' | 'App Router' // the router type
     routePath: string // the route file path, e.g. /app/blog/[dynamic]
-    routeType: 'render' | 'route' | 'action' | 'middleware' // the context in which the error occurred
+    routeType: 'render' | 'route' | 'action' | 'proxy' // the context in which the error occurred
     renderSource:
       | 'react-server-components'
       | 'react-server-components-payload'
@@ -106,7 +106,7 @@ export function onRequestError(
 
 - `error`: The caught error itself (type is always `Error`), and a `digest` property which is the unique ID of the error.
 - `request`: Read-only request information associated with the error.
-- `context`: The context in which the error occurred. This can be the type of router (App or Pages Router), and/or (Server Components (`'render'`), Route Handlers (`'route'`), Server Actions (`'action'`), or Middleware (`'middleware'`)).
+- `context`: The context in which the error occurred. This can be the type of router (App or Pages Router), and/or (Server Components (`'render'`), Route Handlers (`'route'`), Server Actions (`'action'`), or Proxy (`'proxy'`)).
 
 ### Specifying the runtime
 

--- a/packages/next/src/build/templates/middleware.ts
+++ b/packages/next/src/build/templates/middleware.ts
@@ -24,18 +24,18 @@ if (typeof handler !== 'function') {
   )
 }
 
-// Middleware will only sent out the FetchEvent to next server,
-// so load instrumentation module here and track the error inside middleware module.
+// Proxy will only sent out the FetchEvent to next server,
+// so load instrumentation module here and track the error inside proxy module.
 function errorHandledHandler(fn: AdapterOptions['handler']) {
   return async (...args: Parameters<AdapterOptions['handler']>) => {
     try {
       return await fn(...args)
     } catch (err) {
       // In development, error the navigation API usage in runtime,
-      // since it's not allowed to be used in middleware as it's outside of react component tree.
+      // since it's not allowed to be used in proxy as it's outside of react component tree.
       if (process.env.NODE_ENV !== 'production') {
         if (isNextRouterError(err)) {
-          err.message = `Next.js navigation API is not allowed to be used in Middleware.`
+          err.message = `Next.js navigation API is not allowed to be used in ${isProxy ? 'Proxy' : 'Middleware'}.`
           throw err
         }
       }
@@ -51,8 +51,8 @@ function errorHandledHandler(fn: AdapterOptions['handler']) {
         },
         {
           routerKind: 'Pages Router',
-          routePath: '/middleware',
-          routeType: 'middleware',
+          routePath: '/proxy',
+          routeType: 'proxy',
           revalidateReason: undefined,
         }
       )

--- a/packages/next/src/server/instrumentation/types.ts
+++ b/packages/next/src/server/instrumentation/types.ts
@@ -1,7 +1,7 @@
 export type RequestErrorContext = {
   routerKind: 'Pages Router' | 'App Router'
   routePath: string // the route file path, e.g. /app/blog/[dynamic]
-  routeType: 'render' | 'route' | 'action' | 'middleware'
+  routeType: 'render' | 'route' | 'action' | 'proxy'
   renderSource?:
     | 'react-server-components'
     | 'react-server-components-payload'


### PR DESCRIPTION
Follow up on https://github.com/vercel/next.js/pull/84710, `instrumentation` docs had `onRequestError` function's param `context.routeType` has value of `'middleware'`. As it's a user-facing value, update it to `'proxy'`.