### PR TITLE
[devtools]: instrument client navigation hooks for suspense devtools

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -21,6 +21,8 @@ import {
   SearchParamsContext,
   PathnameContext,
   PathParamsContext,
+  NavigationPromisesContext,
+  type NavigationPromises,
 } from '../../shared/lib/hooks-client-context.shared-runtime'
 import { dispatchAppRouterAction, useActionQueue } from './use-action-queue'
 import { AppRouterAnnouncer } from './app-router-announcer'
@@ -48,6 +50,53 @@ import type { StaticIndicatorState } from '../dev/hot-reloader/app/hot-reloader-
 const globalMutable: {
   pendingMpaPath?: string
 } = {}
+
+// Creates an instrumented promise for Suspense DevTools
+// These promises are always fulfilled and exist purely for
+// tracking in React's Suspense DevTools.
+// The value will be updated by the hooks before calling use()
+function createDevToolsInstrumentedNavigationPromise<T>(
+  displayName: string
+): Promise<T> & { status: 'fulfilled'; value: T; displayName: string } {
+  const promise = Promise.resolve(null as T) as Promise<T> & {
+    status: 'fulfilled'
+    value: T
+    displayName: string
+  }
+  promise.status = 'fulfilled'
+  promise.value = null as T
+  promise.displayName = displayName
+  return promise
+}
+
+// Create stable instrumented promises for navigation hooks (dev-only)
+// These are created once and reused throughout the app lifetime
+let navigationPromises: NavigationPromises | null = null
+function getNavigationPromises(): NavigationPromises | null {
+  if (process.env.NODE_ENV !== 'production') {
+    if (!navigationPromises) {
+      navigationPromises = {
+        pathname:
+          createDevToolsInstrumentedNavigationPromise<string>(
+            'usePathname (SSR)'
+          ),
+        searchParams: createDevToolsInstrumentedNavigationPromise<any>(
+          'useSearchParams (SSR)'
+        ),
+        params:
+          createDevToolsInstrumentedNavigationPromise<any>('useParams (SSR)'),
+        selectedLayoutSegment: createDevToolsInstrumentedNavigationPromise<
+          string | null
+        >('useSelectedLayoutSegment (SSR)'),
+        selectedLayoutSegments: createDevToolsInstrumentedNavigationPromise<
+          string[]
+        >('useSelectedLayoutSegments (SSR)'),
+      }
+    }
+    return navigationPromises
+  }
+  return null
+}
 
 function HistoryUpdater({
   appRouterState,
@@ -506,30 +555,35 @@ function Router({
     )
   }
 
+  const devNavigationPromises =
+    process.env.NODE_ENV !== 'production' ? getNavigationPromises() : null
+
   return (
     <>
       <HistoryUpdater appRouterState={state} />
       <RuntimeStyles />
-      <PathParamsContext.Provider value={pathParams}>
-        <PathnameContext.Provider value={pathname}>
-          <SearchParamsContext.Provider value={searchParams}>
-            <GlobalLayoutRouterContext.Provider
-              value={globalLayoutRouterContext}
-            >
-              {/* TODO: We should be able to remove this context. useRouter
-                  should import from app-router-instance instead. It's only
-                  necessary because useRouter is shared between Pages and
-                  App Router. We should fork that module, then remove this
-                  context provider. */}
-              <AppRouterContext.Provider value={publicAppRouterInstance}>
-                <LayoutRouterContext.Provider value={layoutRouterContext}>
-                  {content}
-                </LayoutRouterContext.Provider>
-              </AppRouterContext.Provider>
-            </GlobalLayoutRouterContext.Provider>
-          </SearchParamsContext.Provider>
-        </PathnameContext.Provider>
-      </PathParamsContext.Provider>
+      <NavigationPromisesContext.Provider value={devNavigationPromises}>
+        <PathParamsContext.Provider value={pathParams}>
+          <PathnameContext.Provider value={pathname}>
+            <SearchParamsContext.Provider value={searchParams}>
+              <GlobalLayoutRouterContext.Provider
+                value={globalLayoutRouterContext}
+              >
+                {/* TODO: We should be able to remove this context. useRouter
+                    should import from app-router-instance instead. It's only
+                    necessary because useRouter is shared between Pages and
+                    App Router. We should fork that module, then remove this
+                    context provider. */}
+                <AppRouterContext.Provider value={publicAppRouterInstance}>
+                  <LayoutRouterContext.Provider value={layoutRouterContext}>
+                    {content}
+                  </LayoutRouterContext.Provider>
+                </AppRouterContext.Provider>
+              </GlobalLayoutRouterContext.Provider>
+            </SearchParamsContext.Provider>
+          </PathnameContext.Provider>
+        </PathParamsContext.Provider>
+      </NavigationPromisesContext.Provider>
     </>
   )
 }

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -22,7 +22,7 @@ import {
   PathnameContext,
   PathParamsContext,
   NavigationPromisesContext,
-  createDevToolsInstrumentedPromise,
+  type NavigationPromises,
 } from '../../shared/lib/hooks-client-context.shared-runtime'
 import { dispatchAppRouterAction, useActionQueue } from './use-action-queue'
 import { AppRouterAnnouncer } from './app-router-announcer'
@@ -415,29 +415,19 @@ function Router({
 
   // Create instrumented promises for navigation hooks (dev-only)
   // These are specially instrumented promises to show in the Suspense DevTools
-  const instrumentedNavigationPromises = useMemo(() => {
-    if (process.env.NODE_ENV !== 'production') {
-      const readonlySearchParams = new (
-        require('./navigation.react-server') as typeof import('./navigation.react-server')
-      ).ReadonlyURLSearchParams(searchParams)
+  // Promises are cached outside of render to survive suspense retries.
+  let instrumentedNavigationPromises: NavigationPromises | null = null
+  if (process.env.NODE_ENV !== 'production') {
+    const { createRootNavigationPromises } =
+      require('./navigation-devtools') as typeof import('./navigation-devtools')
 
-      const { createLayoutSegmentPromises } =
-        require('./navigation-devtools') as typeof import('./navigation-devtools')
-
-      const layoutSegmentPromises = createLayoutSegmentPromises(tree)
-
-      return {
-        pathname: createDevToolsInstrumentedPromise('usePathname', pathname),
-        searchParams: createDevToolsInstrumentedPromise(
-          'useSearchParams',
-          readonlySearchParams
-        ),
-        params: createDevToolsInstrumentedPromise('useParams', pathParams),
-        ...layoutSegmentPromises,
-      }
-    }
-    return null
-  }, [pathname, searchParams, pathParams, tree])
+    instrumentedNavigationPromises = createRootNavigationPromises(
+      tree,
+      pathname,
+      searchParams,
+      pathParams
+    )
+  }
 
   const layoutRouterContext = useMemo(() => {
     return {

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -22,7 +22,7 @@ import {
   PathnameContext,
   PathParamsContext,
   NavigationPromisesContext,
-  type NavigationPromises,
+  createDevToolsInstrumentedPromise,
 } from '../../shared/lib/hooks-client-context.shared-runtime'
 import { dispatchAppRouterAction, useActionQueue } from './use-action-queue'
 import { AppRouterAnnouncer } from './app-router-announcer'
@@ -50,53 +50,6 @@ import type { StaticIndicatorState } from '../dev/hot-reloader/app/hot-reloader-
 const globalMutable: {
   pendingMpaPath?: string
 } = {}
-
-// Creates an instrumented promise for Suspense DevTools
-// These promises are always fulfilled and exist purely for
-// tracking in React's Suspense DevTools.
-// The value will be updated by the hooks before calling use()
-function createDevToolsInstrumentedNavigationPromise<T>(
-  displayName: string
-): Promise<T> & { status: 'fulfilled'; value: T; displayName: string } {
-  const promise = Promise.resolve(null as T) as Promise<T> & {
-    status: 'fulfilled'
-    value: T
-    displayName: string
-  }
-  promise.status = 'fulfilled'
-  promise.value = null as T
-  promise.displayName = displayName
-  return promise
-}
-
-// Create stable instrumented promises for navigation hooks (dev-only)
-// These are created once and reused throughout the app lifetime
-let navigationPromises: NavigationPromises | null = null
-function getNavigationPromises(): NavigationPromises | null {
-  if (process.env.NODE_ENV !== 'production') {
-    if (!navigationPromises) {
-      navigationPromises = {
-        pathname:
-          createDevToolsInstrumentedNavigationPromise<string>(
-            'usePathname (SSR)'
-          ),
-        searchParams: createDevToolsInstrumentedNavigationPromise<any>(
-          'useSearchParams (SSR)'
-        ),
-        params:
-          createDevToolsInstrumentedNavigationPromise<any>('useParams (SSR)'),
-        selectedLayoutSegment: createDevToolsInstrumentedNavigationPromise<
-          string | null
-        >('useSelectedLayoutSegment (SSR)'),
-        selectedLayoutSegments: createDevToolsInstrumentedNavigationPromise<
-          string[]
-        >('useSelectedLayoutSegments (SSR)'),
-      }
-    }
-    return navigationPromises
-  }
-  return null
-}
 
 function HistoryUpdater({
   appRouterState,
@@ -460,6 +413,32 @@ function Router({
     return getSelectedParams(tree)
   }, [tree])
 
+  // Create instrumented promises for navigation hooks (dev-only)
+  // These are specially instrumented promises to show in the Suspense DevTools
+  const instrumentedNavigationPromises = useMemo(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      const readonlySearchParams = new (
+        require('./navigation.react-server') as typeof import('./navigation.react-server')
+      ).ReadonlyURLSearchParams(searchParams)
+
+      const { createLayoutSegmentPromises } =
+        require('./navigation-devtools') as typeof import('./navigation-devtools')
+
+      const layoutSegmentPromises = createLayoutSegmentPromises(tree)
+
+      return {
+        pathname: createDevToolsInstrumentedPromise('usePathname', pathname),
+        searchParams: createDevToolsInstrumentedPromise(
+          'useSearchParams',
+          readonlySearchParams
+        ),
+        params: createDevToolsInstrumentedPromise('useParams', pathParams),
+        ...layoutSegmentPromises,
+      }
+    }
+    return null
+  }, [pathname, searchParams, pathParams, tree])
+
   const layoutRouterContext = useMemo(() => {
     return {
       parentTree: tree,
@@ -555,14 +534,13 @@ function Router({
     )
   }
 
-  const devNavigationPromises =
-    process.env.NODE_ENV !== 'production' ? getNavigationPromises() : null
-
   return (
     <>
       <HistoryUpdater appRouterState={state} />
       <RuntimeStyles />
-      <NavigationPromisesContext.Provider value={devNavigationPromises}>
+      <NavigationPromisesContext.Provider
+        value={instrumentedNavigationPromises}
+      >
         <PathParamsContext.Provider value={pathParams}>
           <PathnameContext.Provider value={pathname}>
             <SearchParamsContext.Provider value={searchParams}>

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -19,7 +19,6 @@ import React, {
   Activity,
   useContext,
   use,
-  useMemo,
   startTransition,
   Suspense,
   useDeferredValue,
@@ -44,7 +43,10 @@ import { dispatchAppRouterAction } from './use-action-queue'
 import { useRouterBFCache, type RouterBFCacheEntry } from './bfcache'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
-import { NavigationPromisesContext } from '../../shared/lib/hooks-client-context.shared-runtime'
+import {
+  NavigationPromisesContext,
+  type NavigationPromises,
+} from '../../shared/lib/hooks-client-context.shared-runtime'
 
 /**
  * Add refetch marker to router state at the point of the current layout segment.
@@ -429,25 +431,17 @@ function InnerLayoutRouter({
 
   // In dev, we create a NavigationPromisesContext containing the instrumented promises that provide
   // `useSelectedLayoutSegment` and `useSelectedLayoutSegments`.
-  const navigationPromises = useMemo(() => {
-    if (process.env.NODE_ENV !== 'production') {
-      const { createLayoutSegmentPromises } =
-        require('./navigation-devtools') as typeof import('./navigation-devtools')
+  // Promises are cached outside of render to survive suspense retries.
+  let navigationPromises: NavigationPromises | null = null
+  if (process.env.NODE_ENV !== 'production') {
+    const { createNestedLayoutNavigationPromises } =
+      require('./navigation-devtools') as typeof import('./navigation-devtools')
 
-      const parallelRoutes = tree[1]
-      const parallelRouteKeys = Object.keys(parallelRoutes)
-
-      // Only create promises if there are parallel routes at this level
-      if (parallelRouteKeys.length > 0) {
-        const layoutSegmentPromises = createLayoutSegmentPromises(tree)
-        return {
-          ...parentNavPromises!,
-          ...layoutSegmentPromises,
-        }
-      }
-    }
-    return null
-  }, [tree, parentNavPromises])
+    navigationPromises = createNestedLayoutNavigationPromises(
+      tree,
+      parentNavPromises
+    )
+  }
 
   if (navigationPromises) {
     content = (

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -19,6 +19,7 @@ import React, {
   Activity,
   useContext,
   use,
+  useMemo,
   startTransition,
   Suspense,
   useDeferredValue,
@@ -43,6 +44,7 @@ import { dispatchAppRouterAction } from './use-action-queue'
 import { useRouterBFCache, type RouterBFCacheEntry } from './bfcache'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
+import { NavigationPromisesContext } from '../../shared/lib/hooks-client-context.shared-runtime'
 
 /**
  * Add refetch marker to router state at the point of the current layout segment.
@@ -341,6 +343,8 @@ function InnerLayoutRouter({
   url: string
 }) {
   const context = useContext(GlobalLayoutRouterContext)
+  const parentNavPromises = useContext(NavigationPromisesContext)
+
   if (!context) {
     throw new Error('invariant global layout router not mounted')
   }
@@ -421,6 +425,38 @@ function InnerLayoutRouter({
   }
 
   // If we get to this point, then we know we have something we can render.
+  let content = resolvedRsc
+
+  // In dev, we create a NavigationPromisesContext containing the instrumented promises that provide
+  // `useSelectedLayoutSegment` and `useSelectedLayoutSegments`.
+  const navigationPromises = useMemo(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      const { createLayoutSegmentPromises } =
+        require('./navigation-devtools') as typeof import('./navigation-devtools')
+
+      const parallelRoutes = tree[1]
+      const parallelRouteKeys = Object.keys(parallelRoutes)
+
+      // Only create promises if there are parallel routes at this level
+      if (parallelRouteKeys.length > 0) {
+        const layoutSegmentPromises = createLayoutSegmentPromises(tree)
+        return {
+          ...parentNavPromises!,
+          ...layoutSegmentPromises,
+        }
+      }
+    }
+    return null
+  }, [tree, parentNavPromises])
+
+  if (navigationPromises) {
+    content = (
+      <NavigationPromisesContext.Provider value={navigationPromises}>
+        {resolvedRsc}
+      </NavigationPromisesContext.Provider>
+    )
+  }
+
   const subtree = (
     // The layout router context narrows down tree and childNodes at each level.
     <LayoutRouterContext.Provider
@@ -433,7 +469,7 @@ function InnerLayoutRouter({
         url: url,
       }}
     >
-      {resolvedRsc}
+      {content}
     </LayoutRouterContext.Provider>
   )
   // Ensure root layout is not wrapped in a div as the root layout renders `<html>`

--- a/packages/next/src/client/components/navigation-devtools.ts
+++ b/packages/next/src/client/components/navigation-devtools.ts
@@ -9,7 +9,7 @@ import {
   computeSelectedLayoutSegment,
   getSelectedLayoutSegmentPath,
 } from '../../shared/lib/segment'
-import { ReadonlyURLSearchParams } from './navigation.react-server'
+import { ReadonlyURLSearchParams } from './readonly-url-search-params'
 
 /**
  * Promises are cached by tree to ensure stability across suspense retries.
@@ -62,7 +62,7 @@ export function createLayoutSegmentPromises(
     )
   }
 
-  const result = {
+  const result: LayoutSegmentPromisesCache = {
     selectedLayoutSegmentPromises: segmentPromises,
     selectedLayoutSegmentsPromises: segmentsPromises,
   }

--- a/packages/next/src/client/components/navigation-devtools.ts
+++ b/packages/next/src/client/components/navigation-devtools.ts
@@ -1,21 +1,47 @@
 import type { FlightRouterState } from '../../shared/lib/app-router-types'
+import type { Params } from '../../server/request/params'
 import {
   createDevToolsInstrumentedPromise,
   type InstrumentedPromise,
+  type NavigationPromises,
 } from '../../shared/lib/hooks-client-context.shared-runtime'
 import {
   computeSelectedLayoutSegment,
   getSelectedLayoutSegmentPath,
 } from '../../shared/lib/segment'
+import { ReadonlyURLSearchParams } from './navigation.react-server'
+
+/**
+ * Promises are cached by tree to ensure stability across suspense retries.
+ */
+type LayoutSegmentPromisesCache = {
+  selectedLayoutSegmentPromises: Map<string, InstrumentedPromise<string | null>>
+  selectedLayoutSegmentsPromises: Map<string, InstrumentedPromise<string[]>>
+}
+
+const layoutSegmentPromisesCache = new WeakMap<
+  FlightRouterState,
+  LayoutSegmentPromisesCache
+>()
 
 /**
  * Creates instrumented promises for layout segment hooks at a given tree level.
  * This is dev-only code for React Suspense DevTools instrumentation.
  */
-export function createLayoutSegmentPromises(tree: FlightRouterState): {
-  selectedLayoutSegmentPromises: Map<string, InstrumentedPromise<string | null>>
-  selectedLayoutSegmentsPromises: Map<string, InstrumentedPromise<string[]>>
-} {
+export function createLayoutSegmentPromises(
+  tree: FlightRouterState
+): LayoutSegmentPromisesCache | null {
+  if (process.env.NODE_ENV === 'production') {
+    return null
+  }
+
+  // Check if we already have cached promises for this tree
+  const cached = layoutSegmentPromisesCache.get(tree)
+  if (cached) {
+    return cached
+  }
+
+  // Create new promises and cache them
   const segmentPromises = new Map<string, InstrumentedPromise<string | null>>()
   const segmentsPromises = new Map<string, InstrumentedPromise<string[]>>()
 
@@ -36,8 +62,118 @@ export function createLayoutSegmentPromises(tree: FlightRouterState): {
     )
   }
 
-  return {
+  const result = {
     selectedLayoutSegmentPromises: segmentPromises,
     selectedLayoutSegmentsPromises: segmentsPromises,
   }
+
+  // Cache the result for future renders
+  layoutSegmentPromisesCache.set(tree, result)
+
+  return result
+}
+
+const rootNavigationPromisesCache = new WeakMap<
+  FlightRouterState,
+  Map<string, NavigationPromises>
+>()
+
+/**
+ * Creates instrumented navigation promises for the root app-router.
+ */
+export function createRootNavigationPromises(
+  tree: FlightRouterState,
+  pathname: string,
+  searchParams: URLSearchParams,
+  pathParams: Params
+): NavigationPromises | null {
+  if (process.env.NODE_ENV === 'production') {
+    return null
+  }
+
+  // Create stable cache keys from the values
+  const searchParamsString = searchParams.toString()
+  const pathParamsString = JSON.stringify(pathParams)
+  const cacheKey = `${pathname}:${searchParamsString}:${pathParamsString}`
+
+  // Get or create the cache for this tree
+  let treeCache = rootNavigationPromisesCache.get(tree)
+  if (!treeCache) {
+    treeCache = new Map<string, NavigationPromises>()
+    rootNavigationPromisesCache.set(tree, treeCache)
+  }
+
+  // Check if we have cached promises for this combination
+  const cached = treeCache.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+
+  const readonlySearchParams = new ReadonlyURLSearchParams(searchParams)
+
+  const layoutSegmentPromises = createLayoutSegmentPromises(tree)
+
+  const promises: NavigationPromises = {
+    pathname: createDevToolsInstrumentedPromise('usePathname', pathname),
+    searchParams: createDevToolsInstrumentedPromise(
+      'useSearchParams',
+      readonlySearchParams
+    ),
+    params: createDevToolsInstrumentedPromise('useParams', pathParams),
+    ...layoutSegmentPromises,
+  }
+
+  treeCache.set(cacheKey, promises)
+
+  return promises
+}
+
+const nestedLayoutPromisesCache = new WeakMap<
+  FlightRouterState,
+  Map<NavigationPromises | null, NavigationPromises>
+>()
+
+/**
+ * Creates merged navigation promises for nested layouts.
+ * Merges parent promises with layout-specific segment promises.
+ */
+export function createNestedLayoutNavigationPromises(
+  tree: FlightRouterState,
+  parentNavPromises: NavigationPromises | null
+): NavigationPromises | null {
+  if (process.env.NODE_ENV === 'production') {
+    return null
+  }
+
+  const parallelRoutes = tree[1]
+  const parallelRouteKeys = Object.keys(parallelRoutes)
+
+  // Only create promises if there are parallel routes at this level
+  if (parallelRouteKeys.length === 0) {
+    return null
+  }
+
+  // Get or create the cache for this tree
+  let treeCache = nestedLayoutPromisesCache.get(tree)
+  if (!treeCache) {
+    treeCache = new Map<NavigationPromises | null, NavigationPromises>()
+    nestedLayoutPromisesCache.set(tree, treeCache)
+  }
+
+  // Check if we have cached promises for this parent combination
+  const cached = treeCache.get(parentNavPromises)
+  if (cached) {
+    return cached
+  }
+
+  // Create merged promises
+  const layoutSegmentPromises = createLayoutSegmentPromises(tree)
+  const promises: NavigationPromises = {
+    ...parentNavPromises!,
+    ...layoutSegmentPromises,
+  }
+
+  treeCache.set(parentNavPromises, promises)
+
+  return promises
 }

--- a/packages/next/src/client/components/navigation-devtools.ts
+++ b/packages/next/src/client/components/navigation-devtools.ts
@@ -1,0 +1,43 @@
+import type { FlightRouterState } from '../../shared/lib/app-router-types'
+import {
+  createDevToolsInstrumentedPromise,
+  type InstrumentedPromise,
+} from '../../shared/lib/hooks-client-context.shared-runtime'
+import {
+  computeSelectedLayoutSegment,
+  getSelectedLayoutSegmentPath,
+} from '../../shared/lib/segment'
+
+/**
+ * Creates instrumented promises for layout segment hooks at a given tree level.
+ * This is dev-only code for React Suspense DevTools instrumentation.
+ */
+export function createLayoutSegmentPromises(tree: FlightRouterState): {
+  selectedLayoutSegmentPromises: Map<string, InstrumentedPromise<string | null>>
+  selectedLayoutSegmentsPromises: Map<string, InstrumentedPromise<string[]>>
+} {
+  const segmentPromises = new Map<string, InstrumentedPromise<string | null>>()
+  const segmentsPromises = new Map<string, InstrumentedPromise<string[]>>()
+
+  const parallelRoutes = tree[1]
+  for (const parallelRouteKey of Object.keys(parallelRoutes)) {
+    const segments = getSelectedLayoutSegmentPath(tree, parallelRouteKey)
+
+    // Use the shared logic to compute the segment value
+    const segment = computeSelectedLayoutSegment(segments, parallelRouteKey)
+
+    segmentPromises.set(
+      parallelRouteKey,
+      createDevToolsInstrumentedPromise('useSelectedLayoutSegment', segment)
+    )
+    segmentsPromises.set(
+      parallelRouteKey,
+      createDevToolsInstrumentedPromise('useSelectedLayoutSegments', segments)
+    )
+  }
+
+  return {
+    selectedLayoutSegmentPromises: segmentPromises,
+    selectedLayoutSegmentsPromises: segmentsPromises,
+  }
+}

--- a/packages/next/src/client/components/navigation.react-server.ts
+++ b/packages/next/src/client/components/navigation.react-server.ts
@@ -1,30 +1,4 @@
-/** @internal */
-class ReadonlyURLSearchParamsError extends Error {
-  constructor() {
-    super(
-      'Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams'
-    )
-  }
-}
-
-class ReadonlyURLSearchParams extends URLSearchParams {
-  /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
-  append() {
-    throw new ReadonlyURLSearchParamsError()
-  }
-  /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
-  delete() {
-    throw new ReadonlyURLSearchParamsError()
-  }
-  /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
-  set() {
-    throw new ReadonlyURLSearchParamsError()
-  }
-  /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
-  sort() {
-    throw new ReadonlyURLSearchParamsError()
-  }
-}
+import { ReadonlyURLSearchParams } from './readonly-url-search-params'
 
 export function unstable_isUnrecognizedActionError(): boolean {
   throw new Error(

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -1,4 +1,3 @@
-import type { FlightRouterState } from '../../shared/lib/app-router-types'
 import type { Params } from '../../server/request/params'
 
 import { useContext, useMemo, use } from 'react'
@@ -13,8 +12,10 @@ import {
   PathParamsContext,
   NavigationPromisesContext,
 } from '../../shared/lib/hooks-client-context.shared-runtime'
-import { getSegmentValue } from './router-reducer/reducers/get-segment-value'
-import { PAGE_SEGMENT_KEY, DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
+import {
+  computeSelectedLayoutSegment,
+  getSelectedLayoutSegmentPath,
+} from '../../shared/lib/segment'
 import { ReadonlyURLSearchParams } from './navigation.react-server'
 
 const useDynamicRouteParams =
@@ -55,6 +56,7 @@ const useDynamicSearchParams =
 export function useSearchParams(): ReadonlyURLSearchParams {
   useDynamicSearchParams?.('useSearchParams()')
 
+  const navigationPromises = useContext(NavigationPromisesContext)
   const searchParams = useContext(SearchParamsContext)
 
   // In the case where this is `null`, the compat types added in
@@ -71,15 +73,8 @@ export function useSearchParams(): ReadonlyURLSearchParams {
   }, [searchParams]) as ReadonlyURLSearchParams
 
   // Instrument with Suspense DevTools (dev-only)
-
-  if (process.env.NODE_ENV !== 'production') {
-    // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const navigationPromises = useContext(NavigationPromisesContext)
-    if (navigationPromises) {
-      navigationPromises.searchParams.value = readonlySearchParams
-      return use(navigationPromises.searchParams)
-    }
+  if (process.env.NODE_ENV !== 'production' && navigationPromises) {
+    return use(navigationPromises.searchParams)
   }
 
   return readonlySearchParams
@@ -106,19 +101,14 @@ export function useSearchParams(): ReadonlyURLSearchParams {
 export function usePathname(): string {
   useDynamicRouteParams?.('usePathname()')
 
+  const navigationPromises = useContext(NavigationPromisesContext)
   // In the case where this is `null`, the compat types added in `next-env.d.ts`
   // will add a new overload that changes the return type to include `null`.
   const pathname = useContext(PathnameContext) as string
 
   // Instrument with Suspense DevTools (dev-only)
-  if (process.env.NODE_ENV !== 'production') {
-    // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const navigationPromises = useContext(NavigationPromisesContext)
-    if (navigationPromises) {
-      navigationPromises.pathname.value = pathname
-      return use(navigationPromises.pathname)
-    }
+  if (process.env.NODE_ENV !== 'production' && navigationPromises) {
+    return use(navigationPromises.pathname)
   }
 
   return pathname
@@ -179,57 +169,15 @@ export function useRouter(): AppRouterInstance {
 export function useParams<T extends Params = Params>(): T {
   useDynamicRouteParams?.('useParams()')
 
+  const navigationPromises = useContext(NavigationPromisesContext)
   const params = useContext(PathParamsContext) as T
 
   // Instrument with Suspense DevTools (dev-only)
-  if (process.env.NODE_ENV !== 'production') {
-    // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const navigationPromises = useContext(NavigationPromisesContext)
-    if (navigationPromises) {
-      navigationPromises.params.value = params
-      return use(navigationPromises.params)
-    }
+  if (process.env.NODE_ENV !== 'production' && navigationPromises) {
+    return use(navigationPromises.params) as T
   }
 
   return params
-}
-
-/** Get the canonical parameters from the current level to the leaf node. */
-// Client components API
-function getSelectedLayoutSegmentPath(
-  tree: FlightRouterState,
-  parallelRouteKey: string,
-  first = true,
-  segmentPath: string[] = []
-): string[] {
-  let node: FlightRouterState
-  if (first) {
-    // Use the provided parallel route key on the first parallel route
-    node = tree[1][parallelRouteKey]
-  } else {
-    // After first parallel route prefer children, if there's no children pick the first parallel route.
-    const parallelRoutes = tree[1]
-    node = parallelRoutes.children ?? Object.values(parallelRoutes)[0]
-  }
-
-  if (!node) return segmentPath
-  const segment = node[0]
-
-  let segmentValue = getSegmentValue(segment)
-
-  if (!segmentValue || segmentValue.startsWith(PAGE_SEGMENT_KEY)) {
-    return segmentPath
-  }
-
-  segmentPath.push(segmentValue)
-
-  return getSelectedLayoutSegmentPath(
-    node,
-    parallelRouteKey,
-    false,
-    segmentPath
-  )
 }
 
 /**
@@ -263,27 +211,23 @@ export function useSelectedLayoutSegments(
 ): string[] {
   useDynamicRouteParams?.('useSelectedLayoutSegments()')
 
+  const navigationPromises = useContext(NavigationPromisesContext)
   const context = useContext(LayoutRouterContext)
   // @ts-expect-error This only happens in `pages`. Type is overwritten in navigation.d.ts
   if (!context) return null
 
-  const segments = getSelectedLayoutSegmentPath(
-    context.parentTree,
-    parallelRouteKey
-  )
-
   // Instrument with Suspense DevTools (dev-only)
-  if (process.env.NODE_ENV !== 'production') {
-    // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const navigationPromises = useContext(NavigationPromisesContext)
-    if (navigationPromises) {
-      navigationPromises.selectedLayoutSegments.value = segments
-      return use(navigationPromises.selectedLayoutSegments)
+  if (process.env.NODE_ENV !== 'production' && navigationPromises) {
+    const promise =
+      navigationPromises.selectedLayoutSegmentsPromises?.get(parallelRouteKey)
+    if (promise) {
+      // We should always have a promise here, but if we don't, it's not worth erroring over.
+      // We just won't be able to instrument it, but can still provide the value.
+      return use(promise)
     }
   }
 
-  return segments
+  return getSelectedLayoutSegmentPath(context.parentTree, parallelRouteKey)
 }
 
 /**
@@ -309,35 +253,21 @@ export function useSelectedLayoutSegment(
   parallelRouteKey: string = 'children'
 ): string | null {
   useDynamicRouteParams?.('useSelectedLayoutSegment()')
-
+  const navigationPromises = useContext(NavigationPromisesContext)
   const selectedLayoutSegments = useSelectedLayoutSegments(parallelRouteKey)
 
-  if (!selectedLayoutSegments || selectedLayoutSegments.length === 0) {
-    return null
-  }
-
-  const selectedLayoutSegment =
-    parallelRouteKey === 'children'
-      ? selectedLayoutSegments[0]
-      : selectedLayoutSegments[selectedLayoutSegments.length - 1]
-
-  // if the default slot is showing, we return null since it's not technically "selected" (it's a fallback)
-  // and returning an internal value like `__DEFAULT__` would be confusing.
-  const segment =
-    selectedLayoutSegment === DEFAULT_SEGMENT_KEY ? null : selectedLayoutSegment
-
   // Instrument with Suspense DevTools (dev-only)
-  if (process.env.NODE_ENV !== 'production') {
-    // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const navigationPromises = useContext(NavigationPromisesContext)
-    if (navigationPromises) {
-      navigationPromises.selectedLayoutSegment.value = segment
-      return use(navigationPromises.selectedLayoutSegment)
+  if (process.env.NODE_ENV !== 'production' && navigationPromises) {
+    const promise =
+      navigationPromises.selectedLayoutSegmentPromises?.get(parallelRouteKey)
+    if (promise) {
+      // We should always have a promise here, but if we don't, it's not worth erroring over.
+      // We just won't be able to instrument it, but can still provide the value.
+      return use(promise)
     }
   }
 
-  return segment
+  return computeSelectedLayoutSegment(selectedLayoutSegments, parallelRouteKey)
 }
 
 export { unstable_isUnrecognizedActionError } from './unrecognized-action-error'

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -1,7 +1,7 @@
 import type { FlightRouterState } from '../../shared/lib/app-router-types'
 import type { Params } from '../../server/request/params'
 
-import { useContext, useMemo } from 'react'
+import { useContext, useMemo, use } from 'react'
 import {
   AppRouterContext,
   LayoutRouterContext,
@@ -11,6 +11,7 @@ import {
   SearchParamsContext,
   PathnameContext,
   PathParamsContext,
+  NavigationPromisesContext,
 } from '../../shared/lib/hooks-client-context.shared-runtime'
 import { getSegmentValue } from './router-reducer/reducers/get-segment-value'
 import { PAGE_SEGMENT_KEY, DEFAULT_SEGMENT_KEY } from '../../shared/lib/segment'
@@ -69,6 +70,18 @@ export function useSearchParams(): ReadonlyURLSearchParams {
     return new ReadonlyURLSearchParams(searchParams)
   }, [searchParams]) as ReadonlyURLSearchParams
 
+  // Instrument with Suspense DevTools (dev-only)
+
+  if (process.env.NODE_ENV !== 'production') {
+    // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const navigationPromises = useContext(NavigationPromisesContext)
+    if (navigationPromises) {
+      navigationPromises.searchParams.value = readonlySearchParams
+      return use(navigationPromises.searchParams)
+    }
+  }
+
   return readonlySearchParams
 }
 
@@ -95,7 +108,20 @@ export function usePathname(): string {
 
   // In the case where this is `null`, the compat types added in `next-env.d.ts`
   // will add a new overload that changes the return type to include `null`.
-  return useContext(PathnameContext) as string
+  const pathname = useContext(PathnameContext) as string
+
+  // Instrument with Suspense DevTools (dev-only)
+  if (process.env.NODE_ENV !== 'production') {
+    // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const navigationPromises = useContext(NavigationPromisesContext)
+    if (navigationPromises) {
+      navigationPromises.pathname.value = pathname
+      return use(navigationPromises.pathname)
+    }
+  }
+
+  return pathname
 }
 
 // Client components API
@@ -153,7 +179,20 @@ export function useRouter(): AppRouterInstance {
 export function useParams<T extends Params = Params>(): T {
   useDynamicRouteParams?.('useParams()')
 
-  return useContext(PathParamsContext) as T
+  const params = useContext(PathParamsContext) as T
+
+  // Instrument with Suspense DevTools (dev-only)
+  if (process.env.NODE_ENV !== 'production') {
+    // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const navigationPromises = useContext(NavigationPromisesContext)
+    if (navigationPromises) {
+      navigationPromises.params.value = params
+      return use(navigationPromises.params)
+    }
+  }
+
+  return params
 }
 
 /** Get the canonical parameters from the current level to the leaf node. */
@@ -228,7 +267,23 @@ export function useSelectedLayoutSegments(
   // @ts-expect-error This only happens in `pages`. Type is overwritten in navigation.d.ts
   if (!context) return null
 
-  return getSelectedLayoutSegmentPath(context.parentTree, parallelRouteKey)
+  const segments = getSelectedLayoutSegmentPath(
+    context.parentTree,
+    parallelRouteKey
+  )
+
+  // Instrument with Suspense DevTools (dev-only)
+  if (process.env.NODE_ENV !== 'production') {
+    // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const navigationPromises = useContext(NavigationPromisesContext)
+    if (navigationPromises) {
+      navigationPromises.selectedLayoutSegments.value = segments
+      return use(navigationPromises.selectedLayoutSegments)
+    }
+  }
+
+  return segments
 }
 
 /**
@@ -268,9 +323,21 @@ export function useSelectedLayoutSegment(
 
   // if the default slot is showing, we return null since it's not technically "selected" (it's a fallback)
   // and returning an internal value like `__DEFAULT__` would be confusing.
-  return selectedLayoutSegment === DEFAULT_SEGMENT_KEY
-    ? null
-    : selectedLayoutSegment
+  const segment =
+    selectedLayoutSegment === DEFAULT_SEGMENT_KEY ? null : selectedLayoutSegment
+
+  // Instrument with Suspense DevTools (dev-only)
+  if (process.env.NODE_ENV !== 'production') {
+    // This hook is in a conditional but that is ok because `process.env.NODE_ENV` never changes
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const navigationPromises = useContext(NavigationPromisesContext)
+    if (navigationPromises) {
+      navigationPromises.selectedLayoutSegment.value = segment
+      return use(navigationPromises.selectedLayoutSegment)
+    }
+  }
+
+  return segment
 }
 
 export { unstable_isUnrecognizedActionError } from './unrecognized-action-error'

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -16,7 +16,7 @@ import {
   computeSelectedLayoutSegment,
   getSelectedLayoutSegmentPath,
 } from '../../shared/lib/segment'
-import { ReadonlyURLSearchParams } from './navigation.react-server'
+import { ReadonlyURLSearchParams } from './readonly-url-search-params'
 
 const useDynamicRouteParams =
   typeof window === 'undefined'
@@ -56,7 +56,6 @@ const useDynamicSearchParams =
 export function useSearchParams(): ReadonlyURLSearchParams {
   useDynamicSearchParams?.('useSearchParams()')
 
-  const navigationPromises = useContext(NavigationPromisesContext)
   const searchParams = useContext(SearchParamsContext)
 
   // In the case where this is `null`, the compat types added in
@@ -73,8 +72,11 @@ export function useSearchParams(): ReadonlyURLSearchParams {
   }, [searchParams]) as ReadonlyURLSearchParams
 
   // Instrument with Suspense DevTools (dev-only)
-  if (process.env.NODE_ENV !== 'production' && navigationPromises) {
-    return use(navigationPromises.searchParams)
+  if (process.env.NODE_ENV !== 'production') {
+    const navigationPromises = use(NavigationPromisesContext)
+    if (navigationPromises) {
+      return use(navigationPromises.searchParams)
+    }
   }
 
   return readonlySearchParams
@@ -101,14 +103,16 @@ export function useSearchParams(): ReadonlyURLSearchParams {
 export function usePathname(): string {
   useDynamicRouteParams?.('usePathname()')
 
-  const navigationPromises = useContext(NavigationPromisesContext)
   // In the case where this is `null`, the compat types added in `next-env.d.ts`
   // will add a new overload that changes the return type to include `null`.
   const pathname = useContext(PathnameContext) as string
 
   // Instrument with Suspense DevTools (dev-only)
-  if (process.env.NODE_ENV !== 'production' && navigationPromises) {
-    return use(navigationPromises.pathname)
+  if (process.env.NODE_ENV !== 'production') {
+    const navigationPromises = use(NavigationPromisesContext)
+    if (navigationPromises) {
+      return use(navigationPromises.pathname)
+    }
   }
 
   return pathname
@@ -169,12 +173,14 @@ export function useRouter(): AppRouterInstance {
 export function useParams<T extends Params = Params>(): T {
   useDynamicRouteParams?.('useParams()')
 
-  const navigationPromises = useContext(NavigationPromisesContext)
   const params = useContext(PathParamsContext) as T
 
   // Instrument with Suspense DevTools (dev-only)
-  if (process.env.NODE_ENV !== 'production' && navigationPromises) {
-    return use(navigationPromises.params) as T
+  if (process.env.NODE_ENV !== 'production') {
+    const navigationPromises = use(NavigationPromisesContext)
+    if (navigationPromises) {
+      return use(navigationPromises.params) as T
+    }
   }
 
   return params
@@ -211,19 +217,21 @@ export function useSelectedLayoutSegments(
 ): string[] {
   useDynamicRouteParams?.('useSelectedLayoutSegments()')
 
-  const navigationPromises = useContext(NavigationPromisesContext)
   const context = useContext(LayoutRouterContext)
   // @ts-expect-error This only happens in `pages`. Type is overwritten in navigation.d.ts
   if (!context) return null
 
   // Instrument with Suspense DevTools (dev-only)
-  if (process.env.NODE_ENV !== 'production' && navigationPromises) {
-    const promise =
-      navigationPromises.selectedLayoutSegmentsPromises?.get(parallelRouteKey)
-    if (promise) {
-      // We should always have a promise here, but if we don't, it's not worth erroring over.
-      // We just won't be able to instrument it, but can still provide the value.
-      return use(promise)
+  if (process.env.NODE_ENV !== 'production') {
+    const navigationPromises = use(NavigationPromisesContext)
+    if (navigationPromises) {
+      const promise =
+        navigationPromises.selectedLayoutSegmentsPromises?.get(parallelRouteKey)
+      if (promise) {
+        // We should always have a promise here, but if we don't, it's not worth erroring over.
+        // We just won't be able to instrument it, but can still provide the value.
+        return use(promise)
+      }
     }
   }
 

--- a/packages/next/src/client/components/readonly-url-search-params.ts
+++ b/packages/next/src/client/components/readonly-url-search-params.ts
@@ -1,0 +1,37 @@
+/**
+ * ReadonlyURLSearchParams implementation shared between client and server.
+ * This file is intentionally not marked as 'use client' or 'use server'
+ * so it can be imported by both environments.
+ */
+
+/** @internal */
+class ReadonlyURLSearchParamsError extends Error {
+  constructor() {
+    super(
+      'Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams'
+    )
+  }
+}
+
+/**
+ * A read-only version of URLSearchParams that throws errors when mutation methods are called.
+ * This ensures that the URLSearchParams returned by useSearchParams() cannot be mutated.
+ */
+export class ReadonlyURLSearchParams extends URLSearchParams {
+  /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
+  append() {
+    throw new ReadonlyURLSearchParamsError()
+  }
+  /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
+  delete() {
+    throw new ReadonlyURLSearchParamsError()
+  }
+  /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
+  set() {
+    throw new ReadonlyURLSearchParamsError()
+  }
+  /** @deprecated Method unavailable on `ReadonlyURLSearchParams`. Read more: https://nextjs.org/docs/app/api-reference/functions/use-search-params#updating-searchparams */
+  sort() {
+    throw new ReadonlyURLSearchParamsError()
+  }
+}

--- a/packages/next/src/client/components/router-reducer/reducers/get-segment-value.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/get-segment-value.ts
@@ -1,5 +1,0 @@
-import type { Segment } from '../../../../shared/lib/app-router-types'
-
-export function getSegmentValue(segment: Segment) {
-  return Array.isArray(segment) ? segment[1] : segment
-}

--- a/packages/next/src/shared/lib/hooks-client-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/hooks-client-context.shared-runtime.ts
@@ -9,7 +9,6 @@ export const PathParamsContext = createContext<Params | null>(null)
 
 // Dev-only context for Suspense DevTools instrumentation
 // These promises are used to track navigation hook usage in React DevTools
-// These are instrumented promises with additional properties that React DevTools expects
 export type InstrumentedPromise<T> = Promise<T> & {
   status: 'fulfilled'
   value: T

--- a/packages/next/src/shared/lib/hooks-client-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/hooks-client-context.shared-runtime.ts
@@ -7,8 +7,30 @@ export const SearchParamsContext = createContext<URLSearchParams | null>(null)
 export const PathnameContext = createContext<string | null>(null)
 export const PathParamsContext = createContext<Params | null>(null)
 
+// Dev-only context for Suspense DevTools instrumentation
+// These promises are used to track navigation hook usage in React DevTools
+// The promise values are updated with actual hook values before calling use()
+// These are instrumented promises with additional properties that React DevTools expects
+type InstrumentedPromise<T> = Promise<T> & {
+  status: 'fulfilled'
+  value: T
+  displayName: string
+}
+
+export type NavigationPromises = {
+  pathname: InstrumentedPromise<string>
+  searchParams: InstrumentedPromise<any> // ReadonlyURLSearchParams
+  params: InstrumentedPromise<any> // Params
+  selectedLayoutSegment: InstrumentedPromise<string | null>
+  selectedLayoutSegments: InstrumentedPromise<string[]>
+}
+
+export const NavigationPromisesContext =
+  createContext<NavigationPromises | null>(null)
+
 if (process.env.NODE_ENV !== 'production') {
   SearchParamsContext.displayName = 'SearchParamsContext'
   PathnameContext.displayName = 'PathnameContext'
   PathParamsContext.displayName = 'PathParamsContext'
+  NavigationPromisesContext.displayName = 'NavigationPromisesContext'
 }

--- a/packages/next/src/shared/lib/hooks-client-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/hooks-client-context.shared-runtime.ts
@@ -9,9 +9,8 @@ export const PathParamsContext = createContext<Params | null>(null)
 
 // Dev-only context for Suspense DevTools instrumentation
 // These promises are used to track navigation hook usage in React DevTools
-// The promise values are updated with actual hook values before calling use()
 // These are instrumented promises with additional properties that React DevTools expects
-type InstrumentedPromise<T> = Promise<T> & {
+export type InstrumentedPromise<T> = Promise<T> & {
   status: 'fulfilled'
   value: T
   displayName: string
@@ -21,12 +20,30 @@ export type NavigationPromises = {
   pathname: InstrumentedPromise<string>
   searchParams: InstrumentedPromise<any> // ReadonlyURLSearchParams
   params: InstrumentedPromise<any> // Params
-  selectedLayoutSegment: InstrumentedPromise<string | null>
-  selectedLayoutSegments: InstrumentedPromise<string[]>
+  // Layout segment hooks (updated at each layout boundary)
+  selectedLayoutSegmentPromises?: Map<
+    string,
+    InstrumentedPromise<string | null>
+  >
+  selectedLayoutSegmentsPromises?: Map<string, InstrumentedPromise<string[]>>
 }
 
 export const NavigationPromisesContext =
   createContext<NavigationPromises | null>(null)
+
+// Creates an instrumented promise for Suspense DevTools
+// These promises are always fulfilled and exist purely for
+// tracking in React's Suspense DevTools.
+export function createDevToolsInstrumentedPromise<T>(
+  displayName: string,
+  value: T
+): InstrumentedPromise<T> {
+  const promise = Promise.resolve(value) as InstrumentedPromise<T>
+  promise.status = 'fulfilled'
+  promise.value = value
+  promise.displayName = `${displayName} (SSR)`
+  return promise
+}
 
 if (process.env.NODE_ENV !== 'production') {
   SearchParamsContext.displayName = 'SearchParamsContext'

--- a/packages/next/src/shared/lib/segment.test.ts
+++ b/packages/next/src/shared/lib/segment.test.ts
@@ -1,4 +1,4 @@
-import { getSegmentValue } from './reducers/get-segment-value'
+import { getSegmentValue } from './segment'
 
 describe('getSegmentValue', () => {
   it('should support string segment', () => {

--- a/packages/next/src/shared/lib/segment.ts
+++ b/packages/next/src/shared/lib/segment.ts
@@ -1,4 +1,8 @@
-import type { Segment } from './app-router-types'
+import type { FlightRouterState, Segment } from './app-router-types'
+
+export function getSegmentValue(segment: Segment) {
+  return Array.isArray(segment) ? segment[1] : segment
+}
 
 export function isGroupSegment(segment: string) {
   // Use array[0] for performant purpose
@@ -23,6 +27,61 @@ export function addSearchParamsIfPageSegment(
   }
 
   return segment
+}
+
+export function computeSelectedLayoutSegment(
+  segments: string[] | null,
+  parallelRouteKey: string
+): string | null {
+  if (!segments || segments.length === 0) {
+    return null
+  }
+
+  // For 'children', use first segment; for other parallel routes, use last segment
+  const rawSegment =
+    parallelRouteKey === 'children'
+      ? segments[0]
+      : segments[segments.length - 1]
+
+  // If the default slot is showing, return null since it's not technically "selected" (it's a fallback)
+  // Returning an internal value like `__DEFAULT__` would be confusing
+  return rawSegment === DEFAULT_SEGMENT_KEY ? null : rawSegment
+}
+
+/** Get the canonical parameters from the current level to the leaf node. */
+export function getSelectedLayoutSegmentPath(
+  tree: FlightRouterState,
+  parallelRouteKey: string,
+  first = true,
+  segmentPath: string[] = []
+): string[] {
+  let node: FlightRouterState
+  if (first) {
+    // Use the provided parallel route key on the first parallel route
+    node = tree[1][parallelRouteKey]
+  } else {
+    // After first parallel route prefer children, if there's no children pick the first parallel route.
+    const parallelRoutes = tree[1]
+    node = parallelRoutes.children ?? Object.values(parallelRoutes)[0]
+  }
+
+  if (!node) return segmentPath
+  const segment = node[0]
+
+  let segmentValue = getSegmentValue(segment)
+
+  if (!segmentValue || segmentValue.startsWith(PAGE_SEGMENT_KEY)) {
+    return segmentPath
+  }
+
+  segmentPath.push(segmentValue)
+
+  return getSelectedLayoutSegmentPath(
+    node,
+    parallelRouteKey,
+    false,
+    segmentPath
+  )
 }
 
 export const PAGE_SEGMENT_KEY = '__PAGE__'

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -142,27 +142,26 @@ describe('Error overlay for hydration errors in App router', () => {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
          "componentStack": "...
-           <RenderFromTemplateContext>
-             <ScrollAndFocusHandler segmentPath={[...]}>
-               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary loading={null}>
-                     <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                       <HTTPAccessFallbackErrorBoundary pathname="/extra-att..." notFound={<SegmentViewNode>} ...>
-                         <RedirectBoundary>
-                           <RedirectErrorBoundary router={{...}}>
-                             <InnerLayoutRouter url="/extra-att..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
-                               <SegmentViewNode type="layout" pagePath="(extra-att...">
-                                 <SegmentTrieNode>
-                                 <script>
-                                 <script>
-                                 <ClientSegmentRoot Component={function Root} slots={{...}} params={{}}>
-                                   <Root params={Promise}>
-                                     <html
-       -                               className="server-html"
-                                     >
-                             ...
-                 ...",
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/extra-att..." notFound={<SegmentViewNode>} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/extra-att..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                             <SegmentViewNode type="layout" pagePath="(extra-att...">
+                               <SegmentTrieNode>
+                               <script>
+                               <script>
+                               <ClientSegmentRoot Component={function Root} slots={{...}} params={{}}>
+                                 <Root params={Promise}>
+                                   <html
+       -                             className="server-html"
+                                   >
+                           ...
+               ...",
          "description": "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Console Error",
@@ -179,25 +178,24 @@ describe('Error overlay for hydration errors in App router', () => {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
          "componentStack": "...
-           <RenderFromTemplateContext>
-             <ScrollAndFocusHandler segmentPath={[...]}>
-               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary loading={null}>
-                     <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                       <HTTPAccessFallbackErrorBoundary pathname="/extra-att..." notFound={<SegmentViewNode>} ...>
-                         <RedirectBoundary>
-                           <RedirectErrorBoundary router={{...}}>
-                             <InnerLayoutRouter url="/extra-att..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
-                               <SegmentViewNode type="layout" pagePath="(extra-att...">
-                                 <SegmentTrieNode>
-                                 <ClientSegmentRoot Component={function Root} slots={{...}} params={{}}>
-                                   <Root params={Promise}>
-                                     <html
-       -                               className="server-html"
-                                     >
-                             ...
-                 ...",
+           <ScrollAndFocusHandler segmentPath={[...]}>
+             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
+                 <LoadingBoundary loading={null}>
+                   <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
+                     <HTTPAccessFallbackErrorBoundary pathname="/extra-att..." notFound={<SegmentViewNode>} ...>
+                       <RedirectBoundary>
+                         <RedirectErrorBoundary router={{...}}>
+                           <InnerLayoutRouter url="/extra-att..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
+                             <SegmentViewNode type="layout" pagePath="(extra-att...">
+                               <SegmentTrieNode>
+                               <ClientSegmentRoot Component={function Root} slots={{...}} params={{}}>
+                                 <Root params={Promise}>
+                                   <html
+       -                             className="server-html"
+                                   >
+                           ...
+               ...",
          "description": "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Console Error",
@@ -920,8 +918,7 @@ describe('Error overlay for hydration errors in App router', () => {
                                        <Script src="https://ex..." strategy="beforeInte...">
          >                               <script nonce={undefined} dangerouslySetInnerHTML={{__html:"(self.__ne..."}}>
                                ...
-                   ...
-             ...",
+                   ...",
              "description": "In HTML, <script> cannot be a child of <html>.
          This will cause a hydration error.",
              "environmentLabel": null,
@@ -983,8 +980,7 @@ describe('Error overlay for hydration errors in App router', () => {
                                        <Script src="https://ex..." strategy="beforeInte...">
          >                               <script nonce={undefined} dangerouslySetInnerHTML={{__html:"(self.__ne..."}}>
                                ...
-                   ...
-             ...",
+                   ...",
              "description": "In HTML, <script> cannot be a child of <html>.
          This will cause a hydration error.",
              "environmentLabel": null,

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -238,13 +238,13 @@ describe('Cache Components Errors', () => {
                    at ScrollAndFocusHandler (bundler:///<next-src>)
                    at RenderFromTemplateContext (bundler:///<next-src>)
                    at OuterLayoutRouter (bundler:///<next-src>)
-                 331 |  */
-                 332 | function InnerLayoutRouter({
-               > 333 |   tree,
+                 333 |  */
+                 334 | function InnerLayoutRouter({
+               > 335 |   tree,
                      |   ^
-                 334 |   segmentPath,
-                 335 |   cacheNode,
-                 336 |   url,
+                 336 |   segmentPath,
+                 337 |   cacheNode,
+                 338 |   url,
                To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -745,13 +745,13 @@ describe('Cache Components Errors', () => {
                    at ScrollAndFocusHandler (bundler:///<next-src>)
                    at RenderFromTemplateContext (bundler:///<next-src>)
                    at OuterLayoutRouter (bundler:///<next-src>)
-                 331 |  */
-                 332 | function InnerLayoutRouter({
-               > 333 |   tree,
+                 333 |  */
+                 334 | function InnerLayoutRouter({
+               > 335 |   tree,
                      |   ^
-                 334 |   segmentPath,
-                 335 |   cacheNode,
-                 336 |   url,
+                 336 |   segmentPath,
+                 337 |   cacheNode,
+                 338 |   url,
                To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -2141,13 +2141,13 @@ describe('Cache Components Errors', () => {
                      at ScrollAndFocusHandler (bundler:///<next-src>)
                      at RenderFromTemplateContext (<anonymous>)
                      at OuterLayoutRouter (bundler:///<next-src>)
-                   331 |  */
-                   332 | function InnerLayoutRouter({
-                 > 333 |   tree,
+                   333 |  */
+                   334 | function InnerLayoutRouter({
+                 > 335 |   tree,
                        |   ^
-                   334 |   segmentPath,
-                   335 |   cacheNode,
-                   336 |   url,
+                   336 |   segmentPath,
+                   337 |   cacheNode,
+                   338 |   url,
                  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-guarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/unguarded-async-guarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3157,13 +3157,13 @@ describe('Cache Components Errors', () => {
                      at ScrollAndFocusHandler (bundler:///<next-src>)
                      at RenderFromTemplateContext (bundler:///<next-src>)
                      at OuterLayoutRouter (bundler:///<next-src>)
-                   331 |  */
-                   332 | function InnerLayoutRouter({
-                 > 333 |   tree,
+                   333 |  */
+                   334 | function InnerLayoutRouter({
+                 > 335 |   tree,
                        |   ^
-                   334 |   segmentPath,
-                   335 |   cacheNode,
-                   336 |   url,
+                   336 |   segmentPath,
+                   337 |   cacheNode,
+                   338 |   url,
                  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-without-suspense" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-without-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
 

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -238,13 +238,13 @@ describe('Cache Components Errors', () => {
                    at ScrollAndFocusHandler (bundler:///<next-src>)
                    at RenderFromTemplateContext (bundler:///<next-src>)
                    at OuterLayoutRouter (bundler:///<next-src>)
-                 333 |  */
-                 334 | function InnerLayoutRouter({
-               > 335 |   tree,
+                 335 |  */
+                 336 | function InnerLayoutRouter({
+               > 337 |   tree,
                      |   ^
-                 336 |   segmentPath,
-                 337 |   cacheNode,
-                 338 |   url,
+                 338 |   segmentPath,
+                 339 |   cacheNode,
+                 340 |   url,
                To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -745,13 +745,13 @@ describe('Cache Components Errors', () => {
                    at ScrollAndFocusHandler (bundler:///<next-src>)
                    at RenderFromTemplateContext (bundler:///<next-src>)
                    at OuterLayoutRouter (bundler:///<next-src>)
-                 333 |  */
-                 334 | function InnerLayoutRouter({
-               > 335 |   tree,
+                 335 |  */
+                 336 | function InnerLayoutRouter({
+               > 337 |   tree,
                      |   ^
-                 336 |   segmentPath,
-                 337 |   cacheNode,
-                 338 |   url,
+                 338 |   segmentPath,
+                 339 |   cacheNode,
+                 340 |   url,
                To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -2141,13 +2141,13 @@ describe('Cache Components Errors', () => {
                      at ScrollAndFocusHandler (bundler:///<next-src>)
                      at RenderFromTemplateContext (<anonymous>)
                      at OuterLayoutRouter (bundler:///<next-src>)
-                   333 |  */
-                   334 | function InnerLayoutRouter({
-                 > 335 |   tree,
+                   335 |  */
+                   336 | function InnerLayoutRouter({
+                 > 337 |   tree,
                        |   ^
-                   336 |   segmentPath,
-                   337 |   cacheNode,
-                   338 |   url,
+                   338 |   segmentPath,
+                   339 |   cacheNode,
+                   340 |   url,
                  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-guarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/unguarded-async-guarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3157,13 +3157,13 @@ describe('Cache Components Errors', () => {
                      at ScrollAndFocusHandler (bundler:///<next-src>)
                      at RenderFromTemplateContext (bundler:///<next-src>)
                      at OuterLayoutRouter (bundler:///<next-src>)
-                   333 |  */
-                   334 | function InnerLayoutRouter({
-                 > 335 |   tree,
+                   335 |  */
+                   336 | function InnerLayoutRouter({
+                 > 337 |   tree,
                        |   ^
-                   336 |   segmentPath,
-                   337 |   cacheNode,
-                   338 |   url,
+                   338 |   segmentPath,
+                   339 |   cacheNode,
+                   340 |   url,
                  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-without-suspense" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-without-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
 


### PR DESCRIPTION
Various navigation hooks (eg `usePathname`, `useParams`) could suspend during SSR/prerendering even though they don't necessarily suspend during client side navigation (because it was likely part of a prefetch response). React's Suspense DevTools show all the possible things that could have suspended on the page, but without us calling `use` in these hooks, there'd be no way for React to track them as IO in the same way that we do during prerendering.

In development, this instruments all of the client navigation hooks to call `use` on a fulfilled promise set to the same value that we would have returned previously. For hooks like `useSelectedLayoutSegment`, I'm storing a map of promises at each level of layout (because these hooks take a parallel route key argument and values are relative to the calling layout's position in the tree). These are eagerly pre-computed during dev.