### PR TITLE
fix: incorrect canonicalUrl set when using output: export

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -158,6 +158,10 @@ export async function fetchServerResponse(
     headers[NEXT_URL] = nextUrl
   }
 
+  // In static export mode, we need to modify the URL to request the .txt file,
+  // but we should preserve the original URL for the canonical URL and error handling.
+  const originalUrl = url
+
   try {
     // When creating a "temporary" prefetch (the "on-demand" prefetch that gets created on navigation, if one doesn't exist)
     // we send the request with a "high" priority as it's in response to a user interaction that could be blocking a transition.
@@ -198,7 +202,7 @@ export async function fetchServerResponse(
     )
 
     const responseUrl = urlToUrlWithoutFlightMarker(new URL(res.url))
-    const canonicalUrl = res.redirected ? responseUrl : url
+    const canonicalUrl = res.redirected ? responseUrl : originalUrl
 
     const contentType = res.headers.get('content-type') || ''
     const interception = !!res.headers.get('vary')?.includes(NEXT_URL)
@@ -285,7 +289,7 @@ export async function fetchServerResponse(
   } catch (err) {
     if (!abortController.signal.aborted) {
       console.error(
-        `Failed to fetch RSC payload for ${url}. Falling back to browser navigation.`,
+        `Failed to fetch RSC payload for ${originalUrl}. Falling back to browser navigation.`,
         err
       )
     }
@@ -293,7 +297,7 @@ export async function fetchServerResponse(
     // If fetch fails handle it like a mpa navigation
     // TODO-APP: Add a test for the case where a CORS request fails, e.g. external url redirect coming from the response.
     // See https://github.com/vercel/next.js/issues/43605#issuecomment-1451617521 for a reproduction.
-    return url.toString()
+    return originalUrl.toString()
   }
 }
 


### PR DESCRIPTION
After the changes in https://github.com/vercel/next.js/commit/5ccc9078e094215e6c891c38a31fb94cda03456e, when in `output: 'export'` mode, the `canonicalUrl` value was getting corrupted to be set to one of the URLs of the RSC responses (eg `/another.txt`). This is because the original `url` gets mutated to append a `.txt` extension for the RSC requests.

This ensures we preserve the original canonical URL so it doesn't get corrupted when we mutate the pathname.

Failing test ref: https://github.com/vercel/next.js/actions/runs/18607156298/job/53060147186#step:34:151