### PR TITLE
Update next-lint-to-eslint-cli to support `FlatCompat.config`

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/flat-config-flat-compat-with-other-compat/eslint.config.mjs
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/flat-config-flat-compat-with-other-compat/eslint.config.mjs
@@ -1,0 +1,30 @@
+import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { FlatCompat } from '@eslint/eslintrc'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+})
+
+const eslintConfig = [
+  ...compat.config({
+    extends: ['next/core-web-vitals', 'next/typescript'],
+  }),
+  ...compat.config({
+    extends: ['foo', 'bar'],
+  }),
+  {
+    ignores: [
+      'node_modules/**',
+      '.next/**',
+      'out/**',
+      'build/**',
+      'next-env.d.ts',
+    ],
+  },
+]
+
+export default eslintConfig

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/flat-config-flat-compat-with-other-compat/package.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/flat-config-flat-compat-with-other-compat/package.json
@@ -1,0 +1,26 @@
+{
+  "scripts": {
+    "lint": "next lint --fix --dir src --dir pages",
+    "lint:strict": "next lint --strict",
+    "lint:ci": "next lint --quiet --output-file lint-results.json",
+    "precommit": "next lint --fix && npm test",
+    "test": "jest && next lint",
+    "complex": "npm run build && next lint --dir . --ext .js,.jsx,.ts,.tsx 2>/dev/null",
+    "pipe": "next lint | tee lint.log",
+    "redirect": "next lint > output.txt 2>&1",
+    "multi": "next lint; next build; next lint --fix"
+  },
+  "dependencies": {
+    "react": "^19",
+    "react-dom": "^19",
+    "next": "^16"
+  },
+  "devDependencies": {
+    "typescript": "^5",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "^16"
+  }
+}


### PR DESCRIPTION
ESLint `FlatCompat` can be used in two ways:

```js
compat.extends('next/core-web-vitals', 'next/typescript')
```

```js
compat.config({
  extends: ['next/core-web-vitals', 'next/typescript'],
})
```

Although using `.extends()` is recommended for migration, and the ESLint migration tool also uses that, it is possible to use `.config()`, so handle them as well for the migration.

Confirmed on local apps as well.

Closes NEXT-4742