### PR TITLE
Turbopack: make tracing warning not fail build

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -304,7 +304,7 @@ impl Issue for TooManyMatchesWarning {
     }
 
     fn severity(&self) -> IssueSeverity {
-        IssueSeverity::Error
+        IssueSeverity::Warning
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
It called "warning", but it had severity error.

Closes PACK-5708