### PR TITLE
Turbopack: Remove unneeded warning for telemetry

### DIFF
--- a/packages/next/src/client/dev/hot-reloader/turbopack-hot-reloader-common.ts
+++ b/packages/next/src/client/dev/hot-reloader/turbopack-hot-reloader-common.ts
@@ -142,11 +142,8 @@ function extractModulesFromTurbopackMessage(
 
     for (const mergedUpdate of update.instruction.merged) {
       for (const name of Object.keys(mergedUpdate.entries)) {
-        const res = /(.*)\s+\[.*/.exec(name)
+        const res = /(.*)\s+[([].*/.exec(name)
         if (res === null) {
-          console.error(
-            '[Turbopack HMR] Expected module to match pattern: ' + name
-          )
           continue
         }
 


### PR DESCRIPTION
### What?

* The information is only needed for telementry, we should not error when a module doesn't match the regexp.
* Fix the regex to support json too. (it was missing a layer attribute)

Closes PACK-5709