### PR TITLE
Update deprecated email validation in auth guide

### DIFF
--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -110,7 +110,7 @@ export const SignupFormSchema = z.object({
     .string()
     .min(2, { message: 'Name must be at least 2 characters long.' })
     .trim(),
-  email: z.string().email({ message: 'Please enter a valid email.' }).trim(),
+  email: z.email({ message: 'Please enter a valid email.' }).trim(),
   password: z
     .string()
     .min(8, { message: 'Be at least 8 characters long' })


### PR DESCRIPTION
### What?

The existing guidance for email validation during authentication produces the below compiler warning:

```
'(params?: string | { abort?: boolean | undefined; pattern?: RegExp | undefined; error?: string | $ZodErrorMap<$ZodIssueInvalidStringFormat> | undefined; message?: string | undefined; } | undefined): ZodString' is deprecated.
```

### Why?

The warning traces to `z.string.email()` usage, which was deprecated in Zod 4 with commit [85928](https://github.com/colinhacks/zod/blob/85928549a7c2aff851d8625588ed7aa2e394831f/packages/zod/src/v4/classic/schemas.ts#L286). See the [official guidance](https://zod.dev/api?id=emails) for details on email validation.

### How?

Fixes guidance.
