### PR TITLE
[cache components] stabilize cacheLife profiles

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/cacheLife.mdx
+++ b/docs/01-app/03-api-reference/04-functions/cacheLife.mdx
@@ -113,13 +113,11 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
-  experimental: {
-    cacheLife: {
-      biweekly: {
-        stale: 60 * 60 * 24 * 14, // 14 days
-        revalidate: 60 * 60 * 24, // 1 day
-        expire: 60 * 60 * 24 * 14, // 14 days
-      },
+  cacheLife: {
+    biweekly: {
+      stale: 60 * 60 * 24 * 14, // 14 days
+      revalidate: 60 * 60 * 24, // 1 day
+      expire: 60 * 60 * 24 * 14, // 14 days
     },
   },
 }
@@ -130,13 +128,11 @@ module.exports = nextConfig
 ```js filename="next.config.js" switcher
 const nextConfig = {
   cacheComponents: true,
-  experimental: {
-    cacheLife: {
-      biweekly: {
-        stale: 60 * 60 * 24 * 14, // 14 days
-        revalidate: 60 * 60 * 24, // 1 day
-        expire: 60 * 60 * 24 * 14, // 14 days
-      },
+  cacheLife: {
+    biweekly: {
+      stale: 60 * 60 * 24 * 14, // 14 days
+      revalidate: 60 * 60 * 24, // 1 day
+      expire: 60 * 60 * 24 * 14, // 14 days
     },
   },
 }
@@ -167,13 +163,11 @@ The example below shows how to override the default “days” cache profile:
 ```ts filename="next.config.ts"
 const nextConfig = {
   cacheComponents: true,
-  experimental: {
-    cacheLife: {
-      days: {
-        stale: 3600, // 1 hour
-        revalidate: 900, // 15 minutes
-        expire: 86400, // 1 day
-      },
+  cacheLife: {
+    days: {
+      stale: 3600, // 1 hour
+      revalidate: 900, // 15 minutes
+      expire: 86400, // 1 day
     },
   },
 }

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheLife.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheLife.mdx
@@ -15,13 +15,11 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
-  experimental: {
-    cacheLife: {
-      blog: {
-        stale: 3600, // 1 hour
-        revalidate: 900, // 15 minutes
-        expire: 86400, // 1 day
-      },
+  cacheLife: {
+    blog: {
+      stale: 3600, // 1 hour
+      revalidate: 900, // 15 minutes
+      expire: 86400, // 1 day
     },
   },
 }
@@ -32,13 +30,11 @@ export default nextConfig
 ```js filename="next.config.js" switcher
 module.exports = {
   cacheComponents: true,
-  experimental: {
-    cacheLife: {
-      blog: {
-        stale: 3600, // 1 hour
-        revalidate: 900, // 15 minutes
-        expire: 86400, // 1 day
-      },
+  cacheLife: {
+    blog: {
+      stale: 3600, // 1 hour
+      revalidate: 900, // 15 minutes
+      expire: 86400, // 1 day
     },
   },
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -885,5 +885,7 @@
   "884": "Both %s file \"./%s\" and %s file \"./%s\" are detected. Please use \"./%s\" only.",
   "885": "Page \"%s\" cannot use \\`export const unstable_prefetch = ...\\` without enabling \\`cacheComponents\\` and \\`experimental.clientSegmentCache\\`.",
   "886": "`cacheTag()` is only available with the `cacheComponents` config.",
-  "887": "`cacheLife()` is only available with the `cacheComponents` config."
+  "887": "`cacheLife()` is only available with the `cacheComponents` config.",
+  "888": "Unknown \\`cacheLife()\\` profile \"%s\" is not configured in next.config.js\\nmodule.exports = {\n  cacheLife: {\n    \"%s\": ...\\n  }\n}",
+  "889": "Unknown \\`cacheLife()\\` profile \"%s\" is not configured in next.config.js\\nmodule.exports = {\n  cacheLife: {\n      \"%s\": ...\\n    }\n}"
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1977,7 +1977,7 @@ export default async function build(
               defaultLocale: config.i18n?.defaultLocale,
               nextConfigOutput: config.output,
               pprConfig: config.experimental.ppr,
-              cacheLifeProfiles: config.experimental.cacheLife,
+              cacheLifeProfiles: config.cacheLife,
               buildId,
               sriEnabled,
             })
@@ -2198,7 +2198,7 @@ export default async function build(
                             maxMemoryCacheSize: config.cacheMaxMemorySize,
                             nextConfigOutput: config.output,
                             pprConfig: config.experimental.ppr,
-                            cacheLifeProfiles: config.experimental.cacheLife,
+                            cacheLifeProfiles: config.cacheLife,
                             buildId,
                             sriEnabled,
                           })

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -531,7 +531,7 @@ export async function handler(
 
           multiZoneDraftMode,
           incrementalCache,
-          cacheLifeProfiles: nextConfig.experimental.cacheLife,
+          cacheLifeProfiles: nextConfig.cacheLife,
           basePath: nextConfig.basePath,
           serverActions: nextConfig.experimental.serverActions,
 

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -195,7 +195,7 @@ export async function handler(
       cacheComponents: Boolean(nextConfig.cacheComponents),
       supportsDynamicResponse,
       incrementalCache: getRequestMeta(req, 'incrementalCache'),
-      cacheLifeProfiles: nextConfig.experimental?.cacheLife,
+      cacheLifeProfiles: nextConfig.cacheLife,
       waitUntil: ctx.waitUntil,
       onClose: (cb) => {
         res.on('close', cb)

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -152,7 +152,7 @@ async function requestHandler(
       reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
 
       multiZoneDraftMode: false,
-      cacheLifeProfiles: nextConfig.experimental.cacheLife,
+      cacheLifeProfiles: nextConfig.cacheLife,
       basePath: nextConfig.basePath,
       serverActions: nextConfig.experimental.serverActions,
       cacheComponents: Boolean(nextConfig.cacheComponents),

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2143,7 +2143,7 @@ export default async function getBaseWebpackConfig(
           dev,
           isEdgeServer,
           pageExtensions: config.pageExtensions,
-          cacheLifeConfig: config.experimental.cacheLife,
+          cacheLifeConfig: config.cacheLife,
           originalRewrites,
           originalRedirects,
         }),

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -379,7 +379,7 @@ async function exportAppImpl(
     largePageDataBytes: nextConfig.experimental.largePageDataBytes,
     serverActions: nextConfig.experimental.serverActions,
     serverComponents: enabledDirectories.app,
-    cacheLifeProfiles: nextConfig.experimental.cacheLife,
+    cacheLifeProfiles: nextConfig.cacheLife,
     nextFontManifest: require(
       join(distDir, 'server', `${NEXT_FONT_MANIFEST}.json`)
     ),

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -535,7 +535,7 @@ export default abstract class Server<
       domainLocales: this.nextConfig.i18n?.domains,
       distDir: this.distDir,
       serverComponents: this.enabledDirectories.app,
-      cacheLifeProfiles: this.nextConfig.experimental.cacheLife,
+      cacheLifeProfiles: this.nextConfig.cacheLife,
       enableTainting: this.nextConfig.experimental.taint,
       crossOrigin: this.nextConfig.crossOrigin
         ? this.nextConfig.crossOrigin

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -356,6 +356,15 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
     bundlePagesRouterDependencies: z.boolean().optional(),
     cacheComponents: z.boolean().optional(),
     cacheHandler: z.string().min(1).optional(),
+    cacheLife: z
+      .record(
+        z.object({
+          stale: z.number().optional(),
+          revalidate: z.number().optional(),
+          expire: z.number().optional(),
+        })
+      )
+      .optional(),
     cacheMaxMemorySize: z.number().optional(),
     cleanDistDir: z.boolean().optional(),
     compiler: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -305,6 +305,9 @@ export interface ExperimentalConfig {
     dynamic?: number
     static?: number
   }
+  /**
+   * @deprecated use top-level `cacheLife` instead
+   */
   cacheLife?: {
     [profile: string]: {
       // How long the client can cache a value without checking with the server.
@@ -1270,6 +1273,20 @@ export interface NextConfig {
    */
   cacheComponents?: boolean
 
+  cacheLife?: {
+    [profile: string]: {
+      // How long the client can cache a value without checking with the server.
+      stale?: number
+      // How frequently you want the cache to refresh on the server.
+      // Stale values may be served while revalidating.
+      revalidate?: number
+      // In the worst case scenario, where you haven't had traffic in a while,
+      // how stale can a value be until you prefer deopting to dynamic.
+      // Must be longer than revalidate.
+      expire?: number
+    }
+  }
+
   /**
    * period (in seconds) where the server allow to serve stale cache
    */
@@ -1398,46 +1415,46 @@ export const defaultConfig = Object.freeze({
   // Will default to cacheComponents value.
   enablePrerenderSourceMaps: undefined,
   cacheComponents: false,
+  cacheLife: {
+    default: {
+      stale: undefined, // defaults to staleTimes.static
+      revalidate: 60 * 15, // 15 minutes
+      expire: INFINITE_CACHE,
+    },
+    seconds: {
+      stale: 30, // 30 seconds
+      revalidate: 1, // 1 second
+      expire: 60, // 1 minute
+    },
+    minutes: {
+      stale: 60 * 5, // 5 minutes
+      revalidate: 60, // 1 minute
+      expire: 60 * 60, // 1 hour
+    },
+    hours: {
+      stale: 60 * 5, // 5 minutes
+      revalidate: 60 * 60, // 1 hour
+      expire: 60 * 60 * 24, // 1 day
+    },
+    days: {
+      stale: 60 * 5, // 5 minutes
+      revalidate: 60 * 60 * 24, // 1 day
+      expire: 60 * 60 * 24 * 7, // 1 week
+    },
+    weeks: {
+      stale: 60 * 5, // 5 minutes
+      revalidate: 60 * 60 * 24 * 7, // 1 week
+      expire: 60 * 60 * 24 * 30, // 1 month
+    },
+    max: {
+      stale: 60 * 5, // 5 minutes
+      revalidate: 60 * 60 * 24 * 30, // 1 month
+      expire: 60 * 60 * 24 * 365, // 1 year
+    },
+  },
   experimental: {
     adapterPath: process.env.NEXT_ADAPTER_PATH || undefined,
     useSkewCookie: false,
-    cacheLife: {
-      default: {
-        stale: undefined, // defaults to staleTimes.static
-        revalidate: 60 * 15, // 15 minutes
-        expire: INFINITE_CACHE,
-      },
-      seconds: {
-        stale: 30, // 30 seconds
-        revalidate: 1, // 1 second
-        expire: 60, // 1 minute
-      },
-      minutes: {
-        stale: 60 * 5, // 5 minutes
-        revalidate: 60, // 1 minute
-        expire: 60 * 60, // 1 hour
-      },
-      hours: {
-        stale: 60 * 5, // 5 minutes
-        revalidate: 60 * 60, // 1 hour
-        expire: 60 * 60 * 24, // 1 day
-      },
-      days: {
-        stale: 60 * 5, // 5 minutes
-        revalidate: 60 * 60 * 24, // 1 day
-        expire: 60 * 60 * 24 * 7, // 1 week
-      },
-      weeks: {
-        stale: 60 * 5, // 5 minutes
-        revalidate: 60 * 60 * 24 * 7, // 1 week
-        expire: 60 * 60 * 24 * 30, // 1 month
-      },
-      max: {
-        stale: 60 * 5, // 5 minutes
-        revalidate: 60 * 60 * 24 * 30, // 1 month
-        expire: 60 * 60 * 24 * 365, // 1 year
-      },
-    },
     cacheHandlers: {
       default: process.env.NEXT_DEFAULT_CACHE_HANDLER_PATH,
       remote: process.env.NEXT_REMOTE_CACHE_HANDLER_PATH,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -717,6 +717,13 @@ function assignDefaultsAndValidate(
     configFileName,
     silent
   )
+  warnOptionHasBeenMovedOutOfExperimental(
+    result,
+    'cacheLife',
+    'cacheLife',
+    configFileName,
+    silent
+  )
 
   if ((result.experimental as any).outputStandalone) {
     if (!silent) {
@@ -1086,12 +1093,12 @@ function assignDefaultsAndValidate(
     }
   }
 
-  if (result.experimental) {
-    result.experimental.cacheLife = {
-      ...defaultConfig.experimental?.cacheLife,
-      ...result.experimental.cacheLife,
+  if (result.cacheLife) {
+    result.cacheLife = {
+      ...defaultConfig.cacheLife,
+      ...result.cacheLife,
     }
-    const defaultDefault = defaultConfig.experimental?.cacheLife?.['default']
+    const defaultDefault = defaultConfig.cacheLife?.['default']
     if (
       !defaultDefault ||
       defaultDefault.revalidate === undefined ||
@@ -1100,9 +1107,9 @@ function assignDefaultsAndValidate(
     ) {
       throw new Error('No default cacheLife profile.')
     }
-    const defaultCacheLifeProfile = result.experimental.cacheLife['default']
+    const defaultCacheLifeProfile = result.cacheLife['default']
     if (!defaultCacheLifeProfile) {
-      result.experimental.cacheLife['default'] = defaultDefault
+      result.cacheLife['default'] = defaultDefault
     } else {
       if (defaultCacheLifeProfile.stale === undefined) {
         const staticStaleTime = result.experimental.staleTimes?.static

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -761,7 +761,7 @@ export default class DevServer extends Server {
           requestHeaders,
           cacheHandler: this.nextConfig.cacheHandler,
           cacheHandlers: this.nextConfig.experimental.cacheHandlers,
-          cacheLifeProfiles: this.nextConfig.experimental.cacheLife,
+          cacheLifeProfiles: this.nextConfig.cacheLife,
           fetchCacheKeyPrefix: this.nextConfig.experimental.fetchCacheKeyPrefix,
           isrFlushToDisk: this.nextConfig.experimental.isrFlushToDisk,
           maxMemoryCacheSize: this.nextConfig.cacheMaxMemorySize,

--- a/packages/next/src/server/use-cache/cache-life.ts
+++ b/packages/next/src/server/use-cache/cache-life.ts
@@ -136,10 +136,8 @@ export function cacheLife(profile: CacheLifeProfiles | CacheLife): void {
       throw new Error(
         `Unknown \`cacheLife()\` profile "${profile}" is not configured in next.config.js\n` +
           'module.exports = {\n' +
-          '  experimental: {\n' +
-          '    cacheLife: {\n' +
-          `      "${profile}": ...\n` +
-          '    }\n' +
+          '  cacheLife: {\n' +
+          `    "${profile}": ...\n` +
           '  }\n' +
           '}'
       )

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -111,7 +111,7 @@ export class EdgeRouteModuleWrapper {
         experimental: {
           authInterrupts: !!process.env.__NEXT_EXPERIMENTAL_AUTH_INTERRUPTS,
         },
-        cacheLifeProfiles: this.nextConfig.experimental.cacheLife,
+        cacheLifeProfiles: this.nextConfig.cacheLife,
       },
       sharedContext: {
         buildId: '', // TODO: Populate this properly.

--- a/test/e2e/app-dir/ppr-unstable-cache/next.config.js
+++ b/test/e2e/app-dir/ppr-unstable-cache/next.config.js
@@ -1,12 +1,10 @@
 module.exports = {
   cacheComponents: true,
-  experimental: {
-    cacheLife: {
-      expireNow: {
-        stale: 0,
-        expire: 0,
-        revalidate: 0,
-      },
+  cacheLife: {
+    expireNow: {
+      stale: 0,
+      expire: 0,
+      revalidate: 0,
     },
   },
 }

--- a/test/e2e/app-dir/revalidate-dynamic/next.config.mjs
+++ b/test/e2e/app-dir/revalidate-dynamic/next.config.mjs
@@ -1,11 +1,9 @@
 const nextConfig = {
-  experimental: {
-    cacheLife: {
-      expireNow: {
-        stale: 0,
-        expire: 0,
-        revalidate: 0,
-      },
+  cacheLife: {
+    expireNow: {
+      stale: 0,
+      expire: 0,
+      revalidate: 0,
     },
   },
 }

--- a/test/e2e/app-dir/use-cache/next.config.js
+++ b/test/e2e/app-dir/use-cache/next.config.js
@@ -4,22 +4,22 @@
 const nextConfig = {
   experimental: {
     useCache: true,
-    cacheLife: {
-      frequent: {
-        stale: 19,
-        revalidate: 100,
-        expire: 300,
-      },
-      expireNow: {
-        stale: 0,
-        expire: 0,
-        revalidate: 0,
-      },
-    },
     cacheHandlers: {
       custom: require.resolve(
         'next/dist/server/lib/cache-handlers/default.external'
       ),
+    },
+  },
+  cacheLife: {
+    frequent: {
+      stale: 19,
+      revalidate: 100,
+      expire: 300,
+    },
+    expireNow: {
+      stale: 0,
+      expire: 0,
+      revalidate: 0,
     },
   },
   cacheHandler: require.resolve('./incremental-cache-handler'),

--- a/test/production/app-dir/global-default-cache-handler/next.config.js
+++ b/test/production/app-dir/global-default-cache-handler/next.config.js
@@ -5,12 +5,12 @@ const nextConfig = {
   output: 'standalone',
   experimental: {
     useCache: true,
-    cacheLife: {
-      expireNow: {
-        stale: 0,
-        expire: 0,
-        revalidate: 0,
-      },
+  },
+  cacheLife: {
+    expireNow: {
+      stale: 0,
+      expire: 0,
+      revalidate: 0,
     },
   },
 }


### PR DESCRIPTION
As part of stabilizing `cacheComponents`, `cacheLife` profiles should also be accessible from a top-level config. This updates the configuration, adds the warning, and updates relevant docs. 