### PR TITLE
fix(tsconfig.json): prevent duplicate tsconfig include entries on Windows

### DIFF
--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -5,6 +5,7 @@ import semver from 'next/dist/compiled/semver'
 import os from 'os'
 import type { CompilerOptions } from 'typescript'
 import * as Log from '../../build/output/log'
+import path from 'path'
 
 type DesiredCompilerOptionsShape = {
   [K in keyof CompilerOptions]:
@@ -267,7 +268,10 @@ export async function writeConfigurationDefaults(
     }
   }
 
-  const nextAppTypes: string[] = [`${distDir}/types/**/*.ts`]
+  // Normalize paths to POSIX style and dedupe to avoid duplicates on Windows
+  const toPosix = (p: string) => p.split(path.sep).join(path.posix.sep)
+
+  const nextAppTypes: string[] = [toPosix(`${distDir}/types/**/*.ts`)]
 
   // When isolatedDevBuild is enabled, Next.js uses different distDir paths:
   // - Development: "{distDir}/dev"
@@ -275,17 +279,23 @@ export async function writeConfigurationDefaults(
   // To prevent tsconfig updates when switching between dev/build modes,
   // we proactively include both type paths regardless of current environment.
   if (isolatedDevBuild !== false) {
-    nextAppTypes.push(
+    const extra =
       process.env.NODE_ENV === 'development'
         ? // In dev, distDir is "{distDir}/dev", which is already in the array above, but we also need "{distDir}/types".
           // Here we remove "/dev" at the end of distDir for consistency.
-          `${distDir.replace(/\/dev$/, '')}/types/**/*.ts`
+          toPosix(`${distDir.replace(/\/dev$/, '')}/types/**/*.ts`)
         : // In build, distDir is "{distDir}", which is already in the array above, but we also need "{distDir}/dev/types".
           // Here we add "/dev" at the end of distDir for consistency.
-          `${distDir}/dev/types/**/*.ts`
-    )
-    // Sort the array to ensure consistent order.
-    nextAppTypes.sort((a, b) => a.length - b.length)
+          toPosix(`${distDir}/dev/types/**/*.ts`)
+
+    nextAppTypes.push(extra)
+
+    // Dedupe and sort the array to ensure consistent order.
+    const deduped = Array.from(new Set(nextAppTypes))
+    deduped.sort((a, b) => a.length - b.length)
+    // replace contents
+    nextAppTypes.length = 0
+    nextAppTypes.push(...deduped)
   }
 
   if (!('include' in userTsConfig)) {


### PR DESCRIPTION
Fixes an issue where running `npm run dev` on Windows would add duplicate entries to tsconfig.json's include array - one with backslashes (`.next\dev/types/**/*.ts`) and one with forward slashes (`.next/dev/types/**/*.ts`).

The fix normalizes all paths to POSIX-style (forward slashes) using `path.posix` and deduplicates the `nextAppTypes` array using a Set before adding entries to tsconfig.json.

This solution is cross-platform compatible and works consistently on Windows, macOS, and Linux.

## For Contributors

### Fixing a bug

- [ ] Related issues linked using `fixes #number`
- [x] Tests added - existing test suite (`writeConfigurationDefaults.test.ts`) covers this functionality and passes
- [x] Errors have a helpful link attached (N/A - no new errors introduced)

---

## What?

This PR fixes a Windows-specific bug where duplicate TypeScript config entries were added to `tsconfig.json`'s `include` array during `npm run dev`.

## Why?

On Windows, the `distDir` path separator handling caused the same logical path to appear twice in different formats:
- `.next\dev/types/**/*.ts` (mixed separators from Windows path operations)
- `.next/dev/types/**/*.ts` (POSIX-style from string templates)

This resulted in duplicate console log messages and duplicate entries in the tsconfig, confusing users.

**Changes:**
- Modified `packages/next/src/lib/typescript/writeConfigurationDefaults.ts`
- No breaking changes
- No new dependencies
- Existing tests pass

### **Before**: *Duplicate lines added to tsconfig.json*

Console message:
```
We detected TypeScript in your project and reconfigured your tsconfig.json file for you.
The following suggested values were added to your tsconfig.json. These values can be changed to fit your project's needs:

        - include was updated to add '.next\dev/types/**/*.ts'
        - include was updated to add '.next\dev/types/**/*.ts'
```

<img width="481" height="292" alt="Screenshot 2025-10-18 143141" src="https://github.com/user-attachments/assets/dca84f17-eb65-441c-80d4-e01b1feb2cbb" />

### **After**: *tsconfig.json contains single deduplicated path*
<img width="470" height="235" alt="Screenshot 2025-10-18 192923" src="https://github.com/user-attachments/assets/98eb07c3-1c4e-465d-8c58-47b2c9dafae2" />

## How?

The fix adds path normalization and deduplication in `writeConfigurationDefaults.ts`:

1. **Path Normalization**: Added `toPosix()` helper that converts all paths to POSIX-style (forward slashes) using `path.posix.sep`
2. **Deduplication**: Use `Set` to remove duplicate entries before adding to tsconfig
3. **Cross-platform**: Works on Windows, macOS, and Linux since TypeScript accepts POSIX paths on all platforms


Closes NEXT-
Fixes #85028 

-->
