### PR TITLE
enable mcp server by default

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -799,7 +799,7 @@ export interface ExperimentalConfig {
    * When enabled, Next.js will expose an MCP server at `/_next/mcp` that provides
    * code intelligence and project context to AI assistants.
    *
-   * @default false
+   * @default true
    */
   mcpServer?: boolean
 
@@ -1524,6 +1524,7 @@ export const defaultConfig = Object.freeze({
     isolatedDevBuild: true,
     proxyClientMaxBodySize: 10_485_760, // 10MB
     hideLogsAfterAbort: false,
+    mcpServer: true,
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/packages/next/src/telemetry/events/version.ts
+++ b/packages/next/src/telemetry/events/version.ts
@@ -134,10 +134,11 @@ export function eventCliSession(
       typeof nextConfig.reactCompiler !== 'boolean'
         ? (nextConfig.reactCompiler?.panicThreshold ?? null)
         : null,
+    // Default mcpServer to true if not set
     mcpServer:
       typeof nextConfig.experimental.mcpServer === 'boolean'
         ? nextConfig.experimental.mcpServer
-        : null,
+        : true,
   }
   return [{ eventName: EVENT_VERSION, payload }]
 }

--- a/test/development/mcp-server/fixtures/actions-app/next.config.js
+++ b/test/development/mcp-server/fixtures/actions-app/next.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-  experimental: {
-    mcpServer: true,
-  },
-}
+module.exports = {}

--- a/test/development/mcp-server/fixtures/default-template/next.config.js
+++ b/test/development/mcp-server/fixtures/default-template/next.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-  experimental: {
-    mcpServer: true,
-  },
-}
+module.exports = {}

--- a/test/development/mcp-server/fixtures/log-file-app/next.config.js
+++ b/test/development/mcp-server/fixtures/log-file-app/next.config.js
@@ -1,10 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  experimental: {
-    mcpServer: true,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/test/development/mcp-server/fixtures/pages-router-template/next.config.js
+++ b/test/development/mcp-server/fixtures/pages-router-template/next.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-  experimental: {
-    mcpServer: true,
-  },
-}
+module.exports = {}

--- a/test/development/mcp-server/fixtures/parallel-routes-template/next.config.js
+++ b/test/development/mcp-server/fixtures/parallel-routes-template/next.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-  experimental: {
-    mcpServer: true,
-  },
-}
+module.exports = {}

--- a/test/development/mcp-server/mcp-server-get-errors.test.ts
+++ b/test/development/mcp-server/mcp-server-get-errors.test.ts
@@ -323,7 +323,6 @@ describe('mcp-server get_errors tool', () => {
       'next.config.js',
       `module.exports = {
   experimental: {
-    mcpServer: true,
     invalidTestProperty: 'this should cause a validation warning',
   },
 }`

--- a/test/e2e/app-dir/log-file/next.config.js
+++ b/test/e2e/app-dir/log-file/next.config.js
@@ -1,10 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  experimental: {
-    mcpServer: true,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig


### PR DESCRIPTION
Enable mcp server in Next.js by default