### PR TITLE
[turbopack] Implement improved deobfuscation for free calls and module identifiers.

### DIFF
--- a/examples/basic-css/tsconfig.json
+++ b/examples/basic-css/tsconfig.json
@@ -21,6 +21,12 @@
     "strictNullChecks": true,
     "target": "ES2017"
   },
-  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/dev/types/**/*.ts"
+  ],
   "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/examples/with-turbopack/app/page.tsx
+++ b/examples/with-turbopack/app/page.tsx
@@ -1,3 +1,6 @@
+import { foo } from "./foo";
 export default function Page() {
+  /** @ts-ignore */
+  foo();
   return <h1>Hello, Next.js!</h1>;
 }

--- a/examples/with-turbopack/tsconfig.json
+++ b/examples/with-turbopack/tsconfig.json
@@ -20,6 +20,12 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/hot-linked-text/index.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/hot-linked-text/index.tsx
@@ -1,12 +1,7 @@
 import React from 'react'
-import {
-  decodeMagicIdentifier,
-  MAGIC_IDENTIFIER_REGEX,
-} from '../../../../shared/lib/magic-identifier'
+import { deobfuscateText } from '../../../../shared/lib/magic-identifier'
 
 const linkRegex = /https?:\/\/[^\s/$.?#].[^\s)'"]*/i
-
-const splitRegexp = new RegExp(`(${MAGIC_IDENTIFIER_REGEX.source}|\\s+)`)
 
 export const HotlinkedText: React.FC<{
   text: string
@@ -14,46 +9,31 @@ export const HotlinkedText: React.FC<{
 }> = function HotlinkedText(props) {
   const { text, matcher } = props
 
-  const wordsAndWhitespaces = text.split(splitRegexp)
+  // Deobfuscate the entire text first
+  const deobfuscated = deobfuscateText(text)
+
+  // Split on whitespace and links
+  const parts = deobfuscated.split(/(\s+|https?:\/\/[^\s/$.?#].[^\s)'"]*)/)
 
   return (
     <>
-      {wordsAndWhitespaces.map((word, index) => {
-        if (linkRegex.test(word)) {
-          const link = linkRegex.exec(word)!
+      {parts.map((part, index) => {
+        if (linkRegex.test(part)) {
+          const link = linkRegex.exec(part)!
           const href = link[0]
           // If link matcher is present but the link doesn't match, don't turn it into a link
           if (typeof matcher === 'function' && !matcher(href)) {
-            return word
+            return part
           }
           return (
             <React.Fragment key={`link-${index}`}>
               <a href={href} target="_blank" rel="noreferrer noopener">
-                {word}
+                {part}
               </a>
             </React.Fragment>
           )
         }
-        try {
-          const decodedWord = decodeMagicIdentifier(word)
-          if (decodedWord !== word) {
-            return (
-              <i key={`ident-${index}`}>
-                {'{'}
-                {decodedWord}
-                {'}'}
-              </i>
-            )
-          }
-        } catch (e) {
-          return (
-            <i key={`ident-${index}`}>
-              {'{'}
-              {word} (decoding failed: {'' + e}){'}'}
-            </i>
-          )
-        }
-        return <React.Fragment key={`text-${index}`}>{word}</React.Fragment>
+        return <React.Fragment key={`text-${index}`}>{part}</React.Fragment>
       })}
     </>
   )

--- a/packages/next/src/next-devtools/dev-overlay/components/hot-linked-text/index.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/hot-linked-text/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { deobfuscateText } from '../../../../shared/lib/magic-identifier'
+import { deobfuscateTextParts } from '../../../../shared/lib/magic-identifier'
 
 const linkRegex = /https?:\/\/[^\s/$.?#].[^\s)'"]*/i
 
@@ -10,30 +10,50 @@ export const HotlinkedText: React.FC<{
   const { text, matcher } = props
 
   // Deobfuscate the entire text first
-  const deobfuscated = deobfuscateText(text)
-
-  // Split on whitespace and links
-  const parts = deobfuscated.split(/(\s+|https?:\/\/[^\s/$.?#].[^\s)'"]*)/)
+  const deobfuscatedParts = deobfuscateTextParts(text)
 
   return (
     <>
-      {parts.map((part, index) => {
-        if (linkRegex.test(part)) {
-          const link = linkRegex.exec(part)!
-          const href = link[0]
-          // If link matcher is present but the link doesn't match, don't turn it into a link
-          if (typeof matcher === 'function' && !matcher(href)) {
-            return part
-          }
+      {deobfuscatedParts.map(([type, part], outerIndex) => {
+        if (type === 'raw') {
           return (
-            <React.Fragment key={`link-${index}`}>
-              <a href={href} target="_blank" rel="noreferrer noopener">
-                {part}
-              </a>
-            </React.Fragment>
+            part
+              // Split on whitespace and links
+              .split(/(\s+|https?:\/\/[^\s/$.?#].[^\s)'"]*)/)
+              .map((rawPart, index) => {
+                if (linkRegex.test(rawPart)) {
+                  const link = linkRegex.exec(rawPart)!
+                  const href = link[0]
+                  // If link matcher is present but the link doesn't match, don't turn it into a link
+                  if (typeof matcher === 'function' && !matcher(href)) {
+                    return (
+                      <React.Fragment key={`link-${outerIndex}-${index}`}>
+                        {rawPart}
+                      </React.Fragment>
+                    )
+                  }
+                  return (
+                    <React.Fragment key={`link-${outerIndex}-${index}`}>
+                      <a href={href} target="_blank" rel="noreferrer noopener">
+                        {rawPart}
+                      </a>
+                    </React.Fragment>
+                  )
+                } else {
+                  return (
+                    <React.Fragment key={`text-${outerIndex}-${index}`}>
+                      {rawPart}
+                    </React.Fragment>
+                  )
+                }
+              })
           )
+        } else if (type === 'deobfuscated') {
+          // italicize the deobfuscated part
+          return <i key={`ident-${outerIndex}`}>{part}</i>
+        } else {
+          throw new Error(`Unknown text part type: ${type}`)
         }
-        return <React.Fragment key={`text-${index}`}>{part}</React.Fragment>
       })}
     </>
   )

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -88,6 +88,7 @@ import {
 import { isParallelRouteSegment } from '../../../shared/lib/segment'
 import { ensureLeadingSlash } from '../../../shared/lib/page-path/ensure-leading-slash'
 import { Lockfile } from '../../../build/lockfile'
+import { deobfuscateText } from '../../../shared/lib/magic-identifier'
 
 export type SetupOpts = {
   renderServer: LazyRenderServerInstance
@@ -1224,6 +1225,9 @@ async function startWatcher(
     err: unknown,
     type?: 'unhandledRejection' | 'uncaughtException' | 'warning' | 'app-dir'
   ) {
+    if (err instanceof Error) {
+      err.message = deobfuscateText(err.message)
+    }
     if (err instanceof ModuleBuildError) {
       // Errors that may come from issues from the user's code
       Log.error(err.message)

--- a/packages/next/src/shared/lib/magic-identifier.test.ts
+++ b/packages/next/src/shared/lib/magic-identifier.test.ts
@@ -78,11 +78,15 @@ describe('deobfuscateModuleId', () => {
 
 describe('removeFreeCallWrapper', () => {
   test('removes (0, ) wrapper', () => {
-    expect(removeFreeCallWrapper('(0, foo.bar)')).toBe('foo.bar')
+    expect(removeFreeCallWrapper('(0, __TURBOPACK__foo__.bar)')).toBe(
+      '__TURBOPACK__foo__.bar'
+    )
   })
 
   test('removes (0 , ) wrapper with spaces', () => {
-    expect(removeFreeCallWrapper('(0 , foo.bar)')).toBe('foo.bar')
+    expect(removeFreeCallWrapper('(0 , __TURBOPACK__foo__.bar)')).toBe(
+      '__TURBOPACK__foo__.bar'
+    )
   })
 
   test('leaves non-free-call expressions unchanged', () => {
@@ -96,20 +100,16 @@ describe('deobfuscateText', () => {
     const input =
       '(0 , __TURBOPACK__imported__module__$5b$project$5d2f$examples$2f$with$2d$turbopack$2f$app$2f$foo$2e$ts__$5b$app$2d$rsc$5d$__$28$ecmascript$29$__.foo) is not a function'
     const output = deobfuscateText(input)
-    expect(output).toContain('imported module')
-    expect(output).toContain('./examples/with-turbopack/app/foo.ts')
-    expect(output).not.toContain('[project]')
-    expect(output).not.toContain('[app-rsc]')
-    expect(output).not.toContain('(ecmascript)')
-    expect(output).not.toContain('(0 ,')
+    expect(output).toBe(
+      '{imported module ./examples/with-turbopack/app/foo.ts}.foo is not a function'
+    )
   })
 
   test('handles multiple magic identifiers', () => {
     const input =
       '__TURBOPACK__module__evaluation__ called __TURBOPACK__foo$2f$bar__'
     const output = deobfuscateText(input)
-    expect(output).toContain('module evaluation')
-    expect(output).toContain('foo/bar')
+    expect(output).toBe('{module evaluation} called {foo/bar}')
   })
 
   test('leaves regular text unchanged', () => {

--- a/packages/next/src/shared/lib/magic-identifier.test.ts
+++ b/packages/next/src/shared/lib/magic-identifier.test.ts
@@ -78,19 +78,11 @@ describe('deobfuscateModuleId', () => {
 
 describe('removeFreeCallWrapper', () => {
   test('removes (0, ) wrapper', () => {
-    expect(removeFreeCallWrapper('(0, foo)')).toBe('foo')
+    expect(removeFreeCallWrapper('(0, foo.bar)')).toBe('foo.bar')
   })
 
   test('removes (0 , ) wrapper with spaces', () => {
     expect(removeFreeCallWrapper('(0 , foo.bar)')).toBe('foo.bar')
-  })
-
-  test('handles nested expressions', () => {
-    expect(
-      removeFreeCallWrapper(
-        '(0 , __TURBOPACK__imported__module__$5b$project$5d$__.foo)'
-      )
-    ).toBe('__TURBOPACK__imported__module__$5b$project$5d$__.foo')
   })
 
   test('leaves non-free-call expressions unchanged', () => {

--- a/packages/next/src/shared/lib/magic-identifier.test.ts
+++ b/packages/next/src/shared/lib/magic-identifier.test.ts
@@ -1,0 +1,127 @@
+import {
+  decodeMagicIdentifier,
+  MAGIC_IDENTIFIER_REGEX,
+  deobfuscateModuleId,
+  removeFreeCallWrapper,
+  deobfuscateText,
+} from './magic-identifier'
+
+describe('decodeMagicIdentifier', () => {
+  // Basic decoding tests (ported from Rust)
+  test('decodes module evaluation', () => {
+    expect(decodeMagicIdentifier('__TURBOPACK__module__evaluation__')).toBe(
+      'module evaluation'
+    )
+  })
+
+  test('decodes path with slashes', () => {
+    expect(decodeMagicIdentifier('__TURBOPACK__Hello$2f$World__')).toBe(
+      'Hello/World'
+    )
+  })
+
+  test('decodes emoji', () => {
+    expect(decodeMagicIdentifier('__TURBOPACK__Hello$_1f600$World__')).toBe(
+      'Hello😀World'
+    )
+  })
+
+  test('returns unchanged if not a magic identifier', () => {
+    expect(decodeMagicIdentifier('regular_identifier')).toBe(
+      'regular_identifier'
+    )
+  })
+})
+
+describe('MAGIC_IDENTIFIER_REGEX', () => {
+  test('matches magic identifiers globally', () => {
+    const text =
+      'Hello __TURBOPACK__Hello__World__ and __TURBOPACK__foo$2f$bar__'
+    const matches = text.match(MAGIC_IDENTIFIER_REGEX)
+    expect(matches).toHaveLength(2)
+  })
+})
+
+describe('deobfuscateModuleId', () => {
+  test('replaces [project] with .', () => {
+    expect(
+      deobfuscateModuleId('[project]/examples/with-turbopack/app/foo.ts')
+    ).toBe('./examples/with-turbopack/app/foo.ts')
+  })
+
+  test('removes content in square brackets', () => {
+    expect(
+      deobfuscateModuleId('./examples/with-turbopack/app/foo.ts [app-rsc]')
+    ).toBe('./examples/with-turbopack/app/foo.ts')
+  })
+
+  test('removes content in parentheses', () => {
+    expect(
+      deobfuscateModuleId('./examples/with-turbopack/app/foo.ts (ecmascript)')
+    ).toBe('./examples/with-turbopack/app/foo.ts')
+  })
+
+  test('removes content in angle brackets', () => {
+    expect(
+      deobfuscateModuleId('./examples/with-turbopack/app/foo.ts <locals>')
+    ).toBe('./examples/with-turbopack/app/foo.ts')
+  })
+
+  test('handles combined cleanup', () => {
+    expect(
+      deobfuscateModuleId(
+        '[project]/examples/with-turbopack/app/foo.ts [app-rsc] (ecmascript)'
+      )
+    ).toBe('./examples/with-turbopack/app/foo.ts')
+  })
+})
+
+describe('removeFreeCallWrapper', () => {
+  test('removes (0, ) wrapper', () => {
+    expect(removeFreeCallWrapper('(0, foo)')).toBe('foo')
+  })
+
+  test('removes (0 , ) wrapper with spaces', () => {
+    expect(removeFreeCallWrapper('(0 , foo.bar)')).toBe('foo.bar')
+  })
+
+  test('handles nested expressions', () => {
+    expect(
+      removeFreeCallWrapper(
+        '(0 , __TURBOPACK__imported__module__$5b$project$5d$__.foo)'
+      )
+    ).toBe('__TURBOPACK__imported__module__$5b$project$5d$__.foo')
+  })
+
+  test('leaves non-free-call expressions unchanged', () => {
+    expect(removeFreeCallWrapper('(foo, bar)')).toBe('(foo, bar)')
+    expect(removeFreeCallWrapper('foo()')).toBe('foo()')
+  })
+})
+
+describe('deobfuscateText', () => {
+  test('deobfuscates complete error message with imported module', () => {
+    const input =
+      '(0 , __TURBOPACK__imported__module__$5b$project$5d2f$examples$2f$with$2d$turbopack$2f$app$2f$foo$2e$ts__$5b$app$2d$rsc$5d$__$28$ecmascript$29$__.foo) is not a function'
+    const output = deobfuscateText(input)
+    expect(output).toContain('imported module')
+    expect(output).toContain('./examples/with-turbopack/app/foo.ts')
+    expect(output).not.toContain('[project]')
+    expect(output).not.toContain('[app-rsc]')
+    expect(output).not.toContain('(ecmascript)')
+    expect(output).not.toContain('(0 ,')
+  })
+
+  test('handles multiple magic identifiers', () => {
+    const input =
+      '__TURBOPACK__module__evaluation__ called __TURBOPACK__foo$2f$bar__'
+    const output = deobfuscateText(input)
+    expect(output).toContain('module evaluation')
+    expect(output).toContain('foo/bar')
+  })
+
+  test('leaves regular text unchanged', () => {
+    const input = 'This is a regular error message'
+    expect(deobfuscateText(input)).toBe(input)
+  })
+})

--- a/packages/next/src/shared/lib/magic-identifier.test.ts
+++ b/packages/next/src/shared/lib/magic-identifier.test.ts
@@ -4,6 +4,7 @@ import {
   deobfuscateModuleId,
   removeFreeCallWrapper,
   deobfuscateText,
+  deobfuscateTextParts,
 } from './magic-identifier'
 
 describe('decodeMagicIdentifier', () => {
@@ -123,5 +124,55 @@ describe('deobfuscateText', () => {
   test('leaves regular text unchanged', () => {
     const input = 'This is a regular error message'
     expect(deobfuscateText(input)).toBe(input)
+  })
+})
+
+describe('deobfuscateTextParts', () => {
+  test('returns discriminated parts with raw and deobfuscated text', () => {
+    const input = 'Error in __TURBOPACK__module__evaluation__ at line 10'
+    const output = deobfuscateTextParts(input)
+    expect(output).toEqual([
+      ['raw', 'Error in '],
+      ['deobfuscated', '{module evaluation}'],
+      ['raw', ' at line 10'],
+    ])
+  })
+
+  test('handles multiple magic identifiers with interleaved raw text', () => {
+    const input =
+      '__TURBOPACK__module__evaluation__ called __TURBOPACK__foo$2f$bar__'
+    const output = deobfuscateTextParts(input)
+    expect(output).toEqual([
+      ['deobfuscated', '{module evaluation}'],
+      ['raw', ' called '],
+      ['deobfuscated', '{foo/bar}'],
+    ])
+  })
+
+  test('returns single raw part for text without magic identifiers', () => {
+    const input = 'This is a regular error message'
+    const output = deobfuscateTextParts(input)
+    expect(output).toEqual([['raw', 'This is a regular error message']])
+  })
+
+  test('handles imported module with free call wrapper', () => {
+    const input =
+      '(0 , __TURBOPACK__imported__module__$5b$project$5d2f$examples$2f$with$2d$turbopack$2f$app$2f$foo$2e$ts__$5b$app$2d$rsc$5d$__$28$ecmascript$29$__.foo) is not a function'
+    const output = deobfuscateTextParts(input)
+    expect(output).toEqual([
+      [
+        'deobfuscated',
+        '{imported module ./examples/with-turbopack/app/foo.ts}',
+      ],
+      ['raw', '.foo is not a function'],
+    ])
+  })
+
+  test('produces same result as deobfuscateText when joined', () => {
+    const input =
+      'Error in __TURBOPACK__module__evaluation__ at __TURBOPACK__foo$2f$bar__'
+    const parts = deobfuscateTextParts(input)
+    const joined = parts.map((part) => part[1]).join('')
+    expect(joined).toBe(deobfuscateText(input))
   })
 })

--- a/packages/next/src/shared/lib/magic-identifier.test.ts
+++ b/packages/next/src/shared/lib/magic-identifier.test.ts
@@ -74,6 +74,14 @@ describe('deobfuscateModuleId', () => {
       )
     ).toBe('./examples/with-turbopack/app/foo.ts')
   })
+
+  test('handles parenthesis in path', () => {
+    expect(
+      deobfuscateModuleId(
+        '[project]/examples/(group)/with-turbopack/app/foo.ts [app-rsc] (ecmascript)'
+      )
+    ).toBe('./examples/(group)/with-turbopack/app/foo.ts')
+  })
 })
 
 describe('removeFreeCallWrapper', () => {

--- a/packages/next/src/shared/lib/magic-identifier.ts
+++ b/packages/next/src/shared/lib/magic-identifier.ts
@@ -125,7 +125,7 @@ export function removeFreeCallWrapper(text: string): string {
   // Use Unicode property escapes (\p{ID_Start}, \p{ID_Continue}) for full JS identifier support
   // Requires the 'u' (unicode) flag in the regex
   return text.replace(
-    /\(0\s*,\s*([\p{ID_Start}_$][\p{ID_Continue}$]*\.[\p{ID_Start}_$][\p{ID_Continue}$]*)\)/u,
+    /\(0\s*,\s*(__TURBOPACK__[a-zA-Z0-9_$]+__\.[\p{ID_Start}_$][\p{ID_Continue}$]*)\)/u,
     '$1'
   )
 }

--- a/packages/next/src/shared/lib/magic-identifier.ts
+++ b/packages/next/src/shared/lib/magic-identifier.ts
@@ -137,7 +137,8 @@ export function removeFreeCallWrapper(text: string): string {
  * 3. Removing free call wrappers
  */
 export function deobfuscateText(text: string): string {
-  // First, remove free call wrappers, by doing this
+  // First, remove free call wrappers, doing this first is important since the demangling might
+  // introduce whitespace character that complicate the matching.
   let result = removeFreeCallWrapper(text)
 
   // Then decode magic identifiers and clean up module IDs

--- a/packages/next/src/shared/lib/magic-identifier.ts
+++ b/packages/next/src/shared/lib/magic-identifier.ts
@@ -93,3 +93,76 @@ export function decodeMagicIdentifier(identifier: string): string {
 }
 
 export const MAGIC_IDENTIFIER_REGEX = /__TURBOPACK__[a-zA-Z0-9_$]+__/g
+
+/**
+ * Cleans up module IDs by removing implementation details.
+ * - Replaces [project] with .
+ * - Removes content in brackets [], parentheses (), and angle brackets <>
+ */
+export function deobfuscateModuleId(moduleId: string): string {
+  return (
+    moduleId
+      // Replace [project] with .
+      .replace(/\[project\]/g, '.')
+      // Remove content in square brackets (e.g. [app-rsc])
+      .replace(/\s*\[([^\]]*)\]/g, '')
+      // Remove content in parentheses (e.g. (ecmascript))
+      .replace(/\s*\(([^)]*)\)/g, '')
+      // Remove content in angle brackets (e.g. <locals>)
+      .replace(/\s*<([^>]*)>/g, '')
+      // Clean up any extra whitespace
+      .trim()
+  )
+}
+
+/**
+ * Removes the free call wrapper pattern (0, expr) from expressions.
+ * This is a JavaScript pattern to call a function without binding 'this',
+ * but it's noise for developers reading error messages.
+ */
+export function removeFreeCallWrapper(text: string): string {
+  // Match (0, <ident>.<ident>) patterns anywhere in the text the beginning
+  // Use Unicode property escapes (\p{ID_Start}, \p{ID_Continue}) for full JS identifier support
+  // Requires the 'u' (unicode) flag in the regex
+  return text.replace(
+    /\(0\s*,\s*([\p{ID_Start}_$][\p{ID_Continue}$]*\.[\p{ID_Start}_$][\p{ID_Continue}$]*)\)/u,
+    '$1'
+  )
+}
+
+/**
+ * Deobfuscates text by:
+ * 1. Decoding magic identifiers
+ * 2. Cleaning up module IDs
+ * 3. Removing free call wrappers
+ */
+export function deobfuscateText(text: string): string {
+  // First, remove free call wrappers, by doing this
+  let result = removeFreeCallWrapper(text)
+
+  // Then decode magic identifiers and clean up module IDs
+  result = result.replaceAll(MAGIC_IDENTIFIER_REGEX, (ident) => {
+    try {
+      const decoded = decodeMagicIdentifier(ident)
+      // If it was a magic identifier, clean up the module ID
+      if (decoded !== ident) {
+        // Check if this is an "imported module" reference
+        const importedModuleMatch = decoded.match(/^imported module (.+)$/)
+        if (importedModuleMatch) {
+          // Clean the entire module path (which includes [app-rsc], etc.)
+          const modulePathWithMetadata = importedModuleMatch[1]
+          const cleaned = deobfuscateModuleId(modulePathWithMetadata)
+          return `{imported module ${cleaned}}`
+        }
+
+        const cleaned = deobfuscateModuleId(decoded)
+        return `{${cleaned}}`
+      }
+      return ident
+    } catch (e) {
+      return `{${ident} (decoding failed: ${e})}`
+    }
+  })
+
+  return result
+}

--- a/packages/next/src/shared/lib/magic-identifier.ts
+++ b/packages/next/src/shared/lib/magic-identifier.ts
@@ -130,19 +130,43 @@ export function removeFreeCallWrapper(text: string): string {
   )
 }
 
-/**
- * Deobfuscates text by:
- * 1. Decoding magic identifiers
- * 2. Cleaning up module IDs
- * 3. Removing free call wrappers
- */
-export function deobfuscateText(text: string): string {
-  // First, remove free call wrappers, doing this first is important since the demangling might
-  // introduce whitespace character that complicate the matching.
-  let result = removeFreeCallWrapper(text)
+export type TextPartType = 'raw' | 'deobfuscated'
 
-  // Then decode magic identifiers and clean up module IDs
-  result = result.replaceAll(MAGIC_IDENTIFIER_REGEX, (ident) => {
+/**
+ * Deobfuscates text and returns an array of discriminated parts.
+ * Each part is a tuple of [type, string] where type is either 'raw' (unchanged text)
+ * or 'deobfuscated' (a magic identifier that was decoded).
+ *
+ * This is useful when you need to process or display deobfuscated and raw text differently.
+ */
+export function deobfuscateTextParts(
+  text: string
+): Array<[TextPartType, string]> {
+  // First, remove free call wrappers
+  const withoutFreeCall = removeFreeCallWrapper(text)
+
+  const parts: Array<[TextPartType, string]> = []
+  let lastIndex = 0
+
+  // Create a new regex instance for global matching
+  const regex = new RegExp(MAGIC_IDENTIFIER_REGEX.source, 'g')
+
+  for (
+    let match = regex.exec(withoutFreeCall);
+    match !== null;
+    match = regex.exec(withoutFreeCall)
+  ) {
+    const matchStart = match.index
+    const matchEnd = regex.lastIndex
+    const ident = match[0]
+
+    // Add raw text before this match (if any)
+    if (matchStart > lastIndex) {
+      const rawText = withoutFreeCall.substring(lastIndex, matchStart)
+      parts.push(['raw', rawText])
+    }
+
+    // Process and add the deobfuscated part
     try {
       const decoded = decodeMagicIdentifier(ident)
       // If it was a magic identifier, clean up the module ID
@@ -153,17 +177,38 @@ export function deobfuscateText(text: string): string {
           // Clean the entire module path (which includes [app-rsc], etc.)
           const modulePathWithMetadata = importedModuleMatch[1]
           const cleaned = deobfuscateModuleId(modulePathWithMetadata)
-          return `{imported module ${cleaned}}`
+          parts.push(['deobfuscated', `{imported module ${cleaned}}`])
+        } else {
+          const cleaned = deobfuscateModuleId(decoded)
+          parts.push(['deobfuscated', `{${cleaned}}`])
         }
-
-        const cleaned = deobfuscateModuleId(decoded)
-        return `{${cleaned}}`
+      } else {
+        // Not actually a magic identifier, treat as raw
+        parts.push(['raw', ident])
       }
-      return ident
     } catch (e) {
-      return `{${ident} (decoding failed: ${e})}`
+      parts.push(['deobfuscated', `{${ident} (decoding failed: ${e})}`])
     }
-  })
 
-  return result
+    lastIndex = matchEnd
+  }
+
+  // Add any remaining raw text after the last match
+  if (lastIndex < withoutFreeCall.length) {
+    const rawText = withoutFreeCall.substring(lastIndex)
+    parts.push(['raw', rawText])
+  }
+
+  return parts
+}
+
+/**
+ * Deobfuscates text by:
+ * 1. Decoding magic identifiers
+ * 2. Cleaning up module IDs
+ * 3. Removing free call wrappers
+ */
+export function deobfuscateText(text: string): string {
+  const parts = deobfuscateTextParts(text)
+  return parts.map((part) => part[1]).join('')
 }

--- a/packages/next/src/shared/lib/magic-identifier.ts
+++ b/packages/next/src/shared/lib/magic-identifier.ts
@@ -105,11 +105,11 @@ export function deobfuscateModuleId(moduleId: string): string {
       // Replace [project] with .
       .replace(/\[project\]/g, '.')
       // Remove content in square brackets (e.g. [app-rsc])
-      .replace(/\s*\[([^\]]*)\]/g, '')
+      .replace(/\s\[([^\]]*)\]/g, '')
       // Remove content in parentheses (e.g. (ecmascript))
-      .replace(/\s*\(([^)]*)\)/g, '')
+      .replace(/\s\(([^)]*)\)/g, '')
       // Remove content in angle brackets (e.g. <locals>)
-      .replace(/\s*<([^>]*)>/g, '')
+      .replace(/\s<([^>]*)>/g, '')
       // Clean up any extra whitespace
       .trim()
   )

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -1222,7 +1222,7 @@ describe('Cache Components Errors', () => {
                    ],
                  },
                  {
-                   "description": "(0 , <turbopack-module-id>.cookies)(...).get is not a function",
+                   "description": "<turbopack-module-id>.cookies(...).get is not a function",
                    "environmentLabel": "Prerender",
                    "label": "Runtime TypeError",
                    "source": "app/sync-cookies/page.tsx (18:36) @ CookiesReadingComponent
@@ -1404,13 +1404,14 @@ describe('Cache Components Errors', () => {
                    ],
                  },
                  {
-                   "description": "(0 , <turbopack-module-id>.cookies)(...).get is not a function",
+                   "description": "<turbopack-module-id>.cookies(...).get is not a function",
                    "environmentLabel": "Server",
                    "label": "Runtime TypeError",
                    "source": "app/sync-cookies-runtime/page.tsx (24:36) @ CookiesReadingComponent
                > 24 |   const token = (cookies() as any).get('token')
                     |                                    ^",
                    "stack": [
+                     "TypeError: {imported module ./nodemodules/.pnpm/next file+..+next-repo-0b36d073ae925c4eba722eaa190867133223877e8e123b2c4d00309ed9b3f21fdbdc34df3c435a7ad1512e006943e153/nodemodules/next/headers.js}.cookies(...).get is not a function",
                      "CookiesReadingComponent app/sync-cookies-runtime/page.tsx (24:36)",
                    ],
                  },
@@ -1573,13 +1574,14 @@ describe('Cache Components Errors', () => {
                    ],
                  },
                  {
-                   "description": "(0 , <turbopack-module-id>.headers)(...).get is not a function",
+                   "description": "<turbopack-module-id>.headers(...).get is not a function",
                    "environmentLabel": "Prerender",
                    "label": "Runtime TypeError",
                    "source": "app/sync-headers/page.tsx (18:40) @ HeadersReadingComponent
                > 18 |   const userAgent = (headers() as any).get('user-agent')
                     |                                        ^",
                    "stack": [
+                     "TypeError: {imported module ./nodemodules/.pnpm/next file+..+next-repo-0b36d073ae925c4eba722eaa190867133223877e8e123b2c4d00309ed9b3f21fdbdc34df3c435a7ad1512e006943e153/nodemodules/next/headers.js}.headers(...).get is not a function",
                      "HeadersReadingComponent app/sync-headers/page.tsx (18:40)",
                    ],
                  },
@@ -1755,13 +1757,14 @@ describe('Cache Components Errors', () => {
                    ],
                  },
                  {
-                   "description": "(0 , <turbopack-module-id>.headers)(...).get is not a function",
+                   "description": "<turbopack-module-id>.headers(...).get is not a function",
                    "environmentLabel": "Server",
                    "label": "Runtime TypeError",
                    "source": "app/sync-headers-runtime/page.tsx (24:40) @ HeadersReadingComponent
                > 24 |   const userAgent = (headers() as any).get('user-agent')
                     |                                        ^",
                    "stack": [
+                     "TypeError: {imported module ./nodemodules/.pnpm/next file+..+next-repo-0b36d073ae925c4eba722eaa190867133223877e8e123b2c4d00309ed9b3f21fdbdc34df3c435a7ad1512e006943e153/nodemodules/next/headers.js}.headers(...).get is not a function",
                      "HeadersReadingComponent app/sync-headers-runtime/page.tsx (24:40)",
                    ],
                  },

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -1411,7 +1411,6 @@ describe('Cache Components Errors', () => {
                > 24 |   const token = (cookies() as any).get('token')
                     |                                    ^",
                    "stack": [
-                     "TypeError: {imported module ./nodemodules/.pnpm/next file+..+next-repo-0b36d073ae925c4eba722eaa190867133223877e8e123b2c4d00309ed9b3f21fdbdc34df3c435a7ad1512e006943e153/nodemodules/next/headers.js}.cookies(...).get is not a function",
                      "CookiesReadingComponent app/sync-cookies-runtime/page.tsx (24:36)",
                    ],
                  },
@@ -1581,7 +1580,6 @@ describe('Cache Components Errors', () => {
                > 18 |   const userAgent = (headers() as any).get('user-agent')
                     |                                        ^",
                    "stack": [
-                     "TypeError: {imported module ./nodemodules/.pnpm/next file+..+next-repo-0b36d073ae925c4eba722eaa190867133223877e8e123b2c4d00309ed9b3f21fdbdc34df3c435a7ad1512e006943e153/nodemodules/next/headers.js}.headers(...).get is not a function",
                      "HeadersReadingComponent app/sync-headers/page.tsx (18:40)",
                    ],
                  },
@@ -1764,7 +1762,6 @@ describe('Cache Components Errors', () => {
                > 24 |   const userAgent = (headers() as any).get('user-agent')
                     |                                        ^",
                    "stack": [
-                     "TypeError: {imported module ./nodemodules/.pnpm/next file+..+next-repo-0b36d073ae925c4eba722eaa190867133223877e8e123b2c4d00309ed9b3f21fdbdc34df3c435a7ad1512e006943e153/nodemodules/next/headers.js}.headers(...).get is not a function",
                      "HeadersReadingComponent app/sync-headers-runtime/page.tsx (24:40)",
                    ],
                  },

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -268,6 +268,8 @@ impl ReferencedAsset {
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<String> {
         let id = asset.chunk_item_id(chunking_context).await?;
+        // There are a number of places in `next` that match on this prefix.
+        // See `packages/next/src/shared/lib/magic-identifier.ts`
         Ok(magic_identifier::mangle(&format!("imported module {id}")))
     }
 }


### PR DESCRIPTION
Improve deobfuscation of 'imported module identifier' and attempt to deobfuscate error messages logged by the server.

Before
```
 ⨯ TypeError: (0 , __TURBOPACK__imported__module__$5b$project$5d2f$examples$2f$with$2d$turbopack$2f$app$2f$foo$2e$ts__$5b$app$2d$rsc$5d$__$28$ecmascript$29$__.foo) is not a function
    at Page (app/page.tsx:5:6)
  3 | export default function Page() {
  4 |   /** @ts-ignore */
> 5 |   foo();
    |      ^
  6 |   return <h1>Hello, Next.js!</h1>;
  7 | }
  8 | {
```
after 
```
 ⨯ TypeError: {imported module ./examples/with-turbopack/app/foo.ts}.foo is not a function
    at Page (app/page.tsx:5:6)
  3 | export default function Page() {
  4 |   /** @ts-ignore */
> 5 |   foo();
    |      ^
  6 |   return <h1>Hello, Next.js!</h1>;
  7 | }
  8 | {
```

Similarly in devtools
before:

![image.png](https://app.graphite.dev/user-attachments/assets/fd50d94a-d34a-4026-862e-0ca8ee6658ba.png)

after

![image.png](https://app.graphite.dev/user-attachments/assets/d9080ed7-29c8-428a-831a-9bbcd818cc3e.png)


This is definitely an improvement but i am not sure i put the deobfuscation logic in the best place for the console case.  Happy for feedback

Closes PACK-5733