### PR TITLE
[cache components] add cache components indicator to dev start

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -367,10 +367,12 @@ export async function startServer(
       // Only load env and config in dev to for logging purposes
       let envInfo: string[] | undefined
       let experimentalFeatures: ConfiguredExperimentalFeature[] | undefined
+      let cacheComponents: boolean | undefined
       try {
         if (isDev) {
           const startServerInfo = await getStartServerInfo({ dir, dev: isDev })
           envInfo = startServerInfo.envInfo
+          cacheComponents = startServerInfo.cacheComponents
           experimentalFeatures = startServerInfo.experimentalFeatures
         }
         logStartInfo({
@@ -378,6 +380,7 @@ export async function startServer(
           appUrl,
           envInfo,
           experimentalFeatures,
+          cacheComponents,
           logBundler: isDev,
         })
 

--- a/test/development/app-dir/dev-output/app/layout.tsx
+++ b/test/development/app-dir/dev-output/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/dev-output/app/page.tsx
+++ b/test/development/app-dir/dev-output/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Hello, World!</p>
+}

--- a/test/development/app-dir/dev-output/dev-output.test.ts
+++ b/test/development/app-dir/dev-output/dev-output.test.ts
@@ -1,0 +1,50 @@
+import { nextTestSetup } from 'e2e-utils'
+const { version: nextVersion } = require('next/package.json')
+
+const cacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+
+describe('dev-output', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('shows Cache Components indicator when enabled', async () => {
+    const preamble = getPreambleOutput(next.cliOutput)
+
+    if (cacheComponentsEnabled) {
+      if (isTurbopack) {
+        expect(preamble).toContain('Next.js')
+        expect(preamble).toContain('Turbopack')
+        expect(preamble).toContain('Cache Components')
+      } else {
+        expect(preamble).toContain('Next.js')
+        expect(preamble).toContain('webpack')
+        expect(preamble).toContain('Cache Components')
+      }
+    } else {
+      // When cache components env is not set, should not show the indicator
+      expect(preamble).toContain('Next.js')
+      if (isTurbopack) {
+        expect(preamble).toContain('Turbopack')
+      } else {
+        expect(preamble).toContain('webpack')
+      }
+      expect(preamble).not.toContain('Cache Components')
+    }
+  })
+})
+
+function getPreambleOutput(cliOutput: string): string {
+  const lines: string[] = []
+
+  for (const line of cliOutput.split('\n')) {
+    // Capture lines up to and including the "Local:" line
+    lines.push(line.replace(nextVersion, 'x.y.z'))
+
+    if (line.includes('Local:')) {
+      break
+    }
+  }
+
+  return lines.join('\n').trim()
+}


### PR DESCRIPTION
Missed the plumbing for this in `dev`. 