### PR TITLE
Add comment that we expect the function passed to bind to be anonymous

### DIFF
--- a/packages/next/src/server/after/after-context.ts
+++ b/packages/next/src/server/after/after-context.ts
@@ -84,15 +84,19 @@ export class AfterContext {
     //   after(() => x())
     //   after(x())
     //   await x()
-    const wrappedCallback = bindSnapshot(async () => {
-      try {
-        await afterTaskAsyncStorage.run({ rootTaskSpawnPhase }, () =>
-          callback()
-        )
-      } catch (error) {
-        this.reportTaskError('function', error)
+    const wrappedCallback = bindSnapshot(
+      // WARNING: Don't make this a named function. It must be anonymous.
+      // See: https://github.com/facebook/react/pull/34911
+      async () => {
+        try {
+          await afterTaskAsyncStorage.run({ rootTaskSpawnPhase }, () =>
+            callback()
+          )
+        } catch (error) {
+          this.reportTaskError('function', error)
+        }
       }
-    })
+    )
 
     this.callbackQueue.add(wrappedCallback)
   }

--- a/packages/next/src/server/app-render/async-local-storage.ts
+++ b/packages/next/src/server/app-render/async-local-storage.ts
@@ -45,7 +45,10 @@ export function createAsyncLocalStorage<
   return new FakeAsyncLocalStorage()
 }
 
-export function bindSnapshot<T>(fn: T): T {
+export function bindSnapshot<T>(
+  // WARNING: Don't pass a named function to this argument! See: https://github.com/facebook/react/pull/34911
+  fn: T
+): T {
   if (maybeGlobalAsyncLocalStorage) {
     return maybeGlobalAsyncLocalStorage.bind(fn)
   }


### PR DESCRIPTION
See https://github.com/facebook/react/pull/34911

This is a weird one but we need some consistent name to ignore these because otherwise they show up as I/O.

The simplest is to simply not assign a name to the function being passed. It also can't be auto-assigned by a compiler. Because whatever name the function is given is the name given to the AsyncResource.
