### PR TITLE
Fix build crash with parallel routes and root-level dynamic parameters

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -891,5 +891,6 @@
   "890": "Received an underlying cookies object that does not match either `cookies` or `mutableCookies`",
   "891": "Failed to read build paths file \"%s\": %s",
   "892": "Failed to resolve glob pattern \"%s\": %s",
-  "893": "The \"sassOptions.functions\" option is not supported when using Turbopack. Custom Sass functions are only available with webpack. Please remove the \"functions\" property from your sassOptions in %s."
+  "893": "The \"sassOptions.functions\" option is not supported when using Turbopack. Custom Sass functions are only available with webpack. Please remove the \"functions\" property from your sassOptions in %s.",
+  "894": "Param %s not found in childrenRouteParamSegments %s"
 }

--- a/packages/next/src/shared/lib/router/utils/get-segment-param.tsx
+++ b/packages/next/src/shared/lib/router/utils/get-segment-param.tsx
@@ -53,3 +53,29 @@ export function isCatchAll(
     type === 'optional-catchall'
   )
 }
+
+export function getParamProperties(paramType: DynamicParamTypes): {
+  repeat: boolean
+  optional: boolean
+} {
+  let repeat = false
+  let optional = false
+
+  switch (paramType) {
+    case 'catchall':
+    case 'catchall-intercepted':
+      repeat = true
+      break
+    case 'optional-catchall':
+      repeat = true
+      optional = true
+      break
+    case 'dynamic':
+    case 'dynamic-intercepted':
+      break
+    default:
+      paramType satisfies never
+  }
+
+  return { repeat, optional }
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-slotted-non-catchalls/app/[locale]/@slot/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-slotted-non-catchalls/app/[locale]/@slot/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return <div>/[locale]/@slot/default.tsx</div>
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-slotted-non-catchalls/app/[locale]/@slot/other/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-slotted-non-catchalls/app/[locale]/@slot/other/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>/[locale]/@slot/other/page.tsx</div>
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-slotted-non-catchalls/app/[locale]/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-slotted-non-catchalls/app/[locale]/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  slot,
+}: {
+  children: React.ReactNode
+  slot: React.ReactNode
+}) {
+  return (
+    <>
+      Children: <div id="children">{children}</div>
+      Slot: <div id="slot">{slot}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-catchall-slotted-non-catchalls/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-slotted-non-catchalls/app/layout.tsx
@@ -3,9 +3,7 @@ import React from 'react'
 export default function Root({ children }: { children: React.ReactNode }) {
   return (
     <html>
-      <body>
-        Children: <div id="children">{children}</div>
-      </body>
+      <body>{children}</body>
     </html>
   )
 }


### PR DESCRIPTION
### What?

Fixes a build-time crash that occurs when using parallel routes (`@slot` syntax) combined with root-level dynamic parameters (e.g., `[locale]`) in the App Router.

### Why?

When building static paths for routes with both parallel routes and root-level dynamic parameters, the build would crash during pathname generation. This happened because the code was using `RouteRegex.groups` to determine parameter properties (`repeat`/`optional`), but the regex groups didn't properly handle segment names for nested parallel route structures. The pathname replacement logic would fail when trying to match segment patterns, causing the build to abort.

This is a critical issue because it blocks developers from using a common pattern: internationalization with parallel routes (e.g., `/[locale]/@modal/...`).

### How?

The fix refactors the parameter validation logic to use `DynamicParamTypes` directly instead of relying on `RouteRegex`:

1. Created a new `getParamProperties()` utility in `get-segment-param.tsx` that determines `repeat` and `optional` properties based on the parameter type (catchall, optional-catchall, dynamic, etc.)
2. Updated `buildAppStaticPaths()` to use this utility instead of `RouteRegex.groups`
3. Changed pathname replacement to use the segment name from `childrenRouteParamSegments` rather than reconstructing it from the regex pattern

This approach:
- Eliminates the mismatch between regex-based pattern matching and actual segment structure
- Properly handles parallel route segment names
- Makes the code more maintainable by using the type system instead of regex internals

Fixes #84509