### PR TITLE
[Cache Components] Dev - fix hanging cache deadlock

### DIFF
--- a/packages/next/src/server/dynamic-rendering-utils.ts
+++ b/packages/next/src/server/dynamic-rendering-utils.ts
@@ -42,7 +42,7 @@ export function makeHangingPromise<T>(
   expression: string
 ): Promise<T> {
   if (signal.aborted) {
-    return Promise.reject(new HangingPromiseRejectionError(route, expression))
+    return makeRejectedHangingPromise(route, expression)
   } else {
     const hangingPromise = new Promise<T>((_, reject) => {
       const boundRejection = reject.bind(
@@ -72,6 +72,13 @@ export function makeHangingPromise<T>(
     hangingPromise.catch(ignoreReject)
     return hangingPromise
   }
+}
+
+export function makeRejectedHangingPromise(
+  route: string,
+  expression: string
+): Promise<never> {
+  return Promise.reject(new HangingPromiseRejectionError(route, expression))
 }
 
 function ignoreReject() {}

--- a/test/development/app-dir/cache-components-dev-warmup/cache-components.dev-warmup.test.ts
+++ b/test/development/app-dir/cache-components-dev-warmup/cache-components.dev-warmup.test.ts
@@ -246,13 +246,19 @@ describe.each([
             assertLog(logs, 'after cache read - page', 'Prerender')
 
             // Short lived caches are dynamic holes in static prerenders,
-            // so they shouldn't resolve in the static stage.
+            // so they shouldn't resolve in the static stage,
+            // but they should resolve in the runtime stage.
             assertLog(logs, 'after short-lived cache read - page', RUNTIME_ENV)
             assertLog(
               logs,
               'after short-lived cache read - layout',
               RUNTIME_ENV
             )
+
+            // Dynamic caches are holes in static and runtime prerenders,
+            // so they should only resolve in the dynamic stage.
+            assertLog(logs, 'after dynamic cache read - layout', 'Server')
+            assertLog(logs, 'after dynamic cache read - page', 'Server')
 
             assertLog(logs, 'after uncached fetch - layout', 'Server')
             assertLog(logs, 'after uncached fetch - page', 'Server')

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/data-fetching.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/data-fetching.tsx
@@ -23,3 +23,31 @@ async function getShortLivedCachedData(_key: string) {
   await new Promise((r) => setTimeout(r))
   return Math.random()
 }
+
+export async function DynamicCache({
+  label,
+  cacheKey,
+}: {
+  label: string
+  cacheKey: string
+}) {
+  const data = await getDynamicCachedData(cacheKey)
+  console.log(`after dynamic cache read - ${label}`)
+  return (
+    <dl>
+      <dt>Dynamic Cached Data (Page)</dt>
+      <dd>{data}</dd>
+    </dl>
+  )
+}
+
+async function getDynamicCachedData(_key: string) {
+  'use cache'
+  cacheLife({
+    stale: 20, // < DYNAMIC_STALE (excluded from runtime prerenders)
+    revalidate: 2 * 60,
+    expire: 3 * 60, // < DYNAMIC_EXPIRE (excluded from static prerenders)
+  })
+  await new Promise((r) => setTimeout(r))
+  return Math.random()
+}

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 import { UncachedFetch, CachedData } from '../data-fetching'
-import { ShortLivedCache } from './data-fetching'
+import { DynamicCache, ShortLivedCache } from './data-fetching'
 
 export const unstable_prefetch = { mode: 'runtime', samples: [{}] }
 
@@ -18,6 +18,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
         <Suspense fallback="Loading short-lived cache...">
           <ShortLivedCache label="layout" cacheKey={CACHE_KEY} />
+        </Suspense>
+
+        <Suspense fallback="Loading dynamic cache...">
+          <DynamicCache label="layout" cacheKey={CACHE_KEY} />
         </Suspense>
 
         <Suspense fallback="Loading uncached fetch...">

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 import { CachedData, UncachedFetch } from '../data-fetching'
-import { ShortLivedCache } from './data-fetching'
+import { DynamicCache, ShortLivedCache } from './data-fetching'
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 
@@ -13,6 +13,10 @@ export default async function Page() {
 
       <Suspense fallback="Loading short-lived cache...">
         <ShortLivedCache label="page" cacheKey={CACHE_KEY} />
+      </Suspense>
+
+      <Suspense fallback="Loading dynamic cache...">
+        <DynamicCache label="page" cacheKey={CACHE_KEY} />
       </Suspense>
 
       <Suspense fallback="Loading uncached fetch...">

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-lived-cache/data-fetching.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-lived-cache/data-fetching.tsx
@@ -23,3 +23,31 @@ async function getShortLivedCachedData(_key: string) {
   await new Promise((r) => setTimeout(r))
   return Math.random()
 }
+
+export async function DynamicCache({
+  label,
+  cacheKey,
+}: {
+  label: string
+  cacheKey: string
+}) {
+  const data = await getDynamicCachedData(cacheKey)
+  console.log(`after dynamic cache read - ${label}`)
+  return (
+    <dl>
+      <dt>Dynamic Cached Data (Page)</dt>
+      <dd>{data}</dd>
+    </dl>
+  )
+}
+
+async function getDynamicCachedData(_key: string) {
+  'use cache'
+  cacheLife({
+    stale: 20, // < DYNAMIC_STALE (excluded from runtime prerenders)
+    revalidate: 2 * 60,
+    expire: 3 * 60, // < DYNAMIC_EXPIRE (excluded from static prerenders)
+  })
+  await new Promise((r) => setTimeout(r))
+  return Math.random()
+}

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-lived-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-lived-cache/layout.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 import { UncachedFetch, CachedData } from '../data-fetching'
-import { ShortLivedCache } from './data-fetching'
+import { DynamicCache, ShortLivedCache } from './data-fetching'
 
 const CACHE_KEY = __dirname + '/__LAYOUT__'
 
@@ -16,6 +16,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
         <Suspense fallback="Loading short-lived cache...">
           <ShortLivedCache label="layout" cacheKey={CACHE_KEY} />
+        </Suspense>
+
+        <Suspense fallback="Loading dynamic cache...">
+          <DynamicCache label="layout" cacheKey={CACHE_KEY} />
         </Suspense>
 
         <Suspense fallback="Loading uncached fetch...">

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-lived-cache/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/short-lived-cache/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 import { CachedData, UncachedFetch } from '../data-fetching'
-import { ShortLivedCache } from './data-fetching'
+import { DynamicCache, ShortLivedCache } from './data-fetching'
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 
@@ -13,6 +13,10 @@ export default async function Page() {
 
       <Suspense fallback="Loading short-lived cache...">
         <ShortLivedCache label="page" cacheKey={CACHE_KEY} />
+      </Suspense>
+
+      <Suspense fallback="Loading dynamic cache...">
+        <DynamicCache label="page" cacheKey={CACHE_KEY} />
       </Suspense>
 
       <Suspense fallback="Loading uncached fetch...">


### PR DESCRIPTION
In some cases (short expire / short stale), caches might be considered dynamic. In a prerender, we'd return a hanging promise which'd result in a dynamic hole. In staged rendering, we model this using a delay instead -- things that would be holes wait until we reach the target stage (Runtime or Dynamic) and then resolve.

The bug occurs in the "restart on cache miss" flow, if we
1. Have some cache misses in the first render (so we wait for caches)
2. Have a cache hit for a "dynamic" cache that should be omitted from prerenders, i.e. only resolves in the Dynamic stage

Due to 1, the warmup won't advance to the Dynamic stage (we deliberately block that, since we don't want to trigger dynamic code). So any dynamic caches (that nevertheless weren't a cache miss) would have triggered a `beginRead()`, but then we'd delay them from resolving until the dynamic stage, which means that that read will never end, and `cacheReady()` will never fire (because the pending reads never count down to 0). **this causes a deadlock** and results in us hanging forever in the warmup.

The solution here is slightly similar to how we handle those caches in a prerender. There, we'd end the read and return a promise. here, we end the read (to avoid blocking cacheReady) and then wait for the stage (which we might never reach if it's Dynamic). if we reach the stage (which happens for Runtime caches), we start the read again, so it'll show up again, and cacheReady() will wait for it if needed. But if we never reach the target stage, then there's no problem, because there's no pending read anymore, so `cacheReady()` won't be blocked.