### PR TITLE
[cache components]: add 'bypass' cache indicator status

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/cache-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/cache-indicator.tsx
@@ -1,2 +1,2 @@
-export type ServerCacheStatus = 'filling' | 'filled'
-export type CacheIndicatorState = 'disabled' | 'ready' | ServerCacheStatus
+export type ServerCacheStatus = 'filling' | 'filled' | 'bypass' | 'ready'
+export type CacheIndicatorState = 'disabled' | ServerCacheStatus

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -665,7 +665,14 @@ async function generateDynamicFlightRenderResultWithCachesInDev(
     dev = false,
     onInstrumentationRequestError,
     setReactDebugChannel,
+    setCacheStatus,
   } = renderOpts
+
+  // Before we kick off the render, we set the cache status back to it's initial state
+  // in case a previous render bypassed the cache.
+  if (process.env.NODE_ENV === 'development') {
+    setCacheStatus!('ready', htmlRequestId, requestId)
+  }
 
   function onFlightDataRenderError(err: DigestedError) {
     return onInstrumentationRequestError?.(
@@ -1891,6 +1898,11 @@ async function renderToHTMLOrFlightImpl(
             createRequestStore
           )
         } else {
+          // Set cache status to bypass when specifically bypassing caches in dev
+          if (process.env.NODE_ENV === 'development' && bypassCachesInDev) {
+            const { setCacheStatus } = renderOpts
+            setCacheStatus!('bypass', htmlRequestId, requestId)
+          }
           return generateDynamicFlightRenderResult(req, ctx, requestStore)
         }
       }


### PR DESCRIPTION
When caches are disabled (eg via browser devtools, or hard refresh), we'll be rendering a special UI state in the dev indicator. This adds the new state to the existing cache status plumbing and will be used in the next PR. 