### PR TITLE
add new devtools indicator loading state

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/devtools-indicator.tsx
@@ -31,10 +31,6 @@ export function DevToolsIndicator() {
     <Toast
       id="devtools-indicator"
       data-nextjs-toast
-      // TODO: Remove once we have actual UI for this.
-      data-nextjs-cache-indicator={
-        state.cacheIndicator === 'disabled' ? undefined : state.cacheIndicator
-      }
       style={
         {
           '--animate-out-duration-ms': `${MENU_DURATION_MS}ms`,

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.stories.tsx
@@ -10,80 +10,42 @@ const meta: Meta<typeof NextLogo> = {
   },
   args: {
     'aria-label': 'Open Next.js DevTools',
+    onTriggerClick: () => console.log('Logo clicked'),
   },
-  decorators: [withShadowPortal],
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '2rem' }}>
+        <Story />
+      </div>
+    ),
+    withShadowPortal,
+  ],
 }
 
 export default meta
 type Story = StoryObj<typeof NextLogo>
 
-export const NoIssues: Story = {
+export const Idle: Story = {
   decorators: [
     withDevOverlayContexts({
       totalErrorCount: 0,
       state: {
         buildingIndicator: false,
         renderingIndicator: false,
+        cacheIndicator: 'ready',
       },
     }),
   ],
 }
 
-export const SingleIssue: Story = {
-  decorators: [
-    withDevOverlayContexts({
-      totalErrorCount: 1,
-      state: {
-        buildingIndicator: false,
-        renderingIndicator: false,
-      },
-    }),
-  ],
-}
-
-export const MultipleIssues: Story = {
-  decorators: [
-    withDevOverlayContexts({
-      totalErrorCount: 5,
-      state: {
-        buildingIndicator: false,
-        renderingIndicator: false,
-      },
-    }),
-  ],
-}
-
-export const ManyIssues: Story = {
-  decorators: [
-    withDevOverlayContexts({
-      totalErrorCount: 99,
-      state: {
-        buildingIndicator: false,
-        renderingIndicator: false,
-      },
-    }),
-  ],
-}
-
-export const Building: Story = {
+export const Compiling: Story = {
   decorators: [
     withDevOverlayContexts({
       totalErrorCount: 0,
       state: {
         buildingIndicator: true,
         renderingIndicator: false,
-      },
-    }),
-  ],
-}
-
-export const BuildingWithError: Story = {
-  decorators: [
-    withDevOverlayContexts({
-      totalErrorCount: 1,
-      state: {
-        buildingIndicator: true,
-        renderingIndicator: false,
+        cacheIndicator: 'ready',
       },
     }),
   ],
@@ -96,18 +58,72 @@ export const Rendering: Story = {
       state: {
         buildingIndicator: false,
         renderingIndicator: true,
+        cacheIndicator: 'ready',
       },
     }),
   ],
 }
 
-export const RenderingWithError: Story = {
+export const Prerendering: Story = {
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 0,
+      state: {
+        buildingIndicator: false,
+        renderingIndicator: false,
+        cacheIndicator: 'filling',
+      },
+    }),
+  ],
+}
+
+export const CacheDisabled: Story = {
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 0,
+      state: {
+        buildingIndicator: false,
+        renderingIndicator: true,
+        cacheIndicator: 'bypass',
+      },
+    }),
+  ],
+}
+
+export const WithSingleError: Story = {
   decorators: [
     withDevOverlayContexts({
       totalErrorCount: 1,
       state: {
         buildingIndicator: false,
-        renderingIndicator: true,
+        renderingIndicator: false,
+        cacheIndicator: 'ready',
+      },
+    }),
+  ],
+}
+
+export const WithMultipleErrors: Story = {
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 5,
+      state: {
+        buildingIndicator: false,
+        renderingIndicator: false,
+        cacheIndicator: 'ready',
+      },
+    }),
+  ],
+}
+
+export const CompilingWithError: Story = {
+  decorators: [
+    withDevOverlayContexts({
+      totalErrorCount: 1,
+      state: {
+        buildingIndicator: true,
+        renderingIndicator: false,
+        cacheIndicator: 'ready',
       },
     }),
   ],

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
@@ -1,18 +1,19 @@
 import { useRef, useState } from 'react'
 import { useUpdateAnimation } from './hooks/use-update-animation'
 import { useMeasureWidth } from './hooks/use-measure-width'
-import { useMinimumLoadingTimeMultiple } from './hooks/use-minimum-loading-time-multiple'
 import { Cross } from '../../icons/cross'
 import { Warning } from '../../icons/warning'
 import { css } from '../../utils/css'
 import { useDevOverlayContext } from '../../../dev-overlay.browser'
 import { useRenderErrorContext } from '../../dev-overlay'
+import { useDelayedRender } from '../../hooks/use-delayed-render'
 import {
   ACTION_ERROR_OVERLAY_CLOSE,
   ACTION_ERROR_OVERLAY_OPEN,
 } from '../../shared'
 import { usePanelRouterContext } from '../../menu/context'
 import { BASE_LOGO_SIZE } from '../../utils/indicator-metrics'
+import { StatusIndicator, Status, getCurrentStatus } from './status-indicator'
 
 const SHORT_DURATION_MS = 150
 
@@ -40,13 +41,38 @@ export function NextLogo({
     SHORT_DURATION_MS
   )
 
+  // Cache indicator state management
+  const isCacheFilling = state.cacheIndicator === 'filling'
+  const isCacheBypassing = state.cacheIndicator === 'bypass'
+
+  // Determine if we should show any status
+  const shouldShowStatus =
+    state.buildingIndicator ||
+    state.renderingIndicator ||
+    isCacheFilling ||
+    (isCacheBypassing && state.renderingIndicator)
+
+  // Delay showing for 400ms to catch fast operations,
+  // and keep visible for minimum time (longer for warnings)
+  const { rendered: showStatusIndicator } = useDelayedRender(shouldShowStatus, {
+    enterDelay: isCacheBypassing && state.renderingIndicator ? 0 : 400, // Bypass warning shows immediately, others delayed
+    exitDelay: 500,
+  })
+
   const ref = useRef<HTMLDivElement | null>(null)
   const measuredWidth = useMeasureWidth(ref)
 
-  const isLoading = useMinimumLoadingTimeMultiple(
-    state.buildingIndicator || state.renderingIndicator
+  // Get the current status from the state
+  const currentStatus = getCurrentStatus(
+    state.buildingIndicator,
+    state.renderingIndicator,
+    state.cacheIndicator
   )
-  const isExpanded = isErrorExpanded || state.disableDevIndicator
+
+  const displayStatus = showStatusIndicator ? currentStatus : Status.None
+
+  const isExpanded =
+    isErrorExpanded || showStatusIndicator || state.disableDevIndicator
   const width = measuredWidth === 0 ? 'auto' : measuredWidth
 
   return (
@@ -146,6 +172,15 @@ export function NextLogo({
                 &:hover {
                   background: var(--color-hover-alpha-error-2);
                 }
+              }
+            }
+
+            &[data-status='cache-bypassing'] {
+              background: rgba(251, 211, 141, 0.95); /* Warm amber background */
+              --color-inner-border: rgba(245, 158, 11, 0.8);
+
+              [data-indicator-status] {
+                color: rgba(92, 45, 10, 1); /* Dark brown text */
               }
             }
 
@@ -300,15 +335,6 @@ export function NextLogo({
             }
           }
 
-          .path0 {
-            animation: draw0 1.5s ease-in-out infinite;
-          }
-
-          .path1 {
-            animation: draw1 1.5s ease-out infinite;
-            animation-delay: 0.3s;
-          }
-
           .paused {
             stroke-dashoffset: 0;
           }
@@ -339,44 +365,6 @@ export function NextLogo({
             }
           }
 
-          @keyframes draw0 {
-            0%,
-            25% {
-              stroke-dashoffset: -29.6;
-            }
-            25%,
-            50% {
-              stroke-dashoffset: 0;
-            }
-            50%,
-            75% {
-              stroke-dashoffset: 0;
-            }
-            75%,
-            100% {
-              stroke-dashoffset: 29.6;
-            }
-          }
-
-          @keyframes draw1 {
-            0%,
-            20% {
-              stroke-dashoffset: -11.6;
-            }
-            20%,
-            50% {
-              stroke-dashoffset: 0;
-            }
-            50%,
-            75% {
-              stroke-dashoffset: 0;
-            }
-            75%,
-            100% {
-              stroke-dashoffset: 11.6;
-            }
-          }
-
           @media (prefers-reduced-motion) {
             [data-issues-count-exit],
             [data-issues-count-enter],
@@ -390,6 +378,7 @@ export function NextLogo({
         data-next-badge
         data-error={hasError}
         data-error-expanded={isExpanded}
+        data-status={hasError ? Status.None : currentStatus}
         data-animate={newErrorDetected}
         style={{ width }}
       >
@@ -400,7 +389,6 @@ export function NextLogo({
               id="next-logo"
               ref={triggerRef}
               data-next-mark
-              data-next-mark-loading={isLoading}
               onClick={onTriggerClick}
               disabled={state.disableDevIndicator}
               aria-haspopup="menu"
@@ -408,76 +396,89 @@ export function NextLogo({
               aria-controls="nextjs-dev-tools-menu"
               aria-label={`${isMenuOpen ? 'Close' : 'Open'} Next.js Dev Tools`}
               data-nextjs-dev-tools-button
+              style={{
+                display: showStatusIndicator && !hasError ? 'none' : 'flex',
+              }}
               {...buttonProps}
             >
-              <NextMark
-                isLoading={isLoading}
-                isDevBuilding={state.buildingIndicator}
-              />
+              <NextMark />
             </button>
           )}
           {isExpanded && (
-            <div data-issues>
-              <button
-                data-issues-open
-                aria-label="Open issues overlay"
-                onClick={() => {
-                  if (state.isErrorOverlayOpen) {
-                    dispatch({
-                      type: ACTION_ERROR_OVERLAY_CLOSE,
-                    })
-                    return
-                  }
-                  dispatch({ type: ACTION_ERROR_OVERLAY_OPEN })
-                  setPanel(null)
-                }}
-              >
-                {state.disableDevIndicator && (
-                  <div data-disabled-icon>
-                    <Warning />
-                  </div>
-                )}
-                <AnimateCount
-                  // Used the key to force a re-render when the count changes.
-                  key={totalErrorCount}
-                  animate={newErrorDetected}
-                  data-issues-count-animation
-                >
-                  {totalErrorCount}
-                </AnimateCount>{' '}
-                <div>
-                  Issue
-                  {totalErrorCount > 1 && (
-                    <span
-                      aria-hidden
-                      data-issues-count-plural
-                      // This only needs to animate once the count changes from 1 -> 2,
-                      // otherwise it should stay static between re-renders.
-                      data-animate={newErrorDetected && totalErrorCount === 2}
+            <>
+              {/* Error badge has priority over cache indicator */}
+              {(isErrorExpanded || state.disableDevIndicator) && (
+                <div data-issues>
+                  <button
+                    data-issues-open
+                    aria-label="Open issues overlay"
+                    onClick={() => {
+                      if (state.isErrorOverlayOpen) {
+                        dispatch({
+                          type: ACTION_ERROR_OVERLAY_CLOSE,
+                        })
+                        return
+                      }
+                      dispatch({ type: ACTION_ERROR_OVERLAY_OPEN })
+                      setPanel(null)
+                    }}
+                  >
+                    {state.disableDevIndicator && (
+                      <div data-disabled-icon>
+                        <Warning />
+                      </div>
+                    )}
+                    <AnimateCount
+                      // Used the key to force a re-render when the count changes.
+                      key={totalErrorCount}
+                      animate={newErrorDetected}
+                      data-issues-count-animation
                     >
-                      s
-                    </span>
+                      {totalErrorCount}
+                    </AnimateCount>{' '}
+                    <div>
+                      Issue
+                      {totalErrorCount > 1 && (
+                        <span
+                          aria-hidden
+                          data-issues-count-plural
+                          // This only needs to animate once the count changes from 1 -> 2,
+                          // otherwise it should stay static between re-renders.
+                          data-animate={
+                            newErrorDetected && totalErrorCount === 2
+                          }
+                        >
+                          s
+                        </span>
+                      )}
+                    </div>
+                  </button>
+                  {!state.buildError && (
+                    <button
+                      data-issues-collapse
+                      aria-label="Collapse issues badge"
+                      onClick={() => {
+                        if (state.disableDevIndicator) {
+                          setDismissed(true)
+                        } else {
+                          setIsErrorExpanded(false)
+                        }
+                        // Move focus to the trigger to prevent having it stuck on this element
+                        triggerRef.current?.focus()
+                      }}
+                    >
+                      <Cross data-cross />
+                    </button>
                   )}
                 </div>
-              </button>
-              {!state.buildError && (
-                <button
-                  data-issues-collapse
-                  aria-label="Collapse issues badge"
-                  onClick={() => {
-                    if (state.disableDevIndicator) {
-                      setDismissed(true)
-                    } else {
-                      setIsErrorExpanded(false)
-                    }
-                    // Move focus to the trigger to prevent having it stuck on this element
-                    triggerRef.current?.focus()
-                  }}
-                >
-                  <Cross data-cross />
-                </button>
               )}
-            </div>
+              {/* Status indicator shown when no errors */}
+              {showStatusIndicator &&
+                !hasError &&
+                !state.disableDevIndicator && (
+                  <StatusIndicator status={displayStatus} />
+                )}
+            </>
           )}
         </div>
       </div>
@@ -506,25 +507,12 @@ function AnimateCount({
   )
 }
 
-function NextMark({
-  isLoading,
-  isDevBuilding,
-}: {
-  isLoading?: boolean
-  isDevBuilding?: boolean
-}) {
-  const strokeColor = isDevBuilding ? 'rgba(255,255,255,0.7)' : 'white'
+function NextMark() {
   return (
-    <svg
-      width="40"
-      height="40"
-      viewBox="0 0 40 40"
-      fill="none"
-      data-next-mark-loading={isLoading}
-    >
+    <svg width="40" height="40" viewBox="0 0 40 40" fill="none">
       <g transform="translate(8.5, 13)">
         <path
-          className={isLoading ? 'path0' : 'paused'}
+          className="paused"
           d="M13.3 15.2 L2.34 1 V12.6"
           fill="none"
           stroke="url(#next_logo_paint0_linear_1357_10853)"
@@ -534,7 +522,7 @@ function NextMark({
           strokeDashoffset="29.6"
         />
         <path
-          className={isLoading ? 'path1' : 'paused'}
+          className="paused"
           d="M11.825 1.5 V13.1"
           strokeWidth="1.86"
           stroke="url(#next_logo_paint1_linear_1357_10853)"
@@ -551,9 +539,9 @@ function NextMark({
           y2="17.9671"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stopColor={strokeColor} />
-          <stop offset="0.604072" stopColor={strokeColor} stopOpacity="0" />
-          <stop offset="1" stopColor={strokeColor} stopOpacity="0" />
+          <stop stopColor="white" />
+          <stop offset="0.604072" stopColor="white" stopOpacity="0" />
+          <stop offset="1" stopColor="white" stopOpacity="0" />
         </linearGradient>
         <linearGradient
           id="next_logo_paint1_linear_1357_10853"
@@ -563,8 +551,8 @@ function NextMark({
           y2="9.62542"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stopColor={strokeColor} />
-          <stop offset="1" stopColor={strokeColor} stopOpacity="0" />
+          <stop stopColor="white" />
+          <stop offset="1" stopColor="white" stopOpacity="0" />
         </linearGradient>
         <mask id="next_logo_mask0">
           <rect width="100%" height="100%" fill="white" />

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/status-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/status-indicator.tsx
@@ -1,0 +1,190 @@
+import type { CacheIndicatorState } from '../../cache-indicator'
+import { css } from '../../utils/css'
+
+export enum Status {
+  None = 'none',
+  Rendering = 'rendering',
+  Compiling = 'compiling',
+  Prerendering = 'prerendering',
+  CacheBypassing = 'cache-bypassing',
+}
+
+export function getCurrentStatus(
+  buildingIndicator: boolean,
+  renderingIndicator: boolean,
+  cacheIndicator: CacheIndicatorState
+): Status {
+  const isCacheFilling = cacheIndicator === 'filling'
+  const isCacheBypassing = cacheIndicator === 'bypass'
+
+  // Priority order: cache bypassing > prerendering > compiling > rendering
+  if (isCacheBypassing && renderingIndicator) {
+    return Status.CacheBypassing
+  }
+  if (isCacheFilling) {
+    return Status.Prerendering
+  }
+  if (buildingIndicator) {
+    return Status.Compiling
+  }
+  if (renderingIndicator) {
+    return Status.Rendering
+  }
+  return Status.None
+}
+
+interface StatusIndicatorProps {
+  status: Status
+}
+
+export function StatusIndicator({ status }: StatusIndicatorProps) {
+  const statusText: Record<Status, string> = {
+    [Status.None]: '',
+    [Status.CacheBypassing]: 'Cache disabled',
+    [Status.Prerendering]: 'Prerendering',
+    [Status.Compiling]: 'Compiling',
+    [Status.Rendering]: 'Rendering',
+  }
+
+  // Status dot colors
+  const statusDotColor: Record<Status, string> = {
+    [Status.None]: '',
+    [Status.CacheBypassing]: '', // No dot for bypass, uses full pill color
+    [Status.Prerendering]: '#f5a623',
+    [Status.Compiling]: '#f5a623',
+    [Status.Rendering]: '#50e3c2',
+  }
+
+  if (status === Status.None) {
+    return null
+  }
+
+  return (
+    <>
+      <style>
+        {css`
+          [data-indicator-status] {
+            --padding-left: 8px;
+            display: flex;
+            gap: 6px;
+            align-items: center;
+            padding-left: 12px;
+            padding-right: 8px;
+            height: var(--size-32);
+            margin-right: 2px;
+            border-radius: var(--rounded-full);
+            transition: background var(--duration-short) ease;
+            color: white;
+            font-size: var(--size-13);
+            font-weight: 500;
+            white-space: nowrap;
+          }
+
+          [data-status-dot] {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            flex-shrink: 0;
+          }
+
+          [data-status-text-animation] {
+            display: inline-flex;
+            align-items: center;
+            position: relative;
+            overflow: hidden;
+            height: 100%;
+
+            > * {
+              white-space: nowrap;
+              line-height: 1;
+            }
+
+            [data-status-text-enter] {
+              animation: slotMachineEnter 150ms cubic-bezier(0, 0, 0.2, 1)
+                forwards;
+            }
+          }
+
+          [data-status-ellipsis] {
+            display: inline-flex;
+            margin-left: 2px;
+          }
+
+          [data-status-ellipsis] span {
+            animation: ellipsisFade 1.2s infinite;
+            margin: 0 1px;
+          }
+
+          [data-status-ellipsis] span:nth-child(2) {
+            animation-delay: 0.2s;
+          }
+
+          [data-status-ellipsis] span:nth-child(3) {
+            animation-delay: 0.4s;
+          }
+
+          @keyframes ellipsisFade {
+            0%,
+            60%,
+            100% {
+              opacity: 0.2;
+            }
+            30% {
+              opacity: 1;
+            }
+          }
+
+          @keyframes slotMachineEnter {
+            0% {
+              transform: translateY(0.8em);
+              opacity: 0;
+            }
+            50% {
+              opacity: 0.8;
+            }
+            100% {
+              transform: translateY(0);
+              opacity: 1;
+            }
+          }
+        `}
+      </style>
+      <div data-indicator-status>
+        {statusDotColor[status] && (
+          <div
+            data-status-dot
+            style={{
+              backgroundColor: statusDotColor[status],
+            }}
+          />
+        )}
+        <AnimateStatusText
+          key={status} // Key here triggers re-mount and animation
+          statusKey={status}
+        >
+          {statusText[status]}
+        </AnimateStatusText>
+      </div>
+    </>
+  )
+}
+
+function AnimateStatusText({
+  children: text,
+}: {
+  children: string
+  statusKey?: string // Keep for type compatibility but unused
+}) {
+  return (
+    <div data-status-text-animation>
+      <div data-status-text-enter>
+        {text}
+        <span data-status-ellipsis>
+          <span>.</span>
+          <span>.</span>
+          <span>.</span>
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -213,6 +213,7 @@ import { ImageConfigContext } from '../../shared/lib/image-config-context.shared
 import { imageConfigDefault } from '../../shared/lib/image-config'
 import { RenderStage, StagedRenderingController } from './staged-rendering'
 import { anySegmentHasRuntimePrefetchEnabled } from './staged-validation'
+import { warnOnce } from '../../shared/lib/utils/warn-once'
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -5266,7 +5267,7 @@ function isBypassingCachesInDev(
 }
 
 function WarnForBypassCachesInDev({ route }: { route: string }) {
-  console.warn(
+  warnOnce(
     `Route ${route} is rendering with server caches disabled. For this navigation, Component Metadata in React DevTools will not accurately reflect what is statically prerenderable and runtime prefetchable. See more info here: https://nextjs.org/docs/messages/cache-bypass-in-dev`
   )
   return null

--- a/test/development/acceptance-app/editor-links.test.ts
+++ b/test/development/acceptance-app/editor-links.test.ts
@@ -72,9 +72,15 @@ describe('Error overlay - editor links', () => {
         return Boolean(
           [].slice
             .call(document.querySelectorAll('nextjs-portal'))
-            .find((p) =>
-              p.shadowRoot.querySelector('[data-next-mark-loading="false"]')
-            )
+            .find((p) => {
+              const badge = p.shadowRoot.querySelector('[data-next-badge]')
+              // Check if badge exists and is not showing any loading status
+              return (
+                badge &&
+                (badge.getAttribute('data-status') === 'none' ||
+                  !badge.getAttribute('data-status'))
+              )
+            })
         )
       })
       expect(loaded).toBe(true)

--- a/test/development/app-dir/cache-indicator/app/navigation/loading.tsx
+++ b/test/development/app-dir/cache-indicator/app/navigation/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>Loading...</div>
+}

--- a/test/development/app-dir/cache-indicator/app/navigation/page.tsx
+++ b/test/development/app-dir/cache-indicator/app/navigation/page.tsx
@@ -1,11 +1,41 @@
-import { setTimeout } from 'timers/promises'
+import { cacheTag } from 'next/cache'
+import { Suspense } from 'react'
 
-async function triggerSlowCacheFilling() {
-  'use cache'
-  await setTimeout(1000)
+export default function Page() {
+  return (
+    <div id="navigation-page">
+      Hello navigation page!
+      <Suspense fallback={<div>Loading</div>}>
+        <Component />
+      </Suspense>
+      <SlowThing />
+    </div>
+  )
 }
 
-export default async function NavigationPage() {
-  await triggerSlowCacheFilling()
-  return <p>Hello, navigation!</p>
+async function Component() {
+  const posts = await getBlogPosts()
+  return (
+    <div>
+      {posts.map((post) => (
+        <div key={post.id}>{post.content}</div>
+      ))}
+    </div>
+  )
+}
+
+async function getBlogPosts() {
+  'use cache'
+  cacheTag('blog-posts')
+  // sleep for 2s
+  await new Promise((resolve) => setTimeout(resolve, 2000))
+
+  return [{ id: 'foo', content: 'bar' }]
+}
+
+async function SlowThing() {
+  // sleep for 2s
+  await new Promise((resolve) => setTimeout(resolve, 2000))
+
+  return <div>Slow Thing</div>
 }

--- a/test/development/app-dir/cache-indicator/app/page.tsx
+++ b/test/development/app-dir/cache-indicator/app/page.tsx
@@ -1,11 +1,3 @@
-import { setTimeout } from 'timers/promises'
-
-async function triggerSlowCacheFilling() {
-  'use cache'
-  await setTimeout(1000)
-}
-
 export default async function Page() {
-  await triggerSlowCacheFilling()
   return <p>Hello, initial load!</p>
 }

--- a/test/development/app-dir/cache-indicator/cache-indicator.test.ts
+++ b/test/development/app-dir/cache-indicator/cache-indicator.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 const enableCacheComponents = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
@@ -7,13 +8,36 @@ describe('cache-indicator', () => {
     files: __dirname,
   })
 
-  it('is filled on initial load', async () => {
+  it('is none on initial load', async () => {
     const browser = await next.browser('/')
 
-    const toast = await browser.elementByCss('[data-nextjs-toast]')
-
-    expect(await toast.getAttribute('data-nextjs-cache-indicator')).toEqual(
-      enableCacheComponents ? 'filled' : null
-    )
+    const badge = await browser.elementByCss('[data-next-badge]')
+    const cacheStatus = await badge.getAttribute('data-status')
+    expect(cacheStatus).toBe('none')
   })
+
+  if (enableCacheComponents) {
+    it('renders the cache warming indicator when navigating to a page that needs to warm the cache', async () => {
+      const browser = await next.browser('/')
+
+      // navigate to the navigation page
+      const link = await browser.waitForElementByCss('a[href="/navigation"]')
+      await link.click()
+
+      await retry(async () => {
+        const badge = await browser.elementByCss('[data-next-badge]')
+        const cacheStatus = await badge.getAttribute('data-status')
+        expect(cacheStatus).toBe('prerendering')
+      })
+
+      await retry(async () => {
+        const text = await browser.elementByCss('#navigation-page').text()
+        expect(text).toContain('Hello navigation page!')
+      })
+
+      const badge = await browser.elementByCss('[data-next-badge]')
+      const status = await badge.getAttribute('data-status')
+      expect(status).toBe('none')
+    })
+  }
 })

--- a/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
+++ b/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
@@ -10,9 +10,13 @@ const installCheckVisible = (browser) => {
   return browser.eval(`(function() {
       window.checkInterval = setInterval(function() {
       const root = document.querySelector('nextjs-portal').shadowRoot;
-      const indicator = root.querySelector('[data-next-mark]')
+      const statusElement = root.querySelector('[data-indicator-status]')
+      const badge = root.querySelector('[data-next-badge]')
+      const status = badge ? badge.getAttribute('data-status') : null
+
+      // Check if we're showing any status
       window.showedBuilder = window.showedBuilder || (
-        indicator.getAttribute('data-next-mark-loading') === 'true'
+        statusElement !== null || (status && status !== 'none')
       )
       if (window.showedBuilder) clearInterval(window.checkInterval)
     }, 50)

--- a/test/development/dev-indicator/dev-rendering-indicator.test.ts
+++ b/test/development/dev-indicator/dev-rendering-indicator.test.ts
@@ -7,9 +7,13 @@ const installCheckVisible = (browser) => {
   return browser.eval(`(function() {
       window.checkInterval = setInterval(function() {
       const root = document.querySelector('nextjs-portal').shadowRoot;
-      const indicator = root.querySelector('[data-next-mark]')
+      const statusElement = root.querySelector('[data-indicator-status]')
+      const badge = root.querySelector('[data-next-badge]')
+      const status = badge ? badge.getAttribute('data-status') : null
+
+      // Check if we're showing any status (rendering, compiling, etc.)
       window.showedBuilder = window.showedBuilder || (
-        indicator.getAttribute('data-next-mark-loading') === 'true'
+        statusElement !== null || (status && status !== 'none')
       )
       if (window.showedBuilder) clearInterval(window.checkInterval)
     }, 5)

--- a/test/e2e/app-dir/cache-components-errors/cache-components-dev-cache-bypass.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-dev-cache-bypass.test.ts
@@ -28,13 +28,13 @@ describe('Cache Components Errors', () => {
       it('warns if you render with cache-control: no-cache in dev on client navigation', async () => {
         const from = next.cliOutput.length
 
-        await next.fetch('/', {
+        await next.fetch('/other', {
           headers: { 'cache-control': 'no-cache', RSC: '1' },
         })
 
         expect(stripGetLines(next.cliOutput.slice(from)))
           .toMatchInlineSnapshot(`
-         "Route / is rendering with server caches disabled. For this navigation, Component Metadata in React DevTools will not accurately reflect what is statically prerenderable and runtime prefetchable. See more info here: https://nextjs.org/docs/messages/cache-bypass-in-dev
+         "Route /other is rendering with server caches disabled. For this navigation, Component Metadata in React DevTools will not accurately reflect what is statically prerenderable and runtime prefetchable. See more info here: https://nextjs.org/docs/messages/cache-bypass-in-dev
          "
         `)
       })

--- a/test/e2e/build-indicator/test/index.test.ts
+++ b/test/e2e/build-indicator/test/index.test.ts
@@ -7,10 +7,13 @@ const installCheckVisible = (browser) => {
   return browser.eval(`(function() {
       window.checkInterval = setInterval(function() {
       const root = document.querySelector('nextjs-portal').shadowRoot;
-      const indicator = root.querySelector('[data-next-mark]')
-      if(!indicator) return
+      const statusElement = root.querySelector('[data-indicator-status]')
+      const badge = root.querySelector('[data-next-badge]')
+      const status = badge ? badge.getAttribute('data-status') : null
+
+      // Check if we're showing any build/compile status
       window.showedBuilder = window.showedBuilder || (
-        indicator.getAttribute('data-next-mark-loading') === 'true'
+        statusElement !== null || (status && status !== 'none')
       )
       if (window.showedBuilder) clearInterval(window.checkInterval)
     }, 5)


### PR DESCRIPTION
This removes the Next logo animation/dimming and replaces it with more explicit states. We also use this UI to show when caches are being warmed (when using Cache Components). When caches are being bypassed in DevTools, we also will show this in the indicator with warning text, indicating that we cannot accurately reflect what can be statically prerendered.


https://github.com/user-attachments/assets/665d4f8b-8c01-4def-a60e-bc4ecdd1f879

