### PR TITLE
Turbopack: Disable LightningCSS MediaRangeSyntax feature

### DIFF
--- a/test/e2e/app-dir/css-media-query/app/layout.tsx
+++ b/test/e2e/app-dir/css-media-query/app/layout.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react'
+import './styles.css'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/css-media-query/app/page.tsx
+++ b/test/e2e/app-dir/css-media-query/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>CSS Media Query Test</h1>
+}

--- a/test/e2e/app-dir/css-media-query/app/styles.css
+++ b/test/e2e/app-dir/css-media-query/app/styles.css
@@ -1,0 +1,9 @@
+h1 {
+  color: red;
+}
+
+@media screen and (max-width: 768px) {
+  h1 {
+    color: blue;
+  }
+}

--- a/test/e2e/app-dir/css-media-query/css-media-query.test.ts
+++ b/test/e2e/app-dir/css-media-query/css-media-query.test.ts
@@ -1,0 +1,67 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('css-media-query', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should preserve max-width media query syntax instead of transpiling to range syntax', async () => {
+    const browser = await next.browser('/')
+
+    // Get all stylesheets from the document
+    const stylesheetContents = await browser.eval(() => {
+      const stylesheets = Array.from(document.styleSheets)
+      const contents: string[] = []
+
+      for (const stylesheet of stylesheets) {
+        try {
+          // Only check stylesheets that have cssRules (not external ones we can't access)
+          if (stylesheet.cssRules) {
+            const rules = Array.from(stylesheet.cssRules)
+            for (const rule of rules) {
+              contents.push(rule.cssText)
+            }
+          }
+        } catch (e) {
+          // Skip stylesheets we can't access due to CORS
+          continue
+        }
+      }
+
+      return contents
+    })
+
+    // Find the media query rule
+    const mediaQueryRule = stylesheetContents.find(
+      (rule) => rule.includes('@media') && rule.includes('max-width')
+    )
+
+    expect(mediaQueryRule).toBeDefined()
+
+    // Verify that the media query uses the original max-width syntax
+    // and not the newer range syntax (width <= 768px)
+    expect(mediaQueryRule).toContain('max-width: 768px')
+    expect(mediaQueryRule).not.toContain('width <= 768px')
+    expect(mediaQueryRule).not.toContain('width<=768px')
+
+    // Also verify the rule contains our expected styles (CSS may convert blue to rgb format)
+    expect(mediaQueryRule).toMatch(/color:\s*(blue|rgb\(0,\s*0,\s*255\))/)
+  })
+
+  it('should apply the correct styles based on media query', async () => {
+    const browser = await next.browser('/')
+
+    // Check that the h1 element exists
+    const h1Text = await browser.elementByCss('h1').text()
+    expect(h1Text).toBe('CSS Media Query Test')
+
+    // Get the computed color (should be red by default, blue on small screens)
+    const defaultColor = await browser.eval(() => {
+      const h1 = document.querySelector('h1')
+      return window.getComputedStyle(h1!).color
+    })
+
+    // The exact color values may vary by browser, but we can check that styles are applied
+    expect(defaultColor).toBeDefined()
+  })
+})

--- a/test/e2e/app-dir/css-media-query/next.config.js
+++ b/test/e2e/app-dir/css-media-query/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/integration/css-features/test/browserslist.test.js
+++ b/test/integration/css-features/test/browserslist.test.js
@@ -110,7 +110,7 @@ describe('Browserslist: New', () => {
 
         if (process.env.IS_TURBOPACK_TEST) {
           expect(cssContentWithoutSourceMap).toMatchInlineSnapshot(
-            `"a{all:initial}@media (resolution>=2x){.image{background-image:url(data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==)}}"`
+            `"a{all:initial}@media (min-resolution:2x){.image{background-image:url(data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==)}}"`
           )
         } else {
           expect(cssContentWithoutSourceMap).toMatchInlineSnapshot(

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -78,12 +78,13 @@ async fn get_lightningcss_browser_targets(
             Ok(if handle_nesting {
                 Vc::cell(Targets {
                     browsers: browserslist_browsers,
-                    include: Features::Nesting,
+                    include: Features::Nesting | Features::MediaRangeSyntax,
                     ..Default::default()
                 })
             } else {
                 Vc::cell(Targets {
                     browsers: browserslist_browsers,
+                    include: Features::MediaRangeSyntax,
                     ..Default::default()
                 })
             })


### PR DESCRIPTION
## What?

Always downlevels MediaRangeSyntax to ensure max-width doesn't get upleveled to MediaRangeSyntax which is shorter but doesn't work with Chrome devtools `show media queries` feature.

Fixes #72559

Closes PACK-5723