### PR TITLE
Update blocking prerender error message

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-message/error-message.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-message/error-message.tsx
@@ -1,31 +1,38 @@
 import { useState, useRef, useLayoutEffect } from 'react'
+import type { ErrorType } from '../error-type-label/error-type-label'
 
 export type ErrorMessageType = React.ReactNode
 
 type ErrorMessageProps = {
   errorMessage: ErrorMessageType
+  errorType: ErrorType
 }
 
-export function ErrorMessage({ errorMessage }: ErrorMessageProps) {
+export function ErrorMessage({ errorMessage, errorType }: ErrorMessageProps) {
   const [isExpanded, setIsExpanded] = useState(false)
-  const [shouldTruncate, setShouldTruncate] = useState(false)
-  const messageRef = useRef<HTMLParagraphElement>(null)
+  const [isTooTall, setIsTooTall] = useState(false)
+  const messageRef = useRef<HTMLDivElement>(null)
 
   useLayoutEffect(() => {
     if (messageRef.current) {
-      setShouldTruncate(messageRef.current.scrollHeight > 200)
+      setIsTooTall(messageRef.current.scrollHeight > 200)
     }
   }, [errorMessage])
 
+  // The "Blocking Route" error message is specifically formatted to look nice
+  // in the overlay (rather than just passed through from the console), so we
+  // intentionally don't truncate it and rely on the scroll overflow instead.
+  const shouldTruncate = isTooTall && errorType !== 'Blocking Route'
+
   return (
     <div className="nextjs__container_errors_wrapper">
-      <p
+      <div
         ref={messageRef}
         id="nextjs__container_errors_desc"
         className={`nextjs__container_errors_desc ${shouldTruncate && !isExpanded ? 'truncated' : ''}`}
       >
         {errorMessage}
-      </p>
+      </div>
       {shouldTruncate && !isExpanded && (
         <>
           <div className="nextjs__container_errors_gradient_overlay" />

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -158,7 +158,10 @@ export function ErrorOverlayLayout({
                     generateErrorInfo={generateErrorInfo}
                   />
                 </div>
-                <ErrorMessage errorMessage={errorMessage} />
+                <ErrorMessage
+                  errorMessage={errorMessage}
+                  errorType={errorType}
+                />
               </ErrorOverlayDialogHeader>
 
               <ErrorOverlayDialogBody>{children}</ErrorOverlayDialogBody>

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-type-label/error-type-label.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-type-label/error-type-label.tsx
@@ -3,6 +3,7 @@ export type ErrorType =
   | `Runtime ${string}`
   | `Console ${string}`
   | `Recoverable ${string}`
+  | 'Blocking Route'
 
 type ErrorTypeLabelProps = {
   errorType: ErrorType
@@ -12,7 +13,7 @@ export function ErrorTypeLabel({ errorType }: ErrorTypeLabelProps) {
   return (
     <span
       id="nextjs__container_errors_label"
-      className="nextjs__container_errors_label"
+      className={`nextjs__container_errors_label ${errorType === 'Blocking Route' ? 'nextjs__container_errors_label_blocking_page' : ''}`}
     >
       {errorType}
     </span>
@@ -30,5 +31,10 @@ export const styles = `
     color: var(--color-red-900);
     font-family: var(--font-stack-monospace);
     line-height: var(--size-20);
+  }
+
+  .nextjs__container_errors_label_blocking_page {
+    background: var(--color-blue-100);
+    color: var(--color-blue-900);
   }
 `

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
@@ -56,6 +56,43 @@ function GenericErrorDescription({ error }: { error: Error }) {
   )
 }
 
+function BlockingPageLoadErrorDescription() {
+  return (
+    <div className="nextjs__blocking_page_load_error_description">
+      <h3 className="nextjs__blocking_page_load_error_description_title">
+        Uncached data was accessed outside of {'<Suspense>'}
+      </h3>
+      <p>
+        This delays the entire page from rendering, resulting in a slow user
+        experience. Next.js uses this error to ensure your app loads instantly
+        on every navigation.
+      </p>
+      <p>To fix this, you can:</p>
+      <ul>
+        <li>
+          Wrap the component in a {'<Suspense>'} boundary. This allows Next.js
+          to stream its contents to the user as soon as it's ready, without
+          blocking the rest of the app.
+        </li>
+        <li>
+          Move the asynchronous await into a Cache Component (
+          <code>"use cache"</code>). This allows Next.js to statically prerender
+          the component as part of the HTML document, so it's instantly visible
+          to the user. Note that request-specific information &mdash; such as
+          params, cookies, and headers &mdash; is not available during static
+          prerendering.
+        </li>
+      </ul>
+      <p>
+        Learn more:{' '}
+        <a href="https://nextjs.org/docs/messages/blocking-route">
+          https://nextjs.org/docs/messages/blocking-route
+        </a>
+      </p>
+    </div>
+  )
+}
+
 export function getErrorTypeLabel(
   error: Error,
   type: ReadyRuntimeError['type']
@@ -64,6 +101,12 @@ export function getErrorTypeLabel(
     return `Recoverable ${error.name}`
   }
   if (type === 'console') {
+    const isBlockingPageLoadError = error.message.includes(
+      'https://nextjs.org/docs/messages/blocking-route'
+    )
+    if (isBlockingPageLoadError) {
+      return 'Blocking Route'
+    }
     return `Console ${error.name}`
   }
   return `Runtime ${error.name}`
@@ -237,6 +280,8 @@ Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\
       errorMessage={
         hydrationWarning ? (
           <HydrationErrorDescription message={hydrationWarning} />
+        ) : errorType === 'Blocking Route' ? (
+          <BlockingPageLoadErrorDescription />
         ) : (
           <GenericErrorDescription error={error} />
         )
@@ -348,5 +393,11 @@ export const styles = `
   }
   .error-overlay-notes-container p {
     white-space: pre-wrap;
+  }
+  .nextjs__blocking_page_load_error_description {
+    color: var(--color-stack-notes);
+  }
+  .nextjs__blocking_page_load_error_description_title {
+    color: var(--color-title-color);
   }
 `

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -759,7 +759,11 @@ export function trackAllowedDynamicAccess(
     )
     return
   } else {
-    const message = `Route "${workStore.route}": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense`
+    const message =
+      `Route "${workStore.route}": Uncached data was accessed outside of ` +
+      '<Suspense>. This delays the entire page from rendering, resulting in a ' +
+      'slow user experience. Learn more: ' +
+      'https://nextjs.org/docs/messages/blocking-route'
     const error = createErrorWithComponentOrOwnerStack(message, componentStack)
     dynamicValidation.dynamicErrors.push(error)
     return

--- a/test/development/app-dir/cache-components-dev-cache-scope/cache-components-dev-cache-scope.test.ts
+++ b/test/development/app-dir/cache-components-dev-cache-scope/cache-components-dev-cache-scope.test.ts
@@ -75,16 +75,12 @@ describe('Cache Components Dev Errors', () => {
     await openRedbox(browser)
     desc = await getRedboxDescription(browser)
 
-    expect(desc).toContain(
-      'Route "/uncached": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it'
-    )
+    expect(desc).toContain('https://nextjs.org/docs/messages/blocking-route')
 
     await browser.refresh()
     await openRedbox(browser)
     desc = await getRedboxDescription(browser)
 
-    expect(desc).toContain(
-      'Route "/uncached": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it'
-    )
+    expect(desc).toContain('https://nextjs.org/docs/messages/blocking-route')
   })
 })

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -94,22 +94,23 @@ describe('Cache Components Dev Errors', () => {
     })
 
     expect(stripAnsi(next.cliOutput.slice(outputIndex))).toContain(
-      `Error: Route "/no-accessed-data": ` +
-        `A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. ` +
-        `See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense` +
-        '\n    at Page (app/no-accessed-data/page.js:1:31)' +
-        '\n> 1 | export default async function Page() {' +
-        '\n    |                               ^' +
-        '\n  2 |   await new Promise((r) => setTimeout(r, 200))' +
-        '\n  3 |   return <p>Page</p>' +
-        '\n  4 | }'
+      'https://nextjs.org/docs/messages/blocking-route'
     )
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
-       "description": "Route "/no-accessed-data": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+       "description": "Uncached data was accessed outside of <Suspense>
+
+     This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+     To fix this, you can:
+
+     Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+     Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+     Learn more: https://nextjs.org/docs/messages/blocking-route",
        "environmentLabel": "Server",
-       "label": "Console Error",
+       "label": "Blocking Route",
        "source": "app/no-accessed-data/page.js (1:31) @ Page
      > 1 | export default async function Page() {
          |                               ^",
@@ -141,17 +142,17 @@ describe('Cache Components Dev Errors', () => {
     const { browser, session } = sandbox
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
-         {
-           "description": "Ecmascript file had an error",
-           "environmentLabel": null,
-           "label": "Build Error",
-           "source": "./app/page.tsx (1:14)
-         Ecmascript file had an error
-         > 1 | export const revalidate = 10
-             |              ^^^^^^^^^^",
-           "stack": [],
-         }
-        `)
+       {
+         "description": "Ecmascript file had an error",
+         "environmentLabel": null,
+         "label": "Build Error",
+         "source": "./app/page.tsx (1:14)
+       Ecmascript file had an error
+       > 1 | export const revalidate = 10
+           |              ^^^^^^^^^^",
+         "stack": [],
+       }
+      `)
     } else {
       await expect(browser).toDisplayRedbox(`
        {

--- a/test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts
+++ b/test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts
@@ -52,9 +52,18 @@ describe('Cache Components Fallback Validation', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/partial/[top]/unwrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
        > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
            |                          ^",
@@ -67,9 +76,18 @@ describe('Cache Components Fallback Validation', () => {
     } else {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/partial/[top]/unwrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
        > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
            |                          ^",
@@ -85,9 +103,18 @@ describe('Cache Components Fallback Validation', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/partial/[top]/unwrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
        > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
            |                          ^",
@@ -100,9 +127,18 @@ describe('Cache Components Fallback Validation', () => {
     } else {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/partial/[top]/unwrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
        > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
            |                          ^",
@@ -118,9 +154,18 @@ describe('Cache Components Fallback Validation', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/partial/[top]/unwrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
        > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
            |                          ^",
@@ -133,9 +178,18 @@ describe('Cache Components Fallback Validation', () => {
     } else {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/partial/[top]/unwrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
        > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
            |                          ^",
@@ -155,9 +209,18 @@ describe('Cache Components Fallback Validation', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/none/[top]/wrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
        > 10 |   await params
             |   ^",
@@ -170,9 +233,18 @@ describe('Cache Components Fallback Validation', () => {
     } else {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/none/[top]/wrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
        > 10 |   await params
             |   ^",
@@ -188,9 +260,18 @@ describe('Cache Components Fallback Validation', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/none/[top]/wrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
        > 10 |   await params
             |   ^",
@@ -203,9 +284,18 @@ describe('Cache Components Fallback Validation', () => {
     } else {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/none/[top]/wrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
        > 10 |   await params
             |   ^",
@@ -221,9 +311,18 @@ describe('Cache Components Fallback Validation', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/none/[top]/wrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
        > 10 |   await params
             |   ^",
@@ -236,9 +335,18 @@ describe('Cache Components Fallback Validation', () => {
     } else {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/none/[top]/wrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/none/[top]/wrapped/layout.tsx (10:3) @ Layout
        > 10 |   await params
             |   ^",
@@ -254,9 +362,18 @@ describe('Cache Components Fallback Validation', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/none/[top]/unwrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
        >  8 |   await params
             |   ^",
@@ -269,9 +386,18 @@ describe('Cache Components Fallback Validation', () => {
     } else {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/none/[top]/unwrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
        >  8 |   await params
             |   ^",
@@ -287,9 +413,18 @@ describe('Cache Components Fallback Validation', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/none/[top]/unwrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
        >  8 |   await params
             |   ^",
@@ -302,9 +437,18 @@ describe('Cache Components Fallback Validation', () => {
     } else {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/none/[top]/unwrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
        >  8 |   await params
             |   ^",
@@ -320,9 +464,18 @@ describe('Cache Components Fallback Validation', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/none/[top]/unwrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
        >  8 |   await params
             |   ^",
@@ -335,9 +488,18 @@ describe('Cache Components Fallback Validation', () => {
     } else {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
-         "description": "Route "/none/[top]/unwrapped/[bottom]": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+         "description": "Uncached data was accessed outside of <Suspense>
+
+       This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+       To fix this, you can:
+
+       Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+       Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+       Learn more: https://nextjs.org/docs/messages/blocking-route",
          "environmentLabel": "Server",
-         "label": "Console Error",
+         "label": "Blocking Route",
          "source": "app/none/[top]/unwrapped/layout.tsx (8:3) @ Layout
        >  8 |   await params
             |   ^",

--- a/test/development/app-dir/error-overlay/cache-components-errors/app/blocking-page-load/page.tsx
+++ b/test/development/app-dir/error-overlay/cache-components-errors/app/blocking-page-load/page.tsx
@@ -1,0 +1,11 @@
+async function dynamicDataFetch() {
+  // Intentionally using a timer instead of a built-in API like `connection`
+  // because eventually we may discriminate the errors between the different
+  // types of dynamic conditions.
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+}
+
+export default async function Page() {
+  await dynamicDataFetch()
+  return 'Blocking Page Load'
+}

--- a/test/development/app-dir/error-overlay/cache-components-errors/app/layout.tsx
+++ b/test/development/app-dir/error-overlay/cache-components-errors/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/error-overlay/cache-components-errors/app/page.tsx
+++ b/test/development/app-dir/error-overlay/cache-components-errors/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'Home'
+}

--- a/test/development/app-dir/error-overlay/cache-components-errors/next.config.js
+++ b/test/development/app-dir/error-overlay/cache-components-errors/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
+++ b/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
@@ -169,7 +169,7 @@ describe('async imports in cacheComponents - external packages', () => {
   // This is currently expected to fail because we can only track `import()` in bundled code,
   // and packages marked as external aren't bundled.
   it('does not instrument import() in external packages', async () => {
-    const expectedError = `Error: Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it.`
+    const expectedError = 'https://nextjs.org/docs/messages/blocking-route'
     if (isNextStart) {
       // in prod, we fail during the build
       await expect(() => next.start()).rejects.toThrow()

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -156,9 +156,18 @@ describe('Cache Components Errors', () => {
 
           await expect(browser).toDisplayCollapsedRedbox(`
            {
-             "description": "Route "/dynamic-metadata-error-route": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+             "description": "Uncached data was accessed outside of <Suspense>
+
+           This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+           To fix this, you can:
+
+           Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+           Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+           Learn more: https://nextjs.org/docs/messages/blocking-route",
              "environmentLabel": "Server",
-             "label": "Console Error",
+             "label": "Blocking Route",
              "source": "app/dynamic-metadata-error-route/page.tsx (20:16) @ Dynamic
            > 20 | async function Dynamic() {
                 |                ^",
@@ -187,7 +196,7 @@ describe('Cache Components Errors', () => {
           if (isTurbopack) {
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/dynamic-metadata-error-route": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               "Error: Route "/dynamic-metadata-error-route": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                    at main (<anonymous>)
                    at body (<anonymous>)
                    at html (<anonymous>)
@@ -199,7 +208,7 @@ describe('Cache Components Errors', () => {
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/dynamic-metadata-error-route": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               "Error: Route "/dynamic-metadata-error-route": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                    at main (<anonymous>)
                    at body (<anonymous>)
                    at html (<anonymous>)
@@ -213,7 +222,7 @@ describe('Cache Components Errors', () => {
           } else {
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/dynamic-metadata-error-route": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               "Error: Route "/dynamic-metadata-error-route": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                    at InnerLayoutRouter (bundler:///<next-src>)
                    at RedirectErrorBoundary (bundler:///<next-src>)
                    at RedirectBoundary (bundler:///<next-src>)
@@ -253,7 +262,7 @@ describe('Cache Components Errors', () => {
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/dynamic-metadata-error-route": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               "Error: Route "/dynamic-metadata-error-route": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                    at a (<next-dist-dir>)
                    at b (<next-dist-dir>)
                    at c (<next-dist-dir>)
@@ -552,9 +561,18 @@ describe('Cache Components Errors', () => {
             await expect(browser).toDisplayCollapsedRedbox(`
              [
                {
-                 "description": "Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+                 "description": "Uncached data was accessed outside of <Suspense>
+
+             This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+             To fix this, you can:
+
+             Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+             Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+             Learn more: https://nextjs.org/docs/messages/blocking-route",
                  "environmentLabel": "Server",
-                 "label": "Console Error",
+                 "label": "Blocking Route",
                  "source": "app/dynamic-root/page.tsx (59:26) @ fetchRandom
              > 59 |   const response = await fetch(
                   |                          ^",
@@ -566,9 +584,18 @@ describe('Cache Components Errors', () => {
                  ],
                },
                {
-                 "description": "Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+                 "description": "Uncached data was accessed outside of <Suspense>
+
+             This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+             To fix this, you can:
+
+             Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+             Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+             Learn more: https://nextjs.org/docs/messages/blocking-route",
                  "environmentLabel": "Server",
-                 "label": "Console Error",
+                 "label": "Blocking Route",
                  "source": "app/dynamic-root/page.tsx (59:26) @ fetchRandom
              > 59 |   const response = await fetch(
                   |                          ^",
@@ -585,9 +612,18 @@ describe('Cache Components Errors', () => {
             await expect(browser).toDisplayCollapsedRedbox(`
              [
                {
-                 "description": "Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+                 "description": "Uncached data was accessed outside of <Suspense>
+
+             This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+             To fix this, you can:
+
+             Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+             Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+             Learn more: https://nextjs.org/docs/messages/blocking-route",
                  "environmentLabel": "Server",
-                 "label": "Console Error",
+                 "label": "Blocking Route",
                  "source": "app/dynamic-root/page.tsx (59:26) @ fetchRandom
              > 59 |   const response = await fetch(
                   |                          ^",
@@ -599,9 +635,18 @@ describe('Cache Components Errors', () => {
                  ],
                },
                {
-                 "description": "Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+                 "description": "Uncached data was accessed outside of <Suspense>
+
+             This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+             To fix this, you can:
+
+             Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+             Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+             Learn more: https://nextjs.org/docs/messages/blocking-route",
                  "environmentLabel": "Server",
-                 "label": "Console Error",
+                 "label": "Blocking Route",
                  "source": "app/dynamic-root/page.tsx (59:26) @ fetchRandom
              > 59 |   const response = await fetch(
                   |                          ^",
@@ -632,7 +677,7 @@ describe('Cache Components Errors', () => {
           if (isTurbopack) {
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               "Error: Route "/dynamic-root": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                    at IndirectionTwo (bundler:///app/dynamic-root/indirection.tsx:7:34)
                    at main (<anonymous>)
                    at body (<anonymous>)
@@ -645,7 +690,7 @@ describe('Cache Components Errors', () => {
                   9 | }
                  10 |
                To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
-               Error: Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               Error: Route "/dynamic-root": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                    at main (<anonymous>)
                    at body (<anonymous>)
                    at html (<anonymous>)
@@ -657,7 +702,7 @@ describe('Cache Components Errors', () => {
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               "Error: Route "/dynamic-root": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                    at a (bundler:///app/dynamic-root/indirection.tsx:7:34)
                    at main (<anonymous>)
                    at body (<anonymous>)
@@ -672,7 +717,7 @@ describe('Cache Components Errors', () => {
                To get a more detailed stack trace and pinpoint the issue, try one of the following:
                  - Start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-               Error: Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               Error: Route "/dynamic-root": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                    at main (<anonymous>)
                    at body (<anonymous>)
                    at html (<anonymous>)
@@ -686,7 +731,7 @@ describe('Cache Components Errors', () => {
           } else {
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               "Error: Route "/dynamic-root": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                    at IndirectionTwo (bundler:///app/dynamic-root/indirection.tsx:7:34)
                    at InnerLayoutRouter (bundler:///<next-src>)
                    at RedirectErrorBoundary (bundler:///<next-src>)
@@ -720,7 +765,7 @@ describe('Cache Components Errors', () => {
                   9 | }
                  10 |
                To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
-               Error: Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               Error: Route "/dynamic-root": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                    at InnerLayoutRouter (bundler:///<next-src>)
                    at RedirectErrorBoundary (bundler:///<next-src>)
                    at RedirectBoundary (bundler:///<next-src>)
@@ -760,7 +805,7 @@ describe('Cache Components Errors', () => {
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               "Error: Route "/dynamic-root": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                    at a (<next-dist-dir>)
                    at b (<next-dist-dir>)
                    at c (<next-dist-dir>)
@@ -789,7 +834,7 @@ describe('Cache Components Errors', () => {
                To get a more detailed stack trace and pinpoint the issue, try one of the following:
                  - Start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
                  - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
-               Error: Route "/dynamic-root": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+               Error: Route "/dynamic-root": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                    at w (<next-dist-dir>)
                    at x (<next-dist-dir>)
                    at y (<next-dist-dir>)
@@ -2021,9 +2066,18 @@ describe('Cache Components Errors', () => {
             if (isTurbopack) {
               await expect(browser).toDisplayCollapsedRedbox(`
                {
-                 "description": "Route "/sync-attribution/unguarded-async-guarded-clientsync": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+                 "description": "Uncached data was accessed outside of <Suspense>
+
+               This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+               To fix this, you can:
+
+               Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+               Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route",
                  "environmentLabel": "Server",
-                 "label": "Console Error",
+                 "label": "Blocking Route",
                  "source": "app/sync-attribution/unguarded-async-guarded-clientsync/page.tsx (34:18) @ RequestData
                > 34 |   ;(await cookies()).get('foo')
                     |                  ^",
@@ -2037,9 +2091,18 @@ describe('Cache Components Errors', () => {
             } else {
               await expect(browser).toDisplayCollapsedRedbox(`
                {
-                 "description": "Route "/sync-attribution/unguarded-async-guarded-clientsync": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense",
+                 "description": "Uncached data was accessed outside of <Suspense>
+
+               This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation.
+
+               To fix this, you can:
+
+               Wrap the component in a <Suspense> boundary. This allows Next.js to stream its contents to the user as soon as it's ready, without blocking the rest of the app.
+               Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender the component as part of the HTML document, so it's instantly visible to the user. Note that request-specific information — such as params, cookies, and headers — is not available during static prerendering.
+
+               Learn more: https://nextjs.org/docs/messages/blocking-route",
                  "environmentLabel": "Server",
-                 "label": "Console Error",
+                 "label": "Blocking Route",
                  "source": "app/sync-attribution/unguarded-async-guarded-clientsync/page.tsx (34:18) @ RequestData
                > 34 |   ;(await cookies()).get('foo')
                     |                  ^",
@@ -2068,7 +2131,7 @@ describe('Cache Components Errors', () => {
             if (isTurbopack) {
               if (isDebugPrerender) {
                 expect(output).toMatchInlineSnapshot(`
-                 "Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+                 "Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                      at section (<anonymous>)
                      at main (<anonymous>)
                      at RenderFromTemplateContext (<anonymous>)
@@ -2085,7 +2148,7 @@ describe('Cache Components Errors', () => {
                 `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                 "Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+                 "Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                      at a (<anonymous>)
                      at main (<anonymous>)
                      at b (<anonymous>)
@@ -2104,7 +2167,7 @@ describe('Cache Components Errors', () => {
             } else {
               if (isDebugPrerender) {
                 expect(output).toMatchInlineSnapshot(`
-                 "Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+                 "Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                      at section (<anonymous>)
                      at main (<anonymous>)
                      at InnerLayoutRouter (bundler:///<next-src>)
@@ -2156,7 +2219,7 @@ describe('Cache Components Errors', () => {
                 `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                 "Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+                 "Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                      at a (<anonymous>)
                      at main (<anonymous>)
                      at b (<next-dist-dir>)
@@ -3106,7 +3169,7 @@ describe('Cache Components Errors', () => {
             if (isTurbopack) {
               if (isDebugPrerender) {
                 expect(output).toMatchInlineSnapshot(`
-                 "Error: Route "/use-cache-private-without-suspense": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+                 "Error: Route "/use-cache-private-without-suspense": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                      at main (<anonymous>)
                      at body (<anonymous>)
                      at html (<anonymous>)
@@ -3118,7 +3181,7 @@ describe('Cache Components Errors', () => {
                 `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                 "Error: Route "/use-cache-private-without-suspense": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+                 "Error: Route "/use-cache-private-without-suspense": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                      at main (<anonymous>)
                      at body (<anonymous>)
                      at html (<anonymous>)
@@ -3132,7 +3195,7 @@ describe('Cache Components Errors', () => {
             } else {
               if (isDebugPrerender) {
                 expect(output).toMatchInlineSnapshot(`
-                 "Error: Route "/use-cache-private-without-suspense": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+                 "Error: Route "/use-cache-private-without-suspense": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                      at InnerLayoutRouter (bundler:///<next-src>)
                      at RedirectErrorBoundary (bundler:///<next-src>)
                      at RedirectBoundary (bundler:///<next-src>)
@@ -3172,7 +3235,7 @@ describe('Cache Components Errors', () => {
                 `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                 "Error: Route "/use-cache-private-without-suspense": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense
+                 "Error: Route "/use-cache-private-without-suspense": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                      at a (<next-dist-dir>)
                      at b (<next-dist-dir>)
                      at c (<next-dist-dir>)

--- a/test/e2e/app-dir/missing-suspense-with-csr-bailout/missing-suspense-with-csr-bailout.test.ts
+++ b/test/e2e/app-dir/missing-suspense-with-csr-bailout/missing-suspense-with-csr-bailout.test.ts
@@ -26,7 +26,7 @@ describe('missing-suspense-with-csr-bailout', () => {
 
   describe('useSearchParams', () => {
     const message = isCacheComponentsEnabled
-      ? `Route "/": A component accessed data, headers, params, searchParams, or a short-lived cache without a Suspense boundary nor a "use cache" above it. See more info: https://nextjs.org/docs/messages/next-prerender-missing-suspense`
+      ? 'https://nextjs.org/docs/messages/blocking-route'
       : `useSearchParams() should be wrapped in a suspense boundary at page "/".`
 
     it('should fail build if useSearchParams is not wrapped in a suspense boundary', async () => {


### PR DESCRIPTION
<img width="972" height="716" alt="Screenshot 2025-10-21 at 3 25 52 AM" src="https://github.com/user-attachments/assets/5974debf-8362-4bcb-a6df-83753da30f96" />

To update the affected snapshots, I ran this command (and also with `pnpm test-dev-webpack ...`)

```sh
pnpm test-dev-turbo -u test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts test/development/app-dir/cache-components-dev-cache-scope/cache-components-dev-cache-scope.test.ts test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts test/integration/app-dir-export/test/start.test.ts
```