### PR TITLE
  Fix navigation overlay background consistency in new docs app

### DIFF
--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -1,3 +1,28 @@
 @import 'tailwindcss';
 @import 'fumadocs-ui/css/neutral.css';
 @import 'fumadocs-ui/css/preset.css';
+
+/* Navigation overlay background matches site theme */
+[data-overlay],
+[data-fd-dialog-overlay],
+.fd-dialog-overlay,
+[role='dialog'] ~ [data-radix-dialog-overlay],
+[data-state='open'][data-radix-dialog-overlay],
+[data-radix-dialog-overlay],
+[data-vaul-drawer-wrapper] [data-vaul-overlay],
+[data-vaul-overlay],
+.vaul-overlay {
+  background-color: hsla(0, 0%, 7.04%, 0.8) !important;
+}
+
+.dark [data-overlay],
+.dark [data-fd-dialog-overlay],
+.dark .fd-dialog-overlay,
+.dark [role='dialog'] ~ [data-radix-dialog-overlay],
+.dark [data-state='open'][data-radix-dialog-overlay],
+.dark [data-radix-dialog-overlay],
+.dark [data-vaul-drawer-wrapper] [data-vaul-overlay],
+.dark [data-vaul-overlay],
+.dark .vaul-overlay {
+  background-color: hsla(0, 0%, 7.04%, 0.95) !important;
+}


### PR DESCRIPTION
## What?

  Fixes the navigation overlay background color in the new documentation app (`apps/docs`) to match the site's        
  theme.

  ## Why?

  **Context:** There are currently two separate Next.js documentation systems:
  1. **Current live nextjs.org/docs** - Runs on Vercel's private monorepo (not this repo)
  2. **New WIP docs at `/apps/docs`** - Open-source fumadocs-based platform (this repo, not yet live)

  This PR fixes issue #85088 in the **new docs app** (`/apps/docs`), which will eventually replace the current        
  live site. The navigation overlay currently uses pure black (`#000000`), while the rest of the docs uses a soft     
  dark-gray background (`hsl(0, 0%, 7.04%)`) from the fumadocs neutral theme, creating a jarring visual
  inconsistency.

  ## How?

  Added CSS overrides in `apps/docs/app/global.css` that target:
  - Radix UI dialog overlays (used by fumadocs for navigation)
  - Vaul drawer overlays (mobile navigation)
  - Various overlay states and wrappers

  The overlay now uses `hsla(0, 0%, 7.04%, 0.8)` in light mode and `hsla(0, 0%, 7.04%, 0.95)` in dark mode,
  matching the fumadocs neutral theme background for visual consistency.

  **Note:** This does **not** fix the current live nextjs.org/docs site, as that runs on a separate codebase. The     
  Vercel team will need to apply a similar fix to their private monorepo to address the live site.

  Fixes #85088

  ---

  ### Improving Documentation

  - [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines:
  https://nextjs.org/docs/community/contribution-guide