### PR TITLE
[test] Current behavior of dynamic APIs integration with React DevTools

### DIFF
--- a/test/development/app-dir/react-performance-track/app/cookies/page.tsx
+++ b/test/development/app-dir/react-performance-track/app/cookies/page.tsx
@@ -1,0 +1,7 @@
+import { cookies } from 'next/headers'
+
+export default async function CookiesPage() {
+  await cookies()
+
+  return <p>Done cookies</p>
+}

--- a/test/development/app-dir/react-performance-track/app/draftMode/page.tsx
+++ b/test/development/app-dir/react-performance-track/app/draftMode/page.tsx
@@ -1,0 +1,7 @@
+import { draftMode } from 'next/headers'
+
+export default async function DraftModePage() {
+  await draftMode()
+
+  return <p>Done draftMode</p>
+}

--- a/test/development/app-dir/react-performance-track/app/headers/page.tsx
+++ b/test/development/app-dir/react-performance-track/app/headers/page.tsx
@@ -1,0 +1,7 @@
+import { headers } from 'next/headers'
+
+export default async function HeadersPage() {
+  await headers()
+
+  return <p>Done headers</p>
+}

--- a/test/development/app-dir/react-performance-track/app/layout.tsx
+++ b/test/development/app-dir/react-performance-track/app/layout.tsx
@@ -16,13 +16,28 @@ export default function Root({ children }: { children: ReactNode }) {
           <li>
             <Link href="/set-timeout">setTimeout</Link>
           </li>
+          <li>
+            <Link href="/params/next">params</Link>
+          </li>
+          <li>
+            <Link href="/searchparams?slug=next">searchParams</Link>
+          </li>
+          <li>
+            <Link href="/headers">headers</Link>
+          </li>
+          <li>
+            <Link href="/cookies">cookies</Link>
+          </li>
+          <li>
+            <Link href="/draftMode">draftMode</Link>
+          </li>
         </ul>
         <main>
-          <ReactServerRequests />
           <Suspense fallback="Loading Server Requests">
             <div data-react-server-requests-done />
             {children}
           </Suspense>
+          <ReactServerRequests />
         </main>
       </body>
     </html>

--- a/test/development/app-dir/react-performance-track/app/params/[slug]/page.tsx
+++ b/test/development/app-dir/react-performance-track/app/params/[slug]/page.tsx
@@ -1,0 +1,9 @@
+export default async function ParamsSlugPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  return <p>Done {slug}</p>
+}

--- a/test/development/app-dir/react-performance-track/app/searchparams/page.tsx
+++ b/test/development/app-dir/react-performance-track/app/searchparams/page.tsx
@@ -1,0 +1,7 @@
+export default async function SearchParamsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, unknown>>
+}) {
+  return <p>Done {JSON.stringify(await searchParams)}</p>
+}

--- a/test/development/app-dir/react-performance-track/instrumentation-client.ts
+++ b/test/development/app-dir/react-performance-track/instrumentation-client.ts
@@ -55,16 +55,14 @@ window.reactServerRequests = {
   },
 }
 
-let registeredServerRequestsTrack = false
-
 const originalConsoleTimeStamp = console.timeStamp
 console.timeStamp = (...args: any) => {
   originalConsoleTimeStamp.apply(console, args)
-  const [_entryName, startTime, endTime, track, name] = args
+  const [name, startTime, endTime, track] = args
 
   if (track === 'Server Requests ⚛') {
-    // React will always call one console.timeStamp to register the track in Chrome's performance panel.
-    if (registeredServerRequestsTrack) {
+    const isRegisterTrackRequest = startTime === 0.001 && endTime === 0.001
+    if (!isRegisterTrackRequest) {
       reactServerRequests.push({
         type: 'console',
         name: name ?? '',
@@ -76,7 +74,6 @@ console.timeStamp = (...args: any) => {
         listener()
       }
     }
-    registeredServerRequestsTrack = true
   }
 }
 

--- a/test/development/app-dir/react-performance-track/next.config.js
+++ b/test/development/app-dir/react-performance-track/next.config.js
@@ -2,8 +2,11 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  // Some flag to enable react@experimental
-  experimental: { taint: true },
+  cacheComponents: true,
+  experimental: {
+    // Future but produces bad results.
+    reactDebugChannel: false,
+  },
 }
 
 module.exports = nextConfig

--- a/test/development/app-dir/react-performance-track/react-performance-track.test.ts
+++ b/test/development/app-dir/react-performance-track/react-performance-track.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// Entries are flaky in CI. Without a name and without being able to repro locally,
-// it's impossible to fix. Deactivating while we iterate on the track.
-// It's still useful as a fixture.
 describe('react-performance-track', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -35,11 +32,120 @@ describe('react-performance-track', () => {
         {
           // React might decide to display the shorthand in round brackets differently.
           // Double check with React changes if a shorthand change is intended.
-          name: '\u200bfetch (…/random)',
+          // TODO: Should include short name "(…/random)" and URL
+          name: '\u200bfetch',
           properties: expect.arrayContaining([
             ['status', '200'],
-            ['url', '"https://next-data-api-endpoint.vercel.app/api/random"'],
+            ['url', '""'],
           ]),
+        },
+      ])
+    )
+  })
+
+  it('should show params', async () => {
+    const browser = await next.browser('/params/next')
+    await browser.elementByCss('[data-react-server-requests-done]', {
+      state: 'attached',
+    })
+
+    const track = await browser.eval('window.reactServerRequests.getSnapshot()')
+    expect(track).toEqual(
+      expect.arrayContaining([
+        {
+          name: '\u200bparams [Prefetch]',
+          properties: [],
+        },
+      ])
+    )
+  })
+
+  it('should show searchParams', async () => {
+    const browser = await next.browser('/searchparams?slug=next')
+    await browser.elementByCss('[data-react-server-requests-done]', {
+      state: 'attached',
+    })
+
+    const track = await browser.eval('window.reactServerRequests.getSnapshot()')
+    expect(track).toEqual(
+      expect.arrayContaining([
+        {
+          name: '\u200bsearchParams [Prefetch]',
+          properties: [],
+        },
+      ])
+    )
+  })
+
+  it('should show cookies', async () => {
+    const browser = await next.browser('/cookies')
+    await browser.elementByCss('[data-react-server-requests-done]', {
+      state: 'attached',
+    })
+
+    const track = await browser.eval('window.reactServerRequests.getSnapshot()')
+    expect(track).toEqual(
+      expect.arrayContaining([
+        {
+          name: '\u200bcookies [Prefetch]',
+          properties: [],
+        },
+        // TODO: The error message makes this seem like it shouldn't pop up here.
+        {
+          name: '\u200bcookies',
+          properties: [
+            [
+              'rejected with',
+              'During prerendering, `cookies()` rejects when the prerender is complete. ' +
+                'Typically these errors are handled by React but if you move `cookies()` to a different context by using `setTimeout`, `after`, or similar functions you may observe this error and you should handle it in that context. ' +
+                'This occurred at route "/cookies".',
+            ],
+          ],
+        },
+      ])
+    )
+  })
+
+  it('should show draftMode', async () => {
+    const browser = await next.browser('/draftMode')
+    await browser.elementByCss('[data-react-server-requests-done]', {
+      state: 'attached',
+    })
+
+    const track = await browser.eval('window.reactServerRequests.getSnapshot()')
+    // TODO: Should include "draftMode [Prefetch]".
+    expect(track).toEqual([
+      {
+        name: '\u200b',
+        properties: [],
+      },
+    ])
+  })
+
+  it('should show headers', async () => {
+    const browser = await next.browser('/headers')
+    await browser.elementByCss('[data-react-server-requests-done]', {
+      state: 'attached',
+    })
+
+    const track = await browser.eval('window.reactServerRequests.getSnapshot()')
+    expect(track).toEqual(
+      expect.arrayContaining([
+        {
+          name: '\u200bheaders [Prefetch]',
+          properties: [],
+        },
+        // TODO: The error message makes this seem like it shouldn't pop up here.
+        {
+          name: '\u200bheaders',
+          properties: [
+            [
+              'rejected with',
+              'During prerendering, `headers()` rejects when the prerender is complete. ' +
+                'Typically these errors are handled by React but if you move `headers()` to a different context by using `setTimeout`, `after`, or similar functions you may observe this error and you should handle it in that context. ' +
+                'This occurred at route "/headers".',
+            ],
+          ],
         },
       ])
     )

--- a/test/development/app-dir/react-performance-track/react-performance-track.test.ts
+++ b/test/development/app-dir/react-performance-track/react-performance-track.test.ts
@@ -1,12 +1,20 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('react-performance-track', () => {
+  // false is the default when visiting pages as an ordinary user.
+  // true is the default when having Chrome DevTools open.
+  // Hardcoded for now since most of the actual behavior is not intended.
+  const disableCache = false
+  const extraHTTPHeaders = disableCache
+    ? { 'Cache-Control': 'no-cache' }
+    : undefined
+
   const { next } = nextTestSetup({
     files: __dirname,
   })
 
   it('should show setTimeout', async () => {
-    const browser = await next.browser('/set-timeout')
+    const browser = await next.browser('/set-timeout', { extraHTTPHeaders })
     await browser.elementByCss('[data-react-server-requests-done]', {
       state: 'attached',
     })
@@ -21,7 +29,7 @@ describe('react-performance-track', () => {
   })
 
   it('should show fetch', async () => {
-    const browser = await next.browser('/fetch')
+    const browser = await next.browser('/fetch', { extraHTTPHeaders })
     await browser.elementByCss('[data-react-server-requests-done]', {
       state: 'attached',
     })
@@ -44,7 +52,7 @@ describe('react-performance-track', () => {
   })
 
   it('should show params', async () => {
-    const browser = await next.browser('/params/next')
+    const browser = await next.browser('/params/next', { extraHTTPHeaders })
     await browser.elementByCss('[data-react-server-requests-done]', {
       state: 'attached',
     })
@@ -61,7 +69,9 @@ describe('react-performance-track', () => {
   })
 
   it('should show searchParams', async () => {
-    const browser = await next.browser('/searchparams?slug=next')
+    const browser = await next.browser('/searchparams?slug=next', {
+      extraHTTPHeaders,
+    })
     await browser.elementByCss('[data-react-server-requests-done]', {
       state: 'attached',
     })
@@ -78,7 +88,7 @@ describe('react-performance-track', () => {
   })
 
   it('should show cookies', async () => {
-    const browser = await next.browser('/cookies')
+    const browser = await next.browser('/cookies', { extraHTTPHeaders })
     await browser.elementByCss('[data-react-server-requests-done]', {
       state: 'attached',
     })
@@ -107,7 +117,7 @@ describe('react-performance-track', () => {
   })
 
   it('should show draftMode', async () => {
-    const browser = await next.browser('/draftMode')
+    const browser = await next.browser('/draftMode', { extraHTTPHeaders })
     await browser.elementByCss('[data-react-server-requests-done]', {
       state: 'attached',
     })
@@ -123,7 +133,7 @@ describe('react-performance-track', () => {
   })
 
   it('should show headers', async () => {
-    const browser = await next.browser('/headers')
+    const browser = await next.browser('/headers', { extraHTTPHeaders })
     await browser.elementByCss('[data-react-server-requests-done]', {
       state: 'attached',
     })

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -250,6 +250,10 @@ export class Playwright<TCurrent = undefined> {
       cpuThrottleRate?: number
       pushErrorAsConsoleLog?: boolean
       beforePageLoad?: (page: Page) => void | Promise<void>
+      /**
+       * @see {@link https://playwright.dev/docs/api/class-page#page-set-extra-http-headers Playwright.Page.setExtraHTTPHeaders}
+       */
+      extraHTTPHeaders?: Record<string, string>
       waitUntil?: PlaywrightNavigationWaitUntil
     }
   ) {
@@ -265,6 +269,10 @@ export class Playwright<TCurrent = undefined> {
 
     page.setDefaultTimeout(defaultTimeout)
     page.setDefaultNavigationTimeout(defaultTimeout)
+    const extraHTTPHeaders = opts?.extraHTTPHeaders
+    if (extraHTTPHeaders !== undefined) {
+      page.setExtraHTTPHeaders(extraHTTPHeaders)
+    }
 
     pageLogs = []
     websocketFrames = []

--- a/test/lib/next-webdriver.ts
+++ b/test/lib/next-webdriver.ts
@@ -71,6 +71,10 @@ export interface WebdriverOptions {
    */
   beforePageLoad?: (page: Page) => void | Promise<void>
   /**
+   * @see {@link https://playwright.dev/docs/api/class-page#page-set-extra-http-headers Playwright.Page.setExtraHTTPHeaders}
+   */
+  extraHTTPHeaders?: Record<string, string>
+  /**
    * browser locale
    */
   locale?: string
@@ -114,6 +118,7 @@ export default async function webdriver(
     retryWaitHydration,
     disableCache,
     beforePageLoad,
+    extraHTTPHeaders,
     locale,
     disableJavaScript,
     ignoreHTTPSErrors,
@@ -152,6 +157,7 @@ export default async function webdriver(
     disableCache,
     cpuThrottleRate,
     beforePageLoad,
+    extraHTTPHeaders,
     pushErrorAsConsoleLog,
     waitUntil,
   })


### PR DESCRIPTION
Notable:
- `config.experimental.reactDebugChannel` will cause less names to be transmitted
- with disabled cache, `params` and `searchParams` no longer show up
- `cookies`, `headers`, `draftMode` will include their rejected Promise unless cache is disabled. Notably because the attached error message indicates this should not be observable.  The rejected Promises don't show up in RDT's "suspended by". Only the Performance track show them. 
- the URL from `fetch` in the short name is absent once `config.cacheComponents` is enabled. It does show up again once caching is disabled