### PR TITLE
[Cache Components] Allow stale longer than expire in cacheLife

### DIFF
--- a/packages/next/src/server/use-cache/cache-life.ts
+++ b/packages/next/src/server/use-cache/cache-life.ts
@@ -72,17 +72,6 @@ function validateCacheLife(profile: CacheLife) {
       )
     }
   }
-
-  if (profile.stale !== undefined && profile.expire !== undefined) {
-    if (profile.stale > profile.expire) {
-      throw new Error(
-        'If providing both the stale and expire options, ' +
-          'the expire option must be greater than the stale option. ' +
-          'The expire option indicates how many seconds from the start ' +
-          'until it can no longer be used.'
-      )
-    }
-  }
 }
 
 export function cacheLife(profile: CacheLifeProfiles | CacheLife): void {


### PR DESCRIPTION
We previously encoded an invariant with cacheLife that required stale to be greater than expire. This doesn't really make sense because these describe completely different lifetimes. Stale starts from when the client reads the response but expire starts from when the cache entry is created. This removes the the requirement that expire be greater than stale