### PR TITLE
fix(experimental.lockDistDir): Acquire the lock in dev earlier

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -121,6 +121,7 @@ import { handlePageMetadataResponse } from '../mcp/tools/get-page-metadata'
 import { setStackFrameResolver } from '../mcp/tools/utils/format-errors'
 import { getFileLogger } from './browser-logs/file-logger'
 import type { ServerCacheStatus } from '../../next-devtools/dev-overlay/cache-indicator'
+import type { Lockfile } from '../../build/lockfile'
 
 const wsServer = new ws.Server({ noServer: true })
 const isTestMode = !!(
@@ -182,7 +183,8 @@ export async function createHotReloaderTurbopack(
   opts: SetupOpts & { isSrcDir: boolean },
   serverFields: ServerFields,
   distDir: string,
-  resetFetch: () => void
+  resetFetch: () => void,
+  lockfile: Lockfile | undefined
 ): Promise<NextJsHotReloaderInterface> {
   const dev = true
   const buildId = 'development'
@@ -288,6 +290,7 @@ export async function createHotReloaderTurbopack(
   opts.onDevServerCleanup?.(async () => {
     setBundlerFindSourceMapImplementation(() => undefined)
     await project.onExit()
+    await lockfile?.unlock()
   })
   const entrypointsSubscription = project.entrypointsSubscribe()
 

--- a/test/development/lockfile/lockfile.test.ts
+++ b/test/development/lockfile/lockfile.test.ts
@@ -26,5 +26,9 @@ describe('lockfile', () => {
     )
     expect(stripAnsi(stdout + stderr)).toContain('Unable to acquire lock')
     expect(exitCode).toBe(1)
+
+    // make sure the other instance of `next dev` didn't mess anything up
+    browser.refresh()
+    expect(await browser.elementByCss('p').text()).toBe('Page')
   })
 })

--- a/test/integration/dynamic-optional-routing/test/index.test.js
+++ b/test/integration/dynamic-optional-routing/test/index.test.js
@@ -240,21 +240,26 @@ describe('Dynamic Optional Routing', () => {
   ;(process.env.TURBOPACK_BUILD ? describe.skip : describe)(
     'development mode',
     () => {
-      beforeAll(async () => {
-        appPort = await findPort()
-        app = await launchApp(appDir, appPort)
-      })
-      afterAll(() => killApp(app))
-
-      runTests()
-
-      runInvalidPagesTests(async (appDir) => {
-        stderr = ''
-        await launchApp(appDir, await findPort(), {
-          onStderr: (msg) => {
-            stderr += msg
-          },
+      describe('rendering', () => {
+        beforeAll(async () => {
+          appPort = await findPort()
+          app = await launchApp(appDir, appPort)
         })
+        afterAll(() => killApp(app))
+        runTests()
+      })
+
+      describe('invalid pages', () => {
+        runInvalidPagesTests(async (appDir) => {
+          stderr = ''
+          appPort = await findPort()
+          app = await launchApp(appDir, appPort, {
+            onStderr: (msg) => {
+              stderr += msg
+            },
+          })
+        })
+        afterEach(() => killApp(app))
       })
     }
   )


### PR DESCRIPTION
Apparently I grabbed the lock too late, which led to the second process still managing the `distDir` before exiting... https://vercel.slack.com/archives/C03EWR7LGEN/p1760910025067089

This moves the acquisition earlier for dev, and extends the e2e test to cover this.

[Screen Recording 2025-10-20 at 10.42.49 AM.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/68785bda-1dd5-437a-bf16-54de2d54a49c.webm" />](https://app.graphite.dev/user-attachments/video/68785bda-1dd5-437a-bf16-54de2d54a49c.webm)

Closes PACK-5720