### PR TITLE
warn: add deprecation warning of eslint config

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -172,7 +172,7 @@ function checkDeprecations(
   warnOptionHasBeenDeprecated(
     userConfig,
     'eslint',
-    `\`eslint\` configuration in ${configFileName} is no longer supported. Please checkout https://nextjs.org/docs/app/api-reference/cli/next#next-lint-options for migration steps.`,
+    `\`eslint\` configuration in ${configFileName} is no longer supported. See more info here: https://nextjs.org/docs/app/api-reference/cli/next#next-lint-options`,
     silent
   )
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -169,6 +169,13 @@ function checkDeprecations(
     silent
   )
 
+  warnOptionHasBeenDeprecated(
+    userConfig,
+    'eslint',
+    `\`eslint\` configuration in ${configFileName} is no longer supported. Please checkout https://nextjs.org/docs/app/api-reference/cli/next#next-lint-options for migration steps.`,
+    silent
+  )
+
   if (userConfig.images?.domains?.length) {
     warnOptionHasBeenDeprecated(
       userConfig,


### PR DESCRIPTION
Add a deprection warning on eslint option in next.config

```
 ⚠ `eslint` configuration in next.config.js is no longer supported. Please checkout https://nextjs.org/doc
s/app/api-reference/cli/next#next-lint-options for migration steps.
 ⚠ Invalid next.config.js options detected:
 ⚠     Unrecognized key(s) in object: 'eslint'
 ⚠ See more info here: https://nextjs.org/docs/messages/invalid-next-config
   ▲ Next.js 16.0.0-canary.15 (Turbopack)
   - Local:        http://localhost:3000
   - Network:      http://10.208.10.212:3000
```

Closes NEXT-4744