### PR TITLE
Hook Error inspection to deobfuscate messages.

### DIFF
--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -88,7 +88,6 @@ import {
 import { isParallelRouteSegment } from '../../../shared/lib/segment'
 import { ensureLeadingSlash } from '../../../shared/lib/page-path/ensure-leading-slash'
 import { Lockfile } from '../../../build/lockfile'
-import { deobfuscateText } from '../../../shared/lib/magic-identifier'
 
 export type SetupOpts = {
   renderServer: LazyRenderServerInstance
@@ -1225,9 +1224,6 @@ async function startWatcher(
     err: unknown,
     type?: 'unhandledRejection' | 'uncaughtException' | 'warning' | 'app-dir'
   ) {
-    if (err instanceof Error) {
-      err.message = deobfuscateText(err.message)
-    }
     if (err instanceof ModuleBuildError) {
       // Errors that may come from issues from the user's code
       Log.error(err.message)


### PR DESCRIPTION
Next.js integrates with node to implement source map deobfuscation of stack frames.  Use the same mechanism to deobfuscate error messages. 

Closes PACK-5730