### PR TITLE
feat(cache-components): require non-empty generateStaticParams for validation

### DIFF
--- a/errors/empty-generate-static-params.mdx
+++ b/errors/empty-generate-static-params.mdx
@@ -1,0 +1,69 @@
+---
+title: Empty generateStaticParams with Cache Components
+---
+
+## Why This Error Occurred
+
+You're using [Cache Components](https://nextjs.org/docs/beta/app/api-reference/config/next-config-js/cacheComponents) in your Next.js application, and one of your `generateStaticParams` functions returned an empty array, which causes a build error.
+
+When Cache Components is enabled, Next.js performs build-time validation to ensure your routes can be properly prerendered without runtime dynamic access errors. If `generateStaticParams` returns an empty array, Next.js cannot validate that your route won't access dynamic values (like `await cookies()`, `await headers()`, or `await searchParams`) at runtime, which would cause errors.
+
+This strict requirement ensures:
+
+- Build-time validation catches potential runtime errors early
+- All routes using Cache Components have at least one static variant to validate against
+- You don't accidentally deploy routes that will fail at runtime
+
+## Possible Ways to Fix It
+
+### Option 1: Return at least one static param
+
+Modify your `generateStaticParams` function to return at least one set of parameters. This is the most common fix and allows build-time validation to work properly.
+
+```tsx filename="app/blog/[slug]/page.tsx"
+// ❌ This will cause an error with Cache Components
+export async function generateStaticParams() {
+  return [] // Empty array not allowed
+}
+
+// ✅ Return at least one param
+export async function generateStaticParams() {
+  return [{ slug: 'hello-world' }, { slug: 'getting-started' }]
+}
+```
+
+### Option 2: Use a placeholder param for validation
+
+If you don't know the actual values at build time but still want Cache Components, you can return a placeholder param for build-time validation:
+
+> This is not recommended and should only be used if you absolutely need to as it prevents build-time validation from working which will likely cause runtime errors.
+
+```tsx filename="app/blog/[slug]/page.tsx"
+export async function generateStaticParams() {
+  // Return a placeholder for build-time validation
+  // Real params will be generated at runtime via ISR
+  return [{ slug: '__placeholder__' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  // Handle placeholder case
+  if (slug === '__placeholder__') {
+    notFound()
+  }
+
+  // Your actual page logic
+  const post = await getPost(slug)
+  return <div>{post.title}</div>
+}
+```
+
+## Useful Links
+
+- [Cache Components Documentation](https://nextjs.org/docs/beta/app/api-reference/config/next-config-js/cacheComponents)
+- [generateStaticParams API Reference](https://nextjs.org/docs/app/api-reference/functions/generate-static-params)

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -895,5 +895,6 @@
   "894": "Param %s not found in childrenRouteParamSegments %s",
   "895": "Invalid React HTML document. Should start with doctype prefix.",
   "896": "oops",
-  "897": "Expected HTML document to start with doctype prefix"
+  "897": "Expected HTML document to start with doctype prefix",
+  "898": "When using Cache Components, all `generateStaticParams` functions must return at least one result. This is to ensure that we can perform build-time validation that there is no other dynamic accesses that would cause a runtime error.\n\nLearn more: https://nextjs.org/docs/messages/empty-generate-static-params"
 }

--- a/packages/next/src/build/static-paths/app.test.ts
+++ b/packages/next/src/build/static-paths/app.test.ts
@@ -834,7 +834,7 @@ describe('generateRouteStaticParams', () => {
   describe('Basic functionality', () => {
     it('should return empty array for empty segments', async () => {
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams([], store)
+      const result = await generateRouteStaticParams([], store, false)
       expect(result).toEqual([])
     })
 
@@ -844,7 +844,7 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toEqual([])
     })
 
@@ -853,7 +853,7 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async () => [{ id: '1' }, { id: '2' }]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toEqual([{ id: '1' }, { id: '2' }])
     })
 
@@ -869,7 +869,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toEqual([
         { category: 'tech', slug: 'tech-post-1' },
         { category: 'tech', slug: 'tech-post-2' },
@@ -888,7 +888,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toEqual([
         { lang: 'en', category: 'en-tech' },
         { lang: 'fr', category: 'fr-tech' },
@@ -904,7 +904,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toEqual([{ lang: 'en', slug: 'en-slug' }])
     })
   })
@@ -913,7 +913,7 @@ describe('generateRouteStaticParams', () => {
     it('should handle empty generateStaticParams results', async () => {
       const segments: TestAppSegment[] = [createMockSegment(async () => [])]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toEqual([])
     })
 
@@ -923,7 +923,7 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async () => []), // Empty result
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toEqual([{ lang: 'en' }])
     })
 
@@ -935,7 +935,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toEqual([
         { lang: 'en', category: 'en-tech' },
         { category: 'default-tech' },
@@ -951,7 +951,7 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await generateRouteStaticParams(segments, store)
+      await generateRouteStaticParams(segments, store, false)
       expect(store.fetchCache).toBe('force-cache')
     })
 
@@ -960,7 +960,7 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async () => [{ id: '1' }]),
       ]
       const store = createMockWorkStore('force-cache')
-      await generateRouteStaticParams(segments, store)
+      await generateRouteStaticParams(segments, store, false)
       expect(store.fetchCache).toBe('force-cache')
     })
 
@@ -974,7 +974,7 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await generateRouteStaticParams(segments, store)
+      await generateRouteStaticParams(segments, store, false)
       // Should have the last fetchCache value
       expect(store.fetchCache).toBe('default-cache')
     })
@@ -989,7 +989,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toEqual([{ slug: ['a', 'b'] }, { slug: ['c', 'd', 'e'] }])
     })
 
@@ -1001,7 +1001,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toEqual([{ lang: 'en', slug: ['en', 'post'] }])
     })
   })
@@ -1015,7 +1015,7 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async ({ params }) => [{ d: `${params?.c}-4` }]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toEqual([{ a: '1', b: '1-2', c: '1-2-3', d: '1-2-3-4' }])
     })
 
@@ -1026,7 +1026,7 @@ describe('generateRouteStaticParams', () => {
         createMockSegment(async () => [{ z: 'i' }, { z: 'ii' }]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toEqual([
         { x: '1', y: 'a', z: 'i' },
         { x: '1', y: 'a', z: 'ii' },
@@ -1048,9 +1048,9 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await expect(generateRouteStaticParams(segments, store)).rejects.toThrow(
-        'Test error'
-      )
+      await expect(
+        generateRouteStaticParams(segments, store, false)
+      ).rejects.toThrow('Test error')
     })
 
     it('should handle generateStaticParams returning a rejected promise', async () => {
@@ -1060,9 +1060,9 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await expect(generateRouteStaticParams(segments, store)).rejects.toThrow(
-        'Async error'
-      )
+      await expect(
+        generateRouteStaticParams(segments, store, false)
+      ).rejects.toThrow('Async error')
     })
 
     it('should handle partially failing generateStaticParams', async () => {
@@ -1076,9 +1076,53 @@ describe('generateRouteStaticParams', () => {
         }),
       ]
       const store = createMockWorkStore()
-      await expect(generateRouteStaticParams(segments, store)).rejects.toThrow(
-        'Tech not allowed'
+      await expect(
+        generateRouteStaticParams(segments, store, false)
+      ).rejects.toThrow('Tech not allowed')
+    })
+
+    it('should throw error when generateStaticParams returns empty array with isRoutePPREnabled=true', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ lang: 'en' }]),
+        createMockSegment(async () => []), // Empty result
+      ]
+      const store = createMockWorkStore()
+      await expect(
+        generateRouteStaticParams(segments, store, true)
+      ).rejects.toThrow(
+        'When using Cache Components, all `generateStaticParams` functions must return at least one result'
       )
+    })
+
+    it('should throw error when first segment returns empty array with isRoutePPREnabled=true', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => []), // Empty result at root level
+      ]
+      const store = createMockWorkStore()
+      await expect(
+        generateRouteStaticParams(segments, store, true)
+      ).rejects.toThrow(
+        'When using Cache Components, all `generateStaticParams` functions must return at least one result'
+      )
+    })
+
+    it('should NOT throw error when generateStaticParams returns empty array with isRoutePPREnabled=false', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => [{ lang: 'en' }]),
+        createMockSegment(async () => []), // Empty result
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store, false)
+      expect(result).toEqual([{ lang: 'en' }])
+    })
+
+    it('should NOT throw error when first segment returns empty array with isRoutePPREnabled=false', async () => {
+      const segments: TestAppSegment[] = [
+        createMockSegment(async () => []), // Empty result at root level
+      ]
+      const store = createMockWorkStore()
+      const result = await generateRouteStaticParams(segments, store, false)
+      expect(result).toEqual([])
     })
   })
 
@@ -1100,7 +1144,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toHaveLength(12) // 3 langs × 2 categories × 2 slugs
       expect(result).toContainEqual({
         lang: 'en',
@@ -1132,7 +1176,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toEqual([
         {
           category: 'electronics',
@@ -1167,7 +1211,7 @@ describe('generateRouteStaticParams', () => {
         ]),
       ]
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toHaveLength(8) // 2 years × 2 months × 2 slug variations
       expect(result).toContainEqual({
         year: '2023',
@@ -1187,7 +1231,7 @@ describe('generateRouteStaticParams', () => {
         )
       }
       const store = createMockWorkStore()
-      const result = await generateRouteStaticParams(segments, store)
+      const result = await generateRouteStaticParams(segments, store, false)
       expect(result).toHaveLength(1)
       expect(Object.keys(result[0])).toHaveLength(5000)
     })

--- a/packages/next/src/shared/lib/errors/empty-generate-static-params-error.ts
+++ b/packages/next/src/shared/lib/errors/empty-generate-static-params-error.ts
@@ -1,0 +1,13 @@
+export function throwEmptyGenerateStaticParamsError(): never {
+  const error = new Error(
+    'When using Cache Components, all `generateStaticParams` functions must return at least one result. ' +
+      'This is to ensure that we can perform build-time validation that there is no other dynamic accesses that would cause a runtime error.\n\n' +
+      'Learn more: https://nextjs.org/docs/messages/empty-generate-static-params'
+  )
+  error.name = 'EmptyGenerateStaticParamsError'
+  // This error is meant to interrupt the server start/build process
+  // but the stack trace isn't meaningful, as it points to internal code.
+  error.stack = undefined
+
+  throw error
+}

--- a/packages/next/src/shared/lib/errors/missing-default-parallel-route-error.ts
+++ b/packages/next/src/shared/lib/errors/missing-default-parallel-route-error.ts
@@ -1,16 +1,14 @@
-export class MissingDefaultParallelRouteError extends Error {
+import { UsageError } from './usage-error'
+
+export class MissingDefaultParallelRouteError extends UsageError {
   constructor(fullSegmentPath: string, slotName: string) {
     super(
       `Missing required default.js file for parallel route at ${fullSegmentPath}\n` +
         `The parallel route slot "${slotName}" is missing a default.js file. When using parallel routes, each slot must have a default.js file to serve as a fallback.\n\n` +
-        `Create a default.js file at: ${fullSegmentPath}/default.js\n\n` +
-        `https://nextjs.org/docs/messages/slot-missing-default`
+        `Create a default.js file at: ${fullSegmentPath}/default.js`,
+      'https://nextjs.org/docs/messages/slot-missing-default'
     )
 
     this.name = 'MissingDefaultParallelRouteError'
-
-    // This error is meant to interrupt the server start/build process
-    // but the stack trace isn't meaningful, as it points to internal code.
-    this.stack = undefined
   }
 }

--- a/packages/next/src/shared/lib/errors/usage-error.ts
+++ b/packages/next/src/shared/lib/errors/usage-error.ts
@@ -1,0 +1,10 @@
+export class UsageError extends Error {
+  constructor(message: string, docUrl: string) {
+    super(`${message}\n\nLearn more: ${docUrl}`)
+    this.name = 'UsageError'
+
+    // This error is meant to interrupt the server start/build process
+    // but the stack trace isn't meaningful, as it points to internal code.
+    this.stack = undefined
+  }
+}

--- a/test/e2e/app-dir/app-alias/src/app/typing/[slug]/page.tsx
+++ b/test/e2e/app-dir/app-alias/src/app/typing/[slug]/page.tsx
@@ -8,5 +8,5 @@ export async function generateStaticParams({
   params: { slug: string }
 }) {
   console.log(params)
-  return []
+  return [{ slug: 'foo' }]
 }

--- a/test/e2e/app-dir/app-catch-all-optional/app/[lang]/[flags]/[[...rest]]/page.tsx
+++ b/test/e2e/app-dir/app-catch-all-optional/app/[lang]/[flags]/[[...rest]]/page.tsx
@@ -1,5 +1,5 @@
 export async function generateStaticParams() {
-  return []
+  return [{ lang: 'en', flags: 'us', rest: ['home'] }]
 }
 
 export default async function Page(props) {

--- a/test/e2e/app-dir/not-found-with-pages-i18n/app/app-dir/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/not-found-with-pages-i18n/app/app-dir/[[...slug]]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation'
 
 export async function generateStaticParams() {
-  return []
+  return [{ slug: ['about'] }]
 }
 
 async function validateSlug(slug: string[]) {

--- a/test/e2e/app-dir/sub-shell-generation-middleware/app/rewrite/[slug]/page.tsx
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/app/rewrite/[slug]/page.tsx
@@ -8,5 +8,5 @@ export default async function RewritePage({
 }
 
 export async function generateStaticParams() {
-  return []
+  return [{ slug: 'foo' }]
 }

--- a/test/e2e/app-dir/sub-shell-generation/app/[lang]/[slug]/page.tsx
+++ b/test/e2e/app-dir/sub-shell-generation/app/[lang]/[slug]/page.tsx
@@ -16,5 +16,5 @@ export default async function Page({
 }
 
 export function generateStaticParams({ params }: { params: { lang: string } }) {
-  return params.lang === 'fr' ? [{ slug: '1' }] : []
+  return params.lang === 'fr' ? [{ slug: '1' }] : [{ slug: 'foo' }]
 }

--- a/test/production/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
+++ b/test/production/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
@@ -4,31 +4,47 @@ import { retry } from 'next-test-utils'
 describe('empty-generate-static-params', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    skipStart: true,
     skipDeployment: true,
   })
 
   if (skipped) return
 
-  it('should mark the page with empty generateStaticParams as SSG in build output', async () => {
-    const isPPREnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
-    expect(next.cliOutput).toContain(`${isPPREnabled ? '◐' : '●'} /[slug]`)
-  })
-
-  it('should be a cache miss on the initial render followed by a HIT after being generated', async () => {
-    const firstResponse = await next.fetch('/foo')
-    expect(firstResponse.status).toBe(200)
-
-    // With PPR enabled, the initial request doesn't send back a cache header
-    const isPPREnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
-
-    expect(firstResponse.headers.get('x-nextjs-cache')).toBe(
-      isPPREnabled ? null : 'MISS'
-    )
-
-    retry(async () => {
-      const secondResponse = await next.fetch('/foo')
-      expect(secondResponse.status).toBe(200)
-      expect(secondResponse.headers.get('x-nextjs-cache')).toBe('HIT')
+  // If we're not using cache components, there shouldn't be any build errors!
+  if (process.env.__NEXT_CACHE_COMPONENTS !== 'true') {
+    beforeAll(async () => {
+      await next.start()
     })
-  })
+
+    it('should mark the page with empty generateStaticParams as SSG in build output', async () => {
+      const isPPREnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+      expect(next.cliOutput).toContain(`${isPPREnabled ? '◐' : '●'} /[slug]`)
+    })
+
+    it('should be a cache miss on the initial render followed by a HIT after being generated', async () => {
+      const firstResponse = await next.fetch('/foo')
+      expect(firstResponse.status).toBe(200)
+
+      // With PPR enabled, the initial request doesn't send back a cache header
+      const isPPREnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+
+      expect(firstResponse.headers.get('x-nextjs-cache')).toBe(
+        isPPREnabled ? null : 'MISS'
+      )
+
+      retry(async () => {
+        const secondResponse = await next.fetch('/foo')
+        expect(secondResponse.status).toBe(200)
+        expect(secondResponse.headers.get('x-nextjs-cache')).toBe('HIT')
+      })
+    })
+  } else {
+    it('should throw an error when generateStaticParams returns an empty array', async () => {
+      await expect(() => next.start()).rejects.toThrow()
+
+      expect(next.cliOutput).toContain(
+        'https://nextjs.org/docs/messages/empty-generate-static-params'
+      )
+    })
+  }
 })

--- a/test/production/standalone-mode/required-server-files/app/optional-catchall/[lang]/[flags]/[[...slug]]/page.jsx
+++ b/test/production/standalone-mode/required-server-files/app/optional-catchall/[lang]/[flags]/[[...slug]]/page.jsx
@@ -1,5 +1,5 @@
 export async function generateStaticParams() {
-  return []
+  return [{ lang: 'en', flags: 'us', slug: ['home'] }]
 }
 
 export default async function Page(props) {


### PR DESCRIPTION
### What?

This PR adds build-time validation that requires `generateStaticParams` to return at least one result when Cache Components (experimental `cacheComponents` feature) is enabled.

### Why?

Previously, users could return an empty array (`[]`) from `generateStaticParams` to indicate a route should be treated statically without providing specific parameter values. This pattern has a critical issue with Cache Components:

**The Problem:**
- With Cache Components enabled, accessing `params` is treated as a dynamic API usage
- When `generateStaticParams` returns empty results, Next.js cannot perform build-time validation to detect if the route accesses other dynamic APIs (like `await cookies()`, `await headers()`, or `await searchParams`)
- This means users could successfully build routes that would fail at runtime with dynamic API errors

**The Solution:**
- By requiring at least one parameter value, we can execute the route during build time with real params
- This allows us to validate that the route doesn't make additional dynamic API calls that would cause runtime failures
- Build-time validation catches configuration errors early, before deployment

### How?

- Modified `buildAppStaticPaths` in `packages/next/src/build/static-paths/app.ts` to check if PPR is enabled and throw error when `generateStaticParams` returns empty array with Cache Components enabled
- Added comprehensive error documentation at `errors/empty-generate-static-params.mdx` with migration options

Migration paths provided in error documentation:
1. Return at least one real param (recommended)
2. Use placeholder params (not recommended, bypasses validation)

The breaking change is acceptable because `cacheComponents` is still experimental and only available in canary releases.

### Related

- Addresses discrepancy discovered with https://github.com/vercel/next.js/discussions/84925.
- Fixes https://github.com/vercel/next.js/issues/84801