### PR TITLE
Fix subtree layout alignment for route summary in `next build`

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -430,7 +430,7 @@ export async function printTreeView(
 
       if (pageInfo?.ssgPageRoutes?.length) {
         const totalRoutes = pageInfo.ssgPageRoutes.length
-        const contSymbol = i === arr.length - 1 ? ' ' : '├'
+        const contSymbol = i === arr.length - 1 ? ' ' : '│'
 
         // HERE
 
@@ -482,7 +482,7 @@ export async function printTreeView(
               pageInfos.get(route)?.initialCacheControl
 
             messages.push([
-              `${contSymbol}   ${innerSymbol} ${route}${
+              `${contSymbol} ${innerSymbol} ${route}${
                 duration > MIN_DURATION
                   ? ` (${getPrettyDuration(duration)})`
                   : ''

--- a/test/production/app-dir/build-output-ssg-bailout/build-output-ssg-bailout.test.ts
+++ b/test/production/app-dir/build-output-ssg-bailout/build-output-ssg-bailout.test.ts
@@ -44,13 +44,13 @@ describe('build-output-ssg-bailout', () => {
      ┌ ○ /_not-found
      ├ ƒ /ssg-bailout-partial/[id]
      ├ ● /ssg-bailout-partial/[id]
-     ├   ├ /ssg-bailout-partial/2
-     ├   └ /ssg-bailout-partial/3
+     │ ├ /ssg-bailout-partial/2
+     │ └ /ssg-bailout-partial/3
      ├ ƒ /ssg-bailout/[id]
      └ ● /ssg/[id]
-         ├ /ssg/1
-         ├ /ssg/2
-         └ /ssg/3
+       ├ /ssg/1
+       ├ /ssg/2
+       └ /ssg/3
 
 
      ○  (Static)   prerendered as static content

--- a/test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts
+++ b/test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts
@@ -25,9 +25,9 @@ describe('build-output-tree-view', () => {
        ├ ○ /cache-life-hours           1h      1d
        ├ ƒ /dynamic
        ├ ◐ /ppr/[slug]                 1w     30d
-       ├   ├ /ppr/[slug]               1w     30d
-       ├   ├ /ppr/days                 1d      1w
-       ├   └ /ppr/weeks                1w     30d
+       │ ├ /ppr/[slug]                 1w     30d
+       │ ├ /ppr/days                   1d      1w
+       │ └ /ppr/weeks                  1w     30d
        └ ○ /revalidate                15m      1y
 
        Route (pages)           Revalidate  Expire


### PR DESCRIPTION
before
```
├ ◐ /with-root-param/[lang]/in-page/root-params
├   ├ /with-root-param/[lang]/in-page/root-params
├   └ /with-root-param/en/in-page/root-params
```

after:
```
├ ◐ /with-root-param/[lang]/in-private-cache/root-params
│ ├ /with-root-param/[lang]/in-private-cache/root-params
│ └ /with-root-param/en/in-private-cache/root-params
```
<img width="1596" height="628" alt="CleanShot 2025-10-21 at 01 13 30@2x" src="https://github.com/user-attachments/assets/eb7e644a-1098-4f17-8c45-d5daf254fe66" />
