### PR TITLE
[BF Cache]: skip lazyData fetch logic for inactive segments

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -437,6 +437,8 @@ function Router({
       // Root node always has `url`
       // Provided in AppTreeContext to ensure it can be overwritten in layout-router
       url: canonicalUrl,
+      // Root segment is always active
+      isActive: true,
     }
   }, [tree, cache, canonicalUrl])
 

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -62,6 +62,7 @@ export const LayoutRouterContext = React.createContext<{
   parentCacheNode: CacheNode
   parentSegmentPath: FlightSegmentPath | null
   url: string
+  isActive: boolean
 } | null>(null)
 
 export const GlobalLayoutRouterContext = React.createContext<{

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -457,7 +457,7 @@ describe('Error overlay for hydration errors in App router', () => {
                <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                  <RedirectBoundary>
                    <RedirectErrorBoundary router={{...}}>
-                     <InnerLayoutRouter url="/extra-nod..." tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                     <InnerLayoutRouter url="/extra-nod..." tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]} ...>
                        <SegmentViewNode type="page" pagePath="(default)/...">
                          <SegmentTrieNode>
                          <ClientPageRoot Component={function Mismatch} searchParams={{}} params={{}}>
@@ -514,7 +514,7 @@ describe('Error overlay for hydration errors in App router', () => {
                    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/p-under-p" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                         <InnerLayoutRouter url="/p-under-p" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]} ...>
                            <SegmentViewNode type="page" pagePath="(default)/...">
                              <SegmentTrieNode>
                              <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>
@@ -570,7 +570,7 @@ describe('Error overlay for hydration errors in App router', () => {
                  <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                    <RedirectBoundary>
                      <RedirectErrorBoundary router={{...}}>
-                       <InnerLayoutRouter url="/div-under-p" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                       <InnerLayoutRouter url="/div-under-p" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]} ...>
                          <SegmentViewNode type="page" pagePath="(default)/...">
                            <SegmentTrieNode>
                            <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>

--- a/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
+++ b/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
@@ -72,7 +72,7 @@ describe('hydration-error-count', () => {
                    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/html-diff" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]}>
+                         <InnerLayoutRouter url="/html-diff" tree={[...]} cacheNode={{lazyData:null, ...}} segmentPath={[...]} ...>
                            <SegmentViewNode type="page" pagePath="html-diff/...">
                              <SegmentTrieNode>
                              <ClientPageRoot Component={function Page} searchParams={{}} params={{}}>


### PR DESCRIPTION
When `routerBfCache` is enabled, React's Activity API renders inactive route segments offscreen to enable instant back/forward navigation. However, the layout-router's lazy data fetching logic was incorrectly triggering fetchServerResponse calls for these offscreen segments when data was missing. 

This PR adds an isActive prop to InnerLayoutRouter that tracks whether a segment is currently visible via the existing `stateKey` check. 