### PR TITLE
Pass `startTime` to initial RSC payload stream

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -175,7 +175,13 @@ if (
 
 const initialServerResponse = createFromReadableStream<InitialRSCPayload>(
   readable,
-  { callServer, findSourceMapURL, debugChannel }
+  {
+    callServer,
+    findSourceMapURL,
+    debugChannel,
+    // @ts-expect-error This is not yet part of the React types
+    startTime: 0,
+  }
 )
 
 function ServerRoot({


### PR DESCRIPTION
`startTime: 0` tells React to align the debug start time of the initial RSC stream (i.e. the one used for hydration) to the start of the document navigation. In other words, the timing information will now include the network latency of the HTML document request.