### PR TITLE
[turbopack] Remove the canary icon from the cache components docs

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheComponents.mdx
@@ -1,7 +1,6 @@
 ---
 title: cacheComponents
 description: Learn how to enable the cacheComponents flag in Next.js.
-version: canary
 ---
 
 The `cacheComponents` flag is a feature in Next.js that causes data fetching operations in the App Router to be excluded from pre-renders unless they are explicitly cached. This can be useful for optimizing the performance of dynamic data fetching in Server Components.


### PR DESCRIPTION
Its not canary anymore.

Closes PACK-5725