### PR TITLE
Update Activity names given to routes

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -435,6 +435,9 @@ function Router({
       parentCacheNode: cache,
       parentSegmentPath: null,
       parentParams: {},
+      // This is the <Activity> "name" that shows up in the Suspense DevTools.
+      // It represents the root of the app.
+      debugNameContext: '/',
       // Root node always has `url`
       // Provided in AppTreeContext to ensure it can be overwritten in layout-router
       url: canonicalUrl,

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -63,6 +63,7 @@ export const LayoutRouterContext = React.createContext<{
   parentCacheNode: CacheNode
   parentSegmentPath: FlightSegmentPath | null
   parentParams: Params
+  debugNameContext: string | undefined
   url: string
   isActive: boolean
 } | null>(null)

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -45,7 +45,7 @@ describe('Error overlay for hydration errors in App router', () => {
            <ScrollAndFocusHandler segmentPath={[...]}>
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary loading={null}>
+                 <LoadingBoundary name={undefined} loading={null}>
                    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
@@ -107,7 +107,7 @@ describe('Error overlay for hydration errors in App router', () => {
            <ScrollAndFocusHandler segmentPath={[...]}>
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary loading={null}>
+                 <LoadingBoundary name={undefined} loading={null}>
                    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
@@ -181,7 +181,7 @@ describe('Error overlay for hydration errors in App router', () => {
            <ScrollAndFocusHandler segmentPath={[...]}>
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary loading={null}>
+                 <LoadingBoundary name="(extra-att..." loading={null}>
                    <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
                      <HTTPAccessFallbackErrorBoundary pathname="/extra-att..." notFound={<SegmentViewNode>} ...>
                        <RedirectBoundary>
@@ -221,7 +221,7 @@ describe('Error overlay for hydration errors in App router', () => {
            <ScrollAndFocusHandler segmentPath={[...]}>
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary loading={null}>
+                 <LoadingBoundary name={undefined} loading={null}>
                    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
@@ -262,7 +262,7 @@ describe('Error overlay for hydration errors in App router', () => {
            <ScrollAndFocusHandler segmentPath={[...]}>
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary loading={null}>
+                 <LoadingBoundary name={undefined} loading={null}>
                    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
@@ -300,7 +300,7 @@ describe('Error overlay for hydration errors in App router', () => {
            <ScrollAndFocusHandler segmentPath={[...]}>
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary loading={null}>
+                 <LoadingBoundary name={undefined} loading={null}>
                    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
@@ -342,7 +342,7 @@ describe('Error overlay for hydration errors in App router', () => {
          <ScrollAndFocusHandler segmentPath={[...]}>
            <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
              <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-               <LoadingBoundary loading={null}>
+               <LoadingBoundary name={undefined} loading={null}>
                  <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                    <RedirectBoundary>
                      <RedirectErrorBoundary router={{...}}>
@@ -376,7 +376,7 @@ describe('Error overlay for hydration errors in App router', () => {
            <ScrollAndFocusHandler segmentPath={[...]}>
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary loading={null}>
+                 <LoadingBoundary name={undefined} loading={null}>
                    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
@@ -415,7 +415,7 @@ describe('Error overlay for hydration errors in App router', () => {
            <ScrollAndFocusHandler segmentPath={[...]}>
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary loading={null}>
+                 <LoadingBoundary name={undefined} loading={null}>
                    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
@@ -453,7 +453,7 @@ describe('Error overlay for hydration errors in App router', () => {
        "componentStack": "...
          <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
            <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-             <LoadingBoundary loading={null}>
+             <LoadingBoundary name={undefined} loading={null}>
                <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                  <RedirectBoundary>
                    <RedirectErrorBoundary router={{...}}>
@@ -510,7 +510,7 @@ describe('Error overlay for hydration errors in App router', () => {
            <ScrollAndFocusHandler segmentPath={[...]}>
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary loading={null}>
+                 <LoadingBoundary name={undefined} loading={null}>
                    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
@@ -566,7 +566,7 @@ describe('Error overlay for hydration errors in App router', () => {
          <ScrollAndFocusHandler segmentPath={[...]}>
            <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
              <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-               <LoadingBoundary loading={null}>
+               <LoadingBoundary name={undefined} loading={null}>
                  <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                    <RedirectBoundary>
                      <RedirectErrorBoundary router={{...}}>
@@ -625,7 +625,7 @@ describe('Error overlay for hydration errors in App router', () => {
            <ScrollAndFocusHandler segmentPath={[...]}>
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary loading={null}>
+                 <LoadingBoundary name={undefined} loading={null}>
                    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
@@ -682,7 +682,7 @@ describe('Error overlay for hydration errors in App router', () => {
            <ScrollAndFocusHandler segmentPath={[...]}>
              <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary loading={null}>
+                 <LoadingBoundary name={undefined} loading={null}>
                    <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                      <RedirectBoundary>
                        <RedirectErrorBoundary router={{...}}>
@@ -966,7 +966,7 @@ describe('Error overlay for hydration errors in App router', () => {
                <ScrollAndFocusHandler segmentPath={[...]}>
                  <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                    <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                     <LoadingBoundary loading={null}>
+                     <LoadingBoundary name="(script-un..." loading={null}>
                        <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
                          <HTTPAccessFallbackErrorBoundary pathname="/script-un..." notFound={<SegmentViewNode>} ...>
                            <RedirectBoundary>

--- a/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
+++ b/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
@@ -17,7 +17,7 @@ describe('hydration-error-count', () => {
              <ScrollAndFocusHandler segmentPath={[...]}>
                <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                  <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary loading={null}>
+                   <LoadingBoundary name={undefined} loading={null}>
                      <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                        <RedirectBoundary>
                          <RedirectErrorBoundary router={{...}}>
@@ -66,7 +66,7 @@ describe('hydration-error-count', () => {
              <ScrollAndFocusHandler segmentPath={[...]}>
                <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                  <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary loading={null}>
+                   <LoadingBoundary name={undefined} loading={null}>
                      <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                        <RedirectBoundary>
                          <RedirectErrorBoundary router={{...}}>
@@ -120,7 +120,7 @@ describe('hydration-error-count', () => {
              <ScrollAndFocusHandler segmentPath={[...]}>
                <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                  <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary loading={null}>
+                   <LoadingBoundary name={undefined} loading={null}>
                      <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                        <RedirectBoundary>
                          <RedirectErrorBoundary router={{...}}>
@@ -155,7 +155,7 @@ describe('hydration-error-count', () => {
              <ScrollAndFocusHandler segmentPath={[...]}>
                <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                  <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary loading={null}>
+                   <LoadingBoundary name={undefined} loading={null}>
                      <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                        <RedirectBoundary>
                          <RedirectErrorBoundary router={{...}}>
@@ -197,7 +197,7 @@ describe('hydration-error-count', () => {
              <ScrollAndFocusHandler segmentPath={[...]}>
                <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                  <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary loading={null}>
+                   <LoadingBoundary name={undefined} loading={null}>
                      <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                        <RedirectBoundary>
                          <RedirectErrorBoundary router={{...}}>
@@ -229,7 +229,7 @@ describe('hydration-error-count', () => {
              <ScrollAndFocusHandler segmentPath={[...]}>
                <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                  <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary loading={null}>
+                   <LoadingBoundary name={undefined} loading={null}>
                      <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                        <RedirectBoundary>
                          <RedirectErrorBoundary router={{...}}>
@@ -267,7 +267,7 @@ describe('hydration-error-count', () => {
              <ScrollAndFocusHandler segmentPath={[...]}>
                <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                  <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary loading={null}>
+                   <LoadingBoundary name={undefined} loading={null}>
                      <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                        <RedirectBoundary>
                          <RedirectErrorBoundary router={{...}}>
@@ -299,7 +299,7 @@ describe('hydration-error-count', () => {
              <ScrollAndFocusHandler segmentPath={[...]}>
                <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                  <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary loading={null}>
+                   <LoadingBoundary name={undefined} loading={null}>
                      <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                        <RedirectBoundary>
                          <RedirectErrorBoundary router={{...}}>
@@ -343,7 +343,7 @@ describe('hydration-error-count', () => {
              <ScrollAndFocusHandler segmentPath={[...]}>
                <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
                  <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary loading={null}>
+                   <LoadingBoundary name={undefined} loading={null}>
                      <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                        <RedirectBoundary>
                          <RedirectErrorBoundary router={{...}}>

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -238,13 +238,13 @@ describe('Cache Components Errors', () => {
                    at ScrollAndFocusHandler (bundler:///<next-src>)
                    at RenderFromTemplateContext (bundler:///<next-src>)
                    at OuterLayoutRouter (bundler:///<next-src>)
-                 337 |  */
-                 338 | function InnerLayoutRouter({
-               > 339 |   tree,
+                 340 |  */
+                 341 | function InnerLayoutRouter({
+               > 342 |   tree,
                      |   ^
-                 340 |   segmentPath,
-                 341 |   cacheNode,
-                 342 |   params,
+                 343 |   segmentPath,
+                 344 |   debugNameContext,
+                 345 |   cacheNode,
                To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -745,13 +745,13 @@ describe('Cache Components Errors', () => {
                    at ScrollAndFocusHandler (bundler:///<next-src>)
                    at RenderFromTemplateContext (bundler:///<next-src>)
                    at OuterLayoutRouter (bundler:///<next-src>)
-                 337 |  */
-                 338 | function InnerLayoutRouter({
-               > 339 |   tree,
+                 340 |  */
+                 341 | function InnerLayoutRouter({
+               > 342 |   tree,
                      |   ^
-                 340 |   segmentPath,
-                 341 |   cacheNode,
-                 342 |   params,
+                 343 |   segmentPath,
+                 344 |   debugNameContext,
+                 345 |   cacheNode,
                To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -2141,13 +2141,13 @@ describe('Cache Components Errors', () => {
                      at ScrollAndFocusHandler (bundler:///<next-src>)
                      at RenderFromTemplateContext (<anonymous>)
                      at OuterLayoutRouter (bundler:///<next-src>)
-                   337 |  */
-                   338 | function InnerLayoutRouter({
-                 > 339 |   tree,
+                   340 |  */
+                   341 | function InnerLayoutRouter({
+                 > 342 |   tree,
                        |   ^
-                   340 |   segmentPath,
-                   341 |   cacheNode,
-                   342 |   params,
+                   343 |   segmentPath,
+                   344 |   debugNameContext,
+                   345 |   cacheNode,
                  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-guarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/unguarded-async-guarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3157,13 +3157,13 @@ describe('Cache Components Errors', () => {
                      at ScrollAndFocusHandler (bundler:///<next-src>)
                      at RenderFromTemplateContext (bundler:///<next-src>)
                      at OuterLayoutRouter (bundler:///<next-src>)
-                   337 |  */
-                   338 | function InnerLayoutRouter({
-                 > 339 |   tree,
+                   340 |  */
+                   341 | function InnerLayoutRouter({
+                 > 342 |   tree,
                        |   ^
-                   340 |   segmentPath,
-                   341 |   cacheNode,
-                   342 |   params,
+                   343 |   segmentPath,
+                   344 |   debugNameContext,
+                   345 |   cacheNode,
                  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-without-suspense" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-without-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
 


### PR DESCRIPTION
In practical terms, clicking the name of a route segment in the Suspense DevTools should select the child slots of that layout, because when you focus on it, what you're interested in debugging are navigations that occur within the shared layout.

So the name we apply to the Activity boundary is actually based on the name of the *parent* segment.