### PR TITLE
Don't assign displayName to the internal Promises

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3174,12 +3174,12 @@ function createAsyncApiPromisesInDev(
     // These are not used directly, but we chain other `params`/`searchParams` promises off of them.
     sharedParamsParent: stagedRendering.delayUntilStage(
       RenderStage.Runtime,
-      'params',
+      undefined,
       '<internal params>'
     ),
     sharedSearchParamsParent: stagedRendering.delayUntilStage(
       RenderStage.Runtime,
-      'searchParams',
+      undefined,
       '<internal searchParams>'
     ),
     connection: stagedRendering.delayUntilStage(


### PR DESCRIPTION
Follow up to #85158.

We shouldn't assign a display name to internal one because now that wins over the one we actually want.