### PR TITLE
Assign name to hydration stream

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -163,6 +163,10 @@ const readable = new ReadableStream({
     nextServerDataRegisterWriter(controller)
   },
 })
+if (process.env.NODE_ENV !== 'production') {
+  // @ts-expect-error
+  readable.name = 'hydration'
+}
 
 let debugChannel:
   | { readable?: ReadableStream; writable?: WritableStream }
@@ -190,8 +194,6 @@ if (clientResumeFetch) {
       callServer,
       findSourceMapURL,
       debugChannel,
-      // @ts-expect-error This is not yet part of the React types
-      startTime: 0,
     })
   ).then(async (fallbackInitialRSCPayload) =>
     createInitialRSCPayloadFromFallbackPrerender(


### PR DESCRIPTION
This allows React DevTools to show a name for this which doesn't have a url like the fetches.

Also, don't set startTime for client resume fetch. The start time for this data didn't start on the server as an MPA nav. The start of the fetch actually is a waterfall and should be shown as such.