### PR TITLE
[upgrade] Version gate adding `--turbopack` flag

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -188,7 +188,15 @@ export async function runUpgrade(
         `react@${targetNextPackageJson.peerDependencies['react']}`
       )
 
-  if (compareVersions(targetNextVersion, '15.0.0-canary') >= 0) {
+  console.log({
+    compare1: compareVersions(targetNextVersion, '15.0.0-canary') >= 0,
+    compare2: compareVersions(targetNextVersion, '16.0.0-canary') < 0,
+  })
+
+  if (
+    compareVersions(targetNextVersion, '15.0.0-canary') >= 0 &&
+    compareVersions(targetNextVersion, '16.0.0-canary') < 0
+  ) {
     await suggestTurbopack(appPackageJson, targetNextVersion)
   }
 

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -188,11 +188,6 @@ export async function runUpgrade(
         `react@${targetNextPackageJson.peerDependencies['react']}`
       )
 
-  console.log({
-    compare1: compareVersions(targetNextVersion, '15.0.0-canary') >= 0,
-    compare2: compareVersions(targetNextVersion, '16.0.0-canary') < 0,
-  })
-
   if (
     compareVersions(targetNextVersion, '15.0.0-canary') >= 0 &&
     compareVersions(targetNextVersion, '16.0.0-canary') < 0


### PR DESCRIPTION
`--turbopack` flag is not needed for v16 upgrade.