### PR TITLE
[codemod] Install ESLint v9 if version under for next-lint-to-eslint-cli

### DIFF
--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/flat-config-flat-compat-with-other-compat/package.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/flat-config-flat-compat-with-other-compat/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "eslint": "^9",
+    "eslint": "^8",
     "eslint-config-next": "^16"
   }
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/flat-config-flat-compat/package.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/flat-config-flat-compat/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "eslint": "^9",
+    "eslint": "^8",
     "eslint-config-next": "^16"
   }
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/flat-config/package.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/flat-config/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "eslint": "^9",
+    "eslint": "^8",
     "eslint-config-next": "^16"
   }
 }

--- a/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/legacy-config/package.json
+++ b/packages/next-codemod/transforms/__testfixtures__/next-lint-to-eslint-cli/legacy-config/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "eslint": "^9",
+    "eslint": "^8",
     "eslint-config-next": "^16"
   }
 }

--- a/packages/next-codemod/transforms/__tests__/next-lint-to-eslint-cli.test.js
+++ b/packages/next-codemod/transforms/__tests__/next-lint-to-eslint-cli.test.js
@@ -94,7 +94,7 @@ describe('next-lint-to-eslint-cli', () => {
             "@types/node": "^20",
             "@types/react": "^19",
             "@types/react-dom": "^19",
-            "eslint": "^9",
+            "eslint": "^8",
             "eslint-config-next": "^16"
           }
         }
@@ -232,7 +232,7 @@ describe('next-lint-to-eslint-cli', () => {
             "@types/node": "^20",
             "@types/react": "^19",
             "@types/react-dom": "^19",
-            "eslint": "^9",
+            "eslint": "^8",
             "eslint-config-next": "^16"
           }
         }
@@ -474,7 +474,7 @@ describe('next-lint-to-eslint-cli', () => {
             "@types/node": "^20",
             "@types/react": "^19",
             "@types/react-dom": "^19",
-            "eslint": "^9",
+            "eslint": "^8",
             "eslint-config-next": "^16"
           }
         }

--- a/packages/next-codemod/transforms/next-lint-to-eslint-cli.ts
+++ b/packages/next-codemod/transforms/next-lint-to-eslint-cli.ts
@@ -966,7 +966,8 @@ function updatePackageJsonScripts(packageJsonContent: string): {
     if (
       packageJson.dependencies?.['eslint'] &&
       semver.lt(
-        semver.minVersion(packageJson.dependencies['eslint']).version,
+        semver.minVersion(packageJson.dependencies['eslint'])?.version ??
+          '0.0.0',
         '9.0.0'
       )
     ) {
@@ -976,7 +977,8 @@ function updatePackageJsonScripts(packageJsonContent: string): {
     if (
       packageJson.devDependencies?.['eslint'] &&
       semver.lt(
-        semver.minVersion(packageJson.devDependencies['eslint']).version,
+        semver.minVersion(packageJson.devDependencies['eslint'])?.version ??
+          '0.0.0',
         '9.0.0'
       )
     ) {

--- a/packages/next-codemod/transforms/next-lint-to-eslint-cli.ts
+++ b/packages/next-codemod/transforms/next-lint-to-eslint-cli.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs'
 import path from 'node:path'
 import { execSync } from 'node:child_process'
+import semver from 'semver'
 import { getPkgManager, installPackages } from '../lib/handle-package'
 import { createParserFromPath } from '../lib/parser'
 import { white, bold, red, yellow, green, magenta } from 'picocolors'
@@ -958,6 +959,28 @@ function updatePackageJsonScripts(packageJsonContent: string): {
         packageJson.dependencies?.next || packageJson.devDependencies?.next
       packageJson.devDependencies['eslint-config-next'] =
         nextVersion || 'latest'
+      needsUpdate = true
+    }
+
+    // Bump eslint to v9 for full Flat config support
+    if (
+      packageJson.dependencies?.['eslint'] &&
+      semver.lt(
+        semver.minVersion(packageJson.dependencies['eslint']).version,
+        '9.0.0'
+      )
+    ) {
+      packageJson.dependencies['eslint'] = '^9'
+      needsUpdate = true
+    }
+    if (
+      packageJson.devDependencies?.['eslint'] &&
+      semver.lt(
+        semver.minVersion(packageJson.devDependencies['eslint']).version,
+        '9.0.0'
+      )
+    ) {
+      packageJson.devDependencies['eslint'] = '^9'
       needsUpdate = true
     }
 


### PR DESCRIPTION
When running `next-lint-to-eslint-cli` and ESLint version lower than 9, upgrade to `^9` to ensure full Flat config support.