### PR TITLE
Remove layout-router sticky/fixed debug warning

### DIFF
--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -140,12 +140,6 @@ function shouldSkipElement(element: HTMLElement) {
   // and will result in a situation we bail on scroll because of something like a fixed nav,
   // even though the actual page content is offscreen
   if (['sticky', 'fixed'].includes(getComputedStyle(element).position)) {
-    if (process.env.NODE_ENV === 'development') {
-      console.warn(
-        'Skipping auto-scroll behavior due to `position: sticky` or `position: fixed` on element:',
-        element
-      )
-    }
     return true
   }
 

--- a/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+++ b/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
@@ -197,20 +197,6 @@ describe('router autoscrolling on navigation', () => {
         .click()
         .waitForElementByCss('#content-that-is-visible')
       await check(() => browser.eval('window.scrollY'), 0)
-
-      if (isNextDev) {
-        // Check that we've logged a warning
-        await check(async () => {
-          const logs = await browser.log()
-          return logs.some((log) =>
-            log.message.includes(
-              'Skipping auto-scroll behavior due to `position: sticky` or `position: fixed` on element:'
-            )
-          )
-            ? 'success'
-            : undefined
-        }, 'success')
-      }
     })
 
     it('Should scroll to the top of the layout when the first child is position sticky', async () => {
@@ -221,20 +207,6 @@ describe('router autoscrolling on navigation', () => {
         .click()
         .waitForElementByCss('#content-that-is-visible')
       await check(() => browser.eval('window.scrollY'), 0)
-
-      if (isNextDev) {
-        // Check that we've logged a warning
-        await check(async () => {
-          const logs = await browser.log()
-          return logs.some((log) =>
-            log.message.includes(
-              'Skipping auto-scroll behavior due to `position: sticky` or `position: fixed` on element:'
-            )
-          )
-            ? 'success'
-            : undefined
-        }, 'success')
-      }
     })
 
     it('Should apply scroll when loading.js is used', async () => {


### PR DESCRIPTION
Fixes an issue that reproduces due to a combination of the log forwarding logic alongside logging out an explicit element. We can add this back in the future once our log forwarding library properly ignores non-enumerable properties. 