### PR TITLE
docs: proxy runtime defaults to nodejs

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -192,14 +192,6 @@ Proxy will be invoked for **every route in your project**. Given this, it's cruc
 
 Proxy defaults to using the Node.js runtime. The [`runtime`](/docs/app/api-reference/file-conventions/route-segment-config#runtime) config option is not available in Proxy files. Setting the `runtime` config option in Proxy will throw an error.
 
-```diff filename="proxy.ts"
--export const config = {
--   runtime: 'edge',
-- }
--
-- export const runtime = 'edge'
-```
-
 ## Advanced Proxy flags
 
 In `v13.1` of Next.js two additional flags were introduced for proxy, `skipMiddlewareUrlNormalize` and `skipTrailingSlashRedirect` to handle advanced use cases.

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -190,18 +190,26 @@ Proxy will be invoked for **every route in your project**. Given this, it's cruc
 
 ## Runtime
 
-Proxy defaults to using the Edge runtime. As of v15.5, we have support for using the Node.js runtime. To enable, in your proxy file, set the runtime to `nodejs` in the `config` object:
+Proxy defaults to using the Node.js runtime. The [`runtime`](/docs/app/api-reference/file-conventions/route-segment-config#runtime) config option is not available in Proxy files.
 
 ```js highlight={2} filename="proxy.js" switcher
+// Setting the runtime config in Proxy will throw an error.
+
 export const config = {
-  runtime: 'nodejs',
+  runtime: 'edge',
 }
+
+export const runtime = 'edge'
 ```
 
 ```ts highlight={2} filename="proxy.ts" switcher
+// Setting the runtime config in Proxy will throw an error.
+
 export const config = {
-  runtime: 'nodejs',
+  runtime: 'edge',
 }
+
+export const runtime = 'edge'
 ```
 
 ## Advanced Proxy flags

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -190,26 +190,14 @@ Proxy will be invoked for **every route in your project**. Given this, it's cruc
 
 ## Runtime
 
-Proxy defaults to using the Node.js runtime. The [`runtime`](/docs/app/api-reference/file-conventions/route-segment-config#runtime) config option is not available in Proxy files.
+Proxy defaults to using the Node.js runtime. The [`runtime`](/docs/app/api-reference/file-conventions/route-segment-config#runtime) config option is not available in Proxy files. Setting the `runtime` config option in Proxy will throw an error.
 
-```js filename="proxy.js" switcher
-// Setting the runtime config in Proxy will throw an error.
-
-export const config = {
-  runtime: 'edge',
-}
-
-export const runtime = 'edge'
-```
-
-```ts filename="proxy.ts" switcher
-// Setting the runtime config in Proxy will throw an error.
-
-export const config = {
-  runtime: 'edge',
-}
-
-export const runtime = 'edge'
+```diff filename="proxy.ts"
+-export const config = {
+-   runtime: 'edge',
+- }
+-
+- export const runtime = 'edge'
 ```
 
 ## Advanced Proxy flags

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -192,7 +192,7 @@ Proxy will be invoked for **every route in your project**. Given this, it's cruc
 
 Proxy defaults to using the Node.js runtime. The [`runtime`](/docs/app/api-reference/file-conventions/route-segment-config#runtime) config option is not available in Proxy files.
 
-```js highlight={2} filename="proxy.js" switcher
+```js filename="proxy.js" switcher
 // Setting the runtime config in Proxy will throw an error.
 
 export const config = {
@@ -202,7 +202,7 @@ export const config = {
 export const runtime = 'edge'
 ```
 
-```ts highlight={2} filename="proxy.ts" switcher
+```ts filename="proxy.ts" switcher
 // Setting the runtime config in Proxy will throw an error.
 
 export const config = {


### PR DESCRIPTION
Proxy runtime defaults to nodejs and does not allow runtime config since https://github.com/vercel/next.js/pull/85139