### PR TITLE
chore: polish made-by-vercel badge

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -7,7 +7,7 @@
   </a>
   <h1>Next.js</h1>
 
-<a href="https://vercel.com"><img alt="Vercel logo" src="https://img.shields.io/badge/MADE%20BY%20Vercel-000000.svg?style=for-the-badge&logo=Vercel&labelColor=000"></a>
+<a href="https://vercel.com"><img alt="Vercel logo" src="https://img.shields.io/badge/Made%20by%20Vercel-000000?logo=vercel&logoColor=fff&style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/next"><img alt="NPM version" src="https://img.shields.io/npm/v/next.svg?style=for-the-badge&labelColor=000000"></a>
 <a href="https://github.com/vercel/next.js/blob/canary/license.md"><img alt="License" src="https://img.shields.io/npm/l/next.svg?style=for-the-badge&labelColor=000000"></a>
 <a href="https://github.com/vercel/next.js/discussions"><img alt="Join the community on GitHub" src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&logo=Next.js&labelColor=000000&logoWidth=20"></a>


### PR DESCRIPTION
### Preview

|Before|After|
|:-:|:-:|
|![](https://img.shields.io/badge/MADE%20BY%20Vercel-000000.svg?style=for-the-badge&logo=Vercel&labelColor=000)|![](https://img.shields.io/badge/Made%20by%20Vercel-000000?logo=vercel&logoColor=fff&style=for-the-badge)|

### How?

Typically, a shields.io badge consists of three parts: icon, label, and message. Here is a simplest badge with `for-the-badge` style:

```
https://img.shields.io/badge/label-message-blue?logo=vercel&style=for-the-badge
```

![](https://img.shields.io/badge/label-message-blue?logo=vercel&style=for-the-badge)

Here is the previously made-by-vercel badge with in colors (icon + message):

```
https://img.shields.io/badge/MADE%20BY%20Vercel-000000.svg?style=for-the-badge&logo=Vercel
```

![](https://img.shields.io/badge/MADE%20BY%20Vercel-blue.svg?style=for-the-badge&logo=Vercel&labelColor=gray)

We should use the "icon + label" to avoid the wide gap between the icon and text. Here is the polished badge (icon + label):

![](https://img.shields.io/badge/Made%20by%20Vercel-gray?logo=vercel&logoColor=fff&style=for-the-badge)

### Why?

I'm the active contributor of the https://github.com/badges/shields project. I'm also the maintainer of https://github.com/simple-icons/simple-icons (the icon provider of shields.io). So I am very sensitive to the style of this badge.

Although this is a one-line contribution PR for a documentation update, I'd like to elaborate on my reasoning for submitting it. Thanks for reading.