### PR TITLE
Update command to install babel-plugin-react-compiler as a devDependency

### DIFF
--- a/docs/01-app/02-guides/upgrading/version-16.mdx
+++ b/docs/01-app/02-guides/upgrading/version-16.mdx
@@ -375,7 +375,7 @@ module.exports = nextConfig
 Install the latest version of the React Compiler plugin:
 
 ```bash filename="Terminal"
-npm install babel-plugin-react-compiler@latest
+npm install -D babel-plugin-react-compiler
 ```
 
 > **Good to know:** Expect compile times in development and during builds to be higher when enabling this option as the React Compiler relies on Babel.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/reactCompiler.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/reactCompiler.mdx
@@ -16,7 +16,7 @@ This avoids compiling everything and keeps the performance cost minimal. You may
 To use it, install the `babel-plugin-react-compiler`:
 
 ```bash filename="Terminal"
-npm install babel-plugin-react-compiler
+npm install -D babel-plugin-react-compiler
 ```
 
 Then, add `reactCompiler` option in `next.config.js`:


### PR DESCRIPTION
Updated command to install babel-plugin-react-compiler as a devDependency instead of as a dependency, mirroring React's instructions - https://react.dev/learn/react-compiler/installation
