### PR TITLE
docs: add a note that cache components is opt-in near the top

### DIFF
--- a/docs/01-app/01-getting-started/06-cache-components.mdx
+++ b/docs/01-app/01-getting-started/06-cache-components.mdx
@@ -50,6 +50,8 @@ When a user visits a route:
 
 ## How it works
 
+> **Good to know:** Cache Components is an opt-in feature. Enable it by setting the `cacheComponents` flag to `true` in your Next config file. See [Enabling Cache Components](#enabling-cache-components) for more details.
+
 Cache Components gives you three key tools to control rendering:
 
 ### 1. Suspense for runtime data


### PR DESCRIPTION
We do mention how to enable this feature, but a little note can go a long way, specially highlighting that it is opt-in 