### PR TITLE
[Cache Components] Allow cacheLife to be a noop in unknown contexts

### DIFF
--- a/packages/next/src/server/use-cache/cache-life.ts
+++ b/packages/next/src/server/use-cache/cache-life.ts
@@ -91,10 +91,11 @@ export function cacheLife(profile: CacheLifeProfiles | CacheLife): void {
     case 'prerender-legacy':
     case 'request':
     case 'unstable-cache':
-    case undefined:
       throw new Error(
         '`cacheLife()` can only be called inside a "use cache" function.'
       )
+    case undefined:
+      return
     case 'cache':
     case 'private-cache':
       break


### PR DESCRIPTION
If we do not know the context we are running in allow `cacheLife()` to be a noop. There are some contexts in which cacheLife can run that will not have a workUnitStore but can have the next-js conditon, namely proxy. While we should support "use cache" in proxy we can for now at least allow these functions to be noops since there is no reasonable semantic in this context as no actual caching happens in this context. This is better than an error however.