### PR TITLE
Add missing env inlining and hash replacing for standalone mode

### DIFF
--- a/packages/next/src/lib/inline-static-env.ts
+++ b/packages/next/src/lib/inline-static-env.ts
@@ -23,6 +23,15 @@ export async function inlineStaticEnv({
   const serverChunks = await glob('**/*.{js,json,js.map}', {
     cwd: serverDir,
   })
+  const standaloneServerDir = path.join(
+    distDir,
+    'standalone',
+    '.next',
+    'server'
+  )
+  const standaloneServerChunks = await glob('**/*.{js,json,js.map}', {
+    cwd: standaloneServerDir,
+  })
   const clientDir = path.join(distDir, 'static')
   const clientChunks = await glob('**/*.{js,json,js.map}', {
     cwd: clientDir,
@@ -48,6 +57,7 @@ export async function inlineStaticEnv({
   for (const [parentDir, files] of [
     [serverDir, serverChunks],
     [clientDir, clientChunks],
+    [standaloneServerDir, standaloneServerChunks],
   ] as const) {
     await Promise.all(
       files.map(async (file) => {


### PR DESCRIPTION
Fix #80194.
This adds the missing env inlining and hash replacing for standalone mode bundled by webpack. This issue does not occur in turbopack mode because `generate-env` is not involved. 
To reproduce, please clone https://github.com/hood/nextjs-env-repro. And change the build script to:
```sh
  "scripts": {
    "build": "cp .env.local .env.production && rm -rf ./.next/ && next build --webpack --experimental-build-mode compile && next build --webpack --experimental-build-mode generate-env && cp -r ./.next/static ./.next/standalone/.next/static"
  },
```
This repository uses `next@15.3.3`, I added `--webpack` to ensure it works as expected in the latest `next@16.0.0` since the default bundler is changed to Turbopack now.
Then run:
```sh
pnpm build && node .next/standalone/server.js
```
The expected result is the NEXT_PUBLIC_  environment varaible is defined for client component.
The actual result is it's `undefined`, because the referenced js file path (hash) in standalone directory is not correct anymore after `generate-env`.