### PR TITLE
Add `TURBOPACK_LOADER_CPU` ENV

### DIFF
--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -1,6 +1,4 @@
-use std::{
-    borrow::Cow, iter, ops::ControlFlow, sync::Arc, thread::available_parallelism, time::Duration,
-};
+use std::{borrow::Cow, iter, ops::ControlFlow, sync::Arc, time::Duration};
 
 use anyhow::{Result, anyhow, bail};
 use async_stream::try_stream as generator;
@@ -45,6 +43,7 @@ use crate::{
     AssetsForSourceMapping,
     embed_js::embed_file_path,
     emit, emit_package_json, internal_assets_for_source_mapping,
+    node_loader_cpu::get_loader_cpu,
     pool::{FormattingMode, NodeJsOperation, NodeJsPool},
     source_map::StructuredError,
 };
@@ -300,7 +299,7 @@ pub async fn get_evaluate_pool(
         assets_for_source_mapping,
         output_root.clone(),
         chunking_context.root_path().owned().await?,
-        available_parallelism().map_or(1, |v| v.get()),
+        get_loader_cpu(),
         debug,
     );
     additional_invalidation.await?;

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -2,7 +2,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 
-use std::{iter::once, thread::available_parallelism};
+use std::iter::once;
 
 use anyhow::{Result, bail};
 use rustc_hash::FxHashMap;
@@ -25,12 +25,14 @@ use turbopack_core::{
 };
 
 use self::pool::NodeJsPool;
+use crate::node_loader_cpu::get_loader_cpu;
 
 pub mod debug;
 pub mod embed_js;
 pub mod evaluate;
 pub mod execution_context;
 mod heap_queue;
+mod node_loader_cpu;
 mod pool;
 pub mod route_matcher;
 pub mod source_map;
@@ -248,7 +250,7 @@ pub async fn get_renderer_pool_operation(
         assets_for_source_mapping.to_resolved().await?,
         output_root,
         project_dir,
-        available_parallelism().map_or(1, |v| v.get()),
+        get_loader_cpu(),
         debug,
     )
     .cell())

--- a/turbopack/crates/turbopack-node/src/node_loader_cpu.rs
+++ b/turbopack/crates/turbopack-node/src/node_loader_cpu.rs
@@ -1,0 +1,12 @@
+use std::{env, thread::available_parallelism};
+
+const LOADER_CPU_VAR: &str = "TURBOPACK_LOADER_CPU";
+
+pub fn get_loader_cpu() -> usize {
+    let Ok(val) = env::var(LOADER_CPU_VAR) else {
+        return available_parallelism().map_or(1, |v| v.get());
+    };
+
+    val.parse()
+        .unwrap_or(available_parallelism().map_or(1, |v| v.get()))
+}

--- a/turbopack/crates/turbopack-node/src/node_loader_cpu.rs
+++ b/turbopack/crates/turbopack-node/src/node_loader_cpu.rs
@@ -7,6 +7,11 @@ pub fn get_loader_cpu() -> usize {
         return available_parallelism().map_or(1, |v| v.get());
     };
 
-    val.parse()
-        .unwrap_or(available_parallelism().map_or(1, |v| v.get()))
+    let result = val.parse().unwrap_or(0);
+    let default = available_parallelism().map_or(1, |v| v.get());
+    if default < result || result < 1 {
+        default
+    } else {
+        result
+    }
 }


### PR DESCRIPTION
## What?

Add an environment variable TURBOPACK_LOADER_CPU to configure the maximum CPU usage for the Turbopack loader.

## Why?

Sometimes, libraries or systems need to control the maximum number of CPUs used for parallel processing.
This change allows developers to limit or adjust CPU usage when Turbopack executes its loaders.

## How?

When TURBOPACK_LOADER_CPU is set to a valid number, that value is used as the maximum number of CPUs for the loader.
If the value exceeds the available CPUs, is less than 1, or is invalid, Turbopack automatically falls back to the system’s available CPU count.


https://github.com/vercel/next.js/discussions/85226