### PR TITLE
Turbopack: chore: Remove mopa dependency in turbo-tasks (2nd attempt)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4106,12 +4106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mopa"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a785740271256c230f57462d3b83e52f998433a7062fc18f96d5999474a9f915"
-
-[[package]]
 name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9184,7 +9178,6 @@ dependencies = [
  "futures",
  "indexmap 2.9.0",
  "inventory",
- "mopa",
  "once_cell",
  "parking_lot",
  "pin-project-lite",

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -31,7 +31,6 @@ erased-serde = { workspace = true }
 event-listener = "5.4.0"
 futures = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
-mopa = "0.2.0"
 once_cell = { workspace = true }
 parking_lot = { workspace = true, features = ["serde"]}
 pin-project-lite = { workspace = true }

--- a/turbopack/crates/turbo-tasks/src/magic_any.rs
+++ b/turbopack/crates/turbo-tasks/src/magic_any.rs
@@ -1,67 +1,24 @@
-use core::fmt;
-use std::{
-    any::{Any, TypeId},
-    fmt::Debug,
-    hash::Hash,
-    sync::Arc,
-};
+use std::{any::Any, fmt::Debug, hash::Hash};
 
 use serde::{Deserialize, Serialize, de::DeserializeSeed};
 use turbo_dyn_eq_hash::{
-    DynEq, DynHash, DynPartialEq, impl_eq_for_dyn, impl_hash_for_dyn, impl_partial_eq_for_dyn,
+    DynEq, DynHash, impl_eq_for_dyn, impl_hash_for_dyn, impl_partial_eq_for_dyn,
 };
 
-use crate::trace::{TraceRawVcs, TraceRawVcsContext};
+use crate::trace::TraceRawVcs;
 
-pub trait MagicAny: mopa::Any + DynPartialEq + DynEq + DynHash + Send + Sync {
-    fn magic_any_arc(self: Arc<Self>) -> Arc<dyn Any + Sync + Send>;
-
-    fn magic_debug(&self, f: &mut fmt::Formatter) -> fmt::Result;
-
-    fn magic_trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext);
-
+pub trait MagicAny: Debug + DynEq + DynHash + TraceRawVcs + Send + Sync + 'static {
     #[cfg(debug_assertions)]
     fn magic_type_name(&self) -> &'static str;
 }
 
-#[allow(clippy::transmute_ptr_to_ref)] // can't fix as it's in the macro
-mod clippy {
-    use mopa::mopafy;
-
-    use super::MagicAny;
-
-    mopafy!(MagicAny);
-}
-
-impl<T: Debug + Eq + Hash + Send + Sync + TraceRawVcs + 'static> MagicAny for T {
-    fn magic_any_arc(self: Arc<Self>) -> Arc<dyn Any + Sync + Send> {
-        self
-    }
-
-    fn magic_debug(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut d = f.debug_tuple("MagicAny");
-        d.field(&TypeId::of::<Self>());
-
-        #[cfg(debug_assertions)]
-        d.field(&std::any::type_name::<Self>());
-
-        d.field(&(self as &Self));
-        d.finish()
-    }
-
-    fn magic_trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
-        self.trace_raw_vcs(trace_context);
-    }
-
+impl<T> MagicAny for T
+where
+    T: Debug + Eq + Hash + Send + Sync + TraceRawVcs + 'static,
+{
     #[cfg(debug_assertions)]
     fn magic_type_name(&self) -> &'static str {
         std::any::type_name::<T>()
-    }
-}
-
-impl fmt::Debug for dyn MagicAny {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.magic_debug(f)
     }
 }
 
@@ -69,24 +26,18 @@ impl_partial_eq_for_dyn!(dyn MagicAny);
 impl_eq_for_dyn!(dyn MagicAny);
 impl_hash_for_dyn!(dyn MagicAny);
 
-impl TraceRawVcs for dyn MagicAny {
-    fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
-        self.magic_trace_raw_vcs(trace_context)
-    }
-}
-
 impl dyn MagicAny {
     pub fn as_serialize<T: Debug + Eq + Hash + Serialize + Send + Sync + TraceRawVcs + 'static>(
         &self,
     ) -> &dyn erased_serde::Serialize {
-        if let Some(r) = self.downcast_ref::<T>() {
+        if let Some(r) = (self as &dyn Any).downcast_ref::<T>() {
             r
         } else {
             #[cfg(debug_assertions)]
             panic!(
                 "MagicAny::as_serializable broken: got {} but expected {}",
                 self.magic_type_name(),
-                std::any::type_name::<T>()
+                std::any::type_name::<T>(),
             );
             #[cfg(not(debug_assertions))]
             panic!("MagicAny::as_serializable bug");

--- a/turbopack/crates/turbo-tasks/src/task/function.rs
+++ b/turbopack/crates/turbo-tasks/src/task/function.rs
@@ -172,10 +172,13 @@ macro_rules! task_inputs_impl {
 /// gives the compiler more chances to dedupe monomorphized code across small functions with less
 /// typevars.
 fn get_args<T: MagicAny + Clone>(arg: &dyn MagicAny) -> Result<T> {
-    let value = arg.downcast_ref::<T>().cloned();
+    let value = (arg as &dyn std::any::Any).downcast_ref::<T>().cloned();
     #[cfg(debug_assertions)]
     return anyhow::Context::with_context(value, || {
-        crate::native_function::debug_downcast_args_error_msg(std::any::type_name::<T>(), arg)
+        crate::native_function::debug_downcast_args_error_msg(
+            std::any::type_name::<T>(),
+            arg.magic_type_name(),
+        )
     });
     #[cfg(not(debug_assertions))]
     return anyhow::Context::context(value, "Invalid argument type");


### PR DESCRIPTION
This is a recreation of my _very first_ Turbopack PR in https://github.com/vercel/turborepo/pull/7206 (reverted in https://github.com/vercel/turborepo/pull/7573)

Instead of using a trait upcast helper method, this uses the recently-stabilized trait upcasting compiler feature.

I used claude to help write this, but cleaned it up by hand.