### PR TITLE
Turbopack: correctly trace files with npm

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -568,14 +568,7 @@ async fn validate_pages_css_imports(
         .map(async |issue| {
             // We allow imports of global CSS files which are inside of `node_modules`.
             Ok(
-                if !issue
-                    .module
-                    .ident()
-                    .path()
-                    .await?
-                    .path
-                    .contains("/node_modules/")
-                {
+                if !issue.module.ident().path().await?.is_in_node_modules() {
                     Some(issue)
                 } else {
                     None

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1239,6 +1239,10 @@ impl FileSystemPath {
         self.path.is_empty()
     }
 
+    pub fn is_in_node_modules(&self) -> bool {
+        self.path.starts_with("node_modules/") || self.path.contains("/node_modules/")
+    }
+
     /// Returns the path of `inner` relative to `self`.
     ///
     /// Note: this method always strips the leading `/` from the result.


### PR DESCRIPTION
The `.contains("/node_modules/")` condition didn't work for npm, where the path might be `"node_modules/.prisma/client"`

This fixes cases of the following error with Prisma and npm
```
Prisma Client could not locate the Query Engine for runtime "rhel-openssl-3.0.x".

We detected that you are using Next.js, learn how to fix this: https://pris.ly/d/engine-not-found-nextjs.

This is likely caused by tooling that has not copied "libquery_engine-rhel-openssl-3.0.x.so.node" to the deployment folder.
Ensure that you ran `prisma generate` and that "libquery_engine-rhel-openssl-3.0.x.so.node" has been copied to "node_modules/.prisma/client".

We would appreciate if you could take the time to share some information with us.
Please help us by answering a few questions: https://pris.ly/engine-not-found-tooling-investigation

The following locations have been searched:
  /var/task/node_modules/.prisma/client
  /var/task/node_modules/@prisma/client
  /vercel/path0/node_modules/@prisma/client
  /tmp/prisma-engines

```