### PR TITLE
docs: regexp removed from middleware config

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -85,7 +85,6 @@ Additionally, the `matcher` option supports complex path specifications through 
 The `matcher` option accepts an array of objects with the following keys:
 
 - `source`: The path or pattern used to match the request paths. It can be a string for direct path matching or a pattern for more complex matching.
-- `regexp` (optional): A regular expression string that fine-tunes the matching based on the source. It provides additional control over which paths are included or excluded.
 - `locale` (optional): A boolean that, when set to `false`, ignores locale-based routing in path matching.
 - `has` (optional): Specifies conditions based on the presence of specific request elements such as headers, query parameters, or cookies.
 - `missing` (optional): Focuses on conditions where certain request elements are absent, like missing headers or cookies.

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -94,8 +94,7 @@ The `matcher` option accepts an array of objects with the following keys:
 export const config = {
   matcher: [
     {
-      source: '/api/*',
-      regexp: '^/api/(.*)',
+      source: '/api/:path*',
       locale: false,
       has: [
         { type: 'header', key: 'Authorization', value: 'Bearer Token' },


### PR DESCRIPTION
Closes https://github.com/vercel/next.js/issues/84307

It seems that the `regexp` prop is not currently supported in the matcher object (./packages/next/src/build/segment-config/middleware/middleware-config.ts → MiddlewareMatcherInputSchema). Adjusting docs accordingly.