### PR TITLE
Incorrect `eslint-config-next` Type Export - Fix

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -44,19 +44,19 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/src/index.d.ts",
       "default": "./dist/index.js"
     },
     "./core-web-vitals": {
-      "types": "./dist/core-web-vitals.d.ts",
+      "types": "./dist/src/core-web-vitals.d.ts",
       "default": "./dist/core-web-vitals.js"
     },
     "./typescript": {
-      "types": "./dist/typescript.d.ts",
+      "types": "./dist/src/typescript.d.ts",
       "default": "./dist/typescript.js"
     },
     "./parser": {
-      "types": "./dist/parser.d.ts",
+      "types": "./dist/src/parser.d.ts",
       "default": "./dist/parser.js"
     }
   }


### PR DESCRIPTION
Fix an issue where the types are not correctly linked to. They generate in the `dist/src` folder, not in the `dist` folder.

Fixes #85379

### What?
Types are not propagating via imports.

### Why?
Type Definition files are not being linked to properly.
The type def files are generating in a sub folder, `src` not in the `dist` folder.

### How?
Incorrect `package.json` configuration, the types' path is not correct.