### PR TITLE
Handle `Origin: null` headers

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -551,9 +551,10 @@ export async function handleAction({
   // When running actions the default is no-store, you can still `cache: 'force-cache'`
   workStore.fetchCache = 'default-no-store'
 
+  const originHeader = req.headers['origin']
   const originDomain =
-    typeof req.headers['origin'] === 'string'
-      ? new URL(req.headers['origin']).host
+    typeof originHeader === 'string' && originHeader !== 'null'
+      ? new URL(originHeader).host
       : undefined
   const host = parseHostHeader(req.headers)
 

--- a/packages/next/src/server/lib/router-utils/block-cross-site.ts
+++ b/packages/next/src/server/lib/router-utils/block-cross-site.ts
@@ -85,7 +85,7 @@ export const blockCrossSite = (
   // ensure websocket requests from allowed origin
   const rawOrigin = req.headers['origin']
 
-  if (rawOrigin) {
+  if (rawOrigin && rawOrigin !== 'null') {
     const parsedOrigin = parseUrl(rawOrigin)
 
     if (parsedOrigin) {

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
@@ -26,4 +26,17 @@ describe('app-dir action allowed origins', () => {
       return await browser.elementByCss('#res').text()
     }, 'hi')
   })
+
+  it('should not crash for requests from privacy sensitive contexts', async function () {
+    const res = await next.fetch('/', {
+      method: 'POST',
+      headers: {
+        Origin: 'null',
+        'Content-type': 'application/x-www-form-urlencoded',
+        'Sec-Fetch-Site': 'same-origin',
+      },
+    })
+
+    expect({ status: res.status }).toEqual({ status: 500 })
+  })
 })

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
@@ -37,6 +37,6 @@ describe('app-dir action allowed origins', () => {
       },
     })
 
-    expect({ status: res.status }).toEqual({ status: 500 })
+    expect({ status: res.status }).toEqual({ status: 200 })
   })
 })


### PR DESCRIPTION
Closes https://linear.app/vercel/issue/NEXT-4752
Closes https://github.com/vercel/next.js/issues/84786

`Origin: null` is valid per spec: https://www.rfc-editor.org/rfc/rfc6454#section-7.3

The original issue description is a bit sus to me. But then it's probably just good discipline to handle valid spec values.