### PR TITLE
fix: build CLI output not displaying Proxy (Middleware) when nodejs runtime

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4263,6 +4263,7 @@ export default async function build(
           pageExtensions: config.pageExtensions,
           buildManifest,
           middlewareManifest,
+          functionsConfigManifest,
           hasGSPAndRevalidateZero,
         })
       )

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -75,6 +75,7 @@ import { formatExpire, formatRevalidate } from './output/format'
 import type { AppRouteRouteModule } from '../server/route-modules/app-route/module'
 import { formatIssue, isRelevantWarning } from '../shared/lib/turbopack/utils'
 import type { TurbopackResult } from './swc/types'
+import type { FunctionsConfigManifest } from './index'
 
 export type ROUTER_TYPE = 'pages' | 'app'
 
@@ -274,6 +275,7 @@ export async function printTreeView(
     pagesDir,
     pageExtensions,
     middlewareManifest,
+    functionsConfigManifest,
     useStaticPages404,
     hasGSPAndRevalidateZero,
   }: {
@@ -281,6 +283,7 @@ export async function printTreeView(
     pageExtensions: PageExtensions
     buildManifest: BuildManifest
     middlewareManifest: MiddlewareManifest
+    functionsConfigManifest: FunctionsConfigManifest
     useStaticPages404: boolean
     hasGSPAndRevalidateZero: Set<string>
   }
@@ -533,8 +536,12 @@ export async function printTreeView(
     list: lists.pages,
   })
 
-  const middlewareInfo = middlewareManifest.middleware?.['/']
-  if (middlewareInfo?.files.length > 0) {
+  if (
+    middlewareManifest.middleware?.['/']?.files.length > 0 ||
+    // 'nodejs' runtime middleware or proxy is set to
+    // functions-config-manifest instead of middleware-manifest.
+    functionsConfigManifest.functions?.['/_middleware']
+  ) {
     messages.push([])
     messages.push(['ƒ Proxy (Middleware)'])
   }

--- a/test/production/app-dir/proxy-build-cli-output/app/layout.tsx
+++ b/test/production/app-dir/proxy-build-cli-output/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/proxy-build-cli-output/app/page.tsx
+++ b/test/production/app-dir/proxy-build-cli-output/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/proxy-build-cli-output/next.config.js
+++ b/test/production/app-dir/proxy-build-cli-output/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/app-dir/proxy-build-cli-output/proxy-build-cli-output.test.ts
+++ b/test/production/app-dir/proxy-build-cli-output/proxy-build-cli-output.test.ts
@@ -1,0 +1,14 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('proxy-build-cli-output', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should print proxy in the build CLI output', async () => {
+    expect(next.cliOutput).toContain('ƒ Proxy (Middleware)')
+
+    const browser = await next.browser('/foo')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+  })
+})

--- a/test/production/app-dir/proxy-build-cli-output/proxy.ts
+++ b/test/production/app-dir/proxy-build-cli-output/proxy.ts
@@ -1,0 +1,8 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export default function proxy(request: NextRequest) {
+  if (request.nextUrl.pathname === '/foo') {
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+  return NextResponse.next()
+}


### PR DESCRIPTION
`ƒ Proxy (Middleware)` on build CLI output is not displayed on Node.js Middleware/Proxy, as they were written to function-config-manifest, not middleware-manifest.

Current behavior: https://github.com/vercel/next.js/actions/runs/18875245068/job/53863328312?pr=85403#step:34:185