### PR TITLE
[CNA] Do not prompt for Turbopack

### DIFF
--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -77,7 +77,6 @@ Would you like to use React Compiler? No / Yes
 Would you like to use Tailwind CSS? No / Yes
 Would you like your code inside a `src/` directory? No / Yes
 Would you like to use App Router? (recommended) No / Yes
-Would you like to use Turbopack? (recommended) No / Yes
 Would you like to customize the import alias (`@/*` by default)? No / Yes
 What import alias would you like configured? @/*
 ```

--- a/docs/01-app/03-api-reference/06-cli/create-next-app.mdx
+++ b/docs/01-app/03-api-reference/06-cli/create-next-app.mdx
@@ -76,7 +76,6 @@ Would you like to use React Compiler? No / Yes
 Would you like to use Tailwind CSS? No / Yes
 Would you like your code inside a `src/` directory? No / Yes
 Would you like to use App Router? (recommended) No / Yes
-Would you like to use Turbopack? (recommended) No / Yes
 Would you like to customize the import alias (`@/*` by default)? No / Yes
 What import alias would you like configured? @/*
 ```

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -241,7 +241,6 @@ async function run(): Promise<void> {
       importAlias: '@/*',
       customizeImportAlias: false,
       empty: false,
-      turbopack: true,
       disableGit: false,
       reactCompiler: false,
     }
@@ -261,7 +260,6 @@ async function run(): Promise<void> {
       { key: 'tailwind', values: { true: 'Tailwind CSS' } },
       { key: 'srcDir', values: { true: 'src/ dir' } },
       { key: 'app', values: { true: 'App Router', false: 'Pages Router' } },
-      { key: 'turbopack', values: { true: 'Turbopack' } },
     ]
 
     // Helper to format settings for display based on displayConfig
@@ -545,32 +543,6 @@ async function run(): Promise<void> {
         opts.app = Boolean(app)
         preferences.app = Boolean(app)
       }
-    }
-
-    if (
-      !opts.turbopack &&
-      !args.includes('--no-turbopack') &&
-      !opts.webpack &&
-      !opts.rspack
-    ) {
-      if (skipPrompt) {
-        opts.turbopack = getPrefOrDefault('turbopack')
-      } else {
-        const styledTurbo = blue('Turbopack')
-        const { turbopack } = await prompts({
-          onState: onPromptState,
-          type: 'toggle',
-          name: 'turbopack',
-          message: `Would you like to use ${styledTurbo}? (recommended)`,
-          initial: getPrefOrDefault('turbopack'),
-          active: 'Yes',
-          inactive: 'No',
-        })
-        opts.turbopack = Boolean(turbopack)
-        preferences.turbopack = Boolean(turbopack)
-      }
-      // If Turbopack is not selected, default to Webpack
-      opts.webpack = !opts.turbopack
     }
 
     const importAliasPattern = /^[^*"]+\/\*\s*$/


### PR DESCRIPTION
Remove the Turbopack prompt as it's enabled by default. `--turbopack` option is still available to match bundler options (`--webpack`, `--rspack`) but is noop.