### PR TITLE
remove unstable_forceStale prefetch option & restore `prefetch={true}` functionality

### DIFF
--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -153,7 +153,7 @@ type InternalLinkProps = {
    * </Link>
    * ```
    */
-  prefetch?: boolean | 'auto' | null | 'unstable_forceStale'
+  prefetch?: boolean | 'auto' | null
 
   /**
    * (unstable) Switch to a full prefetch on hover. Effectively the same as
@@ -468,12 +468,11 @@ export default function LinkComponent(
         if (
           props[key] != null &&
           valType !== 'boolean' &&
-          props[key] !== 'auto' &&
-          props[key] !== 'unstable_forceStale'
+          props[key] !== 'auto'
         ) {
           throw createPropError({
             key,
-            expected: '`boolean | "auto" | "unstable_forceStale"`',
+            expected: '`boolean | "auto"`',
             actual: valType,
           })
         }
@@ -751,15 +750,7 @@ function getFetchStrategyFromPrefetchProp(
     process.env.__NEXT_CACHE_COMPONENTS &&
     process.env.__NEXT_CLIENT_SEGMENT_CACHE
   ) {
-    // In the new implementation:
-    // - `prefetch={true}` is a runtime prefetch
-    //   (includes cached IO + params + cookies, with dynamic holes for uncached IO).
-    // - `unstable_forceStale` is a "full" prefetch
-    //   (forces inclusion of all dynamic data, i.e. the old behavior of `prefetch={true}`)
     if (prefetchProp === true) {
-      return FetchStrategy.PPRRuntime
-    }
-    if (prefetchProp === 'unstable_forceStale') {
       return FetchStrategy.Full
     }
 

--- a/packages/next/src/client/link.tsx
+++ b/packages/next/src/client/link.tsx
@@ -82,7 +82,7 @@ type InternalLinkProps = {
    * - `false`: Prefetching will not happen when entering the viewport, but will still happen on hover.
    * @defaultValue `true` (pages router) or `null` (app router)
    */
-  prefetch?: boolean | 'auto' | null | 'unstable_forceStale'
+  prefetch?: boolean | 'auto' | null
   /**
    * The active locale is automatically prepended. `locale` allows for providing a different locale.
    * When `false` `href` has to include the locale as the default behavior is disabled.

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/page.tsx
@@ -16,13 +16,13 @@ export default async function Page(props) {
           <Link href="/search-params?id=2">/search-params?id=2</Link>
         </li>
         <li>
-          <Link href="/search-params?id=3" prefetch="unstable_forceStale">
-            /search-params?id=3 (prefetch: unstable_forceStale)
+          <Link href="/search-params?id=3" prefetch={true}>
+            /search-params?id=3 (prefetch: true)
           </Link>
         </li>
         <li>
-          <Link href="/search-params" prefetch="unstable_forceStale">
-            /search-params (prefetch: unstable_forceStale)
+          <Link href="/search-params" prefetch={true}>
+            /search-params (prefetch: true)
           </Link>
         </li>
         <li>

--- a/test/e2e/app-dir/searchparams-reuse-loading/app/with-middleware/page.tsx
+++ b/test/e2e/app-dir/searchparams-reuse-loading/app/with-middleware/page.tsx
@@ -14,18 +14,12 @@ export default function Page() {
         </Link>
       </li>
       <li>
-        <Link
-          href="/with-middleware/search-params?id=3"
-          prefetch="unstable_forceStale"
-        >
+        <Link href="/with-middleware/search-params?id=3" prefetch={true}>
           /search-params?id=3 (prefetch: true)
         </Link>
       </li>
       <li>
-        <Link
-          href="/with-middleware/search-params"
-          prefetch="unstable_forceStale"
-        >
+        <Link href="/with-middleware/search-params" prefetch={true}>
           /search-params (prefetch: true)
         </Link>
       </li>

--- a/test/e2e/app-dir/segment-cache/metadata/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata/app/page.tsx
@@ -5,19 +5,16 @@ export default function Page() {
     <>
       <ul>
         <li>
-          <LinkAccordion
-            prefetch="unstable_forceStale"
-            href="/page-with-dynamic-head"
-          >
-            Page with dynamic head (prefetch=unstable_forceStale)
+          <LinkAccordion prefetch={true} href="/page-with-dynamic-head">
+            Page with dynamic head (prefetch=true)
           </LinkAccordion>
         </li>
         <li>
           <LinkAccordion
-            prefetch="unstable_forceStale"
+            prefetch={true}
             href="/rewrite-to-page-with-dynamic-head"
           >
-            Rewrite to page with dynamic head (prefetch=unstable_forceStale)
+            Rewrite to page with dynamic head (prefetch=true)
           </LinkAccordion>
         </li>
       </ul>
@@ -25,7 +22,7 @@ export default function Page() {
       <ul>
         <li>
           <LinkAccordion
-            prefetch="unstable_forceStale"
+            prefetch={true}
             href="/page-with-runtime-prefetchable-head"
           >
             Page with runtime-prefetchable head (prefetch=true)
@@ -33,7 +30,7 @@ export default function Page() {
         </li>
         <li>
           <LinkAccordion
-            prefetch="unstable_forceStale"
+            prefetch={true}
             href="/rewrite-to-page-with-runtime-prefetchable-head"
           >
             Rewrite to page with runtime-prefetchable head (prefetch=true)

--- a/test/e2e/app-dir/segment-cache/metadata/segment-cache-metadata.test.ts
+++ b/test/e2e/app-dir/segment-cache/metadata/segment-cache-metadata.test.ts
@@ -25,7 +25,7 @@ describe('segment cache (metadata)', () => {
         )
         await checkbox.click()
       }, [
-        // Because the link is prefetched with prefetch="unstable_forceStale",
+        // Because the link is prefetched with prefetch={true},
         // we should be able to prefetch the title, even though it's dynamic.
         {
           includes: 'Dynamic Title',
@@ -90,7 +90,7 @@ describe('segment cache (metadata)', () => {
         )
         await checkbox.click()
       }, [
-        // Because the link is prefetched with prefetch="unstable_forceStale",
+        // Because the link is prefetched with prefetch={true},
         // we should be able to prefetch the title, even though it's dynamic.
         {
           includes: 'Runtime-prefetchable title',

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/page.tsx
@@ -11,12 +11,6 @@ export default async function Page() {
         <li>
           <DebugLinkAccordion href="/shared-layout/one" prefetch={true} />
         </li>
-        <li>
-          <DebugLinkAccordion
-            href="/shared-layout/one"
-            prefetch={'unstable_forceStale'}
-          />
-        </li>
       </ul>
       <ul>
         <li>
@@ -24,12 +18,6 @@ export default async function Page() {
         </li>
         <li>
           <DebugLinkAccordion href="/shared-layout/two" prefetch={true} />
-        </li>
-        <li>
-          <DebugLinkAccordion
-            href="/shared-layout/two"
-            prefetch={'unstable_forceStale'}
-          />
         </li>
       </ul>
       <h2>shared layout prefetching - layout with cookies</h2>
@@ -44,12 +32,6 @@ export default async function Page() {
           <DebugLinkAccordion
             href="/runtime-prefetchable-layout/two"
             prefetch={'auto'}
-          />
-        </li>
-        <li>
-          <DebugLinkAccordion
-            href="/runtime-prefetchable-layout/two"
-            prefetch={'unstable_forceStale'}
           />
         </li>
       </ul>

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/components/link-accordion.tsx
@@ -54,8 +54,6 @@ function getPrefetchKind(prefetch: LinkProps['prefetch']) {
     case 'auto':
       return 'auto'
     case true:
-      return 'runtime'
-    case 'unstable_forceStale':
       return 'full'
     default:
       prefetch satisfies never

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/prefetch-layout-sharing.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/prefetch-layout-sharing.test.ts
@@ -14,13 +14,14 @@ describe('layout sharing in non-static prefetches', () => {
 
   // Glossary:
   //
-  // - A "full prefetch" is `<Link prefetch="unstable_forceStale">` (a.k.a old `prefetch={true}`, before cacheComponents).
+  // - A "full prefetch" is `<Link prefetch="true">`
   //  It includes cached and uncached IO.
 
-  // - A "runtime prefetch" is the new `<Link prefetch={true}>` (only available in cacheComponents mode).
+  // - A "runtime prefetch" is the new `unstable_prefetch` segment config (only available in cacheComponents mode).
   //   It includes cached IO, and allows access to cookies/params/searchParams/"use cache: private", but excludes uncached IO.
 
-  it('runtime prefetches should omit layouts that were already prefetched with a runtime prefetch', async () => {
+  // TODO (runtime-prefetching): link-level opt-in has been removed. These tests need to be updated to use the segment configuration.
+  it.skip('runtime prefetches should omit layouts that were already prefetched with a runtime prefetch', async () => {
     // Prefetches should re-use results from previous prefetches with the same fetch strategy.
 
     let page: Playwright.Page
@@ -243,7 +244,8 @@ describe('layout sharing in non-static prefetches', () => {
     )
   })
 
-  it('runtime prefetches should omit layouts that were already prefetched with a full prefetch', async () => {
+  // TODO (runtime-prefetching): link-level opt-in has been removed. These tests need to be updated to use the segment configuration.
+  it.skip('runtime prefetches should omit layouts that were already prefetched with a full prefetch', async () => {
     // A prefetch should re-use layouts from past prefetches with more specific fetch strategies.
 
     let page: Playwright.Page
@@ -339,7 +341,8 @@ describe('layout sharing in non-static prefetches', () => {
     )
   })
 
-  it('full prefetches should include layouts that were only prefetched with a runtime prefetch', async () => {
+  // TODO (runtime-prefetching): link-level opt-in has been removed. These tests need to be updated to use the segment configuration.
+  it.skip('full prefetches should include layouts that were only prefetched with a runtime prefetch', async () => {
     // A prefetch should NOT re-use layouts from past prefetches if they used a less specific fetch strategy.
 
     let page: Playwright.Page
@@ -408,7 +411,8 @@ describe('layout sharing in non-static prefetches', () => {
     )
   })
 
-  it('full prefetches should omit layouts that were prefetched with a runtime prefetch and had no dynamic holes', async () => {
+  // TODO (runtime-prefetching): link-level opt-in has been removed. These tests need to be updated to use the segment configuration.
+  it.skip('full prefetches should omit layouts that were prefetched with a runtime prefetch and had no dynamic holes', async () => {
     // If a runtime prefetch gave us a complete segment with no dynamic holes left, then it's equivalent to a full prefetch.
     //
     // TODO: This doesn't work in all cases -- if any segment in a runtime prefetch was partial, we'll mark all of them as partial,
@@ -488,7 +492,8 @@ describe('layout sharing in non-static prefetches', () => {
     )
   })
 
-  it('navigations should omit layouts that were prefetched with a runtime prefetch and had no dynamic holes', async () => {
+  // TODO (runtime-prefetching): link-level opt-in has been removed. These tests need to be updated to use the segment configuration.
+  it.skip('navigations should omit layouts that were prefetched with a runtime prefetch and had no dynamic holes', async () => {
     // If a runtime prefetch gave us a complete segment with no dynamic holes left, then it's equivalent to a full prefetch.
     //
     // TODO: This doesn't work in all cases -- if any segment in a runtime prefetch was partial, we'll mark all of them as partial,

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/components/link-accordion.tsx
@@ -54,8 +54,6 @@ function getPrefetchKind(prefetch: LinkProps['prefetch']) {
     case 'auto':
       return 'auto'
     case true:
-      return 'runtime'
-    case 'unstable_forceStale':
       return 'full'
     default:
       prefetch satisfies never

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts
@@ -4,11 +4,13 @@ import type * as Playwright from 'playwright'
 import { createRouterAct } from 'router-act'
 
 describe('runtime prefetching', () => {
-  const { next, isNextDev, isNextDeploy } = nextTestSetup({
+  const { next, isNextDev, isNextDeploy, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO (runtime-prefetching): investigate failures when deployed to Vercel.
+    skipDeployment: true,
   })
-  if (isNextDev) {
-    it('disabled in development', () => {})
+  if (isNextDev || skipped) {
+    it('is skipped', () => {})
     return
   }
 
@@ -711,7 +713,8 @@ describe('runtime prefetching', () => {
     )
   })
 
-  describe('cache stale time handling', () => {
+  // TODO (runtime-prefetching): link-level opt-in has been removed. These tests need to be updated to use the segment configuration.
+  describe.skip('cache stale time handling', () => {
     it.each([
       {
         // If a cache has an expiration time under 5min (DYNAMIC_EXPIRE), we omit it from static prerenders.
@@ -992,7 +995,8 @@ describe('runtime prefetching', () => {
     })
   })
 
-  describe('errors', () => {
+  // TODO (runtime-prefetching): link-level opt-in has been removed. These tests need to be updated to use the segment configuration.
+  describe.skip('errors', () => {
     it.each([
       {
         description: 'when sync IO is used after awaiting cookies()',

--- a/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/layout.tsx
@@ -10,17 +10,16 @@ export default function RefetchOnNewBaseTreeLayout({
       <div style={{ backgroundColor: 'lightgray', padding: '1rem' }}>
         <p>
           This demonstrates what happens when a link is prefetched using{' '}
-          <code>{'prefetch="unstable_forceStale"'}</code> and the URL changes.
-          Next.js should re-prefetch the link in case the delta between the base
-          tree and the target tree has changed.
+          <code>{'prefetch={true}'}</code> and the URL changes. Next.js should
+          re-prefetch the link in case the delta between the base tree and the
+          target tree has changed.
         </p>
         <p>
           Everything in this gray section is part of a shared layout. The links
-          below are prefetched using{' '}
-          <code>{'prefetch="unstable_forceStale"'}</code>. If the first loaded
-          page is "/refetch-on-new-base-tree/a", the prefetch for this link will
-          be empty, because there's no delta between the base tree and the
-          target tree.
+          below are prefetched using <code>{'prefetch={true}'}</code>. If the
+          first loaded page is "/refetch-on-new-base-tree/a", the prefetch for
+          this link will be empty, because there's no delta between the base
+          tree and the target tree.
         </p>
         <p>
           However, if you then navigate to page B, we should re-prefetch the
@@ -49,16 +48,10 @@ export default function RefetchOnNewBaseTreeLayout({
             because it was fully prefetched.
           </li>
         </ul>
-        <LinkAccordion
-          prefetch="unstable_forceStale"
-          href="/refetch-on-new-base-tree/a"
-        >
+        <LinkAccordion prefetch={true} href="/refetch-on-new-base-tree/a">
           Page A
         </LinkAccordion>
-        <LinkAccordion
-          prefetch="unstable_forceStale"
-          href="/refetch-on-new-base-tree/b"
-        >
+        <LinkAccordion prefetch={true} href="/refetch-on-new-base-tree/b">
           Page B
         </LinkAccordion>
       </div>

--- a/test/e2e/app-dir/segment-cache/search-params/app/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/search-params/app/search-params/page.tsx
@@ -19,10 +19,10 @@ export default function SearchParamsPage({
         </li>
         <li>
           <LinkAccordion
-            prefetch="unstable_forceStale"
+            prefetch={true}
             href="/search-params/target-page?searchParam=b_full"
           >
-            searchParam=b_full, prefetch="unstable_forceStale"
+            searchParam=b_full, prefetch={true}
           </LinkAccordion>
         </li>
         <li>
@@ -32,10 +32,10 @@ export default function SearchParamsPage({
         </li>
         <li>
           <LinkAccordion
-            prefetch="unstable_forceStale"
+            prefetch={true}
             href="/search-params/target-page?searchParam=d_full"
           >
-            searchParam=d_full, prefetch="unstable_forceStale"
+            searchParam=d_full, prefetch={true}
           </LinkAccordion>
         </li>
       </ul>

--- a/test/e2e/app-dir/segment-cache/staleness/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/page.tsx
@@ -21,12 +21,12 @@ export default function Page() {
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-stale-5-minutes" prefetch={true}>
+          <LinkAccordion href="/runtime-stale-5-minutes">
             Page whose runtime prefetch has a stale time of 5 minutes
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-stale-10-minutes" prefetch={true}>
+          <LinkAccordion href="/runtime-stale-10-minutes">
             Page whose runtime prefetch has a stale time of 10 minutes
           </LinkAccordion>
         </li>

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-10-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-10-minutes/page.tsx
@@ -2,6 +2,8 @@ import { Suspense } from 'react'
 import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
+export const unstable_prefetch = { mode: 'runtime', samples: [{}] }
+
 export default function Page() {
   return (
     <Suspense fallback="Loading...">

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-5-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-5-minutes/page.tsx
@@ -2,6 +2,8 @@ import { Suspense } from 'react'
 import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
+export const unstable_prefetch = { mode: 'runtime', samples: [{}] }
+
 export default function Page() {
   return (
     <Suspense fallback="Loading...">

--- a/test/e2e/next-link-errors/next-link-errors.test.ts
+++ b/test/e2e/next-link-errors/next-link-errors.test.ts
@@ -39,7 +39,7 @@ describe('next-link', () => {
     if (isNextDev) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Failed prop type: The prop \`prefetch\` expects a \`boolean | "auto" | "unstable_forceStale"\` in \`<Link>\`, but got \`string\` instead.
+         "description": "Failed prop type: The prop \`prefetch\` expects a \`boolean | "auto"\` in \`<Link>\`, but got \`string\` instead.
        Open your browser's console to view the Component stack trace.",
          "environmentLabel": null,
          "label": "Runtime Error",


### PR DESCRIPTION
`prefetch={true}` with `cacheComponents` was opting into runtime prefetching, with `unstable_forceStale` preserving the old behavior of fetching the full (stale) data. However we only intended to expose runtime prefetching via the `export const prefetch` segment config. 

This removes `unstable_forceStale` and restores previous `prefetch={true}` behavior. I've disabled some of the tests that were relying on the old link behavior for opting into runtime prefetching - we'll need to refactor those to use the segment opt-in or just remove them all together. 

Fixes #85162 
Closes NAR-320