### PR TITLE
Ensure the pages router /_error page is included in development

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1341,7 +1341,6 @@ impl Project {
                 EndpointGroup::from(instrumentation.edge),
             ));
         }
-
         for (key, route) in entrypoints.routes.iter() {
             match route {
                 Route::Page {
@@ -1407,7 +1406,6 @@ impl Project {
                 }
             }
         }
-
         if add_pages_entries {
             endpoint_groups.push((
                 EndpointGroupKey::PagesError,

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1406,6 +1406,11 @@ impl Project {
                 }
             }
         }
+        // For app-only projects in dev mode, ensure pages shared endpoints
+        // (like /_error) are available as fallbacks for error handling
+        if !app_dir_only && !add_pages_entries && self.next_mode().await?.is_development() {
+            add_pages_entries = true;
+        }
         if add_pages_entries {
             endpoint_groups.push((
                 EndpointGroupKey::PagesError,

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -587,7 +587,7 @@ describe('app-dir - server source maps', () => {
           // Feel free to adjust these locations. They're just here to showcase
           // sourcemapping is broken on invalid sources.
           '' +
-            `\nwebpack-internal:///(rsc)/./app/bad-sourcemap/page.js: Invalid source map. Only conformant source maps can be used to find the original code. Cause: TypeError [ERR_INVALID_ARG_TYPE]: The "payload" argument must be of type object. Received null` +
+            `webpack-internal:///(rsc)/./app/bad-sourcemap/page.js: Invalid source map. Only conformant source maps can be used to find the original code. Cause: TypeError [ERR_INVALID_ARG_TYPE]: The "payload" argument must be of type object. Received null` +
             '\nError: bad-sourcemap' +
             '\n    at logError (webpack-internal:///(rsc)/./app/bad-sourcemap/page.js:12:19)' +
             '\n    at Page (webpack-internal:///(rsc)/./app/bad-sourcemap/page.js:15:5)'


### PR DESCRIPTION
Accumulate `/_error` endpoints in development mode to support fallback error pages.

In an app router only app, the pages router `/_error` page is still used to display the dev overlay when there is a compilation error during initial rendering of a route.  This isn't ideal but we do need some kind of fallback error page to display errors that affect bootstrapping the app router.

Accumulating this as an endpoint here is important to enable 'whole_app_module_graph' modes.  It is part of the app so the error page needs to be included.