### PR TITLE
[test] Speed up prefetching suite

### DIFF
--- a/test/e2e/app-dir/app-prefetch/app/dashboard/[id]/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/dashboard/[id]/page.js
@@ -14,8 +14,7 @@ export function generateStaticParams() {
 
 export default function IdPage(props) {
   const params = use(props.params)
-  const data = use(getData())
-  console.log(data)
+  use(getData())
 
   if (params.id === '123') {
     return (

--- a/test/e2e/app-dir/app-prefetch/app/layout.js
+++ b/test/e2e/app-dir/app-prefetch/app/layout.js
@@ -2,7 +2,6 @@ export default function Root({ children }) {
   return (
     <html>
       <head>
-        <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
         <title>Hello World</title>
         <script
           dangerouslySetInnerHTML={{

--- a/test/e2e/app-dir/app-prefetch/app/prefetch-auto-route-groups/layout.tsx
+++ b/test/e2e/app-dir/app-prefetch/app/prefetch-auto-route-groups/layout.tsx
@@ -5,22 +5,16 @@ import Link from 'next/link'
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <>
-      <nav className="bg-gray-800">
-        <ul className="flex">
-          <li className="mr-6">
-            <Link href="/prefetch-auto-route-groups">
-              <p className="text-white hover:text-gray-300">Dashboard</p>
-            </Link>
+      <nav style={{ border: '1px solid #1f2937' }}>
+        <ul style={{ display: 'flex' }}>
+          <li style={{ marginRight: '1.5rem' }}>
+            <Link href="/prefetch-auto-route-groups">Dashboard</Link>
           </li>
-          <li className="mr-6">
-            <Link href="/prefetch-auto-route-groups/sub/foo">
-              <p className="text-white hover:text-gray-300">Foo</p>
-            </Link>
+          <li style={{ marginRight: '1.5rem' }}>
+            <Link href="/prefetch-auto-route-groups/sub/foo">Foo</Link>
           </li>
-          <li className="mr-6">
-            <Link href="/prefetch-auto-route-groups/sub/bar">
-              <p className="text-white hover:text-gray-300">Bar</p>
-            </Link>
+          <li style={{ marginRight: '1.5rem' }}>
+            <Link href="/prefetch-auto-route-groups/sub/bar">Bar</Link>
           </li>
         </ul>
       </nav>

--- a/test/e2e/app-dir/app-prefetch/app/prefetch-auto/[slug]/layout.js
+++ b/test/e2e/app-dir/app-prefetch/app/prefetch-auto/[slug]/layout.js
@@ -1,12 +1,10 @@
-import Link from 'next/link'
-
 export const dynamic = 'force-dynamic'
 
 function getData() {
   const res = new Promise((resolve) => {
     setTimeout(() => {
       resolve({ message: 'Layout Data!' })
-    }, 2000)
+    }, 1000)
   })
   return res
 }
@@ -17,9 +15,6 @@ export default async function Layout({ children }) {
   return (
     <div>
       <h1>Layout</h1>
-      <Link prefetch={undefined} href="/prefetch-auto/justputit">
-        Prefetch Link
-      </Link>
       {children}
       <h3>{JSON.stringify(result)}</h3>
     </div>

--- a/test/e2e/app-dir/app-prefetch/app/prefetch-auto/[slug]/page.js
+++ b/test/e2e/app-dir/app-prefetch/app/prefetch-auto/[slug]/page.js
@@ -4,7 +4,7 @@ function getData() {
   const res = new Promise((resolve) => {
     setTimeout(() => {
       resolve({ message: 'Page Data!' })
-    }, 2000)
+    }, 1000)
   })
   return res
 }

--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -314,22 +314,20 @@ describe('app dir - prefetching', () => {
       async () => {
         const reveal = await browser.elementByCss('#accordion-to-dynamic-page')
         await reveal.click()
-        await browser.waitForElementByCss('#to-dynamic-page')
-        return await browser.elementByCss('#to-dynamic-page')
+        return browser.elementByCss('#to-dynamic-page')
       },
       { includes: 'Loading Prefetch Auto' }
     )
 
     // Click the link to navigate - should trigger dynamic data fetch
-    await act(
+    const loadingText = await act(
       async () => {
         await link.click()
-        await browser.waitForElementByCss('#loading-text')
-        const loadingText = await browser.elementByCss('#loading-text').text()
-        expect(loadingText).toBe('Loading Prefetch Auto')
+        return browser.elementByCss('#loading-text').text()
       },
       { includes: 'prefetch-auto-page-data' }
     )
+    expect(loadingText).toBe('Loading Prefetch Auto')
 
     // Wait for final data to appear
     await browser.waitForElementByCss('#prefetch-auto-page-data')


### PR DESCRIPTION
I couldn't figure out what exactly was the cause of `prefetching should immediately render the loading state for a dynamic segment when fetched from higher up in the tree` being flaky. Though this should make it a lot faster (4s instead of 10s).

The main idea is to remove things that aren't being asserted on. Reducing idle time of async data is important since `act` will wait for all requests to settle that are triggered during scope. If a prefetch takes 2s, then the `act` will take 2s. Even if we discard the prefetch due to a navigation within that `act` scope.