### PR TITLE
[test] Exclude likely Next.js internal Components from component stacks in Redbox assertions

### DIFF
--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/layout.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(default)/layout.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react'
-export default function Root({ children }: { children: ReactNode }) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html>
       <body>{children}</body>

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(extra-attributes)/layout.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(extra-attributes)/layout.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react'
 
 const isServer = typeof window === 'undefined'
 
-export default function Root({ children }: { children: ReactNode }) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html {...(isServer ? { className: 'server-html' } : undefined)}>
       <body>{children}</body>

--- a/test/development/acceptance-app/fixtures/hydration-errors/app/(script-under-html)/layout.tsx
+++ b/test/development/acceptance-app/fixtures/hydration-errors/app/(script-under-html)/layout.tsx
@@ -1,7 +1,7 @@
 import Script from 'next/script'
 import { ReactNode } from 'react'
 
-export default function Root({ children }: { children: ReactNode }) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html>
       <body>{children}</body>

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -9,8 +9,6 @@ import {
   retry,
 } from 'next-test-utils'
 
-const pprEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
-
 describe('Error overlay for hydration errors in App router', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'hydration-errors')),
@@ -41,18 +39,18 @@ describe('Error overlay for hydration errors in App router', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "componentStack": "...
-         <RenderFromTemplateContext>
-           <ScrollAndFocusHandler segmentPath={[...]}>
-             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary name="text-misma..." loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/text-mism..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                           <SegmentViewNode type="page" pagePath="(default)/...">
-                             <SegmentTrieNode>
-                             <ClientPageRoot Component={function Mismatch} serverProvidedParams={{...}}>
+         <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                             <Next.js Internal Component>
                                <Mismatch params={Promise} searchParams={Promise}>
                                  <div className="parent">
                                    <main className="child">
@@ -103,18 +101,18 @@ describe('Error overlay for hydration errors in App router', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "componentStack": "...
-         <RenderFromTemplateContext>
-           <ScrollAndFocusHandler segmentPath={[...]}>
-             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary name="extra-elem..." loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/extra-ele..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                           <SegmentViewNode type="page" pagePath="(default)/...">
-                             <SegmentTrieNode>
-                             <ClientPageRoot Component={function Mismatch} serverProvidedParams={{...}}>
+         <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                             <Next.js Internal Component>
                                <Mismatch params={Promise} searchParams={Promise}>
                                  <div className="parent">
      +                             <main className="only">
@@ -142,21 +140,21 @@ describe('Error overlay for hydration errors in App router', () => {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
          "componentStack": "...
-           <ScrollAndFocusHandler segmentPath={[...]}>
-             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary name="/" loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                     <HTTPAccessFallbackErrorBoundary pathname="/extra-att..." notFound={<SegmentViewNode>} ...>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/extra-att..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                             <SegmentViewNode type="layout" pagePath="(extra-att...">
-                               <SegmentTrieNode>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                               <Next.js Internal Component>
                                <script>
                                <script>
-                               <ClientSegmentRoot Component={function Root} slots={{...}} ...>
-                                 <Root params={Promise}>
+                               <Next.js Internal Component>
+                                 <RootLayout params={Promise}>
                                    <html
        -                             className="server-html"
                                    >
@@ -165,12 +163,12 @@ describe('Error overlay for hydration errors in App router', () => {
          "description": "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Console Error",
-         "source": "app/(extra-attributes)/layout.tsx (9:5) @ Root
+         "source": "app/(extra-attributes)/layout.tsx (9:5) @ RootLayout
        >  9 |     <html {...(isServer ? { className: 'server-html' } : undefined)}>
             |     ^",
          "stack": [
            "html <anonymous>",
-           "Root app/(extra-attributes)/layout.tsx (9:5)",
+           "RootLayout app/(extra-attributes)/layout.tsx (9:5)",
          ],
        }
       `)
@@ -178,19 +176,19 @@ describe('Error overlay for hydration errors in App router', () => {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
          "componentStack": "...
-           <ScrollAndFocusHandler segmentPath={[...]}>
-             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary name="/" loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                     <HTTPAccessFallbackErrorBoundary pathname="/extra-att..." notFound={<SegmentViewNode>} ...>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/extra-att..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                             <SegmentViewNode type="layout" pagePath="(extra-att...">
-                               <SegmentTrieNode>
-                               <ClientSegmentRoot Component={function Root} slots={{...}} ...>
-                                 <Root params={Promise}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                               <Next.js Internal Component>
+                               <Next.js Internal Component>
+                                 <RootLayout params={Promise}>
                                    <html
        -                             className="server-html"
                                    >
@@ -199,12 +197,12 @@ describe('Error overlay for hydration errors in App router', () => {
          "description": "A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:",
          "environmentLabel": null,
          "label": "Console Error",
-         "source": "app/(extra-attributes)/layout.tsx (9:5) @ Root
+         "source": "app/(extra-attributes)/layout.tsx (9:5) @ RootLayout
        >  9 |     <html {...(isServer ? { className: 'server-html' } : undefined)}>
             |     ^",
          "stack": [
            "html <anonymous>",
-           "Root app/(extra-attributes)/layout.tsx (9:5)",
+           "RootLayout app/(extra-attributes)/layout.tsx (9:5)",
          ],
        }
       `)
@@ -217,18 +215,18 @@ describe('Error overlay for hydration errors in App router', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "componentStack": "...
-         <RenderFromTemplateContext>
-           <ScrollAndFocusHandler segmentPath={[...]}>
-             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary name="extra-text..." loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/extra-tex..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                           <SegmentViewNode type="page" pagePath="(default)/...">
-                             <SegmentTrieNode>
-                             <ClientPageRoot Component={function Mismatch} serverProvidedParams={{...}}>
+         <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                             <Next.js Internal Component>
                                <Mismatch params={Promise} searchParams={Promise}>
                                  <div className="parent">
                                    <header>
@@ -258,18 +256,18 @@ describe('Error overlay for hydration errors in App router', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "componentStack": "...
-         <RenderFromTemplateContext>
-           <ScrollAndFocusHandler segmentPath={[...]}>
-             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary name="extra-elem..." loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/extra-ele..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                           <SegmentViewNode type="page" pagePath="(default)/...">
-                             <SegmentTrieNode>
-                             <ClientPageRoot Component={function Mismatch} serverProvidedParams={{...}}>
+         <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                             <Next.js Internal Component>
                                <Mismatch params={Promise} searchParams={Promise}>
                                  <div className="parent">
      -                             <main className="only">
@@ -296,18 +294,18 @@ describe('Error overlay for hydration errors in App router', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "componentStack": "...
-         <RenderFromTemplateContext>
-           <ScrollAndFocusHandler segmentPath={[...]}>
-             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary name="extra-text..." loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/extra-tex..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                           <SegmentViewNode type="page" pagePath="(default)/...">
-                             <SegmentTrieNode>
-                             <ClientPageRoot Component={function Mismatch} serverProvidedParams={{...}}>
+         <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                             <Next.js Internal Component>
                                <Mismatch params={Promise} searchParams={Promise}>
                                  <div className="parent">
      -                             only
@@ -339,17 +337,17 @@ describe('Error overlay for hydration errors in App router', () => {
      [
        {
          "componentStack": "...
-         <ScrollAndFocusHandler segmentPath={[...]}>
-           <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-             <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-               <LoadingBoundary name="extra-text..." loading={null}>
-                 <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                   <RedirectBoundary>
-                     <RedirectErrorBoundary router={{...}}>
-                       <InnerLayoutRouter url="/extra-tex..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                         <SegmentViewNode type="page" pagePath="(default)/...">
-                           <SegmentTrieNode>
-                           <ClientPageRoot Component={function Page} serverProvidedParams={{...}}>
+         <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                           <Next.js Internal Component>
                              <Page params={Promise} searchParams={Promise}>
                                <table>
                                  <tbody>
@@ -372,18 +370,18 @@ describe('Error overlay for hydration errors in App router', () => {
        },
        {
          "componentStack": "...
-         <RenderFromTemplateContext>
-           <ScrollAndFocusHandler segmentPath={[...]}>
-             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary name="extra-text..." loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/extra-tex..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                           <SegmentViewNode type="page" pagePath="(default)/...">
-                             <SegmentTrieNode>
-                             <ClientPageRoot Component={function Page} serverProvidedParams={{...}}>
+         <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                             <Next.js Internal Component>
                                <Page params={Promise} searchParams={Promise}>
      +                           <table>
      -                           test
@@ -411,18 +409,18 @@ describe('Error overlay for hydration errors in App router', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "componentStack": "...
-         <RenderFromTemplateContext>
-           <ScrollAndFocusHandler segmentPath={[...]}>
-             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary name="extra-whit..." loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/extra-whi..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                           <SegmentViewNode type="page" pagePath="(default)/...">
-                             <SegmentTrieNode>
-                             <ClientPageRoot Component={function Page} serverProvidedParams={{...}}>
+         <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                             <Next.js Internal Component>
                                <Page params={Promise} searchParams={Promise}>
      >                           <table>
      >                             {" "}
@@ -451,16 +449,16 @@ describe('Error overlay for hydration errors in App router', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      {
        "componentStack": "...
-         <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-           <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-             <LoadingBoundary name="extra-node..." loading={null}>
-               <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                 <RedirectBoundary>
-                   <RedirectErrorBoundary router={{...}}>
-                     <InnerLayoutRouter url="/extra-nod..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                       <SegmentViewNode type="page" pagePath="(default)/...">
-                         <SegmentTrieNode>
-                         <ClientPageRoot Component={function Mismatch} serverProvidedParams={{...}}>
+         <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                         <Next.js Internal Component>
                            <Mismatch params={Promise} searchParams={Promise}>
                              <div className="parent">
                                <Suspense fallback={<p>}>
@@ -506,18 +504,18 @@ describe('Error overlay for hydration errors in App router', () => {
      [
        {
          "componentStack": "...
-         <RenderFromTemplateContext>
-           <ScrollAndFocusHandler segmentPath={[...]}>
-             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary name="p-under-p/" loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/p-under-p" tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                           <SegmentViewNode type="page" pagePath="(default)/...">
-                             <SegmentTrieNode>
-                             <ClientPageRoot Component={function Page} serverProvidedParams={{...}}>
+         <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                             <Next.js Internal Component>
                                <Page params={Promise} searchParams={Promise}>
      >                           <p>
      >                             <p>
@@ -563,17 +561,17 @@ describe('Error overlay for hydration errors in App router', () => {
      [
        {
          "componentStack": "...
-         <ScrollAndFocusHandler segmentPath={[...]}>
-           <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-             <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-               <LoadingBoundary name="div-under-p/" loading={null}>
-                 <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                   <RedirectBoundary>
-                     <RedirectErrorBoundary router={{...}}>
-                       <InnerLayoutRouter url="/div-under-p" tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                         <SegmentViewNode type="page" pagePath="(default)/...">
-                           <SegmentTrieNode>
-                           <ClientPageRoot Component={function Page} serverProvidedParams={{...}}>
+         <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                           <Next.js Internal Component>
                              <Page params={Promise} searchParams={Promise}>
                                <div>
                                  <div>
@@ -621,18 +619,18 @@ describe('Error overlay for hydration errors in App router', () => {
      [
        {
          "componentStack": "...
-         <RenderFromTemplateContext>
-           <ScrollAndFocusHandler segmentPath={[...]}>
-             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary name="tr-under-div/" loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/tr-under-div" tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                           <SegmentViewNode type="page" pagePath="(default)/...">
-                             <SegmentTrieNode>
-                             <ClientPageRoot Component={function Page} serverProvidedParams={{...}}>
+         <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                             <Next.js Internal Component>
                                <Page params={Promise} searchParams={Promise}>
      >                           <div>
      >                             <tr>
@@ -678,18 +676,18 @@ describe('Error overlay for hydration errors in App router', () => {
      [
        {
          "componentStack": "...
-         <RenderFromTemplateContext>
-           <ScrollAndFocusHandler segmentPath={[...]}>
-             <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-               <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                 <LoadingBoundary name="bad-nesting/" loading={null}>
-                   <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                     <RedirectBoundary>
-                       <RedirectErrorBoundary router={{...}}>
-                         <InnerLayoutRouter url="/bad-nesting" tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                           <SegmentViewNode type="page" pagePath="(default)/...">
-                             <SegmentTrieNode>
-                             <ClientPageRoot Component={function Page} serverProvidedParams={{...}}>
+         <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                             <Next.js Internal Component>
                                <Page params={Promise} searchParams={Promise}>
      >                           <p>
                                    <span>
@@ -751,264 +749,132 @@ describe('Error overlay for hydration errors in App router', () => {
       )
     })
 
-    if (pprEnabled) {
-      if (isTurbopack) {
-        await expect(browser).toDisplayCollapsedRedbox(`
-         [
-           {
-             "description": "Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.",
-             "environmentLabel": null,
-             "label": "Console Error",
-             "source": "app/(script-under-html)/layout.tsx (8:7) @ Root
-         >  8 |       <Script
-              |       ^",
-             "stack": [
-               "Root app/(script-under-html)/layout.tsx (8:7)",
-             ],
-           },
-           {
-             "componentStack": "...
-             <RenderFromTemplateContext>
-               <ScrollAndFocusHandler segmentPath={[...]}>
-                 <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                   <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                     <LoadingBoundary loading={null}>
-                       <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                         <HTTPAccessFallbackErrorBoundary pathname="/script-un..." notFound={<SegmentViewNode>} ...>
-                           <RedirectBoundary>
-                             <RedirectErrorBoundary router={{...}}>
-                               <InnerLayoutRouter url="/script-un..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
-                                 <SegmentViewNode type="layout" pagePath="(script-un...">
-                                   <SegmentTrieNode>
-                                   <script>
-                                   <script>
-                                   <Root>
-         >                           <html>
-                                       <body>
-                                       <Script src="https://ex..." strategy="beforeInte...">
-         >                               <script nonce={undefined} dangerouslySetInnerHTML={{__html:"(self.__ne..."}}>
-                               ...
-                   ...
-             ...",
-             "description": "In HTML, <script> cannot be a child of <html>.
-         This will cause a hydration error.",
-             "environmentLabel": null,
-             "label": "Console Error",
-             "source": "app/(script-under-html)/layout.tsx (8:7) @ Root
-         >  8 |       <Script
-              |       ^",
-             "stack": [
-               "script <anonymous>",
-               "Root app/(script-under-html)/layout.tsx (8:7)",
-             ],
-           },
-           {
-             "description": "<html> cannot contain a nested <script>.
-         See this log for the ancestor stack trace.",
-             "environmentLabel": null,
-             "label": "Console Error",
-             "source": "app/(script-under-html)/layout.tsx (6:5) @ Root
-         > 6 |     <html>
-             |     ^",
-             "stack": [
-               "html <anonymous>",
-               "Root app/(script-under-html)/layout.tsx (6:5)",
-             ],
-           },
-         ]
-        `)
-      } else {
-        await expect(browser).toDisplayCollapsedRedbox(`
-         [
-           {
-             "description": "Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.",
-             "environmentLabel": null,
-             "label": "Console Error",
-             "source": "app/(script-under-html)/layout.tsx (8:7) @ Root
-         >  8 |       <Script
-              |       ^",
-             "stack": [
-               "Root app/(script-under-html)/layout.tsx (8:7)",
-             ],
-           },
-           {
-             "componentStack": "...
-             <RenderFromTemplateContext>
-               <ScrollAndFocusHandler segmentPath={[...]}>
-                 <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                   <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                     <LoadingBoundary loading={null}>
-                       <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                         <HTTPAccessFallbackErrorBoundary pathname="/script-un..." notFound={<SegmentViewNode>} ...>
-                           <RedirectBoundary>
-                             <RedirectErrorBoundary router={{...}}>
-                               <InnerLayoutRouter url="/script-un..." tree={[...]} cacheNode={{lazyData:null, ...}} ...>
-                                 <SegmentViewNode type="layout" pagePath="(script-un...">
-                                   <SegmentTrieNode>
-                                   <Root>
-         >                           <html>
-                                       <body>
-                                       <Script src="https://ex..." strategy="beforeInte...">
-         >                               <script nonce={undefined} dangerouslySetInnerHTML={{__html:"(self.__ne..."}}>
-                               ...
-                   ...
-             ...",
-             "description": "In HTML, <script> cannot be a child of <html>.
-         This will cause a hydration error.",
-             "environmentLabel": null,
-             "label": "Console Error",
-             "source": "app/(script-under-html)/layout.tsx (8:7) @ Root
-         >  8 |       <Script
-              |       ^",
-             "stack": [
-               "script <anonymous>",
-               "Root app/(script-under-html)/layout.tsx (8:7)",
-             ],
-           },
-           {
-             "description": "<html> cannot contain a nested <script>.
-         See this log for the ancestor stack trace.",
-             "environmentLabel": null,
-             "label": "Console Error",
-             "source": "app/(script-under-html)/layout.tsx (6:5) @ Root
-         > 6 |     <html>
-             |     ^",
-             "stack": [
-               "html <anonymous>",
-               "Root app/(script-under-html)/layout.tsx (6:5)",
-             ],
-           },
-         ]
-        `)
-      }
+    if (isTurbopack) {
+      await expect(browser).toDisplayCollapsedRedbox(`
+       [
+         {
+           "description": "Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.",
+           "environmentLabel": null,
+           "label": "Console Error",
+           "source": "app/(script-under-html)/layout.tsx (8:7) @ RootLayout
+       >  8 |       <Script
+            |       ^",
+           "stack": [
+             "RootLayout app/(script-under-html)/layout.tsx (8:7)",
+           ],
+         },
+         {
+           "componentStack": "...
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                               <Next.js Internal Component>
+                                 <Next.js Internal Component>
+                                 <script>
+                                 <script>
+                                 <RootLayout>
+       >                           <html>
+                                     <body>
+                                     <Script src="https://ex..." strategy="beforeInte...">
+       >                               <script nonce={undefined} dangerouslySetInnerHTML={{__html:"(self.__ne..."}}>
+                             ...
+                 ...",
+           "description": "In HTML, <script> cannot be a child of <html>.
+       This will cause a hydration error.",
+           "environmentLabel": null,
+           "label": "Console Error",
+           "source": "app/(script-under-html)/layout.tsx (8:7) @ RootLayout
+       >  8 |       <Script
+            |       ^",
+           "stack": [
+             "script <anonymous>",
+             "RootLayout app/(script-under-html)/layout.tsx (8:7)",
+           ],
+         },
+         {
+           "description": "<html> cannot contain a nested <script>.
+       See this log for the ancestor stack trace.",
+           "environmentLabel": null,
+           "label": "Console Error",
+           "source": "app/(script-under-html)/layout.tsx (6:5) @ RootLayout
+       > 6 |     <html>
+           |     ^",
+           "stack": [
+             "html <anonymous>",
+             "RootLayout app/(script-under-html)/layout.tsx (6:5)",
+           ],
+         },
+       ]
+      `)
     } else {
-      if (isTurbopack) {
-        await expect(browser).toDisplayCollapsedRedbox(`
-         [
-           {
-             "description": "Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.",
-             "environmentLabel": null,
-             "label": "Console Error",
-             "source": "app/(script-under-html)/layout.tsx (8:7) @ Root
-         >  8 |       <Script
-              |       ^",
-             "stack": [
-               "Root app/(script-under-html)/layout.tsx (8:7)",
-             ],
-           },
-           {
-             "componentStack": "...
-             <RenderFromTemplateContext>
-               <ScrollAndFocusHandler segmentPath={[...]}>
-                 <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                   <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                     <LoadingBoundary name="/" loading={null}>
-                       <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                         <HTTPAccessFallbackErrorBoundary pathname="/script-un..." notFound={<SegmentViewNode>} ...>
-                           <RedirectBoundary>
-                             <RedirectErrorBoundary router={{...}}>
-                               <InnerLayoutRouter url="/script-un..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                                 <SegmentViewNode type="layout" pagePath="(script-un...">
-                                   <SegmentTrieNode>
-                                   <script>
-                                   <script>
-                                   <Root>
-         >                           <html>
-                                       <body>
-                                       <Script src="https://ex..." strategy="beforeInte...">
-         >                               <script nonce={undefined} dangerouslySetInnerHTML={{__html:"(self.__ne..."}}>
-                               ...
-                   ...",
-             "description": "In HTML, <script> cannot be a child of <html>.
-         This will cause a hydration error.",
-             "environmentLabel": null,
-             "label": "Console Error",
-             "source": "app/(script-under-html)/layout.tsx (8:7) @ Root
-         >  8 |       <Script
-              |       ^",
-             "stack": [
-               "script <anonymous>",
-               "Root app/(script-under-html)/layout.tsx (8:7)",
-             ],
-           },
-           {
-             "description": "<html> cannot contain a nested <script>.
-         See this log for the ancestor stack trace.",
-             "environmentLabel": null,
-             "label": "Console Error",
-             "source": "app/(script-under-html)/layout.tsx (6:5) @ Root
-         > 6 |     <html>
-             |     ^",
-             "stack": [
-               "html <anonymous>",
-               "Root app/(script-under-html)/layout.tsx (6:5)",
-             ],
-           },
-         ]
-        `)
-      } else {
-        await expect(browser).toDisplayCollapsedRedbox(`
-         [
-           {
-             "description": "Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.",
-             "environmentLabel": null,
-             "label": "Console Error",
-             "source": "app/(script-under-html)/layout.tsx (8:7) @ Root
-         >  8 |       <Script
-              |       ^",
-             "stack": [
-               "Root app/(script-under-html)/layout.tsx (8:7)",
-             ],
-           },
-           {
-             "componentStack": "...
-             <RenderFromTemplateContext>
-               <ScrollAndFocusHandler segmentPath={[...]}>
-                 <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                   <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                     <LoadingBoundary name="/" loading={null}>
-                       <HTTPAccessFallbackBoundary notFound={<SegmentViewNode>} forbidden={undefined} unauthorized={undefined}>
-                         <HTTPAccessFallbackErrorBoundary pathname="/script-un..." notFound={<SegmentViewNode>} ...>
-                           <RedirectBoundary>
-                             <RedirectErrorBoundary router={{...}}>
-                               <InnerLayoutRouter url="/script-un..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                                 <SegmentViewNode type="layout" pagePath="(script-un...">
-                                   <SegmentTrieNode>
-                                   <Root>
-         >                           <html>
-                                       <body>
-                                       <Script src="https://ex..." strategy="beforeInte...">
-         >                               <script nonce={undefined} dangerouslySetInnerHTML={{__html:"(self.__ne..."}}>
-                               ...
-                   ...",
-             "description": "In HTML, <script> cannot be a child of <html>.
-         This will cause a hydration error.",
-             "environmentLabel": null,
-             "label": "Console Error",
-             "source": "app/(script-under-html)/layout.tsx (8:7) @ Root
-         >  8 |       <Script
-              |       ^",
-             "stack": [
-               "script <anonymous>",
-               "Root app/(script-under-html)/layout.tsx (8:7)",
-             ],
-           },
-           {
-             "description": "<html> cannot contain a nested <script>.
-         See this log for the ancestor stack trace.",
-             "environmentLabel": null,
-             "label": "Console Error",
-             "source": "app/(script-under-html)/layout.tsx (6:5) @ Root
-         > 6 |     <html>
-             |     ^",
-             "stack": [
-               "html <anonymous>",
-               "Root app/(script-under-html)/layout.tsx (6:5)",
-             ],
-           },
-         ]
-        `)
-      }
+      await expect(browser).toDisplayCollapsedRedbox(`
+       [
+         {
+           "description": "Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.",
+           "environmentLabel": null,
+           "label": "Console Error",
+           "source": "app/(script-under-html)/layout.tsx (8:7) @ RootLayout
+       >  8 |       <Script
+            |       ^",
+           "stack": [
+             "RootLayout app/(script-under-html)/layout.tsx (8:7)",
+           ],
+         },
+         {
+           "componentStack": "...
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                               <Next.js Internal Component>
+                                 <Next.js Internal Component>
+                                 <RootLayout>
+       >                           <html>
+                                     <body>
+                                     <Script src="https://ex..." strategy="beforeInte...">
+       >                               <script nonce={undefined} dangerouslySetInnerHTML={{__html:"(self.__ne..."}}>
+                             ...
+                 ...",
+           "description": "In HTML, <script> cannot be a child of <html>.
+       This will cause a hydration error.",
+           "environmentLabel": null,
+           "label": "Console Error",
+           "source": "app/(script-under-html)/layout.tsx (8:7) @ RootLayout
+       >  8 |       <Script
+            |       ^",
+           "stack": [
+             "script <anonymous>",
+             "RootLayout app/(script-under-html)/layout.tsx (8:7)",
+           ],
+         },
+         {
+           "description": "<html> cannot contain a nested <script>.
+       See this log for the ancestor stack trace.",
+           "environmentLabel": null,
+           "label": "Console Error",
+           "source": "app/(script-under-html)/layout.tsx (6:5) @ RootLayout
+       > 6 |     <html>
+           |     ^",
+           "stack": [
+             "html <anonymous>",
+             "RootLayout app/(script-under-html)/layout.tsx (6:5)",
+           ],
+         },
+       ]
+      `)
     }
   })
 })

--- a/test/development/acceptance/hydration-error.test.ts
+++ b/test/development/acceptance/hydration-error.test.ts
@@ -102,12 +102,12 @@ describe('Error overlay for hydration errors in Pages router', () => {
       await expect(browser).toDisplayRedbox(`
        {
          "componentStack": "...
-           <AppContainer>
-             <Container fn={function fn}>
-               <PagesDevOverlayBridge>
-                 <PagesDevOverlayErrorBoundary>
-                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                     <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
                        <Mismatch>
                          <div className="parent">
                            <main className="child">
@@ -207,12 +207,12 @@ describe('Error overlay for hydration errors in Pages router', () => {
       await expect(browser).toDisplayRedbox(`
        {
          "componentStack": "...
-           <AppContainer>
-             <Container fn={function fn}>
-               <PagesDevOverlayBridge>
-                 <PagesDevOverlayErrorBoundary>
-                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                     <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
                        <Mismatch>
                          <div className="parent">
        +                   <main className="only">
@@ -297,12 +297,12 @@ describe('Error overlay for hydration errors in Pages router', () => {
       await expect(browser).toDisplayRedbox(`
        {
          "componentStack": "...
-           <AppContainer>
-             <Container fn={function fn}>
-               <PagesDevOverlayBridge>
-                 <PagesDevOverlayErrorBoundary>
-                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                     <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
                        <Mismatch>
                          <div className="parent">
                            <header>
@@ -370,14 +370,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "componentStack": "<Root callbacks={[...]}>
-           <Head>
-           <AppContainer>
-             <Container fn={function fn}>
-               <PagesDevOverlayBridge>
-                 <PagesDevOverlayErrorBoundary>
-                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                     <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+         "componentStack": "<Next.js Internal Component>
+           <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
                        <Mismatch>
                          <div className="parent">
        -                   <main className="only">
@@ -440,14 +440,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "componentStack": "<Root callbacks={[...]}>
-           <Head>
-           <AppContainer>
-             <Container fn={function fn}>
-               <PagesDevOverlayBridge>
-                 <PagesDevOverlayErrorBoundary>
-                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                     <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+         "componentStack": "<Next.js Internal Component>
+           <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
                        <Mismatch>
                          <div className="parent">
        -                   only
@@ -532,11 +532,11 @@ describe('Error overlay for hydration errors in Pages router', () => {
       await expect(browser).toDisplayRedbox(`
        {
          "componentStack": "...
-           <Container fn={function fn}>
-             <PagesDevOverlayBridge>
-               <PagesDevOverlayErrorBoundary>
-                 <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                   <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
                      <Page>
                        <table>
                          <tbody>
@@ -617,14 +617,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "componentStack": "<Root callbacks={[...]}>
-           <Head>
-           <AppContainer>
-             <Container fn={function fn}>
-               <PagesDevOverlayBridge>
-                 <PagesDevOverlayErrorBoundary>
-                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                     <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+         "componentStack": "<Next.js Internal Component>
+           <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
                        <Page>
        >                 <table>
        >                   {" 123"}
@@ -714,10 +714,10 @@ describe('Error overlay for hydration errors in Pages router', () => {
       await expect(browser).toDisplayRedbox(`
        {
          "componentStack": "...
-           <PagesDevOverlayBridge>
-             <PagesDevOverlayErrorBoundary>
-               <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                 <App pageProps={{}} Component={function Mismatch} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
                    <Mismatch>
                      <div className="parent">
                        <Suspense fallback={<p>}>
@@ -833,14 +833,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "componentStack": "<Root callbacks={[...]}>
-           <Head>
-           <AppContainer>
-             <Container fn={function fn}>
-               <PagesDevOverlayBridge>
-                 <PagesDevOverlayErrorBoundary>
-                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                     <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+         "componentStack": "<Next.js Internal Component>
+           <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
                        <Page>
        >                 <p>
        >                   <p>
@@ -929,11 +929,11 @@ describe('Error overlay for hydration errors in Pages router', () => {
       await expect(browser).toDisplayRedbox(`
        {
          "componentStack": "...
-           <Container fn={function fn}>
-             <PagesDevOverlayBridge>
-               <PagesDevOverlayErrorBoundary>
-                 <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                   <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
                      <Page>
                        <div>
                          <div>
@@ -1011,14 +1011,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "componentStack": "<Root callbacks={[...]}>
-           <Head>
-           <AppContainer>
-             <Container fn={function fn}>
-               <PagesDevOverlayBridge>
-                 <PagesDevOverlayErrorBoundary>
-                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                     <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+         "componentStack": "<Next.js Internal Component>
+           <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
                        <Page>
        >                 <div>
        >                   <tr>
@@ -1104,14 +1104,14 @@ describe('Error overlay for hydration errors in Pages router', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "componentStack": "<Root callbacks={[...]}>
-           <Head>
-           <AppContainer>
-             <Container fn={function fn}>
-               <PagesDevOverlayBridge>
-                 <PagesDevOverlayErrorBoundary>
-                   <PathnameContextProviderAdapter router={{sdc:{},sbc:{}, ...}} isAutoExport={true}>
-                     <App pageProps={{}} Component={function Page} err={undefined} router={{sdc:{},sbc:{}, ...}}>
+         "componentStack": "<Next.js Internal Component>
+           <Next.js Internal Component>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
                        <Page>
        >                 <p>
                            <span>

--- a/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
+++ b/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
@@ -13,18 +13,18 @@ describe('hydration-error-count', () => {
        [
          {
            "componentStack": "...
-           <RenderFromTemplateContext>
-             <ScrollAndFocusHandler segmentPath={[...]}>
-               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary name="bad-nesting/" loading={null}>
-                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/bad-nesting" tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                             <SegmentViewNode type="page" pagePath="bad-nestin...">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} serverProvidedParams={null}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                               <Next.js Internal Component>
+                               <Next.js Internal Component>
                                  <Page params={Promise} searchParams={Promise}>
        >                           <p>
        >                             <p>
@@ -62,18 +62,18 @@ describe('hydration-error-count', () => {
        [
          {
            "componentStack": "...
-           <RenderFromTemplateContext>
-             <ScrollAndFocusHandler segmentPath={[...]}>
-               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary name="bad-nesting/" loading={null}>
-                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/bad-nesting" tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                             <SegmentViewNode type="page" pagePath="bad-nestin...">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} serverProvidedParams={{...}}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                               <Next.js Internal Component>
+                               <Next.js Internal Component>
                                  <Page params={Promise} searchParams={Promise}>
        >                           <p>
        >                             <p>
@@ -116,18 +116,18 @@ describe('hydration-error-count', () => {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
          "componentStack": "...
-           <RenderFromTemplateContext>
-             <ScrollAndFocusHandler segmentPath={[...]}>
-               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary name="html-diff/" loading={null}>
-                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/html-diff" tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                             <SegmentViewNode type="page" pagePath="html-diff/...">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} serverProvidedParams={null}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                               <Next.js Internal Component>
+                               <Next.js Internal Component>
                                  <Page params={Promise} searchParams={Promise}>
                                    <p>
        +                             client
@@ -151,18 +151,18 @@ describe('hydration-error-count', () => {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
          "componentStack": "...
-           <RenderFromTemplateContext>
-             <ScrollAndFocusHandler segmentPath={[...]}>
-               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary name="html-diff/" loading={null}>
-                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/html-diff" tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                             <SegmentViewNode type="page" pagePath="html-diff/...">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} serverProvidedParams={{...}}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                               <Next.js Internal Component>
+                               <Next.js Internal Component>
                                  <Page params={Promise} searchParams={Promise}>
                                    <p>
        +                             client
@@ -193,18 +193,18 @@ describe('hydration-error-count', () => {
        [
          {
            "componentStack": "...
-           <RenderFromTemplateContext>
-             <ScrollAndFocusHandler segmentPath={[...]}>
-               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary name="two-issues/" loading={null}>
-                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/two-issues" tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                             <SegmentViewNode type="page" pagePath="two-issues...">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} serverProvidedParams={null}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                               <Next.js Internal Component>
+                               <Next.js Internal Component>
                                  <Page params={Promise} searchParams={Promise}>
        >                           <p className="client">
        >                             <p>
@@ -225,18 +225,18 @@ describe('hydration-error-count', () => {
          },
          {
            "componentStack": "...
-           <RenderFromTemplateContext>
-             <ScrollAndFocusHandler segmentPath={[...]}>
-               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary name="two-issues/" loading={null}>
-                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/two-issues" tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                             <SegmentViewNode type="page" pagePath="two-issues...">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} serverProvidedParams={null}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                               <Next.js Internal Component>
+                               <Next.js Internal Component>
                                  <Page params={Promise} searchParams={Promise}>
                                    <p
        +                             className="client"
@@ -263,18 +263,18 @@ describe('hydration-error-count', () => {
        [
          {
            "componentStack": "...
-           <RenderFromTemplateContext>
-             <ScrollAndFocusHandler segmentPath={[...]}>
-               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary name="two-issues/" loading={null}>
-                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/two-issues" tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                             <SegmentViewNode type="page" pagePath="two-issues...">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} serverProvidedParams={{...}}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                               <Next.js Internal Component>
+                               <Next.js Internal Component>
                                  <Page params={Promise} searchParams={Promise}>
        >                           <p className="client">
        >                             <p>
@@ -295,18 +295,18 @@ describe('hydration-error-count', () => {
          },
          {
            "componentStack": "...
-           <RenderFromTemplateContext>
-             <ScrollAndFocusHandler segmentPath={[...]}>
-               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary name="two-issues/" loading={null}>
-                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/two-issues" tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                             <SegmentViewNode type="page" pagePath="two-issues...">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} serverProvidedParams={{...}}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                               <Next.js Internal Component>
+                               <Next.js Internal Component>
                                  <Page params={Promise} searchParams={Promise}>
                                    <p
        +                             className="client"
@@ -339,18 +339,18 @@ describe('hydration-error-count', () => {
        [
          {
            "componentStack": "...
-           <RenderFromTemplateContext>
-             <ScrollAndFocusHandler segmentPath={[...]}>
-               <InnerScrollAndFocusHandler segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
-                 <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
-                   <LoadingBoundary name="hydration-..." loading={null}>
-                     <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
-                       <RedirectBoundary>
-                         <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/hydration..." tree={[...]} params={{}} cacheNode={{lazyData:null, ...}} ...>
-                             <SegmentViewNode type="page" pagePath="hydration-...">
-                               <SegmentTrieNode>
-                               <ClientPageRoot Component={function Page} serverProvidedParams={null}>
+           <Next.js Internal Component>
+             <Next.js Internal Component>
+               <Next.js Internal Component>
+                 <Next.js Internal Component>
+                   <Next.js Internal Component>
+                     <Next.js Internal Component>
+                       <Next.js Internal Component>
+                         <Next.js Internal Component>
+                           <Next.js Internal Component>
+                             <Next.js Internal Component>
+                               <Next.js Internal Component>
+                               <Next.js Internal Component>
                                  <Page params={Promise} searchParams={Promise}>
        >                           <p>
        >                             <p>


### PR DESCRIPTION
This means that their props can be changed without updating snapshots. Introducing new Components still requires updating the snapshots. Excluding 3rd party Components would require leveraging ignore-listing by React.