### PR TITLE
[test] Exclude Next.js internal stack frames from cache-component-error CLI output assertions

### DIFF
--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -226,44 +226,15 @@ describe('Cache Components Errors', () => {
             }
           } else {
             if (isDebugPrerender) {
-              // expect(output).toMatchInlineSnapshot(`
-              //  "Error: Route "/dynamic-metadata-error-route": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
-              //      at InnerLayoutRouter (bundler:///<next-src>)
-              //      at RedirectErrorBoundary (bundler:///<next-src>)
-              //      at RedirectBoundary (bundler:///<next-src>)
-              //      at HTTPAccessFallbackBoundary (bundler:///<next-src>)
-              //      at LoadingBoundary (bundler:///<next-src>)
-              //      at ErrorBoundary (bundler:///<next-src>)
-              //      at InnerScrollAndFocusHandler (bundler:///<next-src>)
-              //      at ScrollAndFocusHandler (bundler:///<next-src>)
-              //      at RenderFromTemplateContext (bundler:///<next-src>)
-              //      at OuterLayoutRouter (bundler:///<next-src>)
-              //      at main (<anonymous>)
-              //      at body (<anonymous>)
-              //      at html (<anonymous>)
-              //      at InnerLayoutRouter (bundler:///<next-src>)
-              //      at RedirectErrorBoundary (bundler:///<next-src>)
-              //      at RedirectBoundary (bundler:///<next-src>)
-              //      at HTTPAccessFallbackErrorBoundary (bundler:///<next-src>)
-              //      at HTTPAccessFallbackBoundary (bundler:///<next-src>)
-              //      at LoadingBoundary (bundler:///<next-src>)
-              //      at ErrorBoundary (bundler:///<next-src>)
-              //      at InnerScrollAndFocusHandler (bundler:///<next-src>)
-              //      at ScrollAndFocusHandler (bundler:///<next-src>)
-              //      at RenderFromTemplateContext (bundler:///<next-src>)
-              //      at OuterLayoutRouter (bundler:///<next-src>)
-              //    339 |  */
-              //    340 | function InnerLayoutRouter({
-              //  > 341 |   tree,
-              //        |   ^
-              //    342 |   segmentPath,
-              //    343 |   debugNameContext,
-              //    344 |   cacheNode,
-              //  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
-              //  Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
-              //  > Export encountered errors on following paths:
-              //  	/dynamic-metadata-error-route/page: /dynamic-metadata-error-route"
-              // `)
+              expect(output).toMatchInlineSnapshot(`
+               "Error: Route "/dynamic-metadata-error-route": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                   at <FIXME-library-internal>
+               To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
+               Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
+
+               > Export encountered errors on following paths:
+               	/dynamic-metadata-error-route/page: /dynamic-metadata-error-route"
+              `)
             } else {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/dynamic-metadata-error-route": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
@@ -754,78 +725,26 @@ describe('Cache Components Errors', () => {
             }
           } else {
             if (isDebugPrerender) {
-              // expect(output).toMatchInlineSnapshot(`
-              //  "Error: Route "/dynamic-root": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
-              //      at IndirectionTwo (bundler:///app/dynamic-root/indirection.tsx:7:34)
-              //      at InnerLayoutRouter (bundler:///<next-src>)
-              //      at RedirectErrorBoundary (bundler:///<next-src>)
-              //      at RedirectBoundary (bundler:///<next-src>)
-              //      at HTTPAccessFallbackBoundary (bundler:///<next-src>)
-              //      at LoadingBoundary (bundler:///<next-src>)
-              //      at ErrorBoundary (bundler:///<next-src>)
-              //      at InnerScrollAndFocusHandler (bundler:///<next-src>)
-              //      at ScrollAndFocusHandler (bundler:///<next-src>)
-              //      at RenderFromTemplateContext (bundler:///<next-src>)
-              //      at OuterLayoutRouter (bundler:///<next-src>)
-              //      at main (<anonymous>)
-              //      at body (<anonymous>)
-              //      at html (<anonymous>)
-              //      at InnerLayoutRouter (bundler:///<next-src>)
-              //      at RedirectErrorBoundary (bundler:///<next-src>)
-              //      at RedirectBoundary (bundler:///<next-src>)
-              //      at HTTPAccessFallbackErrorBoundary (bundler:///<next-src>)
-              //      at HTTPAccessFallbackBoundary (bundler:///<next-src>)
-              //      at LoadingBoundary (bundler:///<next-src>)
-              //      at ErrorBoundary (bundler:///<next-src>)
-              //      at InnerScrollAndFocusHandler (bundler:///<next-src>)
-              //      at ScrollAndFocusHandler (bundler:///<next-src>)
-              //      at RenderFromTemplateContext (bundler:///<next-src>)
-              //      at OuterLayoutRouter (bundler:///<next-src>)
-              //     5 | }
-              //     6 |
-              //  >  7 | export function IndirectionTwo({ children }) {
-              //       |                                  ^
-              //     8 |   return children
-              //     9 | }
-              //    10 |
-              //  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
-              //  Error: Route "/dynamic-root": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
-              //      at InnerLayoutRouter (bundler:///<next-src>)
-              //      at RedirectErrorBoundary (bundler:///<next-src>)
-              //      at RedirectBoundary (bundler:///<next-src>)
-              //      at HTTPAccessFallbackBoundary (bundler:///<next-src>)
-              //      at LoadingBoundary (bundler:///<next-src>)
-              //      at ErrorBoundary (bundler:///<next-src>)
-              //      at InnerScrollAndFocusHandler (bundler:///<next-src>)
-              //      at ScrollAndFocusHandler (bundler:///<next-src>)
-              //      at RenderFromTemplateContext (bundler:///<next-src>)
-              //      at OuterLayoutRouter (bundler:///<next-src>)
-              //      at main (<anonymous>)
-              //      at body (<anonymous>)
-              //      at html (<anonymous>)
-              //      at InnerLayoutRouter (bundler:///<next-src>)
-              //      at RedirectErrorBoundary (bundler:///<next-src>)
-              //      at RedirectBoundary (bundler:///<next-src>)
-              //      at HTTPAccessFallbackErrorBoundary (bundler:///<next-src>)
-              //      at HTTPAccessFallbackBoundary (bundler:///<next-src>)
-              //      at LoadingBoundary (bundler:///<next-src>)
-              //      at ErrorBoundary (bundler:///<next-src>)
-              //      at InnerScrollAndFocusHandler (bundler:///<next-src>)
-              //      at ScrollAndFocusHandler (bundler:///<next-src>)
-              //      at RenderFromTemplateContext (bundler:///<next-src>)
-              //      at OuterLayoutRouter (bundler:///<next-src>)
-              //    339 |  */
-              //    340 | function InnerLayoutRouter({
-              //  > 341 |   tree,
-              //        |   ^
-              //    342 |   segmentPath,
-              //    343 |   debugNameContext,
-              //    344 |   cacheNode,
-              //  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
-              //  Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
-              //  > Export encountered errors on following paths:
-              //  	/dynamic-root/page: /dynamic-root"
-              // `)
+              expect(output).toMatchInlineSnapshot(`
+               "Error: Route "/dynamic-root": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                   at IndirectionTwo (bundler:///app/dynamic-root/indirection.tsx:7:34)
+                   at <FIXME-library-internal>
+                  5 | }
+                  6 |
+               >  7 | export function IndirectionTwo({ children }) {
+                    |                                  ^
+                  8 |   return children
+                  9 | }
+                 10 |
+               To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
+               Error: Route "/dynamic-root": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                   at <FIXME-library-internal>
+               To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
+               Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
+
+               > Export encountered errors on following paths:
+               	/dynamic-root/page: /dynamic-root"
+              `)
             } else {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/dynamic-root": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
@@ -2199,56 +2118,17 @@ describe('Cache Components Errors', () => {
               }
             } else {
               if (isDebugPrerender) {
-                // expect(output).toMatchInlineSnapshot(`
-                //  "Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
-                //      at section (<anonymous>)
-                //      at main (<anonymous>)
-                //      at InnerLayoutRouter (bundler:///<next-src>)
-                //      at RedirectErrorBoundary (bundler:///<next-src>)
-                //      at RedirectBoundary (bundler:///<next-src>)
-                //      at HTTPAccessFallbackBoundary (bundler:///<next-src>)
-                //      at LoadingBoundary (bundler:///<next-src>)
-                //      at ErrorBoundary (bundler:///<next-src>)
-                //      at InnerScrollAndFocusHandler (bundler:///<next-src>)
-                //      at ScrollAndFocusHandler (bundler:///<next-src>)
-                //      at RenderFromTemplateContext (<anonymous>)
-                //      at OuterLayoutRouter (bundler:///<next-src>)
-                //      at main (<anonymous>)
-                //      at body (<anonymous>)
-                //      at html (<anonymous>)
-                //      at InnerLayoutRouter (bundler:///<next-src>)
-                //      at RedirectErrorBoundary (bundler:///<next-src>)
-                //      at RedirectBoundary (bundler:///<next-src>)
-                //      at HTTPAccessFallbackBoundary (bundler:///<next-src>)
-                //      at LoadingBoundary (bundler:///<next-src>)
-                //      at ErrorBoundary (bundler:///<next-src>)
-                //      at InnerScrollAndFocusHandler (bundler:///<next-src>)
-                //      at ScrollAndFocusHandler (bundler:///<next-src>)
-                //      at RenderFromTemplateContext (<anonymous>)
-                //      at OuterLayoutRouter (bundler:///<next-src>)
-                //      at InnerLayoutRouter (bundler:///<next-src>)
-                //      at RedirectErrorBoundary (bundler:///<next-src>)
-                //      at RedirectBoundary (bundler:///<next-src>)
-                //      at HTTPAccessFallbackErrorBoundary (bundler:///<next-src>)
-                //      at HTTPAccessFallbackBoundary (bundler:///<next-src>)
-                //      at LoadingBoundary (bundler:///<next-src>)
-                //      at ErrorBoundary (bundler:///<next-src>)
-                //      at InnerScrollAndFocusHandler (bundler:///<next-src>)
-                //      at ScrollAndFocusHandler (bundler:///<next-src>)
-                //      at RenderFromTemplateContext (<anonymous>)
-                //      at OuterLayoutRouter (bundler:///<next-src>)
-                //    339 |  */
-                //    340 | function InnerLayoutRouter({
-                //  > 341 |   tree,
-                //        |   ^
-                //    342 |   segmentPath,
-                //    343 |   debugNameContext,
-                //    344 |   cacheNode,
-                //  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-guarded-clientsync" in your browser to investigate the error.
-                //  Error occurred prerendering page "/sync-attribution/unguarded-async-guarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
-                //  > Export encountered errors on following paths:
-                //  	/sync-attribution/unguarded-async-guarded-clientsync/page: /sync-attribution/unguarded-async-guarded-clientsync"
-                // `)
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                     at section (<anonymous>)
+                     at main (<anonymous>)
+                     at <FIXME-library-internal>
+                 To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-guarded-clientsync" in your browser to investigate the error.
+                 Error occurred prerendering page "/sync-attribution/unguarded-async-guarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                 > Export encountered errors on following paths:
+                 	/sync-attribution/unguarded-async-guarded-clientsync/page: /sync-attribution/unguarded-async-guarded-clientsync"
+                `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: Route "/sync-attribution/unguarded-async-guarded-clientsync": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
@@ -3123,30 +3003,31 @@ describe('Cache Components Errors', () => {
               }
             } else {
               if (isDebugPrerender) {
-                // expect(output).toMatchInlineSnapshot(`
-                //  "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                //      at 0 (bundler:///app/use-cache-private-in-use-cache/page.tsx:15:1)
-                //    13 | }
-                //    14 |
-                //  > 15 | async function Private() {
-                //       | ^
-                //    16 |   'use cache: private'
-                //    17 |
-                //    18 |   return <p>Private</p>
-                //  Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                //      at 1 (bundler:///app/use-cache-private-in-use-cache/page.tsx:15:1)
-                //    13 | }
-                //    14 |
-                //  > 15 | async function Private() {
-                //       | ^
-                //    16 |   'use cache: private'
-                //    17 |
-                //    18 |   return <p>Private</p>
-                //  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
-                //  Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
-                //  > Export encountered errors on following paths:
-                //  	/use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache"
-                // `)
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                     at 0 (bundler:///app/use-cache-private-in-use-cache/page.tsx:15:1)
+                   13 | }
+                   14 |
+                 > 15 | async function Private() {
+                      | ^
+                   16 |   'use cache: private'
+                   17 |
+                   18 |   return <p>Private</p>
+                 Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                     at 1 (bundler:///app/use-cache-private-in-use-cache/page.tsx:15:1)
+                   13 | }
+                   14 |
+                 > 15 | async function Private() {
+                      | ^
+                   16 |   'use cache: private'
+                   17 |
+                   18 |   return <p>Private</p>
+                 To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                 > Export encountered errors on following paths:
+                 	/use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache"
+                `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
@@ -3227,37 +3108,7 @@ describe('Cache Components Errors', () => {
               if (isDebugPrerender) {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: Route "/use-cache-private-without-suspense": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
-                     at InnerLayoutRouter (bundler:///<next-src>)
-                     at RedirectErrorBoundary (bundler:///<next-src>)
-                     at RedirectBoundary (bundler:///<next-src>)
-                     at HTTPAccessFallbackBoundary (bundler:///<next-src>)
-                     at LoadingBoundary (bundler:///<next-src>)
-                     at ErrorBoundary (bundler:///<next-src>)
-                     at InnerScrollAndFocusHandler (bundler:///<next-src>)
-                     at ScrollAndFocusHandler (bundler:///<next-src>)
-                     at RenderFromTemplateContext (bundler:///<next-src>)
-                     at OuterLayoutRouter (bundler:///<next-src>)
-                     at main (<anonymous>)
-                     at body (<anonymous>)
-                     at html (<anonymous>)
-                     at InnerLayoutRouter (bundler:///<next-src>)
-                     at RedirectErrorBoundary (bundler:///<next-src>)
-                     at RedirectBoundary (bundler:///<next-src>)
-                     at HTTPAccessFallbackErrorBoundary (bundler:///<next-src>)
-                     at HTTPAccessFallbackBoundary (bundler:///<next-src>)
-                     at LoadingBoundary (bundler:///<next-src>)
-                     at ErrorBoundary (bundler:///<next-src>)
-                     at InnerScrollAndFocusHandler (bundler:///<next-src>)
-                     at ScrollAndFocusHandler (bundler:///<next-src>)
-                     at RenderFromTemplateContext (bundler:///<next-src>)
-                     at OuterLayoutRouter (bundler:///<next-src>)
-                   332 |  */
-                   333 | function InnerLayoutRouter({
-                 > 334 |   tree,
-                       |   ^
-                   335 |   segmentPath,
-                   336 |   debugNameContext,
-                   337 |   cacheNode,
+                     at <FIXME-library-internal>
                  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-without-suspense" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-without-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
 


### PR DESCRIPTION
These assertions required updating during internal refactorings. That they show up at all is a bug in Webpack's sourcemap loader anyway.