### PR TITLE
chore: Add `opt-level = s` for not frequently used crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,6 +248,31 @@ opt-level = 3
 [profile.release.package.serde]
 opt-level = 3
 
+[profile.release.package.wasmer]
+opt-level = "s"
+
+[profile.release.package.wasmer-vm]
+opt-level = "s"
+
+[profile.release.package.wasmer-compiler-cranelift]
+opt-level = "s"
+
+[profile.release.package.regalloc2]
+opt-level = "s"
+
+[profile.release.package.swc_plugin_backend_wasmer]
+opt-level = "s"
+
+[profile.release.package.globset]
+opt-level = "s"
+
+[profile.release.package.toml_edit]
+opt-level = "s"
+
+[profile.release.package.miette]
+opt-level = "s"
+
+
 # Use a custom profile for CI where many tests are performance sensitive but we still want the additional validation of debug-assertions
 [profile.release-with-assertions]
 inherits = "release"


### PR DESCRIPTION
### What?

Combined with `codegen-units = 1` (I'll send another PR for this), these two patches reduce the binary size by 4MB (36MB -> 32MB)

Before: https://github.com/swc-project/swc/pull/11188#issuecomment-3453793457 (`swc.linux-x64-gnu.node | 36M (37113184 bytes)`)

After: https://github.com/swc-project/swc/pull/11190#issuecomment-3453932183 (`swc.linux-x64-gnu.node | 32M (32959328 bytes)`)

### Why?

To reduce the binary size 

### How?
