### PR TITLE
chore: Add codegen-units = 1 to reduce the binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ opt-level = 1
 opt-level = 3
 
 [profile.release]
+# Reduce binary size
+codegen-units = 1
 
 [profile.release.package]
 


### PR DESCRIPTION
### What?

See description in https://github.com/vercel/next.js/pull/85426.

Combined with #85426, these PR would reduce the binary size by margin.

In the case of `@swc/core`, the difference is

Before: https://github.com/swc-project/swc/pull/11188#issuecomment-3453793457 (`swc.linux-x64-gnu.node | 36M (37113184 bytes)`)

After: https://github.com/swc-project/swc/pull/11190#issuecomment-3453932183 (`swc.linux-x64-gnu.node | 32M (32959328 bytes)`)


but for turbopack, it would be far bigger

### Why?

This increases the compile time, but this would have a very big impact on the binary size.

### How?

