### PR TITLE
[test] Ensure we can toggle the DevTools menu while status indicators are active

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/next-logo.tsx
@@ -539,6 +539,7 @@ function CacheBypassBadge({
     <div data-issues data-cache-bypass-badge>
       <button
         data-issues-open
+        data-nextjs-dev-tools-button
         aria-label="Open Next.js Dev Tools"
         onClick={onTriggerClick}
       >

--- a/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/status-indicator.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/devtools-indicator/status-indicator.tsx
@@ -158,6 +158,7 @@ export function StatusIndicator({ status, onClick }: StatusIndicatorProps) {
       </style>
       <button
         data-indicator-status
+        data-nextjs-dev-tools-button
         onClick={onClick}
         aria-label="Open Next.js Dev Tools"
       >

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -615,7 +615,7 @@ export class Playwright<TCurrent = undefined> {
   }
 
   locateDevToolsIndicator(): Locator {
-    return page.locator('nextjs-portal [data-nextjs-dev-tools-button]')
+    return page.locator('nextjs-portal [data-nextjs-dev-tools-button]:visible')
   }
 
   locator(selector: string, options?: Parameters<(typeof page)['locator']>[1]) {


### PR DESCRIPTION
There's currently a bug where the status indicator can get stuck on compiling. If we enter this faulty state, tests will not be able to open the devtools menu when that's normally possible. 

This updates the markup to make all toggles openable in tests.