### PR TITLE
[test] Deflake cache-components-allow-otel-spans

### DIFF
--- a/test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts
@@ -4,6 +4,9 @@ describe('hello-world', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     dependencies: require('./package.json').dependencies,
+    // This test sometimes takes longer than the default timeout, extending it bit longer
+    // to avoid flakiness.
+    startServerTimeout: 15_000,
   })
 
   if (isNextDev) {


### PR DESCRIPTION
The server startup may take a while. Now we use the same timeout as `client-trace-metadata.test.ts` (15s) which also uses OTEL.