### PR TITLE
Update E2E tests workflow

### DIFF
--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -91,7 +91,7 @@ jobs:
       afterBuild: |
         # e2e and ${{ inputs.test_type }} tests with `node run-tests.js`
 
-        export NEXT_TEST_CONTINUE_ON_ERROR=TRUE
+        export NEXT_TEST_CONTINUE_ON_ERROR=true
         export NEXT_TEST_MODE=${{
           inputs.test_type == 'development' && 'dev' || 'start'
         }}
@@ -123,7 +123,7 @@ jobs:
       afterBuild: |
         # legacy integration tests with `node run-tests.js`
 
-        export NEXT_TEST_CONTINUE_ON_ERROR=TRUE
+        export NEXT_TEST_CONTINUE_ON_ERROR=true
 
         # HACK: Despite the name, these environment variables are just used to
         # gate tests, so they're applicable to both turbopack and rspack tests

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -19,6 +19,10 @@ on:
         description: Override the proxy address to use for the test
         default: ''
         type: string
+      continueOnError:
+        description: whether the tests should continue on failure
+        default: false
+        type: boolean
 
 env:
   TURBO_TEAM: 'vercel'
@@ -81,6 +85,7 @@ jobs:
         NEXT_E2E_TEST_TIMEOUT=240000 \
         NEXT_TEST_MODE=deploy \
         IS_WEBPACK_TEST=1 \
+        NEXT_TEST_CONTINUE_ON_ERROR="${{ github.event.inputs.continueOnError || false }}" \
         NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" \
         NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || needs.setup.outputs.next-version || 'canary' }}" \
         VERCEL_CLI_VERSION="${{ github.event.inputs.vercelCliVersion || 'vercel@latest' }}" \


### PR DESCRIPTION
Adds an option to allow continuing tests on error to find all failures in single run also marks jobs as failed if any test failed while running. 