### PR TITLE
Avoid proxying React modules through workUnitStore

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -955,7 +955,6 @@ async function prospectiveRuntimeServerPrerender(
     renderResumeDataCache,
     prerenderResumeDataCache,
     hmrRefreshHash: undefined,
-    captureOwnerStack: undefined,
     // We only need task sequencing in the final prerender.
     runtimeStagePromise: null,
     // These are not present in regular prerenders, but allowed in a runtime prerender.
@@ -1092,7 +1091,6 @@ async function finalRuntimeServerPrerender(
     prerenderResumeDataCache,
     renderResumeDataCache,
     hmrRefreshHash: undefined,
-    captureOwnerStack: undefined,
     // Used to separate the "Static" stage from the "Runtime" stage.
     runtimeStagePromise,
     // These are not present in regular prerenders, but allowed in a runtime prerender.
@@ -3315,9 +3313,7 @@ async function spawnDynamicValidationInDev(
   // ready to cut the render off.
   const cacheSignal = new CacheSignal()
 
-  const captureOwnerStackClient = ReactClient.captureOwnerStack
-  const { captureOwnerStack: captureOwnerStackServer, createElement } =
-    ComponentMod
+  const { createElement } = ComponentMod
 
   // The resume data cache here should use a fresh instance as it's
   // performing a fresh prerender. If we get to implementing the
@@ -3350,7 +3346,6 @@ async function spawnDynamicValidationInDev(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash,
-    captureOwnerStack: captureOwnerStackServer,
   }
 
   // We're not going to use the result of this render because the only time it could be used
@@ -3384,7 +3379,6 @@ async function spawnDynamicValidationInDev(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash,
-    captureOwnerStack: captureOwnerStackServer,
   }
 
   const pendingInitialServerResult = workUnitAsyncStorage.run(
@@ -3505,7 +3499,6 @@ async function spawnDynamicValidationInDev(
       prerenderResumeDataCache,
       renderResumeDataCache: null,
       hmrRefreshHash: undefined,
-      captureOwnerStack: captureOwnerStackClient,
     }
 
     const prerender = (
@@ -3616,7 +3609,6 @@ async function spawnDynamicValidationInDev(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash,
-    captureOwnerStack: captureOwnerStackServer,
   }
 
   const finalAttemptRSCPayload = await workUnitAsyncStorage.run(
@@ -3650,7 +3642,6 @@ async function spawnDynamicValidationInDev(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash,
-    captureOwnerStack: captureOwnerStackServer,
   }
 
   const reactServerResult = await createReactServerPrerenderResult(
@@ -3730,7 +3721,6 @@ async function spawnDynamicValidationInDev(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash,
-    captureOwnerStack: captureOwnerStackClient,
   }
 
   let dynamicValidation = createDynamicValidationState()
@@ -4108,7 +4098,6 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
-        captureOwnerStack: undefined, // Not available in production.
       }
 
       // We're not going to use the result of this render because the only time it could be used
@@ -4142,7 +4131,6 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
-        captureOwnerStack: undefined, // Not available in production.
       })
 
       const pendingInitialServerResult = workUnitAsyncStorage.run(
@@ -4257,7 +4245,6 @@ async function prerenderToStream(
           prerenderResumeDataCache,
           renderResumeDataCache,
           hmrRefreshHash: undefined,
-          captureOwnerStack: undefined, // Not available in production.
         }
 
         const prerender = (
@@ -4367,7 +4354,6 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
-        captureOwnerStack: undefined, // Not available in production.
       }
 
       const finalAttemptRSCPayload = await workUnitAsyncStorage.run(
@@ -4402,7 +4388,6 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
-        captureOwnerStack: undefined, // Not available in production.
       })
 
       let prerenderIsPending = true
@@ -4488,7 +4473,6 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
-        captureOwnerStack: undefined, // Not available in production.
       }
 
       let dynamicValidation = createDynamicValidationState()

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -207,11 +207,6 @@ interface PrerenderStoreModernCommon
    * subsequent dynamic render.
    */
   readonly hmrRefreshHash: string | undefined
-
-  /**
-   * Only available in dev mode.
-   */
-  readonly captureOwnerStack: undefined | (() => string | null)
 }
 
 interface StaticPrerenderStoreCommon {

--- a/packages/next/src/server/node-environment-extensions/console-dim.external.test.ts
+++ b/packages/next/src/server/node-environment-extensions/console-dim.external.test.ts
@@ -321,13 +321,23 @@ describe('console-exit patches', () => {
         }
 
         // Install patches - this wraps the current console.log
-        const {
-          registerGetCacheSignal,
-        } = require('next/dist/server/node-environment-extensions/console-dim.external')
+        require('next/dist/server/node-environment-extensions/console-dim.external')
 
-        registerGetCacheSignal(() => null)
-        registerGetCacheSignal(() => controller?.signal)
-        registerGetCacheSignal(() => null)
+        const {
+          registerServerReact,
+          registerClientReact,
+        } = require('next/dist/server/runtime-reacts.external')
+
+        registerServerReact({
+          cacheSignal() {
+            return controller?.signal
+          },
+        })
+        registerClientReact({
+          cacheSignal() {
+            return null
+          },
+        })
 
         console.log('before abort')
         controller.abort()

--- a/packages/next/src/server/route-modules/app-page/module.ts
+++ b/packages/next/src/server/route-modules/app-page/module.ts
@@ -39,13 +39,12 @@ if (process.env.NEXT_RUNTIME !== 'edge') {
   vendoredReactSSR =
     require('./vendored/ssr/entrypoints') as typeof import('./vendored/ssr/entrypoints')
 
-  // In Node environments we augment console logging with information contextual to a React render.
-  // This patching is global so we need to register the cacheSignal getter from our bundled React instances
-  // here when we load them rather than in the external module itself when the patch is applied.
-  const { registerGetCacheSignal } =
-    require('../../node-environment-extensions/console-dim.external') as typeof import('../../node-environment-extensions/console-dim.external')
-  registerGetCacheSignal(vendoredReactRSC.React.cacheSignal)
-  registerGetCacheSignal(vendoredReactSSR.React.cacheSignal)
+  // In Node environments we need to access the correct React instance from external modules such
+  // as global patches. We register the loaded React instances here.
+  const { registerServerReact, registerClientReact } =
+    require('../../runtime-reacts.external') as typeof import('../../runtime-reacts.external')
+  registerServerReact(vendoredReactRSC.React)
+  registerClientReact(vendoredReactSSR.React)
 }
 
 /**

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -413,7 +413,6 @@ export class AppRouteRouteModule extends RouteModule<
               prerenderResumeDataCache,
               renderResumeDataCache: null,
               hmrRefreshHash: undefined,
-              captureOwnerStack: undefined,
             })
 
           let prospectiveResult
@@ -505,7 +504,6 @@ export class AppRouteRouteModule extends RouteModule<
             prerenderResumeDataCache,
             renderResumeDataCache: null,
             hmrRefreshHash: undefined,
-            captureOwnerStack: undefined,
           })
 
           let responseHandled = false

--- a/packages/next/src/server/runtime-reacts.external.ts
+++ b/packages/next/src/server/runtime-reacts.external.ts
@@ -1,0 +1,15 @@
+let ClientReact: typeof import('react') | null = null
+export function registerClientReact(react: typeof import('react')) {
+  ClientReact = react
+}
+export function getClientReact() {
+  return ClientReact
+}
+
+let ServerReact: typeof import('react') | null = null
+export function registerServerReact(react: typeof import('react')) {
+  ServerReact = react
+}
+export function getServerReact() {
+  return ServerReact
+}

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -321,6 +321,7 @@ const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
          "/node_modules/next/dist/server/route-modules/pages/vendored/contexts/loadable.js",
          "/node_modules/next/dist/server/route-modules/pages/vendored/contexts/router-context.js",
          "/node_modules/next/dist/server/route-modules/pages/vendored/contexts/server-inserted-html.js",
+         "/node_modules/next/dist/server/runtime-reacts.external.js",
          "/node_modules/next/dist/shared/lib/deep-freeze.js",
          "/node_modules/next/dist/shared/lib/invariant-error.js",
          "/node_modules/next/dist/shared/lib/is-plain-object.js",


### PR DESCRIPTION
Today the `captureOwnerStack()` function is provided to shared utilities through an AsyncLocalStorage that scopes the method from the appropriate React instance. This is so that external code like patches to sync IO methods can still generate errors with the appropriate React owner information even when the patched code itself is not bundled and can be called from etiher SSR or RSC contexts.

This works but it makes plumbing the React instances around tricky. There is a simpler way. Most of the time you can just try both React's. If one gives you a non-null/undefined result then you know you are in that scope. If neither do then you're outside a React scope altogether.

In this change I remove `captureOwnerStack()` from the workUnitStore types and just call it from the shared server runtime which gives even external code access to the appropriate React instances for bundled code