### PR TITLE
Export ReactServer from entry-base to avoid passing it through componentMod

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -902,5 +902,6 @@
   "901": "Invalid \"cacheHandlers\" provided, expected an object e.g. { default: '/my-handler.js' }, received %s",
   "902": "Invalid handler fields configured for \"cacheHandlers\":\\n%s",
   "903": "The file \"%s\" must export a function, either as a default export or as a named \"%s\" export.\\nThis function is what Next.js runs for every request handled by this %s.\\n\\nWhy this happens:\\n%s- The file exists but doesn't export a function.\\n- The export is not a function (e.g., an object or constant).\\n- There's a syntax error preventing the export from being recognized.\\n\\nTo fix it:\\n- Ensure this file has either a default or \"%s\" function export.\\n\\nLearn more: https://nextjs.org/docs/messages/middleware-to-proxy",
-  "904": "The file \"%s\" must export a function, either as a default export or as a named \"%s\" export."
+  "904": "The file \"%s\" must export a function, either as a default export or as a named \"%s\" export.",
+  "905": "The next-server runtime is not available in Edge runtime."
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -955,7 +955,6 @@ async function prospectiveRuntimeServerPrerender(
     renderResumeDataCache,
     prerenderResumeDataCache,
     hmrRefreshHash: undefined,
-    captureOwnerStack: undefined,
     // We only need task sequencing in the final prerender.
     runtimeStagePromise: null,
     // These are not present in regular prerenders, but allowed in a runtime prerender.
@@ -1092,7 +1091,6 @@ async function finalRuntimeServerPrerender(
     prerenderResumeDataCache,
     renderResumeDataCache,
     hmrRefreshHash: undefined,
-    captureOwnerStack: undefined,
     // Used to separate the "Static" stage from the "Runtime" stage.
     runtimeStagePromise,
     // These are not present in regular prerenders, but allowed in a runtime prerender.
@@ -3315,9 +3313,7 @@ async function spawnDynamicValidationInDev(
   // ready to cut the render off.
   const cacheSignal = new CacheSignal()
 
-  const captureOwnerStackClient = ReactClient.captureOwnerStack
-  const { captureOwnerStack: captureOwnerStackServer, createElement } =
-    ComponentMod
+  const { createElement } = ComponentMod
 
   // The resume data cache here should use a fresh instance as it's
   // performing a fresh prerender. If we get to implementing the
@@ -3350,7 +3346,6 @@ async function spawnDynamicValidationInDev(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash,
-    captureOwnerStack: captureOwnerStackServer,
   }
 
   // We're not going to use the result of this render because the only time it could be used
@@ -3384,7 +3379,6 @@ async function spawnDynamicValidationInDev(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash,
-    captureOwnerStack: captureOwnerStackServer,
   }
 
   const pendingInitialServerResult = workUnitAsyncStorage.run(
@@ -3505,7 +3499,6 @@ async function spawnDynamicValidationInDev(
       prerenderResumeDataCache,
       renderResumeDataCache: null,
       hmrRefreshHash: undefined,
-      captureOwnerStack: captureOwnerStackClient,
     }
 
     const prerender = (
@@ -3616,7 +3609,6 @@ async function spawnDynamicValidationInDev(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash,
-    captureOwnerStack: captureOwnerStackServer,
   }
 
   const finalAttemptRSCPayload = await workUnitAsyncStorage.run(
@@ -3650,7 +3642,6 @@ async function spawnDynamicValidationInDev(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash,
-    captureOwnerStack: captureOwnerStackServer,
   }
 
   const reactServerResult = await createReactServerPrerenderResult(
@@ -3730,7 +3721,6 @@ async function spawnDynamicValidationInDev(
     prerenderResumeDataCache,
     renderResumeDataCache: null,
     hmrRefreshHash,
-    captureOwnerStack: captureOwnerStackClient,
   }
 
   let dynamicValidation = createDynamicValidationState()
@@ -4108,7 +4098,6 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
-        captureOwnerStack: undefined, // Not available in production.
       }
 
       // We're not going to use the result of this render because the only time it could be used
@@ -4142,7 +4131,6 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
-        captureOwnerStack: undefined, // Not available in production.
       })
 
       const pendingInitialServerResult = workUnitAsyncStorage.run(
@@ -4257,7 +4245,6 @@ async function prerenderToStream(
           prerenderResumeDataCache,
           renderResumeDataCache,
           hmrRefreshHash: undefined,
-          captureOwnerStack: undefined, // Not available in production.
         }
 
         const prerender = (
@@ -4367,7 +4354,6 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
-        captureOwnerStack: undefined, // Not available in production.
       }
 
       const finalAttemptRSCPayload = await workUnitAsyncStorage.run(
@@ -4402,7 +4388,6 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
-        captureOwnerStack: undefined, // Not available in production.
       })
 
       let prerenderIsPending = true
@@ -4488,7 +4473,6 @@ async function prerenderToStream(
         prerenderResumeDataCache,
         renderResumeDataCache,
         hmrRefreshHash: undefined,
-        captureOwnerStack: undefined, // Not available in production.
       }
 
       let dynamicValidation = createDynamicValidationState()

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -30,6 +30,7 @@ import type { DeepReadonly } from '../../shared/lib/deep-readonly'
 import type { BaseNextRequest, BaseNextResponse } from '../base-http'
 import type { IncomingHttpHeaders } from 'http'
 import * as ReactClient from 'react'
+import { ReactServer } from './entry-base'
 
 import RenderResult, {
   type AppPageRenderResultMetadata,
@@ -218,6 +219,9 @@ import { imageConfigDefault } from '../../shared/lib/image-config'
 import { RenderStage, StagedRenderingController } from './staged-rendering'
 import { anySegmentHasRuntimePrefetchEnabled } from './staged-validation'
 import { warnOnce } from '../../shared/lib/utils/warn-once'
+
+const serverCreateElement = ReactServer.createElement
+const ServerFragment = ReactServer.Fragment
 
 export type GetDynamicParamFromSegment = (
   // [slug] / [[slug]] / [...slug]
@@ -421,12 +425,10 @@ function makeGetDynamicParamFromSegment(
 }
 
 function NonIndex({
-  createElement,
   pagePath,
   statusCode,
   isPossibleServerAction,
 }: {
-  createElement: typeof ReactClient.createElement
   pagePath: string
   statusCode: number | undefined
   isPossibleServerAction: boolean
@@ -437,7 +439,7 @@ function NonIndex({
   // Only render noindex for page request, skip for server actions
   // TODO: is this correct if `isPossibleServerAction` is a false positive?
   if (!isPossibleServerAction && (is404Page || isInvalidStatusCode)) {
-    return createElement('meta', {
+    return serverCreateElement('meta', {
       name: 'robots',
       content: 'noindex',
     })
@@ -471,9 +473,7 @@ async function generateDynamicRSCPayload(
       routeModule: {
         userland: { loaderTree },
       },
-      createElement,
       createMetadataComponents,
-      Fragment,
     },
     getDynamicParamFromSegment,
     query,
@@ -505,21 +505,20 @@ async function generateDynamicRSCPayload(
         parentParams: {},
         flightRouterState,
         // For flight, render metadata inside leaf page
-        rscHead: createElement(
-          Fragment,
+        rscHead: serverCreateElement(
+          ServerFragment,
           {
             key: flightDataPathHeadKey,
           },
-          createElement(NonIndex, {
-            createElement,
+          serverCreateElement(NonIndex, {
             pagePath: ctx.pagePath,
             statusCode: ctx.res.statusCode,
             isPossibleServerAction: ctx.isPossibleServerAction,
           }),
-          createElement(Viewport, {
+          serverCreateElement(Viewport, {
             key: getFlightViewportKey(requestId),
           }),
-          createElement(Metadata, {
+          serverCreateElement(Metadata, {
             key: getFlightMetadataKey(requestId),
           })
         ),
@@ -718,13 +717,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
   initialRequestStore: RequestStore,
   createRequestStore: (() => RequestStore) | undefined
 ): Promise<RenderResult> {
-  const {
-    htmlRequestId,
-    renderOpts,
-    requestId,
-    workStore,
-    componentMod: { createElement },
-  } = ctx
+  const { htmlRequestId, renderOpts, requestId, workStore } = ctx
 
   const {
     dev = false,
@@ -758,9 +751,12 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
     if (isBypassingCachesInDev(renderOpts, requestStore)) {
       // Mark the RSC payload to indicate that caches were bypassed in dev.
       // This lets the client know not to cache anything based on this render.
-      payload._bypassCachesInDev = createElement(WarnForBypassCachesInDev, {
-        route: workStore.route,
-      })
+      payload._bypassCachesInDev = serverCreateElement(
+        WarnForBypassCachesInDev,
+        {
+          route: workStore.route,
+        }
+      )
     }
 
     return payload
@@ -1226,7 +1222,7 @@ async function getRSCPayload(
     getDynamicParamFromSegment,
     query,
     appUsingSizeAdjustment,
-    componentMod: { createMetadataComponents, createElement, Fragment },
+    componentMod: { createMetadataComponents },
     url,
     workStore,
   } = ctx
@@ -1278,21 +1274,20 @@ async function getRSCPayload(
   const couldBeIntercepted =
     typeof varyHeader === 'string' && varyHeader.includes(NEXT_URL)
 
-  const initialHead = createElement(
-    Fragment,
+  const initialHead = serverCreateElement(
+    ServerFragment,
     {
       key: flightDataPathHeadKey,
     },
-    createElement(NonIndex, {
-      createElement,
+    serverCreateElement(NonIndex, {
       pagePath: ctx.pagePath,
       statusCode: ctx.res.statusCode,
       isPossibleServerAction: ctx.isPossibleServerAction,
     }),
-    createElement(Viewport, null),
-    createElement(Metadata, null),
+    serverCreateElement(Viewport, null),
+    serverCreateElement(Metadata, null),
     appUsingSizeAdjustment
-      ? createElement('meta', {
+      ? serverCreateElement('meta', {
           name: 'next-size-adjust',
           content: '',
         })
@@ -1316,7 +1311,7 @@ async function getRSCPayload(
 
   return {
     // See the comment above the `Preloads` component (below) for why this is part of the payload
-    P: createElement(Preloads, {
+    P: serverCreateElement(Preloads, {
       preloadCallbacks: preloadCallbacks,
     }),
     b: ctx.sharedContext.buildId,
@@ -1359,7 +1354,7 @@ async function getErrorRSCPayload(
   const {
     getDynamicParamFromSegment,
     query,
-    componentMod: { createMetadataComponents, createElement, Fragment },
+    componentMod: { createMetadataComponents },
     url,
     workStore,
   } = ctx
@@ -1376,24 +1371,23 @@ async function getErrorRSCPayload(
     serveStreamingMetadata: serveStreamingMetadata,
   })
 
-  const initialHead = createElement(
-    Fragment,
+  const initialHead = serverCreateElement(
+    ServerFragment,
     {
       key: flightDataPathHeadKey,
     },
-    createElement(NonIndex, {
-      createElement,
+    serverCreateElement(NonIndex, {
       pagePath: ctx.pagePath,
       statusCode: ctx.res.statusCode,
       isPossibleServerAction: ctx.isPossibleServerAction,
     }),
-    createElement(Viewport, null),
+    serverCreateElement(Viewport, null),
     process.env.NODE_ENV === 'development' &&
-      createElement('meta', {
+      serverCreateElement('meta', {
         name: 'next-error',
         content: 'not-found',
       }),
-    createElement(Metadata, null)
+    serverCreateElement(Metadata, null)
   )
 
   const initialTree = createFlightRouterStateFromLoaderTree(
@@ -1410,17 +1404,17 @@ async function getErrorRSCPayload(
   // For metadata notFound error there's no global not found boundary on top
   // so we create a not found page with AppRouter
   const seedData: CacheNodeSeedData = [
-    createElement(
+    serverCreateElement(
       'html',
       {
         id: '__next_error__',
       },
-      createElement('head', null),
-      createElement(
+      serverCreateElement('head', null),
+      serverCreateElement(
         'body',
         null,
         process.env.NODE_ENV !== 'production' && err
-          ? createElement('template', {
+          ? serverCreateElement('template', {
               'data-next-error-message': err.message,
               'data-next-error-digest': 'digest' in err ? err.digest : '',
               'data-next-error-stack': err.stack,
@@ -2335,10 +2329,7 @@ async function renderToStream(
     basePath,
     buildManifest,
     clientReferenceManifest,
-    ComponentMod: {
-      createElement,
-      renderToReadableStream: serverRenderToReadableStream,
-    },
+    ComponentMod: { renderToReadableStream: serverRenderToReadableStream },
     crossOrigin,
     dev = false,
     experimental,
@@ -2479,9 +2470,12 @@ async function renderToStream(
             // we know this is available  when cacheComponents is enabled, but typeguard to be safe
             renderOpts.setCacheStatus('bypass', htmlRequestId, requestId)
           }
-          payload._bypassCachesInDev = createElement(WarnForBypassCachesInDev, {
-            route: workStore.route,
-          })
+          payload._bypassCachesInDev = serverCreateElement(
+            WarnForBypassCachesInDev,
+            {
+              route: workStore.route,
+            }
+          )
         }
 
         return payload
@@ -3313,8 +3307,6 @@ async function spawnDynamicValidationInDev(
   // ready to cut the render off.
   const cacheSignal = new CacheSignal()
 
-  const { createElement } = ComponentMod
-
   // The resume data cache here should use a fresh instance as it's
   // performing a fresh prerender. If we get to implementing the
   // prerendering of an already prerendered page, we should use the passed
@@ -3444,7 +3436,7 @@ async function spawnDynamicValidationInDev(
   const { invalidDynamicUsageError } = workStore
   if (invalidDynamicUsageError) {
     resolveValidation(
-      createElement(LogSafely, {
+      serverCreateElement(LogSafely, {
         fn: () => {
           console.error(invalidDynamicUsageError)
         },
@@ -3797,7 +3789,7 @@ async function spawnDynamicValidationInDev(
 
     const { preludeIsEmpty } = await processPrelude(unprocessedPrelude)
     resolveValidation(
-      createElement(LogSafely, {
+      serverCreateElement(LogSafely, {
         fn: throwIfDisallowedDynamic.bind(
           null,
           workStore,
@@ -3833,7 +3825,7 @@ async function spawnDynamicValidationInDev(
     }
 
     resolveValidation(
-      createElement(LogSafely, {
+      serverCreateElement(LogSafely, {
         fn: loggingFunction,
       })
     )
@@ -5304,9 +5296,6 @@ const getGlobalErrorStyles = async (
     modules: { 'global-error': globalErrorModule },
   } = parseLoaderTree(tree)
 
-  const {
-    componentMod: { createElement },
-  } = ctx
   const GlobalErrorComponent: GlobalErrorComponent =
     ctx.componentMod.GlobalError
   let globalErrorStyles
@@ -5335,7 +5324,7 @@ const getGlobalErrorStyles = async (
       globalErrorStyles =
         // This will be rendered next to GlobalError component under ErrorBoundary,
         // it requires a key to avoid React warning about duplicate keys.
-        createElement(
+        serverCreateElement(
           SegmentViewNode,
           {
             key: 'ge-svn',

--- a/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
+++ b/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
@@ -4,6 +4,7 @@ import type { AppRenderContext } from './app-render'
 import { getAssetQueryString } from './get-asset-query-string'
 import { encodeURIPath } from '../../shared/lib/encode-uri-path'
 import { renderCssResource } from './render-css-resource'
+import { ReactServer } from './entry-base'
 
 export async function createComponentStylesAndScripts({
   filePath,
@@ -18,9 +19,6 @@ export async function createComponentStylesAndScripts({
   injectedJS: Set<string>
   ctx: AppRenderContext
 }): Promise<[React.ComponentType<any>, React.ReactNode, React.ReactNode]> {
-  const {
-    componentMod: { createElement },
-  } = ctx
   const { styles: entryCssFiles, scripts: jsHrefs } = getLinkAndScriptTags(
     ctx.clientReferenceManifest,
     filePath,
@@ -32,7 +30,7 @@ export async function createComponentStylesAndScripts({
 
   const scripts = jsHrefs
     ? jsHrefs.map((href, index) =>
-        createElement('script', {
+        ReactServer.createElement('script', {
           src: `${ctx.assetPrefix}/_next/${encodeURIPath(href)}${getAssetQueryString(ctx, true)}`,
           async: true,
           key: `script-${index}`,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -36,6 +36,10 @@ import {
   isNextjsBuiltinFilePath,
 } from './segment-explorer-path'
 import type { AppSegmentConfig } from '../../build/segment-config/app/app-segment-config'
+import { ReactServer } from './entry-base'
+
+const serverCreateElement = ReactServer.createElement
+const ServerFragment = ReactServer.Fragment
 
 /**
  * Use the provided loader tree to create the React Component tree.
@@ -106,8 +110,6 @@ async function createComponentTreeInternal(
     renderOpts: { nextConfigOutput, experimental, cacheComponents },
     workStore,
     componentMod: {
-      createElement,
-      Fragment,
       SegmentViewNode,
       HTTPAccessFallbackBoundary,
       LayoutRouter,
@@ -163,7 +165,7 @@ async function createComponentTreeInternal(
         injectedCSS: injectedCSSWithCurrentLayout,
         injectedJS: injectedJSWithCurrentLayout,
       })
-    : [Fragment]
+    : [ServerFragment]
 
   const [ErrorComponent, errorStyles, errorScripts] = error
     ? await createComponentStylesAndScripts({
@@ -544,10 +546,10 @@ async function createComponentTreeInternal(
           childCacheNodeSeedData = seedData
         }
 
-        const templateNode = createElement(
+        const templateNode = serverCreateElement(
           Template,
           null,
-          createElement(RenderFromTemplateContext, null)
+          serverCreateElement(RenderFromTemplateContext, null)
         )
 
         const templateFilePath = getConventionPathByType(tree, dir, 'template')
@@ -559,7 +561,7 @@ async function createComponentTreeInternal(
 
         const wrappedErrorStyles =
           isSegmentViewEnabled && errorFilePath
-            ? createElement(
+            ? serverCreateElement(
                 SegmentViewNode,
                 {
                   type: 'error',
@@ -574,26 +576,26 @@ async function createComponentTreeInternal(
         // rendered: not-found.tsx
         const fileNameSuffix = BOUNDARY_SUFFIX
         const segmentViewBoundaries = isSegmentViewEnabled
-          ? createElement(
-              Fragment,
+          ? serverCreateElement(
+              ServerFragment,
               null,
               notFoundFilePath &&
-                createElement(SegmentViewNode, {
+                serverCreateElement(SegmentViewNode, {
                   type: `${BOUNDARY_PREFIX}not-found`,
                   pagePath: notFoundFilePath + fileNameSuffix,
                 }),
               loadingFilePath &&
-                createElement(SegmentViewNode, {
+                serverCreateElement(SegmentViewNode, {
                   type: `${BOUNDARY_PREFIX}loading`,
                   pagePath: loadingFilePath + fileNameSuffix,
                 }),
               errorFilePath &&
-                createElement(SegmentViewNode, {
+                serverCreateElement(SegmentViewNode, {
                   type: `${BOUNDARY_PREFIX}error`,
                   pagePath: errorFilePath + fileNameSuffix,
                 }),
               globalErrorFilePath &&
-                createElement(SegmentViewNode, {
+                serverCreateElement(SegmentViewNode, {
                   type: `${BOUNDARY_PREFIX}global-error`,
                   pagePath: isNextjsBuiltinFilePath(globalErrorFilePath)
                     ? `${BUILTIN_PREFIX}global-error.js${fileNameSuffix}`
@@ -604,14 +606,14 @@ async function createComponentTreeInternal(
 
         return [
           parallelRouteKey,
-          createElement(LayoutRouter, {
+          serverCreateElement(LayoutRouter, {
             parallelRouterKey: parallelRouteKey,
             error: ErrorComponent,
             errorStyles: wrappedErrorStyles,
             errorScripts: errorScripts,
             template:
               isSegmentViewEnabled && templateFilePath
-                ? createElement(
+                ? serverCreateElement(
                     SegmentViewNode,
                     {
                       type: 'template',
@@ -647,14 +649,14 @@ async function createComponentTreeInternal(
   }
 
   let loadingElement = Loading
-    ? createElement(Loading, {
+    ? serverCreateElement(Loading, {
         key: 'l',
       })
     : null
   const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
   if (isSegmentViewEnabled && loadingElement) {
     if (loadingFilePath) {
-      loadingElement = createElement(
+      loadingElement = serverCreateElement(
         SegmentViewNode,
         {
           key: cacheNodeKey + '-loading',
@@ -673,8 +675,8 @@ async function createComponentTreeInternal(
   // When the segment does not have a layout or page we still have to add the layout router to ensure the path holds the loading component
   if (!MaybeComponent) {
     return [
-      createElement(
-        Fragment,
+      serverCreateElement(
+        ServerFragment,
         {
           key: cacheNodeKey,
         },
@@ -706,12 +708,12 @@ async function createComponentTreeInternal(
     experimental.isRoutePPREnabled
   ) {
     return [
-      createElement(
-        Fragment,
+      serverCreateElement(
+        ServerFragment,
         {
           key: cacheNodeKey,
         },
-        createElement(Postpone, {
+        serverCreateElement(Postpone, {
           reason: 'dynamic = "force-dynamic" was used',
           route: workStore.route,
         }),
@@ -744,7 +746,7 @@ async function createComponentTreeInternal(
     if (isClientComponent) {
       if (cacheComponents) {
         // Params are omitted when Cache Components is enabled
-        pageElement = createElement(ClientPageRoot, {
+        pageElement = serverCreateElement(ClientPageRoot, {
           Component: PageComponent,
           serverProvidedParams: null,
         })
@@ -753,7 +755,7 @@ async function createComponentTreeInternal(
           createPrerenderParamsForClientSegment(currentParams)
         const promiseOfSearchParams =
           createPrerenderSearchParamsForClientPage(workStore)
-        pageElement = createElement(ClientPageRoot, {
+        pageElement = serverCreateElement(ClientPageRoot, {
           Component: PageComponent,
           serverProvidedParams: {
             searchParams: query,
@@ -762,7 +764,7 @@ async function createComponentTreeInternal(
           },
         })
       } else {
-        pageElement = createElement(ClientPageRoot, {
+        pageElement = serverCreateElement(ClientPageRoot, {
           Component: PageComponent,
           serverProvidedParams: {
             searchParams: query,
@@ -788,13 +790,13 @@ async function createComponentTreeInternal(
         const UseCachePageComponent: ComponentType<UseCachePageProps> =
           PageComponent
 
-        pageElement = createElement(UseCachePageComponent, {
+        pageElement = serverCreateElement(UseCachePageComponent, {
           params: params,
           searchParams: searchParams,
           $$isPage: true,
         })
       } else {
-        pageElement = createElement(PageComponent, {
+        pageElement = serverCreateElement(PageComponent, {
           params: params,
           searchParams: searchParams,
         })
@@ -808,7 +810,7 @@ async function createComponentTreeInternal(
     const segmentType = isDefaultSegment ? 'default' : 'page'
     const wrappedPageElement =
       isSegmentViewEnabled && pageFilePath
-        ? createElement(
+        ? serverCreateElement(
             SegmentViewNode,
             {
               key: cacheNodeKey + '-' + segmentType,
@@ -820,14 +822,14 @@ async function createComponentTreeInternal(
         : pageElement
 
     return [
-      createElement(
-        Fragment,
+      serverCreateElement(
+        ServerFragment,
         {
           key: cacheNodeKey,
         },
         wrappedPageElement,
         layerAssets,
-        MetadataOutlet ? createElement(MetadataOutlet, null) : null
+        MetadataOutlet ? serverCreateElement(MetadataOutlet, null) : null
       ),
       parallelRouteCacheNodeSeedData,
       loadingData,
@@ -847,7 +849,7 @@ async function createComponentTreeInternal(
       let clientSegment: React.ReactNode
       if (cacheComponents) {
         // Params are omitted when Cache Components is enabled
-        clientSegment = createElement(ClientSegmentRoot, {
+        clientSegment = serverCreateElement(ClientSegmentRoot, {
           Component: SegmentComponent,
           slots: parallelRouteProps,
           serverProvidedParams: null,
@@ -856,7 +858,7 @@ async function createComponentTreeInternal(
         const promiseOfParams =
           createPrerenderParamsForClientSegment(currentParams)
 
-        clientSegment = createElement(ClientSegmentRoot, {
+        clientSegment = serverCreateElement(ClientSegmentRoot, {
           Component: SegmentComponent,
           slots: parallelRouteProps,
           serverProvidedParams: {
@@ -865,7 +867,7 @@ async function createComponentTreeInternal(
           },
         })
       } else {
-        clientSegment = createElement(ClientSegmentRoot, {
+        clientSegment = serverCreateElement(ClientSegmentRoot, {
           Component: SegmentComponent,
           slots: parallelRouteProps,
           serverProvidedParams: {
@@ -885,7 +887,6 @@ async function createComponentTreeInternal(
         // We should instead look into handling the fallback behavior differently in development mode so that it doesn't
         // rely on the `NotFound` behavior.
         notfoundClientSegment = createErrorBoundaryClientSegmentRoot({
-          ctx,
           ErrorBoundaryComponent: NotFound,
           errorElement: notFoundElement,
           ClientSegmentRoot,
@@ -894,7 +895,6 @@ async function createComponentTreeInternal(
           currentParams,
         })
         forbiddenClientSegment = createErrorBoundaryClientSegmentRoot({
-          ctx,
           ErrorBoundaryComponent: Forbidden,
           errorElement: forbiddenElement,
           ClientSegmentRoot,
@@ -903,7 +903,6 @@ async function createComponentTreeInternal(
           currentParams,
         })
         unauthorizedClientSegment = createErrorBoundaryClientSegmentRoot({
-          ctx,
           ErrorBoundaryComponent: Unauthorized,
           errorElement: unauthorizedElement,
           ClientSegmentRoot,
@@ -916,7 +915,7 @@ async function createComponentTreeInternal(
           forbiddenClientSegment ||
           unauthorizedClientSegment
         ) {
-          segmentNode = createElement(
+          segmentNode = serverCreateElement(
             HTTPAccessFallbackBoundary,
             {
               key: cacheNodeKey,
@@ -928,8 +927,8 @@ async function createComponentTreeInternal(
             clientSegment
           )
         } else {
-          segmentNode = createElement(
-            Fragment,
+          segmentNode = serverCreateElement(
+            ServerFragment,
             {
               key: cacheNodeKey,
             },
@@ -938,8 +937,8 @@ async function createComponentTreeInternal(
           )
         }
       } else {
-        segmentNode = createElement(
-          Fragment,
+        segmentNode = serverCreateElement(
+          ServerFragment,
           {
             key: cacheNodeKey,
           },
@@ -959,7 +958,7 @@ async function createComponentTreeInternal(
         const UseCacheLayoutComponent: ComponentType<UseCacheLayoutProps> =
           SegmentComponent
 
-        serverSegment = createElement(
+        serverSegment = serverCreateElement(
           UseCacheLayoutComponent,
           {
             ...parallelRouteProps,
@@ -971,7 +970,7 @@ async function createComponentTreeInternal(
           parallelRouteProps.children
         )
       } else {
-        serverSegment = createElement(
+        serverSegment = serverCreateElement(
           SegmentComponent,
           {
             ...parallelRouteProps,
@@ -989,16 +988,16 @@ async function createComponentTreeInternal(
         // but it's not ideal, as it needlessly invokes the `NotFound` component and renders the `RootLayout` twice.
         // We should instead look into handling the fallback behavior differently in development mode so that it doesn't
         // rely on the `NotFound` behavior.
-        segmentNode = createElement(
+        segmentNode = serverCreateElement(
           HTTPAccessFallbackBoundary,
           {
             key: cacheNodeKey,
             notFound: notFoundElement
-              ? createElement(
-                  Fragment,
+              ? serverCreateElement(
+                  ServerFragment,
                   null,
                   layerAssets,
-                  createElement(
+                  serverCreateElement(
                     SegmentComponent,
                     {
                       params: params,
@@ -1013,8 +1012,8 @@ async function createComponentTreeInternal(
           serverSegment
         )
       } else {
-        segmentNode = createElement(
-          Fragment,
+        segmentNode = serverCreateElement(
+          ServerFragment,
           {
             key: cacheNodeKey,
           },
@@ -1027,7 +1026,7 @@ async function createComponentTreeInternal(
     const layoutFilePath = getConventionPathByType(tree, dir, 'layout')
     const wrappedSegmentNode =
       isSegmentViewEnabled && layoutFilePath
-        ? createElement(
+        ? serverCreateElement(
             SegmentViewNode,
             {
               key: 'layout',
@@ -1050,7 +1049,6 @@ async function createComponentTreeInternal(
 }
 
 function createErrorBoundaryClientSegmentRoot({
-  ctx,
   ErrorBoundaryComponent,
   errorElement,
   ClientSegmentRoot,
@@ -1058,7 +1056,6 @@ function createErrorBoundaryClientSegmentRoot({
   SegmentComponent,
   currentParams,
 }: {
-  ctx: AppRenderContext
   ErrorBoundaryComponent: ComponentType<any> | undefined
   errorElement: React.ReactNode
   ClientSegmentRoot: ComponentType<any>
@@ -1066,18 +1063,15 @@ function createErrorBoundaryClientSegmentRoot({
   SegmentComponent: ComponentType<any>
   currentParams: Params
 }) {
-  const {
-    componentMod: { createElement, Fragment },
-  } = ctx
   if (ErrorBoundaryComponent) {
     const notFoundParallelRouteProps = {
       children: errorElement,
     }
-    return createElement(
-      Fragment,
+    return serverCreateElement(
+      ServerFragment,
       null,
       layerAssets,
-      createElement(ClientSegmentRoot, {
+      serverCreateElement(ClientSegmentRoot, {
         Component: SegmentComponent,
         slots: notFoundParallelRouteProps,
         params: currentParams,
@@ -1157,9 +1151,6 @@ async function createBoundaryConventionElement({
   styles: React.ReactNode | undefined
   tree: LoaderTree
 }) {
-  const {
-    componentMod: { createElement, Fragment },
-  } = ctx
   const isSegmentViewEnabled = !!ctx.renderOpts.dev
   const dir =
     (process.env.NEXT_RUNTIME === 'edge'
@@ -1167,14 +1158,19 @@ async function createBoundaryConventionElement({
       : ctx.renderOpts.dir) || ''
   const { SegmentViewNode } = ctx.componentMod
   const element = Component
-    ? createElement(Fragment, null, createElement(Component, null), styles)
+    ? serverCreateElement(
+        ServerFragment,
+        null,
+        serverCreateElement(Component, null),
+        styles
+      )
     : undefined
 
   const pagePath = getConventionPathByType(tree, dir, conventionName)
 
   const wrappedElement =
     isSegmentViewEnabled && element
-      ? createElement(
+      ? serverCreateElement(
           SegmentViewNode,
           {
             key: cacheNodeKey + '-' + conventionName,

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -10,8 +10,8 @@ export {
 // eslint-disable-next-line import/no-extraneous-dependencies
 export { prerender } from 'react-server-dom-webpack/static'
 
-// TODO: Just re-export `* as ReactServer`
-export { captureOwnerStack, createElement, Fragment } from 'react'
+import React from 'react'
+export { React as ReactServer }
 
 export { default as LayoutRouter } from '../../client/components/layout-router'
 export { default as RenderFromTemplateContext } from '../../client/components/render-from-template-context'

--- a/packages/next/src/server/app-render/get-layer-assets.tsx
+++ b/packages/next/src/server/app-render/get-layer-assets.tsx
@@ -5,6 +5,7 @@ import { getAssetQueryString } from './get-asset-query-string'
 import { encodeURIPath } from '../../shared/lib/encode-uri-path'
 import type { PreloadCallbacks } from './types'
 import { renderCssResource } from './render-css-resource'
+import { ReactServer } from './entry-base'
 
 export function getLayerAssets({
   ctx,
@@ -21,9 +22,6 @@ export function getLayerAssets({
   ctx: AppRenderContext
   preloadCallbacks: PreloadCallbacks
 }): React.ReactNode {
-  const {
-    componentMod: { createElement },
-  } = ctx
   const { styles: styleTags, scripts: scriptTags } = layoutOrPagePath
     ? getLinkAndScriptTags(
         ctx.clientReferenceManifest,
@@ -83,7 +81,7 @@ export function getLayerAssets({
           href
         )}${getAssetQueryString(ctx, true)}`
 
-        return createElement('script', {
+        return ReactServer.createElement('script', {
           src: fullSrc,
           async: true,
           key: `script-${index}`,

--- a/packages/next/src/server/app-render/render-css-resource.tsx
+++ b/packages/next/src/server/app-render/render-css-resource.tsx
@@ -3,6 +3,7 @@ import { encodeURIPath } from '../../shared/lib/encode-uri-path'
 import type { AppRenderContext } from './app-render'
 import { getAssetQueryString } from './get-asset-query-string'
 import type { PreloadCallbacks } from './types'
+import { ReactServer } from './entry-base'
 
 /**
  * Abstracts the rendering of CSS files based on whether they are inlined or not.
@@ -14,9 +15,6 @@ export function renderCssResource(
   ctx: AppRenderContext,
   preloadCallbacks?: PreloadCallbacks
 ) {
-  const {
-    componentMod: { createElement },
-  } = ctx
   return entryCssFiles.map((entryCssFile, index) => {
     // `Precedence` is an opt-in signal for React to handle resource
     // loading and deduplication, etc. It's also used as the key to sort
@@ -40,7 +38,7 @@ export function renderCssResource(
     )}${getAssetQueryString(ctx, true)}`
 
     if (entryCssFile.inlined && !ctx.parsedRequestHeaders.isRSCRequest) {
-      return createElement(
+      return ReactServer.createElement(
         'style',
         {
           key: index,
@@ -60,7 +58,7 @@ export function renderCssResource(
       )
     })
 
-    return createElement('link', {
+    return ReactServer.createElement('link', {
       key: index,
       rel: 'stylesheet',
       href: fullHref,

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -207,11 +207,6 @@ interface PrerenderStoreModernCommon
    * subsequent dynamic render.
    */
   readonly hmrRefreshHash: string | undefined
-
-  /**
-   * Only available in dev mode.
-   */
-  readonly captureOwnerStack: undefined | (() => string | null)
 }
 
 interface StaticPrerenderStoreCommon {

--- a/packages/next/src/server/node-environment-extensions/console-dim.external.test.ts
+++ b/packages/next/src/server/node-environment-extensions/console-dim.external.test.ts
@@ -321,13 +321,23 @@ describe('console-exit patches', () => {
         }
 
         // Install patches - this wraps the current console.log
-        const {
-          registerGetCacheSignal,
-        } = require('next/dist/server/node-environment-extensions/console-dim.external')
+        require('next/dist/server/node-environment-extensions/console-dim.external')
 
-        registerGetCacheSignal(() => null)
-        registerGetCacheSignal(() => controller?.signal)
-        registerGetCacheSignal(() => null)
+        const {
+          registerServerReact,
+          registerClientReact,
+        } = require('next/dist/server/runtime-reacts.external')
+
+        registerServerReact({
+          cacheSignal() {
+            return controller?.signal
+          },
+        })
+        registerClientReact({
+          cacheSignal() {
+            return null
+          },
+        })
 
         console.log('before abort')
         controller.abort()

--- a/packages/next/src/server/route-modules/app-page/module.ts
+++ b/packages/next/src/server/route-modules/app-page/module.ts
@@ -39,13 +39,12 @@ if (process.env.NEXT_RUNTIME !== 'edge') {
   vendoredReactSSR =
     require('./vendored/ssr/entrypoints') as typeof import('./vendored/ssr/entrypoints')
 
-  // In Node environments we augment console logging with information contextual to a React render.
-  // This patching is global so we need to register the cacheSignal getter from our bundled React instances
-  // here when we load them rather than in the external module itself when the patch is applied.
-  const { registerGetCacheSignal } =
-    require('../../node-environment-extensions/console-dim.external') as typeof import('../../node-environment-extensions/console-dim.external')
-  registerGetCacheSignal(vendoredReactRSC.React.cacheSignal)
-  registerGetCacheSignal(vendoredReactSSR.React.cacheSignal)
+  // In Node environments we need to access the correct React instance from external modules such
+  // as global patches. We register the loaded React instances here.
+  const { registerServerReact, registerClientReact } =
+    require('../../runtime-reacts.external') as typeof import('../../runtime-reacts.external')
+  registerServerReact(vendoredReactRSC.React)
+  registerClientReact(vendoredReactSSR.React)
 }
 
 /**

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -413,7 +413,6 @@ export class AppRouteRouteModule extends RouteModule<
               prerenderResumeDataCache,
               renderResumeDataCache: null,
               hmrRefreshHash: undefined,
-              captureOwnerStack: undefined,
             })
 
           let prospectiveResult
@@ -505,7 +504,6 @@ export class AppRouteRouteModule extends RouteModule<
             prerenderResumeDataCache,
             renderResumeDataCache: null,
             hmrRefreshHash: undefined,
-            captureOwnerStack: undefined,
           })
 
           let responseHandled = false

--- a/packages/next/src/server/runtime-reacts.external.ts
+++ b/packages/next/src/server/runtime-reacts.external.ts
@@ -1,0 +1,15 @@
+let ClientReact: typeof import('react') | null = null
+export function registerClientReact(react: typeof import('react')) {
+  ClientReact = react
+}
+export function getClientReact() {
+  return ClientReact
+}
+
+let ServerReact: typeof import('react') | null = null
+export function registerServerReact(react: typeof import('react')) {
+  ServerReact = react
+}
+export function getServerReact() {
+  return ServerReact
+}

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -321,6 +321,7 @@ const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
          "/node_modules/next/dist/server/route-modules/pages/vendored/contexts/loadable.js",
          "/node_modules/next/dist/server/route-modules/pages/vendored/contexts/router-context.js",
          "/node_modules/next/dist/server/route-modules/pages/vendored/contexts/server-inserted-html.js",
+         "/node_modules/next/dist/server/runtime-reacts.external.js",
          "/node_modules/next/dist/shared/lib/deep-freeze.js",
          "/node_modules/next/dist/shared/lib/invariant-error.js",
          "/node_modules/next/dist/shared/lib/is-plain-object.js",


### PR DESCRIPTION
We have a legacy of proxying react-server values through `componentMod` because it is historically been the entrypoint to RSC land from shared server code. However this is needless indirection. we can just import from `./entry-base` most things that aren't per request.

This change reexports React through entry-base as `ReactServer` and then updates all the callsites where we pull `createElement` and `Fragment` off the ComponentMod value and replaces those with imports of ReactServer.