### PR TITLE
[test] Add test cases for dynamic caches without suspense boundaries

### DIFF
--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -2666,12 +2666,12 @@ describe('Cache Components Errors', () => {
             const browser = await next.browser('/use-cache-low-expire')
 
             if (isTurbopack) {
-              await expect(browser).toDisplayRedbox(
-                `"Expected Redbox but found no visible one."`
+              await expect(browser).toDisplayCollapsedRedbox(
+                `"Redbox did not open."`
               )
             } else {
-              await expect(browser).toDisplayRedbox(
-                `"Expected Redbox but found no visible one."`
+              await expect(browser).toDisplayCollapsedRedbox(
+                `"Redbox did not open."`
               )
             }
           })
@@ -2771,12 +2771,12 @@ describe('Cache Components Errors', () => {
             const browser = await next.browser('/use-cache-revalidate-0')
 
             if (isTurbopack) {
-              await expect(browser).toDisplayRedbox(
-                `"Expected Redbox but found no visible one."`
+              await expect(browser).toDisplayCollapsedRedbox(
+                `"Redbox did not open."`
               )
             } else {
-              await expect(browser).toDisplayRedbox(
-                `"Expected Redbox but found no visible one."`
+              await expect(browser).toDisplayCollapsedRedbox(
+                `"Redbox did not open."`
               )
             }
           })
@@ -2876,12 +2876,12 @@ describe('Cache Components Errors', () => {
             const browser = await next.browser('/use-cache-params/foo')
 
             if (isTurbopack) {
-              await expect(browser).toDisplayRedbox(
-                `"Expected Redbox but found no visible one."`
+              await expect(browser).toDisplayCollapsedRedbox(
+                `"Redbox did not open."`
               )
             } else {
-              await expect(browser).toDisplayRedbox(
-                `"Expected Redbox but found no visible one."`
+              await expect(browser).toDisplayCollapsedRedbox(
+                `"Redbox did not open."`
               )
             }
           })

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -2658,6 +2658,331 @@ describe('Cache Components Errors', () => {
           })
         }
       })
+
+      describe('cacheLife with expire < 5 minutes', () => {
+        if (isNextDev) {
+          // FIXME: This should show a redbox error, but currently does not.
+          it('should show a redbox error', async () => {
+            const browser = await next.browser('/use-cache-low-expire')
+
+            if (isTurbopack) {
+              await expect(browser).toDisplayRedbox(
+                `"Expected Redbox but found no visible one."`
+              )
+            } else {
+              await expect(browser).toDisplayRedbox(
+                `"Expected Redbox but found no visible one."`
+              )
+            }
+          })
+        } else {
+          it('should error the build', async () => {
+            try {
+              await prerender('/use-cache-low-expire')
+            } catch {
+              // we expect the build to fail
+            }
+
+            const output = getPrerenderOutput(
+              next.cliOutput.slice(cliOutputLength),
+              { isMinified: !isDebugPrerender }
+            )
+
+            if (isTurbopack) {
+              if (isDebugPrerender) {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route "/use-cache-low-expire": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                     at main (<anonymous>)
+                     at body (<anonymous>)
+                     at html (<anonymous>)
+                 To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-low-expire". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                 > Export encountered errors on following paths:
+                 	/use-cache-low-expire/page: /use-cache-low-expire"
+                `)
+              } else {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route "/use-cache-low-expire": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                     at main (<anonymous>)
+                     at body (<anonymous>)
+                     at html (<anonymous>)
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-low-expire". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Export encountered an error on /use-cache-low-expire/page: /use-cache-low-expire, exiting the build."
+                `)
+              }
+            } else {
+              if (isDebugPrerender) {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route "/use-cache-low-expire": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                     at <FIXME-library-internal>
+                 To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-low-expire". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                 > Export encountered errors on following paths:
+                 	/use-cache-low-expire/page: /use-cache-low-expire"
+                `)
+              } else {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route "/use-cache-low-expire": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                     at a (<next-dist-dir>)
+                     at b (<next-dist-dir>)
+                     at c (<next-dist-dir>)
+                     at d (<next-dist-dir>)
+                     at e (<next-dist-dir>)
+                     at f (<next-dist-dir>)
+                     at g (<next-dist-dir>)
+                     at h (<next-dist-dir>)
+                     at i (<next-dist-dir>)
+                     at j (<next-dist-dir>)
+                     at main (<anonymous>)
+                     at body (<anonymous>)
+                     at html (<anonymous>)
+                     at k (<next-dist-dir>)
+                     at l (<next-dist-dir>)
+                     at m (<next-dist-dir>)
+                     at n (<next-dist-dir>)
+                     at o (<next-dist-dir>)
+                     at p (<next-dist-dir>)
+                     at q (<next-dist-dir>)
+                     at r (<next-dist-dir>)
+                     at s (<next-dist-dir>)
+                     at t (<next-dist-dir>)
+                     at u (<next-dist-dir>)
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-low-expire". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Export encountered an error on /use-cache-low-expire/page: /use-cache-low-expire, exiting the build."
+                `)
+              }
+            }
+          })
+        }
+      })
+
+      describe('cacheLife with revalidate: 0', () => {
+        if (isNextDev) {
+          // FIXME: This should show a redbox error, but currently does not.
+          it('should show a redbox error', async () => {
+            const browser = await next.browser('/use-cache-revalidate-0')
+
+            if (isTurbopack) {
+              await expect(browser).toDisplayRedbox(
+                `"Expected Redbox but found no visible one."`
+              )
+            } else {
+              await expect(browser).toDisplayRedbox(
+                `"Expected Redbox but found no visible one."`
+              )
+            }
+          })
+        } else {
+          it('should error the build', async () => {
+            try {
+              await prerender('/use-cache-revalidate-0')
+            } catch {
+              // we expect the build to fail
+            }
+
+            const output = getPrerenderOutput(
+              next.cliOutput.slice(cliOutputLength),
+              { isMinified: !isDebugPrerender }
+            )
+
+            if (isTurbopack) {
+              if (isDebugPrerender) {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route "/use-cache-revalidate-0": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                     at main (<anonymous>)
+                     at body (<anonymous>)
+                     at html (<anonymous>)
+                 To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-revalidate-0". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                 > Export encountered errors on following paths:
+                 	/use-cache-revalidate-0/page: /use-cache-revalidate-0"
+                `)
+              } else {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route "/use-cache-revalidate-0": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                     at main (<anonymous>)
+                     at body (<anonymous>)
+                     at html (<anonymous>)
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-revalidate-0". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Export encountered an error on /use-cache-revalidate-0/page: /use-cache-revalidate-0, exiting the build."
+                `)
+              }
+            } else {
+              if (isDebugPrerender) {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route "/use-cache-revalidate-0": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                     at <FIXME-library-internal>
+                 To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-revalidate-0". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                 > Export encountered errors on following paths:
+                 	/use-cache-revalidate-0/page: /use-cache-revalidate-0"
+                `)
+              } else {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route "/use-cache-revalidate-0": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                     at a (<next-dist-dir>)
+                     at b (<next-dist-dir>)
+                     at c (<next-dist-dir>)
+                     at d (<next-dist-dir>)
+                     at e (<next-dist-dir>)
+                     at f (<next-dist-dir>)
+                     at g (<next-dist-dir>)
+                     at h (<next-dist-dir>)
+                     at i (<next-dist-dir>)
+                     at j (<next-dist-dir>)
+                     at main (<anonymous>)
+                     at body (<anonymous>)
+                     at html (<anonymous>)
+                     at k (<next-dist-dir>)
+                     at l (<next-dist-dir>)
+                     at m (<next-dist-dir>)
+                     at n (<next-dist-dir>)
+                     at o (<next-dist-dir>)
+                     at p (<next-dist-dir>)
+                     at q (<next-dist-dir>)
+                     at r (<next-dist-dir>)
+                     at s (<next-dist-dir>)
+                     at t (<next-dist-dir>)
+                     at u (<next-dist-dir>)
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-revalidate-0". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Export encountered an error on /use-cache-revalidate-0/page: /use-cache-revalidate-0, exiting the build."
+                `)
+              }
+            }
+          })
+        }
+      })
+
+      describe('reading fallback params', () => {
+        if (isNextDev) {
+          // FIXME: This should show a redbox error, but currently does not.
+          it('should show a redbox error', async () => {
+            const browser = await next.browser('/use-cache-params/foo')
+
+            if (isTurbopack) {
+              await expect(browser).toDisplayRedbox(
+                `"Expected Redbox but found no visible one."`
+              )
+            } else {
+              await expect(browser).toDisplayRedbox(
+                `"Expected Redbox but found no visible one."`
+              )
+            }
+          })
+        } else {
+          it('should error the build', async () => {
+            try {
+              await prerender('/use-cache-params/[slug]')
+            } catch {
+              // we expect the build to fail
+            }
+
+            const output = getPrerenderOutput(
+              next.cliOutput.slice(cliOutputLength),
+              { isMinified: !isDebugPrerender }
+            )
+
+            if (isTurbopack) {
+              if (isDebugPrerender) {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route "/use-cache-params/[slug]": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                     at main (<anonymous>)
+                     at body (<anonymous>)
+                     at html (<anonymous>)
+                 To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-params/[slug]" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-params/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                 > Export encountered errors on following paths:
+                 	/use-cache-params/[slug]/page: /use-cache-params/[slug]"
+                `)
+              } else {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route "/use-cache-params/[slug]": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                     at main (<anonymous>)
+                     at body (<anonymous>)
+                     at html (<anonymous>)
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-params/[slug]" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-params/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Export encountered an error on /use-cache-params/[slug]/page: /use-cache-params/[slug], exiting the build."
+                `)
+              }
+            } else {
+              if (isDebugPrerender) {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route "/use-cache-params/[slug]": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                     at <FIXME-library-internal>
+                 To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-params/[slug]" in your browser to investigate the error.
+                 Error occurred prerendering page "/use-cache-params/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
+
+                 > Export encountered errors on following paths:
+                 	/use-cache-params/[slug]/page: /use-cache-params/[slug]"
+                `)
+              } else {
+                expect(output).toMatchInlineSnapshot(`
+                 "Error: Route "/use-cache-params/[slug]": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
+                     at a (<next-dist-dir>)
+                     at b (<next-dist-dir>)
+                     at c (<next-dist-dir>)
+                     at d (<next-dist-dir>)
+                     at e (<next-dist-dir>)
+                     at f (<next-dist-dir>)
+                     at g (<next-dist-dir>)
+                     at h (<next-dist-dir>)
+                     at i (<next-dist-dir>)
+                     at j (<next-dist-dir>)
+                     at k (<next-dist-dir>)
+                     at l (<next-dist-dir>)
+                     at m (<next-dist-dir>)
+                     at n (<next-dist-dir>)
+                     at o (<next-dist-dir>)
+                     at p (<next-dist-dir>)
+                     at q (<next-dist-dir>)
+                     at r (<next-dist-dir>)
+                     at s (<next-dist-dir>)
+                     at t (<next-dist-dir>)
+                     at main (<anonymous>)
+                     at body (<anonymous>)
+                     at html (<anonymous>)
+                     at u (<next-dist-dir>)
+                     at v (<next-dist-dir>)
+                     at w (<next-dist-dir>)
+                     at x (<next-dist-dir>)
+                     at y (<next-dist-dir>)
+                     at z (<next-dist-dir>)
+                     at a (<next-dist-dir>)
+                     at b (<next-dist-dir>)
+                     at c (<next-dist-dir>)
+                     at d (<next-dist-dir>)
+                     at e (<next-dist-dir>)
+                 To get a more detailed stack trace and pinpoint the issue, try one of the following:
+                   - Start the app in development mode by running \`next dev\`, then open "/use-cache-params/[slug]" in your browser to investigate the error.
+                   - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
+                 Error occurred prerendering page "/use-cache-params/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
+                 Export encountered an error on /use-cache-params/[slug]/page: /use-cache-params/[slug], exiting the build."
+                `)
+              }
+            }
+          })
+        }
+      })
     })
 
     describe('With `use cache: private`', () => {

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-low-expire/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-low-expire/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-low-expire/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-low-expire/page.tsx
@@ -1,0 +1,17 @@
+import { cacheLife } from 'next/cache'
+
+export default async function Page() {
+  'use cache: remote'
+
+  cacheLife({ expire: 299 }) // 1 second below the threshold of 5 minutes
+
+  return (
+    <>
+      <p>
+        This page is cached with a low expire time. Such a short-lived cache is
+        excluded from prerenders, and creates a dynamic hole. Without a parent
+        suspense boundary, this will cause an error during prerendering.
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-params/[slug]/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-params/[slug]/page.tsx
@@ -1,0 +1,20 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  'use cache'
+
+  const { slug } = await params
+
+  return (
+    <>
+      <p>
+        This page accesses params without defining any static params. This
+        excludes the page from prerenders, and creates a dynamic hole. Without a
+        parent suspense boundary, this will cause an error during prerendering.
+      </p>
+      <p>Slug: {slug}</p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-params/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-params/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-revalidate-0/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-revalidate-0/layout.tsx
@@ -1,0 +1,9 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-revalidate-0/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-revalidate-0/page.tsx
@@ -1,0 +1,17 @@
+import { cacheLife } from 'next/cache'
+
+export default async function Page() {
+  'use cache: remote'
+
+  cacheLife({ revalidate: 0 })
+
+  return (
+    <>
+      <p>
+        This page is cached with a zero revalidate time. Such a short-lived
+        cache is excluded from prerenders, and creates a dynamic hole. Without a
+        parent suspense boundary, this will cause an error during prerendering.
+      </p>
+    </>
+  )
+}


### PR DESCRIPTION
When defining a `cacheLife` with an expire time below 5 minutes or a revalidate time of 0 we consider the `'use cache'` function dynamic during prerendering, i.e. it will be excluded from the static shell. Similarly, accessing runtime `params` (not defined in `generateStaticParams`) also makes the function dynamic. Those cases require adding a parent suspense boundary. If there's no suspense boundary, we should show an error during prerendering at build time, as well as in development as part of the prerender validation. The latter is currently not working as expected when the `'use cache'` directive is used in a page (or layout) directly. As the added snapshot tests show, no redbox is shown in those cases. This is a known issue that we plan to address separately.

We will also follow up with improving the error messages and docs for those dynamic cache cases. This detail got lost in #85087.