### PR TITLE
[test] Log debug info if tests time out during `act`

### DIFF
--- a/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
@@ -127,6 +127,7 @@ describe('app dir - prefetching (custom staleTime)', () => {
     }, 'no-requests')
   })
 
+  // increment if you attempt(ed) to fix flakiness: 1
   it('should not re-fetch cached data when navigating back to a route group', async () => {
     let act: ReturnType<typeof createRouterAct>
     // Just installing so that the page doesn't automatically move past dynamic stale time

--- a/test/lib/router-act.ts
+++ b/test/lib/router-act.ts
@@ -273,6 +273,32 @@ export function createRouterAct(
             headers['next-action'] !== undefined // Matches Server Actions
 
           if (isRouterRequest) {
+            const result = (async () => {
+              const originalResponse = await page.request.fetch(request, {
+                maxRedirects: 0,
+              })
+
+              // WORKAROUND:
+              // intercepting responses with 'Transfer-Encoding: chunked' (used for streaming)
+              // seems to be problematic sometimes, making the browser error with `net::ERR_INCOMPLETE_CHUNKED_ENCODING`.
+              // In particular, this seems to happen when blocking a streaming navigation response. (but not always)
+              // Playwright buffers the whole body anyway, so we can remove the header to sidestep this.
+              const headers = originalResponse.headers()
+              delete headers['transfer-encoding']
+
+              return {
+                text: await originalResponse.text(),
+                body: await originalResponse.body(),
+                headers,
+                status: originalResponse.status(),
+              }
+            })()
+            result.catch((reason) => {
+              error.message = `Router request failed`
+              error.cause = reason
+              console.error(error)
+              throw reason
+            })
             // This request was initiated by the Next.js Router. Intercept it and
             // add it to the current batch.
             pendingRequests.add({

--- a/test/production/router-act/app/layout.tsx
+++ b/test/production/router-act/app/layout.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        <Suspense>{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/production/router-act/app/page.tsx
+++ b/test/production/router-act/app/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function HomePage() {
+  return (
+    <>
+      <Link href="/slow">Go to slow</Link>
+    </>
+  )
+}

--- a/test/production/router-act/app/slow/page.tsx
+++ b/test/production/router-act/app/slow/page.tsx
@@ -1,0 +1,6 @@
+import { setTimeout } from 'timers/promises'
+
+export default async function SlowPage() {
+  // Must be higher than test timeout
+  await setTimeout(10_000)
+}

--- a/test/production/router-act/next.config.js
+++ b/test/production/router-act/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const config = {
+  cacheComponents: true,
+}
+
+module.exports = config

--- a/test/production/router-act/router-act.test.ts
+++ b/test/production/router-act/router-act.test.ts
@@ -1,0 +1,55 @@
+import type * as Playwright from 'playwright'
+import { nextTestSetup } from 'e2e-utils'
+import { createRouterAct } from 'router-act'
+import { setTimeout } from 'node:timers/promises'
+
+describe('router-act', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  describe('prints debug info when test times out on act()', () => {
+    let didTimeout = false
+    let consoleErrorMock: jest.SpyInstance
+    beforeAll(() => {
+      consoleErrorMock = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+    })
+    afterAll(() => {
+      consoleErrorMock?.mockClear()
+    })
+
+    test('example', async () => {
+      let page: Playwright.Page
+      await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page)
+
+      let abortAct
+      const actAborted = new Promise<void>((resolve) => {
+        abortAct = resolve
+      })
+      // Navigation is to a slow page
+      await Promise.race([
+        act(async () => {
+          await page.click('text=Go to slow')
+          // wait for requests to init, and then abort
+          setTimeout(1000).then(abortAct)
+        }),
+        actAborted.then(() => {
+          didTimeout = true
+        }),
+      ])
+    })
+
+    test('assertion', async () => {
+      expect({ didTimeout }).toEqual({ didTimeout: true })
+      // The timing is hard to simulate. We just want to make sure the abort handler was called.
+      expect(consoleErrorMock).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/test/production/router-act/router-act.test.ts
+++ b/test/production/router-act/router-act.test.ts
@@ -8,6 +8,8 @@ describe('router-act', () => {
     files: __dirname,
   })
 
+  // Feel free to disable if this is flaky. It's more useful to manually test
+  // failing `act` anyway.
   describe('prints debug info when test times out on act()', () => {
     let didTimeout = false
     let consoleErrorMock: jest.SpyInstance
@@ -29,7 +31,7 @@ describe('router-act', () => {
       })
       const act = createRouterAct(page)
 
-      let abortAct
+      let abortAct: () => void
       const actAborted = new Promise<void>((resolve) => {
         abortAct = resolve
       })


### PR DESCRIPTION
`act` has currently little timeouts and is cause for quite a bit of flaky tests that result in tests timing out. When tests time out on `act`, we have no way of inspecting what went wrong.

This PR adds some debug logs when we detect that the test timed out during `act` execution. We do this by adding an `AbortSignal` during the test which aborts afterwards. 

That means we also log this debug info for `act` that wasn't awaited. We currently don't fail our tests on `console.error` though we should.