### PR TITLE
[test] Speed up refresh test

### DIFF
--- a/test/development/app-dir/basic/basic.test.ts
+++ b/test/development/app-dir/basic/basic.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
-import { waitFor } from 'next-test-utils'
-import { createSandbox, waitForHydration } from 'development-sandbox'
+import { assertNoRedbox } from 'next-test-utils'
+import { waitForHydration } from 'development-sandbox'
 
 describe('basic app-dir tests', () => {
   const { next } = nextTestSetup({
@@ -8,18 +8,10 @@ describe('basic app-dir tests', () => {
   })
 
   it('should reload app pages without error', async () => {
-    await using sandbox = await createSandbox(next, undefined, '/')
-    const { session, browser } = sandbox
-    await session.assertNoRedbox()
-
-    browser.refresh()
-
-    await waitFor(750)
+    const browser = await next.browser('/')
+    await browser.refresh()
     await waitForHydration(browser)
 
-    for (let i = 0; i < 15; i++) {
-      await session.assertNoRedbox()
-      await waitFor(1000)
-    }
+    await assertNoRedbox(browser)
   })
 })


### PR DESCRIPTION
Test was introduced in https://github.com/vercel/next.js/pull/55447/ when `assertNoRedbox` wasn't waiting for 5s.

This is our slowest test at the moment (p50 of 110s).

We just can't know when the error might occur after reload (see Halting problem). We settled on waiting 5s in all the other tests so we should do the same here.