### PR TITLE
[test] Separate act and assertions

### DIFF
--- a/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
@@ -37,8 +37,7 @@ describe('app dir - prefetching (custom staleTime)', () => {
       async () => {
         const reveal = await browser.elementByCss('#accordion-to-static-page')
         await reveal.click()
-        await browser.waitForElementByCss('#to-static-page')
-        return await browser.elementByCss('#to-static-page')
+        return browser.elementByCss('#to-static-page')
       },
       { includes: 'Static Page [prefetch-sentinel]' }
     )
@@ -46,7 +45,6 @@ describe('app dir - prefetching (custom staleTime)', () => {
     // Navigate to static page - should use prefetched data with no additional requests
     await act(async () => {
       await link.click()
-      await browser.waitForElementByCss('#static-page')
       const staticPageText = await browser.elementByCss('#static-page').text()
       expect(staticPageText).toBe('Static Page [prefetch-sentinel]')
     }, 'no-requests')
@@ -66,12 +64,12 @@ describe('app dir - prefetching (custom staleTime)', () => {
     await browser.waitForElementByCss('#to-static-page')
 
     // Navigate to static page again using the accordion - should still use cached data with no additional requests
-    await act(async () => {
+    const staticPageText = await act(async () => {
       await browser.elementByCss('#to-static-page').click()
-      await browser.waitForElementByCss('#static-page')
-      const staticPageText = await browser.elementByCss('#static-page').text()
-      expect(staticPageText).toBe('Static Page [prefetch-sentinel]')
+      return browser.elementByCss('#static-page').text()
     }, 'no-requests')
+
+    expect(staticPageText).toBe('Static Page [prefetch-sentinel]')
   })
 
   it('should fetch again when a static page was prefetched when navigating to it after the stale time has passed', async () => {
@@ -91,8 +89,7 @@ describe('app dir - prefetching (custom staleTime)', () => {
       async () => {
         const reveal = await browser.elementByCss('#accordion-to-static-page')
         await reveal.click()
-        await browser.waitForElementByCss('#to-static-page')
-        return await browser.elementByCss('#to-static-page')
+        return browser.elementByCss('#to-static-page')
       },
       { includes: 'Static Page [prefetch-sentinel]' }
     )
@@ -118,8 +115,7 @@ describe('app dir - prefetching (custom staleTime)', () => {
       async () => {
         const reveal = await browser.elementByCss('#accordion-to-static-page')
         await reveal.click()
-        await browser.waitForElementByCss('#to-static-page')
-        return await browser.elementByCss('#to-static-page')
+        return browser.elementByCss('#to-static-page')
       },
       { includes: 'Static Page [prefetch-sentinel]' }
     )
@@ -153,8 +149,9 @@ describe('app dir - prefetching (custom staleTime)', () => {
     await act(async () => {
       await browser.elementByCss("[href='/prefetch-auto-route-groups']").click()
       // Confirm that the dashboard page is still rendering the stale fetch count, as it should be cached
-      expect(await browser.elementById('count').text()).toBe('1')
     }, 'no-requests')
+
+    expect(await browser.elementById('count').text()).toBe('1')
 
     // Navigate to a new sub-page - this will trigger another data fetch
     await act(async () => {
@@ -166,12 +163,14 @@ describe('app dir - prefetching (custom staleTime)', () => {
     // Finally, go back to the route group page - should use cached data with no additional fetch
     await act(async () => {
       await browser.elementByCss("[href='/prefetch-auto-route-groups']").click()
-      // Confirm that the dashboard page is still rendering the stale fetch count, as it should be cached
-      expect(await browser.elementById('count').text()).toBe('1')
     }, 'no-requests')
+
+    // Confirm that the dashboard page is still rendering the stale fetch count, as it should be cached
+    expect(await browser.elementById('count').text()).toBe('1')
 
     // Reload the page to get the accurate total number of fetches
     await browser.refresh()
+
     // The initial fetch, 2 sub-page fetches, and a final fetch when reloading the page
     expect(await browser.elementById('count').text()).toBe('4')
   })
@@ -196,8 +195,7 @@ describe('app dir - prefetching (custom staleTime)', () => {
       async () => {
         const reveal = await browser.elementByCss('#accordion-to-home')
         await reveal.click()
-        await browser.waitForElementByCss('#to-home')
-        return await browser.elementByCss('#to-home')
+        return browser.elementByCss('#to-home')
       },
       { includes: 'Home Page [prefetch-sentinel]' }
     )
@@ -216,21 +214,17 @@ describe('app dir - prefetching (custom staleTime)', () => {
           '#accordion-to-static-page-no-prefetch'
         )
         await reveal.click()
-        await browser.waitForElementByCss('#to-static-page-no-prefetch')
-        return await browser.elementByCss('#to-static-page-no-prefetch')
+        return browser.elementByCss('#to-static-page-no-prefetch')
       },
       { includes: 'Static Page No Prefetch [prefetch-sentinel]' }
     )
 
     // Navigate back to static-page-no-prefetch - should use the fresh prefetch data
-    await act(async () => {
+    const staticPageText = await act(async () => {
       await link.click()
-      await browser.waitForElementByCss('#static-page-no-prefetch')
-      const staticPageText = await browser
-        .elementByCss('#static-page-no-prefetch')
-        .text()
-      expect(staticPageText).toBe('Static Page No Prefetch [prefetch-sentinel]')
+      return browser.elementByCss('#static-page-no-prefetch').text()
     }, 'no-requests')
+    expect(staticPageText).toBe('Static Page No Prefetch [prefetch-sentinel]')
   })
 
   it('should renew the stale time after refetching expired RSC data', async () => {
@@ -250,8 +244,7 @@ describe('app dir - prefetching (custom staleTime)', () => {
       async () => {
         const reveal = await browser.elementByCss('#accordion-to-static-page')
         await reveal.click()
-        await browser.waitForElementByCss('#to-static-page')
-        return await browser.elementByCss('#to-static-page')
+        return browser.elementByCss('#to-static-page')
       },
       { includes: 'Static Page [prefetch-sentinel]' }
     )
@@ -280,8 +273,7 @@ describe('app dir - prefetching (custom staleTime)', () => {
       async () => {
         const reveal = await browser.elementByCss('#accordion-to-static-page')
         await reveal.click()
-        await browser.waitForElementByCss('#to-static-page')
-        return await browser.elementByCss('#to-static-page')
+        return browser.elementByCss('#to-static-page')
       },
       { includes: 'Static Page [prefetch-sentinel]' }
     )
@@ -307,17 +299,15 @@ describe('app dir - prefetching (custom staleTime)', () => {
     link = await act(async () => {
       const reveal = await browser.elementByCss('#accordion-to-static-page')
       await reveal.click()
-      await browser.waitForElementByCss('#to-static-page')
-      return await browser.elementByCss('#to-static-page')
+      return browser.elementByCss('#to-static-page')
     }, 'no-requests')
 
     // Navigate to static page again (should NOT refetch - stale time should be renewed)
     // If this assertion passes, it means the stale time was properly renewed after the refetch
-    await act(async () => {
+    const staticPageText = await act(async () => {
       await link.click()
-      await browser.waitForElementByCss('#static-page')
-      const staticPageText = await browser.elementByCss('#static-page').text()
-      expect(staticPageText).toBe('Static Page [prefetch-sentinel]')
+      return browser.elementByCss('#static-page').text()
     }, 'no-requests')
+    expect(staticPageText).toBe('Static Page [prefetch-sentinel]')
   })
 })


### PR DESCRIPTION
Moves the assertions out of `act` and removes redundant waiting for elements. Similar to https://github.com/vercel/next.js/pull/85417