### PR TITLE
Turbopack: remove the .into() alias to .cell()

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -487,7 +487,7 @@ impl Issue for CssGlobalImportIssue {
 
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::ProcessModule.into()
+        IssueStage::ProcessModule.cell()
     }
 
     // TODO(PACK-4879): compute the source information by following the module references

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -122,7 +122,7 @@ struct MiddlewareMissingExportIssue {
 impl Issue for MiddlewareMissingExportIssue {
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Transform.into()
+        IssueStage::Transform.cell()
     }
 
     fn severity(&self) -> IssueSeverity {

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -40,7 +40,7 @@ pub async fn get_app_route_entry(
     let config = if let Some(original_segment_config) = original_segment_config {
         let mut segment_config = segment_from_source.owned().await?;
         segment_config.apply_parent_config(&*original_segment_config.await?);
-        segment_config.into()
+        segment_config.cell()
     } else {
         segment_from_source
     };

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -557,7 +557,7 @@ impl Issue for StaticMetadataFileSizeIssue {
 
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::ProcessModule.into()
+        IssueStage::ProcessModule.cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -146,7 +146,7 @@ impl NextFontGoogleReplacer {
 impl ImportMappingReplacement for NextFontGoogleReplacer {
     #[turbo_tasks::function]
     fn replace(&self, _capture: Vc<Pattern>) -> Vc<ReplacedImportMapping> {
-        ReplacedImportMapping::Ignore.into()
+        ReplacedImportMapping::Ignore.cell()
     }
 
     /// Intercepts requests for `next/font/google/target.css` and returns a
@@ -166,14 +166,14 @@ impl ImportMappingReplacement for NextFontGoogleReplacer {
             fragment: _,
         } = request
         else {
-            return Ok(ImportMapResult::NoEntry.into());
+            return Ok(ImportMapResult::NoEntry.cell());
         };
 
         let this = &*self.await?;
         if can_use_next_font(this.project_path.clone(), query).await? {
             Ok(self.import_map_result(query.clone()))
         } else {
-            Ok(ImportMapResult::NoEntry.into())
+            Ok(ImportMapResult::NoEntry.cell())
         }
     }
 }
@@ -338,7 +338,7 @@ impl NextFontGoogleCssModuleReplacer {
 impl ImportMappingReplacement for NextFontGoogleCssModuleReplacer {
     #[turbo_tasks::function]
     fn replace(&self, _capture: Vc<Pattern>) -> Vc<ReplacedImportMapping> {
-        ReplacedImportMapping::Ignore.into()
+        ReplacedImportMapping::Ignore.cell()
     }
 
     /// Intercepts requests for the css module made by the virtual JavaScript

--- a/crates/next-core/src/next_font/issue.rs
+++ b/crates/next-core/src/next_font/issue.rs
@@ -14,7 +14,7 @@ pub(crate) struct NextFontIssue {
 impl Issue for NextFontIssue {
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::CodeGen.into()
+        IssueStage::CodeGen.cell()
     }
 
     fn severity(&self) -> IssueSeverity {

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -166,7 +166,7 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                         "{}.js",
                         get_request_id(options_vc.font_family().await?, request_hash)
                     ))?,
-                    AssetContent::file(FileContent::Content(file_content.into()).into()),
+                    AssetContent::file(FileContent::Content(file_content.into()).cell()),
                 )
                 .to_resolved()
                 .await?;

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1253,7 +1253,7 @@ impl Issue for MissingNextFolderIssue {
 
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Resolve.into()
+        IssueStage::Resolve.cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -25,7 +25,7 @@ use turbopack_core::{
 
 /// The predicated based on which the [ExternalCjsModulesResolvePlugin] decides
 /// whether to mark a module as external.
-#[turbo_tasks::value(into = "shared")]
+#[turbo_tasks::value(shared)]
 pub enum ExternalPredicate {
     /// Mark all modules as external if they're not listed in the list.
     /// Applies only to imports outside of node_modules.
@@ -483,7 +483,7 @@ impl Issue for ExternalizeIssue {
 
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Config.into()
+        IssueStage::Config.cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -64,7 +64,7 @@ impl Issue for InvalidImportModuleIssue {
 
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Resolve.into()
+        IssueStage::Resolve.cell()
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -304,7 +304,7 @@ struct BabelPluginReactCompilerResolutionIssue {
 impl Issue for BabelPluginReactCompilerResolutionIssue {
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Transform.into()
+        IssueStage::Transform.cell()
     }
 
     fn severity(&self) -> IssueSeverity {

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -309,7 +309,7 @@ impl EcmascriptChunkItem for RawEcmascriptChunkItem {
                 },
                 ..Default::default()
             }
-            .into())
+            .cell())
         }
         .instrument(span)
         .await

--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -235,7 +235,7 @@ impl Issue for NextSegmentConfigParsingIssue {
 
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Parse.into()
+        IssueStage::Parse.cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-backend/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/all_in_one.rs
@@ -25,7 +25,7 @@ async fn all_in_one() {
             value: 42,
             next: Some(MyStructValue::new(a).to_resolved().await?),
         }
-        .into();
+        .cell();
 
         let result = my_function(a, b.get_last(), c, MyEnumValue::Yeah(42));
         assert_eq!(*result.my_trait_function().await?, "42");

--- a/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell_mode.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell_mode.rs
@@ -7,7 +7,7 @@ use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
-// Test that with `cell = "shared"`, the cell will be re-used as long as the
+// Test that with `cell = "compare"`, the cell will be re-used as long as the
 // value is equal.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trait_ref_shared_cell_mode() {
@@ -32,7 +32,7 @@ async fn test_trait_ref_shared_cell_mode() {
             assert_eq!(*TraitRef::cell(trait_ref.clone()).get_value().await?, 42);
         }
 
-        // because we're using `cell = "shared"`, these trait refs must use the same
+        // because we're using `cell = "compare"`, these trait refs must use the same
         // underlying Arc/SharedRef (by identity)
         assert!(TraitRef::ptr_eq(&trait_ref_a, &trait_ref_b));
 
@@ -83,7 +83,7 @@ trait ValueTrait {
     fn get_value(&self) -> Vc<usize>;
 }
 
-#[turbo_tasks::value(transparent, cell = "shared")]
+#[turbo_tasks::value(transparent, cell = "compare")]
 struct SharedValue(usize);
 
 #[turbo_tasks::value(transparent, cell = "new")]

--- a/turbopack/crates/turbo-tasks-fetch/src/error.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/error.rs
@@ -130,7 +130,7 @@ impl Issue for FetchIssue {
 
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Load.into()
+        IssueStage::Load.cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -2201,25 +2201,25 @@ impl FileContent {
 
     #[turbo_tasks::function]
     pub fn parse_json(&self) -> Result<Vc<FileJsonContent>> {
-        Ok(self.parse_json_ref().into())
+        Ok(self.parse_json_ref().cell())
     }
 
     #[turbo_tasks::function]
     pub async fn parse_json_with_comments(self: Vc<Self>) -> Result<Vc<FileJsonContent>> {
         let this = self.await?;
-        Ok(this.parse_json_with_comments_ref().into())
+        Ok(this.parse_json_with_comments_ref().cell())
     }
 
     #[turbo_tasks::function]
     pub async fn parse_json5(self: Vc<Self>) -> Result<Vc<FileJsonContent>> {
         let this = self.await?;
-        Ok(this.parse_json5_ref().into())
+        Ok(this.parse_json5_ref().cell())
     }
 
     #[turbo_tasks::function]
     pub async fn lines(self: Vc<Self>) -> Result<Vc<FileLinesContent>> {
         let this = self.await?;
-        Ok(this.lines_ref().into())
+        Ok(this.lines_ref().cell())
     }
 
     #[turbo_tasks::function]
@@ -2464,7 +2464,7 @@ impl FileSystem for NullFileSystem {
 
     #[turbo_tasks::function]
     fn read_link(&self, _fs_path: FileSystemPath) -> Vc<LinkContent> {
-        LinkContent::NotFound.into()
+        LinkContent::NotFound.cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-macros/src/generic_type_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/generic_type_macro.rs
@@ -73,7 +73,7 @@ pub fn generic_type(input: TokenStream) -> TokenStream {
             turbo_tasks::VcTransparentRead<#ty, #ty, #repr>
         },
         quote! {
-            turbo_tasks::VcCellSharedMode<#ty>
+            turbo_tasks::VcCellCompareMode<#ty>
         },
         quote! {
             turbo_tasks::ValueType::new_with_any_serialization::<#repr>(#name)

--- a/turbopack/crates/turbo-tasks-macros/src/primitive_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/primitive_macro.rs
@@ -41,7 +41,7 @@ pub fn primitive(input: TokenStream) -> TokenStream {
             turbo_tasks::VcTransparentRead<#ty, #ty, #ty>
         },
         quote! {
-            turbo_tasks::VcCellSharedMode<#ty>
+            turbo_tasks::VcCellCompareMode<#ty>
         },
         quote! {
             turbo_tasks::ValueType::new_with_any_serialization::<#ty>(#name)

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -131,8 +131,9 @@ pub use value::{TransientInstance, TransientValue};
 pub use value_type::{TraitMethod, TraitType, ValueType};
 pub use vc::{
     Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, ReadVcFuture, ResolvedVc,
-    Upcast, UpcastStrict, ValueDefault, Vc, VcCast, VcCellNewMode, VcCellSharedMode, VcDefaultRead,
-    VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType, VcValueTypeCast,
+    Upcast, UpcastStrict, ValueDefault, Vc, VcCast, VcCellCompareMode, VcCellNewMode,
+    VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType,
+    VcValueTypeCast,
 };
 
 pub type SliceMap<K, V> = Box<[(K, V)]>;
@@ -189,7 +190,7 @@ macro_rules! fxindexset {
 /// ```
 /// # #![feature(arbitrary_self_types)]
 //  # #![feature(arbitrary_self_types_pointers)]
-/// #[turbo_tasks::value(transparent, into = "shared")]
+/// #[turbo_tasks::value(transparent, shared)]
 /// struct Foo(Vec<u32>);
 /// ```
 ///
@@ -199,7 +200,7 @@ macro_rules! fxindexset {
 /// by setting the [`VcValueType::CellMode`] associated type.
 ///
 /// - **`"new"`:** Always overrides the value in the cell, invalidating all dependent tasks.
-/// - **`"shared"` *(default)*:** Compares with the existing value in the cell, before overriding it.
+/// - **`"compare"` *(default)*:** Compares with the existing value in the cell, before overriding it.
 ///   Requires the value to implement [`Eq`].
 ///
 /// Avoiding unnecessary invalidation is important to reduce downstream recomputation of tasks that
@@ -211,30 +212,10 @@ macro_rules! fxindexset {
 ///
 /// ## `eq = "..."`
 ///
-/// By default, we `#[derive(PartialEq, Eq)]`. [`Eq`] is required by `cell = "shared"`. This
+/// By default, we `#[derive(PartialEq, Eq)]`. [`Eq`] is required by `cell = "compare"`. This
 /// argument allows overriding that default implementation behavior.
 ///
 /// - **`"manual"`:** Prevents deriving [`Eq`] and [`PartialEq`] so you can do it manually.
-///
-/// ## `into = "..."`
-///
-/// This macro always implements a `.cell()` method on your type with the signature:
-///
-/// ```ignore
-/// /// Wraps the value in a cell.
-/// fn cell(self) -> Vc<Self>;
-/// ```
-///
-/// This argument controls the visibility of the `.cell()` method, as well as whether a
-/// [`From<T> for Vc<T>`][From] implementation is generated.
-///
-/// - **`"new"` or `"shared"`:** Exposes both `.cell()` and [`From`]/[`Into`] implementations. Both
-///   of these values (`"new"` or `"shared"`) do the same thing (for legacy reasons).
-/// - **`"none"` *(default)*:** Makes `.cell()` private and prevents implementing [`From`]/[`Into`].
-///
-/// You should use the default value of `"none"` when providing your own public constructor methods.
-///
-/// The naming of this field and it's values are due to legacy reasons.
 ///
 /// ## `serialization = "..."`
 ///
@@ -248,8 +229,7 @@ macro_rules! fxindexset {
 ///
 /// ## `shared`
 ///
-/// Sets both `cell = "shared"` *(already the default)* and `into = "shared"`, exposing the
-/// `.cell()` method and adding a [`From`]/[`Into`] implementation.
+/// Makes the `cell()` method public so everyone can use it.
 ///
 /// ## `transparent`
 ///

--- a/turbopack/crates/turbo-tasks/src/vc/cell_mode.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/cell_mode.rs
@@ -54,11 +54,11 @@ where
 
 /// Mode that compares the cell's content with the new value and only updates
 /// if the new value is different.
-pub struct VcCellSharedMode<T> {
+pub struct VcCellCompareMode<T> {
     _phantom: PhantomData<T>,
 }
 
-impl<T> VcCellMode<T> for VcCellSharedMode<T>
+impl<T> VcCellMode<T> for VcCellCompareMode<T>
 where
     T: VcValueType + PartialEq,
 {

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -22,7 +22,7 @@ use shrink_to_fit::ShrinkToFit;
 
 pub use self::{
     cast::{VcCast, VcValueTraitCast, VcValueTypeCast},
-    cell_mode::{VcCellMode, VcCellNewMode, VcCellSharedMode},
+    cell_mode::{VcCellCompareMode, VcCellMode, VcCellNewMode},
     default::ValueDefault,
     local::NonLocalValue,
     operation::{OperationValue, OperationVc},

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/update.rs
@@ -171,5 +171,5 @@ pub(super) async fn update_chunk_list(
         })
     };
 
-    Ok(update.into())
+    Ok(update.cell())
 }

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -176,7 +176,7 @@ impl GraphEntries {
     }
 }
 
-#[turbo_tasks::value(cell = "new", eq = "manual", into = "new")]
+#[turbo_tasks::value(cell = "new", eq = "manual")]
 #[derive(Clone, Default)]
 pub struct SingleModuleGraph {
     pub graph: TracedDiGraph<SingleModuleGraphNode, RefData>,

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -50,7 +50,7 @@ pub struct ModuleBatchesGraphEdge {
 
 type EntriesList = FxIndexSet<ResolvedVc<Box<dyn Module>>>;
 
-#[turbo_tasks::value(cell = "new", eq = "manual", into = "new")]
+#[turbo_tasks::value(cell = "new", eq = "manual")]
 pub struct ModuleBatchesGraph {
     graph: TracedDiGraph<ModuleOrBatch, ModuleBatchesGraphEdge>,
 

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -906,7 +906,7 @@ impl ResolveResult {
             primary: new_primary,
             affecting_sources: self.affecting_sources.clone(),
         }
-        .into())
+        .cell())
     }
 
     /// Returns a new [ResolveResult] where all [RequestKey]s are updated. The prefix is removed
@@ -932,7 +932,7 @@ impl ResolveResult {
             primary: new_primary,
             affecting_sources: self.affecting_sources.clone(),
         }
-        .into())
+        .cell())
     }
 
     /// Returns a new [ResolveResult] where all [RequestKey]s are updated. All keys matching
@@ -969,7 +969,7 @@ impl ResolveResult {
             primary: new_primary,
             affecting_sources: self.affecting_sources.clone(),
         }
-        .into())
+        .cell())
     }
 
     /// Returns a new [ResolveResult] where all [RequestKey]s are set to the
@@ -993,7 +993,7 @@ impl ResolveResult {
             primary: new_primary,
             affecting_sources: self.affecting_sources.clone(),
         }
-        .into()
+        .cell()
     }
 }
 
@@ -1221,16 +1221,16 @@ pub async fn find_context_file_or_package_key(
             &*read_package_json(Vc::upcast(FileSource::new(package_json_path.clone()))).await?
         && json.get(&*package_key).is_some()
     {
-        return Ok(FindContextFileResult::Found(package_json_path, Vec::new()).into());
+        return Ok(FindContextFileResult::Found(package_json_path, Vec::new()).cell());
     }
     for name in &*names.await? {
         let fs_path = lookup_path.join(name)?;
         if let Some(fs_path) = exists(&fs_path, None).await? {
-            return Ok(FindContextFileResult::Found(fs_path, Vec::new()).into());
+            return Ok(FindContextFileResult::Found(fs_path, Vec::new()).cell());
         }
     }
     if lookup_path.is_root() {
-        return Ok(FindContextFileResult::NotFound(Vec::new()).into());
+        return Ok(FindContextFileResult::NotFound(Vec::new()).cell());
     }
 
     Ok(find_context_file(lookup_path.parent(), names, false))

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -584,10 +584,10 @@ impl ResolvedMap {
                     request,
                 )
                 .await?
-                .into());
+                .cell());
             }
         }
-        Ok(ImportMapResult::NoEntry.into())
+        Ok(ImportMapResult::NoEntry.cell())
     }
 }
 
@@ -647,7 +647,7 @@ impl ResolveOptions {
                 .to_resolved()
                 .await?,
         );
-        Ok(resolve_options.into())
+        Ok(resolve_options.cell())
     }
 
     /// Returns a new [Vc<ResolveOptions>] with its fallback import map extended
@@ -669,7 +669,7 @@ impl ResolveOptions {
             } else {
                 Some(extended_import_map)
             };
-        Ok(resolve_options.into())
+        Ok(resolve_options.cell())
     }
 
     /// Overrides the extensions used for resolving
@@ -677,7 +677,7 @@ impl ResolveOptions {
     pub async fn with_extensions(self: Vc<Self>, extensions: Vec<RcStr>) -> Result<Vc<Self>> {
         let mut resolve_options = self.owned().await?;
         resolve_options.extensions = extensions;
-        Ok(resolve_options.into())
+        Ok(resolve_options.cell())
     }
 
     /// Overrides the fully_specified flag for resolving
@@ -708,7 +708,7 @@ pub async fn resolve_modules_options(
         modules: options.modules.clone(),
         extensions: options.extensions.clone(),
     }
-    .into())
+    .cell())
 }
 
 #[turbo_tasks::value_trait]

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -39,7 +39,7 @@ pub trait VersionedContent {
 
         // Fast path: versions are the same.
         if TraitRef::ptr_eq(&from_ref, &to_ref) {
-            return Ok(Update::None.into());
+            return Ok(Update::None.cell());
         }
 
         // The fast path might not always work since `self` might have been converted
@@ -51,9 +51,9 @@ pub trait VersionedContent {
         let from_id = from_id.await?;
         let to_id = to_id.await?;
         Ok(if *from_id == *to_id {
-            Update::None.into()
+            Update::None.cell()
         } else {
-            Update::Total(TotalUpdate { to: to_ref }).into()
+            Update::Total(TotalUpdate { to: to_ref }).cell()
         })
     }
 }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -339,7 +339,7 @@ impl CssChunkItem for CssModuleChunkItem {
                 import_context: self.module.await?.import_context,
                 source_map: source_map.owned().await?,
             }
-            .into())
+            .cell())
         } else {
             Ok(CssChunkItemContent {
                 inner_code: format!(
@@ -351,7 +351,7 @@ impl CssChunkItem for CssModuleChunkItem {
                 import_context: None,
                 source_map: None,
             }
-            .into())
+            .cell())
         }
     }
 }

--- a/turbopack/crates/turbopack-css/src/code_gen.rs
+++ b/turbopack/crates/turbopack-css/src/code_gen.rs
@@ -5,13 +5,7 @@ use crate::chunk::CssImport;
 
 /// impl of code generation inferred from a ModuleReference.
 /// This is rust only and can't be implemented by non-rust plugins.
-#[turbo_tasks::value(
-    shared,
-    serialization = "none",
-    eq = "manual",
-    into = "new",
-    cell = "new"
-)]
+#[turbo_tasks::value(shared, serialization = "none", eq = "manual", cell = "new")]
 pub struct CodeGeneration {
     #[turbo_tasks(debug_ignore, trace_ignore)]
     pub imports: Vec<CssImport>,

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -285,8 +285,8 @@ pub async fn finalize_css(
                     code,
                     ..
                 } => (stylesheet.to_static(options.clone()), *code),
-                ParseCssResult::Unparsable => return Ok(FinalCssResult::Unparsable.into()),
-                ParseCssResult::NotFound => return Ok(FinalCssResult::NotFound.into()),
+                ParseCssResult::Unparsable => return Ok(FinalCssResult::Unparsable.cell()),
+                ParseCssResult::NotFound => return Ok(FinalCssResult::NotFound.cell()),
             };
 
             let url_references = *url_references;
@@ -330,10 +330,10 @@ pub async fn finalize_css(
                 exports: result.exports,
                 source_map: ResolvedVc::cell(srcmap),
             }
-            .into())
+            .cell())
         }
-        CssWithPlaceholderResult::Unparsable => Ok(FinalCssResult::Unparsable.into()),
-        CssWithPlaceholderResult::NotFound => Ok(FinalCssResult::NotFound.into()),
+        CssWithPlaceholderResult::Unparsable => Ok(FinalCssResult::Unparsable.cell()),
+        CssWithPlaceholderResult::NotFound => Ok(FinalCssResult::NotFound.cell()),
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/references/import.rs
+++ b/turbopack/crates/turbopack-css/src/references/import.rs
@@ -20,7 +20,7 @@ use crate::{
     references::css_resolve,
 };
 
-#[turbo_tasks::value(into = "new", eq = "manual", serialization = "none")]
+#[turbo_tasks::value(eq = "manual", serialization = "none", shared)]
 pub enum ImportAttributes {
     LightningCss {
         #[turbo_tasks(trace_ignore)]
@@ -174,7 +174,7 @@ impl CodeGenerateable for ImportAssetReference {
             )))
         }
 
-        Ok(CodeGeneration { imports }.into())
+        Ok(CodeGeneration { imports }.cell())
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -103,7 +103,7 @@ impl Visitor<'_> for ModuleReferencesVisitor<'_> {
                 self.references.push(Vc::upcast(ImportAssetReference::new(
                     *self.origin,
                     Request::parse(RcStr::from(src).into()),
-                    ImportAttributes::new_from_lightningcss(&i.clone().into_owned()).into(),
+                    ImportAttributes::new_from_lightningcss(&i.clone().into_owned()).cell(),
                     self.import_context.map(|ctx| *ctx),
                     IssueSource::from_line_col(
                         self.source,

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -20,7 +20,7 @@ use turbopack_core::{
 
 use crate::{StyleSheetLike, embed::CssEmbed};
 
-#[turbo_tasks::value(into = "new")]
+#[turbo_tasks::value]
 pub enum ReferencedAsset {
     Some(ResolvedVc<Box<dyn OutputAsset>>),
     None,
@@ -63,7 +63,7 @@ impl UrlAssetReference {
                     .to_resolved()
                     .await?,
             )
-            .into());
+            .cell());
         }
         Ok(ReferencedAsset::cell(ReferencedAsset::None))
     }

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -13,7 +13,7 @@ use turbopack_ecmascript::{CustomTransformer, TransformContext};
 /// Internally this contains a `CompiledPluginModuleBytes`, which points to the
 /// compiled, serialized wasmer::Module instead of raw file bytes to reduce the
 /// cost of the compilation.
-#[turbo_tasks::value(serialization = "none", eq = "manual", into = "new", cell = "new")]
+#[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new")]
 pub struct SwcPluginModule(
     #[turbo_tasks(trace_ignore, debug_ignore)]
     #[cfg(feature = "swc_ecma_transform_plugin")]

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -13,7 +13,7 @@ use turbopack_ecmascript::{CustomTransformer, TransformContext};
 /// Internally this contains a `CompiledPluginModuleBytes`, which points to the
 /// compiled, serialized wasmer::Module instead of raw file bytes to reduce the
 /// cost of the compilation.
-#[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new")]
+#[turbo_tasks::value(serialization = "none", eq = "manual", cell = "new", shared)]
 pub struct SwcPluginModule(
     #[turbo_tasks(trace_ignore, debug_ignore)]
     #[cfg(feature = "swc_ecma_transform_plugin")]

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -146,7 +146,7 @@ impl EcmascriptChunkItem for AsyncLoaderChunkItem {
             inner_code: code.into(),
             ..Default::default()
         }
-        .into())
+        .cell())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -161,7 +161,7 @@ struct SideEffectsInPackageJsonIssue {
 impl Issue for SideEffectsInPackageJsonIssue {
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Parse.into()
+        IssueStage::Parse.cell()
     }
 
     fn severity(&self) -> IssueSeverity {

--- a/turbopack/crates/turbopack-ecmascript/src/inlined_bytes_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/inlined_bytes_module.rs
@@ -142,7 +142,7 @@ var decode = Uint8Array.fromBase64 || function Uint8Array_fromBase64(base64) {
                     inner_code: inner_code.build(),
                     ..Default::default()
                 }
-                .into())
+                .cell())
             }
             FileContent::NotFound => {
                 bail!("File not found: {}", self.module.ident().to_string().await?);

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_item.rs
@@ -60,7 +60,7 @@ impl EcmascriptChunkItem for ManifestChunkItem {
             inner_code: code.into(),
             ..Default::default()
         }
-        .into())
+        .cell())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/loader_item.rs
@@ -177,6 +177,6 @@ impl EcmascriptChunkItem for ManifestLoaderChunkItem {
             inner_code: code.into(),
             ..Default::default()
         }
-        .into())
+        .cell())
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -781,7 +781,7 @@ impl Issue for InvalidExport {
 
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Bindings.into()
+        IssueStage::Bindings.cell()
     }
 
     #[turbo_tasks::function]
@@ -876,7 +876,7 @@ impl Issue for CircularReExport {
 
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Bindings.into()
+        IssueStage::Bindings.cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3731,7 +3731,7 @@ async fn resolve_as_webpack_runtime(
     if let Some(source) = *resolved.first_source().await? {
         Ok(webpack_runtime(*source, transforms))
     } else {
-        Ok(WebpackRuntime::None.into())
+        Ok(WebpackRuntime::None.cell())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/type_issue.rs
@@ -83,7 +83,7 @@ impl Issue for SpecifiedModuleTypeIssue {
 
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Analysis.into()
+        IssueStage::Analysis.cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -69,13 +69,7 @@ pub trait CustomTransformer: Debug {
 
 /// A wrapper around a TransformPlugin instance, allowing it to operate with
 /// the turbo_task caching requirements.
-#[turbo_tasks::value(
-    transparent,
-    serialization = "none",
-    eq = "manual",
-    into = "new",
-    cell = "new"
-)]
+#[turbo_tasks::value(transparent, serialization = "none", eq = "manual", cell = "new")]
 #[derive(Debug)]
 pub struct TransformPlugin(#[turbo_tasks(trace_ignore)] Box<dyn CustomTransformer + Send + Sync>);
 

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/parse.rs
@@ -225,11 +225,11 @@ pub async fn webpack_runtime(
                         chunk_request_expr: value,
                         context_path: source.ident().path().await?.parent(),
                     }
-                    .into());
+                    .cell());
                 }
             }
         }
         ParseResult::Unparsable { .. } | ParseResult::NotFound => {}
     }
-    Ok(WebpackRuntime::None.into())
+    Ok(WebpackRuntime::None.cell())
 }

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -76,7 +76,7 @@ impl EcmascriptChunkItem for WorkerLoaderChunkItem {
             inner_code: code.into(),
             ..Default::default()
         }
-        .into())
+        .cell())
     }
 }
 

--- a/turbopack/crates/turbopack-env/src/issue.rs
+++ b/turbopack/crates/turbopack-env/src/issue.rs
@@ -19,7 +19,7 @@ impl Issue for ProcessEnvIssue {
 
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Load.into()
+        IssueStage::Load.cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-json/src/lib.rs
+++ b/turbopack/crates/turbopack-json/src/lib.rs
@@ -168,7 +168,7 @@ impl EcmascriptChunkItem for JsonChunkItem {
                     inner_code: code.into_source_code(),
                     ..Default::default()
                 }
-                .into())
+                .cell())
             }
             FileJsonContent::Unparsable(e) => {
                 let mut message = "Unable to make a module from invalid JSON: ".to_string();

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -745,7 +745,7 @@ impl Issue for EvaluationIssue {
 
     #[turbo_tasks::function]
     fn stage(&self) -> Vc<IssueStage> {
-        IssueStage::Transform.into()
+        IssueStage::Transform.cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-node/src/pool.rs
+++ b/turbopack/crates/turbopack-node/src/pool.rs
@@ -725,7 +725,7 @@ static ACTIVE_POOLS: Lazy<IdleProcessQueues> = Lazy::new(Default::default);
 ///
 /// The worker will *not* use the env of the parent process by default. All env
 /// vars need to be provided to make the execution as pure as possible.
-#[turbo_tasks::value(into = "new", cell = "new", serialization = "none", eq = "manual")]
+#[turbo_tasks::value(cell = "new", serialization = "none", eq = "manual", shared)]
 pub struct NodeJsPool {
     cwd: PathBuf,
     entrypoint: PathBuf,

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -83,7 +83,7 @@ pub async fn apply_cjs_specific_options(options: Vc<ResolveOptions>) -> Result<V
         conditions.insert(rcstr!("import"), ConditionValue::Unset);
         conditions.insert(rcstr!("require"), ConditionValue::Set);
     }
-    Ok(options.into())
+    Ok(options.cell())
 }
 
 pub async fn esm_resolve(

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -207,7 +207,7 @@ async fn base_resolve_options(
         collect_affecting_sources: opt.collect_affecting_sources,
         ..Default::default()
     }
-    .into())
+    .cell())
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
@@ -112,7 +112,7 @@ impl ResolveOptionsContext {
                 .to_resolved()
                 .await?,
         );
-        Ok(resolve_options_context.into())
+        Ok(resolve_options_context.cell())
     }
 
     /// Returns a new [Vc<ResolveOptionsContext>] with its fallback import map
@@ -133,7 +133,7 @@ impl ResolveOptionsContext {
                 .to_resolved()
                 .await?,
         );
-        Ok(resolve_options_context.into())
+        Ok(resolve_options_context.cell())
     }
 }
 

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -529,7 +529,7 @@ async fn apply_typescript_types_options(
     for conditions in get_condition_maps(&mut resolve_options) {
         conditions.insert(rcstr!("types"), ConditionValue::Set);
     }
-    Ok(resolve_options.into())
+    Ok(resolve_options.cell())
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -93,7 +93,7 @@ impl ChunkableModule for StaticUrlJsModule {
 impl EcmascriptChunkPlaceable for StaticUrlJsModule {
     #[turbo_tasks::function]
     fn get_exports(&self) -> Vc<EcmascriptExports> {
-        EcmascriptExports::Value.into()
+        EcmascriptExports::Value.cell()
     }
 }
 
@@ -152,6 +152,6 @@ impl EcmascriptChunkItem for StaticUrlJsChunkItem {
             .into(),
             ..Default::default()
         }
-        .into())
+        .cell())
     }
 }

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -417,7 +417,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
             )],
             ..Default::default()
         }
-        .into(),
+        .cell(),
         ResolveOptionsContext {
             enable_typescript: true,
             enable_node_modules: Some(project_root.clone()),

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -370,7 +370,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             analyze_mode: AnalyzeMode::CodeGenerationAndTracing,
             ..Default::default()
         }
-        .into(),
+        .cell(),
         ResolveOptionsContext {
             enable_typescript: true,
             enable_react: true,

--- a/turbopack/crates/turbopack-tracing/benches/node_file_trace.rs
+++ b/turbopack/crates/turbopack-tracing/benches/node_file_trace.rs
@@ -80,7 +80,7 @@ fn bench_emit(b: &mut Bencher, bench_input: &BenchInput) {
                 let input = input_fs.root().await?.join(&input)?;
 
                 let input_dir = input.parent().parent();
-                let output_fs: Vc<NullFileSystem> = NullFileSystem.into();
+                let output_fs: Vc<NullFileSystem> = NullFileSystem.cell();
                 let output_dir = output_fs.root().owned().await?;
 
                 let source = FileSource::new(input);

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -152,6 +152,6 @@ impl EcmascriptChunkItem for RawModuleChunkItem {
             .into(),
             ..Default::default()
         }
-        .into())
+        .cell())
     }
 }

--- a/turbopack/crates/turbopack/src/graph/mod.rs
+++ b/turbopack/crates/turbopack/src/graph/mod.rs
@@ -35,9 +35,9 @@ impl AggregatedGraph {
     #[turbo_tasks::function]
     pub async fn content(self: Vc<Self>) -> Result<Vc<AggregatedGraphNodeContent>> {
         Ok(match *self.await? {
-            AggregatedGraph::Leaf(asset) => AggregatedGraphNodeContent::Asset(asset).into(),
+            AggregatedGraph::Leaf(asset) => AggregatedGraphNodeContent::Asset(asset).cell(),
             AggregatedGraph::Node { ref content, .. } => {
-                AggregatedGraphNodeContent::Children(content.clone()).into()
+                AggregatedGraphNodeContent::Children(content.clone()).cell()
             }
         })
     }
@@ -52,7 +52,7 @@ impl AggregatedGraph {
                         refs.insert(AggregatedGraph::leaf(**reference).to_resolved().await?);
                     }
                 }
-                AggregatedGraphsSet { set: refs }.into()
+                AggregatedGraphsSet { set: refs }.cell()
             }
             AggregatedGraph::Node { references, .. } => {
                 let mut set = FxHashSet::default();
@@ -64,7 +64,7 @@ impl AggregatedGraph {
                 {
                     set.insert(item.to_resolved().await?);
                 }
-                AggregatedGraphsSet { set }.into()
+                AggregatedGraphsSet { set }.cell()
             }
         })
     }
@@ -72,9 +72,9 @@ impl AggregatedGraph {
     #[turbo_tasks::function]
     async fn cost(self: Vc<Self>) -> Result<Vc<AggregationCost>> {
         Ok(match *self.await? {
-            AggregatedGraph::Leaf(asset) => AggregationCost(asset.references().await?.len()).into(),
+            AggregatedGraph::Leaf(asset) => AggregationCost(asset.references().await?.len()).cell(),
             AggregatedGraph::Node { ref references, .. } => {
-                AggregationCost(references.len()).into()
+                AggregationCost(references.len()).cell()
             }
         })
     }
@@ -107,7 +107,7 @@ impl AggregatedGraph {
             outer,
             references,
         }
-        .into())
+        .cell())
     }
 }
 
@@ -179,7 +179,7 @@ async fn aggregate_more(node: ResolvedVc<AggregatedGraph>) -> Result<Vc<Aggregat
         content,
         references,
     }
-    .into())
+    .cell())
 }
 
 #[turbo_tasks::value(shared)]


### PR DESCRIPTION
### What?

Get rid of `impl Into` for value types. It's kind of legacy and we want cell creation to be kind of explicit instead of hidden in `into()` calls.

Also reduces the generated code size of the macro, potentially reducing rust build time and binary size.