### PR TITLE
docs: add types to image loader examples

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/images.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/images.mdx
@@ -20,7 +20,7 @@ This `loaderFile` must point to a file relative to the root of your Next.js appl
 
 <AppOnly>
 
-```js filename="my/image/loader.ts"
+```ts filename="my/image/loader.ts"
 'use client'
 
 import type { ImageLoaderProps } from 'next/image'
@@ -40,7 +40,7 @@ To learn more about configuring the behavior of the built-in [Image Optimization
 
 <PagesOnly>
 
-```js filename="my/image/loader.ts"
+```ts filename="my/image/loader.ts"
 import type { ImageLoaderProps } from 'next/image'
 
 export default function myImageLoader({ src, width, quality }: ImageLoaderProps) {
@@ -75,7 +75,7 @@ To learn more about configuring the behavior of the built-in [Image Optimization
 
 ### Akamai
 
-```js
+```ts
 // Docs: https://techdocs.akamai.com/ivm/reference/test-images-on-demand
 import type { ImageLoaderProps } from 'next/image'
 
@@ -86,7 +86,7 @@ export default function akamaiLoader({ src, width, quality }: ImageLoaderProps) 
 
 ### AWS CloudFront
 
-```js
+```ts
 // Docs: https://aws.amazon.com/developer/application-security-performance/articles/image-optimization
 import type { ImageLoaderProps } from 'next/image'
 
@@ -101,7 +101,7 @@ export default function cloudfrontLoader({ src, width, quality }: ImageLoaderPro
 
 ### Cloudinary
 
-```js
+```ts
 // Demo: https://res.cloudinary.com/demo/image/upload/w_300,c_limit,q_auto/turtles.jpg
 import type { ImageLoaderProps } from 'next/image'
 
@@ -113,7 +113,7 @@ export default function cloudinaryLoader({ src, width, quality }: ImageLoaderPro
 
 ### Cloudflare
 
-```js
+```ts
 // Docs: https://developers.cloudflare.com/images/transform-images
 import type { ImageLoaderProps } from 'next/image'
 
@@ -125,7 +125,7 @@ export default function cloudflareLoader({ src, width, quality }: ImageLoaderPro
 
 ### Contentful
 
-```js
+```ts
 // Docs: https://www.contentful.com/developers/docs/references/images-api/
 import type { ImageLoaderProps } from 'next/image'
 
@@ -140,7 +140,7 @@ export default function contentfulLoader({ src, width, quality }: ImageLoaderPro
 
 ### Fastly
 
-```js
+```ts
 // Docs: https://developer.fastly.com/reference/io/
 import type { ImageLoaderProps } from 'next/image'
 
@@ -155,7 +155,7 @@ export default function fastlyLoader({ src, width, quality }: ImageLoaderProps) 
 
 ### Gumlet
 
-```js
+```ts
 // Docs: https://docs.gumlet.com/reference/image-transform-size
 import type { ImageLoaderProps } from 'next/image'
 
@@ -170,7 +170,7 @@ export default function gumletLoader({ src, width, quality }: ImageLoaderProps) 
 
 ### ImageEngine
 
-```js
+```ts
 // Docs: https://support.imageengine.io/hc/en-us/articles/360058880672-Directives
 import type { ImageLoaderProps } from 'next/image'
 
@@ -183,7 +183,7 @@ export default function imageengineLoader({ src, width, quality }: ImageLoaderPr
 
 ### Imgix
 
-```js
+```ts
 // Demo: https://static.imgix.net/daisy.png?format=auto&fit=max&w=300
 import type { ImageLoaderProps } from 'next/image'
 
@@ -200,7 +200,7 @@ export default function imgixLoader({ src, width, quality }: ImageLoaderProps) {
 
 ### PixelBin
 
-```js
+```ts
 // Doc (Resize): https://www.pixelbin.io/docs/transformations/basic/resize/#width-w
 // Doc (Optimise): https://www.pixelbin.io/docs/optimizations/quality/#image-quality-when-delivering
 // Doc (Auto Format Delivery): https://www.pixelbin.io/docs/optimizations/format/#automatic-format-selection-with-f_auto-url-parameter
@@ -215,7 +215,7 @@ export default function pixelBinLoader({ src, width, quality }: ImageLoaderProps
 
 ### Sanity
 
-```js
+```ts
 // Docs: https://www.sanity.io/docs/image-urls
 import type { ImageLoaderProps } from 'next/image'
 
@@ -235,7 +235,7 @@ export default function sanityLoader({ src, width, quality }: ImageLoaderProps) 
 
 ### Sirv
 
-```js
+```ts
 // Docs: https://sirv.com/help/articles/dynamic-imaging/
 import type { ImageLoaderProps } from 'next/image'
 
@@ -251,7 +251,7 @@ export default function sirvLoader({ src, width, quality }: ImageLoaderProps) {
 
 ### Supabase
 
-```js
+```ts
 // Docs: https://supabase.com/docs/guides/storage/image-transformations#nextjs-loader
 import type { ImageLoaderProps } from 'next/image'
 
@@ -265,7 +265,7 @@ export default function supabaseLoader({ src, width, quality }: ImageLoaderProps
 
 ### Thumbor
 
-```js
+```ts
 // Docs: https://thumbor.readthedocs.io/en/latest/
 import type { ImageLoaderProps } from 'next/image'
 
@@ -277,7 +277,7 @@ export default function thumborLoader({ src, width, quality }: ImageLoaderProps)
 
 ### ImageKit.io
 
-```js
+```ts
 // Docs: https://imagekit.io/docs/image-transformation
 import type { ImageLoaderProps } from 'next/image'
 
@@ -289,7 +289,7 @@ export default function imageKitLoader({ src, width, quality }: ImageLoaderProps
 
 ### Nitrogen AIO
 
-```js
+```ts
 // Docs: https://docs.n7.io/aio/intergrations/
 import type { ImageLoaderProps } from 'next/image'
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/images.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/images.mdx
@@ -11,7 +11,7 @@ If you want to use a cloud provider to optimize images instead of using the Next
 module.exports = {
   images: {
     loader: 'custom',
-    loaderFile: './my/image/loader.js',
+    loaderFile: './my/image/loader.ts',
   },
 }
 ```
@@ -20,10 +20,12 @@ This `loaderFile` must point to a file relative to the root of your Next.js appl
 
 <AppOnly>
 
-```js filename="my/image/loader.js"
+```js filename="my/image/loader.ts"
 'use client'
 
-export default function myImageLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function myImageLoader({ src, width, quality }: ImageLoaderProps) {
   return `https://example.com/${src}?w=${width}&q=${quality || 75}`
 }
 ```
@@ -38,8 +40,10 @@ To learn more about configuring the behavior of the built-in [Image Optimization
 
 <PagesOnly>
 
-```js filename="my/image/loader.js"
-export default function myImageLoader({ src, width, quality }) {
+```js filename="my/image/loader.ts"
+import type { ImageLoaderProps } from 'next/image'
+
+export default function myImageLoader({ src, width, quality }: ImageLoaderProps) {
   return `https://example.com/${src}?w=${width}&q=${quality || 75}`
 }
 ```
@@ -73,7 +77,9 @@ To learn more about configuring the behavior of the built-in [Image Optimization
 
 ```js
 // Docs: https://techdocs.akamai.com/ivm/reference/test-images-on-demand
-export default function akamaiLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function akamaiLoader({ src, width, quality }: ImageLoaderProps) {
   return `https://example.com/${src}?imwidth=${width}`
 }
 ```
@@ -82,7 +88,9 @@ export default function akamaiLoader({ src, width, quality }) {
 
 ```js
 // Docs: https://aws.amazon.com/developer/application-security-performance/articles/image-optimization
-export default function cloudfrontLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function cloudfrontLoader({ src, width, quality }: ImageLoaderProps) {
   const url = new URL(`https://example.com${src}`)
   url.searchParams.set('format', 'auto')
   url.searchParams.set('width', width.toString())
@@ -95,7 +103,9 @@ export default function cloudfrontLoader({ src, width, quality }) {
 
 ```js
 // Demo: https://res.cloudinary.com/demo/image/upload/w_300,c_limit,q_auto/turtles.jpg
-export default function cloudinaryLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function cloudinaryLoader({ src, width, quality }: ImageLoaderProps) {
   const params = ['f_auto', 'c_limit', `w_${width}`, `q_${quality || 'auto'}`]
   return `https://example.com/${params.join(',')}${src}`
 }
@@ -105,7 +115,9 @@ export default function cloudinaryLoader({ src, width, quality }) {
 
 ```js
 // Docs: https://developers.cloudflare.com/images/transform-images
-export default function cloudflareLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function cloudflareLoader({ src, width, quality }: ImageLoaderProps) {
   const params = [`width=${width}`, `quality=${quality || 75}`, 'format=auto']
   return `https://example.com/cdn-cgi/image/${params.join(',')}/${src}`
 }
@@ -115,7 +127,9 @@ export default function cloudflareLoader({ src, width, quality }) {
 
 ```js
 // Docs: https://www.contentful.com/developers/docs/references/images-api/
-export default function contentfulLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function contentfulLoader({ src, width, quality }: ImageLoaderProps) {
   const url = new URL(`https://example.com${src}`)
   url.searchParams.set('fm', 'webp')
   url.searchParams.set('w', width.toString())
@@ -128,7 +142,9 @@ export default function contentfulLoader({ src, width, quality }) {
 
 ```js
 // Docs: https://developer.fastly.com/reference/io/
-export default function fastlyLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function fastlyLoader({ src, width, quality }: ImageLoaderProps) {
   const url = new URL(`https://example.com${src}`)
   url.searchParams.set('auto', 'webp')
   url.searchParams.set('width', width.toString())
@@ -141,7 +157,9 @@ export default function fastlyLoader({ src, width, quality }) {
 
 ```js
 // Docs: https://docs.gumlet.com/reference/image-transform-size
-export default function gumletLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function gumletLoader({ src, width, quality }: ImageLoaderProps) {
   const url = new URL(`https://example.com${src}`)
   url.searchParams.set('format', 'auto')
   url.searchParams.set('w', width.toString())
@@ -154,7 +172,9 @@ export default function gumletLoader({ src, width, quality }) {
 
 ```js
 // Docs: https://support.imageengine.io/hc/en-us/articles/360058880672-Directives
-export default function imageengineLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function imageengineLoader({ src, width, quality }: ImageLoaderProps) {
   const compression = 100 - (quality || 50)
   const params = [`w_${width}`, `cmpr_${compression}`)]
   return `https://example.com${src}?imgeng=/${params.join('/')`
@@ -165,7 +185,9 @@ export default function imageengineLoader({ src, width, quality }) {
 
 ```js
 // Demo: https://static.imgix.net/daisy.png?format=auto&fit=max&w=300
-export default function imgixLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function imgixLoader({ src, width, quality }: ImageLoaderProps) {
   const url = new URL(`https://example.com${src}`)
   const params = url.searchParams
   params.set('auto', params.getAll('auto').join(',') || 'format')
@@ -182,7 +204,9 @@ export default function imgixLoader({ src, width, quality }) {
 // Doc (Resize): https://www.pixelbin.io/docs/transformations/basic/resize/#width-w
 // Doc (Optimise): https://www.pixelbin.io/docs/optimizations/quality/#image-quality-when-delivering
 // Doc (Auto Format Delivery): https://www.pixelbin.io/docs/optimizations/format/#automatic-format-selection-with-f_auto-url-parameter
-export default function pixelBinLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function pixelBinLoader({ src, width, quality }: ImageLoaderProps) {
   const name = '<your-cloud-name>'
   const opt = `t.resize(w:${width})~t.compress(q:${quality || 75})`
   return `https://cdn.pixelbin.io/v2/${name}/${opt}/${src}?f_auto=true`
@@ -193,7 +217,9 @@ export default function pixelBinLoader({ src, width, quality }) {
 
 ```js
 // Docs: https://www.sanity.io/docs/image-urls
-export default function sanityLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function sanityLoader({ src, width, quality }: ImageLoaderProps) {
   const prj = 'zp7mbokg'
   const dataset = 'production'
   const url = new URL(`https://cdn.sanity.io/images/${prj}/${dataset}${src}`)
@@ -211,7 +237,9 @@ export default function sanityLoader({ src, width, quality }) {
 
 ```js
 // Docs: https://sirv.com/help/articles/dynamic-imaging/
-export default function sirvLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function sirvLoader({ src, width, quality }: ImageLoaderProps) {
   const url = new URL(`https://example.com${src}`)
   const params = url.searchParams
   params.set('format', params.getAll('format').join(',') || 'optimal')
@@ -225,7 +253,9 @@ export default function sirvLoader({ src, width, quality }) {
 
 ```js
 // Docs: https://supabase.com/docs/guides/storage/image-transformations#nextjs-loader
-export default function supabaseLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function supabaseLoader({ src, width, quality }: ImageLoaderProps) {
   const url = new URL(`https://example.com${src}`)
   url.searchParams.set('width', width.toString())
   url.searchParams.set('quality', (quality || 75).toString())
@@ -237,7 +267,9 @@ export default function supabaseLoader({ src, width, quality }) {
 
 ```js
 // Docs: https://thumbor.readthedocs.io/en/latest/
-export default function thumborLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function thumborLoader({ src, width, quality }: ImageLoaderProps) {
   const params = [`${width}x0`, `filters:quality(${quality || 75})`]
   return `https://example.com${params.join('/')}${src}`
 }
@@ -247,7 +279,9 @@ export default function thumborLoader({ src, width, quality }) {
 
 ```js
 // Docs: https://imagekit.io/docs/image-transformation
-export default function imageKitLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function imageKitLoader({ src, width, quality }: ImageLoaderProps) {
   const params = [`w-${width}`, `q-${quality || 80}`]
   return `https://ik.imagekit.io/your_imagekit_id/${src}?tr=${params.join(',')}`
 }
@@ -257,7 +291,9 @@ export default function imageKitLoader({ src, width, quality }) {
 
 ```js
 // Docs: https://docs.n7.io/aio/intergrations/
-export default function aioLoader({ src, width, quality }) {
+import type { ImageLoaderProps } from 'next/image'
+
+export default function aioLoader({ src, width, quality }: ImageLoaderProps) {
   const url = new URL(src, window.location.href)
   const params = url.searchParams
   const aioParams = params.getAll('aio')

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/images.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/images.mdx
@@ -176,7 +176,7 @@ import type { ImageLoaderProps } from 'next/image'
 
 export default function imageengineLoader({ src, width, quality }: ImageLoaderProps) {
   const compression = 100 - (quality || 50)
-  const params = [`w_${width}`, `cmpr_${compression}`)]
+  const params = [`w_${width}`, `cmpr_${compression}`]
   return `https://example.com${src}?imgeng=/${params.join('/')`
 }
 ```


### PR DESCRIPTION
### What?

Add type definitions to the image loader file documentation.

### Why?

This provides type safety for users.

### How?

Use the `ImageLoaderProps` type to annotate the image loader argument.
