### PR TITLE
Reduce default check retries to 5

### DIFF
--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -707,7 +707,7 @@ export async function check(
   contentFn: () => any | Promise<any>,
   regex: any,
   hardError = true,
-  maxRetries = 30
+  maxRetries = 5
 ) {
   let content
   let lastErr


### PR DESCRIPTION
waiting 30s on a broken test slows down CI too much. This reduces it to 5 retries. This will potentially increase flake but we can add back more retries for tests that now flake.
