### PR TITLE
feat: Add unstable_useRoutes() hook for canonical route structure

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -977,5 +977,6 @@
   "976": "Decompressed resume data cache exceeded %s byte limit",
   "977": "maxPostponedStateSize must be a valid number (bytes) or filesize format string (e.g., \"5mb\")",
   "978": "Next.js has blocked a javascript: URL as a security precaution.",
-  "979": "invariant: expected %s bytes of postponed state but only received %s bytes"
+  "979": "invariant: expected %s bytes of postponed state but only received %s bytes",
+  "980": "unstable_useRoute: Cannot access route during render. Call getRoute() inside useEffect, useLayoutEffect, or event handlers."
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -978,5 +978,6 @@
   "977": "maxPostponedStateSize must be a valid number (bytes) or filesize format string (e.g., \"5mb\")",
   "978": "Next.js has blocked a javascript: URL as a security precaution.",
   "979": "invariant: expected %s bytes of postponed state but only received %s bytes",
-  "980": "unstable_useRoute: Cannot access route during render. Call getRoute() inside useEffect, useLayoutEffect, or event handlers."
+  "980": "unstable_useRoute: Cannot access route during render. Call getRoute() inside useEffect, useLayoutEffect, or event handlers.",
+  "981": "unstable_useRoutes: Cannot access routes during render. Call getRoutes() inside useEffect, useLayoutEffect, or event handlers."
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -978,6 +978,5 @@
   "977": "maxPostponedStateSize must be a valid number (bytes) or filesize format string (e.g., \"5mb\")",
   "978": "Next.js has blocked a javascript: URL as a security precaution.",
   "979": "invariant: expected %s bytes of postponed state but only received %s bytes",
-  "980": "unstable_useRoute: Cannot access route during render. Call getRoute() inside useEffect, useLayoutEffect, or event handlers.",
-  "981": "unstable_useRoutes: Cannot access routes during render. Call getRoutes() inside useEffect, useLayoutEffect, or event handlers."
+  "980": "unstable_useRoutes: Cannot access routes during render. Call getRoutes() inside useEffect, useLayoutEffect, or event handlers."
 }

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -1,6 +1,13 @@
 import type { Params } from '../../server/request/params'
 
-import React, { useContext, useMemo, use } from 'react'
+import React, {
+  useContext,
+  useMemo,
+  use,
+  useRef,
+  useEffect,
+  useCallback,
+} from 'react'
 import {
   AppRouterContext,
   LayoutRouterContext,
@@ -122,56 +129,75 @@ export function usePathname(): string {
 
 /**
  * A [Client Component](https://nextjs.org/docs/app/building-your-application/rendering/client-components) hook
- * that lets you read the canonical route structure including route groups, parallel routes, and dynamic parameters.
+ * that returns a getter function to read the canonical route structure including route groups,
+ * parallel routes, and dynamic parameters.
  *
- * Unlike `usePathname()` which returns the actual URL path, `useRoute()` returns the file-system structure
- * of the route, preserving route groups `(group)`, parallel routes `@slot`, and dynamic parameters `[param]`. When
- * an intercepted route is active, the route will be the path of the intercepted route.
+ * Unlike `usePathname()` which returns the actual URL path, the route returned by this hook's getter
+ * represents the file-system structure of the route, preserving route groups `(group)`, parallel routes
+ * `@slot`, and dynamic parameters `[param]`. When an intercepted route is active, the route will be
+ * the path of the intercepted route.
+ *
+ * **Important:** The getter function can only be called during the effect phase (inside `useEffect`,
+ * `useLayoutEffect`, or event handlers). Calling it during render will throw an error in development.
+ * This restriction exists to prevent route structure from leaking into rendering decisions.
  *
  * @example
  * ```ts
  * "use client"
- * import { useRoute } from 'next/navigation'
+ * import { unstable_useRoute } from 'next/navigation'
+ * import { useEffect, useState } from 'react'
  *
  * export default function Page() {
- *   const route = useRoute()
- *   // On /blog/my-post, returns "/blog/[slug]"
- *   // On /dashboard with @modal slot active, returns "/dashboard/@modal/..."
- *   // With route group (marketing), returns "/(marketing)/about"
- *   // ...
+ *   const getRoute = unstable_useRoute()
+ *   const [route, setRoute] = useState<string | undefined>(undefined)
+ *
+ *   useEffect(() => {
+ *     // Call the getter inside useEffect
+ *     setRoute(getRoute())
+ *     // On /blog/my-post, returns "/blog/[slug]"
+ *     // On /dashboard with @modal slot active, returns "/dashboard/@modal/..."
+ *     // With route group (marketing), returns "/(marketing)/about"
+ *   }, [getRoute])
+ *
+ *   return <div>Route: {route}</div>
  * }
  * ```
  */
 // Client components API
-export function useRoute(): string {
-  useDynamicRouteParams?.('useRoute()')
+/* eslint-disable react-hooks/rules-of-hooks -- unstable_ prefix for experimental API */
+export function unstable_useRoute(): () => string {
+  useDynamicRouteParams?.('unstable_useRoute()')
 
+  const hasMounted = useRef(false)
   const pathname = useContext(PathnameContext)
   const globalContext = useContext(GlobalLayoutRouterContext)
   const tree = globalContext?.tree
 
-  // Compute the canonical route from the tree
-  // The tree structure itself represents the active route state,
-  // so we just traverse it to build the canonical path
-  // Memoized to avoid expensive tree traversal on every render
-  const route = useMemo(() => {
+  useEffect(() => {
+    hasMounted.current = true
+    return () => {
+      hasMounted.current = false
+    }
+  }, [])
+
+  const getRoute = useCallback(() => {
+    if (!hasMounted.current && process.env.NODE_ENV !== 'production') {
+      throw new Error(
+        'unstable_useRoute: Cannot access route during render. ' +
+          'Call getRoute() inside useEffect, useLayoutEffect, or event handlers.'
+      )
+    }
+
     if (!tree || !pathname) {
       return '/'
     }
+
     return extractRouteFromFlightRouterState(pathname, tree) ?? '/'
   }, [pathname, tree])
 
-  // Instrument with Suspense DevTools (dev-only)
-  if (process.env.NODE_ENV !== 'production' && 'use' in React) {
-    const navigationPromises = use(NavigationPromisesContext)
-    if (navigationPromises) {
-      // TODO: Add instrumented promise for route if needed for DevTools
-      // For now, return the computed value directly
-    }
-  }
-
-  return route
+  return getRoute
 }
+/* eslint-enable react-hooks/rules-of-hooks */
 
 // Client components API
 export {

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -4,6 +4,7 @@ import React, { useContext, useMemo, use } from 'react'
 import {
   AppRouterContext,
   LayoutRouterContext,
+  GlobalLayoutRouterContext,
   type AppRouterInstance,
 } from '../../shared/lib/app-router-context.shared-runtime'
 import {
@@ -17,6 +18,7 @@ import {
   computeSelectedLayoutSegment,
   getSelectedLayoutSegmentPath,
 } from '../../shared/lib/segment'
+import { extractRouteFromFlightRouterState } from './router-reducer/extract-route-from-flight-router-state'
 
 const useDynamicRouteParams =
   typeof window === 'undefined'
@@ -116,6 +118,59 @@ export function usePathname(): string {
   }
 
   return pathname
+}
+
+/**
+ * A [Client Component](https://nextjs.org/docs/app/building-your-application/rendering/client-components) hook
+ * that lets you read the canonical route structure including route groups, parallel routes, and dynamic parameters.
+ *
+ * Unlike `usePathname()` which returns the actual URL path, `useRoute()` returns the file-system structure
+ * of the route, preserving route groups `(group)`, parallel routes `@slot`, and dynamic parameters `[param]`. When
+ * an intercepted route is active, the route will be the path of the intercepted route.
+ *
+ * @example
+ * ```ts
+ * "use client"
+ * import { useRoute } from 'next/navigation'
+ *
+ * export default function Page() {
+ *   const route = useRoute()
+ *   // On /blog/my-post, returns "/blog/[slug]"
+ *   // On /dashboard with @modal slot active, returns "/dashboard/@modal/..."
+ *   // With route group (marketing), returns "/(marketing)/about"
+ *   // ...
+ * }
+ * ```
+ */
+// Client components API
+export function useRoute(): string {
+  useDynamicRouteParams?.('useRoute()')
+
+  const pathname = useContext(PathnameContext)
+  const globalContext = useContext(GlobalLayoutRouterContext)
+  const tree = globalContext?.tree
+
+  // Compute the canonical route from the tree
+  // The tree structure itself represents the active route state,
+  // so we just traverse it to build the canonical path
+  // Memoized to avoid expensive tree traversal on every render
+  const route = useMemo(() => {
+    if (!tree || !pathname) {
+      return '/'
+    }
+    return extractRouteFromFlightRouterState(pathname, tree) ?? '/'
+  }, [pathname, tree])
+
+  // Instrument with Suspense DevTools (dev-only)
+  if (process.env.NODE_ENV !== 'production' && 'use' in React) {
+    const navigationPromises = use(NavigationPromisesContext)
+    if (navigationPromises) {
+      // TODO: Add instrumented promise for route if needed for DevTools
+      // For now, return the computed value directly
+    }
+  }
+
+  return route
 }
 
 // Client components API

--- a/packages/next/src/client/components/navigation.ts
+++ b/packages/next/src/client/components/navigation.ts
@@ -25,7 +25,7 @@ import {
   computeSelectedLayoutSegment,
   getSelectedLayoutSegmentPath,
 } from '../../shared/lib/segment'
-import { extractRouteFromFlightRouterState } from './router-reducer/extract-route-from-flight-router-state'
+import { extractRoutesFromFlightRouterState } from './router-reducer/extract-route-from-flight-router-state'
 
 const useDynamicRouteParams =
   typeof window === 'undefined'
@@ -129,13 +129,12 @@ export function usePathname(): string {
 
 /**
  * A [Client Component](https://nextjs.org/docs/app/building-your-application/rendering/client-components) hook
- * that returns a getter function to read the canonical route structure including route groups,
+ * that returns a getter function to read all canonical route structures including route groups,
  * parallel routes, and dynamic parameters.
  *
- * Unlike `usePathname()` which returns the actual URL path, the route returned by this hook's getter
- * represents the file-system structure of the route, preserving route groups `(group)`, parallel routes
- * `@slot`, and dynamic parameters `[param]`. When an intercepted route is active, the route will be
- * the path of the intercepted route.
+ * Unlike `usePathname()` which returns the actual URL path, the routes returned by this hook's getter
+ * represent the file-system structure of all matching routes, preserving route groups `(group)`, parallel routes
+ * `@slot`, and dynamic parameters `[param]`. When parallel routes are active, all matching routes are returned.
  *
  * **Important:** The getter function can only be called during the effect phase (inside `useEffect`,
  * `useLayoutEffect`, or event handlers). Calling it during render will throw an error in development.
@@ -144,29 +143,29 @@ export function usePathname(): string {
  * @example
  * ```ts
  * "use client"
- * import { unstable_useRoute } from 'next/navigation'
+ * import { unstable_useRoutes } from 'next/navigation'
  * import { useEffect, useState } from 'react'
  *
  * export default function Page() {
- *   const getRoute = unstable_useRoute()
- *   const [route, setRoute] = useState<string | undefined>(undefined)
+ *   const getRoutes = unstable_useRoutes()
+ *   const [routes, setRoutes] = useState<string[] | undefined>(undefined)
  *
  *   useEffect(() => {
  *     // Call the getter inside useEffect
- *     setRoute(getRoute())
- *     // On /blog/my-post, returns "/blog/[slug]"
- *     // On /dashboard with @modal slot active, returns "/dashboard/@modal/..."
- *     // With route group (marketing), returns "/(marketing)/about"
- *   }, [getRoute])
+ *     setRoutes(getRoutes())
+ *     // On /blog/my-post, returns ["/blog/[slug]"]
+ *     // On /dashboard with @modal slot active, returns ["/dashboard", "/dashboard/@modal/..."]
+ *     // With route group (marketing), returns ["/(marketing)/about"]
+ *   }, [getRoutes])
  *
- *   return <div>Route: {route}</div>
+ *   return <div>Routes: {routes?.join(', ')}</div>
  * }
  * ```
  */
 // Client components API
 /* eslint-disable react-hooks/rules-of-hooks -- unstable_ prefix for experimental API */
-export function unstable_useRoute(): () => string {
-  useDynamicRouteParams?.('unstable_useRoute()')
+export function unstable_useRoutes(): () => string[] {
+  useDynamicRouteParams?.('unstable_useRoutes()')
 
   const hasMounted = useRef(false)
   const pathname = useContext(PathnameContext)
@@ -180,22 +179,22 @@ export function unstable_useRoute(): () => string {
     }
   }, [])
 
-  const getRoute = useCallback(() => {
+  const getRoutes = useCallback(() => {
     if (!hasMounted.current && process.env.NODE_ENV !== 'production') {
       throw new Error(
-        'unstable_useRoute: Cannot access route during render. ' +
-          'Call getRoute() inside useEffect, useLayoutEffect, or event handlers.'
+        'unstable_useRoutes: Cannot access routes during render. ' +
+          'Call getRoutes() inside useEffect, useLayoutEffect, or event handlers.'
       )
     }
 
     if (!tree || !pathname) {
-      return '/'
+      return []
     }
 
-    return extractRouteFromFlightRouterState(pathname, tree) ?? '/'
+    return extractRoutesFromFlightRouterState(pathname, tree)
   }, [pathname, tree])
 
-  return getRoute
+  return getRoutes
 }
 /* eslint-enable react-hooks/rules-of-hooks */
 

--- a/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.test.ts
+++ b/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.test.ts
@@ -1,0 +1,2077 @@
+import type { FlightRouterState } from '../../../shared/lib/app-router-types'
+import { extractRouteFromFlightRouterState } from './extract-route-from-flight-router-state'
+
+describe('extractRouteFromFlightRouterState', () => {
+  describe('Static Routes', () => {
+    describe('Basic Static Segments', () => {
+      it('should return "/" for root page', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: ['__PAGE__', {}, '/', undefined, true],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/', tree)).toBe('/')
+      })
+
+      it('should extract simple static route', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'about',
+              {
+                children: ['__PAGE__', {}, '/about'],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/about', tree)).toBe('/about')
+      })
+
+      it('should return null for non-matching pathname', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'about',
+              {
+                children: ['__PAGE__', {}, '/about'],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/contact', tree)).toBe(null)
+      })
+
+      it('should return null when searching for root page that does not exist', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'about',
+              {
+                children: ['__PAGE__', {}, '/about'],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // Tree has /about but no root page - should return null, not '/'
+        expect(extractRouteFromFlightRouterState('/', tree)).toBe(null)
+      })
+    })
+
+    describe('Static Segments + Route Groups', () => {
+      it('should preserve single route group', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              '(marketing)',
+              {
+                children: [
+                  'about',
+                  {
+                    children: ['__PAGE__', {}, '/about'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/about', tree)).toBe(
+          '/(marketing)/about'
+        )
+      })
+
+      it('should handle multiple nested route groups', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              '(app)',
+              {
+                children: [
+                  '(dashboard)',
+                  {
+                    children: [
+                      'settings',
+                      {
+                        children: ['__PAGE__', {}, '/settings'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/settings', tree)).toBe(
+          '/(app)/(dashboard)/settings'
+        )
+      })
+
+      it('should handle consecutive route groups', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              '(root)',
+              {
+                children: [
+                  '(auth)',
+                  {
+                    children: [
+                      '(forms)',
+                      {
+                        children: [
+                          'login',
+                          {
+                            children: ['__PAGE__', {}, '/login'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/login', tree)).toBe(
+          '/(root)/(auth)/(forms)/login'
+        )
+      })
+    })
+  })
+
+  describe('Dynamic Routes', () => {
+    describe('Dynamic Parameters ([param]) - Type: d', () => {
+      it('should extract single dynamic parameter', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'blog',
+              {
+                children: [
+                  ['slug', 'my-post', 'd'],
+                  {
+                    children: ['__PAGE__', {}, '/blog/my-post'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/blog/my-post', tree)).toBe(
+          '/blog/[slug]'
+        )
+      })
+
+      it('should handle multiple nested dynamic parameters', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'shop',
+              {
+                children: [
+                  ['category', 'electronics', 'd'],
+                  {
+                    children: [
+                      ['product', 'laptop', 'd'],
+                      {
+                        children: ['__PAGE__', {}, '/shop/electronics/laptop'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState('/shop/electronics/laptop', tree)
+        ).toBe('/shop/[category]/[product]')
+      })
+
+      it('should handle dynamic parameters with route groups', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              '(shop)',
+              {
+                children: [
+                  ['category', 'electronics', 'd'],
+                  {
+                    children: [
+                      ['product', 'laptop', 'd'],
+                      {
+                        children: ['__PAGE__', {}, '/electronics/laptop'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState('/electronics/laptop', tree)
+        ).toBe('/(shop)/[category]/[product]')
+      })
+    })
+
+    describe('Catch-all Parameters ([...param]) - Type: c', () => {
+      it('should handle catch-all parameters', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'docs',
+              {
+                children: [
+                  ['slug', 'api/reference', 'c'],
+                  {
+                    children: ['__PAGE__', {}, '/docs/api/reference'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState('/docs/api/reference', tree)
+        ).toBe('/docs/[...slug]')
+      })
+
+      it('should handle catch-all at root level', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              ['path', 'blog/posts', 'c'],
+              {
+                children: ['__PAGE__', {}, '/blog/posts'],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/blog/posts', tree)).toBe(
+          '/[...path]'
+        )
+      })
+    })
+
+    describe('Optional Catch-all Parameters ([[...param]]) - Type: oc', () => {
+      it('should handle optional catch-all parameters', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'docs',
+              {
+                children: [
+                  ['slug', 'api/reference', 'oc'],
+                  {
+                    children: ['__PAGE__', {}, '/docs/api/reference'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState('/docs/api/reference', tree)
+        ).toBe('/docs/[[...slug]]')
+      })
+
+      it('should handle optional catch-all at root level', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              ['slug', 'about/team', 'oc'],
+              {
+                children: ['__PAGE__', {}, '/about/team'],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/about/team', tree)).toBe(
+          '/[[...slug]]'
+        )
+      })
+    })
+
+    describe('Dynamic Intercepted Parameters - Type: di', () => {
+      it('should handle interception folder with separate dynamic parameter', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'posts',
+              {
+                children: ['__PAGE__', {}, '/posts'],
+                modal: [
+                  '(slot)',
+                  {
+                    children: [
+                      '(.)post',
+                      {
+                        children: [
+                          ['slug', 'my-post', 'd'],
+                          {
+                            children: ['__PAGE__', {}, '/posts/post/my-post'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState('/posts/post/my-post', tree)
+        ).toBe('/posts/@modal/(.)post/[slug]')
+      })
+
+      it('should handle combined interception marker + dynamic parameter folder', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'gallery',
+              {
+                modal: [
+                  '(slot)',
+                  {
+                    children: [
+                      '(group)',
+                      {
+                        children: [
+                          ['id', '123', 'di(.)'],
+                          {
+                            children: ['__PAGE__', {}, '/gallery/123'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // (.)[id] is a SINGLE folder combining interception with dynamic param
+        expect(extractRouteFromFlightRouterState('/gallery/123', tree)).toBe(
+          '/gallery/@modal/(group)/(.)[id]'
+        )
+      })
+
+      it('should handle parent interception marker combined with dynamic parameter', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'store',
+              {
+                children: [
+                  'catalog',
+                  {
+                    children: ['__PAGE__', {}, '/store/catalog'],
+                    modal: [
+                      '(slot)',
+                      {
+                        children: [
+                          ['productId', '999', 'di(..)'],
+                          {
+                            children: ['__PAGE__', {}, '/store/999'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // (..)[productId] intercepts parent's dynamic segment
+        expect(extractRouteFromFlightRouterState('/store/999', tree)).toBe(
+          '/store/catalog/@modal/(..)[productId]'
+        )
+      })
+
+      it('should handle root interception marker combined with dynamic parameter', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'admin',
+              {
+                children: [
+                  'panel',
+                  {
+                    children: ['__PAGE__', {}, '/admin/panel'],
+                    overlay: [
+                      '(slot)',
+                      {
+                        children: [
+                          ['userId', '555', 'di(...)'],
+                          {
+                            children: ['__PAGE__', {}, '/555'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // (...)[userId] intercepts root's dynamic segment
+        expect(extractRouteFromFlightRouterState('/555', tree)).toBe(
+          '/admin/panel/@overlay/(...)[userId]'
+        )
+      })
+    })
+
+    describe('Catch-all Intercepted Parameters - Type: ci', () => {
+      it('should handle interception folder with separate catch-all parameter', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'wiki',
+              {
+                children: ['__PAGE__', {}, '/wiki'],
+                modal: [
+                  '(slot)',
+                  {
+                    children: [
+                      '(.)docs',
+                      {
+                        children: [
+                          ['path', 'getting-started/intro', 'c'],
+                          {
+                            children: [
+                              '__PAGE__',
+                              {},
+                              '/wiki/docs/getting-started/intro',
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState(
+            '/wiki/docs/getting-started/intro',
+            tree
+          )
+        ).toBe('/wiki/@modal/(.)docs/[...path]')
+      })
+
+      it('should handle combined interception marker + catch-all parameter folder', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'docs',
+              {
+                preview: [
+                  '(slot)',
+                  {
+                    children: [
+                      ['path', 'guides/intro', 'ci(.)'],
+                      {
+                        children: ['__PAGE__', {}, '/docs/guides/intro'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // (.)[...path] is a SINGLE folder combining interception with catch-all
+        expect(
+          extractRouteFromFlightRouterState('/docs/guides/intro', tree)
+        ).toBe('/docs/@preview/(.)[...path]')
+      })
+
+      it('should handle two-level parent interception with catch-all', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'app',
+              {
+                children: [
+                  'dashboard',
+                  {
+                    children: [
+                      'settings',
+                      {
+                        children: ['__PAGE__', {}, '/app/dashboard/settings'],
+                        docs: [
+                          '(slot)',
+                          {
+                            children: [
+                              ['path', 'api/reference/config', 'ci(..)(..)'],
+                              {
+                                children: [
+                                  '__PAGE__',
+                                  {},
+                                  '/app/api/reference/config',
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // (..)(..)[...path] intercepts two levels up with catch-all
+        expect(
+          extractRouteFromFlightRouterState('/app/api/reference/config', tree)
+        ).toBe('/app/dashboard/settings/@docs/(..)(..)[...path]')
+      })
+
+      it('should handle root-level interception with catch-all', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'admin',
+              {
+                children: [
+                  'panel',
+                  {
+                    children: [
+                      'users',
+                      {
+                        children: ['__PAGE__', {}, '/admin/panel/users'],
+                        help: [
+                          '(slot)',
+                          {
+                            children: [
+                              ['segments', 'docs/faq/account', 'ci(...)'],
+                              {
+                                children: ['__PAGE__', {}, '/docs/faq/account'],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // (...)[...segments] intercepts from root with catch-all
+        expect(
+          extractRouteFromFlightRouterState('/docs/faq/account', tree)
+        ).toBe('/admin/panel/users/@help/(...)[...segments]')
+      })
+    })
+  })
+
+  describe('Parallel Routes', () => {
+    describe('Basic Parallel Routes (@slot)', () => {
+      it('should handle root-level parallel routes', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: ['__PAGE__', {}, '/'],
+            modal: [
+              '(slot)',
+              {
+                children: [
+                  'login',
+                  {
+                    children: ['__PAGE__', {}, '/login'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/login', tree)).toBe(
+          '/@modal/login'
+        )
+      })
+
+      it('should match non-children parallel route when children does not match', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'app',
+              {
+                children: ['__PAGE__', {}, '/app'],
+                sidebar: [
+                  'nav',
+                  {
+                    children: ['__PAGE__', {}, '/app/nav'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // /app/nav doesn't exist in children, but exists in sidebar
+        expect(extractRouteFromFlightRouterState('/app/nav', tree)).toBe(
+          '/app/@sidebar/nav'
+        )
+      })
+
+      it('should handle parallel route with independent page at slot level', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'gallery',
+              {
+                children: [
+                  ['id', '123', 'd'],
+                  {
+                    children: ['__PAGE__', {}, '/gallery/123'],
+                  },
+                ],
+                modal: [
+                  '(slot)',
+                  {
+                    children: ['__PAGE__', {}, '/gallery/modal'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // Modal has its own page at /gallery/modal (no dynamic segment)
+        expect(extractRouteFromFlightRouterState('/gallery/modal', tree)).toBe(
+          '/gallery/@modal'
+        )
+      })
+
+      it('should filter synthetic (slot) segments after parallel routes', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'see',
+              {
+                children: ['__PAGE__', {}, '/see'],
+                modal: [
+                  '(slot)', // synthetic segment - should be skipped
+                  {
+                    children: ['__PAGE__', {}, '/see'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // Should match the children route, not the modal slot
+        // The (slot) segment is synthetic and should be filtered out
+        expect(extractRouteFromFlightRouterState('/see', tree)).toBe('/see')
+      })
+    })
+
+    describe('Parallel Routes Priority', () => {
+      it('should prioritize children route over named slots', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'dashboard',
+              {
+                children: ['__PAGE__', {}, '/dashboard'],
+                sidebar: [
+                  '(nav)',
+                  {
+                    children: ['__PAGE__', {}, '/dashboard'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // When both children and sidebar match, children wins
+        expect(extractRouteFromFlightRouterState('/dashboard', tree)).toBe(
+          '/dashboard'
+        )
+      })
+
+      it('should handle multiple named slots with first match winning', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'dashboard',
+              {
+                children: ['__PAGE__', {}, '/dashboard'],
+                analytics: [
+                  'chart',
+                  {
+                    children: ['__PAGE__', {}, '/dashboard/chart'],
+                  },
+                ],
+                sidebar: [
+                  'chart',
+                  {
+                    children: ['__PAGE__', {}, '/dashboard/chart'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // Both analytics and sidebar have 'chart', but analytics is checked first
+        const result = extractRouteFromFlightRouterState(
+          '/dashboard/chart',
+          tree
+        )
+        expect(result).toBe('/dashboard/@analytics/chart')
+      })
+    })
+
+    describe('Nested Parallel Routes', () => {
+      it('should handle parallel routes at multiple nested levels', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'app',
+              {
+                children: [
+                  'dashboard',
+                  {
+                    children: ['__PAGE__', {}, '/app/dashboard'],
+                    panel: [
+                      'stats',
+                      {
+                        children: ['__PAGE__', {}, '/app/dashboard/stats'],
+                        chart: [
+                          'line',
+                          {
+                            children: [
+                              '__PAGE__',
+                              {},
+                              '/app/dashboard/stats/line',
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState('/app/dashboard/stats/line', tree)
+        ).toBe('/app/dashboard/@panel/stats/@chart/line')
+      })
+
+      it('should handle parallel routes with different depths', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'app',
+              {
+                children: [
+                  'level1',
+                  {
+                    children: [
+                      'level2',
+                      {
+                        children: [
+                          'level3',
+                          {
+                            children: [
+                              '__PAGE__',
+                              {},
+                              '/app/level1/level2/level3',
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+                shortcut: [
+                  'direct',
+                  {
+                    children: ['__PAGE__', {}, '/app/direct'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // shortcut route is much shorter than children route
+        expect(extractRouteFromFlightRouterState('/app/direct', tree)).toBe(
+          '/app/@shortcut/direct'
+        )
+      })
+    })
+
+    describe('Parallel Routes + Dynamic Segments', () => {
+      it('should handle dynamic segment in both children and parallel route', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'test',
+              {
+                children: [
+                  ['id', '123', 'd'],
+                  {
+                    children: ['__PAGE__', {}, '/test/123'],
+                  },
+                ],
+                modal: [
+                  '(slot)',
+                  {
+                    children: [
+                      ['id', '123', 'd'],
+                      {
+                        children: ['__PAGE__', {}, '/test/123'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // When both children and modal have [id], children should win (priority)
+        expect(extractRouteFromFlightRouterState('/test/123', tree)).toBe(
+          '/test/[id]'
+        )
+      })
+
+      it('should match parallel route when children has different dynamic segment', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'test',
+              {
+                children: [
+                  ['productId', '456', 'd'],
+                  {
+                    children: ['__PAGE__', {}, '/test/product/456'],
+                  },
+                ],
+                modal: [
+                  '(slot)',
+                  {
+                    children: [
+                      ['itemId', '123', 'd'],
+                      {
+                        children: ['__PAGE__', {}, '/test/123'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // /test/123 matches modal's [itemId], not children's [productId]
+        expect(extractRouteFromFlightRouterState('/test/123', tree)).toBe(
+          '/test/@modal/[itemId]'
+        )
+      })
+
+      it('should handle dynamic parameters with parallel routes', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'see',
+              {
+                children: ['__PAGE__', {}, '/see'],
+                modal: [
+                  '(slot)',
+                  {
+                    children: [
+                      '(group)',
+                      {
+                        children: [
+                          ['guid', '14CE0C38-483F-42F0-B2DF-4B1E23C20EFE', 'd'],
+                          {
+                            children: [
+                              '__PAGE__',
+                              {},
+                              '/see/14CE0C38-483F-42F0-B2DF-4B1E23C20EFE',
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState(
+            '/see/14CE0C38-483F-42F0-B2DF-4B1E23C20EFE',
+            tree
+          )
+        ).toBe('/see/@modal/(group)/[guid]')
+      })
+
+      it('should handle catch-all before parallel route', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              ['path', 'blog/posts', 'c'],
+              {
+                children: ['__PAGE__', {}, '/blog/posts'],
+                sidebar: [
+                  'nav',
+                  {
+                    children: ['__PAGE__', {}, '/blog/posts/nav'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/blog/posts/nav', tree)).toBe(
+          '/[...path]/@sidebar/nav'
+        )
+      })
+
+      it('should handle optional catch-all before parallel route', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              ['path', 'docs', 'oc'],
+              {
+                children: ['__PAGE__', {}, '/docs'],
+                toc: [
+                  'sidebar',
+                  {
+                    children: ['__PAGE__', {}, '/docs/sidebar'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/docs/sidebar', tree)).toBe(
+          '/[[...path]]/@toc/sidebar'
+        )
+      })
+    })
+
+    describe('Parallel Routes + Route Groups', () => {
+      it('should preserve user-defined (slot) route groups vs synthetic', () => {
+        // Test case: @modal/(group)/(slot)/[id] where the second (slot) is user-defined
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'product',
+              {
+                children: ['__PAGE__', {}, '/product'],
+                modal: [
+                  '(slot)', // synthetic - should be skipped
+                  {
+                    children: [
+                      '(group)',
+                      {
+                        children: [
+                          '(slot)', // user-defined - should be preserved!
+                          {
+                            children: [
+                              ['id', '123', 'd'],
+                              {
+                                children: ['__PAGE__', {}, '/product/123'],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // The first (slot) is synthetic (right after @modal) - skip it
+        // The second (slot) is user-defined (after (group)) - keep it
+        expect(extractRouteFromFlightRouterState('/product/123', tree)).toBe(
+          '/product/@modal/(group)/(slot)/[id]'
+        )
+      })
+
+      it('should handle route group before parallel route', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              '(app)',
+              {
+                children: [
+                  'dashboard',
+                  {
+                    children: ['__PAGE__', {}, '/dashboard'],
+                    panel: [
+                      'stats',
+                      {
+                        children: ['__PAGE__', {}, '/dashboard/stats'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState('/dashboard/stats', tree)
+        ).toBe('/(app)/dashboard/@panel/stats')
+      })
+    })
+
+    describe('Parallel Routes Edge Cases', () => {
+      it('should return null when no parallel routes match', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'app',
+              {
+                children: ['__PAGE__', {}, '/app'],
+                sidebar: [
+                  'nav',
+                  {
+                    children: ['__PAGE__', {}, '/app/nav'],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // /app/settings doesn't exist in any parallel route
+        expect(extractRouteFromFlightRouterState('/app/settings', tree)).toBe(
+          null
+        )
+      })
+    })
+  })
+
+  describe('Interception Routes', () => {
+    describe('Same-level Interception (.) - Separate Folders', () => {
+      it('should preserve same-level interception marker', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'feed',
+              {
+                children: ['__PAGE__', {}, '/feed'],
+                modal: [
+                  '(slot)',
+                  {
+                    children: [
+                      '(.)photo',
+                      {
+                        children: [
+                          ['id', '123', 'd'],
+                          {
+                            children: ['__PAGE__', {}, '/feed/photo/123'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/feed/photo/123', tree)).toBe(
+          '/feed/@modal/(.)photo/[id]'
+        )
+      })
+
+      it('should handle interception with catch-all parameters', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'blog',
+              {
+                children: ['__PAGE__', {}, '/blog'],
+                modal: [
+                  '(slot)',
+                  {
+                    children: [
+                      '(.)docs',
+                      {
+                        children: [
+                          ['slug', 'api/reference/config', 'c'],
+                          {
+                            children: [
+                              '__PAGE__',
+                              {},
+                              '/blog/docs/api/reference/config',
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState(
+            '/blog/docs/api/reference/config',
+            tree
+          )
+        ).toBe('/blog/@modal/(.)docs/[...slug]')
+      })
+
+      it('should handle interception with route groups', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'gallery',
+              {
+                children: ['__PAGE__', {}, '/gallery'],
+                modal: [
+                  '(slot)',
+                  {
+                    children: [
+                      '(.)(modal-group)',
+                      {
+                        children: [
+                          ['id', '999', 'd'],
+                          {
+                            children: ['__PAGE__', {}, '/gallery/999'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/gallery/999', tree)).toBe(
+          '/gallery/@modal/(.)(modal-group)/[id]'
+        )
+      })
+    })
+
+    describe('Same-level Interception (.) - Combined with Dynamic', () => {
+      it('should handle interception marker combined with dynamic parameter', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'gallery',
+              {
+                modal: [
+                  '(slot)',
+                  {
+                    children: [
+                      '(group)',
+                      {
+                        children: [
+                          ['id', '123', 'di(.)'],
+                          {
+                            children: ['__PAGE__', {}, '/gallery/123'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // (.)[id] is a single segment combining interception with dynamic param
+        expect(extractRouteFromFlightRouterState('/gallery/123', tree)).toBe(
+          '/gallery/@modal/(group)/(.)[id]'
+        )
+      })
+
+      it('should handle interception marker combined with catch-all parameter', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'docs',
+              {
+                children: ['__PAGE__', {}, '/docs'],
+                preview: [
+                  '(slot)',
+                  {
+                    children: [
+                      ['path', 'guides/intro', 'ci(.)'],
+                      {
+                        children: ['__PAGE__', {}, '/docs/guides/intro'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // (.)[...path] is interception marker combined with catch-all
+        expect(
+          extractRouteFromFlightRouterState('/docs/guides/intro', tree)
+        ).toBe('/docs/@preview/(.)[...path]')
+      })
+    })
+
+    describe('Parent-level Interception (..) - Separate Folders', () => {
+      it('should preserve parent-level interception marker', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'app',
+              {
+                children: [
+                  'feed',
+                  {
+                    children: ['__PAGE__', {}, '/app/feed'],
+                    modal: [
+                      '(slot)',
+                      {
+                        children: [
+                          '(..)photo',
+                          {
+                            children: [
+                              ['id', '456', 'd'],
+                              {
+                                children: ['__PAGE__', {}, '/app/photo/456'],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/app/photo/456', tree)).toBe(
+          '/app/feed/@modal/(..)photo/[id]'
+        )
+      })
+
+      it('should handle interception with optional catch-all', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'docs',
+              {
+                children: ['__PAGE__', {}, '/docs'],
+                modal: [
+                  '(slot)',
+                  {
+                    children: [
+                      '(..)preview',
+                      {
+                        children: [
+                          ['slug', 'api/components', 'oc'],
+                          {
+                            children: [
+                              '__PAGE__',
+                              {},
+                              '/preview/api/components',
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState('/preview/api/components', tree)
+        ).toBe('/docs/@modal/(..)preview/[[...slug]]')
+      })
+    })
+
+    describe('Parent-level Interception (..) - Combined with Dynamic', () => {
+      it('should handle parent interception marker combined with dynamic parameter', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'store',
+              {
+                children: [
+                  'catalog',
+                  {
+                    children: ['__PAGE__', {}, '/store/catalog'],
+                    modal: [
+                      '(slot)',
+                      {
+                        children: [
+                          ['productId', '999', 'di(..)'],
+                          {
+                            children: ['__PAGE__', {}, '/store/999'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // (..)[productId] intercepts parent's dynamic segment
+        expect(extractRouteFromFlightRouterState('/store/999', tree)).toBe(
+          '/store/catalog/@modal/(..)[productId]'
+        )
+      })
+    })
+
+    describe('Root-level Interception (...) - Separate Folders', () => {
+      it('should preserve root-level interception marker', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'dashboard',
+              {
+                children: [
+                  'settings',
+                  {
+                    children: ['__PAGE__', {}, '/dashboard/settings'],
+                    modal: [
+                      '(slot)',
+                      {
+                        children: [
+                          '(...)photo',
+                          {
+                            children: [
+                              ['id', '789', 'd'],
+                              {
+                                children: ['__PAGE__', {}, '/photo/789'],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/photo/789', tree)).toBe(
+          '/dashboard/settings/@modal/(...)photo/[id]'
+        )
+      })
+    })
+
+    describe('Root-level Interception (...) - Combined with Dynamic', () => {
+      it('should handle root interception marker combined with dynamic parameter', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'admin',
+              {
+                children: [
+                  'panel',
+                  {
+                    children: ['__PAGE__', {}, '/admin/panel'],
+                    overlay: [
+                      '(slot)',
+                      {
+                        children: [
+                          ['userId', '555', 'di(...)'],
+                          {
+                            children: ['__PAGE__', {}, '/555'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // (...)[userId] intercepts root's dynamic segment
+        expect(extractRouteFromFlightRouterState('/555', tree)).toBe(
+          '/admin/panel/@overlay/(...)[userId]'
+        )
+      })
+    })
+
+    describe('Multiple-level Interception', () => {
+      it('should handle two-level interception marker (..)(..)', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'app',
+              {
+                children: [
+                  'dashboard',
+                  {
+                    children: [
+                      'deep',
+                      {
+                        children: ['__PAGE__', {}, '/app/dashboard/deep'],
+                        modal: [
+                          '(slot)',
+                          {
+                            children: [
+                              '(..)(..)photo',
+                              {
+                                children: [
+                                  ['id', 'abc', 'd'],
+                                  {
+                                    children: [
+                                      '__PAGE__',
+                                      {},
+                                      '/app/photo/abc',
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/app/photo/abc', tree)).toBe(
+          '/app/dashboard/deep/@modal/(..)(..)photo/[id]'
+        )
+      })
+
+      it('should handle three-level interception marker (..)(..)(..)', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'app',
+              {
+                children: [
+                  'level1',
+                  {
+                    children: [
+                      'level2',
+                      {
+                        children: [
+                          'level3',
+                          {
+                            children: [
+                              '__PAGE__',
+                              {},
+                              '/app/level1/level2/level3',
+                            ],
+                            modal: [
+                              '(slot)',
+                              {
+                                children: [
+                                  '(..)(..)(..)photo',
+                                  {
+                                    children: [
+                                      ['id', '999', 'd'],
+                                      {
+                                        children: [
+                                          '__PAGE__',
+                                          {},
+                                          '/photo/999',
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/photo/999', tree)).toBe(
+          '/app/level1/level2/level3/@modal/(..)(..)(..)photo/[id]'
+        )
+      })
+    })
+
+    describe('Optional Catch-all in Parallel Routes', () => {
+      it('should handle optional catch-all parameter in parallel route', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'wiki',
+              {
+                children: ['__PAGE__', {}, '/wiki'],
+                sidebar: [
+                  '(slot)',
+                  {
+                    children: [
+                      ['segments', 'advanced/routing', 'oc'],
+                      {
+                        children: ['__PAGE__', {}, '/wiki/advanced/routing'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        // Note: This is 'oc' type (optional catch-all), NOT 'oci' type.
+        // Interception markers combined with optional catch-all (oci) are not
+        // currently supported in the type system - only separate interception
+        // folders with optional catch-all segments are possible.
+        expect(
+          extractRouteFromFlightRouterState('/wiki/advanced/routing', tree)
+        ).toBe('/wiki/@sidebar/[[...segments]]')
+      })
+    })
+  })
+
+  describe('Complex Multi-Feature Combinations', () => {
+    describe('Route Groups + Dynamic + Parallel', () => {
+      it('should handle route groups + dynamic params + parallel routes', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              '(shop)',
+              {
+                children: [
+                  ['category', 'electronics', 'd'],
+                  {
+                    children: [
+                      ['product', 'laptop', 'd'],
+                      {
+                        children: ['__PAGE__', {}, '/electronics/laptop'],
+                        reviews: [
+                          'list',
+                          {
+                            children: [
+                              '__PAGE__',
+                              {},
+                              '/electronics/laptop/reviews',
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState('/electronics/laptop/reviews', tree)
+        ).toBe('/(shop)/[category]/[product]/@reviews/list')
+      })
+    })
+
+    describe('Multiple Dynamic + Parallel + Interception', () => {
+      it('should handle multiple dynamic params + parallel + interception', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              ['locale', 'en', 'd'],
+              {
+                children: [
+                  'photos',
+                  {
+                    children: [
+                      ['id', '123', 'd'],
+                      {
+                        children: ['__PAGE__', {}, '/en/photos/123'],
+                      },
+                    ],
+                    modal: [
+                      '(slot)',
+                      {
+                        children: [
+                          '(.)photo',
+                          {
+                            children: [
+                              ['photoId', '456', 'd'],
+                              {
+                                children: ['__PAGE__', {}, '/en/photos/456'],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/en/photos/456', tree)).toBe(
+          '/[locale]/photos/@modal/(.)photo/[photoId]'
+        )
+      })
+
+      it('should handle multiple dynamic params before parallel + interception', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              ['locale', 'en', 'd'],
+              {
+                children: [
+                  ['region', 'us', 'd'],
+                  {
+                    children: [
+                      'blog',
+                      {
+                        children: ['__PAGE__', {}, '/en/us/blog'],
+                        modal: [
+                          '(slot)',
+                          {
+                            children: [
+                              '(.)post',
+                              {
+                                children: [
+                                  ['id', '123', 'd'],
+                                  {
+                                    children: [
+                                      '__PAGE__',
+                                      {},
+                                      '/en/us/blog/post/123',
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState('/en/us/blog/post/123', tree)
+        ).toBe('/[locale]/[region]/blog/@modal/(.)post/[id]')
+      })
+    })
+
+    describe('Route Groups + Interception + Multiple Dynamic', () => {
+      it('should handle interception + multiple route groups + dynamic params', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              '(marketing)',
+              {
+                children: [
+                  'products',
+                  {
+                    children: ['__PAGE__', {}, '/products'],
+                    modal: [
+                      '(slot)',
+                      {
+                        children: [
+                          '(.)(modal-layout)',
+                          {
+                            children: [
+                              '(modal-content)',
+                              {
+                                children: [
+                                  ['productId', 'abc123', 'd'],
+                                  {
+                                    children: [
+                                      '__PAGE__',
+                                      {},
+                                      '/products/abc123',
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(
+          extractRouteFromFlightRouterState('/products/abc123', tree)
+        ).toBe(
+          '/(marketing)/products/@modal/(.)(modal-layout)/(modal-content)/[productId]'
+        )
+      })
+    })
+  })
+
+  describe('Edge Cases & Special Behaviors', () => {
+    describe('Client-Side Navigation (null/undefined URLs)', () => {
+      it('should match page with null URL (active page during navigation)', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'products',
+              {
+                children: [
+                  ['id', '123', 'd'],
+                  {
+                    children: ['__PAGE__', {}, null], // null URL during client navigation
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/products/123', tree)).toBe(
+          '/products/[id]'
+        )
+      })
+
+      it('should match page with undefined URL', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'blog',
+              {
+                children: [
+                  ['slug', 'my-post', 'd'],
+                  {
+                    children: ['__PAGE__', {}, undefined], // undefined URL
+                  },
+                ],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/blog/my-post', tree)).toBe(
+          '/blog/[slug]'
+        )
+      })
+    })
+
+    describe('Empty Structures', () => {
+      it('should handle empty parallel routes object', () => {
+        const tree: FlightRouterState = [
+          '',
+          {
+            children: [
+              'page',
+              {
+                children: ['__PAGE__', {}, '/page'],
+              },
+            ],
+          },
+          undefined,
+          undefined,
+          true,
+        ]
+
+        expect(extractRouteFromFlightRouterState('/page', tree)).toBe('/page')
+      })
+    })
+  })
+})

--- a/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.test.ts
+++ b/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.test.ts
@@ -1,7 +1,7 @@
 import type { FlightRouterState } from '../../../shared/lib/app-router-types'
-import { extractRouteFromFlightRouterState } from './extract-route-from-flight-router-state'
+import { extractRoutesFromFlightRouterState } from './extract-route-from-flight-router-state'
 
-describe('extractRouteFromFlightRouterState', () => {
+describe('extractRoutesFromFlightRouterState', () => {
   describe('Static Routes', () => {
     describe('Basic Static Segments', () => {
       it('should return "/" for root page', () => {
@@ -15,7 +15,7 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/', tree)).toBe('/')
+        expect(extractRoutesFromFlightRouterState('/', tree)).toEqual(['/'])
       })
 
       it('should extract simple static route', () => {
@@ -34,10 +34,12 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/about', tree)).toBe('/about')
+        expect(extractRoutesFromFlightRouterState('/about', tree)).toEqual([
+          '/about',
+        ])
       })
 
-      it('should return null for non-matching pathname', () => {
+      it('should return empty array for non-matching pathname', () => {
         const tree: FlightRouterState = [
           '',
           {
@@ -53,10 +55,10 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/contact', tree)).toBe(null)
+        expect(extractRoutesFromFlightRouterState('/contact', tree)).toEqual([])
       })
 
-      it('should return null when searching for root page that does not exist', () => {
+      it('should return empty array when searching for root page that does not exist', () => {
         const tree: FlightRouterState = [
           '',
           {
@@ -72,8 +74,8 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        // Tree has /about but no root page - should return null, not '/'
-        expect(extractRouteFromFlightRouterState('/', tree)).toBe(null)
+        // Tree has /about but no root page - should return empty array
+        expect(extractRoutesFromFlightRouterState('/', tree)).toEqual([])
       })
     })
 
@@ -99,9 +101,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/about', tree)).toBe(
-          '/(marketing)/about'
-        )
+        expect(extractRoutesFromFlightRouterState('/about', tree)).toEqual([
+          '/(marketing)/about',
+        ])
       })
 
       it('should handle multiple nested route groups', () => {
@@ -130,9 +132,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/settings', tree)).toBe(
-          '/(app)/(dashboard)/settings'
-        )
+        expect(extractRoutesFromFlightRouterState('/settings', tree)).toEqual([
+          '/(app)/(dashboard)/settings',
+        ])
       })
 
       it('should handle consecutive route groups', () => {
@@ -166,9 +168,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/login', tree)).toBe(
-          '/(root)/(auth)/(forms)/login'
-        )
+        expect(extractRoutesFromFlightRouterState('/login', tree)).toEqual([
+          '/(root)/(auth)/(forms)/login',
+        ])
       })
     })
   })
@@ -196,9 +198,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/blog/my-post', tree)).toBe(
-          '/blog/[slug]'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/blog/my-post', tree)
+        ).toEqual(['/blog/[slug]'])
       })
 
       it('should handle multiple nested dynamic parameters', () => {
@@ -228,8 +230,8 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState('/shop/electronics/laptop', tree)
-        ).toBe('/shop/[category]/[product]')
+          extractRoutesFromFlightRouterState('/shop/electronics/laptop', tree)
+        ).toEqual(['/shop/[category]/[product]'])
       })
 
       it('should handle dynamic parameters with route groups', () => {
@@ -259,8 +261,8 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState('/electronics/laptop', tree)
-        ).toBe('/(shop)/[category]/[product]')
+          extractRoutesFromFlightRouterState('/electronics/laptop', tree)
+        ).toEqual(['/(shop)/[category]/[product]'])
       })
     })
 
@@ -287,8 +289,8 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState('/docs/api/reference', tree)
-        ).toBe('/docs/[...slug]')
+          extractRoutesFromFlightRouterState('/docs/api/reference', tree)
+        ).toEqual(['/docs/[...slug]'])
       })
 
       it('should handle catch-all at root level', () => {
@@ -307,8 +309,8 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/blog/posts', tree)).toBe(
-          '/[...path]'
+        expect(extractRoutesFromFlightRouterState('/blog/posts', tree)).toEqual(
+          ['/[...path]']
         )
       })
     })
@@ -336,8 +338,8 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState('/docs/api/reference', tree)
-        ).toBe('/docs/[[...slug]]')
+          extractRoutesFromFlightRouterState('/docs/api/reference', tree)
+        ).toEqual(['/docs/[[...slug]]'])
       })
 
       it('should handle optional catch-all at root level', () => {
@@ -356,8 +358,8 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/about/team', tree)).toBe(
-          '/[[...slug]]'
+        expect(extractRoutesFromFlightRouterState('/about/team', tree)).toEqual(
+          ['/[[...slug]]']
         )
       })
     })
@@ -396,8 +398,8 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState('/posts/post/my-post', tree)
-        ).toBe('/posts/@modal/(.)post/[slug]')
+          extractRoutesFromFlightRouterState('/posts/post/my-post', tree)
+        ).toEqual(['/posts/@modal/(.)post/[slug]'])
       })
 
       it('should handle combined interception marker + dynamic parameter folder', () => {
@@ -432,9 +434,9 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         // (.)[id] is a SINGLE folder combining interception with dynamic param
-        expect(extractRouteFromFlightRouterState('/gallery/123', tree)).toBe(
-          '/gallery/@modal/(group)/(.)[id]'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/gallery/123', tree)
+        ).toEqual(['/gallery/@modal/(group)/(.)[id]'])
       })
 
       it('should handle parent interception marker combined with dynamic parameter', () => {
@@ -470,9 +472,9 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         // (..)[productId] intercepts parent's dynamic segment
-        expect(extractRouteFromFlightRouterState('/store/999', tree)).toBe(
-          '/store/catalog/@modal/(..)[productId]'
-        )
+        expect(extractRoutesFromFlightRouterState('/store/999', tree)).toEqual([
+          '/store/catalog/@modal/(..)[productId]',
+        ])
       })
 
       it('should handle root interception marker combined with dynamic parameter', () => {
@@ -508,9 +510,9 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         // (...)[userId] intercepts root's dynamic segment
-        expect(extractRouteFromFlightRouterState('/555', tree)).toBe(
-          '/admin/panel/@overlay/(...)[userId]'
-        )
+        expect(extractRoutesFromFlightRouterState('/555', tree)).toEqual([
+          '/admin/panel/@overlay/(...)[userId]',
+        ])
       })
     })
 
@@ -552,11 +554,11 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState(
+          extractRoutesFromFlightRouterState(
             '/wiki/docs/getting-started/intro',
             tree
           )
-        ).toBe('/wiki/@modal/(.)docs/[...path]')
+        ).toEqual(['/wiki/@modal/(.)docs/[...path]'])
       })
 
       it('should handle combined interception marker + catch-all parameter folder', () => {
@@ -587,8 +589,8 @@ describe('extractRouteFromFlightRouterState', () => {
 
         // (.)[...path] is a SINGLE folder combining interception with catch-all
         expect(
-          extractRouteFromFlightRouterState('/docs/guides/intro', tree)
-        ).toBe('/docs/@preview/(.)[...path]')
+          extractRoutesFromFlightRouterState('/docs/guides/intro', tree)
+        ).toEqual(['/docs/@preview/(.)[...path]'])
       })
 
       it('should handle two-level parent interception with catch-all', () => {
@@ -634,8 +636,8 @@ describe('extractRouteFromFlightRouterState', () => {
 
         // (..)(..)[...path] intercepts two levels up with catch-all
         expect(
-          extractRouteFromFlightRouterState('/app/api/reference/config', tree)
-        ).toBe('/app/dashboard/settings/@docs/(..)(..)[...path]')
+          extractRoutesFromFlightRouterState('/app/api/reference/config', tree)
+        ).toEqual(['/app/dashboard/settings/@docs/(..)(..)[...path]'])
       })
 
       it('should handle root-level interception with catch-all', () => {
@@ -677,8 +679,8 @@ describe('extractRouteFromFlightRouterState', () => {
 
         // (...)[...segments] intercepts from root with catch-all
         expect(
-          extractRouteFromFlightRouterState('/docs/faq/account', tree)
-        ).toBe('/admin/panel/users/@help/(...)[...segments]')
+          extractRoutesFromFlightRouterState('/docs/faq/account', tree)
+        ).toEqual(['/admin/panel/users/@help/(...)[...segments]'])
       })
     })
   })
@@ -707,9 +709,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/login', tree)).toBe(
-          '/@modal/login'
-        )
+        expect(extractRoutesFromFlightRouterState('/login', tree)).toEqual([
+          '/@modal/login',
+        ])
       })
 
       it('should match non-children parallel route when children does not match', () => {
@@ -735,9 +737,9 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         // /app/nav doesn't exist in children, but exists in sidebar
-        expect(extractRouteFromFlightRouterState('/app/nav', tree)).toBe(
-          '/app/@sidebar/nav'
-        )
+        expect(extractRoutesFromFlightRouterState('/app/nav', tree)).toEqual([
+          '/app/@sidebar/nav',
+        ])
       })
 
       it('should handle parallel route with independent page at slot level', () => {
@@ -768,9 +770,9 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         // Modal has its own page at /gallery/modal (no dynamic segment)
-        expect(extractRouteFromFlightRouterState('/gallery/modal', tree)).toBe(
-          '/gallery/@modal'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/gallery/modal', tree)
+        ).toEqual(['/gallery/@modal'])
       })
 
       it('should filter synthetic (slot) segments after parallel routes', () => {
@@ -795,9 +797,12 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        // Should match the children route, not the modal slot
-        // The (slot) segment is synthetic and should be filtered out
-        expect(extractRouteFromFlightRouterState('/see', tree)).toBe('/see')
+        // Both children and modal match - both should be returned
+        // The (slot) segment is synthetic and should be filtered out from modal route
+        expect(extractRoutesFromFlightRouterState('/see', tree)).toEqual([
+          '/see',
+          '/see/@modal',
+        ])
       })
     })
 
@@ -824,10 +829,11 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        // When both children and sidebar match, children wins
-        expect(extractRouteFromFlightRouterState('/dashboard', tree)).toBe(
-          '/dashboard'
-        )
+        // Both children and sidebar match - both should be returned
+        expect(extractRoutesFromFlightRouterState('/dashboard', tree)).toEqual([
+          '/dashboard',
+          '/dashboard/@sidebar/(nav)',
+        ])
       })
 
       it('should handle multiple named slots with first match winning', () => {
@@ -858,12 +864,15 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        // Both analytics and sidebar have 'chart', but analytics is checked first
-        const result = extractRouteFromFlightRouterState(
+        // Both analytics and sidebar have 'chart' - both should be returned
+        const result = extractRoutesFromFlightRouterState(
           '/dashboard/chart',
           tree
         )
-        expect(result).toBe('/dashboard/@analytics/chart')
+        expect(result).toEqual([
+          '/dashboard/@analytics/chart',
+          '/dashboard/@sidebar/chart',
+        ])
       })
     })
 
@@ -906,8 +915,8 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState('/app/dashboard/stats/line', tree)
-        ).toBe('/app/dashboard/@panel/stats/@chart/line')
+          extractRoutesFromFlightRouterState('/app/dashboard/stats/line', tree)
+        ).toEqual(['/app/dashboard/@panel/stats/@chart/line'])
       })
 
       it('should handle parallel routes with different depths', () => {
@@ -952,8 +961,8 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         // shortcut route is much shorter than children route
-        expect(extractRouteFromFlightRouterState('/app/direct', tree)).toBe(
-          '/app/@shortcut/direct'
+        expect(extractRoutesFromFlightRouterState('/app/direct', tree)).toEqual(
+          ['/app/@shortcut/direct']
         )
       })
     })
@@ -991,10 +1000,11 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        // When both children and modal have [id], children should win (priority)
-        expect(extractRouteFromFlightRouterState('/test/123', tree)).toBe(
-          '/test/[id]'
-        )
+        // Both children and modal have [id] - both should be returned
+        expect(extractRoutesFromFlightRouterState('/test/123', tree)).toEqual([
+          '/test/[id]',
+          '/test/@modal/[id]',
+        ])
       })
 
       it('should match parallel route when children has different dynamic segment', () => {
@@ -1030,9 +1040,9 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         // /test/123 matches modal's [itemId], not children's [productId]
-        expect(extractRouteFromFlightRouterState('/test/123', tree)).toBe(
-          '/test/@modal/[itemId]'
-        )
+        expect(extractRoutesFromFlightRouterState('/test/123', tree)).toEqual([
+          '/test/@modal/[itemId]',
+        ])
       })
 
       it('should handle dynamic parameters with parallel routes', () => {
@@ -1072,11 +1082,11 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState(
+          extractRoutesFromFlightRouterState(
             '/see/14CE0C38-483F-42F0-B2DF-4B1E23C20EFE',
             tree
           )
-        ).toBe('/see/@modal/(group)/[guid]')
+        ).toEqual(['/see/@modal/(group)/[guid]'])
       })
 
       it('should handle catch-all before parallel route', () => {
@@ -1101,9 +1111,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/blog/posts/nav', tree)).toBe(
-          '/[...path]/@sidebar/nav'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/blog/posts/nav', tree)
+        ).toEqual(['/[...path]/@sidebar/nav'])
       })
 
       it('should handle optional catch-all before parallel route', () => {
@@ -1128,9 +1138,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/docs/sidebar', tree)).toBe(
-          '/[[...path]]/@toc/sidebar'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/docs/sidebar', tree)
+        ).toEqual(['/[[...path]]/@toc/sidebar'])
       })
     })
 
@@ -1175,9 +1185,9 @@ describe('extractRouteFromFlightRouterState', () => {
 
         // The first (slot) is synthetic (right after @modal) - skip it
         // The second (slot) is user-defined (after (group)) - keep it
-        expect(extractRouteFromFlightRouterState('/product/123', tree)).toBe(
-          '/product/@modal/(group)/(slot)/[id]'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/product/123', tree)
+        ).toEqual(['/product/@modal/(group)/(slot)/[id]'])
       })
 
       it('should handle route group before parallel route', () => {
@@ -1208,8 +1218,8 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState('/dashboard/stats', tree)
-        ).toBe('/(app)/dashboard/@panel/stats')
+          extractRoutesFromFlightRouterState('/dashboard/stats', tree)
+        ).toEqual(['/(app)/dashboard/@panel/stats'])
       })
     })
 
@@ -1237,9 +1247,9 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         // /app/settings doesn't exist in any parallel route
-        expect(extractRouteFromFlightRouterState('/app/settings', tree)).toBe(
-          null
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/app/settings', tree)
+        ).toEqual([])
       })
     })
   })
@@ -1278,9 +1288,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/feed/photo/123', tree)).toBe(
-          '/feed/@modal/(.)photo/[id]'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/feed/photo/123', tree)
+        ).toEqual(['/feed/@modal/(.)photo/[id]'])
       })
 
       it('should handle interception with catch-all parameters', () => {
@@ -1320,11 +1330,11 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState(
+          extractRoutesFromFlightRouterState(
             '/blog/docs/api/reference/config',
             tree
           )
-        ).toBe('/blog/@modal/(.)docs/[...slug]')
+        ).toEqual(['/blog/@modal/(.)docs/[...slug]'])
       })
 
       it('should handle interception with route groups', () => {
@@ -1359,9 +1369,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/gallery/999', tree)).toBe(
-          '/gallery/@modal/(.)(modal-group)/[id]'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/gallery/999', tree)
+        ).toEqual(['/gallery/@modal/(.)(modal-group)/[id]'])
       })
     })
 
@@ -1398,9 +1408,9 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         // (.)[id] is a single segment combining interception with dynamic param
-        expect(extractRouteFromFlightRouterState('/gallery/123', tree)).toBe(
-          '/gallery/@modal/(group)/(.)[id]'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/gallery/123', tree)
+        ).toEqual(['/gallery/@modal/(group)/(.)[id]'])
       })
 
       it('should handle interception marker combined with catch-all parameter', () => {
@@ -1432,8 +1442,8 @@ describe('extractRouteFromFlightRouterState', () => {
 
         // (.)[...path] is interception marker combined with catch-all
         expect(
-          extractRouteFromFlightRouterState('/docs/guides/intro', tree)
-        ).toBe('/docs/@preview/(.)[...path]')
+          extractRoutesFromFlightRouterState('/docs/guides/intro', tree)
+        ).toEqual(['/docs/@preview/(.)[...path]'])
       })
     })
 
@@ -1475,9 +1485,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/app/photo/456', tree)).toBe(
-          '/app/feed/@modal/(..)photo/[id]'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/app/photo/456', tree)
+        ).toEqual(['/app/feed/@modal/(..)photo/[id]'])
       })
 
       it('should handle interception with optional catch-all', () => {
@@ -1517,8 +1527,8 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState('/preview/api/components', tree)
-        ).toBe('/docs/@modal/(..)preview/[[...slug]]')
+          extractRoutesFromFlightRouterState('/preview/api/components', tree)
+        ).toEqual(['/docs/@modal/(..)preview/[[...slug]]'])
       })
     })
 
@@ -1556,9 +1566,9 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         // (..)[productId] intercepts parent's dynamic segment
-        expect(extractRouteFromFlightRouterState('/store/999', tree)).toBe(
-          '/store/catalog/@modal/(..)[productId]'
-        )
+        expect(extractRoutesFromFlightRouterState('/store/999', tree)).toEqual([
+          '/store/catalog/@modal/(..)[productId]',
+        ])
       })
     })
 
@@ -1600,9 +1610,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/photo/789', tree)).toBe(
-          '/dashboard/settings/@modal/(...)photo/[id]'
-        )
+        expect(extractRoutesFromFlightRouterState('/photo/789', tree)).toEqual([
+          '/dashboard/settings/@modal/(...)photo/[id]',
+        ])
       })
     })
 
@@ -1640,9 +1650,9 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         // (...)[userId] intercepts root's dynamic segment
-        expect(extractRouteFromFlightRouterState('/555', tree)).toBe(
-          '/admin/panel/@overlay/(...)[userId]'
-        )
+        expect(extractRoutesFromFlightRouterState('/555', tree)).toEqual([
+          '/admin/panel/@overlay/(...)[userId]',
+        ])
       })
     })
 
@@ -1693,9 +1703,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/app/photo/abc', tree)).toBe(
-          '/app/dashboard/deep/@modal/(..)(..)photo/[id]'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/app/photo/abc', tree)
+        ).toEqual(['/app/dashboard/deep/@modal/(..)(..)photo/[id]'])
       })
 
       it('should handle three-level interception marker (..)(..)(..)', () => {
@@ -1753,9 +1763,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/photo/999', tree)).toBe(
-          '/app/level1/level2/level3/@modal/(..)(..)(..)photo/[id]'
-        )
+        expect(extractRoutesFromFlightRouterState('/photo/999', tree)).toEqual([
+          '/app/level1/level2/level3/@modal/(..)(..)(..)photo/[id]',
+        ])
       })
     })
 
@@ -1792,8 +1802,8 @@ describe('extractRouteFromFlightRouterState', () => {
         // currently supported in the type system - only separate interception
         // folders with optional catch-all segments are possible.
         expect(
-          extractRouteFromFlightRouterState('/wiki/advanced/routing', tree)
-        ).toBe('/wiki/@sidebar/[[...segments]]')
+          extractRoutesFromFlightRouterState('/wiki/advanced/routing', tree)
+        ).toEqual(['/wiki/@sidebar/[[...segments]]'])
       })
     })
   })
@@ -1837,8 +1847,11 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState('/electronics/laptop/reviews', tree)
-        ).toBe('/(shop)/[category]/[product]/@reviews/list')
+          extractRoutesFromFlightRouterState(
+            '/electronics/laptop/reviews',
+            tree
+          )
+        ).toEqual(['/(shop)/[category]/[product]/@reviews/list'])
       })
     })
 
@@ -1885,9 +1898,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/en/photos/456', tree)).toBe(
-          '/[locale]/photos/@modal/(.)photo/[photoId]'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/en/photos/456', tree)
+        ).toEqual(['/[locale]/photos/@modal/(.)photo/[photoId]'])
       })
 
       it('should handle multiple dynamic params before parallel + interception', () => {
@@ -1937,8 +1950,8 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState('/en/us/blog/post/123', tree)
-        ).toBe('/[locale]/[region]/blog/@modal/(.)post/[id]')
+          extractRoutesFromFlightRouterState('/en/us/blog/post/123', tree)
+        ).toEqual(['/[locale]/[region]/blog/@modal/(.)post/[id]'])
       })
     })
 
@@ -1990,10 +2003,10 @@ describe('extractRouteFromFlightRouterState', () => {
         ]
 
         expect(
-          extractRouteFromFlightRouterState('/products/abc123', tree)
-        ).toBe(
-          '/(marketing)/products/@modal/(.)(modal-layout)/(modal-content)/[productId]'
-        )
+          extractRoutesFromFlightRouterState('/products/abc123', tree)
+        ).toEqual([
+          '/(marketing)/products/@modal/(.)(modal-layout)/(modal-content)/[productId]',
+        ])
       })
     })
   })
@@ -2021,9 +2034,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/products/123', tree)).toBe(
-          '/products/[id]'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/products/123', tree)
+        ).toEqual(['/products/[id]'])
       })
 
       it('should match page with undefined URL', () => {
@@ -2047,9 +2060,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/blog/my-post', tree)).toBe(
-          '/blog/[slug]'
-        )
+        expect(
+          extractRoutesFromFlightRouterState('/blog/my-post', tree)
+        ).toEqual(['/blog/[slug]'])
       })
     })
 
@@ -2070,7 +2083,9 @@ describe('extractRouteFromFlightRouterState', () => {
           true,
         ]
 
-        expect(extractRouteFromFlightRouterState('/page', tree)).toBe('/page')
+        expect(extractRoutesFromFlightRouterState('/page', tree)).toEqual([
+          '/page',
+        ])
       })
     })
   })

--- a/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.test.ts
+++ b/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.test.ts
@@ -8,7 +8,7 @@ describe('extractRoutesFromFlightRouterState', () => {
         const tree: FlightRouterState = [
           '',
           {
-            children: ['__PAGE__', {}, '/', undefined, true],
+            children: ['__PAGE__', {}, ['/', ''], undefined, true],
           },
           undefined,
           undefined,
@@ -25,7 +25,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'about',
               {
-                children: ['__PAGE__', {}, '/about'],
+                children: ['__PAGE__', {}, ['/about', '']],
               },
             ],
           },
@@ -46,7 +46,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'about',
               {
-                children: ['__PAGE__', {}, '/about'],
+                children: ['__PAGE__', {}, ['/about', '']],
               },
             ],
           },
@@ -65,7 +65,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'about',
               {
-                children: ['__PAGE__', {}, '/about'],
+                children: ['__PAGE__', {}, ['/about', '']],
               },
             ],
           },
@@ -90,7 +90,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   'about',
                   {
-                    children: ['__PAGE__', {}, '/about'],
+                    children: ['__PAGE__', {}, ['/about', '']],
                   },
                 ],
               },
@@ -119,7 +119,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                     children: [
                       'settings',
                       {
-                        children: ['__PAGE__', {}, '/settings'],
+                        children: ['__PAGE__', {}, ['/settings', '']],
                       },
                     ],
                   },
@@ -153,7 +153,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                         children: [
                           'login',
                           {
-                            children: ['__PAGE__', {}, '/login'],
+                            children: ['__PAGE__', {}, ['/login', '']],
                           },
                         ],
                       },
@@ -187,7 +187,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   ['slug', 'my-post', 'd'],
                   {
-                    children: ['__PAGE__', {}, '/blog/my-post'],
+                    children: ['__PAGE__', {}, ['/blog/my-post', '']],
                   },
                 ],
               },
@@ -216,7 +216,11 @@ describe('extractRoutesFromFlightRouterState', () => {
                     children: [
                       ['product', 'laptop', 'd'],
                       {
-                        children: ['__PAGE__', {}, '/shop/electronics/laptop'],
+                        children: [
+                          '__PAGE__',
+                          {},
+                          ['/shop/electronics/laptop', ''],
+                        ],
                       },
                     ],
                   },
@@ -247,7 +251,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                     children: [
                       ['product', 'laptop', 'd'],
                       {
-                        children: ['__PAGE__', {}, '/electronics/laptop'],
+                        children: ['__PAGE__', {}, ['/electronics/laptop', '']],
                       },
                     ],
                   },
@@ -277,7 +281,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   ['slug', 'api/reference', 'c'],
                   {
-                    children: ['__PAGE__', {}, '/docs/api/reference'],
+                    children: ['__PAGE__', {}, ['/docs/api/reference', '']],
                   },
                 ],
               },
@@ -300,7 +304,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               ['path', 'blog/posts', 'c'],
               {
-                children: ['__PAGE__', {}, '/blog/posts'],
+                children: ['__PAGE__', {}, ['/blog/posts', '']],
               },
             ],
           },
@@ -326,7 +330,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   ['slug', 'api/reference', 'oc'],
                   {
-                    children: ['__PAGE__', {}, '/docs/api/reference'],
+                    children: ['__PAGE__', {}, ['/docs/api/reference', '']],
                   },
                 ],
               },
@@ -349,7 +353,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               ['slug', 'about/team', 'oc'],
               {
-                children: ['__PAGE__', {}, '/about/team'],
+                children: ['__PAGE__', {}, ['/about/team', '']],
               },
             ],
           },
@@ -372,7 +376,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'posts',
               {
-                children: ['__PAGE__', {}, '/posts'],
+                children: ['__PAGE__', {}, ['/posts', '']],
                 modal: [
                   '(slot)',
                   {
@@ -382,7 +386,11 @@ describe('extractRoutesFromFlightRouterState', () => {
                         children: [
                           ['slug', 'my-post', 'd'],
                           {
-                            children: ['__PAGE__', {}, '/posts/post/my-post'],
+                            children: [
+                              '__PAGE__',
+                              {},
+                              ['/posts/post/my-post', ''],
+                            ],
                           },
                         ],
                       },
@@ -418,7 +426,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                         children: [
                           ['id', '123', 'di(.)'],
                           {
-                            children: ['__PAGE__', {}, '/gallery/123'],
+                            children: ['__PAGE__', {}, ['/gallery/123', '']],
                           },
                         ],
                       },
@@ -449,14 +457,14 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   'catalog',
                   {
-                    children: ['__PAGE__', {}, '/store/catalog'],
+                    children: ['__PAGE__', {}, ['/store/catalog', '']],
                     modal: [
                       '(slot)',
                       {
                         children: [
                           ['productId', '999', 'di(..)'],
                           {
-                            children: ['__PAGE__', {}, '/store/999'],
+                            children: ['__PAGE__', {}, ['/store/999', '']],
                           },
                         ],
                       },
@@ -487,14 +495,14 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   'panel',
                   {
-                    children: ['__PAGE__', {}, '/admin/panel'],
+                    children: ['__PAGE__', {}, ['/admin/panel', '']],
                     overlay: [
                       '(slot)',
                       {
                         children: [
                           ['userId', '555', 'di(...)'],
                           {
-                            children: ['__PAGE__', {}, '/555'],
+                            children: ['__PAGE__', {}, ['/555', '']],
                           },
                         ],
                       },
@@ -524,7 +532,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'wiki',
               {
-                children: ['__PAGE__', {}, '/wiki'],
+                children: ['__PAGE__', {}, ['/wiki', '']],
                 modal: [
                   '(slot)',
                   {
@@ -537,7 +545,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                             children: [
                               '__PAGE__',
                               {},
-                              '/wiki/docs/getting-started/intro',
+                              ['/wiki/docs/getting-started/intro', ''],
                             ],
                           },
                         ],
@@ -574,7 +582,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                     children: [
                       ['path', 'guides/intro', 'ci(.)'],
                       {
-                        children: ['__PAGE__', {}, '/docs/guides/intro'],
+                        children: ['__PAGE__', {}, ['/docs/guides/intro', '']],
                       },
                     ],
                   },
@@ -606,7 +614,11 @@ describe('extractRoutesFromFlightRouterState', () => {
                     children: [
                       'settings',
                       {
-                        children: ['__PAGE__', {}, '/app/dashboard/settings'],
+                        children: [
+                          '__PAGE__',
+                          {},
+                          ['/app/dashboard/settings', ''],
+                        ],
                         docs: [
                           '(slot)',
                           {
@@ -616,7 +628,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                                 children: [
                                   '__PAGE__',
                                   {},
-                                  '/app/api/reference/config',
+                                  ['/app/api/reference/config', ''],
                                 ],
                               },
                             ],
@@ -653,14 +665,18 @@ describe('extractRoutesFromFlightRouterState', () => {
                     children: [
                       'users',
                       {
-                        children: ['__PAGE__', {}, '/admin/panel/users'],
+                        children: ['__PAGE__', {}, ['/admin/panel/users', '']],
                         help: [
                           '(slot)',
                           {
                             children: [
                               ['segments', 'docs/faq/account', 'ci(...)'],
                               {
-                                children: ['__PAGE__', {}, '/docs/faq/account'],
+                                children: [
+                                  '__PAGE__',
+                                  {},
+                                  ['/docs/faq/account', ''],
+                                ],
                               },
                             ],
                           },
@@ -691,14 +707,14 @@ describe('extractRoutesFromFlightRouterState', () => {
         const tree: FlightRouterState = [
           '',
           {
-            children: ['__PAGE__', {}, '/'],
+            children: ['__PAGE__', {}, ['/', '']],
             modal: [
               '(slot)',
               {
                 children: [
                   'login',
                   {
-                    children: ['__PAGE__', {}, '/login'],
+                    children: ['__PAGE__', {}, ['/login', '']],
                   },
                 ],
               },
@@ -721,11 +737,11 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'app',
               {
-                children: ['__PAGE__', {}, '/app'],
+                children: ['__PAGE__', {}, ['/app', '']],
                 sidebar: [
                   'nav',
                   {
-                    children: ['__PAGE__', {}, '/app/nav'],
+                    children: ['__PAGE__', {}, ['/app/nav', '']],
                   },
                 ],
               },
@@ -752,13 +768,13 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   ['id', '123', 'd'],
                   {
-                    children: ['__PAGE__', {}, '/gallery/123'],
+                    children: ['__PAGE__', {}, ['/gallery/123', '']],
                   },
                 ],
                 modal: [
                   '(slot)',
                   {
-                    children: ['__PAGE__', {}, '/gallery/modal'],
+                    children: ['__PAGE__', {}, ['/gallery/modal', '']],
                   },
                 ],
               },
@@ -782,11 +798,11 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'see',
               {
-                children: ['__PAGE__', {}, '/see'],
+                children: ['__PAGE__', {}, ['/see', '']],
                 modal: [
                   '(slot)', // synthetic segment - should be skipped
                   {
-                    children: ['__PAGE__', {}, '/see'],
+                    children: ['__PAGE__', {}, ['/see', '']],
                   },
                 ],
               },
@@ -814,11 +830,11 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'dashboard',
               {
-                children: ['__PAGE__', {}, '/dashboard'],
+                children: ['__PAGE__', {}, ['/dashboard', '']],
                 sidebar: [
                   '(nav)',
                   {
-                    children: ['__PAGE__', {}, '/dashboard'],
+                    children: ['__PAGE__', {}, ['/dashboard', '']],
                   },
                 ],
               },
@@ -843,17 +859,17 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'dashboard',
               {
-                children: ['__PAGE__', {}, '/dashboard'],
+                children: ['__PAGE__', {}, ['/dashboard', '']],
                 analytics: [
                   'chart',
                   {
-                    children: ['__PAGE__', {}, '/dashboard/chart'],
+                    children: ['__PAGE__', {}, ['/dashboard/chart', '']],
                   },
                 ],
                 sidebar: [
                   'chart',
                   {
-                    children: ['__PAGE__', {}, '/dashboard/chart'],
+                    children: ['__PAGE__', {}, ['/dashboard/chart', '']],
                   },
                 ],
               },
@@ -887,18 +903,22 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   'dashboard',
                   {
-                    children: ['__PAGE__', {}, '/app/dashboard'],
+                    children: ['__PAGE__', {}, ['/app/dashboard', '']],
                     panel: [
                       'stats',
                       {
-                        children: ['__PAGE__', {}, '/app/dashboard/stats'],
+                        children: [
+                          '__PAGE__',
+                          {},
+                          ['/app/dashboard/stats', ''],
+                        ],
                         chart: [
                           'line',
                           {
                             children: [
                               '__PAGE__',
                               {},
-                              '/app/dashboard/stats/line',
+                              ['/app/dashboard/stats/line', ''],
                             ],
                           },
                         ],
@@ -938,7 +958,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                             children: [
                               '__PAGE__',
                               {},
-                              '/app/level1/level2/level3',
+                              ['/app/level1/level2/level3', ''],
                             ],
                           },
                         ],
@@ -949,7 +969,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                 shortcut: [
                   'direct',
                   {
-                    children: ['__PAGE__', {}, '/app/direct'],
+                    children: ['__PAGE__', {}, ['/app/direct', '']],
                   },
                 ],
               },
@@ -978,7 +998,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   ['id', '123', 'd'],
                   {
-                    children: ['__PAGE__', {}, '/test/123'],
+                    children: ['__PAGE__', {}, ['/test/123', '']],
                   },
                 ],
                 modal: [
@@ -987,7 +1007,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                     children: [
                       ['id', '123', 'd'],
                       {
-                        children: ['__PAGE__', {}, '/test/123'],
+                        children: ['__PAGE__', {}, ['/test/123', '']],
                       },
                     ],
                   },
@@ -1017,7 +1037,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   ['productId', '456', 'd'],
                   {
-                    children: ['__PAGE__', {}, '/test/product/456'],
+                    children: ['__PAGE__', {}, ['/test/product/456', '']],
                   },
                 ],
                 modal: [
@@ -1026,7 +1046,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                     children: [
                       ['itemId', '123', 'd'],
                       {
-                        children: ['__PAGE__', {}, '/test/123'],
+                        children: ['__PAGE__', {}, ['/test/123', '']],
                       },
                     ],
                   },
@@ -1052,7 +1072,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'see',
               {
-                children: ['__PAGE__', {}, '/see'],
+                children: ['__PAGE__', {}, ['/see', '']],
                 modal: [
                   '(slot)',
                   {
@@ -1065,7 +1085,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                             children: [
                               '__PAGE__',
                               {},
-                              '/see/14CE0C38-483F-42F0-B2DF-4B1E23C20EFE',
+                              ['/see/14CE0C38-483F-42F0-B2DF-4B1E23C20EFE', ''],
                             ],
                           },
                         ],
@@ -1096,11 +1116,11 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               ['path', 'blog/posts', 'c'],
               {
-                children: ['__PAGE__', {}, '/blog/posts'],
+                children: ['__PAGE__', {}, ['/blog/posts', '']],
                 sidebar: [
                   'nav',
                   {
-                    children: ['__PAGE__', {}, '/blog/posts/nav'],
+                    children: ['__PAGE__', {}, ['/blog/posts/nav', '']],
                   },
                 ],
               },
@@ -1123,11 +1143,11 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               ['path', 'docs', 'oc'],
               {
-                children: ['__PAGE__', {}, '/docs'],
+                children: ['__PAGE__', {}, ['/docs', '']],
                 toc: [
                   'sidebar',
                   {
-                    children: ['__PAGE__', {}, '/docs/sidebar'],
+                    children: ['__PAGE__', {}, ['/docs/sidebar', '']],
                   },
                 ],
               },
@@ -1153,7 +1173,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'product',
               {
-                children: ['__PAGE__', {}, '/product'],
+                children: ['__PAGE__', {}, ['/product', '']],
                 modal: [
                   '(slot)', // synthetic - should be skipped
                   {
@@ -1166,7 +1186,11 @@ describe('extractRoutesFromFlightRouterState', () => {
                             children: [
                               ['id', '123', 'd'],
                               {
-                                children: ['__PAGE__', {}, '/product/123'],
+                                children: [
+                                  '__PAGE__',
+                                  {},
+                                  ['/product/123', ''],
+                                ],
                               },
                             ],
                           },
@@ -1200,11 +1224,11 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   'dashboard',
                   {
-                    children: ['__PAGE__', {}, '/dashboard'],
+                    children: ['__PAGE__', {}, ['/dashboard', '']],
                     panel: [
                       'stats',
                       {
-                        children: ['__PAGE__', {}, '/dashboard/stats'],
+                        children: ['__PAGE__', {}, ['/dashboard/stats', '']],
                       },
                     ],
                   },
@@ -1231,11 +1255,11 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'app',
               {
-                children: ['__PAGE__', {}, '/app'],
+                children: ['__PAGE__', {}, ['/app', '']],
                 sidebar: [
                   'nav',
                   {
-                    children: ['__PAGE__', {}, '/app/nav'],
+                    children: ['__PAGE__', {}, ['/app/nav', '']],
                   },
                 ],
               },
@@ -1263,7 +1287,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'feed',
               {
-                children: ['__PAGE__', {}, '/feed'],
+                children: ['__PAGE__', {}, ['/feed', '']],
                 modal: [
                   '(slot)',
                   {
@@ -1273,7 +1297,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                         children: [
                           ['id', '123', 'd'],
                           {
-                            children: ['__PAGE__', {}, '/feed/photo/123'],
+                            children: ['__PAGE__', {}, ['/feed/photo/123', '']],
                           },
                         ],
                       },
@@ -1300,7 +1324,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'blog',
               {
-                children: ['__PAGE__', {}, '/blog'],
+                children: ['__PAGE__', {}, ['/blog', '']],
                 modal: [
                   '(slot)',
                   {
@@ -1313,7 +1337,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                             children: [
                               '__PAGE__',
                               {},
-                              '/blog/docs/api/reference/config',
+                              ['/blog/docs/api/reference/config', ''],
                             ],
                           },
                         ],
@@ -1344,7 +1368,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'gallery',
               {
-                children: ['__PAGE__', {}, '/gallery'],
+                children: ['__PAGE__', {}, ['/gallery', '']],
                 modal: [
                   '(slot)',
                   {
@@ -1354,7 +1378,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                         children: [
                           ['id', '999', 'd'],
                           {
-                            children: ['__PAGE__', {}, '/gallery/999'],
+                            children: ['__PAGE__', {}, ['/gallery/999', '']],
                           },
                         ],
                       },
@@ -1392,7 +1416,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                         children: [
                           ['id', '123', 'di(.)'],
                           {
-                            children: ['__PAGE__', {}, '/gallery/123'],
+                            children: ['__PAGE__', {}, ['/gallery/123', '']],
                           },
                         ],
                       },
@@ -1420,14 +1444,14 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'docs',
               {
-                children: ['__PAGE__', {}, '/docs'],
+                children: ['__PAGE__', {}, ['/docs', '']],
                 preview: [
                   '(slot)',
                   {
                     children: [
                       ['path', 'guides/intro', 'ci(.)'],
                       {
-                        children: ['__PAGE__', {}, '/docs/guides/intro'],
+                        children: ['__PAGE__', {}, ['/docs/guides/intro', '']],
                       },
                     ],
                   },
@@ -1458,7 +1482,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   'feed',
                   {
-                    children: ['__PAGE__', {}, '/app/feed'],
+                    children: ['__PAGE__', {}, ['/app/feed', '']],
                     modal: [
                       '(slot)',
                       {
@@ -1468,7 +1492,11 @@ describe('extractRoutesFromFlightRouterState', () => {
                             children: [
                               ['id', '456', 'd'],
                               {
-                                children: ['__PAGE__', {}, '/app/photo/456'],
+                                children: [
+                                  '__PAGE__',
+                                  {},
+                                  ['/app/photo/456', ''],
+                                ],
                               },
                             ],
                           },
@@ -1497,7 +1525,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'docs',
               {
-                children: ['__PAGE__', {}, '/docs'],
+                children: ['__PAGE__', {}, ['/docs', '']],
                 modal: [
                   '(slot)',
                   {
@@ -1510,7 +1538,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                             children: [
                               '__PAGE__',
                               {},
-                              '/preview/api/components',
+                              ['/preview/api/components', ''],
                             ],
                           },
                         ],
@@ -1543,14 +1571,14 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   'catalog',
                   {
-                    children: ['__PAGE__', {}, '/store/catalog'],
+                    children: ['__PAGE__', {}, ['/store/catalog', '']],
                     modal: [
                       '(slot)',
                       {
                         children: [
                           ['productId', '999', 'di(..)'],
                           {
-                            children: ['__PAGE__', {}, '/store/999'],
+                            children: ['__PAGE__', {}, ['/store/999', '']],
                           },
                         ],
                       },
@@ -1583,7 +1611,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   'settings',
                   {
-                    children: ['__PAGE__', {}, '/dashboard/settings'],
+                    children: ['__PAGE__', {}, ['/dashboard/settings', '']],
                     modal: [
                       '(slot)',
                       {
@@ -1593,7 +1621,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                             children: [
                               ['id', '789', 'd'],
                               {
-                                children: ['__PAGE__', {}, '/photo/789'],
+                                children: ['__PAGE__', {}, ['/photo/789', '']],
                               },
                             ],
                           },
@@ -1627,14 +1655,14 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   'panel',
                   {
-                    children: ['__PAGE__', {}, '/admin/panel'],
+                    children: ['__PAGE__', {}, ['/admin/panel', '']],
                     overlay: [
                       '(slot)',
                       {
                         children: [
                           ['userId', '555', 'di(...)'],
                           {
-                            children: ['__PAGE__', {}, '/555'],
+                            children: ['__PAGE__', {}, ['/555', '']],
                           },
                         ],
                       },
@@ -1670,7 +1698,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                     children: [
                       'deep',
                       {
-                        children: ['__PAGE__', {}, '/app/dashboard/deep'],
+                        children: ['__PAGE__', {}, ['/app/dashboard/deep', '']],
                         modal: [
                           '(slot)',
                           {
@@ -1683,7 +1711,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                                     children: [
                                       '__PAGE__',
                                       {},
-                                      '/app/photo/abc',
+                                      ['/app/photo/abc', ''],
                                     ],
                                   },
                                 ],
@@ -1727,7 +1755,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                             children: [
                               '__PAGE__',
                               {},
-                              '/app/level1/level2/level3',
+                              ['/app/level1/level2/level3', ''],
                             ],
                             modal: [
                               '(slot)',
@@ -1741,7 +1769,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                                         children: [
                                           '__PAGE__',
                                           {},
-                                          '/photo/999',
+                                          ['/photo/999', ''],
                                         ],
                                       },
                                     ],
@@ -1777,14 +1805,18 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'wiki',
               {
-                children: ['__PAGE__', {}, '/wiki'],
+                children: ['__PAGE__', {}, ['/wiki', '']],
                 sidebar: [
                   '(slot)',
                   {
                     children: [
                       ['segments', 'advanced/routing', 'oc'],
                       {
-                        children: ['__PAGE__', {}, '/wiki/advanced/routing'],
+                        children: [
+                          '__PAGE__',
+                          {},
+                          ['/wiki/advanced/routing', ''],
+                        ],
                       },
                     ],
                   },
@@ -1823,14 +1855,14 @@ describe('extractRoutesFromFlightRouterState', () => {
                     children: [
                       ['product', 'laptop', 'd'],
                       {
-                        children: ['__PAGE__', {}, '/electronics/laptop'],
+                        children: ['__PAGE__', {}, ['/electronics/laptop', '']],
                         reviews: [
                           'list',
                           {
                             children: [
                               '__PAGE__',
                               {},
-                              '/electronics/laptop/reviews',
+                              ['/electronics/laptop/reviews', ''],
                             ],
                           },
                         ],
@@ -1869,7 +1901,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                     children: [
                       ['id', '123', 'd'],
                       {
-                        children: ['__PAGE__', {}, '/en/photos/123'],
+                        children: ['__PAGE__', {}, ['/en/photos/123', '']],
                       },
                     ],
                     modal: [
@@ -1881,7 +1913,11 @@ describe('extractRoutesFromFlightRouterState', () => {
                             children: [
                               ['photoId', '456', 'd'],
                               {
-                                children: ['__PAGE__', {}, '/en/photos/456'],
+                                children: [
+                                  '__PAGE__',
+                                  {},
+                                  ['/en/photos/456', ''],
+                                ],
                               },
                             ],
                           },
@@ -1916,7 +1952,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                     children: [
                       'blog',
                       {
-                        children: ['__PAGE__', {}, '/en/us/blog'],
+                        children: ['__PAGE__', {}, ['/en/us/blog', '']],
                         modal: [
                           '(slot)',
                           {
@@ -1929,7 +1965,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                                     children: [
                                       '__PAGE__',
                                       {},
-                                      '/en/us/blog/post/123',
+                                      ['/en/us/blog/post/123', ''],
                                     ],
                                   },
                                 ],
@@ -1966,7 +2002,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                 children: [
                   'products',
                   {
-                    children: ['__PAGE__', {}, '/products'],
+                    children: ['__PAGE__', {}, ['/products', '']],
                     modal: [
                       '(slot)',
                       {
@@ -1982,7 +2018,7 @@ describe('extractRoutesFromFlightRouterState', () => {
                                     children: [
                                       '__PAGE__',
                                       {},
-                                      '/products/abc123',
+                                      ['/products/abc123', ''],
                                     ],
                                   },
                                 ],
@@ -2074,7 +2110,7 @@ describe('extractRoutesFromFlightRouterState', () => {
             children: [
               'page',
               {
-                children: ['__PAGE__', {}, '/page'],
+                children: ['__PAGE__', {}, ['/page', '']],
               },
             ],
           },

--- a/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.ts
@@ -1,0 +1,162 @@
+import type {
+  FlightRouterState,
+  Segment,
+} from '../../../shared/lib/app-router-types'
+import { convertDynamicParamType } from '../../../shared/lib/convert-dynamic-param-type'
+import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
+
+/**
+ * Extracts the route structure from a FlightRouterState tree by finding
+ * the page that matches the given pathname. The route includes:
+ * - Route groups: (groupName)
+ * - Parallel routes: @slotName
+ * - Dynamic parameters: [paramName]
+ *
+ * This differs from extractPathFromFlightRouterState in that it:
+ * 1. Searches for a specific pathname match first
+ * 2. Preserves route groups and parallel route markers
+ * 3. Returns the file-system structure rather than the URL structure
+ *
+ * @param targetPathname - The pathname to find in the tree (e.g., "/blog/post-1")
+ * @param flightRouterState - The FlightRouterState tree to search
+ * @returns The canonical route (e.g., "/blog/[slug]") or null if not found
+ */
+export function extractRouteFromFlightRouterState(
+  targetPathname: string,
+  flightRouterState: FlightRouterState
+): string | null {
+  return extract(targetPathname, flightRouterState, [])
+}
+
+function extract(
+  targetPathname: string,
+  flightRouterState: FlightRouterState,
+  segments: string[]
+): string | null {
+  const [segment, parallelRoutes, url] = flightRouterState
+
+  // Skip root segment (empty string) but check all parallel routes
+  if (segment === '') {
+    if (parallelRoutes) {
+      // Try children first (the default parallel route)
+      if (parallelRoutes.children) {
+        const result = extract(
+          targetPathname,
+          parallelRoutes.children,
+          segments
+        )
+        if (result !== null) {
+          return result
+        }
+      }
+
+      // If children didn't match, try other parallel routes
+      for (const parallelRouteKey in parallelRoutes) {
+        if (parallelRouteKey === 'children') continue
+        const parallelRouteValue = parallelRoutes[parallelRouteKey]
+
+        // For root-level named parallel routes, add the @slot marker
+        const segmentsWithSlot = [`@${parallelRouteKey}`]
+
+        const result = extract(
+          targetPathname,
+          parallelRouteValue,
+          segmentsWithSlot
+        )
+
+        if (result !== null) {
+          return result
+        }
+      }
+    }
+    // If nothing matched in any parallel route, return null
+    return null
+  }
+
+  // Check if we've reached a page marker
+  if (typeof segment === 'string' && segment.startsWith(PAGE_SEGMENT_KEY)) {
+    // During client-side navigation, the url field may be null/undefined
+    // If the url matches OR is null (meaning this is the active page for the current path),
+    // we should return the canonical route we've built
+    const urlMatches = url === targetPathname
+    const isNullUrl = url === null || url === undefined
+
+    if (urlMatches || isNullUrl) {
+      return segments.length > 0 ? '/' + segments.join('/') : '/'
+    }
+    // This page doesn't match - return null to continue searching
+    return null
+  }
+
+  // Get the segment value for the canonical route
+  const segmentValue = getCanonicalSegmentValue(segment)
+
+  // Skip synthetic '(slot)' segments that Next.js adds internally for parallel routes
+  // These only appear immediately after a @parallelRoute marker, e.g., @modal/(slot)
+  // We must be careful not to skip user-defined (slot) route groups elsewhere
+  const lastSegment = segments.length > 0 ? segments[segments.length - 1] : null
+  const isAfterParallelRoute = lastSegment?.startsWith('@')
+  const isSyntheticSlot = segmentValue === '(slot)' && isAfterParallelRoute
+
+  // Build the current path with this segment (skip synthetic slots)
+  const currentSegments = isSyntheticSlot
+    ? segments
+    : [...segments, segmentValue]
+
+  // Search parallel routes in priority order
+  if (parallelRoutes) {
+    // Try children first (the default parallel route)
+    // If children matches, return immediately - don't check other parallel routes
+    if (parallelRoutes.children) {
+      const result = extract(
+        targetPathname,
+        parallelRoutes.children,
+        currentSegments
+      )
+      if (result !== null) {
+        return result
+      }
+    }
+
+    // Only check other parallel routes (named slots) if children didn't match
+    // This happens during intercepted routes where the modal is active
+    for (const parallelRouteKey in parallelRoutes) {
+      // Skip children since we already tried it
+      if (parallelRouteKey === 'children') continue
+      const parallelRouteValue = parallelRoutes[parallelRouteKey]
+
+      // For named parallel routes, the @slot marker comes AFTER the parent segment
+      // Example: /see/@modal/(slot) where "see" is parent, @modal is the slot marker
+      const segmentsWithSlot = [...currentSegments, `@${parallelRouteKey}`]
+
+      const result = extract(
+        targetPathname,
+        parallelRouteValue,
+        segmentsWithSlot
+      )
+
+      if (result !== null) {
+        return result
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Converts a Segment to its canonical string representation matching the file system structure:
+ * - Dynamic segments: [paramName, value, 'd'|'di'] → [paramName]
+ * - Catch-all segments: [paramName, value, 'c'|'ci'] → [...paramName]
+ * - Optional catch-all segments: [paramName, value, 'oc'] → [[...paramName]]
+ * - Static segments/route groups: kept as-is
+ */
+function getCanonicalSegmentValue(segment: Segment): string {
+  if (Array.isArray(segment)) {
+    const [paramName, , paramType] = segment
+    return convertDynamicParamType(paramType, paramName)
+  }
+
+  // Static segment or route group - keep as-is
+  return segment
+}

--- a/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.ts
@@ -6,51 +6,47 @@ import { convertDynamicParamType } from '../../../shared/lib/convert-dynamic-par
 import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 
 /**
- * Extracts the route structure from a FlightRouterState tree by finding
- * the page that matches the given pathname. The route includes:
+ * Extracts all route structures from a FlightRouterState tree by finding
+ * all pages that match the given pathname. Each route includes:
  * - Route groups: (groupName)
  * - Parallel routes: @slotName
  * - Dynamic parameters: [paramName]
  *
  * This differs from extractPathFromFlightRouterState in that it:
- * 1. Searches for a specific pathname match first
+ * 1. Searches for all pathname matches across parallel routes
  * 2. Preserves route groups and parallel route markers
  * 3. Returns the file-system structure rather than the URL structure
  *
  * @param targetPathname - The pathname to find in the tree (e.g., "/blog/post-1")
  * @param flightRouterState - The FlightRouterState tree to search
- * @returns The canonical route (e.g., "/blog/[slug]") or null if not found
+ * @returns Array of canonical routes (e.g., ["/blog/[slug]", "/blog/@modal/[slug]"])
  */
-export function extractRouteFromFlightRouterState(
+export function extractRoutesFromFlightRouterState(
   targetPathname: string,
   flightRouterState: FlightRouterState
-): string | null {
-  return extract(targetPathname, flightRouterState, [])
+): string[] {
+  const results: string[] = []
+  extract(targetPathname, flightRouterState, [], results)
+  return results
 }
 
 function extract(
   targetPathname: string,
   flightRouterState: FlightRouterState,
-  segments: string[]
-): string | null {
+  segments: string[],
+  results: string[]
+): void {
   const [segment, parallelRoutes, url] = flightRouterState
 
   // Skip root segment (empty string) but check all parallel routes
   if (segment === '') {
     if (parallelRoutes) {
-      // Try children first (the default parallel route)
+      // Check children (the default parallel route)
       if (parallelRoutes.children) {
-        const result = extract(
-          targetPathname,
-          parallelRoutes.children,
-          segments
-        )
-        if (result !== null) {
-          return result
-        }
+        extract(targetPathname, parallelRoutes.children, segments, results)
       }
 
-      // If children didn't match, try other parallel routes
+      // Also check other parallel routes
       for (const parallelRouteKey in parallelRoutes) {
         if (parallelRouteKey === 'children') continue
         const parallelRouteValue = parallelRoutes[parallelRouteKey]
@@ -58,34 +54,26 @@ function extract(
         // For root-level named parallel routes, add the @slot marker
         const segmentsWithSlot = [`@${parallelRouteKey}`]
 
-        const result = extract(
-          targetPathname,
-          parallelRouteValue,
-          segmentsWithSlot
-        )
-
-        if (result !== null) {
-          return result
-        }
+        extract(targetPathname, parallelRouteValue, segmentsWithSlot, results)
       }
     }
-    // If nothing matched in any parallel route, return null
-    return null
+    return
   }
 
   // Check if we've reached a page marker
   if (typeof segment === 'string' && segment.startsWith(PAGE_SEGMENT_KEY)) {
     // During client-side navigation, the url field may be null/undefined
     // If the url matches OR is null (meaning this is the active page for the current path),
-    // we should return the canonical route we've built
+    // we should add the canonical route we've built to results
     const urlMatches = url === targetPathname
     const isNullUrl = url === null || url === undefined
 
     if (urlMatches || isNullUrl) {
-      return segments.length > 0 ? '/' + segments.join('/') : '/'
+      const route = segments.length > 0 ? '/' + segments.join('/') : '/'
+      results.push(route)
     }
-    // This page doesn't match - return null to continue searching
-    return null
+    // This page doesn't match or was added - return to continue searching other branches
+    return
   }
 
   // Get the segment value for the canonical route
@@ -103,25 +91,16 @@ function extract(
     ? segments
     : [...segments, segmentValue]
 
-  // Search parallel routes in priority order
+  // Search all parallel routes
   if (parallelRoutes) {
-    // Try children first (the default parallel route)
-    // If children matches, return immediately - don't check other parallel routes
+    // Check children (the default parallel route)
     if (parallelRoutes.children) {
-      const result = extract(
-        targetPathname,
-        parallelRoutes.children,
-        currentSegments
-      )
-      if (result !== null) {
-        return result
-      }
+      extract(targetPathname, parallelRoutes.children, currentSegments, results)
     }
 
-    // Only check other parallel routes (named slots) if children didn't match
-    // This happens during intercepted routes where the modal is active
+    // Also check other parallel routes (named slots)
     for (const parallelRouteKey in parallelRoutes) {
-      // Skip children since we already tried it
+      // Skip children since we already checked it
       if (parallelRouteKey === 'children') continue
       const parallelRouteValue = parallelRoutes[parallelRouteKey]
 
@@ -129,19 +108,9 @@ function extract(
       // Example: /see/@modal/(slot) where "see" is parent, @modal is the slot marker
       const segmentsWithSlot = [...currentSegments, `@${parallelRouteKey}`]
 
-      const result = extract(
-        targetPathname,
-        parallelRouteValue,
-        segmentsWithSlot
-      )
-
-      if (result !== null) {
-        return result
-      }
+      extract(targetPathname, parallelRouteValue, segmentsWithSlot, results)
     }
   }
-
-  return null
 }
 
 /**

--- a/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.ts
@@ -71,7 +71,7 @@ function extract(
     const isNullUrl = url === null
 
     if (urlMatches || isNullUrl) {
-      const route = segments.length > 0 ? '/' + segments.join('/') : '/'
+      const route = '/' + segments.join('/')
       results.push(route)
     }
     // This page doesn't match or was added - return to continue searching other branches

--- a/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.ts
@@ -36,7 +36,7 @@ function extract(
   segments: string[],
   results: string[]
 ): void {
-  const [segment, parallelRoutes, url] = flightRouterState
+  const [segment, parallelRoutes, refreshState] = flightRouterState
 
   // Skip root segment (empty string) but check all parallel routes
   if (segment === '') {
@@ -62,11 +62,13 @@ function extract(
 
   // Check if we've reached a page marker
   if (typeof segment === 'string' && segment.startsWith(PAGE_SEGMENT_KEY)) {
-    // During client-side navigation, the url field may be null/undefined
+    // During client-side navigation, the refreshState field may be null/undefined
     // If the url matches OR is null (meaning this is the active page for the current path),
     // we should add the canonical route we've built to results
+    // refreshState is [url, renderedSearch] if present, otherwise null/undefined
+    const url = refreshState ? refreshState[0] : null
     const urlMatches = url === targetPathname
-    const isNullUrl = url === null || url === undefined
+    const isNullUrl = url === null
 
     if (urlMatches || isNullUrl) {
       const route = segments.length > 0 ? '/' + segments.join('/') : '/'

--- a/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/extract-route-from-flight-router-state.ts
@@ -81,9 +81,11 @@ function extract(
   // Get the segment value for the canonical route
   const segmentValue = getCanonicalSegmentValue(segment)
 
-  // Skip synthetic '(slot)' segments that Next.js adds internally for parallel routes
-  // These only appear immediately after a @parallelRoute marker, e.g., @modal/(slot)
-  // We must be careful not to skip user-defined (slot) route groups elsewhere
+  // Next.js internally adds synthetic '(slot)' segments for parallel route state management.
+  // These appear immediately after @parallelRoute markers (e.g., @modal/(slot)/...).
+  // We skip these to avoid polluting the canonical route with internal implementation details.
+  // User-defined route groups named "(slot)" elsewhere in the tree are preserved because
+  // they won't appear immediately after a @parallelRoute marker.
   const lastSegment = segments.length > 0 ? segments[segments.length - 1] : null
   const isAfterParallelRoute = lastSegment?.startsWith('@')
   const isSyntheticSlot = segmentValue === '(slot)' && isAfterParallelRoute

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -2,7 +2,6 @@ import type ws from 'next/dist/compiled/ws'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type { NextConfigComplete } from '../config-shared'
 import type {
-  DynamicParamTypesShort,
   FlightRouterState,
   FlightSegmentPath,
 } from '../../shared/lib/app-router-types'
@@ -48,6 +47,7 @@ import { PAGE_TYPES } from '../../lib/page-types'
 import { getNextFlightSegmentPath } from '../../client/flight-data-helpers'
 import { handleErrorStateResponse } from '../mcp/tools/get-errors'
 import { handlePageMetadataResponse } from '../mcp/tools/get-page-metadata'
+import { convertDynamicParamType } from '../../shared/lib/convert-dynamic-param-type'
 
 const debug = createDebug('next:on-demand-entry-handler')
 
@@ -79,30 +79,6 @@ function treePathToEntrypoint(
 
   const childSegmentPath = getNextFlightSegmentPath(segmentPath)
   return treePathToEntrypoint(childSegmentPath, path)
-}
-
-function convertDynamicParamTypeToSyntax(
-  dynamicParamTypeShort: DynamicParamTypesShort,
-  param: string
-) {
-  switch (dynamicParamTypeShort) {
-    case 'c':
-    case 'ci(..)(..)':
-    case 'ci(.)':
-    case 'ci(..)':
-    case 'ci(...)':
-      return `[...${param}]`
-    case 'oc':
-      return `[[...${param}]]`
-    case 'd':
-    case 'di(..)(..)':
-    case 'di(.)':
-    case 'di(..)':
-    case 'di(...)':
-      return `[${param}]`
-    default:
-      throw new Error('Unknown dynamic param type')
-  }
 }
 
 /**
@@ -143,7 +119,7 @@ function getEntrypointsFromTree(
   const [segment, parallelRoutes] = tree
 
   const currentSegment = Array.isArray(segment)
-    ? convertDynamicParamTypeToSyntax(segment[2], segment[0])
+    ? convertDynamicParamType(segment[2], segment[0])
     : segment
 
   const isPageSegment = currentSegment.startsWith(PAGE_SEGMENT_KEY)

--- a/packages/next/src/shared/lib/convert-dynamic-param-type.test.ts
+++ b/packages/next/src/shared/lib/convert-dynamic-param-type.test.ts
@@ -1,0 +1,110 @@
+import type { DynamicParamTypesShort } from './app-router-types'
+import { convertDynamicParamType } from './convert-dynamic-param-type'
+
+describe('convertDynamicParamType', () => {
+  describe('basic dynamic parameters', () => {
+    it('should convert dynamic param type "d" to [param]', () => {
+      expect(convertDynamicParamType('d', 'slug')).toBe('[slug]')
+      expect(convertDynamicParamType('d', 'id')).toBe('[id]')
+    })
+
+    it('should convert catch-all param type "c" to [...param]', () => {
+      expect(convertDynamicParamType('c', 'slug')).toBe('[...slug]')
+      expect(convertDynamicParamType('c', 'path')).toBe('[...path]')
+    })
+
+    it('should convert optional catch-all param type "oc" to [[...param]]', () => {
+      expect(convertDynamicParamType('oc', 'slug')).toBe('[[...slug]]')
+      expect(convertDynamicParamType('oc', 'segments')).toBe('[[...segments]]')
+    })
+  })
+
+  describe('intercepted dynamic parameters (di)', () => {
+    it('should preserve same-level interception marker for di(.)', () => {
+      expect(convertDynamicParamType('di(.)', 'id')).toBe('(.)[id]')
+      expect(convertDynamicParamType('di(.)', 'photoId')).toBe('(.)[photoId]')
+    })
+
+    it('should preserve parent-level interception marker for di(..)', () => {
+      expect(convertDynamicParamType('di(..)', 'id')).toBe('(..)[id]')
+      expect(convertDynamicParamType('di(..)', 'productId')).toBe(
+        '(..)[productId]'
+      )
+    })
+
+    it('should preserve root-level interception marker for di(...)', () => {
+      expect(convertDynamicParamType('di(...)', 'id')).toBe('(...)[id]')
+      expect(convertDynamicParamType('di(...)', 'userId')).toBe('(...)[userId]')
+    })
+
+    it('should preserve two-level interception marker for di(..)(..)', () => {
+      expect(convertDynamicParamType('di(..)(..)', 'id')).toBe('(..)(..)[id]')
+    })
+  })
+
+  describe('intercepted catch-all parameters (ci)', () => {
+    it('should preserve same-level interception marker for ci(.)', () => {
+      expect(convertDynamicParamType('ci(.)', 'path')).toBe('(.)[...path]')
+      expect(convertDynamicParamType('ci(.)', 'slug')).toBe('(.)[...slug]')
+    })
+
+    it('should preserve parent-level interception marker for ci(..)', () => {
+      expect(convertDynamicParamType('ci(..)', 'path')).toBe('(..)[...path]')
+    })
+
+    it('should preserve root-level interception marker for ci(...)', () => {
+      expect(convertDynamicParamType('ci(...)', 'segments')).toBe(
+        '(...)[...segments]'
+      )
+    })
+
+    it('should preserve two-level interception marker for ci(..)(..)', () => {
+      expect(convertDynamicParamType('ci(..)(..)', 'path')).toBe(
+        '(..)(..)[...path]'
+      )
+    })
+  })
+
+  describe('entrypoint resolution compatibility', () => {
+    // These tests verify that the output matches actual folder names in the app directory.
+    // This is critical for on-demand-entry-handler to correctly resolve entrypoints.
+
+    it('should produce folder-matching names for intercepted dynamic routes', () => {
+      // Folder: app/gallery/@modal/(group)/(.)[id]/page.tsx
+      // The segment type would be 'di(.)' and param 'id'
+      const result = convertDynamicParamType('di(.)', 'id')
+      expect(result).toBe('(.)[id]')
+      // This should match the actual folder name "(.)[id]"
+    })
+
+    it('should produce folder-matching names for intercepted catch-all routes', () => {
+      // Folder: app/docs/@preview/(.)[...path]/page.tsx
+      // The segment type would be 'ci(.)' and param 'path'
+      const result = convertDynamicParamType('ci(.)', 'path')
+      expect(result).toBe('(.)[...path]')
+      // This should match the actual folder name "(.)[...path]"
+    })
+
+    it('should handle all DynamicParamTypesShort values', () => {
+      const types: DynamicParamTypesShort[] = [
+        'd',
+        'c',
+        'oc',
+        'di(.)',
+        'di(..)',
+        'di(...)',
+        'di(..)(..)',
+        'ci(.)',
+        'ci(..)',
+        'ci(...)',
+        'ci(..)(..)',
+      ]
+
+      for (const type of types) {
+        const result = convertDynamicParamType(type, 'param')
+        expect(typeof result).toBe('string')
+        expect(result.length).toBeGreaterThan(0)
+      }
+    })
+  })
+})

--- a/packages/next/src/shared/lib/convert-dynamic-param-type.ts
+++ b/packages/next/src/shared/lib/convert-dynamic-param-type.ts
@@ -1,0 +1,35 @@
+import type { DynamicParamTypesShort } from './app-router-types'
+
+export function convertDynamicParamType(
+  dynamicParamTypeShort: DynamicParamTypesShort,
+  param: string
+) {
+  let result: string
+  switch (dynamicParamTypeShort) {
+    case 'c':
+      result = `[...${param}]`
+      break
+    case 'ci(..)(..)':
+    case 'ci(.)':
+    case 'ci(..)':
+    case 'ci(...)':
+      result = `${dynamicParamTypeShort.slice(2)}[...${param}]`
+      break
+    case 'oc':
+      result = `[[...${param}]]`
+      break
+    case 'd':
+      result = `[${param}]`
+      break
+    case 'di(..)(..)':
+    case 'di(.)':
+    case 'di(..)':
+    case 'di(...)':
+      result = `${dynamicParamTypeShort.slice(2)}[${param}]`
+      break
+    default:
+      dynamicParamTypeShort satisfies never
+      result = ''
+  }
+  return result
+}

--- a/test/e2e/app-dir/app-use-route/app/(app)/(dashboard)/settings/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/(app)/(dashboard)/settings/page.tsx
@@ -1,0 +1,10 @@
+import { RouteDisplay } from '../../../components/route-display'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Settings Page</h1>
+      <RouteDisplay testId="settings-page" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/(shop)/[category]/[product]/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/(shop)/[category]/[product]/page.tsx
@@ -1,0 +1,17 @@
+import { RouteDisplay } from '../../../components/route-display'
+
+export function generateStaticParams() {
+  return [
+    { category: 'electronics', product: 'laptop' },
+    { category: 'books', product: 'novel' },
+  ]
+}
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Shop Product</h1>
+      <RouteDisplay testId="shop-product-page" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/about/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/about/page.tsx
@@ -1,0 +1,10 @@
+import { RouteDisplay } from '../components/route-display'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>About Page</h1>
+      <RouteDisplay testId="about-page" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/app/dashboard/@panel/default.tsx
+++ b/test/e2e/app-dir/app-use-route/app/app/dashboard/@panel/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/app-use-route/app/app/dashboard/@panel/stats/@chart/default.tsx
+++ b/test/e2e/app-dir/app-use-route/app/app/dashboard/@panel/stats/@chart/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/app-use-route/app/app/dashboard/@panel/stats/@chart/line/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/app/dashboard/@panel/stats/@chart/line/page.tsx
@@ -1,0 +1,10 @@
+import { RouteDisplay } from '../../../../../../components/route-display'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Dashboard Chart Line</h1>
+      <RouteDisplay testId="dashboard-chart-page" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/app/dashboard/@panel/stats/default.tsx
+++ b/test/e2e/app-dir/app-use-route/app/app/dashboard/@panel/stats/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/app-use-route/app/app/dashboard/@panel/stats/layout.tsx
+++ b/test/e2e/app-dir/app-use-route/app/app/dashboard/@panel/stats/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  chart,
+}: {
+  children: React.ReactNode
+  chart: React.ReactNode
+}) {
+  return (
+    <div>
+      {children}
+      {chart}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/app/dashboard/@panel/stats/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/app/dashboard/@panel/stats/page.tsx
@@ -1,0 +1,10 @@
+import { RouteDisplay } from '../../../../components/route-display'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Dashboard Stats</h1>
+      <RouteDisplay testId="dashboard-stats-page" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/app/dashboard/default.tsx
+++ b/test/e2e/app-dir/app-use-route/app/app/dashboard/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/app-use-route/app/app/dashboard/layout.tsx
+++ b/test/e2e/app-dir/app-use-route/app/app/dashboard/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  panel,
+}: {
+  children: React.ReactNode
+  panel: React.ReactNode
+}) {
+  return (
+    <div>
+      {children}
+      {panel}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/app/dashboard/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/app/dashboard/page.tsx
@@ -1,0 +1,10 @@
+import { RouteDisplay } from '../../components/route-display'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <RouteDisplay testId="dashboard-page" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/blog/[slug]/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/blog/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { RouteDisplay } from '../../components/route-display'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Blog Post</h1>
+      <RouteDisplay testId="blog-post-page" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/components/route-display.tsx
+++ b/test/e2e/app-dir/app-use-route/app/components/route-display.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import React from 'react'
+import { useRoute, usePathname } from 'next/navigation'
+
+export function RouteDisplay({ testId }: { testId?: string }) {
+  const route = useRoute()
+  const pathname = usePathname()
+
+  return (
+    <div>
+      <div id="pathname" data-testid="pathname">
+        {pathname}
+      </div>
+      <div id="route" data-testid={testId || 'route'}>
+        {route}
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/components/route-display.tsx
+++ b/test/e2e/app-dir/app-use-route/app/components/route-display.tsx
@@ -1,24 +1,24 @@
 'use client'
 
 import React, { useState, useEffect } from 'react'
-import { unstable_useRoute, usePathname } from 'next/navigation'
+import { unstable_useRoutes, usePathname } from 'next/navigation'
 
 export function RouteDisplay({ testId }: { testId?: string | undefined }) {
-  const getRoute = unstable_useRoute()
+  const getRoutes = unstable_useRoutes()
   const pathname = usePathname()
-  const [route, setRoute] = useState<string | undefined>(undefined)
+  const [routes, setRoutes] = useState<string[] | undefined>(undefined)
 
   useEffect(() => {
-    setRoute(getRoute())
-  }, [getRoute])
+    setRoutes(getRoutes())
+  }, [getRoutes])
 
   return (
     <div>
       <div id="pathname" data-testid="pathname">
         {pathname}
       </div>
-      <div id="route" data-testid={testId || 'route'}>
-        {route ?? 'loading...'}
+      <div id="routes" data-testid={testId || 'routes'}>
+        {routes ? JSON.stringify(routes) : 'loading...'}
       </div>
     </div>
   )

--- a/test/e2e/app-dir/app-use-route/app/components/route-display.tsx
+++ b/test/e2e/app-dir/app-use-route/app/components/route-display.tsx
@@ -1,11 +1,16 @@
 'use client'
 
-import React from 'react'
-import { useRoute, usePathname } from 'next/navigation'
+import React, { useState, useEffect } from 'react'
+import { unstable_useRoute, usePathname } from 'next/navigation'
 
-export function RouteDisplay({ testId }: { testId?: string }) {
-  const route = useRoute()
+export function RouteDisplay({ testId }: { testId?: string | undefined }) {
+  const getRoute = unstable_useRoute()
   const pathname = usePathname()
+  const [route, setRoute] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    setRoute(getRoute())
+  }, [getRoute])
 
   return (
     <div>
@@ -13,7 +18,7 @@ export function RouteDisplay({ testId }: { testId?: string }) {
         {pathname}
       </div>
       <div id="route" data-testid={testId || 'route'}>
-        {route}
+        {route ?? 'loading...'}
       </div>
     </div>
   )

--- a/test/e2e/app-dir/app-use-route/app/docs/[...slug]/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/docs/[...slug]/page.tsx
@@ -1,0 +1,10 @@
+import { RouteDisplay } from '../../components/route-display'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Docs</h1>
+      <RouteDisplay testId="docs-page" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/feed/@modal/(.)photo/[id]/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/feed/@modal/(.)photo/[id]/page.tsx
@@ -1,0 +1,10 @@
+import { RouteDisplay } from '../../../../components/route-display'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Feed Photo Modal (Intercepted)</h1>
+      <RouteDisplay testId="feed-modal-page" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/feed/@modal/default.tsx
+++ b/test/e2e/app-dir/app-use-route/app/feed/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/app-use-route/app/feed/layout.tsx
+++ b/test/e2e/app-dir/app-use-route/app/feed/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode
+  modal: React.ReactNode
+}) {
+  return (
+    <div>
+      {children}
+      {modal}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/feed/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/feed/page.tsx
@@ -1,0 +1,14 @@
+import { RouteDisplay } from '../components/route-display'
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Feed</h1>
+      <RouteDisplay testId="feed-page" />
+      <Link href="/feed/photo/123" id="link-to-photo">
+        View Photo 123
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/gallery/@modal/(group)/(.)[id]/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/gallery/@modal/(group)/(.)[id]/page.tsx
@@ -1,0 +1,10 @@
+import { RouteDisplay } from '../../../../components/route-display'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Gallery Modal (Intercepted)</h1>
+      <RouteDisplay testId="gallery-modal-page" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/gallery/@modal/default.tsx
+++ b/test/e2e/app-dir/app-use-route/app/gallery/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/app-use-route/app/gallery/[id]/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/gallery/[id]/page.tsx
@@ -1,0 +1,10 @@
+import { RouteDisplay } from '../../components/route-display'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Gallery Page</h1>
+      <RouteDisplay testId="gallery-id-page" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/gallery/layout.tsx
+++ b/test/e2e/app-dir/app-use-route/app/gallery/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode
+  modal: React.ReactNode
+}) {
+  return (
+    <div>
+      {children}
+      {modal}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/gallery/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/gallery/page.tsx
@@ -1,0 +1,14 @@
+import { RouteDisplay } from '../components/route-display'
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Gallery</h1>
+      <RouteDisplay testId="gallery-page" />
+      <Link href="/gallery/123" id="link-to-photo">
+        View Photo 123
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/layout.tsx
+++ b/test/e2e/app-dir/app-use-route/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/page.tsx
@@ -1,0 +1,62 @@
+import { RouteDisplay } from './components/route-display'
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>useRoute() Test Home</h1>
+      <RouteDisplay testId="root-page" />
+
+      <h2>Test Routes</h2>
+      <nav>
+        <ul>
+          <li>
+            <Link href="/about" id="link-about">
+              Static: /about
+            </Link>
+          </li>
+          <li>
+            <Link href="/settings" id="link-settings">
+              Route Group: /(app)/(dashboard)/settings
+            </Link>
+          </li>
+          <li>
+            <Link href="/blog/my-post" id="link-blog-post">
+              Dynamic: /blog/[slug]
+            </Link>
+          </li>
+          <li>
+            <Link href="/docs/api/reference" id="link-docs">
+              Catch-all: /docs/[...slug]
+            </Link>
+          </li>
+          <li>
+            <Link href="/wiki/advanced/routing" id="link-optional-catchall">
+              Optional Catch-all: /wiki/[[...segments]]
+            </Link>
+          </li>
+          <li>
+            <Link href="/gallery/123" id="link-gallery">
+              Parallel + Interception: /gallery/@modal/(group)/(.)[id]
+            </Link>
+          </li>
+          <li>
+            <Link href="/feed/photo/123" id="link-feed-photo">
+              Interception: /feed/@modal/(.)photo/[id]
+            </Link>
+          </li>
+          <li>
+            <Link href="/app/dashboard/stats/line" id="link-nested-parallel">
+              Nested Parallel: /app/dashboard/@panel/stats/@chart/line
+            </Link>
+          </li>
+          <li>
+            <Link href="/shop/electronics/laptop" id="link-shop">
+              Dynamic + Route Groups: /(shop)/[category]/[product]
+            </Link>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/app/wiki/[[...segments]]/page.tsx
+++ b/test/e2e/app-dir/app-use-route/app/wiki/[[...segments]]/page.tsx
@@ -1,0 +1,10 @@
+import { RouteDisplay } from '../../components/route-display'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Wiki (Optional Catch-all)</h1>
+      <RouteDisplay testId="wiki-page" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-use-route/use-route.test.ts
+++ b/test/e2e/app-dir/app-use-route/use-route.test.ts
@@ -1,0 +1,186 @@
+import { nextTestSetup, FileRef } from 'e2e-utils'
+import { join } from 'path'
+
+describe('useRoute() hook', () => {
+  const { next } = nextTestSetup({
+    files: {
+      app: new FileRef(join(__dirname, 'app')),
+    },
+  })
+
+  describe('Static Routes', () => {
+    it('should return "/" for root page', async () => {
+      const browser = await next.browser('/')
+      const route = await browser.elementById('route').text()
+      expect(route).toBe('/')
+    })
+
+    it('should return "/about" for simple static route', async () => {
+      const browser = await next.browser('/about')
+      const route = await browser.elementById('route').text()
+      expect(route).toBe('/about')
+    })
+
+    it('should preserve route groups in canonical route', async () => {
+      const browser = await next.browser('/settings')
+      const route = await browser.elementById('route').text()
+      expect(route).toBe('/(app)/(dashboard)/settings')
+    })
+  })
+
+  describe('Dynamic Routes', () => {
+    it('should return canonical route for dynamic parameter [slug]', async () => {
+      const browser = await next.browser('/blog/my-post')
+      const route = await browser.elementById('route').text()
+      expect(route).toBe('/blog/[slug]')
+    })
+
+    it('should return canonical route for catch-all [...slug]', async () => {
+      const browser = await next.browser('/docs/api/reference')
+      const route = await browser.elementById('route').text()
+      expect(route).toBe('/docs/[...slug]')
+    })
+
+    it('should return canonical route for optional catch-all [[...segments]]', async () => {
+      const browser = await next.browser('/wiki/advanced/routing')
+      const route = await browser.elementById('route').text()
+      expect(route).toBe('/wiki/[[...segments]]')
+    })
+
+    it('should handle multiple dynamic parameters with route groups', async () => {
+      const browser = await next.browser('/electronics/laptop')
+      const route = await browser.elementById('route').text()
+      expect(route).toBe('/(shop)/[category]/[product]')
+    })
+  })
+
+  describe('Parallel Routes', () => {
+    it('should show @modal parallel route when intercepting', async () => {
+      const browser = await next.browser('/gallery')
+      // Initially on the gallery page
+      let route = await browser.elementById('route').text()
+      expect(route).toBe('/gallery')
+
+      // Click link to trigger interception
+      await browser.elementById('link-to-photo').click()
+      await browser.waitForElementByCss('[data-testid="gallery-modal-page"]')
+
+      // Should show the intercepted route with @modal and (.) marker
+      route = await browser.elementById('route').text()
+      expect(route).toBe('/gallery/@modal/(group)/(.)[id]')
+
+      await browser.refresh()
+      await browser.waitForElementByCss('[data-testid="gallery-id-page"]')
+
+      // Should show the canonical route
+      route = await browser.elementById('route').text()
+      expect(route).toBe('/gallery/[id]')
+    })
+
+    it('should show interception route with separate folder structure', async () => {
+      const browser = await next.browser('/feed')
+      // Initially on the feed page
+      let route = await browser.elementById('route').text()
+      expect(route).toBe('/feed')
+
+      // Click link to trigger interception
+      await browser.elementById('link-to-photo').click()
+      await browser.waitForElementByCss('[data-testid="feed-modal-page"]')
+
+      // Should show the intercepted route
+      route = await browser.elementById('route').text()
+      expect(route).toBe('/feed/@modal/(.)photo/[id]')
+    })
+
+    it('should handle nested parallel routes', async () => {
+      const browser = await next.browser('/app/dashboard/stats/line')
+      const route = await browser.elementById('route').text()
+      expect(route).toBe('/app/dashboard/@panel/stats/@chart/line')
+    })
+  })
+
+  describe('Navigation', () => {
+    it('should update route when navigating between pages', async () => {
+      const browser = await next.browser('/')
+
+      // Start at root
+      let route = await browser.elementById('route').text()
+      expect(route).toBe('/')
+
+      // Navigate to about
+      await browser.elementById('link-about').click()
+      await browser.waitForElementByCss('[data-testid="about-page"]')
+      route = await browser.elementById('route').text()
+      expect(route).toBe('/about')
+
+      // Navigate back to home
+      await browser.back()
+      await browser.waitForElementByCss('[data-testid="root-page"]')
+      route = await browser.elementById('route').text()
+      expect(route).toBe('/')
+
+      // Navigate to blog post
+      await browser.elementById('link-blog-post').click()
+      await browser.waitForElementByCss('[data-testid="blog-post-page"]')
+      route = await browser.elementById('route').text()
+      expect(route).toBe('/blog/[slug]')
+
+      // Navigate back to home
+      await browser.back()
+      await browser.waitForElementByCss('[data-testid="root-page"]')
+      route = await browser.elementById('route').text()
+      expect(route).toBe('/')
+
+      // Navigate to docs
+      await browser.elementById('link-docs').click()
+      await browser.waitForElementByCss('[data-testid="docs-page"]')
+      route = await browser.elementById('route').text()
+      expect(route).toBe('/docs/[...slug]')
+    })
+
+    it('should show correct route for client-side navigation', async () => {
+      const browser = await next.browser('/')
+
+      // Navigate via Link component
+      await browser.elementById('link-settings').click()
+      await browser.waitForElementByCss('[data-testid="settings-page"]')
+
+      const route = await browser.elementById('route').text()
+      expect(route).toBe('/(app)/(dashboard)/settings')
+    })
+  })
+
+  describe('Comparison with usePathname()', () => {
+    it('should differ from usePathname for dynamic routes', async () => {
+      const browser = await next.browser('/blog/my-post')
+
+      const pathname = await browser.elementById('pathname').text()
+      const route = await browser.elementById('route').text()
+
+      expect(pathname).toBe('/blog/my-post')
+      expect(route).toBe('/blog/[slug]')
+    })
+
+    it('should differ from usePathname for route groups', async () => {
+      const browser = await next.browser('/settings')
+
+      const pathname = await browser.elementById('pathname').text()
+      const route = await browser.elementById('route').text()
+
+      // usePathname doesn't include route groups
+      expect(pathname).toBe('/settings')
+      // useRoute preserves route groups
+      expect(route).toBe('/(app)/(dashboard)/settings')
+    })
+
+    it('should match usePathname for simple static routes', async () => {
+      const browser = await next.browser('/about')
+
+      const pathname = await browser.elementById('pathname').text()
+      const route = await browser.elementById('route').text()
+
+      expect(pathname).toBe('/about')
+      expect(route).toBe('/about')
+    })
+  })
+})

--- a/test/e2e/app-dir/app-use-route/use-route.test.ts
+++ b/test/e2e/app-dir/app-use-route/use-route.test.ts
@@ -1,56 +1,61 @@
 import { nextTestSetup, FileRef } from 'e2e-utils'
 import { join } from 'path'
 
-describe('useRoute() hook', () => {
+describe('useRoutes() hook', () => {
   const { next } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
     },
   })
 
+  async function getRoutes(browser: any): Promise<string[]> {
+    const text = await browser.elementById('routes').text()
+    return JSON.parse(text)
+  }
+
   describe('Static Routes', () => {
-    it('should return "/" for root page', async () => {
+    it('should return ["/"] for root page', async () => {
       const browser = await next.browser('/')
-      const route = await browser.elementById('route').text()
-      expect(route).toBe('/')
+      const routes = await getRoutes(browser)
+      expect(routes).toEqual(['/'])
     })
 
-    it('should return "/about" for simple static route', async () => {
+    it('should return ["/about"] for simple static route', async () => {
       const browser = await next.browser('/about')
-      const route = await browser.elementById('route').text()
-      expect(route).toBe('/about')
+      const routes = await getRoutes(browser)
+      expect(routes).toEqual(['/about'])
     })
 
     it('should preserve route groups in canonical route', async () => {
       const browser = await next.browser('/settings')
-      const route = await browser.elementById('route').text()
-      expect(route).toBe('/(app)/(dashboard)/settings')
+      const routes = await getRoutes(browser)
+      expect(routes).toEqual(['/(app)/(dashboard)/settings'])
     })
   })
 
   describe('Dynamic Routes', () => {
     it('should return canonical route for dynamic parameter [slug]', async () => {
       const browser = await next.browser('/blog/my-post')
-      const route = await browser.elementById('route').text()
-      expect(route).toBe('/blog/[slug]')
+      const routes = await getRoutes(browser)
+      expect(routes).toEqual(['/blog/[slug]'])
     })
 
     it('should return canonical route for catch-all [...slug]', async () => {
       const browser = await next.browser('/docs/api/reference')
-      const route = await browser.elementById('route').text()
-      expect(route).toBe('/docs/[...slug]')
+      const routes = await getRoutes(browser)
+      expect(routes).toEqual(['/docs/[...slug]'])
     })
 
     it('should return canonical route for optional catch-all [[...segments]]', async () => {
       const browser = await next.browser('/wiki/advanced/routing')
-      const route = await browser.elementById('route').text()
-      expect(route).toBe('/wiki/[[...segments]]')
+      const routes = await getRoutes(browser)
+      expect(routes).toEqual(['/wiki/[[...segments]]'])
     })
 
     it('should handle multiple dynamic parameters with route groups', async () => {
       const browser = await next.browser('/electronics/laptop')
-      const route = await browser.elementById('route').text()
-      expect(route).toBe('/(shop)/[category]/[product]')
+      const routes = await getRoutes(browser)
+      expect(routes).toEqual(['/(shop)/[category]/[product]'])
     })
   })
 
@@ -58,95 +63,95 @@ describe('useRoute() hook', () => {
     it('should show @modal parallel route when intercepting', async () => {
       const browser = await next.browser('/gallery')
       // Initially on the gallery page
-      let route = await browser.elementById('route').text()
-      expect(route).toBe('/gallery')
+      let routes = await getRoutes(browser)
+      expect(routes).toEqual(['/gallery'])
 
       // Click link to trigger interception
       await browser.elementById('link-to-photo').click()
       await browser.waitForElementByCss('[data-testid="gallery-modal-page"]')
 
       // Should show the intercepted route with @modal and (.) marker
-      route = await browser.elementById('route').text()
-      expect(route).toBe('/gallery/@modal/(group)/(.)[id]')
+      routes = await getRoutes(browser)
+      expect(routes).toEqual(['/gallery/@modal/(group)/(.)[id]'])
 
       await browser.refresh()
       await browser.waitForElementByCss('[data-testid="gallery-id-page"]')
 
       // Should show the canonical route
-      route = await browser.elementById('route').text()
-      expect(route).toBe('/gallery/[id]')
+      routes = await getRoutes(browser)
+      expect(routes).toEqual(['/gallery/[id]'])
     })
 
     it('should show interception route with separate folder structure', async () => {
       const browser = await next.browser('/feed')
       // Initially on the feed page
-      let route = await browser.elementById('route').text()
-      expect(route).toBe('/feed')
+      let routes = await getRoutes(browser)
+      expect(routes).toEqual(['/feed'])
 
       // Click link to trigger interception
       await browser.elementById('link-to-photo').click()
       await browser.waitForElementByCss('[data-testid="feed-modal-page"]')
 
       // Should show the intercepted route
-      route = await browser.elementById('route').text()
-      expect(route).toBe('/feed/@modal/(.)photo/[id]')
+      routes = await getRoutes(browser)
+      expect(routes).toEqual(['/feed/@modal/(.)photo/[id]'])
     })
 
     it('should handle nested parallel routes', async () => {
       const browser = await next.browser('/app/dashboard/stats/line')
-      const route = await browser.elementById('route').text()
-      expect(route).toBe('/app/dashboard/@panel/stats/@chart/line')
+      const routes = await getRoutes(browser)
+      expect(routes).toEqual(['/app/dashboard/@panel/stats/@chart/line'])
     })
   })
 
   describe('Navigation', () => {
-    it('should update route when navigating between pages', async () => {
+    it('should update routes when navigating between pages', async () => {
       const browser = await next.browser('/')
 
       // Start at root
-      let route = await browser.elementById('route').text()
-      expect(route).toBe('/')
+      let routes = await getRoutes(browser)
+      expect(routes).toEqual(['/'])
 
       // Navigate to about
       await browser.elementById('link-about').click()
       await browser.waitForElementByCss('[data-testid="about-page"]')
-      route = await browser.elementById('route').text()
-      expect(route).toBe('/about')
+      routes = await getRoutes(browser)
+      expect(routes).toEqual(['/about'])
 
       // Navigate back to home
       await browser.back()
       await browser.waitForElementByCss('[data-testid="root-page"]')
-      route = await browser.elementById('route').text()
-      expect(route).toBe('/')
+      routes = await getRoutes(browser)
+      expect(routes).toEqual(['/'])
 
       // Navigate to blog post
       await browser.elementById('link-blog-post').click()
       await browser.waitForElementByCss('[data-testid="blog-post-page"]')
-      route = await browser.elementById('route').text()
-      expect(route).toBe('/blog/[slug]')
+      routes = await getRoutes(browser)
+      expect(routes).toEqual(['/blog/[slug]'])
 
       // Navigate back to home
       await browser.back()
       await browser.waitForElementByCss('[data-testid="root-page"]')
-      route = await browser.elementById('route').text()
-      expect(route).toBe('/')
+      routes = await getRoutes(browser)
+      expect(routes).toEqual(['/'])
 
       // Navigate to docs
       await browser.elementById('link-docs').click()
       await browser.waitForElementByCss('[data-testid="docs-page"]')
-      route = await browser.elementById('route').text()
-      expect(route).toBe('/docs/[...slug]')
+      routes = await getRoutes(browser)
+      expect(routes).toEqual(['/docs/[...slug]'])
     })
 
-    it('should show correct route for client-side navigation', async () => {
+    it('should show correct routes for client-side navigation', async () => {
       const browser = await next.browser('/')
 
       // Navigate via Link component
       await browser.elementById('link-settings').click()
       await browser.waitForElementByCss('[data-testid="settings-page"]')
 
-      const route = await browser.elementById('route').text()
-      expect(route).toBe('/(app)/(dashboard)/settings')
+      const routes = await getRoutes(browser)
+      expect(routes).toEqual(['/(app)/(dashboard)/settings'])
     })
   })
 
@@ -155,32 +160,32 @@ describe('useRoute() hook', () => {
       const browser = await next.browser('/blog/my-post')
 
       const pathname = await browser.elementById('pathname').text()
-      const route = await browser.elementById('route').text()
+      const routes = await getRoutes(browser)
 
       expect(pathname).toBe('/blog/my-post')
-      expect(route).toBe('/blog/[slug]')
+      expect(routes).toEqual(['/blog/[slug]'])
     })
 
     it('should differ from usePathname for route groups', async () => {
       const browser = await next.browser('/settings')
 
       const pathname = await browser.elementById('pathname').text()
-      const route = await browser.elementById('route').text()
+      const routes = await getRoutes(browser)
 
       // usePathname doesn't include route groups
       expect(pathname).toBe('/settings')
-      // useRoute preserves route groups
-      expect(route).toBe('/(app)/(dashboard)/settings')
+      // useRoutes preserves route groups
+      expect(routes).toEqual(['/(app)/(dashboard)/settings'])
     })
 
     it('should match usePathname for simple static routes', async () => {
       const browser = await next.browser('/about')
 
       const pathname = await browser.elementById('pathname').text()
-      const route = await browser.elementById('route').text()
+      const routes = await getRoutes(browser)
 
       expect(pathname).toBe('/about')
-      expect(route).toBe('/about')
+      expect(routes).toEqual(['/about'])
     })
   })
 })


### PR DESCRIPTION
### What?

This PR introduces a new `unstable_useRoutes()` client-side hook that returns the canonical route structure, preserving route groups, parallel routes, and dynamic parameter placeholders.

Unlike `usePathname()` which returns the actual URL path (e.g., `/blog/my-post`), `unstable_useRoutes()` returns an array of file-system route structures (e.g., `["/blog/[slug]"]`), including:
- Route groups: `(marketing)`
- Parallel routes: `@modal`
- Dynamic parameters: `[slug]`, `[...path]`, `[[...slug]]`
- Interception routes: `(.)`, `(..)`, `(..)(..)`, `(...)`
- Combined interception + dynamic: `(.)[id]`, `(..)[...path]`

When parallel routes are active, all matching routes are returned in the array.

### Why?

Developers need access to the canonical route structure for several use cases:

1. **Route-based UI logic**: Conditionally render UI based on the route structure rather than matching URL patterns
2. **Analytics & debugging**: Track which route template is being rendered, not just the final URL
3. **Dynamic navigation**: Build navigation menus that understand the route hierarchy including parallel routes and route groups
4. **Framework integrations**: Tools that need to understand the Next.js routing structure (monitoring, testing, etc.)

Currently, developers only have access to `usePathname()`, which loses all routing metadata. This forces them to parse URLs or maintain separate route configuration, which is error-prone and duplicates information that Next.js already has.

### How?

**Core Implementation:**

1. **`extractRoutesFromFlightRouterState()`**: New function that traverses the FlightRouterState tree to find all pages matching the target pathname and builds the canonical route strings. Handles synthetic `(slot)` segments that Next.js adds internally for parallel routes while preserving user-defined route groups.

2. **`unstable_useRoutes()` hook**: Leverages the existing `GlobalLayoutRouterContext` to access the FlightRouterState tree and the `PathnameContext` for the current pathname. Returns a getter function that must be called during effect phase (useEffect, useLayoutEffect, or event handlers) to prevent route structure from leaking into server-rendered output.

3. **`convertDynamicParamType()` utility**: Shared utility extracted to `shared/lib/convert-dynamic-param-type.ts` that converts the short parameter type codes (e.g., `'d'`, `'di(.)'`, `'ci(..)'`) back to their file-system representations (e.g., `[param]`, `(.)[param]`, `(..)[...param]`). Refactored from `on-demand-entry-handler.ts` for reuse.

### API Design

The hook returns a getter function rather than the routes directly:

```tsx
"use client"
import { unstable_useRoutes } from 'next/navigation'
import { useEffect, useState } from 'react'

export default function Page() {
  const getRoutes = unstable_useRoutes()
  const [routes, setRoutes] = useState<string[] | undefined>(undefined)

  useEffect(() => {
    setRoutes(getRoutes())
    // On /blog/my-post → ["/blog/[slug]"]
    // On /dashboard with @modal active → ["/dashboard", "/dashboard/@modal/..."]
    // With route group → ["/(marketing)/about"]
  }, [getRoutes])

  return <div>Routes: {routes?.join(', ')}</div>
}
```

**Design decisions:**

- **Effect-phase restriction**: Prevents route structure from appearing in server-rendered output, avoiding hydration mismatches
- **Returns `[]` when unavailable**: Gracefully handles edge cases during SSR or initial hydration without throwing
- **Stable function identity**: Uses `useCallback` with proper dependencies to prevent unnecessary re-renders in consuming components

### Test Plan

**Unit Tests** (`extract-route-from-flight-router-state.test.ts`):
- Static routes with and without route groups
- Dynamic parameters (`[param]`, `[...param]`, `[[...param]]`)
- Parallel routes (`@slot`) at various nesting levels
- Interception routes (`(.)`, `(..)`, `(...)`, `(..)(..)`)
- Combined interception + dynamic parameter folders (`(.)[id]`, `(..)[...path]`)
- Synthetic `(slot)` segment filtering vs user-defined route groups
- Client-side navigation with null/undefined URLs
- Complex multi-feature combinations

**E2E Tests** (`use-route.test.ts`):
- Navigation between pages updates routes correctly
- Parallel route interception shows `@modal` routes
- Comparison with `usePathname()` demonstrating the difference
- Route groups preserved in canonical output

NAR-538