### PR TITLE
[turbopack] Drop duration and allocation tracking from CaptureFuture

### DIFF
--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -6,7 +6,6 @@ use std::{
     hash::{BuildHasherDefault, Hash},
     pin::Pin,
     sync::Arc,
-    time::Duration,
 };
 
 use anyhow::{Result, anyhow};
@@ -541,8 +540,6 @@ pub trait Backend: Sync + Send {
     fn task_execution_completed(
         &self,
         task: TaskId,
-        duration: Duration,
-        memory_usage: usize,
         result: Result<RawVc, TurboTasksExecutionError>,
         cell_counters: &AutoMap<ValueTypeId, u32, BuildHasherDefault<FxHasher>, 8>,
         stateful: bool,

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -578,7 +578,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
             .scope(
                 self.pin(),
                 CURRENT_TASK_STATE.scope(current_task_state, async {
-                    let (result, _duration, _alloc_info) = CaptureFuture::new(future).await;
+                    let result = CaptureFuture::new(future).await;
 
                     // wait for all spawned local tasks using `local` to finish
                     let ltt =
@@ -736,7 +736,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
                     };
 
                     async {
-                        let (result, duration, alloc_info) = CaptureFuture::new(future).await;
+                        let result = CaptureFuture::new(future).await;
 
                         // wait for all spawned local tasks using `local` to finish
                         let ltt = CURRENT_TASK_STATE
@@ -758,8 +758,6 @@ impl<B: Backend + 'static> TurboTasks<B> {
                             .with(|ts| ts.write().unwrap().cell_counters.take().unwrap());
                         this.backend.task_execution_completed(
                             task_id,
-                            duration,
-                            alloc_info.memory_usage(),
                             result,
                             &cell_counters,
                             stateful,
@@ -835,7 +833,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
             let TaskExecutionSpec { future, span } =
                 crate::task::local_task::get_local_task_execution_spec(&*this, &ty, persistence);
             async move {
-                let (result, _duration, _memory_usage) = CaptureFuture::new(future).await;
+                let result = CaptureFuture::new(future).await;
 
                 let result = match result {
                     Ok(Ok(raw_vc)) => Ok(raw_vc),

--- a/turbopack/crates/turbo-tasks/src/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks/src/task_statistics.rs
@@ -46,17 +46,6 @@ impl TaskStatistics {
         self.with_task_type_statistics(native_fn, |stats| stats.cache_miss += 1)
     }
 
-    pub fn increment_execution_duration(
-        &self,
-        native_fn: &'static NativeFunction,
-        duration: std::time::Duration,
-    ) {
-        self.with_task_type_statistics(native_fn, |stats| {
-            stats.executions += 1;
-            stats.duration += duration
-        })
-    }
-
     fn with_task_type_statistics(
         &self,
         native_fn: &'static NativeFunction,
@@ -75,10 +64,6 @@ impl TaskStatistics {
 pub struct TaskFunctionStatistics {
     pub cache_hit: u32,
     pub cache_miss: u32,
-    // Generally executions == cache_miss, however they can diverge when there are invalidations.
-    // The caller gets one cache miss but we might execute multiple times.
-    pub executions: u32,
-    pub duration: std::time::Duration,
 }
 
 impl Serialize for TaskStatistics {


### PR DESCRIPTION
This data was mostly unused

* allocation tracking was completely dead.  So this saves a bit of memory and some data copies
* duration tracking was only used for task statistics.  This was a relatively new feature and not particularly useful.  I considered wrapping it in a `feature` but dropping is simpler and this data is very redundant with tracing output anyway.

