### PR TITLE
[test] Disallow custom `RegExp`-like implementations in `check`

### DIFF
--- a/test/e2e/basepath/basepath.test.ts
+++ b/test/e2e/basepath/basepath.test.ts
@@ -126,33 +126,26 @@ describe('basePath', () => {
           '/gssp'
         )
 
-        await check(
-          async () => {
-            const links = await browser.elementsByCss('link[rel=prefetch]')
+        await check(async () => {
+          const links = await browser.elementsByCss('link[rel=prefetch]')
 
-            for (const link of links) {
-              const href = await link.getAttribute('href')
-              if (href.includes(chunk)) {
-                return true
-              }
+          for (const link of links) {
+            const href = await link.getAttribute('href')
+            if (href.includes(chunk)) {
+              return true
             }
-
-            const scripts = await browser.elementsByCss('script')
-
-            for (const script of scripts) {
-              const src = await script.getAttribute('src')
-              if (src.includes(chunk)) {
-                return true
-              }
-            }
-            return false
-          },
-          {
-            test(result) {
-              return result === true
-            },
           }
-        )
+
+          const scripts = await browser.elementsByCss('script')
+
+          for (const script of scripts) {
+            const src = await script.getAttribute('src')
+            if (src.includes(chunk)) {
+              return true
+            }
+          }
+          return false
+        }, true)
       })
 
       it('should prefetch pages correctly in viewport with <Link>', async () => {

--- a/test/e2e/basepath/error-pages.test.ts
+++ b/test/e2e/basepath/error-pages.test.ts
@@ -1,6 +1,6 @@
 import webdriver from 'next-webdriver'
 import { nextTestSetup } from 'e2e-utils'
-import { check, renderViaHTTP } from 'next-test-utils'
+import { check, renderViaHTTP, retry } from 'next-test-utils'
 
 describe('basePath', () => {
   const basePath = '/docs'
@@ -121,10 +121,8 @@ describe('basePath', () => {
       await browser.eval('window.beforeNav = "hi"')
       await browser.elementByCss('#other-page-link').click()
 
-      await check(() => browser.eval('window.beforeNav'), {
-        test(content) {
-          return content !== 'hi'
-        },
+      await retry(async () => {
+        expect(await browser.eval('window.beforeNav')).not.toEqual('hi')
       })
 
       await check(
@@ -138,10 +136,8 @@ describe('basePath', () => {
       await browser.eval('window.beforeNav = "hi"')
       await browser.eval(`window.next.router.push("${basePath}/other-page")`)
 
-      await check(() => browser.eval('window.beforeNav'), {
-        test(content) {
-          return content !== 'hi'
-        },
+      await retry(async () => {
+        expect(await browser.eval('window.beforeNav')).not.toEqual('hi')
       })
 
       const html = await browser.eval('document.documentElement.innerHTML')
@@ -153,10 +149,8 @@ describe('basePath', () => {
       await browser.eval('window.beforeNav = "hi"')
       await browser.eval(`window.next.router.replace("${basePath}/other-page")`)
 
-      await check(() => browser.eval('window.beforeNav'), {
-        test(content) {
-          return content !== 'hi'
-        },
+      await retry(async () => {
+        expect(await browser.eval('window.beforeNav')).not.toEqual('hi')
       })
 
       const html = await browser.eval('document.documentElement.innerHTML')

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -638,13 +638,9 @@ const runTests = (isDev = false, isDeploy = false) => {
     await waitFor(500)
     await browser.eval('window.beforeClick = "abc"')
     await browser.elementByCss('#broken-post').click()
-    expect(
-      await check(() => browser.eval('window.beforeClick'), {
-        test(v) {
-          return v !== 'abc'
-        },
-      })
-    ).toBe(true)
+    await retry(async () => {
+      expect(await browser.eval('window.beforeClick')).not.toEqual('abc')
+    })
   })
 
   it('should always call getServerSideProps without caching', async () => {

--- a/test/e2e/link-with-api-rewrite/index.test.ts
+++ b/test/e2e/link-with-api-rewrite/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 
@@ -27,8 +27,8 @@ describe('link-with-api-rewrite', () => {
       // unset).
       await browser.eval('window.beforeNav = "hi"')
       await browser.elementById('rewrite').click()
-      await check(() => browser.eval('window.beforeNav'), {
-        test: (content) => content !== 'hi',
+      await retry(async () => {
+        expect(await browser.eval('window.beforeNav')).not.toEqual('hi')
       })
 
       // Check to see that we were in fact navigated to the correct page.
@@ -54,8 +54,8 @@ describe('link-with-api-rewrite', () => {
       // unset).
       await browser.eval('window.beforeNav = "hi"')
       await browser.elementById('direct').click()
-      await check(() => browser.eval('window.beforeNav'), {
-        test: (content) => content !== 'hi',
+      await retry(async () => {
+        expect(await browser.eval('window.beforeNav')).not.toEqual('hi')
       })
 
       // Check to see that we were in fact navigated to the correct page.

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -772,13 +772,9 @@ describe('Prerender', () => {
       const browser = await webdriver(next.url, '/')
       await browser.eval('window.beforeClick = "abc"')
       await browser.elementByCss('#broken-post').click()
-      expect(
-        await check(() => browser.eval('window.beforeClick'), {
-          test(v) {
-            return v !== 'abc'
-          },
-        })
-      ).toBe(true)
+      await retry(async () => {
+        expect(await browser.eval('window.beforeClick')).not.toEqual('abc')
+      })
     })
 
     it('should SSR dynamic page with brackets in param as object', async () => {
@@ -906,13 +902,9 @@ describe('Prerender', () => {
         const browser = await webdriver(next.url, '/')
         await browser.eval('window.beforeClick = "abc"')
         await browser.elementByCss('#broken-at-first-post').click()
-        expect(
-          await check(() => browser.eval('window.beforeClick'), {
-            test(v) {
-              return v !== 'abc'
-            },
-          })
-        ).toBe(true)
+        await retry(async () => {
+          expect(await browser.eval('window.beforeClick')).not.toEqual('abc')
+        })
 
         const text = await browser.elementByCss('#params').text()
         expect(text).toMatch(/post.*?post-999/)

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -700,7 +700,7 @@ export async function startCleanStaticServer(dir: string) {
  */
 export async function check(
   contentFn: () => unknown | Promise<unknown>,
-  regex: any
+  regex: boolean | number | string | RegExp
 ): Promise<boolean> {
   let content: unknown
   let lastErr: unknown
@@ -712,7 +712,7 @@ export async function check(
         if (regex === content) {
           return true
         }
-      } else if (regex.test(content)) {
+      } else if (regex.test('' + content)) {
         // found the content
         return true
       }


### PR DESCRIPTION
Can be implemented with `retry` instead and will simplify an upcoming codemod.