### PR TITLE
fully remove clientSegmentCache flag

### DIFF
--- a/docs/01-app/02-guides/prefetching.mdx
+++ b/docs/01-app/02-guides/prefetching.mdx
@@ -188,8 +188,6 @@ For example, you may still want to have consistent usage of `<Link>` in your app
 
 ## Prefetching optimizations
 
-> **Good to know:** Layout deduplication and prefetch scheduling are part of upcoming optimizations. Currently available in Next.js canary via the `experimental.clientSegmentCache` flag.
-
 ### Client cache
 
 Next.js stores prefetched React Server Component payloads in memory, keyed by route segments. When navigating between sibling routes (e.g. `/dashboard/settings` → `/dashboard/analytics`), it reuses the parent layout and only fetches the updated leaf page. This reduces network traffic and improves navigation speed.

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -902,5 +902,6 @@
   "901": "Invalid \"cacheHandlers\" provided, expected an object e.g. { default: '/my-handler.js' }, received %s",
   "902": "Invalid handler fields configured for \"cacheHandlers\":\\n%s",
   "903": "The file \"%s\" must export a function, either as a default export or as a named \"%s\" export.\\nThis function is what Next.js runs for every request handled by this %s.\\n\\nWhy this happens:\\n%s- The file exists but doesn't export a function.\\n- The export is not a function (e.g., an object or constant).\\n- There's a syntax error preventing the export from being recognized.\\n\\nTo fix it:\\n- Ensure this file has either a default or \"%s\" function export.\\n\\nLearn more: https://nextjs.org/docs/messages/middleware-to-proxy",
-  "904": "The file \"%s\" must export a function, either as a default export or as a named \"%s\" export."
+  "904": "The file \"%s\" must export a function, either as a default export or as a named \"%s\" export.",
+  "905": "Page \"%s\" cannot use \\`export const unstable_prefetch = ...\\` without enabling \\`cacheComponents\\`."
 }

--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -1502,12 +1502,7 @@ export async function handleBuildComplete({
           route.page
         ) + getDestinationQuery(route.routeKeys)
 
-      if (
-        appPageKeys &&
-        appPageKeys.length > 0 &&
-        (config.experimental.cacheComponents ||
-          config.experimental.clientSegmentCache)
-      ) {
+      if (appPageKeys && appPageKeys.length > 0 && config.cacheComponents) {
         // If we have fallback root params (implying we've already
         // emitted a rewrite for the /_tree request), or if the route
         // has PPR enabled and client param parsing is enabled, then

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -681,14 +681,9 @@ export async function getAppPageStaticInfo({
     )
   }
 
-  if (
-    'unstable_prefetch' in config &&
-    (!nextConfig.cacheComponents ||
-      // don't allow in `clientSegmentCache: 'client-only'` mode
-      nextConfig.experimental?.clientSegmentCache !== true)
-  ) {
+  if ('unstable_prefetch' in config && !nextConfig.cacheComponents) {
     throw new Error(
-      `Page "${page}" cannot use \`export const unstable_prefetch = ...\` without enabling \`cacheComponents\` and \`experimental.clientSegmentCache\`.`
+      `Page "${page}" cannot use \`export const unstable_prefetch = ...\` without enabling \`cacheComponents\`.`
     )
   }
 

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -198,9 +198,6 @@ export function getDefineEnv({
       clientRouterFilters?.staticFilter ?? false,
     'process.env.__NEXT_CLIENT_ROUTER_D_FILTER':
       clientRouterFilters?.dynamicFilter ?? false,
-    'process.env.__NEXT_CLIENT_SEGMENT_CACHE': Boolean(
-      config.experimental.clientSegmentCache
-    ),
     'process.env.__NEXT_CLIENT_VALIDATE_RSC_REQUEST_HEADERS': Boolean(
       config.experimental.validateRSCRequestHeaders
     ),

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3000,10 +3000,7 @@ export default async function build(
                     // following enabled. This is because the flight data now
                     // does not contain any of the route params and is instead
                     // completely static.
-                    !(
-                      config.experimental.clientSegmentCache &&
-                      config.cacheComponents
-                    )
+                    !config.cacheComponents
                   ) {
                     return
                   }
@@ -3311,16 +3308,12 @@ export default async function build(
                 if (
                   !isAppRouteHandler &&
                   isAppPPREnabled &&
-                  // Don't add a prefetch data route if we have both
-                  // clientSegmentCache and clientParamParsing enabled. This is
+                  // Don't add a prefetch data route if we have
+                  // cacheComponents enabled. This is
                   // because we don't actually use the prefetch data route in
                   // this case. This only applies if we have PPR enabled for
                   // this route.
-                  !(
-                    config.experimental.clientSegmentCache &&
-                    config.cacheComponents &&
-                    isRoutePPREnabled
-                  )
+                  !(config.cacheComponents && isRoutePPREnabled)
                 ) {
                   prefetchDataRoute = path.posix.join(
                     `${normalizedRoute}${RSC_PREFETCH_SUFFIX}`
@@ -3422,12 +3415,11 @@ export default async function build(
                 )
                 if (!isAppRouteHandler && isAppPPREnabled) {
                   if (
-                    // Don't add a prefetch data route if we have both
-                    // clientSegmentCache and clientParamParsing enabled. This is
+                    // Don't add a prefetch data route if we have
+                    // cacheComponents enabled. This is
                     // because we don't actually use the prefetch data route in
                     // this case. This only applies if we have PPR enabled for
                     // this route.
-                    !config.experimental.clientSegmentCache ||
                     !config.cacheComponents ||
                     !isRoutePPREnabled
                   ) {

--- a/packages/next/src/build/segment-config/app/app-segment-config.ts
+++ b/packages/next/src/build/segment-config/app/app-segment-config.ts
@@ -126,7 +126,6 @@ const AppSegmentConfigSchema = z.object({
 
   /**
    * How this segment should be prefetched.
-   * (only applicable when `clientSegmentCache` is enabled)
    */
   unstable_prefetch: PrefetchSchema.optional(),
 
@@ -224,7 +223,6 @@ export type AppSegmentConfig = {
 
   /**
    * How this segment should be prefetched.
-   * (only applicable when `clientSegmentCache` is enabled)
    */
   unstable_prefetch?: Prefetch
 

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -563,9 +563,6 @@ export async function handler(
             isRoutePPREnabled,
             expireTime: nextConfig.expireTime,
             staleTimes: nextConfig.experimental.staleTimes,
-            clientSegmentCache: Boolean(
-              nextConfig.experimental.clientSegmentCache
-            ),
             dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
             inlineCss: Boolean(nextConfig.experimental.inlineCss),
             authInterrupts: Boolean(nextConfig.experimental.authInterrupts),

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -158,7 +158,6 @@ async function requestHandler(
         isRoutePPREnabled: false,
         expireTime: nextConfig.expireTime,
         staleTimes: nextConfig.experimental.staleTimes,
-        clientSegmentCache: Boolean(nextConfig.experimental.clientSegmentCache),
         dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
         inlineCss: Boolean(nextConfig.experimental.inlineCss),
         authInterrupts: Boolean(nextConfig.experimental.authInterrupts),

--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -746,10 +746,7 @@ export const useLinkStatus = () => {
 function getFetchStrategyFromPrefetchProp(
   prefetchProp: Exclude<LinkProps['prefetch'], undefined | false>
 ): PrefetchTaskFetchStrategy {
-  if (
-    process.env.__NEXT_CACHE_COMPONENTS &&
-    process.env.__NEXT_CLIENT_SEGMENT_CACHE
-  ) {
+  if (process.env.__NEXT_CACHE_COMPONENTS) {
     if (prefetchProp === true) {
       return FetchStrategy.Full
     }
@@ -758,13 +755,10 @@ function getFetchStrategyFromPrefetchProp(
     // This will also include invalid prop values that don't match the types specified here.
     // (although those should've been filtered out by prop validation in dev)
     prefetchProp satisfies null | 'auto'
-    // In `clientSegmentCache`, we default to PPR, and we'll discover whether or not the route supports it with the initial prefetch.
-    // If we're not using `clientSegmentCache`, this will be converted into a `PrefetchKind.AUTO`.
     return FetchStrategy.PPR
   } else {
     return prefetchProp === null || prefetchProp === 'auto'
-      ? // In `clientSegmentCache`, we default to PPR, and we'll discover whether or not the route supports it with the initial prefetch.
-        // If we're not using `clientSegmentCache`, this will be converted into a `PrefetchKind.AUTO`.
+      ? // We default to PPR, and we'll discover whether or not the route supports it with the initial prefetch.
         FetchStrategy.PPR
       : // In the old implementation without runtime prefetches, `prefetch={true}` forces all dynamic data to be prefetched.
         // To preserve backwards-compatibility, anything other than `false`, `null`, or `"auto"` results in a full prefetch.

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -97,9 +97,7 @@ function HistoryUpdater({
     // task. Re-prefetch all visible links with the updated values. In most
     // cases, this will not result in any new network requests, only if
     // the prefetch result actually varies on one of these inputs.
-    if (process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
-      pingVisibleLinks(appRouterState.nextUrl, appRouterState.tree)
-    }
+    pingVisibleLinks(appRouterState.nextUrl, appRouterState.tree)
   }, [appRouterState.nextUrl, appRouterState.tree])
 
   return null

--- a/packages/next/src/client/components/links.ts
+++ b/packages/next/src/client/components/links.ts
@@ -14,8 +14,6 @@ import {
   reschedulePrefetchTask,
 } from './segment-cache'
 import { startTransition } from 'react'
-import { PrefetchKind } from './router-reducer/router-reducer-types'
-import { InvariantError } from '../../shared/lib/invariant-error'
 
 type LinkElement = HTMLAnchorElement | SVGAElement
 
@@ -298,13 +296,6 @@ function rescheduleLinkPrefetch(
       return
     }
 
-    if (!process.env.__NEXT_CLIENT_SEGMENT_CACHE) {
-      // The old prefetch implementation does not have different priority levels.
-      // Just schedule a new prefetch task.
-      prefetchWithOldCacheImplementation(instance)
-      return
-    }
-
     const { getCurrentAppRouterState } =
       require('./app-router-instance') as typeof import('./app-router-instance')
 
@@ -368,55 +359,4 @@ export function pingVisibleLinks(
       null
     )
   }
-}
-
-function prefetchWithOldCacheImplementation(instance: PrefetchableInstance) {
-  // This is the path used when the Segment Cache is not enabled.
-  if (typeof window === 'undefined') {
-    return
-  }
-
-  const doPrefetch = async () => {
-    // note that `appRouter.prefetch()` is currently sync,
-    // so we have to wrap this call in an async function to be able to catch() errors below.
-
-    let prefetchKind: PrefetchKind
-    switch (instance.fetchStrategy) {
-      case FetchStrategy.PPR: {
-        prefetchKind = PrefetchKind.AUTO
-        break
-      }
-      case FetchStrategy.Full: {
-        prefetchKind = PrefetchKind.FULL
-        break
-      }
-      case FetchStrategy.PPRRuntime: {
-        // We can only get here if Client Segment Cache is off, and in that case
-        // it shouldn't be possible for a link to request a runtime prefetch.
-        throw new InvariantError(
-          'FetchStrategy.PPRRuntime should never be used when `experimental.clientSegmentCache` is disabled'
-        )
-      }
-      default: {
-        instance.fetchStrategy satisfies never
-        // Unreachable, but otherwise typescript will consider the variable unassigned
-        prefetchKind = undefined!
-      }
-    }
-
-    return instance.router.prefetch(instance.prefetchHref, {
-      kind: prefetchKind,
-    })
-  }
-
-  // Prefetch the page if asked (only in the client)
-  // We need to handle a prefetch error here since we may be
-  // loading with priority which can reject but we don't
-  // want to force navigation since this is only a prefetch
-  doPrefetch().catch((err) => {
-    if (process.env.NODE_ENV !== 'production') {
-      // rethrow to show invalid URL errors
-      throw err
-    }
-  })
 }

--- a/packages/next/src/client/components/segment-cache.ts
+++ b/packages/next/src/client/components/segment-cache.ts
@@ -24,92 +24,68 @@ export type {
   NormalizedSearch,
 } from './segment-cache-impl/cache-key'
 
-const notEnabled: any = () => {
-  throw new Error(
-    'Segment Cache experiment is not enabled. This is a bug in Next.js.'
-  )
-}
-
 export const prefetch: typeof import('./segment-cache-impl/prefetch').prefetch =
-  process.env.__NEXT_CLIENT_SEGMENT_CACHE
-    ? function (...args) {
-        return (
-          require('./segment-cache-impl/prefetch') as typeof import('./segment-cache-impl/prefetch')
-        ).prefetch(...args)
-      }
-    : notEnabled
+  function (...args) {
+    return (
+      require('./segment-cache-impl/prefetch') as typeof import('./segment-cache-impl/prefetch')
+    ).prefetch(...args)
+  }
 
 export const navigate: typeof import('./segment-cache-impl/navigation').navigate =
-  process.env.__NEXT_CLIENT_SEGMENT_CACHE
-    ? function (...args) {
-        return (
-          require('./segment-cache-impl/navigation') as typeof import('./segment-cache-impl/navigation')
-        ).navigate(...args)
-      }
-    : notEnabled
+  function (...args) {
+    return (
+      require('./segment-cache-impl/navigation') as typeof import('./segment-cache-impl/navigation')
+    ).navigate(...args)
+  }
 
 export const revalidateEntireCache: typeof import('./segment-cache-impl/cache').revalidateEntireCache =
-  process.env.__NEXT_CLIENT_SEGMENT_CACHE
-    ? function (...args) {
-        return (
-          require('./segment-cache-impl/cache') as typeof import('./segment-cache-impl/cache')
-        ).revalidateEntireCache(...args)
-      }
-    : notEnabled
+  function (...args) {
+    return (
+      require('./segment-cache-impl/cache') as typeof import('./segment-cache-impl/cache')
+    ).revalidateEntireCache(...args)
+  }
 
 export const getCurrentCacheVersion: typeof import('./segment-cache-impl/cache').getCurrentCacheVersion =
-  process.env.__NEXT_CLIENT_SEGMENT_CACHE
-    ? function (...args) {
-        return (
-          require('./segment-cache-impl/cache') as typeof import('./segment-cache-impl/cache')
-        ).getCurrentCacheVersion(...args)
-      }
-    : notEnabled
+  function (...args) {
+    return (
+      require('./segment-cache-impl/cache') as typeof import('./segment-cache-impl/cache')
+    ).getCurrentCacheVersion(...args)
+  }
 
 export const schedulePrefetchTask: typeof import('./segment-cache-impl/scheduler').schedulePrefetchTask =
-  process.env.__NEXT_CLIENT_SEGMENT_CACHE
-    ? function (...args) {
-        return (
-          require('./segment-cache-impl/scheduler') as typeof import('./segment-cache-impl/scheduler')
-        ).schedulePrefetchTask(...args)
-      }
-    : notEnabled
+  function (...args) {
+    return (
+      require('./segment-cache-impl/scheduler') as typeof import('./segment-cache-impl/scheduler')
+    ).schedulePrefetchTask(...args)
+  }
 
 export const cancelPrefetchTask: typeof import('./segment-cache-impl/scheduler').cancelPrefetchTask =
-  process.env.__NEXT_CLIENT_SEGMENT_CACHE
-    ? function (...args) {
-        return (
-          require('./segment-cache-impl/scheduler') as typeof import('./segment-cache-impl/scheduler')
-        ).cancelPrefetchTask(...args)
-      }
-    : notEnabled
+  function (...args) {
+    return (
+      require('./segment-cache-impl/scheduler') as typeof import('./segment-cache-impl/scheduler')
+    ).cancelPrefetchTask(...args)
+  }
 
 export const reschedulePrefetchTask: typeof import('./segment-cache-impl/scheduler').reschedulePrefetchTask =
-  process.env.__NEXT_CLIENT_SEGMENT_CACHE
-    ? function (...args) {
-        return (
-          require('./segment-cache-impl/scheduler') as typeof import('./segment-cache-impl/scheduler')
-        ).reschedulePrefetchTask(...args)
-      }
-    : notEnabled
+  function (...args) {
+    return (
+      require('./segment-cache-impl/scheduler') as typeof import('./segment-cache-impl/scheduler')
+    ).reschedulePrefetchTask(...args)
+  }
 
 export const isPrefetchTaskDirty: typeof import('./segment-cache-impl/scheduler').isPrefetchTaskDirty =
-  process.env.__NEXT_CLIENT_SEGMENT_CACHE
-    ? function (...args) {
-        return (
-          require('./segment-cache-impl/scheduler') as typeof import('./segment-cache-impl/scheduler')
-        ).isPrefetchTaskDirty(...args)
-      }
-    : notEnabled
+  function (...args) {
+    return (
+      require('./segment-cache-impl/scheduler') as typeof import('./segment-cache-impl/scheduler')
+    ).isPrefetchTaskDirty(...args)
+  }
 
 export const createCacheKey: typeof import('./segment-cache-impl/cache-key').createCacheKey =
-  process.env.__NEXT_CLIENT_SEGMENT_CACHE
-    ? function (...args) {
-        return (
-          require('./segment-cache-impl/cache-key') as typeof import('./segment-cache-impl/cache-key')
-        ).createCacheKey(...args)
-      }
-    : notEnabled
+  function (...args) {
+    return (
+      require('./segment-cache-impl/cache-key') as typeof import('./segment-cache-impl/cache-key')
+    ).createCacheKey(...args)
+  }
 
 /**
  * Below are public constants. They're small enough that we don't need to

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -395,10 +395,6 @@ async function exportAppImpl(
       clientTraceMetadata: nextConfig.experimental.clientTraceMetadata,
       expireTime: nextConfig.expireTime,
       staleTimes: nextConfig.experimental.staleTimes,
-      clientSegmentCache:
-        nextConfig.experimental.clientSegmentCache === 'client-only'
-          ? 'client-only'
-          : Boolean(nextConfig.experimental.clientSegmentCache),
       clientParamParsingOrigins:
         nextConfig.experimental.clientParamParsingOrigins,
       dynamicOnHover: nextConfig.experimental.dynamicOnHover ?? false,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -5381,17 +5381,7 @@ async function collectSegmentData(
   // decomposed into a separate stream per segment.
 
   const clientReferenceManifest = renderOpts.clientReferenceManifest
-  if (
-    !clientReferenceManifest ||
-    // Do not generate per-segment data unless the experimental Segment Cache
-    // flag is enabled.
-    //
-    // We also skip generating segment data if flag is set to "client-only",
-    // rather than true. (The "client-only" option only affects the behavior of
-    // the client-side implementation; per-segment prefetches are intentionally
-    // disabled in that configuration).
-    renderOpts.experimental.clientSegmentCache !== true
-  ) {
+  if (!clientReferenceManifest) {
     return
   }
 

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -137,7 +137,6 @@ export interface RenderOptsPartial {
     expireTime: number | undefined
     staleTimes: ExperimentalConfig['staleTimes'] | undefined
     clientTraceMetadata: string[] | undefined
-    clientSegmentCache: boolean | 'client-only'
 
     /**
      * The origins that are allowed to write the rewritten headers when

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -421,7 +421,6 @@ export default abstract class Server<
   }
 
   private readonly isAppPPREnabled: boolean
-  private readonly isAppSegmentPrefetchEnabled: boolean
 
   /**
    * This is used to persist cache scopes across
@@ -489,10 +488,6 @@ export default abstract class Server<
       this.enabledDirectories.app &&
       checkIsAppPPREnabled(this.nextConfig.experimental.ppr)
 
-    this.isAppSegmentPrefetchEnabled =
-      this.enabledDirectories.app &&
-      this.nextConfig.experimental.clientSegmentCache === true
-
     this.normalizers = {
       // We should normalize the pathname from the RSC prefix only in minimal
       // mode as otherwise that route is not exposed external to the server as
@@ -505,10 +500,9 @@ export default abstract class Server<
         this.isAppPPREnabled && this.minimalMode
           ? new PrefetchRSCPathnameNormalizer()
           : undefined,
-      segmentPrefetchRSC:
-        this.isAppSegmentPrefetchEnabled && this.minimalMode
-          ? new SegmentPrefixRSCPathnameNormalizer()
-          : undefined,
+      segmentPrefetchRSC: this.minimalMode
+        ? new SegmentPrefixRSCPathnameNormalizer()
+        : undefined,
       data: this.enabledDirectories.pages
         ? new NextDataPathnameNormalizer(this.buildId)
         : undefined,
@@ -550,10 +544,6 @@ export default abstract class Server<
         expireTime: this.nextConfig.expireTime,
         staleTimes: this.nextConfig.experimental.staleTimes,
         clientTraceMetadata: this.nextConfig.experimental.clientTraceMetadata,
-        clientSegmentCache:
-          this.nextConfig.experimental.clientSegmentCache === 'client-only'
-            ? 'client-only'
-            : Boolean(this.nextConfig.experimental.clientSegmentCache),
         clientParamParsingOrigins:
           this.nextConfig.experimental.clientParamParsingOrigins,
         dynamicOnHover: this.nextConfig.experimental.dynamicOnHover ?? false,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -192,9 +192,6 @@ export const experimentalSchema = {
   memoryBasedWorkersCount: z.boolean().optional(),
   craCompat: z.boolean().optional(),
   caseSensitiveRoutes: z.boolean().optional(),
-  clientSegmentCache: z
-    .union([z.boolean(), z.literal('client-only')])
-    .optional(),
   clientParamParsingOrigins: z.array(z.string()).optional(),
   dynamicOnHover: z.boolean().optional(),
   disableOptimizedLoading: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -279,8 +279,6 @@ export interface ExperimentalConfig {
   prerenderEarlyExit?: boolean
   linkNoTouchStart?: boolean
   caseSensitiveRoutes?: boolean
-  clientSegmentCache?: boolean | 'client-only'
-
   /**
    * The origins that are allowed to write the rewritten headers when
    * performing a non-relative rewrite. When undefined, no non-relative
@@ -1455,7 +1453,6 @@ export const defaultConfig = Object.freeze({
     serverSourceMaps: false,
     linkNoTouchStart: false,
     caseSensitiveRoutes: false,
-    clientSegmentCache: true,
     clientParamParsingOrigins: undefined,
     dynamicOnHover: false,
     preloadEntriesOnStart: true,

--- a/test/e2e/app-dir/resuming-head-runtime-search-param/next.config.js
+++ b/test/e2e/app-dir/resuming-head-runtime-search-param/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  experimental: { clientSegmentCache: true },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
+++ b/test/e2e/app-dir/rsc-redirect/rsc-redirect.test.ts
@@ -37,18 +37,16 @@ describe('rsc-redirect', () => {
 // TODO: these tests aren't currently run at all during testing
 if (process.env.NODE_ENV === 'production') {
   describe.each([
-    { cacheComponents: true, segmentCache: true },
-    { cacheComponents: true, segmentCache: false },
-    { cacheComponents: false, segmentCache: true },
-    { cacheComponents: false, segmentCache: false },
+    { cacheComponents: true },
+    { cacheComponents: false },
   ] as const)(
-    'rsc-redirect /old-about -> /about (cacheComponents: $cacheComponents, segmentCache: $segmentCache)',
-    ({ cacheComponents, segmentCache }) => {
+    'rsc-redirect /old-about -> /about (cacheComponents: $cacheComponents)',
+    ({ cacheComponents }) => {
       beforeAll(() => {
         // Write next.config.js with the current flags
         fs.writeFileSync(
           configPath,
-          `module.exports = { experimental: { cacheComponents: ${cacheComponents}, clientSegmentCache: ${segmentCache} } }\n`
+          `module.exports = { experimental: { cacheComponents: ${cacheComponents}} }\n`
         )
       })
 

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/next.config.js
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   experimental: {
-    clientSegmentCache: true,
     validateRSCRequestHeaders: true,
   },
 }

--- a/test/e2e/app-dir/segment-cache/deployment-skew/next.config.js
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/next.config.js
@@ -7,10 +7,6 @@ if (!BUILD_ID) {
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  experimental: {
-    clientSegmentCache: true,
-  },
-
   distDir: '.next.' + BUILD_ID,
 
   async generateBuildId() {

--- a/test/e2e/app-dir/segment-cache/dynamic-on-hover/next.config.js
+++ b/test/e2e/app-dir/segment-cache/dynamic-on-hover/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
-    clientSegmentCache: true,
     dynamicOnHover: true,
   },
 }

--- a/test/e2e/app-dir/segment-cache/export/next.config.js
+++ b/test/e2e/app-dir/segment-cache/export/next.config.js
@@ -3,9 +3,6 @@
  */
 const nextConfig = {
   output: 'export',
-  experimental: {
-    clientSegmentCache: true,
-  },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/memory-pressure/next.config.js
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  experimental: { clientSegmentCache: true },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/metadata/next.config.js
+++ b/test/e2e/app-dir/segment-cache/metadata/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  experimental: { clientSegmentCache: true },
   async rewrites() {
     return [
       {

--- a/test/e2e/app-dir/segment-cache/mpa-navigations/next.config.js
+++ b/test/e2e/app-dir/segment-cache/mpa-navigations/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  experimental: { clientSegmentCache: true },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/no-prefetch/next.config.js
+++ b/test/e2e/app-dir/segment-cache/no-prefetch/next.config.js
@@ -1,7 +1,4 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
-  experimental: {
-    clientSegmentCache: true,
-  },
   productionBrowserSourceMaps: true,
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/next.config.ts
@@ -2,7 +2,6 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
-  experimental: { clientSegmentCache: true },
   productionBrowserSourceMaps: true,
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/next.config.ts
@@ -2,7 +2,6 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   cacheComponents: true,
-  experimental: { clientSegmentCache: true },
   productionBrowserSourceMaps: true,
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-scheduling/next.config.js
+++ b/test/e2e/app-dir/segment-cache/prefetch-scheduling/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  experimental: { clientSegmentCache: true },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/revalidation/next.config.js
+++ b/test/e2e/app-dir/segment-cache/revalidation/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  experimental: { clientSegmentCache: true },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/search-params/next.config.js
+++ b/test/e2e/app-dir/segment-cache/search-params/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  experimental: { clientSegmentCache: true },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/staleness/next.config.js
+++ b/test/e2e/app-dir/segment-cache/staleness/next.config.js
@@ -4,7 +4,6 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
-    clientSegmentCache: true,
     staleTimes: {
       dynamic: 30,
     },

--- a/test/production/app-dir/resume-data-cache/next.config.js
+++ b/test/production/app-dir/resume-data-cache/next.config.js
@@ -3,7 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  experimental: { clientSegmentCache: true },
 }
 
 module.exports = nextConfig

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -55,10 +55,7 @@ describe.skip('required server files app router', () => {
       },
       nextConfig: {
         cacheHandler: './cache-handler.js',
-        experimental: {
-          cacheComponents: true,
-          clientSegmentCache: true,
-        },
+        cacheComponents: true,
         output: 'standalone',
       },
     })


### PR DESCRIPTION
Turning this flag off would have already caused client-side invariants because we deleted all the old codepaths. This fully removes the remaining plumbing that supported the flag. 