### PR TITLE
Update parallel routes in build-complete

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -966,6 +966,18 @@ export async function handleBuildComplete({
               return {} as Record<string, string>
             }
           )
+
+          // If this is a parallel route we just need to merge
+          // the assets as they share the same pathname
+          const existingOutput = appOutputMap[normalizedPage]
+          if (existingOutput) {
+            Object.assign(existingOutput.assets, assets)
+            existingOutput.assets[path.relative(tracingRoot, pageFile)] =
+              pageFile
+
+            continue
+          }
+
           const functionConfig =
             functionsConfigManifest.functions[normalizedPage] || {}
 

--- a/test/production/adapter-config/adapter-config-export.test.ts
+++ b/test/production/adapter-config/adapter-config-export.test.ts
@@ -23,6 +23,9 @@ describe('adapter-config export', () => {
       'pages/api/node-pages.ts',
       'pages/edge-pages/index.tsx',
       'pages/node-pages/index.tsx',
+      'app/node-app/[slug]/page.tsx',
+      'app/node-app/@dialog/default.tsx',
+      'app/node-app/@dialog/[slug]/page.tsx',
     ]
 
     for (const file of nonExportFiles) {

--- a/test/production/adapter-config/app/node-app/@dialog/[slug]/page.tsx
+++ b/test/production/adapter-config/app/node-app/@dialog/[slug]/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <>
+      <p>@dialog parallel route for /node-app/[slug]</p>
+    </>
+  )
+}

--- a/test/production/adapter-config/app/node-app/@dialog/default.tsx
+++ b/test/production/adapter-config/app/node-app/@dialog/default.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return 'default dialog'
+}

--- a/test/production/adapter-config/app/node-app/[slug]/page.tsx
+++ b/test/production/adapter-config/app/node-app/[slug]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <>/node-app/[slug]</>
+}

--- a/test/production/adapter-config/app/node-app/layout.tsx
+++ b/test/production/adapter-config/app/node-app/layout.tsx
@@ -1,0 +1,8 @@
+export default function Layout({ dialog, children }: any) {
+  return (
+    <>
+      {dialog}
+      {children}
+    </>
+  )
+}

--- a/test/production/adapter-config/my-adapter.mjs
+++ b/test/production/adapter-config/my-adapter.mjs
@@ -5,6 +5,7 @@ import fs from 'fs'
 const myAdapter = {
   name: 'my-custom-adapter',
   modifyConfig: (config, { phase }) => {
+    if (process.env.NODE_ENV !== 'production') return config
     if (typeof phase !== 'string') {
       throw new Error(`invalid phase value provided to modifyConfig ${phase}`)
     }


### PR DESCRIPTION
This fixes parallel routes being considered separate outputs with the same pathname in the adapters build-complete hook and instead merges them into the same output combining the necessary outputs. 