### PR TITLE
fix(third-parties): remove global `Window` augmentation to avoid type degradation

### DIFF
--- a/packages/third-parties/src/google/ga.tsx
+++ b/packages/third-parties/src/google/ga.tsx
@@ -5,12 +5,6 @@ import Script from 'next/script'
 
 import type { GAParams } from '../types/google'
 
-declare global {
-  interface Window {
-    dataLayer?: Object[]
-  }
-}
-
 let currDataLayerName: string | undefined = undefined
 
 export function GoogleAnalytics(props: GAParams) {
@@ -61,6 +55,8 @@ export function sendGAEvent(..._args: Object[]) {
     console.warn(`@next/third-parties: GA has not been initialized`)
     return
   }
+
+  const window = globalThis.window as unknown as { [key: string]: Object[] }
 
   if (window[currDataLayerName]) {
     window[currDataLayerName].push(arguments)

--- a/packages/third-parties/src/google/gtm.tsx
+++ b/packages/third-parties/src/google/gtm.tsx
@@ -75,6 +75,7 @@ export function GoogleTagManager(props: GTMParams) {
 }
 
 export const sendGTMEvent = (data: Object, dataLayerName?: string) => {
+  const window = globalThis.window as unknown as { [key: string]: Object[] }
   // special case if we are sending events before GTM init and we have custom dataLayerName
   const dataLayer = dataLayerName || currDataLayerName
   // define dataLayer so we can still queue up events before GTM init

--- a/packages/third-parties/src/types/google.ts
+++ b/packages/third-parties/src/types/google.ts
@@ -1,10 +1,3 @@
-declare global {
-  interface Window {
-    dataLayer?: Object[]
-    [key: string]: any
-  }
-}
-
 type JSONValue =
   | string
   | number


### PR DESCRIPTION
Fixes #85555

## Summary

Removes the global `Window` augmentation in `@next/third-parties` that introduced a string index signature (`[key: string]: any]`),
which caused mapped types involving `Window` to collapse into `{ [k: string]: any }`.
The change uses a local cast instead, preserving runtime behavior while maintaining type safety across the ecosystem.

## Details

- Deleted `packages/third-parties/src/types/google.ts` global `Window` declaration.
- Updated `google/ga.tsx` and `google/gtm.tsx` to locally cast window as `{ [key: string]: Object[] }` before accessing dynamic data layer keys.

No runtime behavior changes.

## Rationale

- The `dataLayer` key name is dynamic; declaring it globally adds no type safety.
- The global index signature caused far-reaching type degradation in apps, DOM utilities, and libraries.
- Removing it restores consistency with `lib.dom.d.ts` and avoids polluting global scope.

## Notes

- Jest-based type tests are out of scope; this fix only targets type definitions.
- While this issue surfaced clearly with `@types/jsdom`, it applies equally to any consumer using `Omit<Window, ...>` or similar type operations.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
