### PR TITLE
[test] Deflake nested `after()` tests

### DIFF
--- a/test/e2e/app-dir/next-after-app-api-usage/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-api-usage/index.test.ts
@@ -58,24 +58,27 @@ describe('nextjs APIs in after()', () => {
           `[${path}] headers(): error: Error: Route ${path} used \`headers()\` inside \`after()\`. This is not supported.`
         )
 
-        expect(logs).not.toContain(`[${path}] nested headers(): ok`)
-        expect(logs).toContain(
-          `[${path}] nested headers(): error: Error: Route ${path} used \`headers()\` inside \`after()\`. This is not supported.`
-        )
-
         expect(logs).not.toContain(`[${path}] cookies(): ok`)
         expect(logs).toContain(
           `[${path}] cookies(): error: Error: Route ${path} used \`cookies()\` inside \`after()\`. This is not supported.`
         )
 
-        expect(logs).not.toContain(`[${path}] nested cookies(): ok`)
-        expect(logs).toContain(
-          `[${path}] nested cookies(): error: Error: Route ${path} used \`cookies()\` inside \`after()\`. This is not supported.`
-        )
-
         expect(logs).not.toContain(`[${path}] connection(): ok`)
         expect(logs).toContain(
           `[${path}] connection(): error: Error: Route ${path} used \`connection()\` inside \`after()\`.`
+        )
+      })
+      await retry(() => {
+        const logs = getLogs()
+
+        expect(logs).not.toContain(`[${path}] nested headers(): ok`)
+        expect(logs).toContain(
+          `[${path}] nested headers(): error: Error: Route ${path} used \`headers()\` inside \`after()\`. This is not supported.`
+        )
+
+        expect(logs).not.toContain(`[${path}] nested cookies(): ok`)
+        expect(logs).toContain(
+          `[${path}] nested cookies(): error: Error: Route ${path} used \`cookies()\` inside \`after()\`. This is not supported.`
         )
 
         expect(logs).not.toContain(`[${path}] nested connection(): ok`)
@@ -105,24 +108,27 @@ describe('nextjs APIs in after()', () => {
             `[${path}] headers(): error: Error: Route ${path} used \`headers()\` inside \`after()\`. This is not supported.`
           )
 
-          expect(logs).not.toContain(`[${path}] nested headers(): ok`)
-          expect(logs).toContain(
-            `[${path}] nested headers(): error: Error: Route ${path} used \`headers()\` inside \`after()\`. This is not supported.`
-          )
-
           expect(logs).not.toContain(`[${path}] cookies(): ok`)
           expect(logs).toContain(
             `[${path}] cookies(): error: Error: Route ${path} used \`cookies()\` inside \`after()\`. This is not supported.`
           )
 
-          expect(logs).not.toContain(`[${path}] nested cookies(): ok`)
-          expect(logs).toContain(
-            `[${path}] nested cookies(): error: Error: Route ${path} used \`cookies()\` inside \`after()\`. This is not supported.`
-          )
-
           expect(logs).not.toContain(`[${path}] connection(): ok`)
           expect(logs).toContain(
             `[${path}] connection(): error: Error: Route ${path} used \`connection()\` inside \`after()\`.`
+          )
+        })
+        await retry(() => {
+          const logs = isNextDev ? getLogs() : buildLogs // in `next start` the error was logged at build time
+
+          expect(logs).not.toContain(`[${path}] nested headers(): ok`)
+          expect(logs).toContain(
+            `[${path}] nested headers(): error: Error: Route ${path} used \`headers()\` inside \`after()\`. This is not supported.`
+          )
+
+          expect(logs).not.toContain(`[${path}] nested cookies(): ok`)
+          expect(logs).toContain(
+            `[${path}] nested cookies(): error: Error: Route ${path} used \`cookies()\` inside \`after()\`. This is not supported.`
           )
 
           expect(logs).not.toContain(`[${path}] nested connection(): ok`)


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/actions/runs/18941629713/job/54081745985?pr=85563

Nested after calls are delayed further it seems. Moving the assertions for the nested calls into a subsequent retry.