### PR TITLE
eslint-plugin-next: Fix types not referenced correctly from package.json

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -44,19 +44,19 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/src/index.d.ts",
       "default": "./dist/index.js"
     },
     "./core-web-vitals": {
-      "types": "./dist/core-web-vitals.d.ts",
+      "types": "./dist/src/core-web-vitals.d.ts",
       "default": "./dist/core-web-vitals.js"
     },
     "./typescript": {
-      "types": "./dist/typescript.d.ts",
+      "types": "./dist/src/typescript.d.ts",
       "default": "./dist/typescript.js"
     },
     "./parser": {
-      "types": "./dist/parser.d.ts",
+      "types": "./dist/src/parser.d.ts",
       "default": "./dist/parser.js"
     }
   }


### PR DESCRIPTION
According to package.json the types should be in `./dist/` (https://github.com/vercel/next.js/blob/canary/packages/eslint-config-next/package.json#L45-L61), but if you just download the package, you'll see they are somehow in `./dist/src`

This PR updates the reference in package.json to fix that - but we could also update the script to output the type files straight into `./dist`, just tell me what you'd prefer.