### PR TITLE
[test] Deflake tests comparing two random numbers

### DIFF
--- a/test/e2e/app-dir/cache-components/app/node-crypto/random-int/between/cached/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/node-crypto/random-int/between/cached/page.tsx
@@ -25,8 +25,8 @@ async function getRandomIntBetween(nonce: number) {
   if (nonce === 2) {
     // We want to exercise the case where the function arguments are length 3
     // but the third arg is still not a callback so it runs sync
-    return crypto.randomInt(128, 256, undefined) as undefined as number
+    return crypto.randomInt(0, 2 ** 48 - 1, undefined) as undefined as number
   } else {
-    return crypto.randomInt(128, 256)
+    return crypto.randomInt(0, 2 ** 48 - 1)
   }
 }

--- a/test/e2e/app-dir/cache-components/app/node-crypto/random-int/up-to/cached/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/node-crypto/random-int/up-to/cached/page.tsx
@@ -20,7 +20,7 @@ export default async function Page() {
   )
 }
 
-async function getRandomIntUpTo(_nonce: number) {
+async function getRandomIntUpTo(nonce: number) {
   'use cache'
-  return crypto.randomInt(128)
+  return crypto.randomInt(2 ** 48 - 1)
 }

--- a/test/e2e/app-dir/cache-components/app/node-crypto/random-int/up-to/cached/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/node-crypto/random-int/up-to/cached/page.tsx
@@ -20,7 +20,7 @@ export default async function Page() {
   )
 }
 
-async function getRandomIntUpTo(nonce: number) {
+async function getRandomIntUpTo(_nonce: number) {
   'use cache'
   return crypto.randomInt(2 ** 48 - 1)
 }


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/actions/runs/18941959686/job/54089826267

Tests asserted that two consecutive random numbers are not equal. If random number generators would work that way, they wouldn't be truly random.

The range was very low (<=128) so every 128 tests failed without fault. We retry 2 more times so it only showed up as truly failed 1 in a million. That's not that unreasonable to hit.

1:2^48 should be actually rare. I buy you a beer if you get a test failure on that.