### PR TITLE
Docs: Updating router.refresh description in caching.mdx

### DIFF
--- a/docs/01-app/02-guides/caching.mdx
+++ b/docs/01-app/02-guides/caching.mdx
@@ -437,7 +437,7 @@ See the [`useRouter` hook](/docs/app/api-reference/functions/use-router) API ref
 
 ### `router.refresh`
 
-The `refresh` option of the `useRouter` hook can be used to manually refresh a route. This completely clears the Router Cache, and makes a new request to the server for the current route. `refresh` does not affect the Data or Full Route Cache.
+The `refresh` option of the `useRouter` hook can be used to manually refresh a route. This completely clears the Client-Side Router Cache, and makes a new request to the server for the current route. `refresh` does not expire/revalidate [Cache Components](/docs/app/getting-started/cache-components), affect the Data or Full Route Cache.
 
 The rendered result will be reconciled on the client while preserving React state and browser state.
 


### PR DESCRIPTION
The description is a little confusind on the "This completely clears the Router Cache" wording when it does not expire or revalidate the new cache components. I am not sure how to update the wording properly as I am not entirely sure what "the Data or Full Route Cache" indicated here.

Feel free to make updates to this branch if you have a better way of wording it. I have inserted the link for Cache Components, but needs a better transition between that and the old text.
