### PR TITLE
Turbopack: chore: Remove the serde_regex dependency, which wasn't very heavily used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6495,16 +6495,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_regex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
-dependencies = [
- "regex",
- "serde",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9209,7 +9199,6 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "serde_regex",
  "shrink-to-fit",
  "smallvec",
  "thiserror 1.0.69",

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -39,7 +39,6 @@ regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["rc", "derive"] }
 serde_json = { workspace = true }
-serde_regex = "1.1.0"
 shrink-to-fit = { workspace=true,features = ["indexmap", "serde_json", "smallvec", "nightly"] }
 smallvec = { workspace = true }
 thiserror = { workspace = true }

--- a/turbopack/crates/turbo-tasks/src/primitives.rs
+++ b/turbopack/crates/turbo-tasks/src/primitives.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, time::Duration};
+use std::time::Duration;
 
 use turbo_rcstr::RcStr;
 use turbo_tasks_macros::primitive as __turbo_tasks_internal_primitive;
@@ -33,27 +33,3 @@ __turbo_tasks_internal_primitive!(serde_json::Value);
 __turbo_tasks_internal_primitive!(Duration);
 __turbo_tasks_internal_primitive!(Vec<u8>, manual_shrink_to_fit);
 __turbo_tasks_internal_primitive!(Vec<bool>, manual_shrink_to_fit);
-
-#[turbo_tasks::value(transparent, eq = "manual")]
-#[derive(Debug, Clone)]
-pub struct Regex(
-    #[turbo_tasks(trace_ignore)]
-    #[serde(with = "serde_regex")]
-    pub regex::Regex,
-);
-
-impl Deref for Regex {
-    type Target = regex::Regex;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl PartialEq for Regex {
-    fn eq(&self, other: &Regex) -> bool {
-        // Context: https://github.com/rust-lang/regex/issues/313#issuecomment-269898900
-        self.0.as_str() == other.0.as_str()
-    }
-}
-impl Eq for Regex {}

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -3,12 +3,12 @@ use std::{
     mem::{replace, take},
 };
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use either::Either;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use turbo_esregex::EsRegex;
-use turbo_tasks::{NonLocalValue, ReadRef, ResolvedVc, primitives::Regex, trace::TraceRawVcs};
+use turbo_tasks::{NonLocalValue, ReadRef, ResolvedVc, trace::TraceRawVcs};
 use turbo_tasks_fs::{FileContent, FileSystemPath, glob::Glob};
 use turbopack_core::{
     asset::Asset, reference_type::ReferenceType, source::Source, virtual_source::VirtualSource,
@@ -30,7 +30,6 @@ pub enum RuleCondition {
     ResourcePathInExactDirectory(FileSystemPath),
     ContentTypeStartsWith(String),
     ContentTypeEmpty,
-    ResourcePathRegex(#[turbo_tasks(trace_ignore)] Regex),
     ResourcePathEsRegex(#[turbo_tasks(trace_ignore)] ReadRef<EsRegex>),
     ResourceContentEsRegex(#[turbo_tasks(trace_ignore)] ReadRef<EsRegex>),
     /// For paths that are within the same filesystem as the `base`, it need to
@@ -267,9 +266,6 @@ impl RuleCondition {
                             .rsplit_once('/')
                             .map_or(path.path.as_str(), |(_, b)| b);
                         return Ok(glob.matches(basename));
-                    }
-                    RuleCondition::ResourcePathRegex(_) => {
-                        bail!("ResourcePathRegex not implemented yet");
                     }
                     RuleCondition::ResourcePathEsRegex(regex) => {
                         return Ok(regex.is_match(&path.path));


### PR DESCRIPTION
It doesn't seem like it's worth pulling in this dependency anymore. Most of the places we need to serialize a regex, we use `EsRegex`, which handles serialization itself, and is a superset of `Regex`.