### PR TITLE
Turbopack: bincode: Implement bincode Encode/Decode traits on all turbo task values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 name = "auto-hash-map"
 version = "0.1.0"
 dependencies = [
+ "bincode 2.0.1",
  "hashbrown 0.14.5",
  "rustc-hash 2.1.1",
  "serde",
@@ -4261,6 +4262,7 @@ name = "next-api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "byteorder",
  "either",
  "futures",
@@ -4275,6 +4277,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "turbo-bincode",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-backend",
@@ -4337,6 +4340,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.4",
+ "bincode 2.0.1",
  "either",
  "futures",
  "indexmap 2.9.0",
@@ -4361,6 +4365,7 @@ dependencies = [
  "swc_sourcemap",
  "thiserror 1.0.69",
  "tracing",
+ "turbo-bincode",
  "turbo-esregex",
  "turbo-rcstr",
  "turbo-tasks",
@@ -4425,6 +4430,7 @@ name = "next-swc-napi"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "console-subscriber",
  "dhat",
  "either",
@@ -6762,7 +6768,9 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
+ "bincode 2.0.1",
  "serde",
+ "unty",
 ]
 
 [[package]]
@@ -9108,6 +9116,7 @@ name = "turbo-esregex"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "regex",
  "regress",
  "serde",
@@ -9156,6 +9165,7 @@ version = "0.1.0"
 name = "turbo-rcstr"
 version = "0.1.0"
 dependencies = [
+ "bincode 2.0.1",
  "bytes-str",
  "codspeed-criterion-compat",
  "napi",
@@ -9195,6 +9205,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "auto-hash-map",
+ "bincode 2.0.1",
  "codspeed-criterion-compat",
  "concurrent-queue",
  "dashmap 6.1.0",
@@ -9234,6 +9245,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "auto-hash-map",
+ "bincode 2.0.1",
  "bitfield",
  "byteorder",
  "codspeed-criterion-compat",
@@ -9287,6 +9299,7 @@ name = "turbo-tasks-bytes"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "bytes",
  "futures",
  "serde",
@@ -9301,6 +9314,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dotenvs",
+ "turbo-bincode",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-fs",
@@ -9331,6 +9345,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
+ "bincode 2.0.1",
  "bitflags 1.3.2",
  "bytes",
  "codspeed-criterion-compat",
@@ -9356,6 +9371,7 @@ dependencies = [
  "tokio",
  "tracing",
  "triomphe 0.1.12",
+ "turbo-bincode",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-backend",
@@ -9446,6 +9462,7 @@ name = "turbopack"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "either",
  "regex",
  "rustc-hash 2.1.1",
@@ -9478,6 +9495,7 @@ name = "turbopack-analyze"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -9521,12 +9539,14 @@ name = "turbopack-browser"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "either",
  "indoc",
  "serde",
  "serde_json",
  "serde_qs",
  "tracing",
+ "turbo-bincode",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-fs",
@@ -9604,6 +9624,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "auto-hash-map",
+ "bincode 2.0.1",
  "bitfield",
  "browserslist-rs",
  "bytes-str",
@@ -9627,6 +9648,7 @@ dependencies = [
  "swc_sourcemap",
  "tokio",
  "tracing",
+ "turbo-bincode",
  "turbo-prehash",
  "turbo-rcstr",
  "turbo-tasks",
@@ -9659,6 +9681,7 @@ name = "turbopack-css"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "indoc",
  "lightningcss",
  "parcel_selectors",
@@ -9669,6 +9692,7 @@ dependencies = [
  "swc_core",
  "tokio",
  "tracing",
+ "turbo-bincode",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-fs",
@@ -9683,6 +9707,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
+ "bincode 2.0.1",
  "flate2",
  "futures",
  "hyper 0.14.32",
@@ -9700,6 +9725,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "turbo-bincode",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-backend",
@@ -9720,6 +9746,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "auto-hash-map",
+ "bincode 2.0.1",
  "bytes-str",
  "codspeed-criterion-compat",
  "dashmap 6.1.0",
@@ -9743,6 +9770,7 @@ dependencies = [
  "swc_sourcemap",
  "tokio",
  "tracing",
+ "turbo-bincode",
  "turbo-esregex",
  "turbo-rcstr",
  "turbo-tasks",
@@ -9775,6 +9803,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode 2.0.1",
  "indexmap 2.9.0",
  "rustc-hash 2.1.1",
  "serde",
@@ -9827,6 +9856,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
+ "bincode 2.0.1",
  "image",
  "mime",
  "once_cell",
@@ -9834,6 +9864,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_with",
+ "turbo-bincode",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-fs",
@@ -9902,6 +9933,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64 0.21.4",
+ "bincode 2.0.1",
  "const_format",
  "either",
  "futures",
@@ -9917,6 +9949,7 @@ dependencies = [
  "serde_with",
  "tokio",
  "tracing",
+ "turbo-bincode",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-bytes",
@@ -9933,8 +9966,10 @@ name = "turbopack-nodejs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "indoc",
  "tracing",
+ "turbo-bincode",
  "turbo-rcstr",
  "turbo-tasks",
  "turbo-tasks-fs",
@@ -9992,6 +10027,7 @@ name = "turbopack-test-utils"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "once_cell",
  "regex",
  "rustc-hash 2.1.1",
@@ -10010,6 +10046,7 @@ name = "turbopack-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "dunce",
  "once_cell",
  "rustc-hash 2.1.1",
@@ -10109,6 +10146,7 @@ name = "turbopack-wasm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "indoc",
  "serde",
  "turbo-rcstr",
@@ -10465,8 +10503,7 @@ dependencies = [
 [[package]]
 name = "virtue"
 version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+source = "git+https://github.com/bgw/virtue.git?branch=bgw%2Ffix-generic-default-parsing#e386f35cf7f22d04a4db32231904cbe5dc52c01d"
 
 [[package]]
 name = "vlq"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,11 +451,12 @@ serde_bytes = "0.11.15"
 serde_path_to_error = "0.1.16"
 serde_qs = "0.13.0"
 serde_with = "3.12.0"
-smallvec = { version = "1.13.1", features = [
+smallvec = { version = "1.15.1", features = [
   "serde",
   "const_generics",
   "union",
   "const_new",
+  "impl_bincode",
 ] }
 swc_sourcemap = "9.3.4"
 strsim = "0.11.1"
@@ -481,4 +482,5 @@ inventory = "0.3.21"
 
 [patch.crates-io]
 bincode = { git = "https://github.com/bgw/bincode.git", branch = "bgw/patches" }
+virtue = { git = "https://github.com/bgw/virtue.git", branch = "bgw/fix-generic-default-parsing" }
 mdxjs = { git = "https://github.com/mischnic/mdxjs-rs.git", branch = "swc-core-32" }

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -56,6 +56,7 @@ ignored = [
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
 dhat = { workspace = true, optional = true }
 either = { workspace = true }

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, io::Write, path::PathBuf, sync::Arc, thread, time::Duration};
 
 use anyhow::{Context, Result, anyhow, bail};
+use bincode::{Decode, Encode};
 use flate2::write::GzEncoder;
 use futures_util::TryFutureExt;
 use napi::{
@@ -1528,6 +1529,8 @@ pub fn project_compilation_events_subscribe(
     Serialize,
     TaskInput,
     TraceRawVcs,
+    Encode,
+    Decode,
 )]
 pub struct StackFrame {
     pub is_server: bool,

--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 byteorder = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
@@ -26,6 +27,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 swc_core = { workspace = true }
 tracing = { workspace = true }
+turbo-bincode = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-hash = { workspace = true }

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use bincode::{Decode, Encode};
 use next_core::{
     app_structure::{
         AppPageLoaderTree, CollectedRootParams, Entrypoint as AppEntrypoint,
@@ -1068,13 +1069,27 @@ pub fn app_entry_point_to_route(
 #[turbo_tasks::value(transparent)]
 struct OutputAssetsWithAvailability((ResolvedVc<OutputAssets>, AvailabilityInfo));
 
-#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Debug, TraceRawVcs, NonLocalValue)]
+#[derive(
+    Copy,
+    Clone,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Debug,
+    TraceRawVcs,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
 enum AppPageEndpointType {
     Html,
     Rsc,
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug, TraceRawVcs, NonLocalValue)]
+#[derive(
+    Clone, Serialize, Deserialize, PartialEq, Eq, Debug, TraceRawVcs, NonLocalValue, Encode, Decode,
+)]
 enum AppEndpointType {
     Page {
         ty: AppPageEndpointType,

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use next_core::{
     next_client_reference::{CssClientReferenceModule, EcmascriptClientReferenceModule},
     next_server_component::server_component_module::NextServerComponentModule,
@@ -12,7 +13,17 @@ use turbopack_core::{module::Module, module_graph::SingleModuleGraph};
 use turbopack_css::chunk::CssChunkPlaceable;
 
 #[derive(
-    Copy, Clone, Serialize, Deserialize, Eq, PartialEq, TraceRawVcs, ValueDebugFormat, NonLocalValue,
+    Copy,
+    Clone,
+    Serialize,
+    Deserialize,
+    Eq,
+    PartialEq,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum ClientManifestEntryType {
     EcmascriptClientReference {

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -20,6 +20,7 @@
 //!      won't occur
 
 use anyhow::{Context, Result};
+use bincode::{Decode, Encode};
 use next_core::{
     next_app::ClientReferencesChunks, next_client_reference::EcmascriptClientReferenceModule,
     next_dynamic::NextDynamicEntryModule,
@@ -102,6 +103,7 @@ pub(crate) async fn collect_next_dynamic_chunks(
 #[turbo_tasks::value(transparent)]
 #[derive(Default)]
 pub struct DynamicImportedChunks(
+    #[bincode(with = "turbo_bincode::indexmap")]
     pub  FxIndexMap<
         ResolvedVc<NextDynamicEntryModule>,
         (ResolvedVc<ModuleId>, ResolvedVc<OutputAssetsWithReferenced>),
@@ -109,7 +111,16 @@ pub struct DynamicImportedChunks(
 );
 
 #[derive(
-    Clone, PartialEq, Eq, ValueDebugFormat, Serialize, Deserialize, TraceRawVcs, NonLocalValue,
+    Clone,
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum DynamicImportEntriesMapType {
     DynamicEntry(ResolvedVc<NextDynamicEntryModule>),
@@ -118,7 +129,8 @@ pub enum DynamicImportEntriesMapType {
 
 #[turbo_tasks::value(transparent)]
 pub struct DynamicImportEntries(
-    pub FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportEntriesMapType>,
+    #[bincode(with = "turbo_bincode::indexmap")]
+    pub  FxIndexMap<ResolvedVc<Box<dyn Module>>, DynamicImportEntriesMapType>,
 );
 
 #[turbo_tasks::function]

--- a/crates/next-api/src/entrypoints.rs
+++ b/crates/next-api/src/entrypoints.rs
@@ -8,6 +8,7 @@ use crate::{
 
 #[turbo_tasks::value(shared)]
 pub struct Entrypoints {
+    #[bincode(with = "turbo_bincode::indexmap")]
     pub routes: FxIndexMap<RcStr, Route>,
     pub middleware: Option<Middleware>,
     pub instrumentation: Option<Instrumentation>,

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -761,7 +761,7 @@ impl Issue for CssGlobalImportIssue {
 type FxModuleNameMap = FxIndexMap<ResolvedVc<Box<dyn Module>>, RcStr>;
 
 #[turbo_tasks::value(transparent)]
-struct ModuleNameMap(pub FxModuleNameMap);
+struct ModuleNameMap(#[bincode(with = "turbo_bincode::indexmap")] pub FxModuleNameMap);
 
 #[tracing::instrument(level = "info", name = "validate pages css imports", skip_all)]
 #[turbo_tasks::function]

--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use anyhow::{Context, Result, bail};
+use bincode::{Decode, Encode};
 use either::Either;
 use next_core::{get_next_package, next_server::get_tracing_compile_time_info};
 use serde::{Deserialize, Serialize};
@@ -31,7 +32,18 @@ use crate::{
 };
 
 #[derive(
-    PartialEq, Eq, TraceRawVcs, NonLocalValue, Deserialize, Serialize, Debug, Clone, Hash, TaskInput,
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    NonLocalValue,
+    Deserialize,
+    Serialize,
+    Debug,
+    Clone,
+    Hash,
+    TaskInput,
+    Encode,
+    Decode,
 )]
 enum ServerNftType {
     Minimal,

--- a/crates/next-api/src/operation.rs
+++ b/crates/next-api/src/operation.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
@@ -22,6 +23,7 @@ use crate::{
 /// This is needed to call `write_to_disk` which expects an `OperationVc<Endpoint>`.
 #[turbo_tasks::value(shared)]
 pub struct EntrypointsOperation {
+    #[bincode(with = "turbo_bincode::indexmap")]
     pub routes: FxIndexMap<RcStr, RouteOperation>,
     pub middleware: Option<MiddlewareOperation>,
     pub instrumentation: Option<InstrumentationOperation>,
@@ -204,13 +206,33 @@ async fn pick_endpoint(
     Ok(Vc::cell(endpoint))
 }
 
-#[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, NonLocalValue)]
+#[derive(
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
 pub struct InstrumentationOperation {
     pub node_js: OperationVc<OptionEndpoint>,
     pub edge: OperationVc<OptionEndpoint>,
 }
 
-#[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, NonLocalValue)]
+#[derive(
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
 pub struct MiddlewareOperation {
     pub endpoint: OperationVc<OptionEndpoint>,
     pub is_proxy: bool,
@@ -244,6 +266,8 @@ pub enum RouteOperation {
     Clone,
     Debug,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct AppPageRouteOperation {
     pub original_name: RcStr,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use bincode::{Decode, Encode};
 use futures::future::BoxFuture;
 use next_core::{
     PageLoaderAsset, create_page_loader_entry_module, get_asset_path_from_pathname,
@@ -597,6 +598,8 @@ struct PageEndpoint {
     TaskInput,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 enum PageEndpointType {
     Api,

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
+use bincode::{Decode, Encode};
 use indexmap::map::Entry;
 use next_core::{
     app_structure::find_app_dir,
@@ -105,6 +106,8 @@ use crate::{
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct DraftModeOptions {
@@ -127,6 +130,8 @@ pub struct DraftModeOptions {
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct WatchOptions {
@@ -150,6 +155,8 @@ pub struct WatchOptions {
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectOptions {
@@ -263,6 +270,8 @@ pub struct PartialProjectOptions {
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct DefineEnv {
@@ -271,13 +280,33 @@ pub struct DefineEnv {
     pub nodejs: Vec<(RcStr, Option<RcStr>)>,
 }
 
-#[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, NonLocalValue)]
+#[derive(
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
 pub struct Middleware {
     pub endpoint: ResolvedVc<Box<dyn Endpoint>>,
     pub is_proxy: bool,
 }
 
-#[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, ValueDebugFormat, NonLocalValue)]
+#[derive(
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
 pub struct Instrumentation {
     pub node_js: ResolvedVc<Box<dyn Endpoint>>,
     pub edge: ResolvedVc<Box<dyn Endpoint>>,

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
@@ -24,6 +25,8 @@ use crate::{operation::OptionEndpoint, paths::ServerPath, project::Project};
     Clone,
     Debug,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct AppPageRoute {
     pub original_name: RcStr,
@@ -84,6 +87,8 @@ pub trait Endpoint {
     Clone,
     Debug,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum EndpointGroupKey {
     Instrumentation,
@@ -133,6 +138,8 @@ impl Display for EndpointGroupKey {
     Clone,
     Debug,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct EndpointGroupEntry {
     pub endpoint: ResolvedVc<Box<dyn Endpoint>>,
@@ -149,6 +156,8 @@ pub struct EndpointGroupEntry {
     Clone,
     Debug,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct EndpointGroup {
     pub primary: Vec<EndpointGroupEntry>,
@@ -309,4 +318,4 @@ pub enum EndpointOutputPaths {
 /// The routes as map from pathname to route. (pathname includes the leading
 /// slash)
 #[turbo_tasks::value(transparent)]
-pub struct Routes(FxIndexMap<RcStr, Route>);
+pub struct Routes(#[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<RcStr, Route>);

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -434,6 +434,7 @@ impl AllActions {
 #[turbo_tasks::value]
 #[derive(Debug)]
 pub struct ActionMap {
+    #[bincode(with = "turbo_bincode::indexmap")]
     pub actions: FxIndexMap<String, String>,
     pub entry_path: String,
     pub entry_query: String,
@@ -446,7 +447,10 @@ struct OptionActionMap(Option<ResolvedVc<ActionMap>>);
 type LayerAndActions = (ActionLayer, ResolvedVc<ActionMap>);
 /// A mapping of every module module containing Server Actions, mapping to its layer and actions.
 #[turbo_tasks::value(transparent)]
-pub struct AllModuleActions(FxIndexMap<ResolvedVc<Box<dyn Module>>, LayerAndActions>);
+pub struct AllModuleActions(
+    #[bincode(with = "turbo_bincode::indexmap")]
+    FxIndexMap<ResolvedVc<Box<dyn Module>>, LayerAndActions>,
+);
 
 #[turbo_tasks::function]
 pub async fn map_server_actions(graph: Vc<SingleModuleGraph>) -> Result<Vc<AllModuleActions>> {

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -15,27 +15,28 @@ workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = "0.21.0"
+allsorts = { workspace = true }
+bincode = { workspace = true }
 either = { workspace = true, features = ["serde"] }
+futures = { workspace = true }
+indexmap = { workspace = true, features = ["serde"] }
+indoc = { workspace = true }
+itertools = { workspace = true }
+mime_guess = "2.0.4"
 once_cell = { workspace = true }
+percent-encoding = "2.3.1"
 qstring = { workspace = true }
+react_remove_properties = { workspace = true }
 regex = { workspace = true }
+regress = { workspace = true }
+remove_console = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-indexmap = { workspace = true, features = ["serde"] }
-mime_guess = "2.0.4"
-indoc = { workspace = true }
-allsorts = { workspace = true }
-futures = { workspace = true }
-thiserror = { workspace = true }
-tracing = { workspace = true }
-regress = { workspace = true }
-rustc-hash = { workspace = true }
-react_remove_properties = { workspace = true }
-remove_console = { workspace = true }
-itertools = { workspace = true }
-percent-encoding = "2.3.1"
 serde_path_to_error = { workspace = true }
 swc_sourcemap = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
 
 swc_core = { workspace = true, features = [
   "base",
@@ -59,6 +60,7 @@ modularize_imports = { workspace = true }
 next-custom-transforms = { workspace = true }
 next-taskless = { workspace = true }
 
+turbo-bincode = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-esregex = { workspace = true }
 turbo-tasks = { workspace = true }

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -32,7 +32,7 @@ pub fn route_bootstrap(
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct BootstrapConfig(FxIndexMap<String, String>);
+pub struct BootstrapConfig(#[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<String, String>);
 
 #[turbo_tasks::value_impl]
 impl BootstrapConfig {

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -22,10 +22,13 @@ use crate::{
 
 #[turbo_tasks::value]
 pub struct ClientReferencesChunks {
+    #[bincode(with = "turbo_bincode::indexmap")]
     pub client_component_client_chunks:
         FxIndexMap<ClientReferenceType, ResolvedVc<ChunkGroupResult>>,
+    #[bincode(with = "turbo_bincode::indexmap")]
     pub client_component_ssr_chunks:
         FxIndexMap<ClientReferenceType, ResolvedVc<OutputAssetsWithReferenced>>,
+    #[bincode(with = "turbo_bincode::indexmap")]
     pub layout_segment_client_chunks:
         FxIndexMap<ResolvedVc<NextServerComponentModule>, ResolvedVc<OutputAssetsWithReferenced>>,
 }

--- a/crates/next-core/src/next_app/mod.rs
+++ b/crates/next-core/src/next_app/mod.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
@@ -38,6 +39,8 @@ pub use crate::next_app::{
     TaskInput,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum PageSegment {
     /// e.g. `/dashboard`
@@ -143,6 +146,8 @@ impl Display for PageSegment {
     TaskInput,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum PageType {
     Page,
@@ -173,6 +178,8 @@ impl Display for PageType {
     TaskInput,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct AppPage(pub Vec<PageSegment>);
 
@@ -357,6 +364,8 @@ impl PartialOrd for AppPage {
     TaskInput,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum PathSegment {
     /// e.g. `/dashboard`
@@ -409,6 +418,8 @@ impl Display for PathSegment {
     TaskInput,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct AppPath(pub Vec<PathSegment>);
 

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use tracing::{Instrument, Level, Span};
 use turbo_rcstr::RcStr;
@@ -36,6 +37,8 @@ use crate::{
     ValueDebugFormat,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct ClientReference {
     pub server_component: Option<ResolvedVc<NextServerComponentModule>>,
@@ -54,6 +57,8 @@ pub struct ClientReference {
     ValueDebugFormat,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum ClientReferenceType {
     EcmascriptClientReference(ResolvedVc<EcmascriptClientReferenceModule>),

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use bincode::{Decode, Encode};
 use either::Either;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -49,7 +50,9 @@ struct CustomRoutes {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct ModularizeImports(FxIndexMap<String, ModularizeImportPackageConfig>);
+pub struct ModularizeImports(
+    #[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<String, ModularizeImportPackageConfig>,
+);
 
 #[turbo_tasks::value(transparent)]
 #[derive(Clone, Debug)]
@@ -87,7 +90,9 @@ pub struct NextConfig {
     cache_max_memory_size: Option<f64>,
     /// custom path to a cache handler to use
     cache_handler: Option<RcStr>,
+    #[bincode(with_serde)]
     cache_handlers: Option<FxIndexMap<RcStr, RcStr>>,
+    #[bincode(with = "turbo_bincode::serde_json")]
     env: FxIndexMap<String, JsonValue>,
     experimental: ExperimentalConfig,
     images: ImageConfig,
@@ -96,10 +101,12 @@ pub struct NextConfig {
     react_production_profiling: Option<bool>,
     react_strict_mode: Option<bool>,
     transpile_packages: Option<Vec<RcStr>>,
+    #[bincode(with = "turbo_bincode::serde_json")]
     modularize_imports: Option<FxIndexMap<String, ModularizeImportPackageConfig>>,
     dist_dir: RcStr,
     dist_dir_root: RcStr,
     deployment_id: Option<RcStr>,
+    #[bincode(with = "turbo_bincode::serde_json")]
     sass_options: Option<serde_json::Value>,
     trailing_slash: Option<bool>,
     asset_prefix: Option<RcStr>,
@@ -112,7 +119,9 @@ pub struct NextConfig {
     output: Option<OutputType>,
     turbopack: Option<TurbopackConfig>,
     production_browser_source_maps: bool,
+    #[bincode(with = "turbo_bincode::serde_json")]
     output_file_tracing_includes: Option<serde_json::Value>,
+    #[bincode(with = "turbo_bincode::serde_json")]
     output_file_tracing_excludes: Option<serde_json::Value>,
     // TODO: This option is not respected, it uses Turbopack's root instead.
     output_file_tracing_root: Option<RcStr>,
@@ -145,7 +154,9 @@ pub struct NextConfig {
     http_agent_options: HttpAgentConfig,
     on_demand_entries: OnDemandEntriesConfig,
     powered_by_header: bool,
+    #[bincode(with = "turbo_bincode::serde_json")]
     public_runtime_config: FxIndexMap<String, serde_json::Value>,
+    #[bincode(with = "turbo_bincode::serde_json")]
     server_runtime_config: FxIndexMap<String, serde_json::Value>,
     static_page_generation_timeout: f64,
     target: Option<String>,
@@ -171,7 +182,17 @@ impl NextConfig {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum CrossOriginConfig {
@@ -192,6 +213,8 @@ pub struct OptionCrossOriginConfig(Option<CrossOriginConfig>);
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 struct EslintConfig {
@@ -209,6 +232,8 @@ struct EslintConfig {
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum BuildActivityPositions {
@@ -229,6 +254,8 @@ pub enum BuildActivityPositions {
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct DevIndicatorsOptions {
@@ -237,7 +264,16 @@ pub struct DevIndicatorsOptions {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(untagged)]
 pub enum DevIndicatorsConfig {
@@ -255,6 +291,8 @@ pub enum DevIndicatorsConfig {
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 struct OnDemandEntriesConfig {
@@ -272,6 +310,8 @@ struct OnDemandEntriesConfig {
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 struct HttpAgentConfig {
@@ -279,7 +319,17 @@ struct HttpAgentConfig {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct DomainLocale {
@@ -290,7 +340,17 @@ pub struct DomainLocale {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct I18NConfig {
@@ -304,7 +364,17 @@ pub struct I18NConfig {
 pub struct OptionI18NConfig(Option<I18NConfig>);
 
 #[derive(
-    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum OutputType {
@@ -329,6 +399,8 @@ pub struct OptionOutputType(Option<OutputType>);
     Deserialize,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum RouteHas {
@@ -375,7 +447,16 @@ pub struct Header {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub enum RedirectStatus {
@@ -384,7 +465,16 @@ pub enum RedirectStatus {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct Redirect {
@@ -403,7 +493,9 @@ pub struct Redirect {
     pub status: RedirectStatus,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
+#[derive(
+    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, Encode, Decode,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct Rewrite {
     pub source: String,
@@ -437,6 +529,8 @@ pub struct Rewrites {
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct TypeScriptConfig {
@@ -496,7 +590,16 @@ impl Default for ImageConfig {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum ImageLoader {
@@ -508,7 +611,16 @@ pub enum ImageLoader {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 pub enum ImageFormat {
     #[serde(rename = "image/webp")]
@@ -527,6 +639,8 @@ pub enum ImageFormat {
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct RemotePattern {
@@ -540,7 +654,16 @@ pub struct RemotePattern {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum RemotePatternProtocol {
@@ -558,12 +681,14 @@ pub enum RemotePatternProtocol {
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct TurbopackConfig {
-    /// This option has been replaced by `rules`.
-    pub loaders: Option<JsonValue>,
+    #[bincode(with = "turbo_bincode::serde_json")]
     pub rules: Option<FxIndexMap<RcStr, RuleConfigCollection>>,
+    #[bincode(with = "turbo_bincode::serde_json")]
     pub resolve_alias: Option<FxIndexMap<RcStr, JsonValue>>,
     pub resolve_extensions: Option<Vec<RcStr>>,
     pub debug_ids: Option<bool>,
@@ -731,7 +856,16 @@ pub enum ModuleIds {
 pub struct OptionModuleIds(pub Option<ModuleIds>);
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(untagged)]
 pub enum MdxRsOptions {
@@ -771,7 +905,16 @@ pub struct ReactCompilerOptions {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(untagged)]
 pub enum ReactCompilerOptionsOrBoolean {
@@ -793,6 +936,8 @@ pub struct OptionalReactCompilerOptions(Option<ResolvedVc<ReactCompilerOptions>>
     ValueDebugFormat,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct ExperimentalConfig {
@@ -810,6 +955,7 @@ pub struct ExperimentalConfig {
     /// @see [api reference](https://nextjs.org/docs/app/api-reference/next-config-js/mdxRs)
     mdx_rs: Option<MdxRsOptions>,
     strict_next_head: Option<bool>,
+    #[bincode(with = "turbo_bincode::serde_json")]
     swc_plugins: Option<Vec<(RcStr, serde_json::Value)>>,
     external_middleware_rewrites_resolve: Option<bool>,
     scroll_restoration: Option<bool>,
@@ -818,6 +964,7 @@ pub struct ExperimentalConfig {
     middleware_prefetch: Option<MiddlewarePrefetchType>,
     /// optimizeCss can be boolean or critters' option object
     /// Use Record<string, unknown> as critters doesn't export its Option type ([link](https://github.com/GoogleChromeLabs/critters/blob/a590c05f9197b656d2aeaae9369df2483c26b072/packages/critters/src/index.d.ts))
+    #[bincode(with = "turbo_bincode::serde_json")]
     optimize_css: Option<serde_json::Value>,
     next_script_workers: Option<bool>,
     web_vitals_attribution: Option<Vec<RcStr>>,
@@ -835,6 +982,7 @@ pub struct ExperimentalConfig {
     adjust_font_fallbacks_with_size_adjust: Option<bool>,
     after: Option<bool>,
     app_document_preloading: Option<bool>,
+    #[bincode(with = "turbo_bincode::serde_json")]
     cache_life: Option<FxIndexMap<String, CacheLifeProfile>>,
     case_sensitive_routes: Option<bool>,
     cpus: Option<f64>,
@@ -842,6 +990,7 @@ pub struct ExperimentalConfig {
     disable_optimized_loading: Option<bool>,
     disable_postcss_preset_env: Option<bool>,
     esm_externals: Option<EsmExternals>,
+    #[bincode(with = "turbo_bincode::serde_json")]
     extension_alias: Option<serde_json::Value>,
     external_dir: Option<bool>,
     /// If set to `false`, webpack won't fall back to polyfill Node.js modules
@@ -856,6 +1005,7 @@ pub struct ExperimentalConfig {
     instrumentation_hook: Option<bool>,
     client_trace_metadata: Option<Vec<String>>,
     large_page_data_bytes: Option<f64>,
+    #[bincode(with = "turbo_bincode::serde_json")]
     logging: Option<serde_json::Value>,
     memory_based_workers_count: Option<bool>,
     /// Optimize React APIs for server builds.
@@ -874,6 +1024,7 @@ pub struct ExperimentalConfig {
     /// @internal Used by the Next.js internals only.
     trust_host_header: Option<bool>,
 
+    #[bincode(with = "turbo_bincode::serde_json")]
     url_imports: Option<serde_json::Value>,
     /// This option is to enable running the Webpack build in a worker thread
     /// (doesn't apply to Turbopack).
@@ -966,7 +1117,17 @@ fn test_cache_life_profiles_invalid() {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct SubResourceIntegrity {
@@ -974,7 +1135,16 @@ pub struct SubResourceIntegrity {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Deserialize, Serialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Deserialize,
+    Serialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(untagged)]
 pub enum ServerActionsOrLegacyBool {
@@ -987,7 +1157,16 @@ pub enum ServerActionsOrLegacyBool {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Deserialize, Serialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Deserialize,
+    Serialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum EsmExternalsValue {
@@ -995,7 +1174,16 @@ pub enum EsmExternalsValue {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Deserialize, Serialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Deserialize,
+    Serialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(untagged)]
 pub enum EsmExternals {
@@ -1033,6 +1221,8 @@ fn test_esm_externals_deserialization() {
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct ServerActions {
@@ -1040,7 +1230,9 @@ pub struct ServerActions {
     pub body_size_limit: Option<SizeLimit>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue)]
+#[derive(
+    Clone, Debug, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue, Encode, Decode,
+)]
 #[serde(untagged)]
 pub enum SizeLimit {
     Number(f64),
@@ -1062,7 +1254,16 @@ impl PartialEq for SizeLimit {
 impl Eq for SizeLimit {}
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum MiddlewarePrefetchType {
@@ -1071,7 +1272,16 @@ pub enum MiddlewarePrefetchType {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(untagged)]
 pub enum EmotionTransformOptionsOrBoolean {
@@ -1089,7 +1299,16 @@ impl EmotionTransformOptionsOrBoolean {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(untagged)]
 pub enum StyledComponentsTransformOptionsOrBoolean {
@@ -1118,7 +1337,16 @@ pub struct CompilerConfig {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(untagged, rename_all = "camelCase")]
 pub enum ReactRemoveProperties {
@@ -1136,7 +1364,16 @@ impl ReactRemoveProperties {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(untagged)]
 pub enum RemoveConsoleConfig {
@@ -1157,7 +1394,9 @@ impl RemoveConsoleConfig {
 pub struct ResolveExtensions(Option<Vec<RcStr>>);
 
 #[turbo_tasks::value(transparent)]
-pub struct SwcPlugins(Vec<(RcStr, serde_json::Value)>);
+pub struct SwcPlugins(
+    #[bincode(with = "turbo_bincode::serde_json")] Vec<(RcStr, serde_json::Value)>,
+);
 
 #[turbo_tasks::value(transparent)]
 pub struct OptionalMdxTransformOptions(Option<ResolvedVc<MdxTransformOptions>>);
@@ -1173,7 +1412,9 @@ pub struct OptionFileSystemPath(Option<FileSystemPath>);
 pub struct OptionServerActions(Option<ServerActions>);
 
 #[turbo_tasks::value(transparent)]
-pub struct OptionJsonValue(pub Option<serde_json::Value>);
+pub struct OptionJsonValue(
+    #[bincode(with = "turbo_bincode::serde_json")] pub Option<serde_json::Value>,
+);
 
 fn turbopack_config_documentation_link() -> RcStr {
     rcstr!("https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#configuring-webpack-loaders")
@@ -1225,6 +1466,7 @@ impl Issue for InvalidLoaderRuleRenameAsIssue {
 
 #[turbo_tasks::value(shared)]
 struct InvalidLoaderRuleConditionIssue {
+    #[bincode(with = "turbo_bincode::serde_json")]
     condition: ConfigConditionItem,
     config_file_path: FileSystemPath,
 }

--- a/crates/next-core/src/next_font/font_fallback.rs
+++ b/crates/next-core/src/next_font/font_fallback.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
@@ -79,7 +80,7 @@ impl FontFallbacks {
 /// An adjustment to be made to a fallback font to approximate the geometry of
 /// the main webfont. Rendered as e.g. `ascent-override: 56.8%;` in the
 /// stylesheet
-#[derive(Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, Encode, Decode)]
 pub(crate) struct FontAdjustment {
     pub ascent: f64,
     pub descent: f64,

--- a/crates/next-core/src/next_font/google/font_fallback.rs
+++ b/crates/next-core/src/next_font/google/font_fallback.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use bincode::{Decode, Encode};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -7,13 +8,13 @@ use turbo_tasks::{FxIndexMap, NonLocalValue, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{IssueExt, IssueSeverity, StyledString};
 
-use super::options::NextFontGoogleOptions;
 use crate::{
     next_font::{
         font_fallback::{
             AutomaticFontFallback, DEFAULT_SANS_SERIF_FONT, DEFAULT_SERIF_FONT, FontAdjustment,
             FontFallback,
         },
+        google::options::NextFontGoogleOptions,
         issue::NextFontIssue,
         util::{FontFamilyType, get_scoped_font_family},
     },
@@ -21,7 +22,9 @@ use crate::{
 };
 
 /// An entry in the Google fonts metrics map
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, TraceRawVcs, NonLocalValue)]
+#[derive(
+    Deserialize, Serialize, Debug, PartialEq, Eq, TraceRawVcs, NonLocalValue, Encode, Decode,
+)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct FontMetricsMapEntry {
     category: RcStr,
@@ -34,7 +37,9 @@ pub(super) struct FontMetricsMapEntry {
 
 #[derive(Debug)]
 #[turbo_tasks::value]
-pub(super) struct FontMetricsMap(pub FxIndexMap<RcStr, FontMetricsMapEntry>);
+pub(super) struct FontMetricsMap(
+    #[bincode(with = "turbo_bincode::indexmap")] pub FxIndexMap<RcStr, FontMetricsMapEntry>,
+);
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
 struct Fallback {

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -74,7 +74,7 @@ pub const USER_AGENT_FOR_GOOGLE_FONTS: &str = "Mozilla/5.0 (Macintosh; Intel Mac
 pub const GOOGLE_FONTS_INTERNAL_PREFIX: &str = "@vercel/turbopack-next/internal/font/google/font";
 
 #[turbo_tasks::value(transparent)]
-struct FontData(FxIndexMap<RcStr, FontDataEntry>);
+struct FontData(#[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<RcStr, FontDataEntry>);
 
 #[turbo_tasks::value(shared)]
 pub(crate) struct NextFontGoogleReplacer {

--- a/crates/next-core/src/next_font/google/options.rs
+++ b/crates/next-core/src/next_font/google/options.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
@@ -56,20 +57,24 @@ impl NextFontGoogleOptions {
     TraceRawVcs,
     NonLocalValue,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub(super) enum FontWeights {
     Variable,
     Fixed(Vec<u16>),
 }
 
-#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, TraceRawVcs, NonLocalValue)]
+#[derive(
+    Debug, PartialEq, Eq, Deserialize, Serialize, TraceRawVcs, NonLocalValue, Encode, Decode,
+)]
 pub(super) struct FontDataEntry {
     pub weights: Vec<RcStr>,
     pub styles: Vec<RcStr>,
     pub axes: Option<Vec<Axis>>,
 }
 
-#[derive(Debug, PartialEq, Deserialize, Serialize, TraceRawVcs, NonLocalValue)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, TraceRawVcs, NonLocalValue, Encode, Decode)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct Axis {
     pub tag: RcStr,

--- a/crates/next-core/src/next_font/local/errors.rs
+++ b/crates/next-core/src/next_font/local/errors.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, trace::TraceRawVcs};
@@ -9,7 +10,9 @@ pub(crate) enum FontResult<T> {
     FontFileNotFound(FontFileNotFound),
 }
 
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, NonLocalValue, TraceRawVcs)]
+#[derive(
+    Debug, Eq, PartialEq, Serialize, Deserialize, NonLocalValue, TraceRawVcs, Encode, Decode,
+)]
 pub(crate) struct FontFileNotFound(pub RcStr);
 
 impl Display for FontFileNotFound {

--- a/crates/next-core/src/next_font/local/font_fallback.rs
+++ b/crates/next-core/src/next_font/local/font_fallback.rs
@@ -7,15 +7,15 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 
-use super::{
-    errors::{FontFileNotFound, FontResult},
-    options::{FontDescriptor, FontDescriptors, FontWeight, NextFontLocalOptions},
-    request::AdjustFontFallback,
-};
 use crate::next_font::{
     font_fallback::{
         AutomaticFontFallback, DEFAULT_SANS_SERIF_FONT, DEFAULT_SERIF_FONT, DefaultFallbackFont,
         FontAdjustment, FontFallback, FontFallbacks,
+    },
+    local::{
+        errors::{FontFileNotFound, FontResult},
+        options::{FontDescriptor, FontDescriptors, FontWeight, NextFontLocalOptions},
+        request::AdjustFontFallback,
     },
     util::{FontFamilyType, get_scoped_font_family},
 };

--- a/crates/next-core/src/next_font/local/options.rs
+++ b/crates/next-core/src/next_font/local/options.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Display, str::FromStr};
 
 use anyhow::{Context, Result};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, TaskInput, Vc, trace::TraceRawVcs};
@@ -66,6 +67,8 @@ impl NextFontLocalOptions {
     TraceRawVcs,
     NonLocalValue,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub(super) struct FontDescriptor {
     pub weight: Option<FontWeight>,
@@ -108,6 +111,8 @@ impl FontDescriptor {
     TraceRawVcs,
     NonLocalValue,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub(super) enum FontDescriptors {
     /// `One` is a special case when the user did not provide a `src` field and
@@ -131,6 +136,8 @@ pub(super) enum FontDescriptors {
     TraceRawVcs,
     NonLocalValue,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub(super) enum FontWeight {
     Variable(RcStr, RcStr),
@@ -141,7 +148,7 @@ pub struct ParseFontWeightErr;
 impl FromStr for FontWeight {
     type Err = ParseFontWeightErr;
 
-    fn from_str(weight_str: &str) -> std::result::Result<Self, Self::Err> {
+    fn from_str(weight_str: &str) -> Result<Self, Self::Err> {
         if let Some((start, end)) = weight_str.split_once(' ') {
             Ok(FontWeight::Variable(start.into(), end.into()))
         } else {

--- a/crates/next-core/src/next_font/local/request.rs
+++ b/crates/next-core/src/next_font/local/request.rs
@@ -1,3 +1,4 @@
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
@@ -25,6 +26,8 @@ pub(super) struct NextFontLocalRequest {
     Deserialize,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub(super) struct NextFontLocalDeclaration {
     pub prop: RcStr,
@@ -79,6 +82,8 @@ pub(super) struct SrcDescriptor {
     TraceRawVcs,
     NonLocalValue,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub(super) enum AdjustFontFallback {
     Arial,

--- a/crates/next-core/src/next_image/module.rs
+++ b/crates/next-core/src/next_image/module.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::rcstr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, fxindexmap, trace::TraceRawVcs};
@@ -26,6 +27,8 @@ use super::source_asset::StructuredImageFileSource;
     NonLocalValue,
     Serialize,
     Deserialize,
+    Encode,
+    Decode,
 )]
 pub enum BlurPlaceholderMode {
     /// Do not generate a blur placeholder at all.

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -4,6 +4,7 @@ pub mod client_reference_manifest;
 mod encode_uri_component;
 
 use anyhow::{Context, Result};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
@@ -32,6 +33,7 @@ pub struct BuildManifest {
 
     pub polyfill_files: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
     pub root_main_files: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
+    #[bincode(with = "turbo_bincode::indexmap")]
     pub pages: FxIndexMap<RcStr, ResolvedVc<OutputAssets>>,
 }
 
@@ -164,6 +166,7 @@ pub struct ClientBuildManifest {
     pub output_path: FileSystemPath,
     pub client_relative_path: FileSystemPath,
 
+    #[bincode(with = "turbo_bincode::indexmap")]
     pub pages: FxIndexMap<RcStr, ResolvedVc<Box<dyn OutputAsset>>>,
 }
 
@@ -244,6 +247,8 @@ impl Default for MiddlewaresManifest {
     Serialize,
     Deserialize,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase", default)]
 pub struct ProxyMatcher {
@@ -419,6 +424,8 @@ pub enum ActionManifestModuleId<'a> {
     Serialize,
     Deserialize,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum ActionLayer {

--- a/crates/next-core/src/next_root_params/mod.rs
+++ b/crates/next-core/src/next_root_params/mod.rs
@@ -67,6 +67,7 @@ async fn get_next_root_params_mapping(
 #[turbo_tasks::value]
 struct NextRootParamsMapper {
     is_root_params_enabled: ResolvedVc<bool>,
+    #[bincode(with = "turbo_bincode::either")]
     context_type: Either<ServerContextType, ClientContextType>,
     collected_root_params: Option<ResolvedVc<CollectedRootParams>>,
 }

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use next_taskless::NEVER_EXTERNAL_RE;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
@@ -333,7 +334,9 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
     }
 }
 
-#[derive(Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, Debug, NonLocalValue)]
+#[derive(
+    Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, Debug, NonLocalValue, Encode, Decode,
+)]
 pub struct PackagesGlobs {
     path_glob: ResolvedVc<Glob>,
     request_glob: ResolvedVc<Glob>,

--- a/crates/next-core/src/next_shared/transforms/modularize_imports.rs
+++ b/crates/next-core/src/next_shared/transforms/modularize_imports.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use bincode::{Decode, Encode};
 use modularize_imports::{Config, PackageConfig, modularize_imports};
 use serde::{Deserialize, Serialize};
 use swc_core::ecma::ast::Program;
@@ -22,6 +23,8 @@ use super::module_rule_match_js_no_url;
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct ModularizeImportPackageConfig {
@@ -43,6 +46,8 @@ pub struct ModularizeImportPackageConfig {
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(untagged)]
 pub enum Transform {

--- a/crates/next-core/src/next_shared/webpack_rules/mod.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/mod.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeSet, str::FromStr};
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, OperationValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
@@ -46,6 +47,8 @@ pub(crate) mod sass;
     TraceRawVcs,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum WebpackLoaderBuiltinCondition {

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -223,15 +223,16 @@ impl EcmascriptChunkItem for RawEcmascriptChunkItem {
                                     name,
                                     if let Some(value) =
                                         replacements.get(&DefinableNameSegment::Name(name.into()))
-                                        && let Some((_, value)) = value.iter().find(|(path, _)| {
-                                            matches!(
-                                                path.as_slice(),
-                                                [
-                                                    DefinableNameSegment::Name(a),
-                                                    DefinableNameSegment::Name(b)
-                                                ] if a == "process" && b == "env"
-                                            )
-                                        })
+                                        && let Some((_, value)) =
+                                            value.0.iter().find(|(path, _)| {
+                                                matches!(
+                                                    path.as_slice(),
+                                                    [
+                                                        DefinableNameSegment::Name(a),
+                                                        DefinableNameSegment::Name(b)
+                                                    ] if a == "process" && b == "env"
+                                                )
+                                            })
                                     {
                                         let value = value.await?;
                                         let value = match &*value {

--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, future::Future};
 
 use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use swc_core::{
@@ -42,7 +43,18 @@ use crate::{
 };
 
 #[derive(
-    Default, PartialEq, Eq, Clone, Copy, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
+    Default,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    Debug,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum NextSegmentDynamic {
@@ -54,7 +66,18 @@ pub enum NextSegmentDynamic {
 }
 
 #[derive(
-    Default, PartialEq, Eq, Clone, Copy, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
+    Default,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    Debug,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum NextSegmentFetchCache {
@@ -69,7 +92,18 @@ pub enum NextSegmentFetchCache {
 }
 
 #[derive(
-    Default, PartialEq, Eq, Clone, Copy, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
+    Default,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    Debug,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum NextRevalidate {
     #[default]
@@ -95,6 +129,7 @@ pub struct NextSegmentConfig {
     pub generate_image_metadata: bool,
     pub generate_sitemaps: bool,
     #[turbo_tasks(trace_ignore)]
+    #[bincode(with_serde)]
     pub generate_static_params: Option<Span>,
 }
 
@@ -284,6 +319,8 @@ impl Issue for NextSegmentConfigParsingIssue {
     TaskInput,
     NonLocalValue,
     TraceRawVcs,
+    Encode,
+    Decode,
 )]
 pub enum ParseSegmentMode {
     Base,

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -1,13 +1,12 @@
 use std::{fmt::Display, str::FromStr};
 
 use anyhow::{Result, anyhow, bail};
+use bincode::{Decode, Encode};
 use next_taskless::{expand_next_js_template, expand_next_js_template_no_imports};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, NonLocalValue, TaskInput, Vc, trace::TraceRawVcs};
-use turbo_tasks_fs::{
-    self, File, FileContent, FileJsonContent, FileSystem, FileSystemPath, rope::Rope,
-};
+use turbo_tasks_fs::{File, FileContent, FileJsonContent, FileSystem, FileSystemPath, rope::Rope};
 use turbopack::module_options::RuleCondition;
 use turbopack_core::{
     asset::AssetContent,
@@ -27,7 +26,11 @@ const NEXT_TEMPLATE_PATH: &str = "dist/esm/build/templates";
 /// As opposed to [`EnvMap`], this map allows for `None` values, which means that the variables
 /// should be replace with undefined.
 #[turbo_tasks::value(transparent)]
-pub struct OptionEnvMap(#[turbo_tasks(trace_ignore)] FxIndexMap<RcStr, Option<RcStr>>);
+pub struct OptionEnvMap(
+    #[turbo_tasks(trace_ignore)]
+    #[bincode(with = "turbo_bincode::indexmap")]
+    FxIndexMap<RcStr, Option<RcStr>>,
+);
 
 pub fn defines(define_env: &FxIndexMap<RcStr, Option<RcStr>>) -> CompileTimeDefines {
     let mut defines = FxIndexMap::default();
@@ -198,6 +201,8 @@ pub fn pages_function_name(page: impl Display) -> String {
     Ord,
     TaskInput,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "lowercase")]
 pub enum NextRuntime {
@@ -228,7 +233,9 @@ impl NextRuntime {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
+#[derive(
+    PartialEq, Eq, Clone, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue, Encode, Decode,
+)]
 pub enum MiddlewareMatcherKind {
     Str(String),
     Matcher(ProxyMatcher),

--- a/turbopack/crates/turbo-esregex/Cargo.toml
+++ b/turbopack/crates/turbo-esregex/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 regex = { workspace = true }
 regress = { workspace = true }
 serde = { workspace = true }

--- a/turbopack/crates/turbo-rcstr/Cargo.toml
+++ b/turbopack/crates/turbo-rcstr/Cargo.toml
@@ -10,6 +10,7 @@ atom_size_128 = []
 napi = ["dep:napi"]
 
 [dependencies]
+bincode = { workspace = true }
 triomphe = { workspace = true }
 turbo-tasks-hash = { workspace = true }
 serde = { workspace = true }

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -9,6 +9,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use bincode::{
+    Decode, Encode,
+    de::Decoder,
+    enc::Encoder,
+    error::{DecodeError, EncodeError},
+    impl_borrow_decode,
+};
 use bytes_str::BytesStr;
 use debug_unreachable::debug_unreachable;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -368,6 +375,20 @@ impl<'de> Deserialize<'de> for RcStr {
         Ok(RcStr::from(s))
     }
 }
+
+impl Encode for RcStr {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        self.as_str().encode(encoder)
+    }
+}
+
+impl<Context> Decode<Context> for RcStr {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        Ok(RcStr::from(String::decode(decoder)?))
+    }
+}
+
+impl_borrow_decode!(RcStr);
 
 impl Drop for RcStr {
     fn drop(&mut self) {

--- a/turbopack/crates/turbo-tasks-auto-hash-map/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2024"
 workspace = true
 
 [dependencies]
+bincode = { workspace = true }
 hashbrown = { workspace = true, features = ["serde"]}
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/turbopack/crates/turbo-tasks-auto-hash-map/src/set.rs
+++ b/turbopack/crates/turbo-tasks-auto-hash-map/src/set.rs
@@ -4,13 +4,19 @@ use std::{
     marker::PhantomData,
 };
 
+use bincode::{Decode, Encode};
 use rustc_hash::FxHasher;
 use serde::{Deserialize, Serialize};
 use shrink_to_fit::ShrinkToFit;
 
 use crate::AutoMap;
 
-#[derive(Clone)]
+#[derive(Clone, Encode, Decode)]
+#[bincode(
+    encode_bounds = "K: Encode + Hash + Eq, H: BuildHasher + Default",
+    decode_bounds = "K: Decode<__Context> + Hash + Eq, H: BuildHasher + Default",
+    borrow_decode_bounds = "K: Decode<__Context> + Hash + Eq, H: BuildHasher + Default"
+)]
 pub struct AutoSet<K, H = BuildHasherDefault<FxHasher>, const I: usize = 0> {
     map: AutoMap<K, (), H, I>,
 }

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -30,6 +30,7 @@ lmdb = ["dep:lmdb-rkv"]
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 arc-swap = { version = "1.7.1" }
 auto-hash-map = { workspace = true }
 bitfield = { workspace = true }

--- a/turbopack/crates/turbo-tasks-backend/tests/bug.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/bug.rs
@@ -3,20 +3,25 @@
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, Vc, trace::TraceRawVcs};
 use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
-#[derive(Debug, Clone, PartialEq, Eq, NonLocalValue, Serialize, Deserialize, TraceRawVcs)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, NonLocalValue, Serialize, Deserialize, TraceRawVcs, Encode, Decode,
+)]
 struct TaskReferenceSpec {
     task: u16,
     read: bool,
     read_strongly_consistent: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, NonLocalValue, Serialize, Deserialize, TraceRawVcs)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, NonLocalValue, Serialize, Deserialize, TraceRawVcs, Encode, Decode,
+)]
 struct TaskSpec {
     references: Vec<TaskReferenceSpec>,
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/bug2.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/bug2.rs
@@ -5,6 +5,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, State, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_testing::{Registration, register, run_once};
@@ -12,7 +13,18 @@ use turbo_tasks_testing::{Registration, register, run_once};
 static REGISTRATION: Registration = register!();
 
 #[derive(
-    Clone, Debug, PartialEq, Eq, Hash, NonLocalValue, Serialize, Deserialize, TraceRawVcs, TaskInput,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    NonLocalValue,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    TaskInput,
+    Encode,
+    Decode,
 )]
 pub struct TaskReferenceSpec {
     task: u16,
@@ -22,7 +34,18 @@ pub struct TaskReferenceSpec {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Eq, Hash, NonLocalValue, Serialize, Deserialize, TraceRawVcs, TaskInput,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    NonLocalValue,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    TaskInput,
+    Encode,
+    Decode,
 )]
 pub struct TaskSpec {
     references: Vec<TaskReferenceSpec>,

--- a/turbopack/crates/turbo-tasks-bytes/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-bytes/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }

--- a/turbopack/crates/turbo-tasks-env/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-env/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 dotenvs = "0.1.0"
+turbo-bincode = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }

--- a/turbopack/crates/turbo-tasks-env/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-env/src/lib.rs
@@ -18,7 +18,11 @@ pub use self::{
 };
 
 #[turbo_tasks::value(transparent)]
-pub struct EnvMap(#[turbo_tasks(trace_ignore)] FxIndexMap<RcStr, RcStr>);
+pub struct EnvMap(
+    #[turbo_tasks(trace_ignore)]
+    #[bincode(with = "turbo_bincode::indexmap")]
+    FxIndexMap<RcStr, RcStr>,
+);
 
 #[turbo_tasks::value_impl]
 impl EnvMap {

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -25,6 +25,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 auto-hash-map = { workspace = true }
+bincode = { workspace = true }
 bitflags = "1.3.2"
 bytes = { workspace = true }
 concurrent-queue = { workspace = true }
@@ -46,6 +47,7 @@ serde_path_to_error = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 triomphe = { workspace = true }
+turbo-bincode = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-hash = { workspace = true }

--- a/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
@@ -302,8 +302,11 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
                 #[derive(
                     turbo_tasks::macro_helpers::serde::Serialize,
                     turbo_tasks::macro_helpers::serde::Deserialize,
+                    turbo_tasks::macro_helpers::bincode::Encode,
+                    turbo_tasks::macro_helpers::bincode::Decode,
                 )]
                 #[serde(crate = "turbo_tasks::macro_helpers::serde")]
+                #[bincode(crate = "turbo_tasks::macro_helpers::bincode")]
             });
             if transparent {
                 struct_attributes.push(quote! {

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -25,6 +25,7 @@ workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
+bincode = { workspace = true }
 concurrent-queue = { workspace = true }
 dashmap = { workspace = true }
 either = { workspace = true }

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -5,6 +5,13 @@ use std::{
     ops::Deref,
 };
 
+use bincode::{
+    Decode, Encode,
+    de::Decoder,
+    enc::Encoder,
+    error::{DecodeError, EncodeError},
+    impl_borrow_decode,
+};
 use serde::{Deserialize, Serialize, de::Visitor};
 
 use crate::{
@@ -118,19 +125,19 @@ macro_rules! define_id {
     };
 }
 
-define_id!(TaskId: u32, derive(Serialize, Deserialize), serde(transparent));
+define_id!(TaskId: u32, derive(Serialize, Deserialize, Encode, Decode), serde(transparent));
 define_id!(FunctionId: u16);
 define_id!(ValueTypeId: u16);
 define_id!(TraitTypeId: u16);
 define_id!(
     LocalTaskId: u32,
-    derive(Debug, Serialize, Deserialize),
+    derive(Debug, Serialize, Deserialize, Encode, Decode),
     serde(transparent),
     doc = "Represents the nth `local` function call inside a task.",
 );
 define_id!(
     ExecutionId: u16,
-    derive(Debug, Serialize, Deserialize),
+    derive(Debug, Serialize, Deserialize, Encode, Decode),
     serde(transparent),
     doc = "An identifier for a specific task execution. Used to assert that local `Vc`s don't \
         leak. This value may overflow and re-use old values.",
@@ -158,8 +165,8 @@ impl TaskId {
     }
 }
 
-macro_rules! make_serializable {
-    ($ty:ty, $get_object:path, $validate_type_id:path, $visitor_name:ident) => {
+macro_rules! make_registered_serializable {
+    ($ty:ty, $primitive:ty, $get_object:path, $validate_type_id:path $(,)?) => {
         impl Serialize for $ty {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -174,33 +181,32 @@ macro_rules! make_serializable {
             where
                 D: serde::Deserializer<'de>,
             {
-                deserializer.deserialize_u16($visitor_name)
-            }
-        }
+                struct DeserializeVisitor;
+                impl<'de> Visitor<'de> for DeserializeVisitor {
+                    type Value = $ty;
 
-        struct $visitor_name;
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str(concat!("an id of a registered ", stringify!($ty)))
+                    }
 
-        impl<'de> Visitor<'de> for $visitor_name {
-            type Value = $ty;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str(concat!("an id of a registered ", stringify!($ty)))
-            }
-
-            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                match Self::Value::new(v) {
-                    Some(value) => {
-                        if let Some(error) = $validate_type_id(value) {
-                            Err(E::custom(error))
-                        } else {
-                            Ok(value)
+                    fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match Self::Value::new(v) {
+                            Some(value) => {
+                                if let Some(error) = $validate_type_id(value) {
+                                    Err(E::custom(error))
+                                } else {
+                                    Ok(value)
+                                }
+                            }
+                            None => Err(E::unknown_variant(&format!("{v}"), &["a non zero u16"])),
                         }
                     }
-                    None => Err(E::unknown_variant(&format!("{v}"), &["a non zero u16"])),
                 }
+
+                deserializer.deserialize_u16(DeserializeVisitor)
             }
         }
 
@@ -212,24 +218,45 @@ macro_rules! make_serializable {
                     .finish()
             }
         }
+
+        impl Encode for $ty {
+            fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+                <NonZero<$primitive> as Encode>::encode(&self.id, encoder)
+            }
+        }
+
+        impl<Context> Decode<Context> for $ty {
+            fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
+                let value = Self {
+                    id: NonZero::<$primitive>::decode(decoder)?,
+                };
+                if let Some(error) = $validate_type_id(value) {
+                    Err(DecodeError::OtherString(error.to_string()))
+                } else {
+                    Ok(value)
+                }
+            }
+        }
+
+        impl_borrow_decode!($ty);
     };
 }
 
-make_serializable!(
+make_registered_serializable!(
     ValueTypeId,
+    u16,
     registry::get_value_type,
     registry::validate_value_type_id,
-    ValueTypeVisitor
 );
-make_serializable!(
+make_registered_serializable!(
     TraitTypeId,
+    u16,
     registry::get_trait,
     registry::validate_trait_type_id,
-    TraitTypeVisitor
 );
-make_serializable!(
+make_registered_serializable!(
     FunctionId,
+    u16,
     registry::get_native_function,
     registry::validate_function_id,
-    FunctionTypeVisitor
 );

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -1,6 +1,7 @@
 //! Runtime helpers for [turbo-tasks-macro].
 
 pub use async_trait::async_trait;
+pub use bincode;
 pub use once_cell::sync::{Lazy, OnceCell};
 use rustc_hash::FxHashMap;
 pub use serde;

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -13,6 +13,7 @@ use std::{
 
 use anyhow::{Result, anyhow};
 use auto_hash_map::AutoMap;
+use bincode::{Decode, Encode};
 use rustc_hash::FxHasher;
 use serde::{Deserialize, Serialize};
 use tokio::{select, sync::mpsc::Receiver, task_local};
@@ -268,7 +269,7 @@ pub struct UpdateInfo {
     placeholder_for_future_fields: (),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, Encode, Decode)]
 pub enum TaskPersistence {
     /// Tasks that may be persisted across sessions using serialization.
     Persistent,

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::Result;
 use auto_hash_map::AutoSet;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -35,7 +36,7 @@ pub enum ResolveTypeError {
     ReadError { source: anyhow::Error },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
 pub struct CellId {
     pub type_id: ValueTypeId,
     pub index: u32,
@@ -61,7 +62,7 @@ impl Display for CellId {
 /// otherwise be treated as an internal implementation detail of `turbo-tasks`.
 ///
 /// [monomorphization]: https://doc.rust-lang.org/book/ch10-01-syntax.html#performance-of-code-using-generics
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
 pub enum RawVc {
     /// The synchronous return value of a task (after argument resolution). This is the
     /// representation used by [`OperationVc`][crate::OperationVc].

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -17,6 +17,7 @@ use std::{
 };
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use shrink_to_fit::ShrinkToFit;
 
@@ -161,8 +162,9 @@ type VcReadTarget<T> = <<T as VcValueType>::Read as VcRead<T>>::Target;
 /// [book-cells]: https://turbopack-rust-docs.vercel.sh/turbo-engine/cells.html
 /// [collectibles]: crate::CollectiblesSource
 #[must_use]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Encode, Decode)]
 #[serde(transparent, bound = "")]
+#[bincode(bounds = "T: ?Sized")]
 #[repr(transparent)]
 pub struct Vc<T>
 where

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -2,6 +2,7 @@ use std::{fmt::Debug, hash::Hash, marker::PhantomData};
 
 use anyhow::Result;
 use auto_hash_map::AutoSet;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 pub use turbo_tasks_macros::OperationValue;
 
@@ -48,6 +49,9 @@ use crate::{
 /// [`State`]: crate::State
 /// [`ReadRef`]: crate::ReadRef
 #[must_use]
+#[derive(Serialize, Deserialize, Encode, Decode)]
+#[serde(transparent, bound = "")]
+#[bincode(bounds = "T: ?Sized")]
 #[repr(transparent)]
 pub struct OperationVc<T>
 where
@@ -203,26 +207,6 @@ where
         }
         Ok(Self {
             node: Vc::from(raw),
-        })
-    }
-}
-
-impl<T> Serialize for OperationVc<T>
-where
-    T: ?Sized,
-{
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.node.serialize(serializer)
-    }
-}
-
-impl<'de, T> Deserialize<'de> for OperationVc<T>
-where
-    T: ?Sized,
-{
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(OperationVc {
-            node: Vc::deserialize(deserializer)?,
         })
     }
 }

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -64,8 +65,9 @@ use crate::{
 /// [`NonLocalValue`]: crate::NonLocalValue
 /// [rewritten external signature]: https://turbopack-rust-docs.vercel.sh/turbo-engine/tasks.html#external-signature-rewriting
 /// [`ReadRef`]: crate::ReadRef
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Encode, Decode)]
 #[serde(transparent, bound = "")]
+#[bincode(bounds = "T: ?Sized")]
 #[repr(transparent)]
 pub struct ResolvedVc<T>
 where

--- a/turbopack/crates/turbopack-analyze/Cargo.toml
+++ b/turbopack/crates/turbopack-analyze/Cargo.toml
@@ -10,6 +10,7 @@ bench = false
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 turbo-rcstr = { workspace = true }

--- a/turbopack/crates/turbopack-analyze/src/split_chunk.rs
+++ b/turbopack/crates/turbopack-analyze/src/split_chunk.rs
@@ -1,6 +1,7 @@
 use std::mem::replace;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, NonLocalValue, ValueToString, Vc, trace::TraceRawVcs};
@@ -11,14 +12,18 @@ use turbopack_core::{
     source_map::{GenerateSourceMap, OriginalToken, SourceMap, SyntheticToken, Token},
 };
 
-#[derive(Clone, Debug, Deserialize, Eq, NonLocalValue, PartialEq, Serialize, TraceRawVcs)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, NonLocalValue, PartialEq, Serialize, TraceRawVcs, Encode, Decode,
+)]
 pub struct ChunkPartRange {
     pub line: u32,
     pub start_column: u32,
     pub end_column: u32,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, NonLocalValue, PartialEq, Serialize, TraceRawVcs)]
+#[derive(
+    Clone, Debug, Deserialize, Eq, NonLocalValue, PartialEq, Serialize, TraceRawVcs, Encode, Decode,
+)]
 pub struct ChunkPart {
     pub source: RcStr,
     pub real_size: u32,

--- a/turbopack/crates/turbopack-browser/Cargo.toml
+++ b/turbopack/crates/turbopack-browser/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 either = { workspace = true }
 indoc = { workspace = true }
 serde = { workspace = true }
@@ -28,6 +29,7 @@ serde_qs = { workspace = true }
 tracing = { workspace = true }
 urlencoding = { workspace = true }
 
+turbo-bincode = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
@@ -65,6 +66,8 @@ pub const CURRENT_CHUNK_METHOD_DOCUMENT_CURRENT_SCRIPT_EXPR: &str =
     TraceRawVcs,
     DeterministicHash,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum ContentHashing {
     /// Direct content hashing: Embeds the chunk content hash directly into the referencing chunk.
@@ -252,12 +255,14 @@ pub struct BrowserChunkingContext {
     /// This path is used to compute the url to request assets from
     client_root: FileSystemPath,
     /// This path is used to compute the url to request chunks or assets from
+    #[bincode(with = "turbo_bincode::indexmap")]
     client_roots: FxIndexMap<RcStr, FileSystemPath>,
     /// Chunks are placed at this path
     chunk_root_path: FileSystemPath,
     /// Static assets are placed at this path
     asset_root_path: FileSystemPath,
     /// Static assets are placed at this path
+    #[bincode(with = "turbo_bincode::indexmap")]
     asset_root_paths: FxIndexMap<RcStr, FileSystemPath>,
     /// Base path that will be prepended to all chunk URLs when loading them.
     /// This path will not appear in chunk paths or chunk data.
@@ -270,6 +275,7 @@ pub struct BrowserChunkingContext {
     asset_base_path: Option<RcStr>,
     /// URL prefix that will be prepended to all static asset URLs when loading
     /// them.
+    #[bincode(with = "turbo_bincode::indexmap")]
     asset_base_paths: FxIndexMap<RcStr, RcStr>,
     /// Enable HMR for this chunking
     enable_hot_module_replacement: bool,

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content_entry.rs
@@ -38,6 +38,7 @@ impl EcmascriptDevChunkContentEntry {
 
 #[turbo_tasks::value(transparent)]
 pub struct EcmascriptBrowserChunkContentEntries(
+    #[bincode(with = "turbo_bincode::indexmap")]
     FxIndexMap<ReadRef<ModuleId>, EcmascriptDevChunkContentEntry>,
 );
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, ValueToString, Vc, trace::TraceRawVcs};
@@ -128,6 +129,8 @@ impl Asset for EcmascriptDevChunkList {
     TraceRawVcs,
     Serialize,
     Deserialize,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub enum EcmascriptDevChunkListSource {

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 
 use anyhow::{Context, Result};
+use bincode::{Decode, Encode};
 use either::Either;
 use indoc::writedoc;
 use serde::{Deserialize, Serialize};
@@ -29,7 +30,9 @@ use crate::chunking_context::{
     CURRENT_CHUNK_METHOD_DOCUMENT_CURRENT_SCRIPT_EXPR, CurrentChunkMethod,
 };
 
-#[derive(Clone, Debug, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, NonLocalValue)]
+#[derive(
+    Clone, Debug, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, NonLocalValue, Encode, Decode,
+)]
 enum CurrentChunkMethodWithData {
     StringLiteral(RcStr),
     DocumentCurrentScript,
@@ -39,6 +42,7 @@ enum CurrentChunkMethodWithData {
 #[turbo_tasks::value]
 pub(super) struct EcmascriptDevChunkListContent {
     current_chunk_method: CurrentChunkMethodWithData,
+    #[bincode(with = "turbo_bincode::indexmap")]
     pub(super) chunks_contents: FxIndexMap<String, ResolvedVc<Box<dyn VersionedContent>>>,
     source: EcmascriptDevChunkListSource,
 }

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
+bincode = { workspace = true }
 bitfield = { workspace = true }
 browserslist-rs = { workspace = true }
 bytes-str = { workspace = true }
@@ -37,6 +38,7 @@ smallvec = { workspace = true }
 swc_sourcemap = { workspace = true }
 swc_core = { workspace = true, features = ["ecma_preset_env", "common"] }
 tracing = { workspace = true }
+turbo-bincode = { workspace = true }
 turbo-prehash = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }

--- a/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/availability_info.rs
@@ -1,13 +1,14 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use bitfield::bitfield;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 
-use super::available_modules::{AvailableModules, AvailableModulesSet};
+use crate::chunk::available_modules::{AvailableModules, AvailableModulesSet};
 
 bitfield! {
-    #[derive(Clone, Copy, Default, TaskInput, TraceRawVcs, NonLocalValue, Serialize, Deserialize, PartialEq, Eq, Hash)]
+    #[derive(Clone, Copy, Default, TaskInput, TraceRawVcs, NonLocalValue, Serialize, Deserialize, PartialEq, Eq, Hash, Encode, Decode)]
     pub struct AvailabilityFlags(u8);
     impl Debug;
     pub is_in_async_module, set_is_in_async_module: 0;
@@ -25,6 +26,8 @@ bitfield! {
     NonLocalValue,
     Serialize,
     Deserialize,
+    Encode,
+    Decode,
 )]
 pub struct AvailabilityInfo {
     flags: AvailabilityFlags,

--- a/turbopack/crates/turbopack-core/src/chunk/available_modules.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/available_modules.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString, Vc,
@@ -24,6 +25,8 @@ use crate::{
     TraceRawVcs,
     NonLocalValue,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum AvailableModuleItem {
     Module(ResolvedVc<Box<dyn ChunkableModule>>),
@@ -61,7 +64,9 @@ impl From<ChunkableModuleOrBatch> for AvailableModuleItem {
 
 #[turbo_tasks::value(transparent)]
 #[derive(Debug, Clone)]
-pub struct AvailableModulesSet(FxIndexSet<AvailableModuleItem>);
+pub struct AvailableModulesSet(
+    #[bincode(with = "turbo_bincode::indexset")] FxIndexSet<AvailableModuleItem>,
+);
 
 /// Allows to gather information about which assets are already available.
 /// Adding more roots will form a linked list like structure to allow caching

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_item_batch.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_item_batch.rs
@@ -1,6 +1,7 @@
 use std::{future::Future, hash::Hash, ops::Deref};
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use either::Either;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -49,7 +50,18 @@ pub async fn attach_async_info_to_chunkable_module(
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, TraceRawVcs, NonLocalValue, TaskInput,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum ChunkItemOrBatchWithAsyncModuleInfo {
     ChunkItem(ChunkItemWithAsyncModuleInfo),

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
@@ -1,6 +1,7 @@
 use std::future::IntoFuture;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use smallvec::{SmallVec, smallvec};
@@ -50,7 +51,16 @@ struct BatchChunkItemsWithInfo(
 );
 
 #[derive(
-    Clone, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, ValueDebugFormat,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    ValueDebugFormat,
+    Encode,
+    Decode,
 )]
 enum ChunkItemOrBatchWithInfo {
     ChunkItem {

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
@@ -6,10 +7,12 @@ use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Upcast, Vc, trace::Trace
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::DeterministicHash;
 
-use super::{ChunkableModule, EvaluatableAssets, availability_info::AvailabilityInfo};
 use crate::{
     asset::Asset,
-    chunk::{ChunkItem, ChunkType, ModuleId},
+    chunk::{
+        ChunkItem, ChunkType, ChunkableModule, EvaluatableAssets, ModuleId,
+        availability_info::AvailabilityInfo,
+    },
     environment::Environment,
     ident::AssetIdent,
     module::Module,
@@ -37,6 +40,8 @@ use crate::{
     TraceRawVcs,
     DeterministicHash,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum MangleType {
@@ -86,6 +91,8 @@ pub enum SourceMapsType {
     TraceRawVcs,
     DeterministicHash,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum ChunkGroupType {
     Entry,
@@ -226,6 +233,8 @@ pub struct EntryChunkGroupResult {
     TraceRawVcs,
     NonLocalValue,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub struct ChunkingConfig {
     /// Try to avoid creating more than 1 chunk smaller than this size.

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -14,6 +14,7 @@ use std::fmt::Display;
 
 use anyhow::Result;
 use auto_hash_map::AutoSet;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
@@ -159,6 +160,8 @@ impl MergeableModules {
     NonLocalValue,
     TaskInput,
     Hash,
+    Encode,
+    Decode,
 )]
 pub enum MergeableModuleExposure {
     // This module is only used from within the current group, and only individual exports are
@@ -265,6 +268,8 @@ pub trait OutputChunk: Asset {
     PartialEq,
     ValueDebugFormat,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum ChunkingType {
     /// The referenced module is placed in the same chunk group and is loaded in parallel.
@@ -508,7 +513,18 @@ impl AsyncModuleInfo {
 }
 
 #[derive(
-    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, TraceRawVcs, TaskInput, NonLocalValue,
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    TraceRawVcs,
+    TaskInput,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct ChunkItemWithAsyncModuleInfo {
     pub chunk_item: ResolvedVc<Box<dyn ChunkItem>>,

--- a/turbopack/crates/turbopack-core/src/condition.rs
+++ b/turbopack/crates/turbopack-core/src/condition.rs
@@ -1,8 +1,11 @@
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 
-#[derive(Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, NonLocalValue)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, NonLocalValue, Encode, Decode,
+)]
 pub enum ContextCondition {
     All(Vec<ContextCondition>),
     Any(Vec<ContextCondition>),

--- a/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
+++ b/turbopack/crates/turbopack-core/src/diagnostics/mod.rs
@@ -45,7 +45,9 @@ impl PartialOrd for PlainDiagnostic {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct DiagnosticPayload(pub FxIndexMap<RcStr, RcStr>);
+pub struct DiagnosticPayload(
+    #[bincode(with = "turbo_bincode::indexmap")] pub FxIndexMap<RcStr, RcStr>,
+);
 
 /// An arbitrary payload can be used to analyze, diagnose
 /// Turbopack's behavior.

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -26,6 +27,8 @@ use crate::resolve::ModulePart;
     Serialize,
     Deserialize,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct Layer {
     name: RcStr,

--- a/turbopack/crates/turbopack-core/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/mod.rs
@@ -6,10 +6,11 @@ pub mod utils;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexSet, ResolvedVc, Vc};
 
-type VcDynIntrospectable = ResolvedVc<Box<dyn Introspectable>>;
-
 #[turbo_tasks::value(transparent)]
-pub struct IntrospectableChildren(FxIndexSet<(RcStr, VcDynIntrospectable)>);
+pub struct IntrospectableChildren(
+    #[bincode(with = "turbo_bincode::indexset")]
+    FxIndexSet<(RcStr, ResolvedVc<Box<dyn Introspectable>>)>,
+);
 
 #[turbo_tasks::value_trait]
 pub trait Introspectable {

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -10,6 +10,7 @@ use std::{
 
 use anyhow::{Result, anyhow};
 use auto_hash_map::AutoSet;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
@@ -290,6 +291,8 @@ impl CapturedIssues {
     TaskInput,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct IssueSource {
     source: ResolvedVc<Box<dyn Source>>,
@@ -309,6 +312,8 @@ pub struct IssueSource {
     TaskInput,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 enum SourceRange {
     LineColumn(SourcePos, SourcePos),

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batch.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batch.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
@@ -24,6 +25,8 @@ use crate::{
     TraceRawVcs,
     NonLocalValue,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum ModuleOrBatch {
     Module(ResolvedVc<Box<dyn Module>>),
@@ -55,6 +58,8 @@ impl ModuleOrBatch {
     TraceRawVcs,
     NonLocalValue,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum ChunkableModuleOrBatch {
     Module(ResolvedVc<Box<dyn ChunkableModule>>),

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -37,6 +37,7 @@ pub struct StyleGroupsConfig {
 pub struct StyleGroups {
     /// The key chunk item is contained in the value chunk item batch. All chunk items that are not
     /// contained in this map are placed in a separate chunk per chunk item.
+    #[bincode(with = "turbo_bincode::indexmap")]
     pub shared_chunk_items:
         FxIndexMap<ChunkItemWithAsyncModuleInfo, ResolvedVc<ChunkItemBatchWithAsyncModuleInfo>>,
 }

--- a/turbopack/crates/turbopack-core/src/module_graph/traced_di_graph.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/traced_di_graph.rs
@@ -1,15 +1,21 @@
 use std::ops::Deref;
 
+use bincode::{Decode, Encode};
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use turbo_tasks::{
     NonLocalValue,
     debug::ValueDebugFormat,
     trace::{TraceRawVcs, TraceRawVcsContext},
 };
 
-#[derive(Clone, Debug, ValueDebugFormat, Serialize, Deserialize)]
-pub struct TracedDiGraph<N, E>(pub DiGraph<N, E>);
+#[derive(Clone, Debug, ValueDebugFormat, Serialize, Deserialize, Encode, Decode)]
+#[bincode(
+    encode_bounds = "N: Serialize, E: Serialize",
+    decode_bounds = "N: DeserializeOwned, E: DeserializeOwned",
+    borrow_decode_bounds = "N: Deserialize<'__de>, E: Deserialize<'__de>"
+)]
+pub struct TracedDiGraph<N, E>(#[bincode(with_serde)] pub DiGraph<N, E>);
 impl<N, E> Default for TracedDiGraph<N, E> {
     fn default() -> Self {
         Self(Default::default())

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -107,7 +107,9 @@ pub struct ExpandedOutputAssets(Vec<ResolvedVc<Box<dyn OutputAsset>>>);
 
 /// A set of [OutputAsset]s
 #[turbo_tasks::value(transparent)]
-pub struct OutputAssetsSet(FxIndexSet<ResolvedVc<Box<dyn OutputAsset>>>);
+pub struct OutputAssetsSet(
+    #[bincode(with = "turbo_bincode::indexset")] FxIndexSet<ResolvedVc<Box<dyn OutputAsset>>>,
+);
 
 #[turbo_tasks::value(shared)]
 #[derive(Clone)]

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
@@ -294,7 +295,16 @@ pub async fn primary_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<V
 }
 
 #[derive(
-    Clone, Serialize, Deserialize, Eq, PartialEq, ValueDebugFormat, TraceRawVcs, NonLocalValue,
+    Clone,
+    Serialize,
+    Deserialize,
+    Eq,
+    PartialEq,
+    ValueDebugFormat,
+    TraceRawVcs,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct ResolvedReference {
     pub chunking_type: ChunkingType,

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -1,6 +1,8 @@
 use std::fmt::Display;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 
@@ -11,7 +13,9 @@ use crate::{module::Module, resolve::ModulePart};
 ///
 /// Name is usually in UPPER_CASE to make it clear that this is an inner asset.
 #[turbo_tasks::value(transparent)]
-pub struct InnerAssets(FxIndexMap<RcStr, ResolvedVc<Box<dyn Module>>>);
+pub struct InnerAssets(
+    #[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<RcStr, ResolvedVc<Box<dyn Module>>>,
+);
 
 #[turbo_tasks::value_impl]
 impl InnerAssets {
@@ -32,14 +36,16 @@ impl InnerAssets {
     Eq,
     TraceRawVcs,
     NonLocalValue,
-    serde::Serialize,
-    serde::Deserialize,
+    Serialize,
+    Deserialize,
     Debug,
     Default,
     Clone,
     Copy,
     Hash,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum CommonJsReferenceSubType {
     Custom(u8),
@@ -52,13 +58,15 @@ pub enum CommonJsReferenceSubType {
     Eq,
     TraceRawVcs,
     NonLocalValue,
-    serde::Serialize,
-    serde::Deserialize,
+    Serialize,
+    Deserialize,
     Debug,
     Clone,
     Copy,
     Hash,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum ImportWithType {
     Json,
@@ -70,13 +78,15 @@ pub enum ImportWithType {
     Eq,
     TraceRawVcs,
     NonLocalValue,
-    serde::Serialize,
-    serde::Deserialize,
+    Serialize,
+    Deserialize,
     Debug,
     Default,
     Clone,
     Hash,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum EcmaScriptModulesReferenceSubType {
     ImportPart(ModulePart),
@@ -210,14 +220,16 @@ impl ImportContext {
     Eq,
     TraceRawVcs,
     NonLocalValue,
-    serde::Serialize,
-    serde::Deserialize,
+    Serialize,
+    Deserialize,
     Debug,
     Default,
     Clone,
     Copy,
     Hash,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum CssReferenceSubType {
     AtImport(Option<ResolvedVc<ImportContext>>),
@@ -238,14 +250,16 @@ pub enum CssReferenceSubType {
     Eq,
     TraceRawVcs,
     NonLocalValue,
-    serde::Serialize,
-    serde::Deserialize,
+    Serialize,
+    Deserialize,
     Debug,
     Default,
     Clone,
     Copy,
     Hash,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum UrlReferenceSubType {
     EcmaScriptNewUrl,
@@ -260,13 +274,15 @@ pub enum UrlReferenceSubType {
     Eq,
     TraceRawVcs,
     NonLocalValue,
-    serde::Serialize,
-    serde::Deserialize,
+    Serialize,
+    Deserialize,
     Debug,
     Clone,
     Copy,
     Hash,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum TypeScriptReferenceSubType {
     Custom(u8),
@@ -278,13 +294,15 @@ pub enum TypeScriptReferenceSubType {
     Eq,
     TraceRawVcs,
     NonLocalValue,
-    serde::Serialize,
-    serde::Deserialize,
+    Serialize,
+    Deserialize,
     Debug,
     Clone,
     Copy,
     Hash,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum WorkerReferenceSubType {
     WebWorker,
@@ -302,13 +320,15 @@ pub enum WorkerReferenceSubType {
     Eq,
     TraceRawVcs,
     NonLocalValue,
-    serde::Serialize,
-    serde::Deserialize,
+    Serialize,
+    Deserialize,
     Debug,
     Clone,
     Copy,
     Hash,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum EntryReferenceSubType {
     Web,
@@ -332,13 +352,15 @@ pub enum EntryReferenceSubType {
     Eq,
     TraceRawVcs,
     NonLocalValue,
-    serde::Serialize,
-    serde::Deserialize,
+    Serialize,
+    Deserialize,
     Debug,
     Default,
     Clone,
     Hash,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum ReferenceType {
     CommonJs(CommonJsReferenceSubType),

--- a/turbopack/crates/turbopack-core/src/resolve/alias_map.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/alias_map.rs
@@ -5,8 +5,9 @@ use std::{
 };
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use patricia_tree::PatriciaMap;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     NonLocalValue,
@@ -24,9 +25,15 @@ use super::pattern::Pattern;
 ///
 /// If the pattern does not have a wildcard character, it will only match the
 /// exact string, and return the template as-is.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Encode, Decode)]
 #[serde(transparent)]
+#[bincode(
+    encode_bounds = "T: Serialize",
+    decode_bounds = "T: DeserializeOwned",
+    borrow_decode_bounds = "T: Deserialize<'__de>"
+)]
 pub struct AliasMap<T> {
+    #[bincode(with_serde)]
     map: PatriciaMap<BTreeMap<AliasKey, T>>,
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, future::Future, pin::Pin};
 
 use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
@@ -23,7 +24,7 @@ pub struct LockedVersions {}
 
 #[turbo_tasks::value(transparent)]
 #[derive(Debug)]
-pub struct ExcludedExtensions(pub FxIndexSet<RcStr>);
+pub struct ExcludedExtensions(#[bincode(with = "turbo_bincode::indexset")] pub FxIndexSet<RcStr>);
 
 /// A location where to resolve modules.
 #[derive(
@@ -37,6 +38,8 @@ pub struct ExcludedExtensions(pub FxIndexSet<RcStr>);
     Deserialize,
     ValueDebugFormat,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum ResolveModules {
     /// when inside of path, use the list of directories to
@@ -50,7 +53,18 @@ pub enum ResolveModules {
 }
 
 #[derive(
-    TraceRawVcs, Hash, PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize, NonLocalValue,
+    TraceRawVcs,
+    Hash,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    Debug,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum ConditionValue {
     Set,
@@ -71,7 +85,19 @@ impl From<bool> for ConditionValue {
 pub type ResolutionConditions = BTreeMap<RcStr, ConditionValue>;
 
 /// The different ways to resolve a package, as described in package.json.
-#[derive(TraceRawVcs, Hash, PartialEq, Eq, Clone, Debug, Serialize, Deserialize, NonLocalValue)]
+#[derive(
+    TraceRawVcs,
+    Hash,
+    PartialEq,
+    Eq,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
 pub enum ResolveIntoPackage {
     /// Using the [exports] field.
     ///
@@ -89,7 +115,19 @@ pub enum ResolveIntoPackage {
 }
 
 // The different ways to resolve a request within a package
-#[derive(TraceRawVcs, Hash, PartialEq, Eq, Clone, Debug, Serialize, Deserialize, NonLocalValue)]
+#[derive(
+    TraceRawVcs,
+    Hash,
+    PartialEq,
+    Eq,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
 pub enum ResolveInPackage {
     /// Using a alias field which allows to map requests
     AliasField(RcStr),

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
 use regex::Regex;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
@@ -1498,6 +1499,8 @@ impl ValueToString for Pattern {
     Deserialize,
     ValueDebugFormat,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum PatternMatch {
     File(RcStr, FileSystemPath),

--- a/turbopack/crates/turbopack-core/src/resolve/remap.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/remap.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, collections::BTreeMap, fmt::Display, ops::Deref};
 
 use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -363,7 +364,7 @@ impl<'a> Iterator for ResultsIterMut<'a> {
 }
 
 /// Content of an "exports" field in a package.json
-#[derive(PartialEq, Eq, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Serialize, Deserialize, Encode, Decode)]
 pub struct ExportsField(AliasMap<SubpathValue>);
 
 impl TryFrom<&Value> for ExportsField {
@@ -457,7 +458,7 @@ impl Deref for ExportsField {
 }
 
 /// Content of an "imports" field in a package.json
-#[derive(PartialEq, Eq, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Serialize, Deserialize, Encode, Decode)]
 pub struct ImportsField(AliasMap<SubpathValue>);
 
 impl TryFrom<&Value> for ImportsField {

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
@@ -16,7 +17,17 @@ use crate::{
     source_map::{GenerateSourceMap, SourceMap},
 };
 
-#[derive(PartialEq, Eq, Serialize, Deserialize, NonLocalValue, TraceRawVcs, ValueDebugFormat)]
+#[derive(
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    TraceRawVcs,
+    ValueDebugFormat,
+    Encode,
+    Decode,
+)]
 enum PathType {
     Fixed {
         path: FileSystemPath,

--- a/turbopack/crates/turbopack-core/src/source_pos.rs
+++ b/turbopack/crates/turbopack-core/src/source_pos.rs
@@ -1,3 +1,4 @@
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
 use turbo_tasks_hash::DeterministicHash;
@@ -23,6 +24,8 @@ const U8_CR: u8 = 0x0D;
     Deserialize,
     DeterministicHash,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct SourcePos {
     /// The line, 0-indexed.

--- a/turbopack/crates/turbopack-core/src/target.rs
+++ b/turbopack/crates/turbopack-core/src/target.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, Vc, trace::TraceRawVcs};
 
@@ -174,7 +175,18 @@ impl CompileTarget {
 }
 
 #[derive(
-    PartialEq, Eq, Hash, Debug, Copy, Clone, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Copy,
+    Clone,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 #[repr(u8)]
 #[non_exhaustive]
@@ -217,7 +229,18 @@ impl Display for Arch {
 }
 
 #[derive(
-    PartialEq, Eq, Hash, Debug, Copy, Clone, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Copy,
+    Clone,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 #[repr(u8)]
 #[non_exhaustive]
@@ -256,7 +279,18 @@ impl Display for Platform {
 }
 
 #[derive(
-    PartialEq, Eq, Hash, Debug, Copy, Clone, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Copy,
+    Clone,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 #[repr(u8)]
 pub enum Endianness {
@@ -280,7 +314,18 @@ impl Display for Endianness {
 }
 
 #[derive(
-    PartialEq, Eq, Hash, Debug, Copy, Clone, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Copy,
+    Clone,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 #[repr(u8)]
 pub enum Libc {

--- a/turbopack/crates/turbopack-css/Cargo.toml
+++ b/turbopack/crates/turbopack-css/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 indoc = { workspace = true }
 lightningcss = { workspace = true }
 parcel_selectors = { workspace = true }
@@ -28,6 +29,7 @@ swc_core = { workspace = true, features = [
 ] }
 tokio = { workspace = true }
 tracing = { workspace = true }
+turbo-bincode = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }

--- a/turbopack/crates/turbopack-css/src/lib.rs
+++ b/turbopack/crates/turbopack-css/src/lib.rs
@@ -16,6 +16,7 @@ pub(crate) mod references;
 pub(crate) mod util;
 
 pub use asset::CssModuleAsset;
+use bincode::{Decode, Encode};
 pub use module_asset::ModuleCssAsset;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
@@ -38,6 +39,8 @@ use crate::references::import::ImportAssetReference;
     TaskInput,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum CssModuleAssetType {
     /// Default parsing mode.

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -163,7 +163,9 @@ enum ModuleCssClass {
 /// 3. class3: [Local("exported_class3), Import("class4", "./other.module.css")]
 #[turbo_tasks::value(transparent)]
 #[derive(Debug, Clone)]
-struct ModuleCssClasses(FxIndexMap<String, Vec<ModuleCssClass>>);
+struct ModuleCssClasses(
+    #[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<String, Vec<ModuleCssClass>>,
+);
 
 #[turbo_tasks::value_impl]
 impl ModuleCssAsset {

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -46,7 +46,11 @@ use crate::{
 pub type CssOutput = (ToCssResult, Option<Rope>);
 
 #[turbo_tasks::value(transparent)]
-struct LightningCssTargets(#[turbo_tasks(trace_ignore)] pub Targets);
+struct LightningCssTargets(
+    #[turbo_tasks(trace_ignore)]
+    #[bincode(with_serde)]
+    pub Targets,
+);
 
 /// Returns the LightningCSS targets for the given browserslist query.
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-dev-server/Cargo.toml
+++ b/turbopack/crates/turbopack-dev-server/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 auto-hash-map = { workspace = true }
+bincode = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }
 hyper = { version = "0.14", features = ["full"] }
@@ -35,6 +36,7 @@ tokio = { workspace = true }
 tokio-stream = "0.1.9"
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+turbo-bincode = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-bytes = { workspace = true }

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use mime_guess::mime::TEXT_HTML_UTF_8;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
@@ -20,7 +21,18 @@ use turbopack_core::{
 };
 
 #[derive(
-    Clone, Debug, Deserialize, Eq, Hash, NonLocalValue, PartialEq, Serialize, TaskInput, TraceRawVcs,
+    Clone,
+    Debug,
+    Deserialize,
+    Eq,
+    Hash,
+    NonLocalValue,
+    PartialEq,
+    Serialize,
+    TaskInput,
+    TraceRawVcs,
+    Encode,
+    Decode,
 )]
 pub struct DevHtmlEntry {
     pub chunkable_module: ResolvedVc<Box<dyn ChunkableModule>>,

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -20,7 +20,10 @@ use super::{
 };
 
 #[turbo_tasks::value(transparent)]
-struct OutputAssetsMap(FxIndexMap<RcStr, ResolvedVc<Box<dyn OutputAsset>>>);
+struct OutputAssetsMap(
+    #[bincode(with = "turbo_bincode::indexmap")]
+    FxIndexMap<RcStr, ResolvedVc<Box<dyn OutputAsset>>>,
+);
 
 type ExpandedState = State<FxHashSet<RcStr>>;
 

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -15,6 +15,7 @@ pub mod wrapping_source;
 use std::collections::BTreeSet;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use futures::{TryStreamExt, stream::Stream as StreamTrait};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
@@ -261,7 +262,19 @@ impl ValueDefault for Body {
 }
 
 /// Filter function that describes which information is required.
-#[derive(Debug, Clone, PartialEq, Eq, TraceRawVcs, Hash, Serialize, Deserialize, NonLocalValue)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    Hash,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
 pub enum ContentSourceDataFilter {
     All,
     Subset(BTreeSet<String>),
@@ -486,7 +499,9 @@ impl ContentSource for NoContentSource {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, Encode, Decode,
+)]
 pub enum RewriteType {
     Location {
         /// The new path and query used to lookup content. This _does not_ need to be the original

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Write, mem::replace};
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
@@ -8,7 +9,7 @@ use turbo_tasks::{
     fxindexmap, trace::TraceRawVcs,
 };
 
-use super::{GetContentSourceContent, GetContentSourceContents};
+use crate::source::{GetContentSourceContent, GetContentSourceContents};
 
 /// The type of the route. This will decide about the remaining segments of the
 /// route after the base.
@@ -24,7 +25,18 @@ pub enum RouteType {
 
 /// Some normal segment of a route.
 #[derive(
-    TaskInput, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, TraceRawVcs, NonLocalValue,
+    TaskInput,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum BaseSegment {
     Static(RcStr),
@@ -106,6 +118,7 @@ impl RouteTrees {
 pub struct RouteTree {
     base: Vec<BaseSegment>,
     sources: Vec<ResolvedVc<Box<dyn GetContentSourceContent>>>,
+    #[bincode(with = "turbo_bincode::indexmap")]
     static_segments: FxIndexMap<RcStr, ResolvedVc<RouteTree>>,
     dynamic_segments: Vec<ResolvedVc<RouteTree>>,
     catch_all_sources: Vec<ResolvedVc<Box<dyn GetContentSourceContent>>>,

--- a/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
@@ -25,6 +25,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+bincode = { workspace = true }
 indexmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anyhow::Result;
 use async_trait::async_trait;
+use bincode::{Decode, Encode};
 use indexmap::IndexMap;
 use rustc_hash::{FxBuildHasher, FxHasher};
 use serde::{Deserialize, Serialize};
@@ -23,7 +24,17 @@ use turbo_tasks::{NonLocalValue, OperationValue, ValueDefault, Vc, trace::TraceR
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
 #[derive(
-    Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue, OperationValue,
+    Clone,
+    PartialEq,
+    Eq,
+    Debug,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum EmotionLabelKind {
@@ -70,6 +81,7 @@ pub struct EmotionTransformConfig {
     pub sourcemap: Option<bool>,
     pub label_format: Option<String>,
     pub auto_label: Option<EmotionLabelKind>,
+    #[bincode(with_serde)]
     pub import_map: Option<IndexMap<RcStr, EmotionImportMapValue, FxBuildHasher>>,
 }
 

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
@@ -2,6 +2,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{common::FileName, ecma::ast::Program};
 use swc_relay::RelayLanguageConfig;
@@ -10,7 +11,16 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack_ecmascript::{CustomTransformer, TransformContext};
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct RelayConfig {
@@ -20,7 +30,16 @@ pub struct RelayConfig {
 }
 
 #[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "lowercase")]
 pub enum RelayLanguage {

--- a/turbopack/crates/turbopack-ecmascript/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript/Cargo.toml
@@ -24,6 +24,7 @@ workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 auto-hash-map = { workspace = true }
+bincode = { workspace = true }
 bytes-str = { workspace = true }
 data-encoding = { workspace = true }
 either = { workspace = true }
@@ -45,6 +46,7 @@ smallvec = { workspace = true }
 strsim = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+turbo-bincode = { workspace = true }
 turbo-esregex = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -29,6 +29,7 @@ use crate::{
 pub struct ImportAnnotations {
     // TODO store this in more structured way
     #[turbo_tasks(trace_ignore)]
+    #[bincode(with_serde)]
     map: BTreeMap<Wtf8Atom, Wtf8Atom>,
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -25,9 +25,9 @@ use swc_core::{
 };
 use turbo_esregex::EsRegex;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, FxIndexSet, Vc};
+use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, Vc};
 use turbopack_core::compile_time_info::{
-    CompileTimeDefineValue, DefinableNameSegment, FreeVarReference,
+    CompileTimeDefineValue, DefinableNameSegment, FreeVarReference, FreeVarReferenceVcs,
 };
 
 use self::imports::ImportAnnotations;
@@ -2097,19 +2097,16 @@ impl JsValue {
     ///
     /// Uses the `VarGraph` to verify that the first segment is not a local
     /// variable/was not reassigned.
-    pub fn match_free_var_reference<'a, T>(
+    pub fn match_free_var_reference(
         &self,
         var_graph: &VarGraph,
-        free_var_references: &'a FxIndexMap<
-            DefinableNameSegment,
-            FxIndexMap<Vec<DefinableNameSegment>, T>,
-        >,
+        free_var_references: &FxIndexMap<DefinableNameSegment, FreeVarReferenceVcs>,
         prop: &DefinableNameSegment,
-    ) -> Option<&'a T> {
+    ) -> Option<ResolvedVc<FreeVarReference>> {
         if let Some(def_name_len) = self.get_definable_name_len()
             && let Some(references) = free_var_references.get(prop)
         {
-            for (name, value) in references {
+            for (name, value) in &references.0 {
                 if name.len() != def_name_len {
                     continue;
                 }
@@ -2128,7 +2125,7 @@ impl JsValue {
                         }
                     }
 
-                    return Some(value);
+                    return Some(*value);
                 }
             }
         }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/batch.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/batch.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, Vc, trace::TraceRawVcs};
 use turbopack_core::{
@@ -11,7 +12,18 @@ use turbopack_core::{
 use crate::chunk::EcmascriptChunkItemWithAsyncInfo;
 
 #[derive(
-    Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, TaskInput,
+    Debug,
+    Clone,
+    Hash,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum EcmascriptChunkItemOrBatchWithAsyncInfo {
     ChunkItem(EcmascriptChunkItemWithAsyncInfo),

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 
 use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use turbo_rcstr::{RcStr, rcstr};
@@ -40,6 +41,8 @@ use crate::{
     TaskInput,
     NonLocalValue,
     Default,
+    Encode,
+    Decode,
 )]
 pub enum RewriteSourcePath {
     AbsoluteFilePath(FileSystemPath),
@@ -177,7 +180,17 @@ impl EcmascriptChunkItemContent {
 }
 
 #[derive(
-    PartialEq, Eq, Default, Debug, Clone, Serialize, Deserialize, TraceRawVcs, NonLocalValue,
+    PartialEq,
+    Eq,
+    Default,
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct EcmascriptChunkItemOptions {
     /// Whether this chunk item should be in "use strict" mode.
@@ -195,7 +208,18 @@ pub struct EcmascriptChunkItemOptions {
 }
 
 #[derive(
-    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, TraceRawVcs, TaskInput, NonLocalValue,
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    TraceRawVcs,
+    TaskInput,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct EcmascriptChunkItemWithAsyncInfo {
     pub chunk_item: ResolvedVc<Box<dyn EcmascriptChunkItem>>,

--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     base::SwcComments,
@@ -174,7 +175,17 @@ impl_modify!(visit_mut_switch_case, SwitchCase);
 impl_modify!(visit_mut_program, Program);
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub enum CodeGen {
     // AMD occurs very rarely and makes the enum much bigger

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -45,6 +45,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow, bail};
+use bincode::{Decode, Encode};
 use chunk::EcmascriptChunkItem;
 use code_gen::{CodeGeneration, CodeGenerationHoistedStmt};
 use either::Either;
@@ -144,6 +145,8 @@ use crate::{
     NonLocalValue,
     Serialize,
     Deserialize,
+    Encode,
+    Decode,
 )]
 pub enum SpecifiedModuleType {
     #[default]
@@ -167,6 +170,8 @@ pub enum SpecifiedModuleType {
     TaskInput,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "kebab-case")]
 pub enum TreeShakingMode {
@@ -190,6 +195,8 @@ pub enum TreeShakingMode {
     TaskInput,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum AnalyzeMode {
     /// For bundling only, no tracing of referenced files.
@@ -233,6 +240,8 @@ pub struct OptionTreeShaking(pub Option<TreeShakingMode>);
     TraceRawVcs,
     NonLocalValue,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub enum TypeofWindow {
     Object,

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -1,6 +1,7 @@
 use std::mem::take;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     common::DUMMY_SP,
@@ -99,6 +100,8 @@ impl ChunkableModuleReference for AmdDefineAssetReference {}
     Clone,
     NonLocalValue,
     Hash,
+    Encode,
+    Decode,
 )]
 pub enum AmdDefineDependencyElement {
     Request {
@@ -122,6 +125,8 @@ pub enum AmdDefineDependencyElement {
     Clone,
     NonLocalValue,
     Hash,
+    Encode,
+    Decode,
 )]
 pub enum AmdDefineFactoryType {
     Unknown,
@@ -130,7 +135,17 @@ pub enum AmdDefineFactoryType {
 }
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub struct AmdDefineWithDependenciesCodeGen {
     dependencies_requests: Vec<AmdDefineDependencyElement>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     common::util::take::Take,
@@ -151,7 +152,17 @@ impl IntoCodeGenReference for CjsRequireAssetReference {
 }
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub struct CjsRequireAssetReferenceCodeGen {
     reference: ResolvedVc<CjsRequireAssetReference>,
@@ -277,7 +288,17 @@ impl IntoCodeGenReference for CjsRequireResolveAssetReference {
 }
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub struct CjsRequireResolveAssetReferenceCodeGen {
     reference: ResolvedVc<CjsRequireResolveAssetReference>,
@@ -339,7 +360,17 @@ impl CjsRequireResolveAssetReferenceCodeGen {
 }
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Debug, Hash,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Debug,
+    Hash,
+    Encode,
+    Decode,
 )]
 pub struct CjsRequireCacheAccess {
     pub path: AstPath,

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_condition.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_condition.rs
@@ -1,17 +1,29 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::quote;
 use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
 use turbopack_core::chunk::ChunkingContext;
 
-use super::AstPath;
 use crate::{
     code_gen::{CodeGen, CodeGeneration},
     create_visitor,
+    references::AstPath,
 };
 
 #[derive(
-    Copy, Clone, Hash, PartialEq, Eq, Debug, Serialize, Deserialize, TraceRawVcs, NonLocalValue,
+    Copy,
+    Clone,
+    Hash,
+    PartialEq,
+    Eq,
+    Debug,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum ConstantConditionValue {
     Truthy,
@@ -20,7 +32,17 @@ pub enum ConstantConditionValue {
 }
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Debug, Hash,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Debug,
+    Hash,
+    Encode,
+    Decode,
 )]
 pub struct ConstantConditionCodeGen {
     value: ConstantConditionValue,

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     common::{DUMMY_SP, FileName, SourceMap, sync::Lrc},
@@ -12,10 +13,10 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
 use turbopack_core::{chunk::ChunkingContext, compile_time_info::CompileTimeDefineValue};
 
-use super::AstPath;
 use crate::{
     code_gen::{CodeGen, CodeGeneration},
     create_visitor,
+    references::AstPath,
 };
 
 #[derive(
@@ -29,6 +30,8 @@ use crate::{
     TraceRawVcs,
     ValueDebugFormat,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub struct ConstantValueCodeGen {
     value: CompileTimeDefineValue,

--- a/turbopack/crates/turbopack-ecmascript/src/references/dynamic_expression.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/dynamic_expression.rs
@@ -1,17 +1,28 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::quote;
 use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
 use turbopack_core::chunk::ChunkingContext;
 
-use super::AstPath;
 use crate::{
     code_gen::{CodeGen, CodeGeneration},
     create_visitor,
+    references::AstPath,
 };
 
 #[derive(
-    PartialEq, Eq, TraceRawVcs, Serialize, Deserialize, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 enum DynamicExpressionType {
     Promise,
@@ -19,7 +30,17 @@ enum DynamicExpressionType {
 }
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Debug, Hash,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Debug,
+    Hash,
+    Encode,
+    Decode,
 )]
 pub struct DynamicExpression {
     path: AstPath,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -35,7 +35,6 @@ use turbopack_core::{
 };
 use turbopack_resolve::ecmascript::esm_resolve;
 
-use super::export::{all_known_export_names, is_export_missing};
 use crate::{
     EcmascriptModuleAsset, ScopeHoistingContext, TreeShakingMode,
     analyzer::imports::ImportAnnotations,
@@ -43,7 +42,13 @@ use crate::{
     code_gen::{CodeGeneration, CodeGenerationHoistedStmt},
     export::Liveness,
     magic_identifier,
-    references::{esm::EsmExport, util::throw_module_not_found_expr},
+    references::{
+        esm::{
+            EsmExport,
+            export::{all_known_export_names, is_export_missing},
+        },
+        util::throw_module_not_found_expr,
+    },
     runtime_functions::{TURBOPACK_EXTERNAL_IMPORT, TURBOPACK_EXTERNAL_REQUIRE, TURBOPACK_IMPORT},
     tree_shake::{TURBOPACK_PART_IMPORT_SOURCE, asset::EcmascriptModulePartAsset},
     utils::module_id_to_lit,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/binding.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::ecma::{
     ast::{Expr, KeyValueProp, Prop, PropName, SimpleAssignTarget},
@@ -8,18 +9,32 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs};
 use turbopack_core::chunk::ChunkingContext;
 
-use super::EsmAssetReference;
 use crate::{
     ScopeHoistingContext,
     code_gen::{CodeGen, CodeGeneration},
     create_visitor,
     references::{
         AstPath,
-        esm::base::{ReferencedAsset, ReferencedAssetIdent},
+        esm::{
+            EsmAssetReference,
+            base::{ReferencedAsset, ReferencedAssetIdent},
+        },
     },
 };
 
-#[derive(Hash, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, TraceRawVcs, NonLocalValue)]
+#[derive(
+    Hash,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    TraceRawVcs,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
 pub struct EsmBinding {
     reference: ResolvedVc<EsmAssetReference>,
     export: Option<RcStr>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     common::{DUMMY_SP, util::take::Take},
@@ -23,12 +24,14 @@ use turbopack_core::{
 };
 use turbopack_resolve::ecmascript::esm_resolve;
 
-use super::super::pattern_mapping::{PatternMapping, ResolveType};
 use crate::{
     analyzer::imports::ImportAnnotations,
     code_gen::{CodeGen, CodeGeneration, IntoCodeGenReference},
     create_visitor,
-    references::AstPath,
+    references::{
+        AstPath,
+        pattern_mapping::{PatternMapping, ResolveType},
+    },
 };
 
 #[turbo_tasks::value]
@@ -122,7 +125,17 @@ impl IntoCodeGenReference for EsmAsyncAssetReference {
 }
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub struct EsmAsyncAssetReferenceCodeGen {
     path: AstPath,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     common::DUMMY_SP,
@@ -27,7 +28,17 @@ use crate::{
 ///
 /// This singleton behavior must be enforced by the caller!
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Debug, Hash,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Debug,
+    Hash,
+    Encode,
+    Decode,
 )]
 pub struct ImportMetaBinding {
     path: FileSystemPath,
@@ -88,7 +99,17 @@ impl From<ImportMetaBinding> for CodeGen {
 /// There can be many references to import.meta, and they appear at any nesting
 /// in the file. But all references refer to the same mutable object.
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub struct ImportMetaRef {
     ast_path: AstPath,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::quote;
 use turbo_rcstr::RcStr;
@@ -11,11 +12,13 @@ use turbopack_core::{
     resolve::ModuleResolveResult,
 };
 
-use super::{EsmAssetReference, base::ReferencedAsset};
 use crate::{
     code_gen::{CodeGen, CodeGeneration, IntoCodeGenReference},
     create_visitor,
-    references::AstPath,
+    references::{
+        AstPath,
+        esm::{EsmAssetReference, base::ReferencedAsset},
+    },
     utils::module_id_to_lit,
 };
 
@@ -74,7 +77,17 @@ impl IntoCodeGenReference for EsmModuleIdAssetReference {
 }
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub struct EsmModuleIdAssetReferenceCodeGen {
     path: AstPath,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
@@ -1,6 +1,7 @@
 use std::mem::replace;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     common::DUMMY_SP,
@@ -23,7 +24,17 @@ use crate::{
 /// expr/decl in a normal statement. Unnamed expr/decl will be named with the
 /// magic identifier "export default"
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Debug, Hash,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Debug,
+    Hash,
+    Encode,
+    Decode,
 )]
 pub struct EsmModuleItem {
     pub path: AstPath,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     ecma::ast::{Expr, ExprOrSpread, NewExpr},
@@ -23,11 +24,10 @@ use turbopack_core::{
     },
 };
 
-use super::base::ReferencedAsset;
 use crate::{
     code_gen::{CodeGen, CodeGeneration, IntoCodeGenReference},
     create_visitor,
-    references::AstPath,
+    references::{AstPath, esm::base::ReferencedAsset},
     runtime_functions::{
         TURBOPACK_RELATIVE_URL, TURBOPACK_REQUIRE, TURBOPACK_RESOLVE_MODULE_ID_PATH,
     },
@@ -49,6 +49,8 @@ use crate::{
     TraceRawVcs,
     TaskInput,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum UrlRewriteBehavior {
     /// Omits base, resulting in a relative URL.
@@ -147,7 +149,17 @@ impl IntoCodeGenReference for UrlAssetReference {
 }
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub struct UrlAssetReferenceCodeGen {
     reference: ResolvedVc<UrlAssetReference>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/exports_info.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/exports_info.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     common::DUMMY_SP,
@@ -24,7 +25,17 @@ use crate::{
 ///
 /// This singleton behavior must be enforced by the caller!
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub struct ExportsInfoBinding {}
 
@@ -92,7 +103,17 @@ impl From<ExportsInfoBinding> for CodeGen {
 /// There can be many references, and they appear at any nesting in the file. But all references
 /// refer to the same mutable object.
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub struct ExportsInfoRef {
     ast_path: AstPath,

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, fmt::Display, io::Write};
 
 use anyhow::{Context, Result};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, Vc, trace::TraceRawVcs};
@@ -55,6 +56,8 @@ use crate::{
     TaskInput,
     Hash,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum CachedExternalType {
     CommonJs,
@@ -65,7 +68,18 @@ pub enum CachedExternalType {
 }
 
 #[derive(
-    Clone, Debug, Eq, PartialEq, Serialize, Deserialize, TraceRawVcs, TaskInput, Hash, NonLocalValue,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    TaskInput,
+    Hash,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 /// Whether to add a traced reference to the external module using the given context and resolve
 /// origin.

--- a/turbopack/crates/turbopack-ecmascript/src/references/ident.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/ident.rs
@@ -1,18 +1,29 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{ecma::ast::Expr, quote};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
 use turbopack_core::chunk::ChunkingContext;
 
-use super::AstPath;
 use crate::{
     code_gen::{CodeGen, CodeGeneration},
     create_visitor,
+    references::AstPath,
 };
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Debug, Hash,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Debug,
+    Hash,
+    Encode,
+    Decode,
 )]
 pub struct IdentReplacement {
     value: RcStr,

--- a/turbopack/crates/turbopack-ecmascript/src/references/member.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/member.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     atoms::atom,
@@ -14,14 +15,24 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
 use turbopack_core::chunk::ChunkingContext;
 
-use super::AstPath;
 use crate::{
     code_gen::{CodeGen, CodeGeneration},
     create_visitor,
+    references::AstPath,
 };
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub struct MemberReplacement {
     key: RcStr,

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, collections::HashSet};
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     common::DUMMY_SP,
@@ -37,7 +38,17 @@ use crate::{
     utils::module_id_to_lit,
 };
 
-#[derive(PartialEq, Eq, ValueDebugFormat, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
+#[derive(
+    PartialEq,
+    Eq,
+    ValueDebugFormat,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
 pub(crate) enum SinglePatternMapping {
     /// Invalid request.
     Invalid,
@@ -83,7 +94,7 @@ pub(crate) enum PatternMapping {
     /// ```js
     /// require(`./images/${name}.png`)
     /// ```
-    Map(FxIndexMap<String, SinglePatternMapping>),
+    Map(#[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<String, SinglePatternMapping>),
 }
 
 #[derive(

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, collections::VecDeque, sync::Arc};
 
 use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     common::DUMMY_SP,
@@ -61,7 +62,9 @@ pub(crate) enum DirListEntry {
 }
 
 #[turbo_tasks::value(transparent)]
-pub(crate) struct DirList(FxIndexMap<RcStr, DirListEntry>);
+pub(crate) struct DirList(
+    #[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<RcStr, DirListEntry>,
+);
 
 #[turbo_tasks::value_impl]
 impl DirList {
@@ -151,7 +154,9 @@ impl DirList {
 }
 
 #[turbo_tasks::value(transparent)]
-pub(crate) struct FlatDirList(FxIndexMap<RcStr, FileSystemPath>);
+pub(crate) struct FlatDirList(
+    #[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<RcStr, FileSystemPath>,
+);
 
 #[turbo_tasks::value_impl]
 impl FlatDirList {
@@ -171,7 +176,9 @@ pub struct RequireContextMapEntry {
 
 /// The resolved context map for a `require.context(..)` call.
 #[turbo_tasks::value(transparent)]
-pub struct RequireContextMap(FxIndexMap<RcStr, RequireContextMapEntry>);
+pub struct RequireContextMap(
+    #[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<RcStr, RequireContextMapEntry>,
+);
 
 #[turbo_tasks::value_impl]
 impl RequireContextMap {
@@ -318,7 +325,17 @@ impl IntoCodeGenReference for RequireContextAssetReference {
 }
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub struct RequireContextAssetReferenceCodeGen {
     path: AstPath,

--- a/turbopack/crates/turbopack-ecmascript/src/references/unreachable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/unreachable.rs
@@ -1,6 +1,7 @@
 use std::mem::take;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     atoms::{Atom, atom},
@@ -32,9 +33,18 @@ use crate::{
 };
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Debug, Hash,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Debug,
+    Hash,
+    Encode,
+    Decode,
 )]
-
 pub struct Unreachable {
     range: AstPathRange,
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     common::util::take::Take,
@@ -126,7 +127,17 @@ impl IntoCodeGenReference for WorkerAssetReference {
 }
 
 #[derive(
-    PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue, Hash, Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Hash,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub struct WorkerAssetReferenceCodeGen {
     reference: ResolvedVc<WorkerAssetReference>,

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/chunk_item.rs
@@ -7,10 +7,10 @@ use turbopack_core::{
     output::OutputAssetsReference,
 };
 
-use super::module::EcmascriptModuleLocalsModule;
 use crate::{
     EcmascriptAnalyzableExt,
     chunk::{EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkType},
+    side_effect_optimization::locals::module::EcmascriptModuleLocalsModule,
 };
 
 /// The chunk item for [EcmascriptModuleLocalsModule].

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     common::DUMMY_SP,
@@ -17,19 +18,31 @@ use turbopack_core::{
     resolve::{BindingUsage, ExportUsage, ImportUsage, ModulePart, ModuleResolveResult},
 };
 
-use super::{
-    facade::module::EcmascriptModuleFacadeModule, locals::module::EcmascriptModuleLocalsModule,
-};
 use crate::{
     ScopeHoistingContext,
     chunk::EcmascriptChunkPlaceable,
     code_gen::{CodeGeneration, CodeGenerationHoistedStmt},
     references::esm::base::{ReferencedAsset, ReferencedAssetIdent},
     runtime_functions::TURBOPACK_IMPORT,
+    side_effect_optimization::{
+        facade::module::EcmascriptModuleFacadeModule, locals::module::EcmascriptModuleLocalsModule,
+    },
     utils::module_id_to_lit,
 };
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, NonLocalValue, TraceRawVcs)]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    TraceRawVcs,
+    Encode,
+    Decode,
+)]
 enum EcmascriptModulePartReferenceMode {
     Synthesize,
     Normal,

--- a/turbopack/crates/turbopack-ecmascript/src/utils.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/utils.rs
@@ -1,5 +1,6 @@
 use std::ops::Deref;
 
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use swc_core::{
     common::{DUMMY_SP, SyntaxContext},
@@ -178,13 +179,33 @@ format_iter!(std::fmt::Pointer);
 format_iter!(std::fmt::UpperExp);
 format_iter!(std::fmt::UpperHex);
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, Debug, NonLocalValue, Hash)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    Debug,
+    NonLocalValue,
+    Hash,
+    Encode,
+    Decode,
+)]
 pub enum AstPathRange {
     /// The ast path to the block or expression.
-    Exact(#[turbo_tasks(trace_ignore)] Vec<AstParentKind>),
+    Exact(
+        #[bincode(with_serde)]
+        #[turbo_tasks(trace_ignore)]
+        Vec<AstParentKind>,
+    ),
     /// The ast path to a expression just before the range in the parent of the
     /// specific ast path.
-    StartAfter(#[turbo_tasks(trace_ignore)] Vec<AstParentKind>),
+    StartAfter(
+        #[bincode(with_serde)]
+        #[turbo_tasks(trace_ignore)]
+        Vec<AstParentKind>,
+    ),
 }
 
 /// Converts a module value (ie an import) to a well known object,
@@ -226,8 +247,14 @@ pub fn module_value_to_well_known_object(module_value: &ModuleValue) -> Option<J
     })
 }
 
-#[derive(Hash, Debug, Clone, Copy, Eq, Serialize, Deserialize, PartialEq, TraceRawVcs)]
-pub struct AstSyntaxContext(#[turbo_tasks(trace_ignore)] SyntaxContext);
+#[derive(
+    Hash, Debug, Clone, Copy, Eq, Serialize, Deserialize, PartialEq, TraceRawVcs, Encode, Decode,
+)]
+pub struct AstSyntaxContext(
+    #[turbo_tasks(trace_ignore)]
+    #[bincode(with_serde)]
+    SyntaxContext,
+);
 
 impl TaskInput for AstSyntaxContext {
     fn is_transient(&self) -> bool {

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -75,6 +75,7 @@ impl Asset for WebpackModuleAsset {
 #[turbo_tasks::value(shared)]
 pub struct WebpackChunkAssetReference {
     #[turbo_tasks(trace_ignore)]
+    #[bincode(with_serde)]
     pub chunk_id: Lit,
     pub runtime: ResolvedVc<WebpackRuntime>,
     pub transforms: ResolvedVc<EcmascriptInputTransforms>,

--- a/turbopack/crates/turbopack-image/Cargo.toml
+++ b/turbopack/crates/turbopack-image/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 base64 = "0.21.0"
+bincode = { workspace = true }
 image = { workspace = true, default-features = false, features = [
   "gif",
   "png",
@@ -35,6 +36,7 @@ regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
+turbo-bincode = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }

--- a/turbopack/crates/turbopack-image/src/process/mod.rs
+++ b/turbopack/crates/turbopack-image/src/process/mod.rs
@@ -4,6 +4,7 @@ use std::{io::Cursor, str::FromStr};
 
 use anyhow::{Context, Result, bail};
 use base64::{display::Base64Display, engine::general_purpose::STANDARD};
+use bincode::{Decode, Encode};
 use image::{
     DynamicImage, GenericImageView, ImageEncoder, ImageFormat,
     codecs::{
@@ -32,7 +33,17 @@ use turbopack_core::{
 use self::svg::calculate;
 
 /// Small placeholder version of the image.
-#[derive(PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue)]
+#[derive(
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
 pub struct BlurPlaceholder {
     pub data_url: String,
     pub width: u32,
@@ -62,6 +73,7 @@ pub struct ImageMetaData {
     pub height: u32,
     #[turbo_tasks(trace_ignore, debug_ignore)]
     #[serde_as(as = "Option<DisplayFromStr>")]
+    #[bincode(with = "turbo_bincode::mime_option")]
     pub mime_type: Option<Mime>,
     pub blur_placeholder: Option<BlurPlaceholder>,
 }

--- a/turbopack/crates/turbopack-node/Cargo.toml
+++ b/turbopack/crates/turbopack-node/Cargo.toml
@@ -21,6 +21,7 @@ anyhow = { workspace = true }
 async-stream = "0.3.4"
 async-trait = { workspace = true }
 base64 = "0.21.0"
+bincode = { workspace = true }
 const_format = { workspace = true }
 either = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
@@ -36,6 +37,7 @@ serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["base64"] }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
+turbo-bincode = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-bytes = { workspace = true }

--- a/turbopack/crates/turbopack-node/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-node/src/source_map/mod.rs
@@ -8,7 +8,6 @@ use anyhow::Result;
 use const_format::concatcp;
 use once_cell::sync::Lazy;
 use regex::Regex;
-pub use trace::{StackFrame, TraceResult, trace_source_map};
 use turbo_tasks::{ReadRef, Vc};
 use turbo_tasks_fs::{
     FileLinesContent, FileSystemPath, source_context::get_source_context, to_sys_path,
@@ -20,6 +19,7 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::magic_identifier::unmangle_identifiers;
 
+pub use crate::source_map::trace::{StackFrame, TraceResult, trace_source_map};
 use crate::{AssetsForSourceMapping, pool::FormattingMode};
 
 pub mod trace;

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use bincode::{Decode, Encode};
 use indoc::formatdoc;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
@@ -25,18 +26,19 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::runtime_functions::TURBOPACK_EXTERNAL_IMPORT;
 
-use super::{
-    util::{EmittedAsset, emitted_assets_to_virtual_sources},
-    webpack::WebpackLoaderContext,
-};
 use crate::{
-    embed_js::embed_file_path, evaluate::get_evaluate_entries, execution_context::ExecutionContext,
-    transforms::webpack::evaluate_webpack_loader,
+    embed_js::embed_file_path,
+    evaluate::get_evaluate_entries,
+    execution_context::ExecutionContext,
+    transforms::{
+        util::{EmittedAsset, emitted_assets_to_virtual_sources},
+        webpack::{WebpackLoaderContext, evaluate_webpack_loader},
+    },
 };
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Clone)]
+#[turbo_tasks::value]
 #[serde(rename_all = "camelCase")]
-#[turbo_tasks::value(serialization = "custom")]
 struct PostCssProcessingResult {
     css: String,
     map: Option<String>,
@@ -56,6 +58,8 @@ struct PostCssProcessingResult {
     Deserialize,
     TaskInput,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum PostCssConfigLocation {
     #[default]

--- a/turbopack/crates/turbopack-node/src/transforms/util.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/util.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use turbo_rcstr::RcStr;
@@ -10,11 +11,14 @@ use turbopack_core::{
     asset::AssetContent, server_fs::ServerFileSystem, virtual_source::VirtualSource,
 };
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, TraceRawVcs, NonLocalValue)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Clone, TraceRawVcs, NonLocalValue, Encode, Decode,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct EmittedAsset {
     file: RcStr,
     content: RcStr,
+    #[bincode(with = "turbo_bincode::serde_json")]
     source_map: Option<JsonValue>,
 }
 

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -2,6 +2,7 @@ use std::mem::take;
 
 use anyhow::{Context, Result, bail};
 use base64::Engine;
+use bincode::{Decode, Encode};
 use either::Either;
 use futures::try_join;
 use serde::{Deserialize, Serialize};
@@ -47,7 +48,6 @@ use turbopack_resolve::{
     resolve_options_context::ResolveOptionsContext,
 };
 
-use super::util::{EmittedAsset, emitted_assets_to_virtual_sources};
 use crate::{
     AssetsForSourceMapping,
     debug::should_debug,
@@ -59,20 +59,22 @@ use crate::{
     execution_context::ExecutionContext,
     pool::{FormattingMode, NodeJsPool},
     source_map::{StackFrame, StructuredError},
+    transforms::util::{EmittedAsset, emitted_assets_to_virtual_sources},
 };
 
 #[serde_as]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Encode, Decode)]
 struct BytesBase64 {
     #[serde_as(as = "serde_with::base64::Base64")]
     binary: Vec<u8>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Clone)]
+#[turbo_tasks::value]
 #[serde(rename_all = "camelCase")]
-#[turbo_tasks::value(serialization = "custom")]
 struct WebpackLoadersProcessingResult {
     #[serde(with = "either::serde_untagged")]
+    #[bincode(with = "turbo_bincode::either")]
     #[turbo_tasks(debug_ignore, trace_ignore)]
     source: Either<RcStr, BytesBase64>,
     map: Option<RcStr>,
@@ -81,11 +83,22 @@ struct WebpackLoadersProcessingResult {
 }
 
 #[derive(
-    Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue, OperationValue,
+    Clone,
+    PartialEq,
+    Eq,
+    Debug,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
 )]
 pub struct WebpackLoaderItem {
     pub loader: RcStr,
     #[serde(default)]
+    #[bincode(with = "turbo_bincode::serde_json")]
     pub options: serde_json::Map<String, serde_json::Value>,
 }
 
@@ -327,7 +340,7 @@ pub(crate) async fn evaluate_webpack_loader(
     custom_evaluate(webpack_loader_context).await
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Encode, Decode)]
 #[serde(rename_all = "camelCase")]
 enum LogType {
     Error,
@@ -346,11 +359,12 @@ enum LogType {
     Status,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Encode, Decode)]
 #[serde(rename_all = "camelCase")]
 pub struct LogInfo {
     time: u64,
     log_type: LogType,
+    #[bincode(with = "turbo_bincode::serde_json")]
     args: Vec<JsonValue>,
     trace: Option<Vec<StackFrame<'static>>>,
 }

--- a/turbopack/crates/turbopack-nodejs/Cargo.toml
+++ b/turbopack/crates/turbopack-nodejs/Cargo.toml
@@ -20,10 +20,12 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 indoc = { workspace = true }
 tracing = { workspace = true }
 urlencoding = { workspace = true }
 
+turbo-bincode = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
 turbo-tasks-fs = { workspace = true }

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -165,16 +165,19 @@ pub struct NodeJsChunkingContext {
     /// This path is used to compute the url to request chunks or assets from
     client_root: FileSystemPath,
     /// This path is used to compute the url to request chunks or assets from
+    #[bincode(with = "turbo_bincode::indexmap")]
     client_roots: FxIndexMap<RcStr, FileSystemPath>,
     /// Chunks are placed at this path
     chunk_root_path: FileSystemPath,
     /// Static assets are placed at this path
     asset_root_path: FileSystemPath,
     /// Static assets are placed at this path
+    #[bincode(with = "turbo_bincode::indexmap")]
     asset_root_paths: FxIndexMap<RcStr, FileSystemPath>,
     /// Static assets requested from this url base
     asset_prefix: Option<RcStr>,
     /// Static assets requested from this url base
+    #[bincode(with = "turbo_bincode::indexmap")]
     asset_prefixes: FxIndexMap<RcStr, RcStr>,
     /// The environment chunks will be evaluated in.
     environment: ResolvedVc<Environment>,

--- a/turbopack/crates/turbopack-test-utils/Cargo.toml
+++ b/turbopack/crates/turbopack-test-utils/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true, features = ["pattern"] }
 serde = { workspace = true }

--- a/turbopack/crates/turbopack-test-utils/src/jest.rs
+++ b/turbopack/crates/turbopack-test-utils/src/jest.rs
@@ -1,3 +1,4 @@
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 // Defines common structures returned by jest/jest-circus. Shared across turbo
@@ -5,13 +6,13 @@ use serde::{Deserialize, Serialize};
 
 /// The serialized form of the JS object returned from jest.run()
 /// describing results.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Encode, Decode)]
 #[serde(rename_all = "camelCase")]
 pub struct JestRunResult {
     pub test_results: Vec<JestTestResult>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Encode, Decode)]
 #[serde(rename_all = "camelCase")]
 pub struct JestTestResult {
     pub test_path: Vec<String>,

--- a/turbopack/crates/turbopack-tests/Cargo.toml
+++ b/turbopack/crates/turbopack-tests/Cargo.toml
@@ -17,6 +17,7 @@ turbopack = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 dunce = { workspace = true }
 once_cell = { workspace = true }
 rustc-hash = { workspace = true }

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -8,6 +8,7 @@ mod util;
 use std::{env, path::PathBuf};
 
 use anyhow::{Context, Result};
+use bincode::{Decode, Encode};
 use dunce::canonicalize;
 use serde::{Deserialize, Serialize};
 use tracing_subscriber::{Registry, layer::SubscriberExt, util::SubscriberInitExt};
@@ -233,7 +234,16 @@ async fn run_inner_operation(
 }
 
 #[derive(
-    PartialEq, Eq, Debug, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue,
+    PartialEq,
+    Eq,
+    Debug,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    ValueDebugFormat,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct TestOptions {

--- a/turbopack/crates/turbopack-wasm/Cargo.toml
+++ b/turbopack/crates/turbopack-wasm/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 indoc = { workspace = true }
 serde = { workspace = true }
 turbo-rcstr = { workspace = true }

--- a/turbopack/crates/turbopack-wasm/src/source.rs
+++ b/turbopack/crates/turbopack-wasm/src/source.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::{File, FileContent};
@@ -22,6 +23,8 @@ use turbopack_core::{
     TaskInput,
     TraceRawVcs,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum WebAssemblySourceType {
     /// Binary WebAssembly files (.wasm).

--- a/turbopack/crates/turbopack/Cargo.toml
+++ b/turbopack/crates/turbopack/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 either = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }

--- a/turbopack/crates/turbopack/src/module_options/match_mode.rs
+++ b/turbopack/crates/turbopack/src/module_options/match_mode.rs
@@ -1,8 +1,21 @@
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, trace::TraceRawVcs};
 use turbopack_core::reference_type::ReferenceType;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
 pub enum MatchMode {
     // Match all but internal references.
     NonInternal,

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_esregex::EsRegex;
 use turbo_rcstr::RcStr;
@@ -21,7 +22,9 @@ use turbopack_node::{
 use super::ModuleRule;
 use crate::module_options::RuleCondition;
 
-#[derive(Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
+#[derive(
+    Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue, Encode, Decode,
+)]
 pub struct LoaderRuleItem {
     pub loaders: ResolvedVc<WebpackLoaderItems>,
     pub rename_as: Option<RcStr>,
@@ -37,7 +40,9 @@ pub struct LoaderRuleItem {
 #[turbo_tasks::value(transparent)]
 pub struct WebpackRules(Vec<(RcStr, LoaderRuleItem)>);
 
-#[derive(Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
+#[derive(
+    Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue, Encode, Decode,
+)]
 pub enum ConditionPath {
     Glob(RcStr),
     Regex(ResolvedVc<EsRegex>),
@@ -104,7 +109,9 @@ impl WebpackLoaderBuiltinConditionSet for EmptyWebpackLoaderBuiltinConditionSet 
 
 /// The kind of decorators transform to use.
 /// [TODO]: might need bikeshed for the name (Ecma)
-#[derive(Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
+#[derive(
+    Clone, PartialEq, Eq, Debug, TraceRawVcs, Serialize, Deserialize, NonLocalValue, Encode, Decode,
+)]
 pub enum DecoratorsKind {
     Legacy,
     Ecma,

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, trace::TraceRawVcs};
@@ -13,7 +14,9 @@ use turbopack_wasm::source::WebAssemblySourceType;
 
 use super::{CustomModuleType, RuleCondition, match_mode::MatchMode};
 
-#[derive(Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, NonLocalValue)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, NonLocalValue, Encode, Decode,
+)]
 pub struct ModuleRule {
     condition: RuleCondition,
     effects: Vec<ModuleRuleEffect>,

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use either::Either;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -14,7 +15,9 @@ use turbopack_core::{
     asset::Asset, reference_type::ReferenceType, source::Source, virtual_source::VirtualSource,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, NonLocalValue)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, NonLocalValue, Encode, Decode,
+)]
 pub enum RuleCondition {
     All(Vec<RuleCondition>),
     Any(Vec<RuleCondition>),

--- a/turbopack/crates/turbopack/src/module_options/transition_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/transition_rule.rs
@@ -1,13 +1,18 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, ResolvedVc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{reference_type::ReferenceType, source::Source};
 
-use super::{RuleCondition, match_mode::MatchMode};
-use crate::transition::Transition;
+use crate::{
+    module_options::{RuleCondition, match_mode::MatchMode},
+    transition::Transition,
+};
 
-#[derive(Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, NonLocalValue)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, TraceRawVcs, PartialEq, Eq, NonLocalValue, Encode, Decode,
+)]
 pub struct TransitionRule {
     condition: RuleCondition,
     transition: ResolvedVc<Box<dyn Transition>>,


### PR DESCRIPTION
It looks like bincode should reduce the filesystem cache size by ~10% versus pot, because its not a self-describing format. This attempts to add the `bincode::Encode`/`bincode::Decode` traits everywhere, so that we can use those instead of serde.

## Why not use bincode's serde compatibility feature?

- Unfortunately, serde has some bugs/incompatibilities/footguns with non-self-describing formats. `bincode`'s traits avoid this by not exposing features that would be incompatible with a self-describing format. https://docs.rs/bincode/latest/bincode/serde/index.html#known-issues
- `bincode::Encode`/`Decode` are much simpler traits than serde's equivalents, so we'll probably get some rustc build performance and turbopack binary size benefits from using the bincode versions. In cases where we do have to implement these traits by hand, it's much easier than implementing the serde equivalents.
- I'd like to kill `erased-serde` anyways because we're probably paying some performance cost from the large amounts of dynamic dispatch it performs, and we're not getting any benefits from it if we only ever serialize to a single format.

## Forks of Upstream Crates

- I've forked `bincode` here: https://github.com/bgw/bincode/commits/bgw/patches/
  - I submitted a patch via email to the maintainer via sourcehut
    - Upstream: https://git.sr.ht/~stygianentity/bincode
    - Fork: https://git.sr.ht/~bgw/bincode
  - This adds a few extra derive features and fixes type bounds on `PhantomData`.
  - The type bounds on `PhantomData` aren't very important, and we could work around it in our code.
  - We could just fork the derive crate if upstream doesn't want to accept the patches.
- And `virtue` here: https://github.com/bgw/virtue/commit/e386f35cf7f22d04a4db32231904cbe5dc52c01d
  - I've submitted a PR to `virtue` here: https://github.com/bincode-org/virtue/pull/94
  - This fixes a bug in the parsing of const enums and generics with defaults.
  - We don't hit this very often as most of our types are not generics, so we could work around it in our code if upstream doesn't want to accept the patch.

## Other Notes

- Depends on a patched version of the `bincode` and `virtue` crates to fix a few bugs and add a few new features. I'll work on upstreaming these changes.
- This implements `BorrowDecode` everywhere because the `bincode::Decode` derive macro requires it. I plan to add an attribute in my bincode fork to allow disabling this, and then we can get rid of all of the `BorrowDecode` impls. We don't want/need `BorrowDecode` for turbo task values because everything needs to be owned anyways.