### PR TITLE
[test] Allow CLI integration test to be retryable

### DIFF
--- a/test/integration/cli/test/index.test.js
+++ b/test/integration/cli/test/index.test.js
@@ -15,6 +15,7 @@ import path, { join } from 'path'
 import pkg from 'next/package'
 import http from 'http'
 import stripAnsi from 'strip-ansi'
+import { rmSync } from 'fs'
 
 const dirBasic = join(__dirname, '../basic')
 const dirDuplicateSass = join(__dirname, '../duplicate-sass')
@@ -848,6 +849,13 @@ describe('CLI Usage', () => {
     })
 
     itCI('--experimental-https', async () => {
+      // set by runNextCommandDev
+      const nextDir = path.dirname(require.resolve('next/package'))
+      // hardcoded by Next.js relative to cwd of Next.js
+      const certDir = path.resolve(nextDir, 'certificates')
+      try {
+        rmSync(certDir, { recursive: true, force: true })
+      } catch {}
       // only runs on CI as it requires administrator privileges
       const port = await findPort()
       let output = ''


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/actions/runs/18937795131/job/54068900147#step:34:1879

`--experimental-https` test creates a cert relying on no cert existing in the default path. When it passes, it doesn't cleanup. Retrying that test file due to an unrelated failure would therefore always fail. Now we ensure no cert exists.