### PR TITLE
[test] Consider `test/integration/` in flake detection tests

### DIFF
--- a/scripts/get-changed-tests.mjs
+++ b/scripts/get-changed-tests.mjs
@@ -112,7 +112,10 @@ export default async function getChangedTests() {
       .catch(() => false)
 
     if (fileExists && file.match(/^test\/.*?\.test\.(js|ts|tsx)$/)) {
-      if (file.startsWith('test/e2e/')) {
+      if (
+        file.startsWith('test/e2e/') ||
+        file.startsWith('test/integration/')
+      ) {
         devTests.push(file)
         prodTests.push(file)
       } else if (file.startsWith('test/prod')) {


### PR DESCRIPTION
No mention why integration tests were excluded when the flake detection was introduced in https://github.com/vercel/next.js/pull/63943 so I assume this was an oversight.

The other explainer is that no new tests are added to `test/integration` so there won't be an y "new" tests in there. But since we also use flake detection for changes, integration tests should be considered.

Test is upstack where I change an integration test that correctly gets run in flake detection shards.