### PR TITLE
[@next/codemod] Fix upgrade failing when `devEngines.packageManager` is set to `pnpm`

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -42,7 +42,9 @@ const optionalNextjsPackages = [
  */
 async function loadHighestNPMVersionMatching(query: string) {
   const versionsJSON = execSync(
-    `npm --silent view "${query}" --json --field version`,
+    // Run as global to avoid being affected by devEngines.packageManager field in local package.json
+    // https://github.com/vercel/next.js/issues/85587
+    `npm -g --silent view "${query}" --json --field version`,
     { encoding: 'utf-8' }
   )
   const versionOrVersions = JSON.parse(versionsJSON)
@@ -96,7 +98,9 @@ export async function runUpgrade(
 
   try {
     const targetNextPackage = execSync(
-      `npm --silent view "next@${revision}" --json`,
+      // Run as global to avoid being affected by devEngines.packageManager field in local package.json
+      // https://github.com/vercel/next.js/issues/85587
+      `npm -g --silent view "next@${revision}" --json`,
       { encoding: 'utf-8' }
     )
     targetNextPackageJson = JSON.parse(targetNextPackage)

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -100,7 +100,13 @@ export async function runUpgrade(
       { encoding: 'utf-8' }
     )
     targetNextPackageJson = JSON.parse(targetNextPackage)
-  } catch {}
+  } catch (e) {
+    const output = e.output[1]
+    if (output) {
+      console.error(pc.red(output))
+    }
+    throw new BadInput('Failed to fetch Next.js versions using npm view.')
+  }
 
   const validRevision =
     targetNextPackageJson !== null &&


### PR DESCRIPTION
### What?

- Print clearer errors if `npm view` fails, avoiding the user trying to fix their input that was fine all along.
- Stop fetching of next versions from failing because user has specified `devEngines.packageManager` in their package.json

- Print out more error information when `npm view` fails
- Run `npm view` with `-g` flag to make it ignore any `devEngines.packageManager` rules

### Why?

As a user, if you run `pnpx @next/codemod@canary upgrade latest` inside a repo with the [`devEngines.packageManager`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines) field set to `{ "name": "pnpm" }` (or something else non-npm), you will recieve an error 

```
Invalid revision provided: "latest". Please provide a valid Next.js version or dist-tag (e.g. "latest", "canary", "beta", "rc", or "15.0.0")
```

Which is a very confusing message of course. 

The reason for this is that `npm view` fails to execute because since npm [v10.9.0](https://github.com/npm/cli/releases/tag/v10.9.0), npm will fail _any_ command when `devEngines.packageManager` is set to something else than `npm`. And the code just checks if any value was returned, and if it was not, assumes the user passed a bad revision input.

### How?

As mentioned in the original issue, `npm` does not have any env, flag or command to skip the `devEngines.packageManager` check, see https://github.com/npm/rfcs/issues/830 for discussion.

What npm does have is the general `--force` flag which skips this, and other checks. Obviously skipping other checks is unwanted, but for `npm view` it's probably, arguably fine, considering what the command does. And I was about to open a PR using `npm --force --silent view`, but then I had a thought and tried it with `npm -g` and realized that this works! The operation we're performing is looking up in the registry what versions are available, and not anything specific to the local package, so `-g` for global seems like a good option.

#### Questions

- I was not entirely sure how to parse the errors returned by `npm view´, and right now have opted to just print the errors as is to console, followed by throwing a friendlier message. If we want to parse the error in more detail, I could try it.
    
    ```
    {
      "error": {
        "code": "E404",
        "summary": "No match found for version 17",
        "detail": "The requested resource 'next@17' could not be found or you do not have permission to access it.\n\nNote that you can also install from a\ntarball, folder, http url, or git url."
      }
    }
    
    Failed to fetch Next.js versions using npm view.
    ```
- I wonder if the [code checking if version returned by `npm view`](https://github.com/oBusk/next.js/blob/bf7d5f20180ea09507c9aec30768975678fb7082/packages/next-codemod/bin/upgrade.ts#L115-L124) is now superflous since any fail, such as the spec not hitting would be printed and the checking of the returned value will never run.
- I'm not sure if the `--global` command has any unwanted effects on `npm view`. One thing I'm considering is if a user has configured some other registry in a local `.npmrc`, then I imagine that `npm -g view` might ignore that file? Is that a case that should be catered?

Fixes vercel/next.js#85587

