### PR TITLE
[test]: fix broken scroll restoration test

### DIFF
--- a/test/integration/scroll-back-restoration/test/index.test.js
+++ b/test/integration/scroll-back-restoration/test/index.test.js
@@ -8,7 +8,7 @@ import {
   launchApp,
   nextStart,
   nextBuild,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -35,17 +35,15 @@ const runTests = () => {
 
     await browser.eval(() => window.next.router.push('/another'))
 
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /hi from another/
-    )
+    await retry(async () => {
+      const html = await browser.eval(() => document.documentElement.innerHTML)
+      expect(html).toMatch(/hi from another/)
+    })
     await browser.eval(() => (window.didHydrate = false))
 
     await browser.eval(() => window.history.back())
-    await check(() => browser.eval(() => window.didHydrate), {
-      test(content) {
-        return content
-      },
+    await retry(async () => {
+      expect(await browser.eval(() => window.didHydrate)).toBe(true)
     })
 
     const newScrollX = Math.floor(await browser.eval(() => window.scrollX))


### PR DESCRIPTION
Looks like this broke in #85537. Refactored to use `retry` instead. 