### PR TITLE
[test] Deflake custom cache handler test

### DIFF
--- a/test/e2e/app-dir/use-cache-custom-handler/app/page.tsx
+++ b/test/e2e/app-dir/use-cache-custom-handler/app/page.tsx
@@ -7,7 +7,7 @@ import React from 'react'
 async function getData() {
   'use cache'
 
-  cacheLife({ revalidate: 3 })
+  cacheLife({ revalidate: 6 })
   cacheTag('modern')
 
   return new Date().toISOString()

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -58,12 +58,16 @@ describe('use-cache-custom-handler', () => {
     // Because we use a low `revalidate` value for the "use cache" function, new
     // data should be returned eventually.
 
-    await retry(async () => {
-      await browser.refresh()
-      data = await browser.elementById('data').text()
-      expect(data).toMatch(isoDateRegExp)
-      expect(data).not.toEqual(initialData)
-    }, 5000)
+    await retry(
+      async () => {
+        await browser.refresh()
+        data = await browser.elementById('data').text()
+        expect(data).toMatch(isoDateRegExp)
+        expect(data).not.toEqual(initialData)
+      },
+      10_000,
+      2_000
+    )
   })
 
   it('calls neither refreshTags nor getExpiration if "use cache" is not used', async () => {


### PR DESCRIPTION
[flakiness metric](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.name%3A%22use-cache-custom-handler%20should%20use%20a%20modern%20custom%20cache%20handler%20if%20provided%22%20%40test.type%3A%22nextjs%22%20%40test.status%3A%22fail%22%20%40git.branch%3Acanary&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&index=citest&start=1759310750664&end=1761902750664&paused=false)

The test page used a low revalidate time of 3 seconds. In CI, sometimes that much time passes between the first and second request, causing the test to fail when comparing the data values (locally reproducible with `{ cpuThrottleRate: 20 }`). Increasing the revalidate time to 6 seconds should make the test more robust.