### PR TITLE
[ci] Skip irrelevant jobs for test-only PRs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,6 +36,13 @@ jobs:
           echo "$(node scripts/run-for-change.mjs --not --type docs --exec echo 'false')" >> $GITHUB_OUTPUT;
           echo 'EOF' >> $GITHUB_OUTPUT
 
+      - name: check for test-only change
+        id: test-only-change
+        run: |
+          echo "TEST_ONLY<<EOF" >> $GITHUB_OUTPUT;
+          echo "$(node scripts/run-for-change.mjs --not --type test --exec echo 'false')" >> $GITHUB_OUTPUT;
+          echo 'EOF' >> $GITHUB_OUTPUT
+
       - name: check for release
         id: is-release
         run: |
@@ -48,6 +55,7 @@ jobs:
 
     outputs:
       docs-only: ${{ steps.docs-change.outputs.DOCS_ONLY != 'false' }}
+      test-only: ${{ steps.test-only-change.outputs.TEST_ONLY != 'false' }}
       is-release: ${{ steps.is-release.outputs.IS_RELEASE == 'true' }}
       rspack: >-
         ${{
@@ -104,6 +112,8 @@ jobs:
 
   validate-docs-links:
     runs-on: ubuntu-latest
+    needs: ['changes']
+    if: ${{ needs.changes.outputs.test-only == 'false' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -131,7 +141,7 @@ jobs:
   test-cargo-unit:
     name: test cargo unit
     needs: ['changes', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -146,7 +156,7 @@ jobs:
   test-bench:
     name: test cargo benches
     needs: ['optimize-ci', 'changes', 'build-next']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     uses: ./.github/workflows/test-turbopack-rust-bench-test.yml
     secrets: inherit
@@ -154,7 +164,7 @@ jobs:
   rust-check:
     name: rust check
     needs: ['changes', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -168,7 +178,7 @@ jobs:
   rustdoc-check:
     name: rustdoc check
     needs: ['changes', 'build-next']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -181,6 +191,7 @@ jobs:
 
   ast-grep:
     needs: ['changes', 'build-next']
+    if: ${{ needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
     runs-on: ubuntu-latest
     name: ast-grep lint
     steps:
@@ -194,7 +205,7 @@ jobs:
   devlow-bench:
     name: Run devlow benchmarks
     needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && github.event_name != 'pull_request' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' && github.event_name != 'pull_request' }}
 
     strategy:
       fail-fast: false
@@ -219,7 +230,7 @@ jobs:
   test-devlow:
     name: test devlow package
     needs: ['optimize-ci', 'changes']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipNativeBuild: 'yes'
@@ -231,7 +242,7 @@ jobs:
   test-turbopack-dev:
     name: test turbopack dev
     needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -260,7 +271,7 @@ jobs:
   test-turbopack-integration:
     name: test turbopack development integration
     needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -290,7 +301,7 @@ jobs:
   test-turbopack-production:
     name: test turbopack production
     needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -317,7 +328,7 @@ jobs:
   test-turbopack-production-integration:
     name: test turbopack production integration
     needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -347,7 +358,7 @@ jobs:
   test-rspack-dev:
     name: test rspack dev
     needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.rspack == 'true' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' && needs.changes.outputs.rspack == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -382,7 +393,7 @@ jobs:
   test-rspack-integration:
     name: test rspack development integration
     needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.rspack == 'true' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' && needs.changes.outputs.rspack == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -418,7 +429,7 @@ jobs:
   test-rspack-production:
     name: test rspack production
     needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.rspack == 'true' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' && needs.changes.outputs.rspack == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -451,7 +462,7 @@ jobs:
   test-rspack-production-integration:
     name: test rspack production integration
     needs: ['optimize-ci', 'changes', 'build-next', 'build-native']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.rspack == 'true' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' && needs.changes.outputs.rspack == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -487,7 +498,7 @@ jobs:
   test-next-swc-wasm:
     name: test next-swc wasm
     needs: ['optimize-ci', 'changes', 'build-next']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -550,7 +561,7 @@ jobs:
   test-next-config-ts-native-ts-dev:
     name: test next-config-ts-native-ts dev
     needs: ['changes', 'build-next', 'build-native']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -571,7 +582,7 @@ jobs:
   test-next-config-ts-native-ts-prod:
     name: test next-config-ts-native-ts prod
     needs: ['changes', 'build-next', 'build-native']
-    if: ${{ needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -612,7 +623,7 @@ jobs:
     name: Test new tests for flakes (dev)
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
     # test-new-tests-if
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ (needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false') || needs.changes.outputs.test-only == 'true' }}
     # test-new-tests-end-if
 
     strategy:
@@ -624,9 +635,9 @@ jobs:
     with:
       afterBuild: |
         node scripts/test-new-tests.mjs \
-          --flake-detection \
           --mode dev \
-          --group ${{ matrix.group }}
+          --group ${{ matrix.group }} \
+          ${{ needs.changes.outputs.test-only == 'true' && '--with-webpack' || '' }}
       stepName: 'test-new-tests-dev-${{matrix.group}}'
       timeout_minutes: 60 # Increase the default timeout as tests are intentionally run multiple times to detect flakes
 
@@ -636,7 +647,7 @@ jobs:
     name: Test new tests for flakes (prod)
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
     # test-new-tests-if
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ (needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false') || needs.changes.outputs.test-only == 'true' }}
     # test-new-tests-end-if
 
     strategy:
@@ -648,9 +659,9 @@ jobs:
     with:
       afterBuild: |
         node scripts/test-new-tests.mjs \
-          --flake-detection \
           --mode start \
-          --group ${{ matrix.group }}
+          --group ${{ matrix.group }} \
+          ${{ needs.changes.outputs.test-only == 'true' && '--with-webpack' || '' }}
       stepName: 'test-new-tests-start-${{matrix.group}}'
       timeout_minutes: 60 # Increase the default timeout as tests are intentionally run multiple times to detect flakes
     secrets: inherit
@@ -658,9 +669,15 @@ jobs:
   test-new-tests-deploy:
     name: Test new tests when deployed
     needs:
-      ['optimize-ci', 'test-prod', 'test-new-tests-dev', 'test-new-tests-start']
+      [
+        'optimize-ci',
+        'changes',
+        'test-prod',
+        'test-new-tests-dev',
+        'test-new-tests-start',
+      ]
     # test-new-tests-if
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' }}
+    if: ${{ always() && !cancelled() && (needs.optimize-ci.outputs.skip == 'false' || needs.changes.outputs.test-only == 'true') && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     # test-new-tests-end-if
 
     strategy:
@@ -685,12 +702,13 @@ jobs:
     needs:
       [
         'optimize-ci',
+        'changes',
         'test-cache-components-prod',
         'test-new-tests-dev',
         'test-new-tests-start',
       ]
     # test-new-tests-if
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' }}
+    if: ${{ always() && !cancelled() && (needs.optimize-ci.outputs.skip == 'false' || needs.changes.outputs.test-only == 'true') && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     # test-new-tests-end-if
 
     strategy:
@@ -716,7 +734,7 @@ jobs:
   test-dev: # TODO: rename to include webpack
     name: test dev
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -751,7 +769,7 @@ jobs:
         'build-native',
         'build-next',
       ]
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -780,7 +798,7 @@ jobs:
         'build-native',
         'build-next',
       ]
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -809,7 +827,7 @@ jobs:
         'build-native',
         'build-next',
       ]
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -831,7 +849,7 @@ jobs:
   test-prod:
     name: test prod
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -856,7 +874,7 @@ jobs:
   test-integration:
     name: test integration
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -898,7 +916,7 @@ jobs:
   test-firefox-safari:
     name: test firefox and safari
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -926,7 +944,7 @@ jobs:
   test-cache-components-integration:
     name: test cache components integration
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     uses: ./.github/workflows/build_reusable.yml
     with:
@@ -946,7 +964,7 @@ jobs:
   test-cache-components-dev:
     name: test cache components dev
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     strategy:
       fail-fast: false
@@ -971,7 +989,7 @@ jobs:
   test-cache-components-prod:
     name: test cache components prod
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
-    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.test-only == 'false' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -46,20 +46,24 @@ jobs:
           fetch-depth: 25
 
       - name: Check non-docs only change
-        run: echo "DOCS_CHANGE<<EOF" >> $GITHUB_OUTPUT; echo "$(node scripts/run-for-change.mjs --not --type docs --exec echo 'nope')" >> $GITHUB_OUTPUT; echo 'EOF' >> $GITHUB_OUTPUT
+        run: echo "DOCS_ONLY<<EOF" >> $GITHUB_OUTPUT; echo "$(node scripts/run-for-change.mjs --not --type docs --exec echo 'false')" >> $GITHUB_OUTPUT; echo 'EOF' >> $GITHUB_OUTPUT
         id: docs-change
 
+      - name: Check for test-only change
+        run: echo "TEST_ONLY<<EOF" >> $GITHUB_OUTPUT; echo "$(node scripts/run-for-change.mjs --not --type test --exec echo 'false')" >> $GITHUB_OUTPUT; echo 'EOF' >> $GITHUB_OUTPUT
+        id: test-only-change
+
       - uses: actions/download-artifact@v4
-        if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
+        if: ${{ steps.docs-change.outputs.DOCS_ONLY == 'false' && steps.test-only-change.outputs.TEST_ONLY == 'false' }}
         with:
           name: next-swc-binary
           path: packages/next-swc/native
 
       - run: cp -r packages/next-swc/native .github/actions/next-stats-action/native
-        if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
+        if: ${{ steps.docs-change.outputs.DOCS_ONLY == 'false' && steps.test-only-change.outputs.TEST_ONLY == 'false' }}
 
       - uses: ./.github/actions/next-stats-action
-        if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
+        if: ${{ steps.docs-change.outputs.DOCS_ONLY == 'false' && steps.test-only-change.outputs.TEST_ONLY == 'false' }}
         env:
           # This uses the webpack bundle analyzer and for consistent results we need to use webpack.
           # Once there is an equivalent analyzer for turbopack, we can remove this.

--- a/scripts/get-changed-tests.mjs
+++ b/scripts/get-changed-tests.mjs
@@ -42,8 +42,42 @@ export default async function getChangedTests() {
 
   // run each test 3 times in each test mode (if E2E) with no-retrying
   // and if any fail it's flakey
-  const devTests = []
-  const prodTests = []
+  const devTests = new Set()
+  const prodTests = new Set()
+
+  // Helper function to add test file to appropriate lists
+  const addTestFile = (testFile) => {
+    if (
+      testFile.startsWith('test/e2e/') ||
+      testFile.startsWith('test/integration/')
+    ) {
+      devTests.add(testFile)
+      prodTests.add(testFile)
+    } else if (testFile.startsWith('test/prod')) {
+      prodTests.add(testFile)
+    } else if (testFile.startsWith('test/development')) {
+      devTests.add(testFile)
+    }
+  }
+
+  // Helper function to find test files in directory
+  const findTestFilesInDir = async (dir) => {
+    try {
+      const entries = await fs.readdir(path.join(process.cwd(), dir), {
+        withFileTypes: true,
+      })
+      const testFiles = []
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name).replace(/\\/g, '/')
+        if (entry.isFile() && entry.name.match(/\.test\.(js|ts|tsx)$/)) {
+          testFiles.push(fullPath)
+        }
+      }
+      return testFiles
+    } catch (err) {
+      return []
+    }
+  }
 
   for (let file of changedFiles) {
     // normalize slashes
@@ -54,17 +88,64 @@ export default async function getChangedTests() {
       .catch(() => false)
 
     if (fileExists && file.match(/^test\/.*?\.test\.(js|ts|tsx)$/)) {
-      if (
-        file.startsWith('test/e2e/') ||
-        file.startsWith('test/integration/')
-      ) {
-        devTests.push(file)
-        prodTests.push(file)
-      } else if (file.startsWith('test/prod')) {
-        prodTests.push(file)
-      } else if (file.startsWith('test/development')) {
-        devTests.push(file)
+      // Direct test file change
+      addTestFile(file)
+    } else if (
+      fileExists &&
+      file.match(/^test\/(e2e|development|integration|production)\//)
+    ) {
+      // Changed file in specific test directories
+      // Search upward from the changed file to find the directory containing test files
+      const parts = file.split('/')
+      const testCategory = parts[1] // e2e, development, integration, or production
+      const testCategoryPrefix = `test/${testCategory}`
+
+      // Helper to recursively find all test files in a directory
+      const findTestFilesRecursive = async (dir) => {
+        const testFiles = []
+        try {
+          const entries = await fs.readdir(path.join(process.cwd(), dir), {
+            withFileTypes: true,
+          })
+
+          for (const entry of entries) {
+            const fullPath = path.join(dir, entry.name).replace(/\\/g, '/')
+            if (entry.isDirectory()) {
+              // Recursively search subdirectories
+              const subTests = await findTestFilesRecursive(fullPath)
+              testFiles.push(...subTests)
+            } else if (entry.name.match(/\.test\.(js|ts|tsx)$/)) {
+              testFiles.push(fullPath)
+            }
+          }
+        } catch (err) {
+          // Directory doesn't exist or can't be read
+        }
+        return testFiles
       }
+
+      // Search upward from the changed file's directory to find where test files are
+      // Start from the parent directory of the changed file, working upward
+      // Stop when we find a directory containing test files
+      let testRootDir = null
+      for (let i = parts.length - 1; i >= 2; i--) {
+        const currentDir = parts.slice(0, i).join('/')
+        const testFiles = await findTestFilesInDir(currentDir)
+
+        if (testFiles.length > 0) {
+          testRootDir = currentDir
+          break
+        }
+      }
+
+      // If we found a directory with test files, search it recursively
+      // Otherwise fall back to the test category directory
+      if (!testRootDir) {
+        testRootDir = testCategoryPrefix
+      }
+
+      const testFiles = await findTestFilesRecursive(testRootDir)
+      testFiles.forEach(addTestFile)
     }
   }
 
@@ -72,13 +153,17 @@ export default async function getChangedTests() {
     'Detected tests:',
     JSON.stringify(
       {
-        devTests,
-        prodTests,
+        devTests: Array.from(devTests),
+        prodTests: Array.from(prodTests),
       },
       null,
       2
     )
   )
 
-  return { devTests, prodTests, commitSha }
+  return {
+    devTests: Array.from(devTests),
+    prodTests: Array.from(prodTests),
+    commitSha,
+  }
 }

--- a/scripts/run-for-change.mjs
+++ b/scripts/run-for-change.mjs
@@ -54,6 +54,13 @@ const CHANGE_ITEM_GROUPS = {
     'test/integration/create-next-app',
     'scripts/send-trace-to-jaeger',
   ],
+  test: [
+    'test/e2e',
+    'test/development',
+    'test/integration',
+    'test/production',
+    'test/unit',
+  ],
 }
 
 async function main() {


### PR DESCRIPTION
This PR optimizes our GitHub Actions workflows for pull requests that modify only test files within the`test/e2e`, `test/development`, `test/integration`, `test/production`, or `test/unit` directories.

For such test-only PRs, only essential jobs run: builds, linting, type checking, unit test jobs, and flake detection and deployment tests for the affected changes (for both Turbopack and Webpack).

This optimization reduces CI costs and execution time. It also ensures that when fixing a flaky test, unrelated flaky tests no longer affect the CI run, eliminating the need for retries in those PRs.

The implementation follows the existing docs-only pattern. It also extends the logic to detect related tests when fixtures or supporting files are modified by searching upward to locate the nearest directory containing test files.

This change has been verified with the upstack PR.