### PR TITLE
[ci] Improve change detection logic in `run-for-change` script

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -57,7 +57,7 @@ jobs:
           elif [ '${{ github.event_name }}' == 'workflow_dispatch' ]
           then
             echo "value=force-preview" >> $GITHUB_OUTPUT
-          elif [[ $(node scripts/run-for-change.js --not --type docs --exec echo 'false') != 'false' ]];
+          elif [[ $(node scripts/run-for-change.mjs --not --type docs --exec echo 'false') != 'false' ]];
           then
             echo "value=skipped" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,7 +33,7 @@ jobs:
         id: docs-change
         run: |
           echo "DOCS_ONLY<<EOF" >> $GITHUB_OUTPUT;
-          echo "$(node scripts/run-for-change.js --not --type docs --exec echo 'false')" >> $GITHUB_OUTPUT;
+          echo "$(node scripts/run-for-change.mjs --not --type docs --exec echo 'false')" >> $GITHUB_OUTPUT;
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: check for release

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 25
 
       - name: Check non-docs only change
-        run: echo "DOCS_CHANGE<<EOF" >> $GITHUB_OUTPUT; echo "$(node scripts/run-for-change.js --not --type docs --exec echo 'nope')" >> $GITHUB_OUTPUT; echo 'EOF' >> $GITHUB_OUTPUT
+        run: echo "DOCS_CHANGE<<EOF" >> $GITHUB_OUTPUT; echo "$(node scripts/run-for-change.mjs --not --type docs --exec echo 'nope')" >> $GITHUB_OUTPUT; echo 'EOF' >> $GITHUB_OUTPUT
         id: docs-change
 
       - uses: actions/download-artifact@v4

--- a/scripts/deploy-examples.sh
+++ b/scripts/deploy-examples.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-#CHANGED_EXAMPLES=$(node scripts/run-for-change.js --type deploy-examples --listChangedDirectories)
+#CHANGED_EXAMPLES=$(node scripts/run-for-change.mjs --type deploy-examples --listChangedDirectories)
 ##### TODO: fix the script above so it can work for stable releases which reach back multiple commits
 CHANGED_EXAMPLES="examples/image-component" # always deploy as a workaround
 

--- a/scripts/get-changed-tests.mjs
+++ b/scripts/get-changed-tests.mjs
@@ -2,6 +2,7 @@
 import fs from 'fs/promises'
 import execa from 'execa'
 import path from 'path'
+import { getDiffRevision, getGitInfo } from './git-info.mjs'
 
 /**
  * Detects changed tests files by comparing the current branch with `origin/canary`
@@ -9,76 +10,17 @@ import path from 'path'
  * that the current branch is pointing to
  */
 export default async function getChangedTests() {
-  let eventData = {}
-
   /** @type import('execa').Options */
   const EXECA_OPTS = { shell: true }
-  /** @type import('execa').Options */
-  const EXECA_OPTS_STDIO = { ...EXECA_OPTS, stdio: 'inherit' }
 
-  try {
-    eventData =
-      JSON.parse(
-        await fs.readFile(process.env.GITHUB_EVENT_PATH || '', 'utf8')
-      )['pull_request'] || {}
-  } catch (_) {}
-
-  const branchName =
-    eventData?.head?.ref ||
-    process.env.GITHUB_REF_NAME ||
-    (await execa('git rev-parse --abbrev-ref HEAD', EXECA_OPTS)).stdout
-
-  const remoteUrl =
-    eventData?.head?.repo?.full_name ||
-    process.env.GITHUB_REPOSITORY ||
-    (await execa('git remote get-url origin', EXECA_OPTS)).stdout
-
-  const commitSha =
-    eventData?.head?.sha ||
-    process.env.GITHUB_SHA ||
-    (await execa('git rev-parse HEAD', EXECA_OPTS)).stdout
-
-  const isCanary =
-    branchName.trim() === 'canary' && remoteUrl.includes('vercel/next.js')
+  const { branchName, remoteUrl, commitSha, isCanary } = await getGitInfo()
 
   if (isCanary) {
     console.log(`Skipping flake detection for canary`)
     return { devTests: [], prodTests: [] }
   }
 
-  let diffRevision
-  if (
-    process.env.GITHUB_ACTIONS === 'true' &&
-    process.env.GITHUB_EVENT_NAME === 'pull_request'
-  ) {
-    // GH Actions for `pull_request` run on the merge commit so HEAD~1:
-    // 1. includes all changes in the PR
-    //    e.g. in
-    //    A-B-C-main - F
-    //     \          /
-    //      D-E-branch
-    //    GH actions for `branch` runs on F, so a diff for HEAD~1 includes the diff of D and E combined
-    // 2. Includes all changes of the commit for pushes
-    diffRevision = 'HEAD~1'
-  } else {
-    try {
-      await execa(
-        'git remote set-branches --add origin canary',
-        EXECA_OPTS_STDIO
-      )
-      await execa('git fetch origin canary --depth=20', EXECA_OPTS_STDIO)
-    } catch (err) {
-      console.error(await execa('git remote -v', EXECA_OPTS_STDIO))
-      console.error(`Failed to fetch origin/canary`, err)
-    }
-    // TODO: We should diff against the merge base with origin/canary not directly against origin/canary.
-    // A --- B ---- origin/canary
-    //  \
-    //   \-- C ---- HEAD
-    // `git diff origin/canary` includes B and C
-    // But we should only include C.
-    diffRevision = 'origin/canary'
-  }
+  const diffRevision = await getDiffRevision()
 
   const changesResult = await execa(
     `git diff ${diffRevision} --name-only`,

--- a/scripts/git-info.mjs
+++ b/scripts/git-info.mjs
@@ -1,0 +1,79 @@
+// @ts-check
+import fs from 'fs/promises'
+import { promisify } from 'util'
+import { exec as execOrig } from 'child_process'
+
+const exec = promisify(execOrig)
+
+/**
+ * Gets git repository information from the environment
+ * @returns {Promise<{branchName: string, remoteUrl: string, commitSha: string, isCanary: boolean}>}
+ */
+export async function getGitInfo() {
+  let eventData = {}
+
+  try {
+    eventData =
+      JSON.parse(
+        await fs.readFile(process.env.GITHUB_EVENT_PATH || '', 'utf8')
+      )['pull_request'] || {}
+  } catch (_) {}
+
+  const branchName =
+    eventData?.head?.ref ||
+    process.env.GITHUB_REF_NAME ||
+    (await exec('git rev-parse --abbrev-ref HEAD')).stdout.trim()
+
+  const remoteUrl =
+    eventData?.head?.repo?.full_name ||
+    process.env.GITHUB_REPOSITORY ||
+    (await exec('git remote get-url origin')).stdout.trim()
+
+  const commitSha =
+    eventData?.head?.sha ||
+    process.env.GITHUB_SHA ||
+    (await exec('git rev-parse HEAD')).stdout.trim()
+
+  const isCanary =
+    branchName === 'canary' && remoteUrl.includes('vercel/next.js')
+
+  return { branchName, remoteUrl, commitSha, isCanary }
+}
+
+/**
+ * Determines the appropriate git diff revision based on the environment
+ * @returns {Promise<string>} The git revision to diff against
+ */
+export async function getDiffRevision() {
+  if (
+    process.env.GITHUB_ACTIONS === 'true' &&
+    process.env.GITHUB_EVENT_NAME === 'pull_request'
+  ) {
+    // GH Actions for `pull_request` run on the merge commit so HEAD~1:
+    // 1. includes all changes in the PR
+    //    e.g. in
+    //    A-B-C-main - F
+    //     \          /
+    //      D-E-branch
+    //    GH actions for `branch` runs on F, so a diff for HEAD~1 includes the diff of D and E combined
+    // 2. Includes all changes of the commit for pushes
+    return 'HEAD~1'
+  } else {
+    try {
+      await exec('git remote set-branches --add origin canary')
+      await exec('git fetch origin canary --depth=20')
+    } catch (err) {
+      const remoteInfo = await exec('git remote -v')
+      console.error(remoteInfo.stdout)
+      console.error(remoteInfo.stderr)
+      console.error(`Failed to fetch origin/canary`, err)
+    }
+    // TODO: We should diff against the merge base with origin/canary not directly against origin/canary.
+    // A --- B ---- origin/canary
+    //  \
+    //   \-- C ---- HEAD
+    // `git diff origin/canary` includes B and C
+    // But we should only include C.
+    return 'origin/canary'
+  }
+}


### PR DESCRIPTION
This PR extracts the existing git change detection logic from the `get-changed-tests` script into a separate module. This allows reusing the same logic in the `run-for-change` script, ensuring consistent behavior across the two scripts to determine changed files. Specifically, this ensures that in stacked PRs, the docs-only change detection (and the test-only change detection in the upstack PR) works correctly by diffing against the appropriate base branch.