### PR TITLE
[test] Ignore in deploy tests if a child process isn't available

### DIFF
--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -16,6 +16,22 @@ export class NextDeployInstance extends NextInstance {
   private _buildId: string
   private _writtenHostsLine: string | null = null
 
+  protected throwIfUnavailable(): void | never {
+    if (this.isStopping !== null) {
+      throw new Error('Next.js is no longer available.', {
+        cause: this.isStopping,
+      })
+    }
+    if (this.isDestroyed !== null) {
+      throw new Error('Next.js is no longer available.', {
+        cause: this.isDestroyed,
+      })
+    }
+    if (this.childProcess === undefined) {
+      // deploy tests don't have access to the process
+    }
+  }
+
   public get buildId() {
     // get deployment ID via fetch since we can't access
     // build artifacts directly


### PR DESCRIPTION
Because deploy tests won't have access to the child process.