### PR TITLE
chore: fix types generation for eslint config package

### DIFF
--- a/packages/eslint-config-next/tsconfig.json
+++ b/packages/eslint-config-next/tsconfig.json
@@ -7,8 +7,8 @@
     "strict": true,
     "declaration": true,
     "resolveJsonModule": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src"
   },
-  "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Fixes the type definitions generation on eslint-config-next by setting the rootDir option, so it generates the .d.ts files in the dist folder instead of dist/src.

Fixes #85568 

### Before
<img width="287" height="242" alt="image" src="https://github.com/user-attachments/assets/297d1eeb-6ff3-4425-9aa3-f2376053d5ad" />

### After
<img width="289" height="223" alt="image" src="https://github.com/user-attachments/assets/3d261ff5-d59b-42c1-84d6-0ccfe3877672" />

