### PR TITLE
fix: update Table component prop from searchParams to sortPromise

### DIFF
--- a/docs/01-app/01-getting-started/06-cache-components.mdx
+++ b/docs/01-app/01-getting-started/06-cache-components.mdx
@@ -552,7 +552,7 @@ export default function Page({ searchParams }) {
     <section>
       <h1>This will be pre-rendered</h1>
       <Suspense fallback={<TableSkeleton />}>
-        <Table searchParams={searchParams.then((search) => search.sort)} />
+        <Table sortPromise={searchParams.then((search) => search.sort)} />
       </Suspense>
     </section>
   )


### PR DESCRIPTION
The `Table` component expects a `sortPromise` to be provided to it as a prop instead of `searchParams`.

### What?
Change the prop name being passed to the `Table` component from `searchParams` to `sortPromise`.

### Why?
The `Table` component definition expects a `sortPromise` prop here: https://github.com/vercel/next.js/blob/canary/docs/01-app/01-getting-started/06-cache-components.mdx?plain=1#L565

### How?
By renaming

