### PR TITLE
Build: Log amount of workers during static generation

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -836,6 +836,7 @@ export type StaticWorker = typeof import('./worker') & Worker
 export function createStaticWorker(
   config: NextConfigComplete,
   options: {
+    numberOfWorkers: number
     debuggerPortOffset: number
     progress?: {
       run: () => void
@@ -843,10 +844,10 @@ export function createStaticWorker(
     }
   }
 ): StaticWorker {
-  const { debuggerPortOffset, progress } = options
+  const { numberOfWorkers, debuggerPortOffset, progress } = options
   return new Worker(staticWorkerPath, {
     logger: Log,
-    numWorkers: getNumberOfWorkers(config),
+    numWorkers: numberOfWorkers,
     onActivity: () => {
       progress?.run()
     },
@@ -1915,8 +1916,11 @@ export default async function build(
         traceMemoryUsage('Finished type checking', nextBuildSpan)
       }
 
+      const numberOfWorkers = getNumberOfWorkers(config)
       const collectingPageDataStart = process.hrtime()
-      const postCompileSpinner = createSpinner('Collecting page data')
+      const postCompileSpinner = createSpinner(
+        `Collecting page data using ${numberOfWorkers} worker${numberOfWorkers > 1 ? 's' : ''}`
+      )
 
       const buildManifestPath = path.join(distDir, BUILD_MANIFEST)
 
@@ -1958,7 +1962,10 @@ export default async function build(
 
       process.env.NEXT_PHASE = PHASE_PRODUCTION_BUILD
 
-      const worker = createStaticWorker(config, { debuggerPortOffset: -1 })
+      const worker = createStaticWorker(config, {
+        numberOfWorkers,
+        debuggerPortOffset: -1,
+      })
 
       const analysisBegin = process.hrtime()
       const staticCheckSpan = nextBuildSpan.traceChild('static-check')
@@ -2480,7 +2487,7 @@ export default async function build(
       if (postCompileSpinner) {
         const collectingPageDataEnd = process.hrtime(collectingPageDataStart)
         postCompileSpinner.setText(
-          `Collecting page data in ${hrtimeDurationToString(collectingPageDataEnd)}`
+          `Collecting page data using ${numberOfWorkers} worker${numberOfWorkers > 1 ? 's' : ''} in ${hrtimeDurationToString(collectingPageDataEnd)}`
         )
         postCompileSpinner.stopAndPersist()
       }
@@ -3063,8 +3070,8 @@ export default async function build(
               debugPrerender,
               pages: combinedPages,
               outdir,
-              statusMessage: 'Generating static pages',
-              numWorkers: getNumberOfWorkers(exportConfig),
+              statusMessage: `Generating static pages using ${numberOfWorkers} worker${numberOfWorkers > 1 ? 's' : ''}`,
+              numWorkers: numberOfWorkers,
               appDirOnly,
             },
             nextBuildSpan

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -641,13 +641,15 @@ async function exportAppImpl(
   if (totalExportPaths > 0) {
     const progress = createProgress(
       totalExportPaths,
-      options.statusMessage || 'Exporting'
+      options.statusMessage ??
+        `Exporting using ${options.numWorkers} worker${options.numWorkers > 1 ? 's' : ''}`
     )
 
     worker = createStaticWorker(nextConfig, {
       debuggerPortOffset: getNextBuildDebuggerPortOffset({
         kind: 'export-page',
       }),
+      numberOfWorkers: options.numWorkers,
       progress,
     })
 

--- a/test/integration/polyfills/test/index.test.ts
+++ b/test/integration/polyfills/test/index.test.ts
@@ -49,8 +49,8 @@ describe('Polyfills', () => {
       })
 
       it('should contain generated page count in output', async () => {
-        expect(output).toContain('Generating static pages (0/5)')
-        expect(output).toContain('Generating static pages (5/5)')
+        expect(output).match(/Generating static pages.*\(0\/5\)/g)
+        expect(output).match(/Generating static pages.*\(5\/5\)/g)
         // we should only have 1 segment and the initial message logged out
         expect(output.match(/Generating static pages/g).length).toBe(5)
       })

--- a/test/integration/polyfills/test/index.test.ts
+++ b/test/integration/polyfills/test/index.test.ts
@@ -49,8 +49,8 @@ describe('Polyfills', () => {
       })
 
       it('should contain generated page count in output', async () => {
-        expect(output).match(/Generating static pages.*\(0\/5\)/g)
-        expect(output).match(/Generating static pages.*\(5\/5\)/g)
+        expect(output).toMatch(/Generating static pages.*\(0\/5\)/g)
+        expect(output).toMatch(/Generating static pages.*\(5\/5\)/g)
         // we should only have 1 segment and the initial message logged out
         expect(output.match(/Generating static pages/g).length).toBe(5)
       })

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -112,9 +112,14 @@ describe('Production Usage', () => {
 
   it('should contain generated page count in output', async () => {
     const pageCount = 34
-    expect(next.cliOutput).toContain(`Generating static pages (0/${pageCount})`)
-    expect(next.cliOutput).toContain(
-      `Generating static pages (${pageCount}/${pageCount})`
+    expect(next.cliOutput).toMatch(
+      new RegExp(`Generating static pages.*\\(0\\/${pageCount}\\)`, 'g')
+    )
+    expect(next.cliOutput).toMatch(
+      new RegExp(
+        `Generating static pages.*\\(${pageCount}\\/${pageCount}\\)`,
+        'g'
+      )
     )
     // we should only have 4 segments and the initial message logged out
     expect(next.cliOutput.match(/Generating static pages/g).length).toBe(5)


### PR DESCRIPTION
## What?

Added the amount of workers used to the relevant steps as `using X workers`.

Example:

```
 ✓ Compiled successfully in 610.3ms
 ✓ Finished TypeScript in 954.4ms    
 ✓ Collecting page data using 15 workers in 207.5ms    
 ✓ Generating static pages using 15 workers (4/4) in 258.4ms
 ✓ Finalizing page optimization in 6.7ms    
```