### PR TITLE
Turbopack: cleanup StyleSheetLike

### DIFF
--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -3,6 +3,7 @@ use std::convert::Infallible;
 use anyhow::Result;
 use lightningcss::{
     rules::CssRule,
+    stylesheet::StyleSheet,
     traits::IntoOwned,
     values::url::Url,
     visitor::{Visit, Visitor},
@@ -18,12 +19,9 @@ use turbopack_core::{
     source_pos::SourcePos,
 };
 
-use crate::{
-    StyleSheetLike,
-    references::{
-        import::{ImportAssetReference, ImportAttributes},
-        url::UrlAssetReference,
-    },
+use crate::references::{
+    import::{ImportAssetReference, ImportAttributes},
+    url::UrlAssetReference,
 };
 
 pub(crate) mod compose;
@@ -38,7 +36,7 @@ pub type AnalyzedRefs = (
 
 /// Returns `(all_references, urls)`.
 pub async fn analyze_references(
-    stylesheet: &mut StyleSheetLike<'static, 'static>,
+    stylesheet: &mut StyleSheet<'static, 'static>,
     source: ResolvedVc<Box<dyn Source>>,
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     import_context: Option<ResolvedVc<ImportContext>>,
@@ -48,7 +46,7 @@ pub async fn analyze_references(
 
     let mut visitor =
         ModuleReferencesVisitor::new(source, origin, import_context, &mut references, &mut urls);
-    stylesheet.0.visit(&mut visitor).unwrap();
+    stylesheet.visit(&mut visitor).unwrap();
 
     tokio::try_join!(
         references.into_iter().map(|v| v.to_resolved()).try_join(),

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -2,6 +2,7 @@ use std::convert::Infallible;
 
 use anyhow::Result;
 use lightningcss::{
+    stylesheet::StyleSheet,
     values::url::Url,
     visit_types,
     visitor::{Visit, Visitor},
@@ -18,7 +19,7 @@ use turbopack_core::{
     resolve::{ModuleResolveResult, origin::ResolveOrigin, parse::Request, url_resolve},
 };
 
-use crate::{StyleSheetLike, embed::CssEmbed};
+use crate::embed::CssEmbed;
 
 #[turbo_tasks::value]
 pub enum ReferencedAsset {
@@ -122,12 +123,9 @@ pub async fn resolve_url_reference(
     Ok(Vc::cell(None))
 }
 
-pub fn replace_url_references(
-    ss: &mut StyleSheetLike<'static, 'static>,
-    urls: &FxHashMap<RcStr, RcStr>,
-) {
+pub fn replace_url_references<'i, 'o>(ss: &mut StyleSheet<'i, 'o>, urls: &FxHashMap<RcStr, RcStr>) {
     let mut replacer = AssetReferenceReplacer { urls };
-    ss.0.visit(&mut replacer).unwrap();
+    ss.visit(&mut replacer).unwrap();
 }
 
 struct AssetReferenceReplacer<'a> {


### PR DESCRIPTION
This abstraction was a leftover from when we had a swc_css and a lightningcss backend.

Also inspired by https://github.com/vercel/next.js/pull/85524 as there was another constant-false `PartialEq` impl.