### PR TITLE
[test] Deflake prefetching.stale-times

### DIFF
--- a/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
@@ -129,6 +129,8 @@ describe('app dir - prefetching (custom staleTime)', () => {
 
   it('should not re-fetch cached data when navigating back to a route group', async () => {
     let act: ReturnType<typeof createRouterAct>
+    // Just installing so that the page doesn't automatically move past dynamic stale time
+    createTimeController()
     const browser = await next.browser('/prefetch-auto-route-groups', {
       beforePageLoad(page) {
         act = createRouterAct(page)


### PR DESCRIPTION
Fixes
```
Expected no network requests to be initiated.

    URL: http://localhost:45367/prefetch-auto-route-groups?_rsc=1tsbd
    Headers: {"vary":"rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch, Accept-Encoding","cache-control":"private, no-cache, no-store, max-age=0, must-revalidate","content-type":"text/x-component","content-encoding":"gzip","date":"Mon, 03 Nov 2025 11:16:02 GMT","connection":"keep-alive","keep-alive":"timeout=5"}

    Response:
    1:"$Sreact.fragment"
    3:I[55376,["/_next/static/chunks/c10f3b3b55165f5e.js","/_next/static/chunks/feaf523c4fc943b7.js"],"OutletBoundary"]
    4:"$Sreact.suspense"
    6:I[55376,["/_next/static/chunks/c10f3b3b55165f5e.js","/_next/static/chunks/feaf523c4fc943b7.js"],"ViewportBoundary"]
    8:I[55376,["/_next/static/chunks/c10f3b3b55165f5e.js","/_next/static/chunks/feaf523c4fc943b7.js"],"MetadataBoundary"]
    0:{"b":"5rHUYVeI3Pl5F_zpcrAHh","f":[["children","prefetch-auto-route-groups","children","(dashboard)","children","__PAGE__",["__PAGE__",{}],[["$","$1","c",{"children":["$L2",null,["$","$L3",null,{"children":["$","$4",null,{"name":"Next.MetadataOutlet","children":"$@5"}]}]]}],{},null,false,false],["$","$1","h",{"children":[null,["$","$L6","e3vAEHsQsUW6RJecrFwu4v",{"children":"$@7"}],["$","div","e3vAEHsQsUW6RJecrFwu4m",{"hidden":true,"children":["$","$L8",null,{"children":["$","$4",null,{"name":"Next.Metadata","children":"$@9"}]}]}]]}],false]],"S":false}
    7:[["$","meta","0",{"charSet":"utf-8"}],["$","meta","1",{"name":"viewport","content":"width=device-width, initial-scale=1"}]]
    9:[]
    5:null
    2:["$","h1",null,{"children":["Dashboard ","data",["$","div",null,{"children":["Fetch Count: ",["$","span",null,{"id":"count","children":4}]]}]]}]
```
https://github.com/vercel/next.js/actions/runs/19031423411/job/54349951486#step:34:383


Between navigations the stale time for dynamic data could've been exceeded. I suspect we were hitting that scenario. Installing a fake clock that we don't advance should fix it.