### PR TITLE
Turbopack: trace worker_threads worker entry

### DIFF
--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -290,6 +290,7 @@ pub enum WorkerReferenceSubType {
     WebWorker,
     SharedWorker,
     ServiceWorker,
+    NodeWorker,
     Custom(u8),
     Undefined,
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -1788,7 +1788,11 @@ impl JsValue {
                         "module",
                         "The Node.js `module` module: https://nodejs.org/api/module.html",
                     ),
-                    WellKnownObjectKind::ChildProcess | WellKnownObjectKind::ChildProcessDefault => (
+                    WellKnownObjectKind::WorkerThreadsModule | WellKnownObjectKind::WorkerThreadsModuleDefault => (
+                        "worker_threads",
+                        "The Node.js `worker_threads` module: https://nodejs.org/api/worker_threads.html",
+                    ),
+                    WellKnownObjectKind::ChildProcessModule | WellKnownObjectKind::ChildProcessModuleDefault => (
                         "child_process",
                         "The Node.js child_process module: https://nodejs.org/api/child_process.html",
                     ),
@@ -1796,7 +1800,7 @@ impl JsValue {
                         "os",
                         "The Node.js os module: https://nodejs.org/api/os.html",
                     ),
-                    WellKnownObjectKind::NodeProcess => (
+                    WellKnownObjectKind::NodeProcessModule => (
                         "process",
                         "The Node.js process module: https://nodejs.org/api/process.html",
                     ),
@@ -1953,6 +1957,10 @@ impl JsValue {
                     WellKnownFunctionKind::NodeProtobufLoad => (
                       "load/loadSync".to_string(),
                       "require('@grpc/proto-loader').load(filepath, { includeDirs: [root] }) https://github.com/grpc/grpc-node"
+                    ),
+                    WellKnownFunctionKind::NodeWorkerConstructor => (
+                      "Worker".to_string(),
+                      "The Node.js worker_threads Worker constructor: https://nodejs.org/api/worker_threads.html#worker_threads_class_worker"
                     ),
                     WellKnownFunctionKind::WorkerConstructor => (
                       "Worker".to_string(),
@@ -3468,11 +3476,13 @@ pub enum WellKnownObjectKind {
     ModuleModuleDefault,
     UrlModule,
     UrlModuleDefault,
-    ChildProcess,
-    ChildProcessDefault,
+    WorkerThreadsModule,
+    WorkerThreadsModuleDefault,
+    ChildProcessModule,
+    ChildProcessModuleDefault,
     OsModule,
     OsModuleDefault,
-    NodeProcess,
+    NodeProcessModule,
     NodeProcessArgv,
     NodeProcessEnv,
     NodePreGyp,
@@ -3492,9 +3502,10 @@ impl WellKnownObjectKind {
             Self::PathModule => Some(&["path"]),
             Self::FsModule => Some(&["fs"]),
             Self::UrlModule => Some(&["url"]),
-            Self::ChildProcess => Some(&["child_process"]),
+            Self::ChildProcessModule => Some(&["child_process"]),
             Self::OsModule => Some(&["os"]),
-            Self::NodeProcess => Some(&["process"]),
+            Self::WorkerThreadsModule => Some(&["worker_threads"]),
+            Self::NodeProcessModule => Some(&["process"]),
             Self::NodeProcessArgv => Some(&["process", "argv"]),
             Self::NodeProcessEnv => Some(&["process", "env"]),
             Self::NodeBuffer => Some(&["Buffer"]),
@@ -3623,6 +3634,8 @@ pub enum WellKnownFunctionKind {
     NodeResolveFrom,
     NodeProtobufLoad,
     WorkerConstructor,
+    // The worker_threads Worker class
+    NodeWorkerConstructor,
     URLConstructor,
 }
 
@@ -3797,7 +3810,7 @@ pub mod test_utils {
                 ),
                 "define" => JsValue::WellKnownFunction(WellKnownFunctionKind::Define),
                 "URL" => JsValue::WellKnownFunction(WellKnownFunctionKind::URLConstructor),
-                "process" => JsValue::WellKnownObject(WellKnownObjectKind::NodeProcess),
+                "process" => JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessModule),
                 "Object" => JsValue::WellKnownObject(WellKnownObjectKind::GlobalObject),
                 "Buffer" => JsValue::WellKnownObject(WellKnownObjectKind::NodeBuffer),
                 _ => v.into_unknown(true, "unknown global"),

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -176,15 +176,9 @@ pub async fn parse(
         ty = display(&ty)
     );
 
-    match parse_internal(
-        source,
-        ty,
-        transforms,
-        is_external_tracing && matches!(ty, EcmascriptModuleAssetType::EcmascriptExtensionless),
-        inline_helpers,
-    )
-    .instrument(span)
-    .await
+    match parse_internal(source, ty, transforms, is_external_tracing, inline_helpers)
+        .instrument(span)
+        .await
     {
         Ok(result) => Ok(result),
         Err(error) => Err(error.context(format!(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -151,7 +151,7 @@ use crate::{
         },
         ident::IdentReplacement,
         member::MemberReplacement,
-        node::PackageJsonReference,
+        node::{FilePathModuleReference, PackageJsonReference},
         require_context::{RequireContextAssetReference, RequireContextMap},
         type_issue::SpecifiedModuleTypeIssue,
     },
@@ -1646,8 +1646,27 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             .await
     };
 
-    let make_issue_source =
+    let get_traced_project_dir = async || -> Result<FileSystemPath> {
+        // readFileSync("./foo") should always be relative to the project root, but this is
+        // dangerous inside of node_modules as it can cause a lot of false positives in the tracing,
+        // if some package does `path.join(dynamic)`, it would include everything from the project
+        // root as well.
+        //
+        // Also, when there's no cwd set (i.e. in a tracing-specific module context, as we shouldn't
+        // assume a `process.cwd()` for all of node_modules), fallback to the source file directory.
+        // This still allows relative file accesses, just not from the project root.
+        if allow_project_root_tracing
+            && let Some(cwd) = compile_time_info.environment().cwd().owned().await?
+        {
+            Ok(cwd)
+        } else {
+            Ok(source.ident().path().await?.parent())
+        }
+    };
+
+    let get_issue_source =
         || IssueSource::from_swc_offsets(source, span.lo.to_u32(), span.hi.to_u32());
+
     if new {
         match func {
             JsValue::WellKnownFunction(WellKnownFunctionKind::URLConstructor) => {
@@ -1729,10 +1748,10 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
             JsValue::WellKnownFunction(WellKnownFunctionKind::NodeWorkerConstructor)
                 if analysis.analyze_mode.is_tracing() =>
             {
-                // Only for tracing, not for bundling
+                // Only for tracing, not for bundling (yet?)
                 let args = linked_args(args).await?;
-                if let Some(filename) = args.first() {
-                    let pat = js_value_to_pattern(filename);
+                if !args.is_empty() {
+                    let pat = js_value_to_pattern(&args[0]);
                     if !pat.has_constant_parts() {
                         let (args, hints) = explain_args(&args);
                         handler.span_warn_with_code(
@@ -1746,25 +1765,34 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                             return Ok(());
                         }
                     }
-
-                    analysis.add_reference_code_gen(
-                        WorkerAssetReference::new(
-                            origin,
-                            Request::parse(pat).to_resolved().await?,
-                            issue_source(source, span),
-                            in_try,
-                        ),
-                        ast_path.to_vec().into(),
+                    analysis.add_reference(
+                        FilePathModuleReference::new(
+                            origin.asset_context(),
+                            get_traced_project_dir().await?,
+                            Pattern::new(pat),
+                            collect_affecting_sources,
+                            get_issue_source(),
+                        )
+                        .to_resolved()
+                        .await?,
                     );
-
                     return Ok(());
                 }
-                // Ignore (e.g. dynamic parameter or string literal), just as Webpack does
+                let (args, hints) = explain_args(&args);
+                handler.span_warn_with_code(
+                    span,
+                    &format!("new Worker({args}) is not statically analyze-able{hints}",),
+                    DiagnosticId::Error(
+                        errors::failed_to_analyze::ecmascript::FS_METHOD.to_string(),
+                    ),
+                );
+                // Ignore (e.g. dynamic parameter or string literal)
                 return Ok(());
             }
             _ => {}
         }
 
+        // linked_args wasn't called, so manually add the closure effects
         for arg in args {
             if let EffectArg::Closure(_, block) = arg {
                 add_effects(block.effects);
@@ -1772,24 +1800,6 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
         }
         return Ok(());
     }
-
-    let get_traced_project_dir = async || -> Result<FileSystemPath> {
-        // readFileSync("./foo") should always be relative to the project root, but this is
-        // dangerous inside of node_modules as it can cause a lot of false positives in the tracing,
-        // if some package does `path.join(dynamic)`, it would include everything from the project
-        // root as well.
-        //
-        // Also, when there's no cwd set (i.e. in a tracing-specific module context, as we shouldn't
-        // assume a `process.cwd()` for all of node_modules), fallback to the source file directory.
-        // This still allows relative file accesses, just not from the project root.
-        if allow_project_root_tracing
-            && let Some(cwd) = compile_time_info.environment().cwd().owned().await?
-        {
-            Ok(cwd)
-        } else {
-            Ok(source.ident().path().await?.parent())
-        }
-    };
 
     match func {
         JsValue::Alternatives {
@@ -2024,7 +2034,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         get_traced_project_dir().await?,
                         Pattern::new(pat),
                         collect_affecting_sources,
-                        make_issue_source(),
+                        get_issue_source(),
                     )
                     .to_resolved()
                     .await?,
@@ -2077,7 +2087,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 DirAssetReference::new(
                     get_traced_project_dir().await?,
                     Pattern::new(pat),
-                    make_issue_source(),
+                    get_issue_source(),
                 )
                 .to_resolved()
                 .await?,
@@ -2121,7 +2131,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 DirAssetReference::new(
                     get_traced_project_dir().await?,
                     Pattern::new(pat),
-                    make_issue_source(),
+                    get_issue_source(),
                 )
                 .to_resolved()
                 .await?,
@@ -2412,7 +2422,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                                 DirAssetReference::new(
                                     get_traced_project_dir().await?,
                                     Pattern::new(abs_pattern),
-                                    make_issue_source(),
+                                    get_issue_source(),
                                 )
                                 .to_resolved()
                                 .await?,
@@ -2479,7 +2489,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     DirAssetReference::new(
                         get_traced_project_dir().await?,
                         Pattern::new(abs_pattern),
-                        make_issue_source(),
+                        get_issue_source(),
                     )
                     .to_resolved()
                     .await?,
@@ -2548,7 +2558,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         DirAssetReference::new(
                             context_dir.clone(),
                             Pattern::new(Pattern::Constant(dir.into())),
-                            make_issue_source(),
+                            get_issue_source(),
                         )
                         .to_resolved()
                     })

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1726,6 +1726,42 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 // Ignore (e.g. dynamic parameter or string literal), just as Webpack does
                 return Ok(());
             }
+            JsValue::WellKnownFunction(WellKnownFunctionKind::NodeWorkerConstructor)
+                if analysis.analyze_mode.is_tracing() =>
+            {
+                // Only for tracing, not for bundling
+                let args = linked_args(args).await?;
+                if let Some(filename) = args.first() {
+                    let pat = js_value_to_pattern(filename);
+                    if !pat.has_constant_parts() {
+                        let (args, hints) = explain_args(&args);
+                        handler.span_warn_with_code(
+                            span,
+                            &format!("new Worker({args}) is very dynamic{hints}",),
+                            DiagnosticId::Lint(
+                                errors::failed_to_analyze::ecmascript::NEW_WORKER.to_string(),
+                            ),
+                        );
+                        if ignore_dynamic_requests {
+                            return Ok(());
+                        }
+                    }
+
+                    analysis.add_reference_code_gen(
+                        WorkerAssetReference::new(
+                            origin,
+                            Request::parse(pat).to_resolved().await?,
+                            issue_source(source, span),
+                            in_try,
+                        ),
+                        ast_path.to_vec().into(),
+                    );
+
+                    return Ok(());
+                }
+                // Ignore (e.g. dynamic parameter or string literal), just as Webpack does
+                return Ok(());
+            }
             _ => {}
         }
 
@@ -3147,7 +3183,7 @@ async fn value_visitor_inner(
             ),
             "define" => JsValue::WellKnownFunction(WellKnownFunctionKind::Define),
             "URL" => JsValue::WellKnownFunction(WellKnownFunctionKind::URLConstructor),
-            "process" => JsValue::WellKnownObject(WellKnownObjectKind::NodeProcess),
+            "process" => JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessModule),
             "Object" => JsValue::WellKnownObject(WellKnownObjectKind::GlobalObject),
             "Buffer" => JsValue::WellKnownObject(WellKnownObjectKind::NodeBuffer),
             _ => return Ok((v, false)),

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -1,11 +1,20 @@
 use anyhow::Result;
+use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    file_source::FileSource, raw_module::RawModule, reference::ModuleReference,
-    resolve::ModuleResolveResult,
+    chunk::{ChunkableModuleReference, ChunkingType, ChunkingTypeOption},
+    context::AssetContext,
+    file_source::FileSource,
+    issue::IssueSource,
+    raw_module::RawModule,
+    reference::ModuleReference,
+    reference_type::{ReferenceType, WorkerReferenceSubType},
+    resolve::{ModuleResolveResult, pattern::Pattern, resolve_raw},
 };
+
+use crate::references::util::check_and_emit_too_many_matches_warning;
 
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug)]
@@ -43,6 +52,92 @@ impl ValueToString for PackageJsonReference {
                 self.package_json.value_to_string().await?
             )
             .into(),
+        ))
+    }
+}
+
+#[turbo_tasks::value]
+#[derive(Hash, Debug)]
+pub struct FilePathModuleReference {
+    asset_context: ResolvedVc<Box<dyn AssetContext>>,
+    context_dir: FileSystemPath,
+    path: ResolvedVc<Pattern>,
+    collect_affecting_sources: bool,
+    issue_source: IssueSource,
+}
+
+#[turbo_tasks::value_impl]
+impl FilePathModuleReference {
+    #[turbo_tasks::function]
+    pub fn new(
+        asset_context: ResolvedVc<Box<dyn AssetContext>>,
+        context_dir: FileSystemPath,
+        path: ResolvedVc<Pattern>,
+        collect_affecting_sources: bool,
+        issue_source: IssueSource,
+    ) -> Vc<Self> {
+        Self {
+            asset_context,
+            context_dir,
+            path,
+            collect_affecting_sources,
+            issue_source,
+        }
+        .cell()
+    }
+}
+
+// A reference to an module by absolute or cwd-relative file path (e.g. for the
+// worker-threads `new Worker` which has the resolving behavior of `fs.readFile` but should treat
+// the resolve result as an module instead of a raw source).
+#[turbo_tasks::value_impl]
+impl ModuleReference for FilePathModuleReference {
+    #[turbo_tasks::function]
+    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+        let span = tracing::info_span!(
+            "trace module",
+            pattern = display(self.path.to_string().await?)
+        );
+        async {
+            let result = resolve_raw(
+                self.context_dir.clone(),
+                *self.path,
+                self.collect_affecting_sources,
+                /* force_in_lookup_dir */ false,
+            );
+            let result = self.asset_context.process_resolve_result(
+                result,
+                ReferenceType::Worker(WorkerReferenceSubType::NodeWorker),
+            );
+
+            check_and_emit_too_many_matches_warning(
+                result,
+                self.issue_source,
+                self.context_dir.clone(),
+                self.path,
+            )
+            .await?;
+
+            Ok(result)
+        }
+        .instrument(span)
+        .await
+    }
+}
+#[turbo_tasks::value_impl]
+impl ChunkableModuleReference for FilePathModuleReference {
+    #[turbo_tasks::function]
+    fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Traced))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ValueToString for FilePathModuleReference {
+    #[turbo_tasks::function]
+    async fn to_string(&self) -> Result<Vc<RcStr>> {
+        Ok(Vc::cell(
+            format!("raw asset {}", self.path.to_string().await?,).into(),
         ))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -1,8 +1,16 @@
 use anyhow::Result;
 use swc_core::{ecma::ast::Expr, quote};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::Vc;
-use turbopack_core::{self, resolve::parse::Request};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use turbo_tasks_fs::FileSystemPath;
+use turbopack_core::{
+    self,
+    issue::{
+        Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
+        OptionStyledString, StyledString,
+    },
+    resolve::{ModuleResolveResult, parse::Request, pattern::Pattern},
+};
 
 /// Creates a IIFE expression that throws a "Cannot find module" error for the
 /// given request string
@@ -35,4 +43,81 @@ pub async fn request_to_string(request: Vc<Request>) -> Result<Vc<RcStr>> {
             // TODO: Handle Request::Dynamic, Request::Alternatives
             .unwrap_or(rcstr!("unknown")),
     ))
+}
+
+/// If a pattern resolves to more than 10000 results, it's likely a mistake so issue a warning.
+const TOO_MANY_MATCHES_LIMIT: usize = 10000;
+
+pub async fn check_and_emit_too_many_matches_warning(
+    result: Vc<ModuleResolveResult>,
+    issue_source: IssueSource,
+    context_dir: FileSystemPath,
+    pattern: ResolvedVc<Pattern>,
+) -> Result<()> {
+    let num_matches = result.await?.primary.len();
+    if num_matches > TOO_MANY_MATCHES_LIMIT {
+        TooManyMatchesWarning {
+            source: issue_source,
+            context_dir,
+            num_matches,
+            pattern,
+        }
+        .resolved_cell()
+        .emit();
+    }
+    Ok(())
+}
+
+#[turbo_tasks::value(shared)]
+struct TooManyMatchesWarning {
+    source: IssueSource,
+    context_dir: FileSystemPath,
+    num_matches: usize,
+    pattern: ResolvedVc<Pattern>,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for TooManyMatchesWarning {
+    #[turbo_tasks::function]
+    async fn title(&self) -> Result<Vc<StyledString>> {
+        Ok(StyledString::Text(
+            format!(
+                "The file pattern {pattern} matches {num_matches} files in {context_dir}",
+                pattern = self.pattern.to_string().await?,
+                context_dir = self.context_dir.value_to_string().await?,
+                num_matches = self.num_matches
+            )
+            .into(),
+        )
+        .cell())
+    }
+
+    #[turbo_tasks::function]
+    fn description(&self) -> Vc<OptionStyledString> {
+        Vc::cell(Some(
+            StyledString::Text(rcstr!(
+                "Overly broad patterns can lead to build performance issues and over bundling."
+            ))
+            .resolved_cell(),
+        ))
+    }
+
+    #[turbo_tasks::function]
+    async fn file_path(&self) -> Vc<FileSystemPath> {
+        self.source.file_path()
+    }
+
+    #[turbo_tasks::function]
+    fn stage(&self) -> Vc<IssueStage> {
+        IssueStage::Resolve.cell()
+    }
+
+    fn severity(&self) -> IssueSeverity {
+        IssueSeverity::Warning
+    }
+
+    #[turbo_tasks::function]
+    fn source(&self) -> Vc<OptionIssueSource> {
+        Vc::cell(Some(self.source))
+    }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/static_code.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/static_code.rs
@@ -16,7 +16,6 @@ use crate::EcmascriptAnalyzable;
 /// the final runtime code, while keeping source map information.
 #[turbo_tasks::value]
 pub struct StaticEcmascriptCode {
-    asset_context: ResolvedVc<Box<dyn AssetContext>>,
     asset: ResolvedVc<Box<dyn EcmascriptAnalyzable>>,
     generate_source_map: bool,
 }
@@ -42,7 +41,6 @@ impl StaticEcmascriptCode {
             bail!("asset is not an Ecmascript module")
         };
         Ok(Self::cell(StaticEcmascriptCode {
-            asset_context,
             asset,
             generate_source_map,
         }))

--- a/turbopack/crates/turbopack-ecmascript/src/utils.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/utils.rs
@@ -197,12 +197,17 @@ pub fn module_value_to_well_known_object(module_value: &ModuleValue) -> Option<J
         }
         "node:fs" | "fs" => JsValue::WellKnownObject(WellKnownObjectKind::FsModule),
         "node:child_process" | "child_process" => {
-            JsValue::WellKnownObject(WellKnownObjectKind::ChildProcess)
+            JsValue::WellKnownObject(WellKnownObjectKind::ChildProcessModule)
         }
         "node:os" | "os" => JsValue::WellKnownObject(WellKnownObjectKind::OsModule),
-        "node:process" | "process" => JsValue::WellKnownObject(WellKnownObjectKind::NodeProcess),
+        "node:process" | "process" => {
+            JsValue::WellKnownObject(WellKnownObjectKind::NodeProcessModule)
+        }
         "node:url" | "url" => JsValue::WellKnownObject(WellKnownObjectKind::UrlModule),
         "node:module" | "module" => JsValue::WellKnownObject(WellKnownObjectKind::ModuleModule),
+        "node:worker_threads" | "worker_threads" => {
+            JsValue::WellKnownObject(WellKnownObjectKind::WorkerThreadsModule)
+        }
         "node-pre-gyp" | "@mapbox/node-pre-gyp" => {
             JsValue::WellKnownObject(WellKnownObjectKind::NodePreGyp)
         }

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -76,7 +76,7 @@ async fn node_file_trace_operation(
     let environment = Environment::new(ExecutionEnvironment::NodeJsLambda(
         NodeJsEnvironment::default().resolved_cell(),
     ));
-    let module_asset_context = ModuleAssetContext::new(
+    let module_asset_context = ModuleAssetContext::new_without_replace_externals(
         Default::default(),
         // This config should be kept in sync with
         // turbopack/crates/turbopack-tracing/tests/node-file-trace.rs and
@@ -109,6 +109,7 @@ async fn node_file_trace_operation(
             enable_node_native_modules: true,
             enable_node_modules: Some(input_dir),
             custom_conditions: vec![rcstr!("node")],
+            enable_node_externals: true,
             loose_errors: true,
             collect_affecting_sources: true,
             ..Default::default()

--- a/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
@@ -358,7 +358,7 @@ async fn node_file_trace_operation(
         }
         .resolved_cell(),
     ));
-    let module_asset_context = ModuleAssetContext::new(
+    let module_asset_context = ModuleAssetContext::new_without_replace_externals(
         Default::default(),
         // TODO These test cases should move into the `node-file-trace` crate and use the same
         // config.

--- a/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
+++ b/turbopack/crates/turbopack-tracing/tests/node-file-trace.rs
@@ -149,6 +149,7 @@ static ALLOC: turbo_tasks_malloc::TurboMalloc = turbo_tasks_malloc::TurboMalloc;
 #[case::pdf2json("integration/pdf2json.mjs")]
 #[case::pdfkit("integration/pdfkit.js")]
 #[case::pg("integration/pg.js")]
+#[case::pino("integration/pino.js")]
 #[case::playwright_core("integration/playwright-core.js")]
 #[case::pnpm_like("integration/pnpm/pnpm-like.js")]
 #[case::polyfill_library("integration/polyfill-library.js")]

--- a/turbopack/crates/turbopack-tracing/tests/node-file-trace/integration/pino.js
+++ b/turbopack/crates/turbopack-tracing/tests/node-file-trace/integration/pino.js
@@ -1,0 +1,18 @@
+// for transport({target: 'pino-pretty'}) to work
+require('pino-pretty')
+
+const { pino, transport } = require('pino')
+
+const loggerOptions = {
+  level: 'info',
+  timestamp: false,
+}
+const loggerTransport = transport({
+  target: 'pino-pretty',
+  options: {
+    ignore: 'pid,hostname',
+  },
+})
+const logger = pino(loggerOptions, loggerTransport)
+
+logger.info('foo')

--- a/turbopack/crates/turbopack-tracing/tests/node-file-trace/package.json
+++ b/turbopack/crates/turbopack-tracing/tests/node-file-trace/package.json
@@ -86,6 +86,8 @@
     "pg": "^7.11.0",
     "phantomjs-prebuilt": "^2.1.16",
     "pixelmatch": "^5.3.0",
+    "pino": "^10.1.0",
+    "pino-pretty": "^13.1.2",
     "playwright-core": "^1.17.1",
     "polyfill-library": "3.93.0",
     "prismjs": "^1.25.0",

--- a/turbopack/crates/turbopack-tracing/tests/node-file-trace/pnpm-lock.yaml
+++ b/turbopack/crates/turbopack-tracing/tests/node-file-trace/pnpm-lock.yaml
@@ -258,6 +258,12 @@ importers:
       phantomjs-prebuilt:
         specifier: ^2.1.16
         version: 2.1.16
+      pino:
+        specifier: ^10.1.0
+        version: 10.1.0
+      pino-pretty:
+        specifier: ^13.1.2
+        version: 13.1.2
       pixelmatch:
         specifier: ^5.3.0
         version: 5.3.0
@@ -1841,6 +1847,9 @@ packages:
     resolution: {integrity: sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==}
     engines: {node: '>=10'}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@prisma/instrumentation@6.10.1':
     resolution: {integrity: sha512-JC8qzgEDuFKjuBsqrZvXHINUb12psnE6Qy3q5p2MBhalC1KW1MBBUwuonx6iS5TCfCdtNslHft8uc2r+EdLWWg==}
     peerDependencies:
@@ -3316,6 +3325,10 @@ packages:
     engines: {node: '>= 4.5.0'}
     hasBin: true
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   atomically@2.0.3:
     resolution: {integrity: sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==}
 
@@ -3941,6 +3954,9 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   combine-source-map@0.8.0:
     resolution: {integrity: sha512-UlxQ9Vw0b/Bt/KYwCFqdEwsQ1eL8d1gibiFb7lxQJFdvTgc2hIZi6ugsg+kyhzhPV+QEpUiEIwInIAIrgoEkrg==}
 
@@ -4368,6 +4384,9 @@ packages:
   data-urls@2.0.0:
     resolution: {integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==}
     engines: {node: '>=10'}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   dayjs@1.11.6:
     resolution: {integrity: sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==}
@@ -5117,6 +5136,9 @@ packages:
     resolution: {integrity: sha512-HuC1qF9iTnHDnML9YZAdCDQwT0yKl/U55K4XSUXqGAA2GLoafFgWRqdAbhWJxXaYD4pyoVxAJ8wH670jMpI9DQ==}
     engines: {node: '>=0.4.0'}
 
+  fast-copy@3.0.2:
+    resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -5689,6 +5711,9 @@ packages:
 
   help-me@1.1.0:
     resolution: {integrity: sha512-P/IZ8yOMne3SCTHbVY429NZ67B/2bVQlcYGZh2iPPbdLrEQ/qY5aGChn0YTDmt7Sb4IKRI51fypItav+lNl76w==}
+
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   highlights@3.1.6:
     resolution: {integrity: sha512-WvFo8DzI+DnFWPckWjdK5Sne4ucAaNI4guikzAE5k0qhJE7JX2Px7OOolwVJJQmi7YkJDbubWVAxT3SjMUJWcw==}
@@ -6481,6 +6506,10 @@ packages:
   jose@2.0.6:
     resolution: {integrity: sha512-FVoPY7SflDodE4lknJmbAHSUjLCzE2H1F6MS0RYKMQ8SR+lNccpMf8R4eqkNYyyUjR5qZReOzZo5C5YiHOCjjg==}
     engines: {node: '>=10.13.0 < 13 || >=13.7.0'}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   jpeg-js@0.3.7:
     resolution: {integrity: sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==}
@@ -7759,6 +7788,10 @@ packages:
   omggif@1.0.10:
     resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -8141,6 +8174,20 @@ packages:
     resolution: {integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==}
     engines: {node: '>=0.10.0'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-pretty@13.1.2:
+    resolution: {integrity: sha512-3cN0tCakkT4f3zo9RXDIhy6GTvtYD6bK4CRBLN9j3E/ePqN1tugAXD5rGVfoChW6s0hiek+eyYlLNqc/BG7vBQ==}
+    hasBin: true
+
+  pino-std-serializers@7.0.0:
+    resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
+
+  pino@10.1.0:
+    resolution: {integrity: sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w==}
+    hasBin: true
+
   pirates@4.0.5:
     resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
     engines: {node: '>= 6'}
@@ -8253,6 +8300,9 @@ packages:
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
@@ -8436,6 +8486,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
@@ -8527,6 +8580,10 @@ packages:
   readdirp@2.2.1:
     resolution: {integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==}
     engines: {node: '>=0.10'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   redis-commands@1.7.0:
     resolution: {integrity: sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==}
@@ -8751,6 +8808,10 @@ packages:
   safe-regex@1.1.0:
     resolution: {integrity: sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -8780,6 +8841,9 @@ packages:
   season@6.0.2:
     resolution: {integrity: sha512-5eq1ZKvsIUTkefE/R6PhJyiDDaalPjmdhUPVMuOFh4Yz2n5pBl1COkzNlxQyI8BXEBEIu1nJeJqJPVD0c3vycQ==}
     hasBin: true
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semaphore@1.0.5:
     resolution: {integrity: sha512-15WnK4TxpOk33fL0UoDnJ5myIWwJiodIZHtPRBoSxcaADt1Tm7kxEERd8n0vsw6OWsXwCCeROjSKU9MqfHaS1A==}
@@ -9008,6 +9072,9 @@ packages:
   socks@2.8.5:
     resolution: {integrity: sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonic-boom@4.2.0:
+    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
 
   sort-keys@2.0.0:
     resolution: {integrity: sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==}
@@ -9271,6 +9338,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
+
   stripe@7.63.1:
     resolution: {integrity: sha512-W6R2CzMF87DeWVtxrAD8E9As62VIu2M9Ece+YKVw2P4oOBgvj5M2F2xH8R5VMmnDtmx4RJtg8PIJ4DmijpLU6g==}
     engines: {node: ^6 || ^8.1 || >=10.*}
@@ -9413,6 +9484,9 @@ packages:
 
   third-party-web@0.27.0:
     resolution: {integrity: sha512-h0JYX+dO2Zr3abCQpS6/uFjujaOjA1DyDzGQ41+oFn9VW/ARiq9g5ln7qEP9+BTzDpOMyIfsfj4OvfgXAsMUSA==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
@@ -12507,6 +12581,8 @@ snapshots:
 
   '@phc/format@1.0.0': {}
 
+  '@pinojs/redact@0.4.0': {}
+
   '@prisma/instrumentation@6.10.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -14821,6 +14897,8 @@ snapshots:
 
   atob@2.1.2: {}
 
+  atomic-sleep@1.0.0: {}
+
   atomically@2.0.3:
     dependencies:
       stubborn-fs: 1.2.5
@@ -15718,6 +15796,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
+  colorette@2.0.20: {}
+
   combine-source-map@0.8.0:
     dependencies:
       convert-source-map: 1.1.3
@@ -16024,6 +16104,8 @@ snapshots:
       abab: 2.0.6
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.7.0
+
+  dateformat@4.6.3: {}
 
   dayjs@1.11.6: {}
 
@@ -16841,6 +16923,8 @@ snapshots:
     dependencies:
       acorn: 7.4.1
       isarray: 2.0.5
+
+  fast-copy@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -17666,6 +17750,8 @@ snapshots:
       glob-stream: 6.1.0
       through2: 2.0.5
       xtend: 4.0.2
+
+  help-me@5.0.0: {}
 
   highlights@3.1.6:
     dependencies:
@@ -18703,6 +18789,8 @@ snapshots:
   jose@2.0.6:
     dependencies:
       '@panva/asn1.js': 1.0.0
+
+  joycon@3.1.1: {}
 
   jpeg-js@0.3.7: {}
 
@@ -20249,6 +20337,8 @@ snapshots:
 
   omggif@1.0.10: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -20639,6 +20729,42 @@ snapshots:
 
   pinkie@2.0.4: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.1.0
+
+  pino-pretty@13.1.2:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 3.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.7
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pump: 3.0.0
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.0
+      strip-json-comments: 5.0.3
+
+  pino-std-serializers@7.0.0: {}
+
+  pino@10.1.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.0.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.0
+      thread-stream: 3.1.0
+
   pirates@4.0.5: {}
 
   piscina@3.2.0:
@@ -20781,6 +20907,8 @@ snapshots:
   prismjs@1.29.0: {}
 
   process-nextick-args@2.0.1: {}
+
+  process-warning@5.0.0: {}
 
   process@0.11.10: {}
 
@@ -21041,6 +21169,8 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  quick-format-unescaped@4.0.4: {}
+
   quick-lru@5.1.1: {}
 
   quickselect@1.1.1: {}
@@ -21174,6 +21304,8 @@ snapshots:
       readable-stream: 2.3.8
     transitivePeerDependencies:
       - supports-color
+
+  real-require@0.2.0: {}
 
   redis-commands@1.7.0: {}
 
@@ -21428,6 +21560,8 @@ snapshots:
     dependencies:
       ret: 0.1.15
 
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
 
   saslprep@1.0.3:
@@ -21456,6 +21590,8 @@ snapshots:
       cson-parser: 1.3.5
       fs-plus: 3.1.1
       yargs: 3.32.0
+
+  secure-json-parse@4.1.0: {}
 
   semaphore@1.0.5: {}
 
@@ -21843,6 +21979,10 @@ snapshots:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
 
+  sonic-boom@4.2.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   sort-keys@2.0.0:
     dependencies:
       is-plain-obj: 1.1.0
@@ -22153,6 +22293,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-json-comments@5.0.3: {}
+
   stripe@7.63.1:
     dependencies:
       qs: 6.11.0
@@ -22420,6 +22562,10 @@ snapshots:
   text-encoding@0.6.4: {}
 
   third-party-web@0.27.0: {}
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
 
   throat@5.0.0: {}
 

--- a/turbopack/crates/turbopack-tracing/tests/unit.rs
+++ b/turbopack/crates/turbopack-tracing/tests/unit.rs
@@ -194,7 +194,7 @@ async fn node_file_trace_operation(package_root: RcStr, input: RcStr) -> Result<
         }
         .resolved_cell(),
     ));
-    let module_asset_context = ModuleAssetContext::new(
+    let module_asset_context = ModuleAssetContext::new_without_replace_externals(
         Default::default(),
         // TODO These test cases should move into the `node-file-trace` crate and use the same
         // config.

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -391,8 +391,9 @@ impl ModuleAssetContext {
         })
     }
 
+    /// Doesn't replace external resolve results with a CachedExternalModule.
     #[turbo_tasks::function]
-    fn new_without_replace_externals(
+    pub fn new_without_replace_externals(
         transitions: ResolvedVc<TransitionOptions>,
         compile_time_info: ResolvedVc<CompileTimeInfo>,
         module_options_context: ResolvedVc<ModuleOptionsContext>,


### PR DESCRIPTION
Closes PACK-5688  
Closes https://github.com/vercel/next.js/issues/84766

1. Trace `new require("worker_threads").Worker` calls
2. ignore syntax errors in all traced files

This does lead to a build error currently with cargo run --bin turbopack-nft -- --show-issues --graph bench/app-router-server/node_modules/thread-stream/index.js:

```
error - [analysis] [workspace]/node_modules/.pnpm/thread-stream@3.1.0/node_modules/thread-stream/test/syntax-error.mjs
  [workspace]/node_modules/.pnpm/thread-stream@3.1.0/node_modules/thread-stream/test/syntax-error.mjs:2:6  Parsing ecmascript source code failed
       1 | // this is a syntax error
         +       v
       2 + import
         +       ^
       3 | 
  
  Expected 'from', got '<eof>'
```

Pulled in by this partly dynamic `new Worker()`  call: https://github.com/pinojs/thread-stream/blob/82e011281b8895bf5e8f70008e0242927fcaf0cb/index.js#L53-L55

(Related to https://github.com/vercel/next.js/pull/84408, where this was previously fixed for extensionless files such as `LICENSE`)

