### PR TITLE
docs: update docs to mention ESLint as default

### DIFF
--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -39,7 +39,7 @@ cd my-app
 bun dev
 ```
 
-- `--yes` skips prompts using saved preferences or defaults. The default setup enables TypeScript, Tailwind, App Router, and Turbopack, with import alias `@/*`.
+- `--yes` skips prompts using saved preferences or defaults. The default setup enables TypeScript, Tailwind, ESLint, App Router, and Turbopack, with import alias `@/*`.
 
 </AppOnly>
 


### PR DESCRIPTION
### What?
- Add mention of ESLint being the default linter when specifying `--yes` flag on `create-next-app`

### Why?

- Adds consistency by calling out the default linter.