### PR TITLE
remove unused RSC payload property

### DIFF
--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -118,7 +118,6 @@ export function createInitialRSCPayloadFromFallbackPrerender(
     ],
     m: fallbackInitialRSCPayload.m,
     G: fallbackInitialRSCPayload.G,
-    s: fallbackInitialRSCPayload.s,
     S: fallbackInitialRSCPayload.S,
   }
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1333,7 +1333,6 @@ async function getRSCPayload(
     ],
     m: missingSlots,
     G: [GlobalError, globalErrorStyles],
-    s: typeof ctx.renderOpts.postponed === 'string',
     S: workStore.isStaticGeneration,
   }
 }
@@ -1458,7 +1457,6 @@ async function getErrorRSCPayload(
       ] as FlightDataPath,
     ],
     G: [GlobalError, globalErrorStyles],
-    s: typeof ctx.renderOpts.postponed === 'string',
     S: workStore.isStaticGeneration,
   } satisfies InitialRSCPayload
 }

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -288,8 +288,6 @@ export type InitialRSCPayload = {
   m: Set<string> | undefined
   /** GlobalError */
   G: [React.ComponentType<any>, React.ReactNode | undefined]
-  /** postponed */
-  s: boolean
   /** prerendered */
   S: boolean
 }


### PR DESCRIPTION
This property is from back when we forked client router handling based off the presence of the `postponed` payload, but it's no longer being read by anything, so this PR removes it. 