### PR TITLE
Split each path param into a separate cache key 

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -409,9 +409,10 @@ export function readRouteCacheEntry(
 
 export function getCanonicalSegmentKeypath(
   route: FulfilledRouteCacheEntry,
-  cacheKey: SegmentCacheKey
+  tree: RouteTree
 ): SegmentCacheKeypath {
   // Returns the actual keypath for a segment, without omitting any params.
+  const cacheKey = tree.cacheKey
   return [
     cacheKey,
     cacheKey.endsWith('/' + PAGE_SEGMENT_KEY) || isHeadCacheKey(cacheKey)
@@ -425,7 +426,7 @@ export function getCanonicalSegmentKeypath(
 export function getGenericSegmentKeypathFromFetchStrategy(
   fetchStrategy: FetchStrategy,
   route: FulfilledRouteCacheEntry,
-  cacheKey: SegmentCacheKey
+  tree: RouteTree
 ): SegmentCacheKeypath {
   // Returns the most generic possible keypath for a segment, based on the
   // strategy used to fetch it, i.e. static/PPR versus runtime prefetching.
@@ -437,6 +438,7 @@ export function getGenericSegmentKeypathFromFetchStrategy(
   // we receive it — for example, if the server tells us that the response
   // doesn't vary on a particular param — but even before we send the request,
   // we know somethings based on the fetch strategy alone.
+  const cacheKey = tree.cacheKey
   const doesVaryOnSearchParams =
     // Only page segments and the head may contain search params. There's no
     // reason to include them in the keypath otherwise.
@@ -662,9 +664,9 @@ export function readOrCreateSegmentCacheEntry(
   now: number,
   fetchStrategy: FetchStrategy,
   route: FulfilledRouteCacheEntry,
-  cacheKey: SegmentCacheKey
+  tree: RouteTree
 ): SegmentCacheEntry {
-  const canonicalKeypath = getCanonicalSegmentKeypath(route, cacheKey)
+  const canonicalKeypath = getCanonicalSegmentKeypath(route, tree)
   const existingEntry = readSegmentCacheEntry(now, canonicalKeypath)
   if (existingEntry !== null) {
     return existingEntry
@@ -673,7 +675,7 @@ export function readOrCreateSegmentCacheEntry(
   const genericKeypath = getGenericSegmentKeypathFromFetchStrategy(
     fetchStrategy,
     route,
-    cacheKey
+    tree
   )
   const pendingEntry = createDetachedSegmentCacheEntry(route.staleAt)
   const isRevalidation = false
@@ -685,7 +687,7 @@ export function readOrCreateRevalidatingSegmentEntry(
   now: number,
   fetchStrategy: FetchStrategy,
   route: FulfilledRouteCacheEntry,
-  cacheKey: SegmentCacheKey
+  tree: RouteTree
 ): SegmentCacheEntry {
   // This function is called when we've already confirmed that a particular
   // segment is cached, but we want to perform another request anyway in case it
@@ -714,7 +716,7 @@ export function readOrCreateRevalidatingSegmentEntry(
   // return a less generic entry upon revalidation. For now, though, this isn't
   // a concern because the keypath is based solely on the prefetch strategy,
   // not on data contained in the response.
-  const canonicalKeypath = getCanonicalSegmentKeypath(route, cacheKey)
+  const canonicalKeypath = getCanonicalSegmentKeypath(route, tree)
   const existingEntry = readRevalidatingSegmentCacheEntry(now, canonicalKeypath)
   if (existingEntry !== null) {
     return existingEntry
@@ -723,7 +725,7 @@ export function readOrCreateRevalidatingSegmentEntry(
   const genericKeypath = getGenericSegmentKeypathFromFetchStrategy(
     fetchStrategy,
     route,
-    cacheKey
+    tree
   )
   const pendingEntry = createDetachedSegmentCacheEntry(route.staleAt)
   const isRevalidation = true
@@ -734,7 +736,7 @@ export function readOrCreateRevalidatingSegmentEntry(
 export function overwriteRevalidatingSegmentCacheEntry(
   fetchStrategy: FetchStrategy,
   route: FulfilledRouteCacheEntry,
-  cacheKey: SegmentCacheKey
+  tree: RouteTree
 ) {
   // This function is called when we've already decided to replace an existing
   // revalidation entry. Create a new entry and write it into the cache,
@@ -742,7 +744,7 @@ export function overwriteRevalidatingSegmentCacheEntry(
   const genericKeypath = getGenericSegmentKeypathFromFetchStrategy(
     fetchStrategy,
     route,
-    cacheKey
+    tree
   )
   const pendingEntry = createDetachedSegmentCacheEntry(route.staleAt)
   const isRevalidation = true
@@ -1559,7 +1561,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     | FetchStrategy.PPRRuntime
     | FetchStrategy.Full,
   dynamicRequestTree: FlightRouterState,
-  spawnedEntries: Map<SegmentCacheKey, PendingSegmentCacheEntry>
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry>
 ): Promise<PrefetchSubtaskResult<null> | null> {
   const key = task.key
   const url = new URL(route.canonicalUrl, location.origin)
@@ -1567,7 +1569,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
 
   if (
     spawnedEntries.size === 1 &&
-    spawnedEntries.has(route.metadata.cacheKey)
+    spawnedEntries.has(route.metadata.requestKey)
   ) {
     // The only thing pending is the head. Instruct the server to
     // skip over everything else.
@@ -1768,7 +1770,7 @@ function writeDynamicTreeResponseIntoCache(
 }
 
 function rejectSegmentEntriesIfStillPending(
-  entries: Map<SegmentCacheKey, SegmentCacheEntry>,
+  entries: Map<SegmentRequestKey, SegmentCacheEntry>,
   staleAt: number
 ): Array<FulfilledSegmentCacheEntry> {
   const fulfilledEntries = []
@@ -1793,7 +1795,7 @@ function writeDynamicRenderResponseIntoCache(
   serverData: NavigationFlightResponse,
   isResponsePartial: boolean,
   route: FulfilledRouteCacheEntry,
-  spawnedEntries: Map<SegmentCacheKey, PendingSegmentCacheEntry> | null
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null
 ): Array<FulfilledSegmentCacheEntry> | null {
   if (serverData.b !== getAppBuildId()) {
     // The server build does not match the client. Treat as a 404. During
@@ -1834,22 +1836,17 @@ function writeDynamicRenderResponseIntoCache(
       //
       //   [string, Segment, string, Segment, string, Segment, ...]
       const segmentPath = flightData.segmentPath
-      let requestKey = ROOT_SEGMENT_REQUEST_KEY
-      let cacheKey = ROOT_SEGMENT_CACHE_KEY
+      let tree = route.tree
       for (let i = 0; i < segmentPath.length; i += 2) {
         const parallelRouteKey: string = segmentPath[i]
-        const segment: FlightRouterStateSegment = segmentPath[i + 1]
-        const requestKeyPart = createSegmentRequestKeyPart(segment)
-        requestKey = appendSegmentRequestKeyPart(
-          requestKey,
-          parallelRouteKey,
-          requestKeyPart
-        )
-        cacheKey = appendSegmentCacheKeyPart(
-          cacheKey,
-          parallelRouteKey,
-          createSegmentCacheKeyPart(requestKeyPart, segment)
-        )
+        if (tree?.slots?.[parallelRouteKey] !== undefined) {
+          tree = tree.slots[parallelRouteKey]
+        } else {
+          if (spawnedEntries !== null) {
+            rejectSegmentEntriesIfStillPending(spawnedEntries, now + 10 * 1000)
+          }
+          return null
+        }
       }
 
       writeSeedDataIntoCache(
@@ -1857,12 +1854,10 @@ function writeDynamicRenderResponseIntoCache(
         task,
         fetchStrategy,
         route,
+        tree,
         staleAt,
-        flightData.tree,
         seedData,
         isResponsePartial,
-        cacheKey,
-        requestKey,
         spawnedEntries
       )
     }
@@ -1877,7 +1872,7 @@ function writeDynamicRenderResponseIntoCache(
         null,
         flightData.isHeadPartial,
         staleAt,
-        route.metadata.cacheKey,
+        route.metadata,
         spawnedEntries
       )
     }
@@ -1908,14 +1903,12 @@ function writeSeedDataIntoCache(
     | FetchStrategy.PPRRuntime
     | FetchStrategy.Full,
   route: FulfilledRouteCacheEntry,
+  tree: RouteTree,
   staleAt: number,
-  flightRouterState: FlightRouterState,
   seedData: CacheNodeSeedData,
   isResponsePartial: boolean,
-  cacheKey: SegmentCacheKey,
-  requestKey: SegmentRequestKey,
   entriesOwnedByCurrentTask: Map<
-    SegmentCacheKey,
+    SegmentRequestKey,
     PendingSegmentCacheEntry
   > | null
 ) {
@@ -1932,43 +1925,31 @@ function writeSeedDataIntoCache(
     loading,
     isPartial,
     staleAt,
-    cacheKey,
+    tree,
     entriesOwnedByCurrentTask
   )
 
   // Recursively write the child data into the cache.
-  const flightRouterStateChildren = flightRouterState[1]
-  const seedDataChildren = seedData[1]
-  for (const parallelRouteKey in flightRouterStateChildren) {
-    const childFlightRouterState = flightRouterStateChildren[parallelRouteKey]
-    const childSeedData: CacheNodeSeedData | null | void =
-      seedDataChildren[parallelRouteKey]
-    if (childSeedData !== null && childSeedData !== undefined) {
-      const childSegment = childFlightRouterState[0]
-      const childRequestKeyPart = createSegmentRequestKeyPart(childSegment)
-      const childRequestKey = appendSegmentRequestKeyPart(
-        requestKey,
-        parallelRouteKey,
-        childRequestKeyPart
-      )
-      const childCacheKey = appendSegmentCacheKeyPart(
-        cacheKey,
-        parallelRouteKey,
-        createSegmentCacheKeyPart(childRequestKeyPart, childSegment)
-      )
-      writeSeedDataIntoCache(
-        now,
-        task,
-        fetchStrategy,
-        route,
-        staleAt,
-        childFlightRouterState,
-        childSeedData,
-        isResponsePartial,
-        childCacheKey,
-        childRequestKey,
-        entriesOwnedByCurrentTask
-      )
+  const slots = tree.slots
+  if (slots !== null) {
+    const seedDataChildren = seedData[1]
+    for (const parallelRouteKey in slots) {
+      const childTree = slots[parallelRouteKey]
+      const childSeedData: CacheNodeSeedData | null | void =
+        seedDataChildren[parallelRouteKey]
+      if (childSeedData !== null && childSeedData !== undefined) {
+        writeSeedDataIntoCache(
+          now,
+          task,
+          fetchStrategy,
+          route,
+          childTree,
+          staleAt,
+          childSeedData,
+          isResponsePartial,
+          entriesOwnedByCurrentTask
+        )
+      }
     }
   }
 }
@@ -1984,9 +1965,9 @@ function fulfillEntrySpawnedByRuntimePrefetch(
   loading: LoadingModuleData | Promise<LoadingModuleData>,
   isPartial: boolean,
   staleAt: number,
-  cacheKey: SegmentCacheKey,
+  tree: RouteTree,
   entriesOwnedByCurrentTask: Map<
-    SegmentCacheKey,
+    SegmentRequestKey,
     PendingSegmentCacheEntry
   > | null
 ) {
@@ -1995,7 +1976,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
   // created by a different task, because that causes data races.
   const ownedEntry =
     entriesOwnedByCurrentTask !== null
-      ? entriesOwnedByCurrentTask.get(cacheKey)
+      ? entriesOwnedByCurrentTask.get(tree.requestKey)
       : undefined
   if (ownedEntry !== undefined) {
     fulfillSegmentCacheEntry(ownedEntry, rsc, loading, staleAt, isPartial)
@@ -2005,7 +1986,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
       now,
       fetchStrategy,
       route,
-      cacheKey
+      tree
     )
     if (possiblyNewEntry.status === EntryStatus.Empty) {
       // Confirmed this is a new entry. We can fulfill it.
@@ -2032,11 +2013,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
       )
       upsertSegmentEntry(
         now,
-        getGenericSegmentKeypathFromFetchStrategy(
-          fetchStrategy,
-          route,
-          cacheKey
-        ),
+        getGenericSegmentKeypathFromFetchStrategy(fetchStrategy, route, tree),
         newEntry
       )
     }

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -6,7 +6,6 @@ import type {
 import type { LoadingModuleData } from '../../../shared/lib/app-router-types'
 import type {
   CacheNodeSeedData,
-  DynamicParamTypesShort,
   Segment as FlightRouterStateSegment,
 } from '../../../shared/lib/app-router-types'
 import { HasLoadingBoundary } from '../../../shared/lib/app-router-types'
@@ -33,24 +32,31 @@ import {
   type PrefetchSubtaskResult,
   startRevalidationCooldown,
 } from './scheduler'
+import {
+  type RouteVaryPath,
+  type SegmentVaryPath,
+  type PartialSegmentVaryPath,
+  getRouteVaryPath,
+  getFulfilledRouteVaryPath,
+  getSegmentVaryPathForRequest,
+  appendLayoutVaryPath,
+  finalizeLayoutVaryPath,
+  finalizePageVaryPath,
+  clonePageVaryPathWithNewSearchParams,
+  type PageVaryPath,
+  finalizeMetadataVaryPath,
+} from './vary-path'
 import { getAppBuildId } from '../../app-build-id'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
-import type {
-  NormalizedPathname,
-  NormalizedNextUrl,
-  NormalizedSearch,
-  RouteCacheKey,
-} from './cache-key'
+import type { NormalizedSearch, RouteCacheKey } from './cache-key'
 // TODO: Rename this module to avoid confusion with other types of cache keys
 import { createCacheKey as createPrefetchRequestKey } from './cache-key'
 import {
   doesStaticSegmentAppearInURL,
   getCacheKeyForDynamicParam,
-  getParamValueFromCacheKey,
   getRenderedPathname,
   getRenderedSearch,
   parseDynamicParamFromURLPart,
-  type RouteParam,
 } from '../../route-params'
 import {
   createCacheMap,
@@ -59,23 +65,15 @@ import {
   setSizeInCacheMap,
   deleteFromCacheMap,
   isValueExpired,
-  Fallback,
   type CacheMap,
   type MapEntry,
-  type FallbackType,
 } from './cache-map'
 import {
-  appendSegmentCacheKeyPart,
   appendSegmentRequestKeyPart,
   convertSegmentPathToStaticExportFilename,
-  createSegmentCacheKeyPart,
   createSegmentRequestKeyPart,
-  createHeadCacheKey,
-  isHeadCacheKey,
   HEAD_REQUEST_KEY,
-  ROOT_SEGMENT_CACHE_KEY,
   ROOT_SEGMENT_REQUEST_KEY,
-  type SegmentCacheKey,
   type SegmentRequestKey,
 } from '../../../shared/lib/segment-cache/segment-value-encoding'
 import type {
@@ -125,13 +123,11 @@ export function getStaleTimeMs(staleTimeSeconds: number): number {
 // the root, then it's effectively canceled. This is similar to the design of
 // Rust Futures, or React Suspense.
 
-export type RouteTree = {
-  cacheKey: SegmentCacheKey
+type RouteTreeShared = {
   requestKey: SegmentRequestKey
   // TODO: Remove the `segment` field, now that it can be reconstructed
   // from `param`.
   segment: FlightRouterStateSegment
-  param: RouteParam | null
   slots: null | {
     [parallelRouteKey: string]: RouteTree
   }
@@ -151,6 +147,18 @@ export type RouteTree = {
   hasRuntimePrefetch: boolean
 }
 
+type LayoutRouteTree = RouteTreeShared & {
+  isPage: false
+  varyPath: SegmentVaryPath
+}
+
+type PageRouteTree = RouteTreeShared & {
+  isPage: true
+  varyPath: PageVaryPath
+}
+
+export type RouteTree = LayoutRouteTree | PageRouteTree
+
 type RouteCacheEntryShared = {
   // This is false only if we're certain the route cannot be intercepted. It's
   // true in all other cases, including on initialization when we haven't yet
@@ -158,7 +166,7 @@ type RouteCacheEntryShared = {
   couldBeIntercepted: boolean
 
   // Map-related fields.
-  ref: null | MapEntry<RouteCacheKeypath, RouteCacheEntry>
+  ref: null | MapEntry<RouteCacheEntry>
   size: number
   staleAt: number
   version: number
@@ -215,7 +223,7 @@ type SegmentCacheEntryShared = {
   fetchStrategy: FetchStrategy
 
   // Map-related fields.
-  ref: null | MapEntry<SegmentCacheKeypath, SegmentCacheEntry>
+  ref: null | MapEntry<SegmentCacheEntry>
   size: number
   staleAt: number
   version: number
@@ -275,23 +283,8 @@ const MetadataOnlyRequestTree: FlightRouterState = [
   'metadata-only',
 ]
 
-// Route cache entries vary on multiple keys: the href and the Next-Url. Each of
-// these parts needs to be included in the internal cache key. Rather than
-// concatenate the keys into a single key, we use a multi-level map, where the
-// first level is keyed by href, the second level is keyed by Next-Url, and so
-// on (if were to add more levels).
-type RouteCacheKeypath = [
-  NormalizedPathname,
-  NormalizedSearch,
-  NormalizedNextUrl | null | FallbackType,
-]
-let routeCacheMap: CacheMap<RouteCacheKeypath, RouteCacheEntry> =
-  createCacheMap()
-
-export type SegmentCacheKeypath = [string, NormalizedSearch | FallbackType]
-
-let segmentCacheMap: CacheMap<SegmentCacheKeypath, SegmentCacheEntry> =
-  createCacheMap()
+let routeCacheMap: CacheMap<RouteCacheEntry> = createCacheMap()
+let segmentCacheMap: CacheMap<SegmentCacheEntry> = createCacheMap()
 
 // All invalidation listeners for the whole cache are tracked in single set.
 // Since we don't yet support tag or path-based invalidation, there's no point
@@ -396,90 +389,45 @@ export function readRouteCacheEntry(
   now: number,
   key: RouteCacheKey
 ): RouteCacheEntry | null {
-  const keypath: RouteCacheKeypath = [key.pathname, key.search, key.nextUrl]
+  const varyPath: RouteVaryPath = getRouteVaryPath(
+    key.pathname,
+    key.search,
+    key.nextUrl
+  )
   const isRevalidation = false
   return getFromCacheMap(
     now,
     getCurrentCacheVersion(),
     routeCacheMap,
-    keypath,
+    varyPath,
     isRevalidation
   )
 }
 
-export function getCanonicalSegmentKeypath(
-  route: FulfilledRouteCacheEntry,
-  tree: RouteTree
-): SegmentCacheKeypath {
-  // Returns the actual keypath for a segment, without omitting any params.
-  const cacheKey = tree.cacheKey
-  return [
-    cacheKey,
-    cacheKey.endsWith('/' + PAGE_SEGMENT_KEY) || isHeadCacheKey(cacheKey)
-      ? route.renderedSearch
-      : // Only page segments and the head may contain search params. There's no
-        // reason to include them in the keypath otherwise.
-        Fallback,
-  ]
-}
-
-export function getGenericSegmentKeypathFromFetchStrategy(
-  fetchStrategy: FetchStrategy,
-  route: FulfilledRouteCacheEntry,
-  tree: RouteTree
-): SegmentCacheKeypath {
-  // Returns the most generic possible keypath for a segment, based on the
-  // strategy used to fetch it, i.e. static/PPR versus runtime prefetching.
-  //
-  // This is used when _writing_ to the cache. We want to choose the most
-  // generic keypath so that it can be reused as much as possible.
-  //
-  // We may be able to re-key the response to something even more generic once
-  // we receive it — for example, if the server tells us that the response
-  // doesn't vary on a particular param — but even before we send the request,
-  // we know somethings based on the fetch strategy alone.
-  const cacheKey = tree.cacheKey
-  const doesVaryOnSearchParams =
-    // Only page segments and the head may contain search params. There's no
-    // reason to include them in the keypath otherwise.
-    (cacheKey.endsWith('/' + PAGE_SEGMENT_KEY) || isHeadCacheKey(cacheKey)) &&
-    // Only a runtime prefetch will include search params in the result. Static
-    // prefetches never include search params, so they can be reused across all
-    // possible search param values.
-    (fetchStrategy === FetchStrategy.Full ||
-      fetchStrategy === FetchStrategy.PPRRuntime)
-  const keypath: SegmentCacheKeypath = [
-    cacheKey,
-
-    doesVaryOnSearchParams ? route.renderedSearch : Fallback,
-  ]
-  return keypath
-}
-
 export function readSegmentCacheEntry(
   now: number,
-  keypath: SegmentCacheKeypath
+  varyPath: SegmentVaryPath
 ): SegmentCacheEntry | null {
   const isRevalidation = false
   return getFromCacheMap(
     now,
     getCurrentCacheVersion(),
     segmentCacheMap,
-    keypath,
+    varyPath,
     isRevalidation
   )
 }
 
 function readRevalidatingSegmentCacheEntry(
   now: number,
-  keypath: SegmentCacheKeypath
+  varyPath: SegmentVaryPath
 ): SegmentCacheEntry | null {
   const isRevalidation = true
   return getFromCacheMap(
     now,
     getCurrentCacheVersion(),
     segmentCacheMap,
-    keypath,
+    varyPath,
     isRevalidation
   )
 }
@@ -537,9 +485,13 @@ export function readOrCreateRouteCacheEntry(
     staleAt: Infinity,
     version: getCurrentCacheVersion(),
   }
-  const keypath: RouteCacheKeypath = [key.pathname, key.search, key.nextUrl]
+  const varyPath: RouteVaryPath = getRouteVaryPath(
+    key.pathname,
+    key.search,
+    key.nextUrl
+  )
   const isRevalidation = false
-  setInCacheMap(routeCacheMap, keypath, pendingEntry, isRevalidation)
+  setInCacheMap(routeCacheMap, varyPath, pendingEntry, isRevalidation)
   return pendingEntry
 }
 
@@ -628,6 +580,15 @@ export function requestOptimisticRouteCacheEntry(
   optimisticUrl.search = optimisticCanonicalSearch
   const optimisticCanonicalUrl = createHrefFromUrl(optimisticUrl)
 
+  const optimisticRouteTree = createOptimisticRouteTree(
+    routeWithNoSearchParams.tree,
+    optimisticRenderedSearch
+  )
+  const optimisticMetadataTree = createOptimisticRouteTree(
+    routeWithNoSearchParams.metadata,
+    optimisticRenderedSearch
+  )
+
   // Clone the base route tree, and override the relevant fields with our
   // optimistic values.
   const optimisticEntry: FulfilledRouteCacheEntry = {
@@ -636,8 +597,8 @@ export function requestOptimisticRouteCacheEntry(
     status: EntryStatus.Fulfilled,
     // This isn't cloned because it's instance-specific
     blockedTasks: null,
-    tree: routeWithNoSearchParams.tree,
-    metadata: routeWithNoSearchParams.metadata,
+    tree: optimisticRouteTree,
+    metadata: optimisticMetadataTree,
     couldBeIntercepted: routeWithNoSearchParams.couldBeIntercepted,
     isPPREnabled: routeWithNoSearchParams.isPPREnabled,
 
@@ -656,6 +617,55 @@ export function requestOptimisticRouteCacheEntry(
   return optimisticEntry
 }
 
+function createOptimisticRouteTree(
+  tree: RouteTree,
+  newRenderedSearch: NormalizedSearch
+): RouteTree {
+  // Create a new route tree that identical to the original one except for
+  // the rendered search string, which is contained in the vary path.
+
+  let clonedSlots: Record<string, RouteTree> | null = null
+  const originalSlots = tree.slots
+  if (originalSlots !== null) {
+    clonedSlots = {}
+    for (const parallelRouteKey in originalSlots) {
+      const childTree = originalSlots[parallelRouteKey]
+      clonedSlots[parallelRouteKey] = createOptimisticRouteTree(
+        childTree,
+        newRenderedSearch
+      )
+    }
+  }
+
+  // We only need to clone the vary path if the route is a page.
+  if (tree.isPage) {
+    return {
+      requestKey: tree.requestKey,
+      segment: tree.segment,
+      varyPath: clonePageVaryPathWithNewSearchParams(
+        tree.varyPath,
+        newRenderedSearch
+      ),
+      isPage: true,
+      slots: clonedSlots,
+      isRootLayout: tree.isRootLayout,
+      hasLoadingBoundary: tree.hasLoadingBoundary,
+      hasRuntimePrefetch: tree.hasRuntimePrefetch,
+    }
+  }
+
+  return {
+    requestKey: tree.requestKey,
+    segment: tree.segment,
+    varyPath: tree.varyPath,
+    isPage: false,
+    slots: clonedSlots,
+    isRootLayout: tree.isRootLayout,
+    hasLoadingBoundary: tree.hasLoadingBoundary,
+    hasRuntimePrefetch: tree.hasRuntimePrefetch,
+  }
+}
+
 /**
  * Checks if an entry for a segment exists in the cache. If so, it returns the
  * entry, If not, it adds an empty entry to the cache and returns it.
@@ -666,20 +676,20 @@ export function readOrCreateSegmentCacheEntry(
   route: FulfilledRouteCacheEntry,
   tree: RouteTree
 ): SegmentCacheEntry {
-  const canonicalKeypath = getCanonicalSegmentKeypath(route, tree)
-  const existingEntry = readSegmentCacheEntry(now, canonicalKeypath)
+  const existingEntry = readSegmentCacheEntry(now, tree.varyPath)
   if (existingEntry !== null) {
     return existingEntry
   }
   // Create a pending entry and add it to the cache.
-  const genericKeypath = getGenericSegmentKeypathFromFetchStrategy(
-    fetchStrategy,
-    route,
-    tree
-  )
+  const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
   const pendingEntry = createDetachedSegmentCacheEntry(route.staleAt)
   const isRevalidation = false
-  setInCacheMap(segmentCacheMap, genericKeypath, pendingEntry, isRevalidation)
+  setInCacheMap(
+    segmentCacheMap,
+    varyPathForRequest,
+    pendingEntry,
+    isRevalidation
+  )
   return pendingEntry
 }
 
@@ -716,20 +726,20 @@ export function readOrCreateRevalidatingSegmentEntry(
   // return a less generic entry upon revalidation. For now, though, this isn't
   // a concern because the keypath is based solely on the prefetch strategy,
   // not on data contained in the response.
-  const canonicalKeypath = getCanonicalSegmentKeypath(route, tree)
-  const existingEntry = readRevalidatingSegmentCacheEntry(now, canonicalKeypath)
+  const existingEntry = readRevalidatingSegmentCacheEntry(now, tree.varyPath)
   if (existingEntry !== null) {
     return existingEntry
   }
   // Create a pending entry and add it to the cache.
-  const genericKeypath = getGenericSegmentKeypathFromFetchStrategy(
-    fetchStrategy,
-    route,
-    tree
-  )
+  const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
   const pendingEntry = createDetachedSegmentCacheEntry(route.staleAt)
   const isRevalidation = true
-  setInCacheMap(segmentCacheMap, genericKeypath, pendingEntry, isRevalidation)
+  setInCacheMap(
+    segmentCacheMap,
+    varyPathForRequest,
+    pendingEntry,
+    isRevalidation
+  )
   return pendingEntry
 }
 
@@ -741,20 +751,21 @@ export function overwriteRevalidatingSegmentCacheEntry(
   // This function is called when we've already decided to replace an existing
   // revalidation entry. Create a new entry and write it into the cache,
   // overwriting the previous value.
-  const genericKeypath = getGenericSegmentKeypathFromFetchStrategy(
-    fetchStrategy,
-    route,
-    tree
-  )
+  const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
   const pendingEntry = createDetachedSegmentCacheEntry(route.staleAt)
   const isRevalidation = true
-  setInCacheMap(segmentCacheMap, genericKeypath, pendingEntry, isRevalidation)
+  setInCacheMap(
+    segmentCacheMap,
+    varyPathForRequest,
+    pendingEntry,
+    isRevalidation
+  )
   return pendingEntry
 }
 
 export function upsertSegmentEntry(
   now: number,
-  keypath: SegmentCacheKeypath,
+  varyPath: SegmentVaryPath,
   candidateEntry: SegmentCacheEntry
 ): SegmentCacheEntry | null {
   // We have a new entry that has not yet been inserted into the cache. Before
@@ -769,7 +780,7 @@ export function upsertSegmentEntry(
     return null
   }
 
-  const existingEntry = readSegmentCacheEntry(now, keypath)
+  const existingEntry = readSegmentCacheEntry(now, varyPath)
   if (existingEntry !== null) {
     // Don't replace a more specific segment with a less-specific one. A case where this
     // might happen is if the existing segment was fetched via
@@ -803,7 +814,7 @@ export function upsertSegmentEntry(
   }
 
   const isRevalidation = false
-  setInCacheMap(segmentCacheMap, keypath, candidateEntry, isRevalidation)
+  setInCacheMap(segmentCacheMap, varyPath, candidateEntry, isRevalidation)
   return candidateEntry
 }
 
@@ -860,10 +871,10 @@ function pingBlockedTasks(entry: {
 function fulfillRouteCacheEntry(
   entry: RouteCacheEntry,
   tree: RouteTree,
+  metadataVaryPath: PageVaryPath,
   staleAt: number,
   couldBeIntercepted: boolean,
   canonicalUrl: string,
-  renderedPathname: NormalizedPathname,
   renderedSearch: NormalizedSearch,
   isPPREnabled: boolean
 ): FulfilledRouteCacheEntry {
@@ -872,10 +883,13 @@ function fulfillRouteCacheEntry(
   // object, so rather than fork the logic in all those places, we use this
   // "fake" one.
   const metadata: RouteTree = {
-    cacheKey: createHeadCacheKey(renderedPathname),
     requestKey: HEAD_REQUEST_KEY,
     segment: HEAD_REQUEST_KEY,
-    param: null,
+    varyPath: metadataVaryPath,
+    // The metadata isn't really a "page" (though it isn't really a "segment"
+    // either) but for the purposes of how this field is used, it behaves like
+    // one. If this logic ever gets more complex we can change this to an enum.
+    isPage: true,
     slots: null,
     isRootLayout: false,
     hasLoadingBoundary: HasLoadingBoundary.SubtreeHasNoLoadingBoundary,
@@ -941,33 +955,41 @@ function rejectSegmentCacheEntry(
   }
 }
 
+type RouteTreeAccumulator = {
+  metadataVaryPath: PageVaryPath | null
+}
+
 function convertRootTreePrefetchToRouteTree(
   rootTree: RootTreePrefetch,
-  renderedPathname: string
+  renderedPathname: string,
+  renderedSearch: NormalizedSearch,
+  acc: RouteTreeAccumulator
 ) {
   // Remove trailing and leading slashes
   const pathnameParts = renderedPathname.split('/').filter((p) => p !== '')
   const index = 0
-  const rootSegment = ROOT_SEGMENT_CACHE_KEY
+  const rootSegment = ROOT_SEGMENT_REQUEST_KEY
   return convertTreePrefetchToRouteTree(
     rootTree.tree,
     rootSegment,
     null,
     ROOT_SEGMENT_REQUEST_KEY,
-    ROOT_SEGMENT_CACHE_KEY,
     pathnameParts,
-    index
+    index,
+    renderedSearch,
+    acc
   )
 }
 
 function convertTreePrefetchToRouteTree(
   prefetch: TreePrefetch,
   segment: FlightRouterStateSegment,
-  param: RouteParam | null,
+  partialVaryPath: PartialSegmentVaryPath | null,
   requestKey: SegmentRequestKey,
-  cacheKey: SegmentCacheKey,
   pathnameParts: Array<string>,
-  pathnamePartsIndex: number
+  pathnamePartsIndex: number,
+  renderedSearch: NormalizedSearch,
+  acc: RouteTreeAccumulator
 ): RouteTree {
   // Converts the route tree sent by the server into the format used by the
   // cache. The cached version of the tree includes additional fields, such as a
@@ -976,8 +998,13 @@ function convertTreePrefetchToRouteTree(
   // request the segment from the server.
 
   let slots: { [parallelRouteKey: string]: RouteTree } | null = null
+  let isPage: boolean
+  let varyPath: SegmentVaryPath
   const prefetchSlots = prefetch.slots
   if (prefetchSlots !== null) {
+    isPage = false
+    varyPath = finalizeLayoutVaryPath(requestKey, partialVaryPath)
+
     slots = {}
     for (let parallelRouteKey in prefetchSlots) {
       const childPrefetch = prefetchSlots[parallelRouteKey]
@@ -986,8 +1013,8 @@ function convertTreePrefetchToRouteTree(
       const childServerSentParamKey = childPrefetch.paramKey
 
       let childDoesAppearInURL: boolean
-      let childParam: RouteParam | null = null
       let childSegment: FlightRouterStateSegment
+      let childPartialVaryPath: PartialSegmentVaryPath | null
       if (childParamType !== null) {
         // This segment is parameterized. Get the param from the pathname.
         const childParamValue = parseDynamicParamFromURLPart(
@@ -1006,23 +1033,27 @@ function convertTreePrefetchToRouteTree(
         // This would clearer if we waited to construct the segment until it's
         // read from the cache, since that's effectively what we're
         // doing anyway.
-        const renderedSearch = '' as NormalizedSearch
         const childParamKey =
           // The server omits this field from the prefetch response when
           // cacheComponents is enabled.
           childServerSentParamKey !== null
             ? childServerSentParamKey
             : // If no param key was sent, use the value parsed on the client.
-              getCacheKeyForDynamicParam(childParamValue, renderedSearch)
+              getCacheKeyForDynamicParam(
+                childParamValue,
+                '' as NormalizedSearch
+              )
 
-        childParam = {
-          name: childParamName,
-          value: childParamValue,
-          type: childParamType,
-        }
+        childPartialVaryPath = appendLayoutVaryPath(
+          partialVaryPath,
+          childParamKey
+        )
         childSegment = [childParamName, childParamKey, childParamType]
         childDoesAppearInURL = true
       } else {
+        // This segment does not have a param. Inherit the partial vary path of
+        // the parent.
+        childPartialVaryPath = partialVaryPath
         childSegment = childParamName
         childDoesAppearInURL = doesStaticSegmentAppearInURL(childParamName)
       }
@@ -1039,28 +1070,57 @@ function convertTreePrefetchToRouteTree(
         parallelRouteKey,
         childRequestKeyPart
       )
-      const childCacheKey = appendSegmentCacheKeyPart(
-        cacheKey,
-        parallelRouteKey,
-        createSegmentCacheKeyPart(childRequestKeyPart, childSegment)
-      )
       slots[parallelRouteKey] = convertTreePrefetchToRouteTree(
         childPrefetch,
         childSegment,
-        childParam,
+        childPartialVaryPath,
         childRequestKey,
-        childCacheKey,
         pathnameParts,
-        childPathnamePartsIndex
+        childPathnamePartsIndex,
+        renderedSearch,
+        acc
       )
+    }
+  } else {
+    if (requestKey.endsWith(PAGE_SEGMENT_KEY)) {
+      // This is a page segment.
+      isPage = true
+      varyPath = finalizePageVaryPath(
+        requestKey,
+        renderedSearch,
+        partialVaryPath
+      )
+      // The metadata "segment" is not part the route tree, but it has the same
+      // conceptual params as a page segment. Write the vary path into the
+      // accumulator object. If there are multiple parallel pages, we use the
+      // first one. Which page we choose is arbitrary as long as it's
+      // consistently the same one every time every time. See
+      // finalizeMetadataVaryPath for more details.
+      if (acc.metadataVaryPath === null) {
+        acc.metadataVaryPath = finalizeMetadataVaryPath(
+          requestKey,
+          renderedSearch,
+          partialVaryPath
+        )
+      }
+    } else {
+      // This is a layout segment.
+      isPage = false
+      varyPath = finalizeLayoutVaryPath(requestKey, partialVaryPath)
     }
   }
 
   return {
-    cacheKey,
     requestKey,
     segment,
-    param,
+    varyPath,
+    // TODO: Cheating the type system here a bit because TypeScript can't tell
+    // that the type of isPage and varyPath are consistent. The fix would be to
+    // create separate constructors and call the appropriate one from each of
+    // the branches above. Just seems a bit overkill only for one field so I'll
+    // leave it as-is for now. If isPage were wrong it would break the behavior
+    // and we'd catch it quickly, anyway.
+    isPage: isPage as boolean as any,
     slots,
     isRootLayout: prefetch.isRootLayout,
     // This field is only relevant to dynamic routes. For a PPR/static route,
@@ -1071,20 +1131,82 @@ function convertTreePrefetchToRouteTree(
 }
 
 function convertRootFlightRouterStateToRouteTree(
-  flightRouterState: FlightRouterState
+  flightRouterState: FlightRouterState,
+  renderedSearch: NormalizedSearch,
+  acc: RouteTreeAccumulator
 ): RouteTree {
   return convertFlightRouterStateToRouteTree(
     flightRouterState,
-    ROOT_SEGMENT_CACHE_KEY,
-    ROOT_SEGMENT_REQUEST_KEY
+    ROOT_SEGMENT_REQUEST_KEY,
+    null,
+    renderedSearch,
+    acc
   )
 }
 
 function convertFlightRouterStateToRouteTree(
   flightRouterState: FlightRouterState,
-  cacheKey: SegmentCacheKey,
-  requestKey: SegmentRequestKey
+  requestKey: SegmentRequestKey,
+  parentPartialVaryPath: PartialSegmentVaryPath | null,
+  renderedSearch: NormalizedSearch,
+  acc: RouteTreeAccumulator
 ): RouteTree {
+  const originalSegment = flightRouterState[0]
+
+  let segment: FlightRouterStateSegment
+  let partialVaryPath: PartialSegmentVaryPath | null
+  let isPage: boolean
+  let varyPath: SegmentVaryPath
+  if (Array.isArray(originalSegment)) {
+    isPage = false
+    const paramCacheKey = originalSegment[1]
+    partialVaryPath = appendLayoutVaryPath(parentPartialVaryPath, paramCacheKey)
+    varyPath = finalizeLayoutVaryPath(requestKey, partialVaryPath)
+    segment = originalSegment
+  } else {
+    // This segment does not have a param. Inherit the partial vary path of
+    // the parent.
+    partialVaryPath = parentPartialVaryPath
+    if (requestKey.endsWith(PAGE_SEGMENT_KEY)) {
+      // This is a page segment.
+      isPage = true
+
+      // The navigation implementation expects the search params to be included
+      // in the segment. However, in the case of a static response, the search
+      // params are omitted. So the client needs to add them back in when reading
+      // from the Segment Cache.
+      //
+      // For consistency, we'll do this for dynamic responses, too.
+      //
+      // TODO: We should move search params out of FlightRouterState and handle
+      // them entirely on the client, similar to our plan for dynamic params.
+      segment = PAGE_SEGMENT_KEY
+      varyPath = finalizePageVaryPath(
+        requestKey,
+        renderedSearch,
+        partialVaryPath
+      )
+      // The metadata "segment" is not part the route tree, but it has the same
+      // conceptual params as a page segment. Write the vary path into the
+      // accumulator object. If there are multiple parallel pages, we use the
+      // first one. Which page we choose is arbitrary as long as it's
+      // consistently the same one every time every time. See
+      // finalizeMetadataVaryPath for more details.
+      if (acc.metadataVaryPath === null) {
+        acc.metadataVaryPath = finalizeMetadataVaryPath(
+          requestKey,
+          renderedSearch,
+          partialVaryPath
+        )
+      }
+    } else {
+      // This is a layout segment.
+      isPage = false
+      segment = originalSegment
+      varyPath = finalizeLayoutVaryPath(requestKey, partialVaryPath)
+    }
+  }
+
   let slots: { [parallelRouteKey: string]: RouteTree } | null = null
 
   const parallelRoutes = flightRouterState[1]
@@ -1100,15 +1222,12 @@ function convertFlightRouterStateToRouteTree(
       parallelRouteKey,
       childRequestKeyPart
     )
-    const childCacheKey = appendSegmentCacheKeyPart(
-      cacheKey,
-      parallelRouteKey,
-      createSegmentCacheKeyPart(childRequestKeyPart, childSegment)
-    )
     const childTree = convertFlightRouterStateToRouteTree(
       childRouterState,
-      childCacheKey,
-      childRequestKey
+      childRequestKey,
+      partialVaryPath,
+      renderedSearch,
+      acc
     )
     if (slots === null) {
       slots = {
@@ -1118,42 +1237,18 @@ function convertFlightRouterStateToRouteTree(
       slots[parallelRouteKey] = childTree
     }
   }
-  const originalSegment = flightRouterState[0]
-
-  let segment: FlightRouterStateSegment
-  let param: RouteParam | null = null
-  if (Array.isArray(originalSegment)) {
-    const paramCacheKey = originalSegment[1]
-    const paramType = originalSegment[2]
-    const paramValue = getParamValueFromCacheKey(paramCacheKey, paramType)
-    param = {
-      name: originalSegment[0],
-      value: paramValue === undefined ? null : paramValue,
-      type: originalSegment[2] as DynamicParamTypesShort,
-    }
-    segment = originalSegment
-  } else {
-    // The navigation implementation expects the search params to be included
-    // in the segment. However, in the case of a static response, the search
-    // params are omitted. So the client needs to add them back in when reading
-    // from the Segment Cache.
-    //
-    // For consistency, we'll do this for dynamic responses, too.
-    //
-    // TODO: We should move search params out of FlightRouterState and handle
-    // them entirely on the client, similar to our plan for dynamic params.
-    segment =
-      typeof originalSegment === 'string' &&
-      originalSegment.startsWith(PAGE_SEGMENT_KEY)
-        ? PAGE_SEGMENT_KEY
-        : originalSegment
-  }
 
   return {
-    cacheKey,
     requestKey,
     segment,
-    param,
+    varyPath,
+    // TODO: Cheating the type system here a bit because TypeScript can't tell
+    // that the type of isPage and varyPath are consistent. The fix would be to
+    // create separate constructors and call the appropriate one from each of
+    // the branches above. Just seems a bit overkill only for one field so I'll
+    // leave it as-is for now. If isPage were wrong it would break the behavior
+    // and we'd catch it quickly, anyway.
+    isPage: isPage as boolean as any,
     slots,
     isRootLayout: flightRouterState[4] === true,
     hasLoadingBoundary:
@@ -1349,19 +1444,32 @@ export async function fetchRouteOnCacheMiss(
       const renderedPathname = getRenderedPathname(response)
       const renderedSearch = getRenderedSearch(response)
 
+      // Convert the server-sent data into the RouteTree format used by the
+      // client cache.
+      //
+      // During this traversal, we accumulate additional data into this
+      // "accumulator" object.
+      const acc: RouteTreeAccumulator = { metadataVaryPath: null }
       const routeTree = convertRootTreePrefetchToRouteTree(
         serverData,
-        renderedPathname
+        renderedPathname,
+        renderedSearch,
+        acc
       )
+      const metadataVaryPath = acc.metadataVaryPath
+      if (metadataVaryPath === null) {
+        rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+        return null
+      }
 
       const staleTimeMs = getStaleTimeMs(serverData.staleTime)
       fulfillRouteCacheEntry(
         entry,
         routeTree,
+        metadataVaryPath,
         Date.now() + staleTimeMs,
         couldBeIntercepted,
         canonicalUrl,
-        renderedPathname,
         renderedSearch,
         routeIsPPREnabled
       )
@@ -1421,9 +1529,14 @@ export async function fetchRouteOnCacheMiss(
       // TODO: Treat this as an upsert — should check if an entry already
       // exists at the new keypath, and if so, whether we should keep that
       // one instead.
-      const newKeypath: RouteCacheKeypath = [pathname, search, Fallback]
+      const fulfilledVaryPath: RouteVaryPath = getFulfilledRouteVaryPath(
+        pathname,
+        search,
+        nextUrl,
+        couldBeIntercepted
+      )
       const isRevalidation = false
-      setInCacheMap(routeCacheMap, newKeypath, entry, isRevalidation)
+      setInCacheMap(routeCacheMap, fulfilledVaryPath, entry, isRevalidation)
     }
     // Return a promise that resolves when the network connection closes, so
     // the scheduler can track the number of concurrent network connections.
@@ -1700,7 +1813,6 @@ function writeDynamicTreeResponseIntoCache(
 ) {
   // Get the URL that was used to render the target page. This may be different
   // from the URL in the request URL, if the page was rewritten.
-  const renderedPathname = getRenderedPathname(response)
   const renderedSearch = getRenderedSearch(response)
 
   const normalizedFlightDataResult = normalizeFlightData(serverData.f)
@@ -1737,13 +1849,30 @@ function writeDynamicTreeResponseIntoCache(
   const isResponsePartial =
     response.headers.get(NEXT_DID_POSTPONE_HEADER) === '1'
 
+  // Convert the server-sent data into the RouteTree format used by the
+  // client cache.
+  //
+  // During this traversal, we accumulate additional data into this
+  // "accumulator" object.
+  const acc: RouteTreeAccumulator = { metadataVaryPath: null }
+  const routeTree = convertRootFlightRouterStateToRouteTree(
+    flightRouterState,
+    renderedSearch,
+    acc
+  )
+  const metadataVaryPath = acc.metadataVaryPath
+  if (metadataVaryPath === null) {
+    rejectRouteCacheEntry(entry, now + 10 * 1000)
+    return
+  }
+
   const fulfilledEntry = fulfillRouteCacheEntry(
     entry,
-    convertRootFlightRouterStateToRouteTree(flightRouterState),
+    routeTree,
+    metadataVaryPath,
     now + staleTimeMs,
     couldBeIntercepted,
     canonicalUrl,
-    renderedPathname,
     renderedSearch,
     routeIsPPREnabled
   )
@@ -2013,7 +2142,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
       )
       upsertSegmentEntry(
         now,
-        getGenericSegmentKeypathFromFetchStrategy(fetchStrategy, route, tree),
+        getSegmentVaryPathForRequest(fetchStrategy, tree),
         newEntry
       )
     }

--- a/packages/next/src/client/components/segment-cache/lru.ts
+++ b/packages/next/src/client/components/segment-cache/lru.ts
@@ -7,7 +7,7 @@ import { deleteFromCacheMap } from './cache-map'
 // The MapEntry type is used as an LRU node, too. We choose this one instead of
 // the inner cache entry type (RouteCacheEntry, SegmentCacheEntry) because it's
 // monomorphic and can be optimized by the VM.
-type LRUNode = MapEntry<any, any>
+type LRUNode = MapEntry<any>
 
 let head: LRUNode | null = null
 let didScheduleCleanup: boolean = false

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -347,10 +347,7 @@ function readRenderSnapshotFromCache(
   let loading: LoadingModuleData | Promise<LoadingModuleData> = null
   let isPartial: boolean = true
 
-  const canonicalSegmentKeypath = getCanonicalSegmentKeypath(
-    route,
-    tree.cacheKey
-  )
+  const canonicalSegmentKeypath = getCanonicalSegmentKeypath(route, tree)
   const segmentEntry = readSegmentCacheEntry(now, canonicalSegmentKeypath)
   if (segmentEntry !== null) {
     switch (segmentEntry.status) {
@@ -425,7 +422,7 @@ function readHeadSnapshotFromCache(
   let isPartial: boolean = true
   const canonicalSegmentKeypath = getCanonicalSegmentKeypath(
     route,
-    route.metadata.cacheKey
+    route.metadata
   )
   const segmentEntry = readSegmentCacheEntry(now, canonicalSegmentKeypath)
   if (segmentEntry !== null) {

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -19,7 +19,6 @@ import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
 import {
   EntryStatus,
   readRouteCacheEntry,
-  getCanonicalSegmentKeypath,
   readSegmentCacheEntry,
   waitForSegmentCacheEntry,
   requestOptimisticRouteCacheEntry,
@@ -347,8 +346,7 @@ function readRenderSnapshotFromCache(
   let loading: LoadingModuleData | Promise<LoadingModuleData> = null
   let isPartial: boolean = true
 
-  const canonicalSegmentKeypath = getCanonicalSegmentKeypath(route, tree)
-  const segmentEntry = readSegmentCacheEntry(now, canonicalSegmentKeypath)
+  const segmentEntry = readSegmentCacheEntry(now, tree.varyPath)
   if (segmentEntry !== null) {
     switch (segmentEntry.status) {
       case EntryStatus.Fulfilled: {
@@ -420,11 +418,7 @@ function readHeadSnapshotFromCache(
   // Same as readRenderSnapshotFromCache, but for the head
   let rsc: React.ReactNode | null = null
   let isPartial: boolean = true
-  const canonicalSegmentKeypath = getCanonicalSegmentKeypath(
-    route,
-    route.metadata
-  )
-  const segmentEntry = readSegmentCacheEntry(now, canonicalSegmentKeypath)
+  const segmentEntry = readSegmentCacheEntry(now, route.metadata.varyPath)
   if (segmentEntry !== null) {
     switch (segmentEntry.status) {
       case EntryStatus.Fulfilled: {

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -24,10 +24,9 @@ import {
   upgradeToPendingSegment,
   waitForSegmentCacheEntry,
   overwriteRevalidatingSegmentCacheEntry,
-  getGenericSegmentKeypathFromFetchStrategy,
   canNewFetchStrategyProvideMoreContent,
-  type SegmentCacheKeypath,
 } from './cache'
+import { getSegmentVaryPathForRequest, type SegmentVaryPath } from './vary-path'
 import type { RouteCacheKey } from './cache-key'
 import { createCacheKey } from './cache-key'
 import {
@@ -1517,11 +1516,7 @@ function pingPPRSegmentRevalidation(
             tree
           )
         ),
-        getGenericSegmentKeypathFromFetchStrategy(
-          FetchStrategy.PPR,
-          route,
-          tree
-        )
+        getSegmentVaryPathForRequest(FetchStrategy.PPR, tree)
       )
       break
     case EntryStatus.Pending:
@@ -1562,7 +1557,7 @@ function pingFullSegmentRevalidation(
     )
     upsertSegmentOnCompletion(
       waitForSegmentCacheEntry(pendingSegment),
-      getGenericSegmentKeypathFromFetchStrategy(fetchStrategy, route, tree)
+      getSegmentVaryPathForRequest(fetchStrategy, tree)
     )
     return pendingSegment
   } else {
@@ -1587,7 +1582,7 @@ function pingFullSegmentRevalidation(
       )
       upsertSegmentOnCompletion(
         waitForSegmentCacheEntry(pendingSegment),
-        getGenericSegmentKeypathFromFetchStrategy(fetchStrategy, route, tree)
+        getSegmentVaryPathForRequest(fetchStrategy, tree)
       )
       return pendingSegment
     }
@@ -1612,13 +1607,13 @@ const noop = () => {}
 
 function upsertSegmentOnCompletion(
   promise: Promise<FulfilledSegmentCacheEntry | null>,
-  keypath: SegmentCacheKeypath
+  varyPath: SegmentVaryPath
 ) {
   // Wait for a segment to finish loading, then upsert it into the cache
   promise.then((fulfilled) => {
     if (fulfilled !== null) {
       // Received new data. Attempt to replace the existing entry in the cache.
-      upsertSegmentEntry(Date.now(), keypath, fulfilled)
+      upsertSegmentEntry(Date.now(), varyPath, fulfilled)
     }
   }, noop)
 }

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -40,7 +40,7 @@ import {
   addSearchParamsIfPageSegment,
   PAGE_SEGMENT_KEY,
 } from '../../../shared/lib/segment'
-import type { SegmentCacheKey } from '../../../shared/lib/segment-cache/segment-value-encoding'
+import type { SegmentRequestKey } from '../../../shared/lib/segment-cache/segment-value-encoding'
 
 const scheduleMicrotask =
   typeof queueMicrotask === 'function'
@@ -122,7 +122,7 @@ export type PrefetchTask = {
    * They are reset after each iteration of the task queue.
    */
   hasBackgroundWork: boolean
-  spawnedRuntimePrefetches: Set<SegmentCacheKey> | null
+  spawnedRuntimePrefetches: Set<SegmentRequestKey> | null
 
   /**
    * True if the prefetch was cancelled.
@@ -691,7 +691,7 @@ function pingRootRouteTree(
             // During the first pass, we discovered segments that require a
             // runtime prefetch. Do a second pass to construct a request tree.
             const spawnedEntries = new Map<
-              SegmentCacheKey,
+              SegmentRequestKey,
               PendingSegmentCacheEntry
             >()
             pingRuntimeHead(
@@ -737,7 +737,7 @@ function pingRootRouteTree(
           // really that much duplication, just would be nice to remove one of
           // these codepaths.
           const spawnedEntries = new Map<
-            SegmentCacheKey,
+            SegmentRequestKey,
             PendingSegmentCacheEntry
           >()
           pingRuntimeHead(now, task, route, spawnedEntries, fetchStrategy)
@@ -792,7 +792,7 @@ function pingStaticHead(
       now,
       FetchStrategy.PPR,
       route,
-      route.metadata.cacheKey
+      route.metadata
     ),
     task.key,
     route.metadata
@@ -803,7 +803,7 @@ function pingRuntimeHead(
   now: number,
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
-  spawnedEntries: Map<string, PendingSegmentCacheEntry>,
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry>,
   fetchStrategy:
     | FetchStrategy.Full
     | FetchStrategy.PPRRuntime
@@ -849,7 +849,7 @@ function pingSharedPartOfCacheComponentsTree(
     now,
     task.fetchStrategy,
     route,
-    newTree.cacheKey
+    newTree
   )
   pingStaticSegmentData(now, task, route, segment, task.key, newTree)
 
@@ -937,9 +937,9 @@ function pingNewPartOfCacheComponentsTree(
     // This will signal to the outer task queue that a second traversal is
     // required to construct a request tree.
     if (task.spawnedRuntimePrefetches === null) {
-      task.spawnedRuntimePrefetches = new Set([tree.cacheKey])
+      task.spawnedRuntimePrefetches = new Set([tree.requestKey])
     } else {
-      task.spawnedRuntimePrefetches.add(tree.cacheKey)
+      task.spawnedRuntimePrefetches.add(tree.requestKey)
     }
     // Then exit the traversal without prefetching anything further.
     return PrefetchTaskExitStatus.Done
@@ -950,7 +950,7 @@ function pingNewPartOfCacheComponentsTree(
     now,
     task.fetchStrategy,
     route,
-    tree.cacheKey
+    tree
   )
   pingStaticSegmentData(now, task, route, segment, task.key, tree)
   if (tree.slots !== null) {
@@ -983,7 +983,7 @@ function diffRouteTreeAgainstCurrent(
   route: FulfilledRouteCacheEntry,
   oldTree: FlightRouterState,
   newTree: RouteTree,
-  spawnedEntries: Map<string, PendingSegmentCacheEntry>,
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry>,
   fetchStrategy:
     | FetchStrategy.Full
     | FetchStrategy.PPRRuntime
@@ -1130,7 +1130,7 @@ function pingPPRDisabledRouteTreeUpToLoadingBoundary(
   route: FulfilledRouteCacheEntry,
   tree: RouteTree,
   refetchMarkerContext: 'refetch' | 'inside-shared-layout' | null,
-  spawnedEntries: Map<string, PendingSegmentCacheEntry>
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry>
 ): FlightRouterState {
   // This function is similar to pingRouteTreeAndIncludeDynamicData, except the
   // server is only going to return a minimal loading state — it will stop
@@ -1150,7 +1150,7 @@ function pingPPRDisabledRouteTreeUpToLoadingBoundary(
     now,
     task.fetchStrategy,
     route,
-    tree.cacheKey
+    tree
   )
   switch (segment.status) {
     case EntryStatus.Empty: {
@@ -1164,7 +1164,7 @@ function pingPPRDisabledRouteTreeUpToLoadingBoundary(
 
       // Add the pending cache entry to the result map.
       spawnedEntries.set(
-        tree.cacheKey,
+        tree.requestKey,
         upgradeToPendingSegment(
           segment,
           // Set the fetch strategy to LoadingBoundary to indicate that the server
@@ -1243,7 +1243,7 @@ function pingRouteTreeAndIncludeDynamicData(
   route: FulfilledRouteCacheEntry,
   tree: RouteTree,
   isInsideRefetchingParent: boolean,
-  spawnedEntries: Map<string, PendingSegmentCacheEntry>,
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry>,
   fetchStrategy: FetchStrategy.Full | FetchStrategy.PPRRuntime
 ): FlightRouterState {
   // The tree we're constructing is the same shape as the tree we're navigating
@@ -1263,7 +1263,7 @@ function pingRouteTreeAndIncludeDynamicData(
     // entries that include search params.
     fetchStrategy,
     route,
-    tree.cacheKey
+    tree
   )
 
   let spawnedSegment: PendingSegmentCacheEntry | null = null
@@ -1338,7 +1338,7 @@ function pingRouteTreeAndIncludeDynamicData(
 
   if (spawnedSegment !== null) {
     // Add the pending entry to the result map.
-    spawnedEntries.set(tree.cacheKey, spawnedSegment)
+    spawnedEntries.set(tree.requestKey, spawnedSegment)
   }
 
   // Don't bother to add a refetch marker if one is already present in a parent.
@@ -1360,8 +1360,8 @@ function pingRuntimePrefetches(
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
   tree: RouteTree,
-  spawnedRuntimePrefetches: Set<SegmentCacheKey>,
-  spawnedEntries: Map<string, PendingSegmentCacheEntry>
+  spawnedRuntimePrefetches: Set<SegmentRequestKey>,
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry>
 ): FlightRouterState {
   // Construct a request tree (FlightRouterState) for a runtime prefetch. If
   // a segment is part of the runtime prefetch, the tree is constructed by
@@ -1369,7 +1369,7 @@ function pingRuntimePrefetches(
   // a regular FlightRouterState with no special markers.
   //
   // See pingRouteTreeAndIncludeDynamicData for details.
-  if (spawnedRuntimePrefetches.has(tree.cacheKey)) {
+  if (spawnedRuntimePrefetches.has(tree.requestKey)) {
     // This segment needs a runtime prefetch.
     return pingRouteTreeAndIncludeDynamicData(
       now,
@@ -1502,7 +1502,7 @@ function pingPPRSegmentRevalidation(
     now,
     FetchStrategy.PPR,
     route,
-    tree.cacheKey
+    tree
   )
   switch (revalidatingSegment.status) {
     case EntryStatus.Empty:
@@ -1520,7 +1520,7 @@ function pingPPRSegmentRevalidation(
         getGenericSegmentKeypathFromFetchStrategy(
           FetchStrategy.PPR,
           route,
-          tree.cacheKey
+          tree
         )
       )
       break
@@ -1548,7 +1548,7 @@ function pingFullSegmentRevalidation(
     now,
     fetchStrategy,
     route,
-    tree.cacheKey
+    tree
   )
   if (revalidatingSegment.status === EntryStatus.Empty) {
     // During a Full/PPRRuntime prefetch, a single dynamic request is made for all the
@@ -1562,11 +1562,7 @@ function pingFullSegmentRevalidation(
     )
     upsertSegmentOnCompletion(
       waitForSegmentCacheEntry(pendingSegment),
-      getGenericSegmentKeypathFromFetchStrategy(
-        fetchStrategy,
-        route,
-        tree.cacheKey
-      )
+      getGenericSegmentKeypathFromFetchStrategy(fetchStrategy, route, tree)
     )
     return pendingSegment
   } else {
@@ -1583,7 +1579,7 @@ function pingFullSegmentRevalidation(
       const emptySegment = overwriteRevalidatingSegmentCacheEntry(
         fetchStrategy,
         route,
-        tree.cacheKey
+        tree
       )
       const pendingSegment = upgradeToPendingSegment(
         emptySegment,
@@ -1591,11 +1587,7 @@ function pingFullSegmentRevalidation(
       )
       upsertSegmentOnCompletion(
         waitForSegmentCacheEntry(pendingSegment),
-        getGenericSegmentKeypathFromFetchStrategy(
-          fetchStrategy,
-          route,
-          tree.cacheKey
-        )
+        getGenericSegmentKeypathFromFetchStrategy(fetchStrategy, route, tree)
       )
       return pendingSegment
     }

--- a/packages/next/src/client/components/segment-cache/vary-path.ts
+++ b/packages/next/src/client/components/segment-cache/vary-path.ts
@@ -1,0 +1,279 @@
+import { FetchStrategy } from './types'
+import type {
+  NormalizedPathname,
+  NormalizedSearch,
+  NormalizedNextUrl,
+} from './cache-key'
+import type { RouteTree } from './cache'
+import { Fallback, type FallbackType } from './cache-map'
+import { HEAD_REQUEST_KEY } from '../../../shared/lib/segment-cache/segment-value-encoding'
+
+type Opaque<T, K> = T & { __brand: K }
+
+/**
+ * A linked-list of all the params (or other param-like) inputs that a cache
+ * entry may vary by. This is used by the CacheMap module to reuse cache entries
+ * across different param values. If a param has a value of Fallback, it means
+ * the cache entry is reusable for all possible values of that param. See
+ * cache-map.ts for details.
+ *
+ * A segment's vary path is a pure function of a segment's position in a
+ * particular route tree and the (post-rewrite) URL that is being queried. More
+ * concretely, successive queries of the cache for the same segment always use
+ * the same vary path.
+ *
+ * A route's vary path is simpler: it's comprised of the pathname, search
+ * string, and Next-URL header.
+ */
+export type VaryPath = {
+  value: string | null | FallbackType
+  parent: VaryPath | null
+}
+
+// Because it's so important for vary paths to line up across cache accesses,
+// we use opaque type aliases to ensure these are only created within
+// this module.
+
+// requestKey -> searchParams -> nextUrl
+export type RouteVaryPath = Opaque<
+  {
+    value: NormalizedPathname
+    parent: {
+      value: NormalizedSearch
+      parent: {
+        value: NormalizedNextUrl | null | FallbackType
+        parent: null
+      }
+    }
+  },
+  'RouteVaryPath'
+>
+
+// requestKey -> pathParams
+export type LayoutVaryPath = Opaque<
+  {
+    value: string
+    parent: PartialSegmentVaryPath | null
+  },
+  'LayoutVaryPath'
+>
+
+// requestKey -> searchParams -> pathParams
+export type PageVaryPath = Opaque<
+  {
+    value: string
+    parent: {
+      value: NormalizedSearch | FallbackType
+      parent: PartialSegmentVaryPath | null
+    }
+  },
+  'PageVaryPath'
+>
+
+export type SegmentVaryPath = LayoutVaryPath | PageVaryPath
+
+// Intermediate type used when building a vary path during a recursive traversal
+// of the route tree.
+export type PartialSegmentVaryPath = Opaque<VaryPath, 'PartialSegmentVaryPath'>
+
+export function getRouteVaryPath(
+  pathname: NormalizedPathname,
+  search: NormalizedSearch,
+  nextUrl: NormalizedNextUrl | null
+): RouteVaryPath {
+  // requestKey -> searchParams -> nextUrl
+  const varyPath: VaryPath = {
+    value: pathname,
+    parent: {
+      value: search,
+      parent: {
+        value: nextUrl,
+        parent: null,
+      },
+    },
+  }
+  return varyPath as RouteVaryPath
+}
+
+export function getFulfilledRouteVaryPath(
+  pathname: NormalizedPathname,
+  search: NormalizedSearch,
+  nextUrl: NormalizedNextUrl | null,
+  couldBeIntercepted: boolean
+): RouteVaryPath {
+  // This is called when a route's data is fulfilled. The cache entry will be
+  // re-keyed based on which inputs the response varies by.
+  // requestKey -> searchParams -> nextUrl
+  const varyPath: VaryPath = {
+    value: pathname,
+    parent: {
+      value: search,
+      parent: {
+        value: couldBeIntercepted ? nextUrl : Fallback,
+        parent: null,
+      },
+    },
+  }
+  return varyPath as RouteVaryPath
+}
+
+export function appendLayoutVaryPath(
+  parentPath: PartialSegmentVaryPath | null,
+  cacheKey: string
+): PartialSegmentVaryPath {
+  const varyPathPart: VaryPath = {
+    value: cacheKey,
+    parent: parentPath,
+  }
+  return varyPathPart as PartialSegmentVaryPath
+}
+
+export function finalizeLayoutVaryPath(
+  requestKey: string,
+  varyPath: PartialSegmentVaryPath | null
+): LayoutVaryPath {
+  const layoutVaryPath: VaryPath = {
+    value: requestKey,
+    parent: varyPath,
+  }
+  return layoutVaryPath as LayoutVaryPath
+}
+
+export function finalizePageVaryPath(
+  requestKey: string,
+  renderedSearch: NormalizedSearch,
+  varyPath: PartialSegmentVaryPath | null
+): PageVaryPath {
+  // Unlike layouts, a page segment's vary path also includes the search string.
+  // requestKey -> searchParams -> pathParams
+  const pageVaryPath: VaryPath = {
+    value: requestKey,
+    parent: {
+      value: renderedSearch,
+      parent: varyPath,
+    },
+  }
+  return pageVaryPath as PageVaryPath
+}
+
+export function finalizeMetadataVaryPath(
+  pageRequestKey: string,
+  renderedSearch: NormalizedSearch,
+  varyPath: PartialSegmentVaryPath | null
+): PageVaryPath {
+  // The metadata "segment" is not a real segment because it doesn't exist in
+  // the normal structure of the route tree, but in terms of caching, it
+  // behaves like a page segment because it varies by all the same params as
+  // a page.
+  //
+  // To keep the protocol for querying the server simple, the request key for
+  // the metadata does not include any path information. It's unnecessary from
+  // the server's perspective, because unlike page segments, there's only one
+  // metadata response per URL, i.e. there's no need to distinguish multiple
+  // parallel pages.
+  //
+  // However, this means the metadata request key is insufficient for
+  // caching the the metadata in the client cache, because on the client we
+  // use the request key to distinguish the metadata entry from all other
+  // page's metadata entries.
+  //
+  // So instead we create a simulated request key based on the page segment.
+  // Conceptually this is equivalent to the request key the server would have
+  // assigned the metadata segment if it treated it as part of the actual
+  // route structure.
+
+  // If there are multiple parallel pages, we use whichever is the first one.
+  // This is fine because the only difference between request keys for
+  // different parallel pages are things like route groups and parallel
+  // route slots. As long as it's always the same one, it doesn't matter.
+  const pageVaryPath: VaryPath = {
+    // Append the actual metadata request key to the page request key. Note
+    // that we're not using a separate vary path part; it's unnecessary because
+    // these are not conceptually separate inputs.
+    value: pageRequestKey + HEAD_REQUEST_KEY,
+    parent: {
+      value: renderedSearch,
+      parent: varyPath,
+    },
+  }
+  return pageVaryPath as PageVaryPath
+}
+
+export function getSegmentVaryPathForRequest(
+  fetchStrategy: FetchStrategy,
+  tree: RouteTree
+): SegmentVaryPath {
+  // This is used for storing pending requests in the cache. We want to choose
+  // the most generic vary path based on the strategy used to fetch it, i.e.
+  // static/PPR versus runtime prefetching, so that it can be reused as much
+  // as possible.
+  //
+  // We may be able to re-key the response to something even more generic once
+  // we receive it — for example, if the server tells us that the response
+  // doesn't vary on a particular param — but even before we send the request,
+  // we know some params are reusable based on the fetch strategy alone. For
+  // example, a static prefetch will never vary on search params.
+  //
+  // The original vary path with all the params filled in is stored on the
+  // route tree object. We will clone this one to create a new vary path
+  // where certain params are replaced with Fallback.
+  //
+  // This result of this function is not stored anywhere. It's only used to
+  // access the cache a single time.
+  //
+  // TODO: Rather than create a new list object just to access the cache, the
+  // plan is to add the concept of a "vary mask". This will represent all the
+  // params that can be treated as Fallback. (Or perhaps the inverse.)
+  const originalVaryPath = tree.varyPath
+
+  // Only page segments (and the special "metadata" segment, which is treated
+  // like a page segment for the purposes of caching) may contain search
+  // params. There's no reason to include them in the vary path otherwise.
+  if (tree.isPage) {
+    // Only a runtime prefetch will include search params in the vary path.
+    // Static prefetches never include search params, so they can be reused
+    // across all possible search param values.
+    const doesVaryOnSearchParams =
+      fetchStrategy === FetchStrategy.Full ||
+      fetchStrategy === FetchStrategy.PPRRuntime
+
+    if (!doesVaryOnSearchParams) {
+      // The response from the the server will not vary on search params. Clone
+      // the end of the original vary path to replace the search params
+      // with Fallback.
+      //
+      // requestKey -> searchParams -> pathParams
+      //               ^ This part gets replaced with Fallback
+      const searchParamsVaryPath = (originalVaryPath as PageVaryPath).parent
+      const pathParamsVaryPath = searchParamsVaryPath.parent
+      const patchedVaryPath: VaryPath = {
+        value: originalVaryPath.value,
+        parent: {
+          value: Fallback,
+          parent: pathParamsVaryPath,
+        },
+      }
+      return patchedVaryPath as SegmentVaryPath
+    }
+  }
+
+  // The request does vary on search params. We don't need to modify anything.
+  return originalVaryPath as SegmentVaryPath
+}
+
+export function clonePageVaryPathWithNewSearchParams(
+  originalVaryPath: PageVaryPath,
+  newSearch: NormalizedSearch
+): PageVaryPath {
+  // requestKey -> searchParams -> pathParams
+  //               ^ This part gets replaced with newSearch
+  const searchParamsVaryPath = originalVaryPath.parent
+  const clonedVaryPath: VaryPath = {
+    value: originalVaryPath.value,
+    parent: {
+      value: newSearch,
+      parent: searchParamsVaryPath.parent,
+    },
+  }
+  return clonedVaryPath as PageVaryPath
+}

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -19,12 +19,6 @@ import type { ParsedUrlQuery } from 'querystring'
 
 export type RouteParamValue = string | Array<string> | null
 
-export type RouteParam = {
-  name: string
-  value: RouteParamValue
-  type: DynamicParamTypesShort
-}
-
 export function getRenderedSearch(
   response: RSCResponse<unknown> | Response
 ): NormalizedSearch {

--- a/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
@@ -1,17 +1,13 @@
 import { PAGE_SEGMENT_KEY } from '../segment'
 import type { Segment as FlightRouterStateSegment } from '../app-router-types'
-import type { NormalizedPathname } from '../../../client/components/segment-cache/cache-key'
 
 // TypeScript trick to simulate opaque types, like in Flow.
 type Opaque<K, T> = T & { __brand: K }
 
 export type SegmentRequestKeyPart = Opaque<'SegmentRequestKeyPart', string>
 export type SegmentRequestKey = Opaque<'SegmentRequestKey', string>
-export type SegmentCacheKeyPart = Opaque<'SegmentCacheKeyPart', string>
-export type SegmentCacheKey = Opaque<'SegmentCacheKey', string>
 
 export const ROOT_SEGMENT_REQUEST_KEY = '' as SegmentRequestKey
-export const ROOT_SEGMENT_CACHE_KEY = '' as SegmentCacheKey
 
 export const HEAD_REQUEST_KEY = '/_head' as SegmentRequestKey
 
@@ -69,48 +65,6 @@ export function appendSegmentRequestKeyPart(
       ? childRequestKeyPart
       : `@${encodeToFilesystemAndURLSafeString(parallelRouteKey)}/${childRequestKeyPart}`
   return (parentRequestKey + '/' + slotKey) as SegmentRequestKey
-}
-
-export function createSegmentCacheKeyPart(
-  requestKeyPart: SegmentRequestKeyPart,
-  segment: FlightRouterStateSegment
-): SegmentCacheKeyPart {
-  if (typeof segment === 'string') {
-    return requestKeyPart as any as SegmentCacheKeyPart
-  }
-  const paramValue = segment[1]
-  const safeValue = encodeToFilesystemAndURLSafeString(paramValue)
-  return (requestKeyPart + '$' + safeValue) as SegmentCacheKeyPart
-}
-
-export function appendSegmentCacheKeyPart(
-  parentSegmentKey: SegmentCacheKey,
-  parallelRouteKey: string,
-  childCacheKeyPart: SegmentCacheKeyPart
-): SegmentCacheKey {
-  const slotKey =
-    parallelRouteKey === 'children'
-      ? childCacheKeyPart
-      : `@${encodeToFilesystemAndURLSafeString(parallelRouteKey)}/${childCacheKeyPart}`
-  return (parentSegmentKey + '/' + slotKey) as SegmentCacheKey
-}
-
-export function createHeadCacheKey(
-  renderedPathname: NormalizedPathname
-): SegmentCacheKey {
-  // The "head" segment doesn't exist in the normal hierarchy of the page,
-  // but it needs to vary on all the route params. So we append the entire
-  // rendered pathname.
-  // TODO: Eventually, cache entries will only vary on params if they were
-  // actually accessed during server rendering. We'll do that by creating a
-  // separate key part for each of the route params (see: cache-map.ts). The
-  // same technique will also be used for the head segment.
-  return ('/_head/' +
-    encodeToFilesystemAndURLSafeString(renderedPathname)) as SegmentCacheKey
-}
-
-export function isHeadCacheKey(cacheKey: SegmentCacheKey): boolean {
-  return cacheKey.startsWith('/_head/')
 }
 
 // Define a regex pattern to match the most common characters found in a route


### PR DESCRIPTION
Refactors the keypath used to cache segments so that each route param is a separate cache key. The search string was already its own separate key, so this generalizes it to include path params, too.

This is a prerequisite for reusing cache entries across different values of a param if the server indicates that the response does not vary on that param. Currently the server does not send that information, but we'll add this in a subsequent step.

As part of this change, this refines the concept of a "keypath" to be called a "vary path" instead. From the perspective of the CacheMap module, they are functionally identical, but from the perspective of the overall caching design, it's more specific: a vary path is a pure function of a segment's position in a particular route tree and the (post-rewrite) URL that is being queried. More concretely, successive queries of the cache for the same segment always use the same vary path.