### PR TITLE
fix: eslint-config-next types was exporting to dist/src

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "dev": "pnpm build",
     "build": "swc -d dist src && pnpm types",
-    "types": "tsc --skipLibCheck --declaration --emitDeclarationOnly --esModuleInterop --outDir dist",
+    "types": "tsc --skipLibCheck --declaration --emitDeclarationOnly --esModuleInterop --declarationDir dist --rootDir src",
     "prepublishOnly": "cd ../../ && turbo run build"
   },
   "exports": {


### PR DESCRIPTION
`eslint-config-next` types were being emitted to `dist/src` instead of `dist/` during build.

| Before | After |
|--------|--------|
| <img width="422" height="452" alt="CleanShot 2025-11-04 at 15 50 38@2x" src="https://github.com/user-attachments/assets/09c96d1a-41ba-4da9-87c6-bc05257c6e2a" /> | <img width="386" height="488" alt="CleanShot 2025-11-04 at 15 50 01@2x" src="https://github.com/user-attachments/assets/7b9802a4-e453-4086-90fb-a19e1aec7e20" /> |

Fixes https://github.com/vercel/next.js/issues/85379
Closes: https://github.com/vercel/next.js/pull/84929
Closes: https://github.com/vercel/next.js/pull/85653