### PR TITLE
Enable React's default Transition indicator

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -702,6 +702,7 @@ jobs:
     with:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
+        export __NEXT_EXPERIMENTAL_REACT=true
         export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_E2E_TEST_TIMEOUT=240000
@@ -933,6 +934,7 @@ jobs:
       nodeVersion: 20.9.0
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
+        export __NEXT_EXPERIMENTAL_REACT=true
         export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export IS_WEBPACK_TEST=1
@@ -956,6 +958,7 @@ jobs:
     with:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
+        export __NEXT_EXPERIMENTAL_REACT=true
         export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=dev
@@ -981,6 +984,7 @@ jobs:
     with:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
+        export __NEXT_EXPERIMENTAL_REACT=true
         export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=start

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -854,6 +854,7 @@ pub struct ExperimentalConfig {
     /// Using this feature will enable the `react@experimental` for the `app`
     /// directory.
     ppr: Option<ExperimentalPartialPrerendering>,
+    react_experimental: Option<bool>,
     taint: Option<bool>,
     proxy_timeout: Option<f64>,
     /// enables the minification of server code.
@@ -1726,6 +1727,11 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn enable_taint(&self) -> Vc<bool> {
         Vc::cell(self.experimental.taint.unwrap_or(false))
+    }
+
+    #[turbo_tasks::function]
+    pub fn enable_react_experimental(&self) -> Vc<bool> {
+        Vc::cell(self.experimental.react_experimental.unwrap_or(false))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -128,7 +128,7 @@ pub async fn get_next_client_import_map(
         ClientContextType::Pages { .. } => {}
         ClientContextType::App { app_dir } => {
             // Keep in sync with file:///./../../../packages/next/src/lib/needs-experimental-react.ts
-            let react_flavor = if *next_config.enable_taint().await? {
+            let react_flavor = if *next_config.enable_react_experimental().await? || *next_config.enable_taint().await? {
                 "-experimental"
             } else {
                 ""
@@ -830,7 +830,8 @@ async fn apply_vendored_react_aliases_server(
     next_config: Vc<NextConfig>,
 ) -> Result<()> {
     let taint = *next_config.enable_taint().await?;
-    let react_channel = if taint { "-experimental" } else { "" };
+    let react_experimental = *next_config.enable_react_experimental().await?;
+    let react_channel = if taint || react_experimental { "-experimental" } else { "" };
     let react_condition = if ty.should_use_react_server_condition() {
         "server"
     } else {

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -270,14 +270,9 @@ function Root({ children }: React.PropsWithChildren<{}>) {
   return children
 }
 
-function onDefaultTransitionIndicator() {
-  // TODO: Compose default with user-configureable (e.g. nprogress)
-  // TODO: Use React's default once we figure out hanging indicators: https://codesandbox.io/p/sandbox/charming-moon-hktkp6?file=%2Fsrc%2Findex.js%3A106%2C30
-  return () => {}
-}
-
 const reactRootOptions: ReactDOMClient.RootOptions = {
-  onDefaultTransitionIndicator: onDefaultTransitionIndicator,
+  // TODO: Compose default with user-configureable (e.g. nprogress)
+  onDefaultTransitionIndicator: undefined,
   onRecoverableError,
   onCaughtError,
   onUncaughtError,

--- a/packages/next/src/lib/needs-experimental-react.ts
+++ b/packages/next/src/lib/needs-experimental-react.ts
@@ -2,6 +2,6 @@ import type { NextConfig } from '../server/config-shared'
 
 // Keep in sync with Turbopack's experimental React switch: file://./../../../../crates/next-core/src/next_import_map.rs
 export function needsExperimentalReact(config: NextConfig) {
-  const { taint } = config.experimental || {}
-  return Boolean(taint)
+  const { taint, reactExperimental } = config.experimental || {}
+  return Boolean(taint || reactExperimental)
 }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -667,6 +667,11 @@ export interface ExperimentalConfig {
   reactDebugChannel?: boolean
 
   /**
+   * Will enable the `react@experimental` build for the `app` directory.
+   */
+  reactExperimental?: boolean
+
+  /**
    * @deprecated use top-level `cacheComponents` instead
    */
   cacheComponents?: boolean
@@ -1511,6 +1516,7 @@ export const defaultConfig = Object.freeze({
     },
     allowDevelopmentBuild: undefined,
     reactDebugChannel: false,
+    reactExperimental: false,
     staticGenerationRetryCount: undefined,
     serverComponentsHmrCache: true,
     staticGenerationMaxConcurrency: 8,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1870,6 +1870,24 @@ function enforceExperimentalFeatures(
     config.reactCompiler = true
     // TODO: Report if we enable non-experimental features via env
   }
+
+  if (
+    process.env.__NEXT_EXPERIMENTAL_REACT === 'true' &&
+    // We do respect an explicit value in the user config.
+    (config.experimental.reactExperimental === undefined ||
+      (isDefaultConfig && !config.experimental.reactExperimental))
+  ) {
+    config.experimental.reactExperimental = true
+
+    if (configuredExperimentalFeatures) {
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        'reactExperimental',
+        true,
+        'enabled by `__NEXT_EXPERIMENTAL_REACT`'
+      )
+    }
+  }
 }
 
 function addConfiguredExperimentalFeature<


### PR DESCRIPTION
There are known bugs with this indicator in Chrome. Just testing if we still hit those in our tests.

