### PR TITLE
Turbopack: chore: Remove `extern crate` and `macro_use` syntax

### DIFF
--- a/crates/napi/build.rs
+++ b/crates/napi/build.rs
@@ -2,8 +2,6 @@ use std::{env, fs, path::Path, process::Command, str};
 
 use serde_json::Value;
 
-extern crate napi_build;
-
 fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-env-changed=CI");
     let is_ci = env::var("CI").is_ok_and(|value| !value.is_empty());

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -32,9 +32,6 @@ DEALINGS IN THE SOFTWARE.
 #![feature(arbitrary_self_types_pointers)]
 #![feature(iter_intersperse)]
 
-#[macro_use]
-extern crate napi_derive;
-
 use std::sync::Arc;
 
 use napi::bindgen_prelude::*;

--- a/crates/napi/src/lockfile.rs
+++ b/crates/napi/src/lockfile.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anyhow::Context;
 use napi::bindgen_prelude::External;
+use napi_derive::napi;
 
 /// A wrapper around [`File`] that is passed to JS, and is set to `None` when [`lockfile_unlock`] is
 /// called.

--- a/crates/napi/src/mdx.rs
+++ b/crates/napi/src/mdx.rs
@@ -1,5 +1,6 @@
 use mdxjs::{Options, compile};
 use napi::bindgen_prelude::*;
+use napi_derive::napi;
 
 pub struct MdxCompileTask {
     pub input: String,

--- a/crates/napi/src/minify.rs
+++ b/crates/napi/src/minify.rs
@@ -28,6 +28,7 @@ DEALINGS IN THE SOFTWARE.
 
 use anyhow::Context;
 use napi::bindgen_prelude::*;
+use napi_derive::napi;
 use serde::Serialize;
 use swc_core::{
     base::{config::JsMinifyOptions, try_with_handler},

--- a/crates/napi/src/next_api/endpoint.rs
+++ b/crates/napi/src/next_api/endpoint.rs
@@ -3,6 +3,7 @@ use std::{ops::Deref, sync::Arc};
 use anyhow::Result;
 use futures_util::TryFutureExt;
 use napi::{JsFunction, bindgen_prelude::External};
+use napi_derive::napi;
 use next_api::{
     operation::OptionEndpoint,
     paths::ServerPath,
@@ -15,7 +16,7 @@ use tracing::Instrument;
 use turbo_tasks::{Completion, Effects, OperationVc, ReadRef, Vc};
 use turbopack_core::{diagnostics::PlainDiagnostic, issue::PlainIssue};
 
-use super::utils::{
+use crate::next_api::utils::{
     DetachedVc, NapiDiagnostic, NapiIssue, RootTask, TurbopackResult,
     strongly_consistent_catch_collectables, subscribe,
 };

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -8,6 +8,7 @@ use napi::{
     bindgen_prelude::{External, within_runtime_if_available},
     threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
+use napi_derive::napi;
 use next_api::{
     entrypoints::Entrypoints,
     next_server_nft::next_server_nft_assets,

--- a/crates/napi/src/next_api/turbopack_ctx.rs
+++ b/crates/napi/src/next_api/turbopack_ctx.rs
@@ -12,6 +12,7 @@ use std::{
 use anyhow::Result;
 use either::Either;
 use napi::{JsFunction, threadsafe_function::ThreadsafeFunction};
+use napi_derive::napi;
 use once_cell::sync::Lazy;
 use owo_colors::OwoColorize;
 use serde::Serialize;

--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -7,6 +7,7 @@ use napi::{
     bindgen_prelude::{Buffer, External, ToNapiValue},
     threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
+use napi_derive::napi;
 use rustc_hash::FxHashMap;
 use serde::Serialize;
 use turbo_tasks::{

--- a/crates/napi/src/parse.rs
+++ b/crates/napi/src/parse.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use napi::bindgen_prelude::*;
+use napi_derive::napi;
 use swc_core::{
     base::{config::ParseOptions, try_with_handler},
     common::{

--- a/crates/napi/src/react_compiler.rs
+++ b/crates/napi/src/react_compiler.rs
@@ -1,6 +1,7 @@
 use std::{path::PathBuf, sync::Arc};
 
 use napi::bindgen_prelude::*;
+use napi_derive::napi;
 use next_custom_transforms::react_compiler;
 use swc_core::{
     common::{GLOBALS, SourceMap},

--- a/crates/napi/src/rspack.rs
+++ b/crates/napi/src/rspack.rs
@@ -1,6 +1,7 @@
 use std::{cell::RefCell, fs, path::PathBuf, sync::Arc};
 
 use napi::bindgen_prelude::*;
+use napi_derive::napi;
 use swc_core::{
     base::{
         config::{IsModule, ParseOptions},

--- a/crates/napi/src/transform.rs
+++ b/crates/napi/src/transform.rs
@@ -35,6 +35,7 @@ use std::{
 
 use anyhow::{Context as _, anyhow, bail};
 use napi::bindgen_prelude::*;
+use napi_derive::napi;
 use next_custom_transforms::chain_transforms::{TransformOptions, custom_before_pass};
 use once_cell::sync::Lazy;
 use rustc_hash::{FxHashMap, FxHashSet};

--- a/crates/napi/src/turbo_trace_server.rs
+++ b/crates/napi/src/turbo_trace_server.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use napi_derive::napi;
+
 #[napi]
 pub fn start_turbopack_trace_server(path: String, port: Option<u16>) {
     let path_buf = PathBuf::from(path);

--- a/crates/napi/src/turbopack.rs
+++ b/crates/napi/src/turbopack.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use napi::bindgen_prelude::*;
+use napi_derive::napi;
 use next_build::{
     BuildOptions as NextBuildOptions,
     build_options::{BuildContext, DefineEnv},

--- a/crates/napi/src/util.rs
+++ b/crates/napi/src/util.rs
@@ -30,6 +30,7 @@ use std::{cell::RefCell, env, path::PathBuf};
 
 use anyhow::anyhow;
 use napi::bindgen_prelude::{External, Status};
+use napi_derive::napi;
 use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
 use tracing_subscriber::{Layer, filter, layer::SubscriberExt, util::SubscriberInitExt};
 

--- a/rspack/crates/binding/src/lib.rs
+++ b/rspack/crates/binding/src/lib.rs
@@ -5,6 +5,7 @@ mod handle_externals;
 mod next_externals_plugin;
 
 use napi::bindgen_prelude::*;
+use napi_derive::napi;
 use rspack_binding_builder_macros::register_plugin;
 use rspack_core::BoxPlugin;
 use rspack_regex::RspackRegex;
@@ -14,10 +15,6 @@ use crate::{
     config_shared::{EsmExternalsConfig, ExperimentalConfig, NextConfigComplete},
     next_externals_plugin::{NextExternalsPlugin, NextExternalsPluginOptions},
 };
-
-#[macro_use]
-extern crate napi_derive;
-extern crate rspack_binding_builder;
 
 #[derive(Debug)]
 #[napi(object, object_to_js = false)]

--- a/turbopack/crates/turbo-tasks-macros/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/lib.rs
@@ -14,8 +14,6 @@ mod value_impl_macro;
 mod value_macro;
 mod value_trait_macro;
 
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use proc_macro_error::proc_macro_error;
 


### PR DESCRIPTION
This syntax isn't needed in modern rust.

https://doc.rust-lang.org/reference/names/preludes.html#extern-prelude

> Beginning in the 2018 edition, use declarations can reference crates in the extern prelude, so **it is considered unidiomatic to use extern crate**.