### PR TITLE
Fix 404 responses for interception routes with missing children slots

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1226,17 +1226,19 @@ async fn directory_tree_to_loader_tree_internal(
 
         if let Some(subtree) = subtree {
             if let Some(key) = parallel_route_key {
-                let is_inside_catchall = app_page.is_catchall();
-
                 // Validate that parallel routes (except "children") have a default.js file.
-                // Skip this validation if the slot is UNDER a catch-all route (i.e., the
-                // parallel route is a child of a catch-all segment).
+                // This validation matches the webpack loader's logic but is implemented
+                // differently due to Turbopack's single-pass recursive processing.
+
+                // Check if we're inside a catch-all route (i.e., the parallel route is a child
+                // of a catch-all segment). Only skip validation if the slot is UNDER a catch-all.
                 // For example:
                 //   /[...catchAll]/@slot - is_inside_catchall = true (skip validation) ✓
                 //   /@slot/[...catchAll] - is_inside_catchall = false (require default) ✓
                 // The catch-all provides fallback behavior, so default.js is not required.
-                //
-                // Also skip validation if this is a leaf segment (no child routes).
+                let is_inside_catchall = app_page.is_catchall();
+
+                // Check if this is a leaf segment (no child routes).
                 // Leaf segments don't need default.js because there are no child routes
                 // that could cause the parallel slot to unmatch. For example:
                 //   /repo-overview/@slot/page with no child routes - is_leaf_segment = true (skip
@@ -1245,10 +1247,23 @@ async fn directory_tree_to_loader_tree_internal(
                 // This also handles route groups correctly by filtering them out.
                 let is_leaf_segment = !has_child_routes(directory_tree);
 
+                // Turbopack-specific: Check if the parallel slot has matching child routes.
+                // In webpack, this is checked implicitly via the two-phase processing:
+                // slots with content are processed first and skip validation in the second phase.
+                // In Turbopack's single-pass approach, we check directly if the slot has child
+                // routes. If the slot has child routes that match the parent's
+                // child routes, it can render content for those routes and doesn't
+                // need a default. For example:
+                //   /parent/@slot/page + /parent/@slot/child + /parent/child - slot_has_children =
+                // true (skip validation) ✓   /parent/@slot/page + /parent/child (no
+                // @slot/child) - slot_has_children = false (require default) ✓
+                let slot_has_children = has_child_routes(subdirectory);
+
                 if key != "children"
                     && subdirectory.modules.default.is_none()
                     && !is_inside_catchall
                     && !is_leaf_segment
+                    && !slot_has_children
                 {
                     missing_default_parallel_route_issue(
                         app_dir.clone(),
@@ -1295,12 +1310,11 @@ async fn directory_tree_to_loader_tree_internal(
 
     // make sure we don't have a match for other slots if there's an intercepting route match
     // we only check subtrees as the current level could trigger `is_intercepting`
-    let has_intercepting_parallel_route = tree
+    if tree
         .parallel_routes
         .iter()
-        .any(|(_, parallel_tree)| parallel_tree.is_intercepting());
-
-    if has_intercepting_parallel_route {
+        .any(|(_, parallel_tree)| parallel_tree.is_intercepting())
+    {
         let mut keys_to_replace = Vec::new();
 
         for (key, parallel_tree) in &tree.parallel_routes {
@@ -1340,12 +1354,6 @@ async fn directory_tree_to_loader_tree_internal(
                 .emit();
             }
 
-            // For slots being replaced due to interception, use null default if EITHER:
-            // 1. The app_page path contains interception markers, OR
-            // 2. Any parallel route contains interception (checked above)
-            let is_in_interception_context =
-                app_page.contains_interception() || has_intercepting_parallel_route;
-
             tree.parallel_routes.insert(
                 key.clone(),
                 default_route_tree(
@@ -1354,7 +1362,7 @@ async fn directory_tree_to_loader_tree_internal(
                     app_page.clone(),
                     default,
                     key.clone(),
-                    is_in_interception_context,
+                    for_app_path.clone(),
                 )
                 .await?,
             );
@@ -1363,28 +1371,19 @@ async fn directory_tree_to_loader_tree_internal(
 
     if tree.parallel_routes.is_empty() {
         if modules.default.is_some() || current_level_is_parallel_route {
-            let is_in_interception_context =
-                app_page.contains_interception() || has_intercepting_parallel_route;
-
             tree = default_route_tree(
                 app_dir.clone(),
                 global_metadata,
                 app_page.clone(),
                 modules.default.clone(),
                 rcstr!("children"),
-                is_in_interception_context,
+                for_app_path.clone(),
             )
             .await?;
         } else {
             return Ok(None);
         }
     } else if tree.parallel_routes.get("children").is_none() {
-        // When creating a children default, use null default if EITHER:
-        // 1. The app_page path contains interception markers, OR
-        // 2. Any parallel route contains interception (computed earlier)
-        let is_in_interception_context =
-            app_page.contains_interception() || has_intercepting_parallel_route;
-
         tree.parallel_routes.insert(
             rcstr!("children"),
             default_route_tree(
@@ -1393,7 +1392,7 @@ async fn directory_tree_to_loader_tree_internal(
                 app_page.clone(),
                 modules.default.clone(),
                 rcstr!("children"),
-                is_in_interception_context,
+                for_app_path.clone(),
             )
             .await?,
         );
@@ -1416,7 +1415,7 @@ async fn default_route_tree(
     app_page: AppPage,
     default_component: Option<FileSystemPath>,
     slot_name: RcStr,
-    is_in_interception_context: bool,
+    for_app_path: AppPath,
 ) -> Result<AppPageLoaderTree> {
     Ok(AppPageLoaderTree {
         page: app_page.clone(),
@@ -1428,14 +1427,9 @@ async fn default_route_tree(
                 ..Default::default()
             }
         } else {
-            // When we host applications on Vercel, the status code affects the
-            // underlying behavior of the route, which when we are missing the
-            // children slot of an interception route, will yield a full 404
-            // response for the RSC request instead. For this reason, we expect
-            // that if a default file is missing when we're rendering an
-            // interception route, we instead always render null for the default
-            // slot to avoid the full 404 response.
-            let default_file = if is_in_interception_context && slot_name == "children" {
+            let contains_interception = for_app_path.contains_interception();
+
+            let default_file = if contains_interception && slot_name == "children" {
                 "dist/client/components/builtin/default-null.js"
             } else {
                 "dist/client/components/builtin/default.js"

--- a/crates/next-core/src/next_app/mod.rs
+++ b/crates/next-core/src/next_app/mod.rs
@@ -293,6 +293,20 @@ impl AppPage {
         )
     }
 
+    /// Returns true if ANY segment in the entire path is an interception route.
+    /// This is different from `is_intercepting()` which only checks the last segment.
+    pub fn contains_interception(&self) -> bool {
+        self.0.iter().any(|segment| {
+            matches!(
+                segment,
+                PageSegment::Static(s)
+                    if s.starts_with("(.)")
+                        || s.starts_with("(..)")
+                        || s.starts_with("(...)")
+            )
+        })
+    }
+
     /// Returns true if there is only one segment and it is a group.
     pub fn is_first_layer_group_route(&self) -> bool {
         self.0.len() == 1 && matches!(self.0.last(), Some(PageSegment::Group(_)))

--- a/crates/next-core/src/next_app/mod.rs
+++ b/crates/next-core/src/next_app/mod.rs
@@ -293,20 +293,6 @@ impl AppPage {
         )
     }
 
-    /// Returns true if ANY segment in the entire path is an interception route.
-    /// This is different from `is_intercepting()` which only checks the last segment.
-    pub fn contains_interception(&self) -> bool {
-        self.0.iter().any(|segment| {
-            matches!(
-                segment,
-                PageSegment::Static(s)
-                    if s.starts_with("(.)")
-                        || s.starts_with("(..)")
-                        || s.starts_with("(...)")
-            )
-        })
-    }
-
     /// Returns true if there is only one segment and it is a group.
     pub fn is_first_layer_group_route(&self) -> bool {
         self.0.len() == 1 && matches!(self.0.last(), Some(PageSegment::Group(_)))
@@ -473,6 +459,18 @@ impl AppPath {
         }
 
         true
+    }
+
+    /// Returns true if ANY segment in the entire path is an interception route.
+    /// This is different from `is_intercepting()` which only checks the last
+    /// segment.
+    pub fn contains_interception(&self) -> bool {
+        self.iter().any(|segment| {
+            matches!(
+                segment,
+                PathSegment::Static(s) if s.starts_with("(.)") || s.starts_with("(..)") || s.starts_with("(...)")
+            )
+        })
     }
 }
 

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -35,9 +35,11 @@ import {
 import { getFilesInDir } from '../../../../lib/get-files-in-dir'
 import type { PageExtensions } from '../../../page-extensions-type'
 import { PARALLEL_ROUTE_DEFAULT_PATH } from '../../../../client/components/builtin/default'
+import { PARALLEL_ROUTE_DEFAULT_NULL_PATH } from '../../../../client/components/builtin/default-null'
 import type { Compilation } from 'webpack'
 import { createAppRouteCode } from './create-app-route-code'
 import { MissingDefaultParallelRouteError } from '../../../../shared/lib/errors/missing-default-parallel-route-error'
+import { isInterceptionRouteAppPath } from '../../../../shared/lib/router/utils/interception-routes'
 
 import { normalizePathSep } from '../../../../shared/lib/page-path/normalize-path-sep'
 import { installBindings } from '../../../swc/install-bindings'
@@ -558,7 +560,18 @@ async function createTreeCodeFromPath(
         let defaultPath = await resolver(`${fullSegmentPath}/default`)
         if (!defaultPath) {
           if (adjacentParallelSegment === 'children') {
-            defaultPath = PARALLEL_ROUTE_DEFAULT_PATH
+            // When we host applications on Vercel, the status code affects the
+            // underlying behavior of the route, which when we are missing the
+            // children slot of an interception route, will yield a full 404
+            // response for the RSC request instead. For this reason, we expect
+            // that if a default file is missing when we're rendering an
+            // interception route, we instead always render null for the default
+            // slot to avoid the full 404 response.
+            if (isInterceptionRouteAppPath(page)) {
+              defaultPath = PARALLEL_ROUTE_DEFAULT_NULL_PATH
+            } else {
+              defaultPath = PARALLEL_ROUTE_DEFAULT_PATH
+            }
           } else {
             // Check if we're inside a catch-all route (i.e., the parallel route is a child
             // of a catch-all segment). Only skip validation if the slot is UNDER a catch-all.

--- a/packages/next/src/client/components/builtin/default-null.tsx
+++ b/packages/next/src/client/components/builtin/default-null.tsx
@@ -1,0 +1,6 @@
+export const PARALLEL_ROUTE_DEFAULT_NULL_PATH =
+  'next/dist/client/components/builtin/default-null.js'
+
+export default function ParallelRouteDefaultNull() {
+  return null
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)explicit-layout/deeper/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)explicit-layout/deeper/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div>
+      <h3>Deeper page under explicit layout</h3>
+      <p>This page is nested under the explicit layout</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)explicit-layout/layout.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)explicit-layout/layout.tsx
@@ -1,0 +1,18 @@
+/**
+ * TEST CASE: Interception route WITH explicit layout.tsx but NO parallel routes
+ *
+ * This is the KEY test to determine if we need to check for:
+ * - Implicit layout (from parallel routes) OR
+ * - Explicit layout (layout.tsx file)
+ */
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <div>Explicit layout at (.)explicit-layout</div>
+      <div>
+        <div>children:</div>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)has-both/@sidebar/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)has-both/@sidebar/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <div>
+      <strong>@sidebar content</strong>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)has-both/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)has-both/page.tsx
@@ -1,0 +1,17 @@
+/**
+ * TEST CASE 3: Interception route WITH parallel routes AND page.tsx
+ *
+ * Expected: NO default.tsx needed for children slot
+ * Reason: Has page.tsx which fills the children slot
+ *         The @sidebar slot exists but children slot has content
+ */
+export default function Page() {
+  return (
+    <div>
+      <h3>✅ TEST CASE 3: Has both @sidebar AND page.tsx</h3>
+      <p>This level has @sidebar parallel route AND a page.tsx</p>
+      <p>The page.tsx fills the children slot.</p>
+      <p>NO default.tsx needed!</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)has-page/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)has-page/page.tsx
@@ -1,0 +1,15 @@
+/**
+ * TEST CASE 1: Interception route WITH page.tsx
+ *
+ * Expected: NO default.tsx needed
+ * Reason: Has a page at this level, so no children slot exists
+ */
+export default function Page() {
+  return (
+    <div>
+      <h3>✅ TEST CASE 1: Has page.tsx</h3>
+      <p>This interception route has a page.tsx at this level.</p>
+      <p>No children slot exists, so NO default.tsx needed!</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)no-parallel-routes/deeper/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)no-parallel-routes/deeper/page.tsx
@@ -1,0 +1,17 @@
+/**
+ * TEST CASE 2: Interception route WITHOUT parallel routes
+ *
+ * Expected: NO default.tsx needed at (.)no-parallel-routes level
+ * Reason: No @parallel routes exist, so no implicit layout created
+ *         Only has a nested page, no children slot at root level
+ */
+export default function Page() {
+  return (
+    <div>
+      <h3>✅ TEST CASE 2: No parallel routes</h3>
+      <p>This is a nested page under (.)no-parallel-routes/deeper</p>
+      <p>No @sidebar or other parallel routes exist at parent level.</p>
+      <p>NO default.tsx needed at (.)no-parallel-routes!</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)simple-page/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)simple-page/page.tsx
@@ -1,0 +1,17 @@
+/**
+ * TEST CASE: Interception route WITHOUT parallel routes (just a page)
+ *
+ * Expected: Should work WITHOUT special null default handling
+ * Reason: No parallel routes at this level means no children slot structure
+ *         The page itself is the content, no implicit layout needed
+ */
+export default function Page() {
+  return (
+    <div>
+      <h3>✅ Simple interception page (no parallel routes)</h3>
+      <p>This is just a regular page.tsx at the interception route level.</p>
+      <p>No @sidebar or other parallel routes.</p>
+      <p>Should NOT need null default logic!</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)test-nested/@sidebar/deeper/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)test-nested/@sidebar/deeper/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Intercepted test-nested sidebar/deeper</div>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)test-nested/@sidebar/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)test-nested/@sidebar/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Intercepted test-nested sidebar</div>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)test-nested/deeper/@panel/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)test-nested/deeper/@panel/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Panel at deeper level (deeper than marker)</div>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)test-nested/layout.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/@modal/(.)test-nested/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  sidebar,
+}: {
+  children: React.ReactNode
+  sidebar: React.ReactNode
+}) {
+  return (
+    <div>
+      <div>{sidebar}</div>
+      <div>{children}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/default.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/default.tsx
@@ -1,3 +1,0 @@
-export default function Default() {
-  return null
-}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/explicit-layout/deeper/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/explicit-layout/deeper/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Regular explicit-layout/deeper route</div>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/explicit-layout/layout.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/explicit-layout/layout.tsx
@@ -1,0 +1,8 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <div>Regular explicit-layout layout</div>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/has-both/@sidebar/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/has-both/@sidebar/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Sidebar for regular has-both route</div>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/has-both/layout.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/has-both/layout.tsx
@@ -1,0 +1,21 @@
+export default function Layout({
+  children,
+  sidebar,
+}: {
+  children: React.ReactNode
+  sidebar: React.ReactNode
+}) {
+  return (
+    <div>
+      <div>has-both layout</div>
+      <div>
+        <div>@sidebar:</div>
+        {sidebar}
+      </div>
+      <div>
+        <div>children:</div>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/has-both/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/has-both/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Regular has-both route</div>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/has-page/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/has-page/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Regular has-page route</div>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/layout.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/layout.tsx
@@ -5,8 +5,14 @@ export default function Layout(props: {
   return (
     <html>
       <body>
-        <div id="children">{props.children}</div>
-        <div id="modal">{props.modal}</div>
+        <div id="children">
+          <div>CHILDREN SLOT:</div>
+          {props.children}
+        </div>
+        <div id="modal">
+          <div>MODAL SLOT:</div>
+          {props.modal}
+        </div>
       </body>
     </html>
   )

--- a/test/e2e/app-dir/interception-dynamic-segment/app/no-parallel-routes/deeper/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/no-parallel-routes/deeper/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Regular no-parallel-routes/deeper route</div>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/page.tsx
@@ -2,8 +2,88 @@ import Link from 'next/link'
 
 export default function Page() {
   return (
-    <div>
-      <Link href="/foo/1">Foo</Link> <Link href="/bar/1">Foo</Link>
+    <div id="children">
+      <section>
+        <h2>✅ Should Work WITHOUT default.tsx</h2>
+
+        <div>
+          <h3>Test Case 1a: Simple page (no parallel routes)</h3>
+          <Link href="/simple-page" style={{ color: 'blue', fontSize: '16px' }}>
+            → /simple-page
+          </Link>
+          <p>
+            Interception route with just a page.tsx, no parallel routes at all.
+          </p>
+        </div>
+
+        <div>
+          <h3>Test Case 1b: Has page.tsx</h3>
+          <Link href="/has-page">→ /has-page</Link>
+          <p>
+            Interception route has page.tsx at root level. No children slot
+            exists.
+          </p>
+        </div>
+
+        <div>
+          <h3>Test Case 2: No parallel routes</h3>
+          <Link href="/no-parallel-routes/deeper">
+            → /no-parallel-routes/deeper
+          </Link>
+          <p>No @parallel routes exist, so no implicit layout created.</p>
+        </div>
+
+        <div>
+          <h3>Test Case 3: Has both @sidebar AND page.tsx</h3>
+          <Link href="/has-both">→ /has-both</Link>
+          <p>
+            Has @sidebar parallel route BUT page.tsx fills the children slot.
+          </p>
+        </div>
+      </section>
+
+      <section>
+        <h2>🔬 Test Cases - Require Null Default Logic</h2>
+
+        <div>
+          <h3>Test Case 4a: Has @sidebar but NO page.tsx (implicit layout)</h3>
+          <Link href="/test-nested">→ /test-nested</Link>
+          <p>Has @sidebar (creates implicit layout) but NO page.tsx.</p>
+          <p>✓ Auto-uses null default (no explicit files needed)</p>
+        </div>
+
+        <div>
+          <h3>Test Case 4b: Has explicit layout.tsx but NO parallel routes</h3>
+          <Link href="/explicit-layout/deeper">→ /explicit-layout/deeper</Link>
+          <p>
+            Has explicit layout.tsx with children slot, but NO parallel routes
+            like @sidebar.
+          </p>
+          <p>
+            ? Should it 404 or 200? This determines if we need to check for
+            explicit layouts!
+          </p>
+        </div>
+      </section>
+      <section>
+        <h2>Original Tests</h2>
+        <ul>
+          <li>
+            <Link href="/foo/1">/foo/1</Link>
+          </li>
+          <li>
+            <Link href="/bar/1">/bar/1</Link>
+          </li>
+          <li>
+            <Link href="/test-nested/deeper">/test-nested/deeper</Link>
+          </li>
+          <li>
+            <Link href="/generate-static-params/foo">
+              /generate-static-params/foo
+            </Link>
+          </li>
+        </ul>
+      </section>
     </div>
   )
 }

--- a/test/e2e/app-dir/interception-dynamic-segment/app/regular-route/@sidebar/default.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/regular-route/@sidebar/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/regular-route/@sidebar/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/regular-route/@sidebar/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <div>
+      <strong>Regular route @sidebar</strong>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/regular-route/deeper/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/regular-route/deeper/page.tsx
@@ -1,0 +1,18 @@
+/**
+ * TEST CASE 5: Regular route (NO interception) WITH parallel routes but NO page.tsx
+ *
+ * Expected: REQUIRES default.tsx at regular-route level OR will 404
+ * Reason: This is NOT an interception route, so missing children should 404
+ *         Currently uses PARALLEL_ROUTE_DEFAULT_PATH (calls notFound())
+ *         This is the CORRECT behavior for non-interception routes
+ */
+export default function Page() {
+  return (
+    <div>
+      <h3>❌ TEST CASE 5: Regular route without default.tsx</h3>
+      <p>This is deeper/page.tsx</p>
+      <p>Parent has @sidebar but no page.tsx or default.tsx</p>
+      <p>Should 404 when navigating directly to /regular-route!</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/regular-route/layout.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/regular-route/layout.tsx
@@ -1,0 +1,15 @@
+export default function Layout({
+  children,
+  sidebar,
+}: {
+  children: React.ReactNode
+  sidebar: React.ReactNode
+}) {
+  return (
+    <div>
+      <div>Regular Route Layout</div>
+      <div>{sidebar}</div>
+      <div>{children}</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/simple-page/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/simple-page/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Regular simple-page route</div>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/test-nested/@sidebar/deeper/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/test-nested/@sidebar/deeper/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Actual test-nested sidebar/deeper</div>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/test-nested/@sidebar/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/test-nested/@sidebar/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Actual test-nested sidebar</div>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/test-nested/deeper/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/test-nested/deeper/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Actual test-nested/deeper page</div>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/test-nested/layout.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/test-nested/layout.tsx
@@ -1,0 +1,21 @@
+export default function Layout({
+  children,
+  sidebar,
+}: {
+  children: React.ReactNode
+  sidebar: React.ReactNode
+}) {
+  return (
+    <div>
+      <div>test-nested layout</div>
+      <div>
+        <div>@sidebar slot:</div>
+        {sidebar}
+      </div>
+      <div>
+        <div>children slot:</div>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/test-nested/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/test-nested/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Actual test-nested page</div>
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
+++ b/test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
@@ -1,10 +1,28 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+import { createRouterAct } from 'router-act'
 
 describe('interception-dynamic-segment', () => {
-  const { next, isNextStart } = nextTestSetup({
+  const { next, isNextStart, isNextDev } = nextTestSetup({
     files: __dirname,
   })
+
+  /**
+   * Create a browser with router act that will FAIL if any 404s occur during navigation.
+   * This is critical because if a 404 occurs, the client will perform MPA navigation
+   * (full page reload) which still successfully navigates, hiding the bug.
+   */
+  async function createBrowserWithRouterAct(url: string) {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser(url, {
+      beforePageLoad(page) {
+        // DON'T use allowErrorStatusCodes - we want 404s to fail the test
+        act = createRouterAct(page)
+      },
+    })
+
+    return { act: act!, browser }
+  }
 
   it('should work when interception route is paired with a dynamic segment', async () => {
     const browser = await next.browser('/')
@@ -13,17 +31,17 @@ describe('interception-dynamic-segment', () => {
     await browser.waitForIdleNetwork()
 
     await retry(async () => {
-      expect(await browser.elementById('modal').text()).toEqual('intercepted')
+      expect(await browser.elementById('modal').text()).toContain('intercepted')
     })
 
     await browser.refresh()
     await browser.waitForIdleNetwork()
 
     await retry(async () => {
-      expect(await browser.elementById('modal').text()).toEqual('catch-all')
+      expect(await browser.elementById('modal').text()).toContain('catch-all')
     })
     await retry(async () => {
-      expect(await browser.elementById('children').text()).toEqual(
+      expect(await browser.elementById('children').text()).toContain(
         'not intercepted'
       )
     })
@@ -38,7 +56,7 @@ describe('interception-dynamic-segment', () => {
     await browser.waitForIdleNetwork()
 
     await retry(async () => {
-      expect(await browser.elementById('modal').text()).toEqual('intercepted')
+      expect(await browser.elementById('modal').text()).toContain('intercepted')
     })
 
     // Go back to root
@@ -55,7 +73,7 @@ describe('interception-dynamic-segment', () => {
     await browser.waitForIdleNetwork()
 
     await retry(async () => {
-      expect(await browser.elementById('modal').text()).toEqual('intercepted')
+      expect(await browser.elementById('modal').text()).toContain('intercepted')
     })
   })
 
@@ -68,7 +86,9 @@ describe('interception-dynamic-segment', () => {
       await browser.waitForIdleNetwork()
 
       await retry(async () => {
-        expect(await browser.elementById('modal').text()).toEqual('intercepted')
+        expect(await browser.elementById('modal').text()).toContain(
+          'intercepted'
+        )
       })
 
       await browser.back()
@@ -88,15 +108,259 @@ describe('interception-dynamic-segment', () => {
       expect(res.status).toBe(200)
       expect(res.headers.get('x-nextjs-cache')).toBe('HIT')
     })
+  }
 
-    if (process.env.__NEXT_CACHE_COMPONENTS === 'true') {
-      it('should not render a 404 for the intercepted route', async () => {
-        const meta = JSON.parse(
-          await next.readFile('.next/server/app/(.)[username]/[id].meta')
-        )
+  if (!isNextDev) {
+    /**
+     * Test Case Validation: Ensure NO 404s occur during interception navigation
+     * These tests validate the fix for default.tsx injection with parallel routes.
+     * Using createRouterAct WITHOUT allowErrorStatusCodes ensures that any 404
+     * response will fail the test, preventing the bug where MPA navigation masks 404s.
+     */
+    describe('Default.tsx injection validation (no 404s allowed)', () => {
+      /**
+       * Test Case: Dynamic segment interception route [username]/[id]
+       * Validates that intercepted routes with dynamic segments don't return 404
+       */
+      it('should not render a 404 for the intercepted route with dynamic segments', async () => {
+        const { act, browser } = await createBrowserWithRouterAct('/')
 
-        expect(meta.status).toBe(200)
+        await act(async () => {
+          await browser.elementByCss('[href="/foo/1"]').click()
+        })
+
+        await retry(async () => {
+          expect(await browser.elementById('modal').text()).toContain(
+            'intercepted'
+          )
+        })
       })
-    }
+      /**
+       * Test Case 1a: Simple interception page (no parallel routes)
+       * Structure: @modal/(.)simple-page/page.tsx
+       * Expected: Should work WITHOUT null default logic
+       * Reason: No parallel routes = no implicit layout = no children slot
+       */
+      it('should navigate to /simple-page without 404 (no parallel routes)', async () => {
+        const { act, browser } = await createBrowserWithRouterAct('/')
+
+        await act(async () => {
+          await browser.elementByCss('[href="/simple-page"]').click()
+        })
+
+        await retry(async () => {
+          expect(await browser.elementByCss('#modal h3').text()).toContain(
+            'Simple interception page'
+          )
+        })
+      })
+
+      /**
+       * Test Case 1b: Has page.tsx at interception level
+       * Structure: @modal/(.)has-page/page.tsx
+       * Expected: Should work WITHOUT default.tsx
+       * Reason: page.tsx fills the children slot
+       */
+      it('should navigate to /has-page without 404 (page fills children)', async () => {
+        const { act, browser } = await createBrowserWithRouterAct('/')
+
+        await act(async () => {
+          await browser.elementByCss('[href="/has-page"]').click()
+        })
+
+        await retry(async () => {
+          expect(await browser.elementByCss('#modal h3').text()).toContain(
+            'TEST CASE 1'
+          )
+        })
+      })
+
+      /**
+       * Test Case 2: No parallel routes (nested page)
+       * Structure: @modal/(.)no-parallel-routes/deeper/page.tsx
+       * Expected: Should work WITHOUT default.tsx at parent level
+       * Reason: No parallel routes exist, so no implicit layout
+       */
+      it('should navigate to /no-parallel-routes/deeper without 404', async () => {
+        const { act, browser } = await createBrowserWithRouterAct('/')
+
+        await act(async () => {
+          await browser
+            .elementByCss('[href="/no-parallel-routes/deeper"]')
+            .click()
+        })
+
+        await retry(async () => {
+          expect(await browser.elementByCss('#modal h3').text()).toContain(
+            'TEST CASE 2'
+          )
+        })
+      })
+
+      /**
+       * Test Case 3: Has both @sidebar AND page.tsx
+       * Structure: @modal/(.)has-both/page.tsx + @sidebar/page.tsx
+       * Expected: Should work WITHOUT default.tsx
+       * Reason: page.tsx fills children slot, even though @sidebar creates implicit layout
+       */
+      it('should navigate to /has-both without 404 (has both @sidebar and page)', async () => {
+        const { act, browser } = await createBrowserWithRouterAct('/')
+
+        await act(async () => {
+          await browser.elementByCss('[href="/has-both"]').click()
+        })
+
+        await retry(async () => {
+          expect(await browser.elementByCss('#modal h3').text()).toContain(
+            'TEST CASE 3'
+          )
+        })
+      })
+
+      /**
+       * Test Case 4: Has @sidebar but NO page.tsx (THE KEY BUG CASE)
+       * Structure: @modal/(.)test-nested/@sidebar/page.tsx (NO page.tsx at root)
+       * Expected: Should work WITHOUT explicit default.tsx (auto null default)
+       * Reason: Interception + parallel routes should inject null default
+       *
+       * This is the critical test! Without the fix:
+       * 1. Server returns 404 (default.js calls notFound())
+       * 2. Client sees !res.ok in fetch-server-response.ts:229
+       * 3. Client triggers doMpaNavigation() - full page reload
+       * 4. Navigation still succeeds via MPA, hiding the 404 bug
+       *
+       * With createRouterAct (no allowErrorStatusCodes), 404 fails the test.
+       */
+      it('should navigate to /test-nested without 404 (auto null default)', async () => {
+        const { act, browser } = await createBrowserWithRouterAct('/')
+
+        await act(async () => {
+          await browser.elementByCss('[href="/test-nested"]').click()
+        })
+
+        await retry(async () => {
+          // Modal should show intercepted content
+          const modalContent = await browser.elementByCss('#modal').text()
+          expect(modalContent).toContain('Intercepted test-nested sidebar')
+        })
+
+        await retry(async () => {
+          // Children slot should still show original page (/)
+          const childrenContent = await browser.elementByCss('#children').text()
+          expect(childrenContent).toContain('CHILDREN SLOT')
+        })
+      })
+
+      /**
+       * Test Case 4b: Navigate deeper within intercepted route with parallel routes
+       * This validates that navigating to the deeper page directly (from home) works
+       */
+      it('should navigate to /test-nested/deeper without 404', async () => {
+        const { act, browser } = await createBrowserWithRouterAct('/')
+
+        // Navigate directly to the deeper page from home
+        await act(async () => {
+          await browser.elementByCss('[href="/test-nested/deeper"]').click()
+        })
+
+        await retry(async () => {
+          const modalContent = await browser.elementByCss('#modal').text()
+          // Should show the deeper intercepted content
+          expect(modalContent).toContain('deeper')
+        })
+      })
+
+      it('should navigate to /regular-route/deeper without 404 (has page)', async () => {
+        // Navigate directly via URL to avoid potential link click issues
+        const browser = await next.browser('/regular-route/deeper')
+
+        await retry(async () => {
+          // Since this is NOT an interception route, we should see the actual page content
+          // The page should render in the main content area, not in a modal
+          const bodyText = await browser.elementByCss('body').text()
+          expect(bodyText).toContain('Regular route without default.tsx')
+          expect(bodyText).toContain('deeper/page.tsx')
+        })
+      })
+
+      /**
+       * Explicit layout test: Verify behavior with layout.tsx but no parallel routes
+       */
+      it('should navigate to /explicit-layout/deeper without 404', async () => {
+        const { act, browser } = await createBrowserWithRouterAct('/')
+
+        await act(async () => {
+          await browser.elementByCss('[href="/explicit-layout/deeper"]').click()
+        })
+
+        await retry(async () => {
+          const modalContent = await browser.elementByCss('#modal').text()
+          expect(modalContent).toContain('Explicit layout')
+          expect(modalContent).toContain('Deeper page under explicit layout')
+        })
+      })
+
+      /**
+       * Repeated navigation test: Validate __DEFAULT__ marker handling is consistent
+       * Uses act() to ensure navigation requests return 200 (not 404). Each forward
+       * navigation triggers an RSC request (even if cached), while back navigation
+       * uses browser history without network requests.
+       */
+      it('should handle repeated interceptions without 404', async () => {
+        const { act, browser } = await createBrowserWithRouterAct('/')
+
+        for (let i = 0; i < 3; i++) {
+          // Forward navigation: triggers RSC request (validates no 404)
+          await act(
+            async () => {
+              await browser.elementByCss('[href="/test-nested"]').click()
+            },
+            i > 0 ? 'no-requests' : undefined
+          )
+
+          await retry(async () => {
+            const modalContent = await browser.elementByCss('#modal').text()
+            expect(modalContent).toContain('Intercepted test-nested sidebar')
+          })
+
+          // Back navigation: uses browser history, no network request
+          await act(async () => {
+            await browser.back()
+          }, 'no-requests')
+
+          await retry(async () => {
+            const url = await browser.url()
+            expect(url).toMatch(/\/$/)
+          })
+        }
+      })
+
+      /**
+       * Cross-interception navigation
+       */
+      it('should navigate between different interception routes without 404', async () => {
+        const { act, browser } = await createBrowserWithRouterAct('/')
+
+        // First interception
+        await act(async () => {
+          await browser.elementByCss('[href="/test-nested"]').click()
+        })
+
+        await retry(async () => {
+          const modalContent = await browser.elementByCss('#modal').text()
+          expect(modalContent).toContain('Intercepted test-nested sidebar')
+        })
+
+        // Second interception
+        await act(async () => {
+          await browser.elementByCss('[href="/has-both"]').click()
+        }, 'no-requests')
+
+        await retry(async () => {
+          const modalContent = await browser.elementByCss('#modal').text()
+          expect(modalContent).toContain('TEST CASE 3')
+        })
+      })
+    })
   }
 })


### PR DESCRIPTION
### What?

Introduces a null-rendering default component for interception routes to prevent 404 responses when children slots are missing.

### Why?

When rendering interception routes like `(.)[id]`, there's a segment mismatch where the interception route lacks a children slot that the base `[id]` route has. 

**The Bug:**
Previously, the framework injected a 404 page into the missing default slot for the children route. On platforms like Vercel, this caused full 404 RSC responses because the HTTP status code has semantic meaning for route behavior when using cache components. This resulted in the "unknown segment value fallback page" issue.

**Impact:**
- RSC requests for interception routes would return 404 status codes
- Platform routing behavior was incorrectly triggered by these 404 responses
- Only affects pages rendering with cache components

### How?

- Created new `default-null.tsx` builtin component that renders `null`
- Updated Rust code (`app_structure.rs`) to detect interception routes and use the null default
- Updated webpack loader (`next-app-loader/index.ts`) to check `isInterceptionRouteAppPath()` and inject the null default
- Removed test-specific default component that was working around this bug
- The old `page.tsx` is still used during client navigation, so there's no visible change to users

This ensures minimal RSC payload changes and prevents 404 status codes while maintaining existing client-side behavior.

NAR-483