### PR TITLE
chore: Update patricia_tree dependency, remove manual serde impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4944,11 +4944,11 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "patricia_tree"
-version = "0.5.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062a6297f2cd3969a780156ccb288eafb34bb5ed0f3c9a2b4500dbde869d4b86"
+checksum = "4df0e43512f12f23a6b08c7b893192b7d6ec937b95ee03af040847907fe5cef7"
 dependencies = [
- "bitflags 1.3.2",
+ "serde",
 ]
 
 [[package]]

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -23,7 +23,7 @@ data-encoding = { workspace = true }
 either = { workspace = true }
 indexmap = { workspace = true }
 once_cell = { workspace = true }
-patricia_tree = "0.5.5"
+patricia_tree = { version = "0.10.1", features = ["serde"] }
 petgraph = { workspace = true, features = ["serde-1"] }
 roaring = { workspace = true, features = ["serde"] }
 ref-cast = "1.0.20"


### PR DESCRIPTION
Recent versions of `patricia_tree` have their own serde implementation which is more efficient than what we can do because it serializes the internal nodes in the tree, rather than the public observable key/value entry API.