### PR TITLE
[test] Deflake legacy-link-behavior

### DIFF
--- a/test/e2e/legacy-link-behavior/app/layout.tsx
+++ b/test/e2e/legacy-link-behavior/app/layout.tsx
@@ -8,11 +8,11 @@ export default async function Root({
 }) {
   return (
     <html>
-      <Suspense>
-        <Connection>
-          <body>{children}</body>
-        </Connection>
-      </Suspense>
+      <body>
+        <Suspense>
+          <Connection>{children}</Connection>
+        </Suspense>
+      </body>
     </html>
   )
 }


### PR DESCRIPTION
Suspense around body will trigger "missing tags" warning if something throws in the boundary. This error can come in slightly later and cause flaky test results.

Fixes
```
● Validations for <Link legacyBehavior> › When rendering from a Client Component › warns and throws an error if the child is lazy JSX
  
      expect(received).toMatchInlineSnapshot(snapshot)
  
      Snapshot name: `Validations for <Link legacyBehavior> When rendering from a Client Component warns and throws an error if the child is lazy JSX 1`
```
-- https://github.com/vercel/next.js/actions/runs/19097617827/job/54561506584#step:34:13256
