### PR TITLE
Send dynamic validation errors to browser via WebSocket

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -943,5 +943,8 @@
   "942": "Unexpected stream chunk while in Before stage",
   "943": "getFlightStream should always receive a ReadableStream when using the edge runtime",
   "944": "nodeStreamFromReadableStream cannot be used in the edge runtime",
-  "945": "createNodeStreamFromChunks cannot be used in the edge runtime"
+  "945": "createNodeStreamFromChunks cannot be used in the edge runtime",
+  "946": "Failed to deserialize errors.",
+  "947": "Expected `sendErrorsToBrowser` to be defined in renderOpts.",
+  "948": "Failed to serialize errors."
 }

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -545,6 +545,7 @@ export async function handler(
           setCacheStatus: routerServerContext?.setCacheStatus,
           setIsrStatus: routerServerContext?.setIsrStatus,
           setReactDebugChannel: routerServerContext?.setReactDebugChannel,
+          sendErrorsToBrowser: routerServerContext?.sendErrorsToBrowser,
 
           dir:
             process.env.NEXT_RUNTIME === 'nodejs'

--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -38,14 +38,18 @@ import {
 } from '../../../components/app-router-instance'
 import { InvariantError } from '../../../../shared/lib/invariant-error'
 import { getOrCreateDebugChannelReadableWriterPair } from '../../debug-channel'
+// TODO: Explicitly import from client.browser (doesn't work with Webpack).
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { createFromReadableStream } from 'react-server-dom-webpack/client.browser'
+import { createFromReadableStream as createFromReadableStreamBrowser } from 'react-server-dom-webpack/client'
 import { findSourceMapURL } from '../../../app-find-source-map-url'
 
 export interface StaticIndicatorState {
   pathname: string | null
   appIsrManifest: Record<string, boolean> | null
 }
+
+const createFromReadableStream =
+  createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
 
 let mostRecentCompilationHash: any = null
 let __nextDevClientId = Math.round(Math.random() * 100 + Date.now())

--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -38,6 +38,9 @@ import {
 } from '../../../components/app-router-instance'
 import { InvariantError } from '../../../../shared/lib/invariant-error'
 import { getOrCreateDebugChannelReadableWriterPair } from '../../debug-channel'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { createFromReadableStream } from 'react-server-dom-webpack/client.browser'
+import { findSourceMapURL } from '../../../app-find-source-map-url'
 
 export interface StaticIndicatorState {
   pathname: string | null
@@ -502,6 +505,29 @@ export function processMessage(
     }
     case HMR_MESSAGE_SENT_TO_BROWSER.CACHE_INDICATOR: {
       dispatcher.onCacheIndicator(message.state)
+      return
+    }
+    case HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER: {
+      createFromReadableStream<Error[]>(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(message.serializedErrors)
+            controller.close()
+          },
+        }),
+        { findSourceMapURL }
+      ).then(
+        (errors) => {
+          for (const error of errors) {
+            console.error(error)
+          }
+        },
+        (err) => {
+          console.error(
+            new Error('Failed to deserialize errors.', { cause: err })
+          )
+        }
+      )
       return
     }
     case HMR_MESSAGE_SENT_TO_BROWSER.MIDDLEWARE_CHANGES:

--- a/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
+++ b/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
@@ -223,6 +223,14 @@ function parseBinaryMessage(data: ArrayBuffer): HmrMessageSentToBrowser {
   const messageType = view.getUint8(0)
 
   switch (messageType) {
+    case HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER: {
+      const serializedErrors = new Uint8Array(data, 1)
+
+      return {
+        type: HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER,
+        serializedErrors,
+      }
+    }
     case HMR_MESSAGE_SENT_TO_BROWSER.REACT_DEBUG_CHUNK: {
       assertByteLength(data, 2)
       const requestIdLength = view.getUint8(1)

--- a/packages/next/src/client/dev/hot-reloader/pages/hot-reloader-pages.ts
+++ b/packages/next/src/client/dev/hot-reloader/pages/hot-reloader-pages.ts
@@ -394,6 +394,7 @@ function processMessage(message: HmrMessageSentToBrowser) {
       break
     case HMR_MESSAGE_SENT_TO_BROWSER.CACHE_INDICATOR:
     case HMR_MESSAGE_SENT_TO_BROWSER.REACT_DEBUG_CHUNK:
+    case HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER:
       // Only relevant for app router.
       break
     case HMR_MESSAGE_SENT_TO_BROWSER.MIDDLEWARE_CHANGES:

--- a/packages/next/src/client/page-bootstrap.ts
+++ b/packages/next/src/client/page-bootstrap.ts
@@ -124,6 +124,7 @@ export function pageBootstrap(assetPrefix: string) {
         case HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_CURRENT_ERROR_STATE:
         case HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_PAGE_METADATA:
         case HMR_MESSAGE_SENT_TO_BROWSER.CACHE_INDICATOR:
+        case HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER:
           // Most of these action types are handled in
           // src/client/dev/hot-reloader/pages/hot-reloader-pages.ts and
           // src/client/dev/hot-reloader/app/hot-reloader-app.tsx

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3618,7 +3618,18 @@ async function logMessagesAndSendErrorsToBrowser(
 
   const errors: Error[] = []
   for (const message of messages) {
-    console.error(message)
+    // Log the error to the CLI. Prevent the logs from being dimmed, which we
+    // apply for other logs during the spawned validation.
+    consoleAsyncStorage.exit(() => {
+      console.error(message)
+    })
+
+    // Error instances are also sent to the browser. We're currently using a
+    // non-Error message only in debug build mode as a message that is only
+    // meant for the CLI. FIXME: This is a bit spooky action at a distance. We
+    // should maybe have a more explicit way of determining which messages
+    // should be sent to the browser. Regardless, only real errors with a proper
+    // stack make sense to be "replayed" in the browser.
     if (message instanceof Error) {
       errors.push(message)
     }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -867,7 +867,6 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
       consoleAsyncStorage.run(
         { dim: true },
         spawnStaticShellValidationInDev,
-        resolveValidation,
         staticChunks,
         runtimeChunks,
         dynamicChunks,
@@ -2670,7 +2669,6 @@ async function renderToStream(
       // We only have a Prerender environment for projects opted into cacheComponents
       cacheComponents
     ) {
-      let validationOutlet: Promise<ReactNode> | undefined
       let debugChannel: DebugChannelPair | undefined
 
       const getPayload = async (
@@ -2696,12 +2694,6 @@ async function renderToStream(
           payload._bypassCachesInDev = createElement(WarnForBypassCachesInDev, {
             route: workStore.route,
           })
-        } else if (validationOutlet) {
-          // Placing the validation outlet in the payload is safe
-          // even if we end up discarding a render and restarting,
-          // because we're not going to wait for the stream to complete,
-          // so leaving the validation unresolved is fine.
-          payload._validation = validationOutlet
         }
 
         return payload
@@ -2715,9 +2707,6 @@ async function renderToStream(
         // "disable cache" in devtools or a hard refresh (cache-control: "no-store")
         !isBypassingCachesInDev(renderOpts, requestStore)
       ) {
-        const [resolveValidation, _validationOutlet] = createValidationOutlet()
-        validationOutlet = _validationOutlet
-
         const {
           stream: serverStream,
           staticChunks,
@@ -2747,7 +2736,6 @@ async function renderToStream(
         consoleAsyncStorage.run(
           { dim: true },
           spawnStaticShellValidationInDev,
-          resolveValidation,
           staticChunks,
           runtimeChunks,
           dynamicChunks,
@@ -3627,13 +3615,58 @@ function createValidationOutlet() {
 }
 
 /**
+ * Logs the given messages, and sends the error instances to the browser as an
+ * RSC stream, where they can be deserialized and logged (or otherwise presented
+ * in the devtools), while leveraging React's capabilities to not only
+ * source-map the stack frames (via findSourceMapURL), but also create virtual
+ * server modules that allow users to inspect the server source code in the
+ * browser.
+ */
+async function logMessagesAndSendErrorsToBrowser(
+  messages: unknown[],
+  ctx: AppRenderContext
+): Promise<void> {
+  const {
+    clientReferenceManifest,
+    componentMod: ComponentMod,
+    htmlRequestId,
+    renderOpts,
+  } = ctx
+
+  const { sendErrorsToBrowser } = renderOpts
+
+  const errors: Error[] = []
+  for (const message of messages) {
+    console.error(message)
+    if (message instanceof Error) {
+      errors.push(message)
+    }
+  }
+
+  if (errors.length > 0) {
+    if (!sendErrorsToBrowser) {
+      throw new InvariantError(
+        'Expected `sendErrorsToBrowser` to be defined in renderOpts.'
+      )
+    }
+
+    const errorsRscStream = ComponentMod.renderToReadableStream(
+      errors,
+      clientReferenceManifest.clientModules,
+      { filterStackFrame }
+    )
+
+    sendErrorsToBrowser(errorsRscStream, htmlRequestId)
+  }
+}
+
+/**
  * This function is a fork of prerenderToStream cacheComponents branch.
  * While it doesn't return a stream we want it to have identical
  * prerender semantics to prerenderToStream and should update it
  * in conjunction with any changes to that function.
  */
 async function spawnStaticShellValidationInDev(
-  resolveValidation: (validatingElement: ReactNode) => void,
   staticServerChunks: Array<Uint8Array>,
   runtimeServerChunks: Array<Uint8Array>,
   dynamicServerChunks: Array<Uint8Array>,
@@ -3668,36 +3701,19 @@ async function spawnStaticShellValidationInDev(
     NEXT_HMR_REFRESH_HASH_COOKIE
   )?.value
 
-  const { createElement } = ComponentMod
-
   // We don't need to continue the prerender process if we already
   // detected invalid dynamic usage in the initial prerender phase.
   const { invalidDynamicUsageError } = workStore
   if (invalidDynamicUsageError) {
-    resolveValidation(
-      createElement(ReportValidation, {
-        messages: [invalidDynamicUsageError],
-      })
-    )
-    return
+    return logMessagesAndSendErrorsToBrowser([invalidDynamicUsageError], ctx)
   }
 
   if (staticInterruptReason) {
-    resolveValidation(
-      createElement(ReportValidation, {
-        messages: [staticInterruptReason],
-      })
-    )
-    return
+    return logMessagesAndSendErrorsToBrowser([staticInterruptReason], ctx)
   }
 
   if (runtimeInterruptReason) {
-    resolveValidation(
-      createElement(ReportValidation, {
-        messages: [runtimeInterruptReason],
-      })
-    )
-    return
+    return logMessagesAndSendErrorsToBrowser([runtimeInterruptReason], ctx)
   }
 
   // First we warmup SSR with the runtime chunks. This ensures that when we do
@@ -3736,10 +3752,7 @@ async function spawnStaticShellValidationInDev(
   if (runtimeResult.length > 0) {
     // We have something to report from the runtime validation
     // We can skip the static validation
-    resolveValidation(
-      createElement(ReportValidation, { messages: runtimeResult })
-    )
-    return
+    return logMessagesAndSendErrorsToBrowser(runtimeResult, ctx)
   }
 
   const staticResult = await validateStagedShell(
@@ -3756,11 +3769,7 @@ async function spawnStaticShellValidationInDev(
     trackDynamicHoleInStaticShell
   )
 
-  // We always resolve with whatever results we got. It might be empty in which
-  // case there will be nothing to report once
-  resolveValidation(createElement(ReportValidation, { messages: staticResult }))
-
-  return
+  return logMessagesAndSendErrorsToBrowser(staticResult, ctx)
 }
 
 async function warmupModuleCacheForRuntimeValidationInDev(
@@ -4053,13 +4062,6 @@ async function validateStagedShell(
 
     return errors
   }
-}
-
-function ReportValidation({ messages }: { messages: Array<unknown> }): null {
-  for (const message of messages) {
-    console.error(message)
-  }
-  return null
 }
 
 type PrerenderToStreamResult = {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -57,7 +57,6 @@ import {
   NEXT_URL,
   RSC_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
-  NEXT_HMR_REFRESH_HASH_COOKIE,
   NEXT_REQUEST_ID_HEADER,
   NEXT_HTML_REQUEST_ID_HEADER,
 } from '../../client/components/app-router-headers'
@@ -178,6 +177,7 @@ import {
 } from './app-render-render-utils'
 import { waitAtLeastOneReactRenderTask } from '../../lib/scheduler'
 import {
+  getHmrRefreshHash,
   workUnitAsyncStorage,
   type PrerenderStore,
 } from './work-unit-async-storage.external'
@@ -782,10 +782,11 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
     onFlightDataRenderError
   )
 
-  // If we decide to validate this render we will assign this function when the
-  // payload is constructed.
-  let resolveValidation: null | ReturnType<typeof createValidationOutlet>[0] =
-    null
+  // We only validate RSC requests if it is for HMR refreshes since we know we
+  // will render all the layouts necessary to perform the validation.
+  const shouldValidate =
+    !isBypassingCachesInDev(renderOpts, initialRequestStore) &&
+    initialRequestStore.isHmrRefresh === true
 
   const getPayload = async (requestStore: RequestStore) => {
     const payload: RSCPayload &
@@ -803,18 +804,9 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
       payload._bypassCachesInDev = createElement(WarnForBypassCachesInDev, {
         route: workStore.route,
       })
-    } else if (requestStore.isHmrRefresh) {
-      // We only validate RSC requests if it is for HMR refreshes since
-      // we know we will render all the layouts necessary to perform the validation.
-      // We also must add the canonical URL part of the payload
-
-      // Placing the validation outlet in the payload is safe
-      // even if we end up discarding a render and restarting,
-      // because we're not going to wait for the stream to complete,
-      // so leaving the validation unresolved is fine.
-      const [validationResolver, validationOutlet] = createValidationOutlet()
-      resolveValidation = validationResolver
-      payload._validation = validationOutlet
+    } else if (shouldValidate) {
+      // If this payload will be used for validation, it needs to contain the
+      // canonical URL. Without it we'd get an error.
       payload.c = prepareInitialCanonicalUrl(url)
     }
 
@@ -855,7 +847,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
       onError
     )
 
-    if (resolveValidation) {
+    if (shouldValidate) {
       let validationDebugChannelClient: Readable | undefined = undefined
       if (returnedDebugChannel) {
         const [t1, t2] = returnedDebugChannel.clientSide.readable.tee()
@@ -3587,14 +3579,6 @@ function createDebugChannel(): DebugChannelPair | undefined {
   }
 }
 
-function createValidationOutlet() {
-  let resolveValidation: (value: ReactNode) => void
-  let outlet = new Promise<ReactNode>((resolve) => {
-    resolveValidation = resolve
-  })
-  return [resolveValidation!, outlet] as const
-}
-
 /**
  * Logs the given messages, and sends the error instances to the browser as an
  * RSC stream, where they can be deserialized and logged (or otherwise presented
@@ -3684,9 +3668,7 @@ async function spawnStaticShellValidationInDev(
     getDynamicParamFromSegment
   )
 
-  const hmrRefreshHash = requestStore.cookies.get(
-    NEXT_HMR_REFRESH_HASH_COOKIE
-  )?.value
+  const hmrRefreshHash = getHmrRefreshHash(workStore, requestStore)
 
   // We don't need to continue the prerender process if we already
   // detected invalid dynamic usage in the initial prerender phase.

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -840,9 +840,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
 
     const {
       stream: serverStream,
-      staticChunks,
-      runtimeChunks,
-      dynamicChunks,
+      accumulatedChunksPromise,
       staticInterruptReason,
       runtimeInterruptReason,
       staticStageEndTime,
@@ -867,9 +865,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
       consoleAsyncStorage.run(
         { dim: true },
         spawnStaticShellValidationInDev,
-        staticChunks,
-        runtimeChunks,
-        dynamicChunks,
+        accumulatedChunksPromise,
         staticInterruptReason,
         runtimeInterruptReason,
         staticStageEndTime,
@@ -2709,9 +2705,7 @@ async function renderToStream(
       ) {
         const {
           stream: serverStream,
-          staticChunks,
-          runtimeChunks,
-          dynamicChunks,
+          accumulatedChunksPromise,
           staticInterruptReason,
           runtimeInterruptReason,
           staticStageEndTime,
@@ -2736,9 +2730,7 @@ async function renderToStream(
         consoleAsyncStorage.run(
           { dim: true },
           spawnStaticShellValidationInDev,
-          staticChunks,
-          runtimeChunks,
-          dynamicChunks,
+          accumulatedChunksPromise,
           staticInterruptReason,
           runtimeInterruptReason,
           staticStageEndTime,
@@ -3230,15 +3222,11 @@ async function renderWithRestartOnCacheMissInDev(
 
   let debugChannel = setReactDebugChannel && createDebugChannel()
 
-  const staticChunks: Array<Uint8Array> = []
-  const runtimeChunks: Array<Uint8Array> = []
-  const dynamicChunks: Array<Uint8Array> = []
-
   // Note: The stage controller starts out in the `Before` stage,
   // where sync IO does not cause aborts, so it's okay if it happens before render.
   const initialRscPayload = await getPayload(requestStore)
 
-  const maybeInitialServerStream = await workUnitAsyncStorage.run(
+  const maybeInitialStreamResult = await workUnitAsyncStorage.run(
     requestStore,
     () =>
       pipelineInSequentialTasks(
@@ -3265,17 +3253,14 @@ async function renderWithRestartOnCacheMissInDev(
           })
 
           const [continuationStream, accumulatingStream] = stream.tee()
-          accumulateStreamChunks(
+          const accumulatedChunksPromise = accumulateStreamChunks(
             accumulatingStream,
-            staticChunks,
-            runtimeChunks,
-            dynamicChunks,
             initialStageController,
             initialDataController.signal
           )
-          return continuationStream
+          return { stream: continuationStream, accumulatedChunksPromise }
         },
-        (stream) => {
+        ({ stream, accumulatedChunksPromise }) => {
           // Runtime stage
 
           if (initialStageController.currentStage === RenderStage.Abandoned) {
@@ -3296,12 +3281,12 @@ async function renderWithRestartOnCacheMissInDev(
           }
 
           initialStageController.advanceStage(RenderStage.Runtime)
-          return stream
+          return { stream, accumulatedChunksPromise }
         },
-        async (stream) => {
+        (result) => {
           // Dynamic stage
           if (
-            stream === null ||
+            result === null ||
             initialStageController.currentStage === RenderStage.Abandoned
           ) {
             // If we abandoned the render in the static or runtime stage, we won't proceed further.
@@ -3321,18 +3306,17 @@ async function renderWithRestartOnCacheMissInDev(
           // render we need the unblock runtime b/c it's essential
           // filling caches.
           initialStageController.advanceStage(RenderStage.Dynamic)
-          return stream
+          return result
         }
       )
   )
 
-  if (maybeInitialServerStream !== null) {
-    // No cache misses. We can use the stream as is.
+  if (maybeInitialStreamResult !== null) {
+    // No cache misses. We can use the result as-is.
     return {
-      stream: maybeInitialServerStream,
-      staticChunks,
-      runtimeChunks,
-      dynamicChunks,
+      stream: maybeInitialStreamResult.stream,
+      accumulatedChunksPromise:
+        maybeInitialStreamResult.accumulatedChunksPromise,
       staticInterruptReason: initialStageController.getStaticInterruptReason(),
       runtimeInterruptReason:
         initialStageController.getRuntimeInterruptReason(),
@@ -3393,17 +3377,11 @@ async function renderWithRestartOnCacheMissInDev(
   // We're not using it, so we need to create a new one.
   debugChannel = setReactDebugChannel && createDebugChannel()
 
-  // We had a cache miss and need to restart after filling caches. Let's clear out the
-  // staticChunks and runtimeChunks we previously accumulated
-  staticChunks.length = 0
-  runtimeChunks.length = 0
-  dynamicChunks.length = 0
-
   // Note: The stage controller starts out in the `Before` stage,
   // where sync IO does not cause aborts, so it's okay if it happens before render.
   const finalRscPayload = await getPayload(requestStore)
 
-  const finalServerStream = await workUnitAsyncStorage.run(requestStore, () =>
+  const finalStreamResult = await workUnitAsyncStorage.run(requestStore, () =>
     pipelineInSequentialTasks(
       () => {
         // Static stage
@@ -3421,25 +3399,22 @@ async function renderWithRestartOnCacheMissInDev(
         )
 
         const [continuationStream, accumulatingStream] = stream.tee()
-        accumulateStreamChunks(
+        const accumulatedChunksPromise = accumulateStreamChunks(
           accumulatingStream,
-          staticChunks,
-          runtimeChunks,
-          dynamicChunks,
           finalStageController,
           null
         )
-        return continuationStream
+        return { stream: continuationStream, accumulatedChunksPromise }
       },
-      (stream) => {
+      (result) => {
         // Runtime stage
         finalStageController.advanceStage(RenderStage.Runtime)
-        return stream
+        return result
       },
-      (stream) => {
+      (result) => {
         // Dynamic stage
         finalStageController.advanceStage(RenderStage.Dynamic)
-        return stream
+        return result
       }
     )
   )
@@ -3449,10 +3424,8 @@ async function renderWithRestartOnCacheMissInDev(
   }
 
   return {
-    stream: finalServerStream,
-    staticChunks,
-    runtimeChunks,
-    dynamicChunks,
+    stream: finalStreamResult.stream,
+    accumulatedChunksPromise: finalStreamResult.accumulatedChunksPromise,
     staticInterruptReason: finalStageController.getStaticInterruptReason(),
     runtimeInterruptReason: finalStageController.getRuntimeInterruptReason(),
     staticStageEndTime: finalStageController.getStaticStageEndTime(),
@@ -3462,14 +3435,20 @@ async function renderWithRestartOnCacheMissInDev(
   }
 }
 
+interface AccumulatedStreamChunks {
+  readonly staticChunks: Array<Uint8Array>
+  readonly runtimeChunks: Array<Uint8Array>
+  readonly dynamicChunks: Array<Uint8Array>
+}
+
 async function accumulateStreamChunks(
   stream: ReadableStream<Uint8Array>,
-  staticTarget: Array<Uint8Array>,
-  runtimeTarget: Array<Uint8Array>,
-  dynamicTarget: Array<Uint8Array>,
   stageController: StagedRenderingController,
   signal: AbortSignal | null
-): Promise<void> {
+): Promise<AccumulatedStreamChunks> {
+  const staticChunks: Array<Uint8Array> = []
+  const runtimeChunks: Array<Uint8Array> = []
+  const dynamicChunks: Array<Uint8Array> = []
   const reader = stream.getReader()
 
   let cancelled = false
@@ -3497,13 +3476,13 @@ async function accumulateStreamChunks(
             'Unexpected stream chunk while in Before stage'
           )
         case RenderStage.Static:
-          staticTarget.push(value)
+          staticChunks.push(value)
         // fall through
         case RenderStage.Runtime:
-          runtimeTarget.push(value)
+          runtimeChunks.push(value)
         // fall through
         case RenderStage.Dynamic:
-          dynamicTarget.push(value)
+          dynamicChunks.push(value)
           break
         case RenderStage.Abandoned:
           // If the render was abandoned, we won't use the chunks,
@@ -3517,6 +3496,8 @@ async function accumulateStreamChunks(
   } catch {
     // When we release the lock we may reject the read
   }
+
+  return { staticChunks, runtimeChunks, dynamicChunks }
 }
 
 function createAsyncApiPromisesInDev(
@@ -3667,9 +3648,7 @@ async function logMessagesAndSendErrorsToBrowser(
  * in conjunction with any changes to that function.
  */
 async function spawnStaticShellValidationInDev(
-  staticServerChunks: Array<Uint8Array>,
-  runtimeServerChunks: Array<Uint8Array>,
-  dynamicServerChunks: Array<Uint8Array>,
+  accumulatedChunksPromise: Promise<AccumulatedStreamChunks>,
   staticInterruptReason: Error | null,
   runtimeInterruptReason: Error | null,
   staticStageEndTime: number,
@@ -3680,9 +3659,6 @@ async function spawnStaticShellValidationInDev(
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
   debugChannelClient: Readable | undefined
 ): Promise<void> {
-  // TODO replace this with a delay on the entire dev render once the result is propagated
-  // via the websocket and not the main render itself
-  await new Promise((r) => setTimeout(r, 2000))
   const {
     componentMod: ComponentMod,
     getDynamicParamFromSegment,
@@ -3716,12 +3692,15 @@ async function spawnStaticShellValidationInDev(
     return logMessagesAndSendErrorsToBrowser([runtimeInterruptReason], ctx)
   }
 
+  const { staticChunks, runtimeChunks, dynamicChunks } =
+    await accumulatedChunksPromise
+
   // First we warmup SSR with the runtime chunks. This ensures that when we do
   // the full prerender pass with dynamic tracking module loading won't
   // interrupt the prerender and can properly observe the entire content
   await warmupModuleCacheForRuntimeValidationInDev(
-    runtimeServerChunks,
-    dynamicServerChunks,
+    runtimeChunks,
+    dynamicChunks,
     rootParams,
     fallbackRouteParams,
     allowEmptyStaticShell,
@@ -3736,8 +3715,8 @@ async function spawnStaticShellValidationInDev(
   }
 
   const runtimeResult = await validateStagedShell(
-    runtimeServerChunks,
-    dynamicServerChunks,
+    runtimeChunks,
+    dynamicChunks,
     debugChunks,
     runtimeStageEndTime,
     rootParams,
@@ -3756,8 +3735,8 @@ async function spawnStaticShellValidationInDev(
   }
 
   const staticResult = await validateStagedShell(
-    staticServerChunks,
-    dynamicServerChunks,
+    staticChunks,
+    dynamicChunks,
     debugChunks,
     staticStageEndTime,
     rootParams,

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -116,6 +116,10 @@ export interface RenderOptsPartial {
     htmlRequestId: string,
     requestId: string
   ) => void
+  sendErrorsToBrowser?: (
+    errorsRscStream: ReadableStream<Uint8Array>,
+    htmlRequestId: string
+  ) => void
   nextExport?: boolean
   nextConfigOutput?: 'standalone' | 'export'
   onInstrumentationRequestError?: ServerOnInstrumentationRequestError

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -126,7 +126,11 @@ import { recordMcpTelemetry } from '../mcp/mcp-telemetry-tracker'
 import { getFileLogger } from './browser-logs/file-logger'
 import type { ServerCacheStatus } from '../../next-devtools/dev-overlay/cache-indicator'
 import type { Lockfile } from '../../build/lockfile'
-import { streamToUint8Array } from '../stream-utils/node-web-streams-helper'
+import {
+  sendSerializedErrorsToClient,
+  sendSerializedErrorsToClientForHtmlRequest,
+  setErrorsRscStreamForHtmlRequest,
+} from './serialized-errors'
 
 const wsServer = new ws.Server({ noServer: true })
 const isTestMode = !!(
@@ -443,10 +447,6 @@ export async function createHotReloaderTurbopack(
   const clientsWithoutHtmlRequestId = new Set<ws>()
   const clientsByHtmlRequestId = new Map<string, ws>()
   const cacheStatusesByHtmlRequestId = new Map<string, ServerCacheStatus>()
-  const errorsRscStreamsByHtmlRequestId = new Map<
-    string,
-    ReadableStream<Uint8Array>
-  >()
   const clientStates = new WeakMap<ws, ClientState>()
 
   function sendToClient(client: ws, message: HmrMessageSentToBrowser) {
@@ -919,17 +919,10 @@ export async function createHotReloaderTurbopack(
             sendToClient.bind(null, client)
           )
 
-          const errorsRscStream =
-            errorsRscStreamsByHtmlRequestId.get(htmlRequestId)
-          if (errorsRscStream !== undefined) {
-            streamToUint8Array(errorsRscStream).then((serializedErrors) =>
-              sendToClient(client, {
-                type: HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER,
-                serializedErrors,
-              })
-            )
-            errorsRscStreamsByHtmlRequestId.delete(htmlRequestId)
-          }
+          sendSerializedErrorsToClientForHtmlRequest(
+            htmlRequestId,
+            sendToClient.bind(null, client)
+          )
         } else {
           clientsWithoutHtmlRequestId.add(client)
           onUpgrade(client, { isLegacyClient: true })
@@ -1203,17 +1196,17 @@ export async function createHotReloaderTurbopack(
 
     sendErrorsToBrowser(errorsRscStream, htmlRequestId) {
       const client = clientsByHtmlRequestId.get(htmlRequestId)
-      if (client !== undefined) {
-        streamToUint8Array(errorsRscStream).then((serializedErrors) => {
-          sendToClient(client, {
-            type: HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER,
-            serializedErrors,
-          })
-        })
+
+      if (client) {
+        // If the client is connected, we can send the errors immediately.
+        sendSerializedErrorsToClient(
+          errorsRscStream,
+          sendToClient.bind(null, client)
+        )
       } else {
-        // If the client is not connected, store the errors stream so that we
-        // can send it when the client connects.
-        errorsRscStreamsByHtmlRequestId.set(htmlRequestId, errorsRscStream)
+        // Otherwise, store the errors stream so that we can send it when the
+        // client connects.
+        setErrorsRscStreamForHtmlRequest(htmlRequestId, errorsRscStream)
       }
     },
 

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -126,6 +126,7 @@ import { recordMcpTelemetry } from '../mcp/mcp-telemetry-tracker'
 import { getFileLogger } from './browser-logs/file-logger'
 import type { ServerCacheStatus } from '../../next-devtools/dev-overlay/cache-indicator'
 import type { Lockfile } from '../../build/lockfile'
+import { streamToUint8Array } from '../stream-utils/node-web-streams-helper'
 
 const wsServer = new ws.Server({ noServer: true })
 const isTestMode = !!(
@@ -442,6 +443,10 @@ export async function createHotReloaderTurbopack(
   const clientsWithoutHtmlRequestId = new Set<ws>()
   const clientsByHtmlRequestId = new Map<string, ws>()
   const cacheStatusesByHtmlRequestId = new Map<string, ServerCacheStatus>()
+  const errorsRscStreamsByHtmlRequestId = new Map<
+    string,
+    ReadableStream<Uint8Array>
+  >()
   const clientStates = new WeakMap<ws, ClientState>()
 
   function sendToClient(client: ws, message: HmrMessageSentToBrowser) {
@@ -908,6 +913,23 @@ export async function createHotReloaderTurbopack(
           } else {
             onUpgrade(client, { isLegacyClient: true })
           }
+
+          connectReactDebugChannelForHtmlRequest(
+            htmlRequestId,
+            sendToClient.bind(null, client)
+          )
+
+          const errorsRscStream =
+            errorsRscStreamsByHtmlRequestId.get(htmlRequestId)
+          if (errorsRscStream !== undefined) {
+            streamToUint8Array(errorsRscStream).then((serializedErrors) =>
+              sendToClient(client, {
+                type: HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER,
+                serializedErrors,
+              })
+            )
+            errorsRscStreamsByHtmlRequestId.delete(htmlRequestId)
+          }
         } else {
           clientsWithoutHtmlRequestId.add(client)
           onUpgrade(client, { isLegacyClient: true })
@@ -1099,13 +1121,6 @@ export async function createHotReloaderTurbopack(
           }
 
           sendToClient(client, syncMessage)
-
-          if (htmlRequestId) {
-            connectReactDebugChannelForHtmlRequest(
-              htmlRequestId,
-              sendToClient.bind(null, client)
-            )
-          }
         })()
       })
     },
@@ -1183,6 +1198,22 @@ export async function createHotReloaderTurbopack(
           debugChannel,
           sendToClient.bind(null, client)
         )
+      }
+    },
+
+    sendErrorsToBrowser(errorsRscStream, htmlRequestId) {
+      const client = clientsByHtmlRequestId.get(htmlRequestId)
+      if (client !== undefined) {
+        streamToUint8Array(errorsRscStream).then((serializedErrors) => {
+          sendToClient(client, {
+            type: HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER,
+            serializedErrors,
+          })
+        })
+      } else {
+        // If the client is not connected, store the errors stream so that we
+        // can send it when the client connects.
+        errorsRscStreamsByHtmlRequestId.set(htmlRequestId, errorsRscStream)
       }
     },
 

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -40,6 +40,7 @@ export const enum HMR_MESSAGE_SENT_TO_BROWSER {
 
   // Binary messages:
   REACT_DEBUG_CHUNK = 0,
+  ERRORS_TO_SHOW_IN_BROWSER = 1,
 }
 
 export const enum HMR_MESSAGE_SENT_TO_SERVER {
@@ -157,6 +158,11 @@ export interface ReactDebugChunkMessage {
   chunk: Uint8Array | null
 }
 
+export interface ErrorsToShowInBrowserMessage {
+  type: HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER
+  serializedErrors: Uint8Array
+}
+
 export interface RequestCurrentErrorStateMessage {
   type: HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_CURRENT_ERROR_STATE
   requestId: string
@@ -189,6 +195,7 @@ export type HmrMessageSentToBrowser =
   | ServerErrorMessage
   | AppIsrManifestMessage
   | DevToolsConfigMessage
+  | ErrorsToShowInBrowserMessage
   | ReactDebugChunkMessage
   | RequestCurrentErrorStateMessage
   | RequestPageMetadataMessage
@@ -234,6 +241,10 @@ export interface NextJsHotReloaderInterface {
     debugChannel: ReactDebugChannelForBrowser,
     htmlRequestId: string,
     requestId: string
+  ): void
+  sendErrorsToBrowser(
+    errorsRscStream: ReadableStream<Uint8Array>,
+    htmlRequestId: string
   ): void
   getCompilationErrors(page: string): Promise<any[]>
   onHMR(

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -115,7 +115,11 @@ import { recordMcpTelemetry } from '../mcp/mcp-telemetry-tracker'
 import { getFileLogger } from './browser-logs/file-logger'
 import type { ServerCacheStatus } from '../../next-devtools/dev-overlay/cache-indicator'
 import type { Lockfile } from '../../build/lockfile'
-import { streamToUint8Array } from '../stream-utils/node-web-streams-helper'
+import {
+  sendSerializedErrorsToClient,
+  sendSerializedErrorsToClientForHtmlRequest,
+  setErrorsRscStreamForHtmlRequest,
+} from './serialized-errors'
 
 const MILLISECONDS_IN_NANOSECOND = BigInt(1_000_000)
 
@@ -260,10 +264,6 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
   private reloadAfterInvalidation: boolean = false
   private isSrcDir: boolean
   private cacheStatusesByRequestId = new Map<string, ServerCacheStatus>()
-  private errorsRscStreamsByHtmlRequestId = new Map<
-    string,
-    ReadableStream<Uint8Array>
-  >()
 
   public serverStats: webpack.Stats | null
   public edgeServerStats: webpack.Stats | null
@@ -652,6 +652,11 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
           this.sendToClient.bind(this, client)
         )
 
+        sendSerializedErrorsToClientForHtmlRequest(
+          htmlRequestId,
+          this.sendToClient.bind(this, client)
+        )
+
         if (enableCacheComponents) {
           const status = this.cacheStatusesByRequestId.get(htmlRequestId)
           if (status) {
@@ -661,18 +666,6 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
             })
             this.cacheStatusesByRequestId.delete(htmlRequestId)
           }
-        }
-
-        const errorsRscStream =
-          this.errorsRscStreamsByHtmlRequestId.get(htmlRequestId)
-        if (errorsRscStream !== undefined) {
-          streamToUint8Array(errorsRscStream).then((serializedErrors) => {
-            this.sendToClient(client, {
-              type: HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER,
-              serializedErrors,
-            })
-          })
-          this.errorsRscStreamsByHtmlRequestId.delete(htmlRequestId)
         }
       }
 
@@ -1824,17 +1817,17 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
     htmlRequestId: string
   ): void {
     const client = this.webpackHotMiddleware?.getClient(htmlRequestId)
-    if (client !== undefined) {
-      streamToUint8Array(errorsRscStream).then((serializedErrors) => {
-        this.sendToClient(client, {
-          type: HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER,
-          serializedErrors,
-        })
-      })
+
+    if (client) {
+      // If the client is connected, we can send the errors immediately.
+      sendSerializedErrorsToClient(
+        errorsRscStream,
+        this.sendToClient.bind(this, client)
+      )
     } else {
-      // If the client is not connected, store the errors stream so that we can
-      // send it when the client connects.
-      this.errorsRscStreamsByHtmlRequestId.set(htmlRequestId, errorsRscStream)
+      // Otherwise, store the errors stream so that we can send it when the
+      // client connects.
+      setErrorsRscStreamForHtmlRequest(htmlRequestId, errorsRscStream)
     }
   }
 

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -115,6 +115,7 @@ import { recordMcpTelemetry } from '../mcp/mcp-telemetry-tracker'
 import { getFileLogger } from './browser-logs/file-logger'
 import type { ServerCacheStatus } from '../../next-devtools/dev-overlay/cache-indicator'
 import type { Lockfile } from '../../build/lockfile'
+import { streamToUint8Array } from '../stream-utils/node-web-streams-helper'
 
 const MILLISECONDS_IN_NANOSECOND = BigInt(1_000_000)
 
@@ -259,6 +260,10 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
   private reloadAfterInvalidation: boolean = false
   private isSrcDir: boolean
   private cacheStatusesByRequestId = new Map<string, ServerCacheStatus>()
+  private errorsRscStreamsByHtmlRequestId = new Map<
+    string,
+    ReadableStream<Uint8Array>
+  >()
 
   public serverStats: webpack.Stats | null
   public edgeServerStats: webpack.Stats | null
@@ -646,6 +651,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
           htmlRequestId,
           this.sendToClient.bind(this, client)
         )
+
         if (enableCacheComponents) {
           const status = this.cacheStatusesByRequestId.get(htmlRequestId)
           if (status) {
@@ -655,6 +661,18 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
             })
             this.cacheStatusesByRequestId.delete(htmlRequestId)
           }
+        }
+
+        const errorsRscStream =
+          this.errorsRscStreamsByHtmlRequestId.get(htmlRequestId)
+        if (errorsRscStream !== undefined) {
+          streamToUint8Array(errorsRscStream).then((serializedErrors) => {
+            this.sendToClient(client, {
+              type: HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER,
+              serializedErrors,
+            })
+          })
+          this.errorsRscStreamsByHtmlRequestId.delete(htmlRequestId)
         }
       }
 
@@ -1798,6 +1816,25 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
         debugChannel,
         this.sendToClient.bind(this, client)
       )
+    }
+  }
+
+  public sendErrorsToBrowser(
+    errorsRscStream: ReadableStream<Uint8Array>,
+    htmlRequestId: string
+  ): void {
+    const client = this.webpackHotMiddleware?.getClient(htmlRequestId)
+    if (client !== undefined) {
+      streamToUint8Array(errorsRscStream).then((serializedErrors) => {
+        this.sendToClient(client, {
+          type: HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER,
+          serializedErrors,
+        })
+      })
+    } else {
+      // If the client is not connected, store the errors stream so that we can
+      // send it when the client connects.
+      this.errorsRscStreamsByHtmlRequestId.set(htmlRequestId, errorsRscStream)
     }
   }
 

--- a/packages/next/src/server/dev/messages.ts
+++ b/packages/next/src/server/dev/messages.ts
@@ -13,6 +13,17 @@ export function createBinaryHmrMessageData(
   message: BinaryHmrMessageSentToBrowser
 ): Uint8Array {
   switch (message.type) {
+    case HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER: {
+      const { serializedErrors } = message
+      const totalLength = 1 + serializedErrors.length
+      const data = new Uint8Array(totalLength)
+      const view = new DataView(data.buffer)
+
+      view.setUint8(0, HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER)
+      data.set(serializedErrors, 1)
+
+      return data
+    }
     case HMR_MESSAGE_SENT_TO_BROWSER.REACT_DEBUG_CHUNK: {
       const { requestId, chunk } = message
       const requestIdBytes = textEncoder.encode(requestId)
@@ -41,7 +52,7 @@ export function createBinaryHmrMessageData(
     }
     default: {
       throw new InvariantError(
-        `Invalid binary HMR message of type ${message.type}`
+        `Invalid binary HMR message of type ${(message as any).type}`
       )
     }
   }

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -833,7 +833,7 @@ export default class DevServer extends Server {
             // Ideally, we would want to compare the whole objects, but that is too expensive.
             result.prerenderedRoutes?.length !== prerenderedRoutes?.length
           ) {
-            this.bundlerService.triggerHMR({
+            this.bundlerService.sendHmrMessage({
               type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
               hash: `generateStaticParams-${Date.now()}`,
             })

--- a/packages/next/src/server/dev/serialized-errors.ts
+++ b/packages/next/src/server/dev/serialized-errors.ts
@@ -1,0 +1,55 @@
+import { streamToUint8Array } from '../stream-utils/node-web-streams-helper'
+import {
+  HMR_MESSAGE_SENT_TO_BROWSER,
+  type HmrMessageSentToBrowser,
+} from './hot-reloader-types'
+
+const errorsRscStreamsByHtmlRequestId = new Map<
+  string,
+  ReadableStream<Uint8Array>
+>()
+
+export function sendSerializedErrorsToClient(
+  errorsRscStream: ReadableStream<Uint8Array>,
+  sendToClient: (message: HmrMessageSentToBrowser) => void
+) {
+  streamToUint8Array(errorsRscStream).then(
+    (serializedErrors) => {
+      sendToClient({
+        type: HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER,
+        serializedErrors,
+      })
+    },
+    (err) => {
+      console.error(new Error('Failed to serialize errors.', { cause: err }))
+    }
+  )
+}
+
+export function sendSerializedErrorsToClientForHtmlRequest(
+  htmlRequestId: string,
+  sendToClient: (message: HmrMessageSentToBrowser) => void
+) {
+  const errorsRscStream = errorsRscStreamsByHtmlRequestId.get(htmlRequestId)
+
+  if (!errorsRscStream) {
+    return
+  }
+
+  errorsRscStreamsByHtmlRequestId.delete(htmlRequestId)
+
+  sendSerializedErrorsToClient(errorsRscStream, sendToClient)
+}
+
+export function setErrorsRscStreamForHtmlRequest(
+  htmlRequestId: string,
+  errorsRscStream: ReadableStream<Uint8Array>
+) {
+  // TODO: Clean up after a timeout, in case the client never connects, e.g.
+  // when CURL'ing the page, or loading the page with JavaScript disabled etc.
+  errorsRscStreamsByHtmlRequestId.set(htmlRequestId, errorsRscStream)
+}
+
+export function deleteErrorsRscStreamForHtmlRequest(htmlRequestId: string) {
+  errorsRscStreamsByHtmlRequestId.delete(htmlRequestId)
+}

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -730,6 +730,8 @@ export async function initialize(opts: {
     setReactDebugChannel: config.experimental.reactDebugChannel
       ? devBundlerService?.setReactDebugChannel.bind(devBundlerService)
       : undefined,
+    sendErrorsToBrowser:
+      devBundlerService?.sendErrorsToBrowser.bind(devBundlerService),
   }
 
   const logError = async (

--- a/packages/next/src/server/lib/router-utils/router-server-context.ts
+++ b/packages/next/src/server/lib/router-utils/router-server-context.ts
@@ -45,6 +45,10 @@ export type RouterServerContext = Record<
       requestId: string
     ) => void
     setCacheStatus?: (status: ServerCacheStatus, htmlRequestId: string) => void
+    sendErrorsToBrowser?: (
+      errorsRscStream: ReadableStream<Uint8Array>,
+      htmlRequestId: string
+    ) => void
   }
 >
 

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -30,7 +30,6 @@ describe('Cache Components Dev Errors', () => {
        "stack": [
          "Page app/error/page.tsx (2:23)",
          "Page <anonymous>",
-         "ReportValidation <anonymous>",
        ],
      }
     `)
@@ -60,7 +59,6 @@ describe('Cache Components Dev Errors', () => {
        "stack": [
          "Page app/error/page.tsx (2:23)",
          "Page <anonymous>",
-         "ReportValidation <anonymous>",
        ],
      }
     `)
@@ -118,7 +116,6 @@ describe('Cache Components Dev Errors', () => {
          |         ^",
        "stack": [
          "Page app/no-accessed-data/page.js (2:9)",
-         "ReportValidation <anonymous>",
        ],
      }
     `)

--- a/test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts
+++ b/test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts
@@ -74,7 +74,6 @@ describe('Cache Components Fallback Validation', () => {
            |                          ^",
          "stack": [
            "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -103,7 +102,6 @@ describe('Cache Components Fallback Validation', () => {
            |                          ^",
          "stack": [
            "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -135,7 +133,6 @@ describe('Cache Components Fallback Validation', () => {
            |                          ^",
          "stack": [
            "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -164,7 +161,6 @@ describe('Cache Components Fallback Validation', () => {
            |                          ^",
          "stack": [
            "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -196,7 +192,6 @@ describe('Cache Components Fallback Validation', () => {
            |                          ^",
          "stack": [
            "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -225,7 +220,6 @@ describe('Cache Components Fallback Validation', () => {
            |                          ^",
          "stack": [
            "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -261,7 +255,6 @@ describe('Cache Components Fallback Validation', () => {
             |   ^",
          "stack": [
            "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -290,7 +283,6 @@ describe('Cache Components Fallback Validation', () => {
             |   ^",
          "stack": [
            "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -322,7 +314,6 @@ describe('Cache Components Fallback Validation', () => {
             |   ^",
          "stack": [
            "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -351,7 +342,6 @@ describe('Cache Components Fallback Validation', () => {
             |   ^",
          "stack": [
            "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -383,7 +373,6 @@ describe('Cache Components Fallback Validation', () => {
             |   ^",
          "stack": [
            "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -412,7 +401,6 @@ describe('Cache Components Fallback Validation', () => {
             |   ^",
          "stack": [
            "Layout app/none/[top]/wrapped/layout.tsx (10:3)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -444,7 +432,6 @@ describe('Cache Components Fallback Validation', () => {
             |   ^",
          "stack": [
            "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -473,7 +460,6 @@ describe('Cache Components Fallback Validation', () => {
             |   ^",
          "stack": [
            "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -505,7 +491,6 @@ describe('Cache Components Fallback Validation', () => {
             |   ^",
          "stack": [
            "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -534,7 +519,6 @@ describe('Cache Components Fallback Validation', () => {
             |   ^",
          "stack": [
            "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -566,7 +550,6 @@ describe('Cache Components Fallback Validation', () => {
             |   ^",
          "stack": [
            "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)
@@ -595,7 +578,6 @@ describe('Cache Components Fallback Validation', () => {
             |   ^",
          "stack": [
            "Layout app/none/[top]/unwrapped/layout.tsx (8:3)",
-           "ReportValidation <anonymous>",
          ],
        }
       `)

--- a/test/development/app-dir/react-performance-track/react-performance-track.test.ts
+++ b/test/development/app-dir/react-performance-track/react-performance-track.test.ts
@@ -112,12 +112,7 @@ describe('react-performance-track', () => {
 
     const track = await browser.eval('window.reactServerRequests.getSnapshot()')
     // TODO: Should include "draftMode [Prefetchable]".
-    expect(track).toEqual([
-      {
-        name: '\u200b',
-        properties: [],
-      },
-    ])
+    expect(track).toEqual([])
   })
 
   it('should show headers', async () => {

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -107,7 +107,6 @@ describe('Cache Components Errors', () => {
                |         ^",
              "stack": [
                "Module.generateMetadata app/dynamic-metadata-static-route/page.tsx (2:9)",
-               "ReportValidation <anonymous>",
              ],
            }
           `)
@@ -174,7 +173,6 @@ describe('Cache Components Errors', () => {
              "stack": [
                "Dynamic app/dynamic-metadata-error-route/page.tsx (21:9)",
                "Page app/dynamic-metadata-error-route/page.tsx (15:7)",
-               "ReportValidation <anonymous>",
              ],
            }
           `)
@@ -298,7 +296,6 @@ describe('Cache Components Errors', () => {
                |         ^",
              "stack": [
                "Module.generateMetadata app/dynamic-metadata-static-with-suspense/page.tsx (2:9)",
-               "ReportValidation <anonymous>",
              ],
            }
           `)
@@ -389,7 +386,6 @@ describe('Cache Components Errors', () => {
                |         ^",
              "stack": [
                "Module.generateViewport app/dynamic-viewport-static-route/page.tsx (2:9)",
-               "ReportValidation <anonymous>",
              ],
            }
           `)
@@ -455,7 +451,6 @@ describe('Cache Components Errors', () => {
                |         ^",
              "stack": [
                "Module.generateViewport app/dynamic-viewport-dynamic-route/page.tsx (4:9)",
-               "ReportValidation <anonymous>",
              ],
            }
           `)
@@ -543,7 +538,6 @@ describe('Cache Components Errors', () => {
                  "fetchRandom app/dynamic-root/page.tsx (63:26)",
                  "FetchingComponent app/dynamic-root/page.tsx (46:50)",
                  "Page app/dynamic-root/page.tsx (23:9)",
-                 "ReportValidation <anonymous>",
                ],
              },
              {
@@ -569,7 +563,6 @@ describe('Cache Components Errors', () => {
                  "fetchRandom app/dynamic-root/page.tsx (63:26)",
                  "FetchingComponent app/dynamic-root/page.tsx (46:50)",
                  "Page app/dynamic-root/page.tsx (28:7)",
-                 "ReportValidation <anonymous>",
                ],
              },
            ]
@@ -779,7 +772,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "RandomReadingComponent app/sync-random-with-fallback/page.tsx (37:23)",
                  "Page app/sync-random-with-fallback/page.tsx (18:11)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -890,7 +882,6 @@ describe('Cache Components Errors', () => {
                  "getRandomNumber app/sync-random-without-fallback/page.tsx (32:15)",
                  "RandomReadingComponent app/sync-random-without-fallback/page.tsx (40:18)",
                  "Page app/sync-random-without-fallback/page.tsx (18:11)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -1793,7 +1784,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIO app/sync-attribution/guarded-async-unguarded-clientsync/client.tsx (5:16)",
                  "Page app/sync-attribution/guarded-async-unguarded-clientsync/page.tsx (22:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -1917,7 +1907,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "RequestData app/sync-attribution/unguarded-async-guarded-clientsync/page.tsx (34:18)",
                  "Page app/sync-attribution/unguarded-async-guarded-clientsync/page.tsx (27:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -2058,7 +2047,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIO app/sync-attribution/unguarded-async-unguarded-clientsync/client.tsx (5:16)",
                  "Page app/sync-attribution/unguarded-async-unguarded-clientsync/page.tsx (22:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -2686,7 +2674,6 @@ describe('Cache Components Errors', () => {
                "source": null,
                "stack": [
                  "Page [Prerender] <anonymous>",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -3093,7 +3080,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "Private app/use-cache-private-without-suspense/page.tsx (15:1)",
                  "Page app/use-cache-private-without-suspense/page.tsx (10:7)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -3253,7 +3239,6 @@ describe('Cache Components Errors', () => {
              "stack": [
                "DateReadingComponent app/sync-io-current-time/date/page.tsx (19:16)",
                "Page app/sync-io-current-time/date/page.tsx (11:9)",
-               "ReportValidation <anonymous>",
              ],
            }
           `)
@@ -3356,7 +3341,6 @@ describe('Cache Components Errors', () => {
              "stack": [
                "DateReadingComponent app/sync-io-current-time/date-now/page.tsx (19:21)",
                "Page app/sync-io-current-time/date-now/page.tsx (11:9)",
-               "ReportValidation <anonymous>",
              ],
            }
           `)
@@ -3459,7 +3443,6 @@ describe('Cache Components Errors', () => {
              "stack": [
                "DateReadingComponent app/sync-io-current-time/new-date/page.tsx (19:16)",
                "Page app/sync-io-current-time/new-date/page.tsx (11:9)",
-               "ReportValidation <anonymous>",
              ],
            }
           `)
@@ -3562,7 +3545,6 @@ describe('Cache Components Errors', () => {
              "stack": [
                "SyncIOComponent app/sync-io-random/math-random/page.tsx (19:21)",
                "Page app/sync-io-random/math-random/page.tsx (11:9)",
-               "ReportValidation <anonymous>",
              ],
            }
           `)
@@ -3665,7 +3647,6 @@ describe('Cache Components Errors', () => {
              "stack": [
                "SyncIOComponent app/sync-io-web-crypto/get-random-value/page.tsx (20:10)",
                "Page app/sync-io-web-crypto/get-random-value/page.tsx (11:9)",
-               "ReportValidation <anonymous>",
              ],
            }
           `)
@@ -3771,7 +3752,6 @@ describe('Cache Components Errors', () => {
              "stack": [
                "SyncIOComponent app/sync-io-web-crypto/random-uuid/page.tsx (19:23)",
                "Page app/sync-io-web-crypto/random-uuid/page.tsx (11:9)",
-               "ReportValidation <anonymous>",
              ],
            }
           `)
@@ -3875,7 +3855,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/generate-key-pair-sync/page.tsx (20:24)",
                  "Page app/sync-io-node-crypto/generate-key-pair-sync/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -3891,7 +3870,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/generate-key-pair-sync/page.tsx (20:17)",
                  "Page app/sync-io-node-crypto/generate-key-pair-sync/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -3999,7 +3977,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/generate-key-sync/page.tsx (21:6)",
                  "Page app/sync-io-node-crypto/generate-key-sync/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4015,7 +3992,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/generate-key-sync/page.tsx (20:17)",
                  "Page app/sync-io-node-crypto/generate-key-sync/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4123,7 +4099,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/generate-prime-sync/page.tsx (20:39)",
                  "Page app/sync-io-node-crypto/generate-prime-sync/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4139,7 +4114,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/generate-prime-sync/page.tsx (20:32)",
                  "Page app/sync-io-node-crypto/generate-prime-sync/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4247,7 +4221,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/get-random-values/page.tsx (21:10)",
                  "Page app/sync-io-node-crypto/get-random-values/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4263,7 +4236,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/get-random-values/page.tsx (21:3)",
                  "Page app/sync-io-node-crypto/get-random-values/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4371,7 +4343,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/random-bytes/page.tsx (20:24)",
                  "Page app/sync-io-node-crypto/random-bytes/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4387,7 +4358,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/random-bytes/page.tsx (20:17)",
                  "Page app/sync-io-node-crypto/random-bytes/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4495,7 +4465,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/random-fill-sync/page.tsx (21:10)",
                  "Page app/sync-io-node-crypto/random-fill-sync/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4511,7 +4480,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/random-fill-sync/page.tsx (21:3)",
                  "Page app/sync-io-node-crypto/random-fill-sync/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4619,7 +4587,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/random-int-between/page.tsx (20:24)",
                  "Page app/sync-io-node-crypto/random-int-between/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4635,7 +4602,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/random-int-between/page.tsx (20:17)",
                  "Page app/sync-io-node-crypto/random-int-between/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4743,7 +4709,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/random-int-up-to/page.tsx (20:24)",
                  "Page app/sync-io-node-crypto/random-int-up-to/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4759,7 +4724,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/random-int-up-to/page.tsx (20:17)",
                  "Page app/sync-io-node-crypto/random-int-up-to/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4867,7 +4831,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/random-uuid/page.tsx (20:24)",
                  "Page app/sync-io-node-crypto/random-uuid/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)
@@ -4883,7 +4846,6 @@ describe('Cache Components Errors', () => {
                "stack": [
                  "SyncIOComponent app/sync-io-node-crypto/random-uuid/page.tsx (20:17)",
                  "Page app/sync-io-node-crypto/random-uuid/page.tsx (12:9)",
-                 "ReportValidation <anonymous>",
                ],
              }
             `)


### PR DESCRIPTION
By sending the dynamic validation errors to the browser via WebSocket, instead of rendering a validation outlet into the dynamic dev render stream, we can avoid artificially delaying the spawned validation to implicitly wait for the different chunks (static, runtime, and dynamic), without blocking the dev render stream, and instead wait explicitly for all chunks to accumulate.

Previously, we were using React's console replaying to get full fidelity error stacks in the browser (including inspectable virtual server modules). Now, we're using the same underlying mechanism by sending a separate RSC stream through the WebSocket that contains only the errors. In the browser, the received errors are then logged with `console.error`, which also triggers that they're displayed in a collapsed Redbox, as was the case before with the replaying.