### PR TITLE
Turbopack: store frequently used entries separately in database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9135,6 +9135,7 @@ name = "turbo-persistence"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitfield",
  "byteorder",
  "dashmap 6.1.0",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4513,6 +4513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9130,10 +9136,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
+ "dashmap 6.1.0",
  "either",
  "jiff",
  "lzzzz",
  "memmap2 0.9.5",
+ "nohash-hasher",
  "parking_lot",
  "pot",
  "qfilter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -422,6 +422,7 @@ napi = { version = "2", default-features = false, features = [
   "napi5",
   "compat-mode",
 ] }
+nohash-hasher = "0.2.0"
 notify = "8.1.0"
 once_cell = "1.17.1"
 owo-colors = "4.2.2"

--- a/turbopack/crates/turbo-persistence-tools/src/main.rs
+++ b/turbopack/crates/turbo-persistence-tools/src/main.rs
@@ -34,14 +34,14 @@ fn main() -> Result<()> {
             amqf_size,
             amqf_entries,
             sst_size,
-            cold,
+            flags,
             key_compression_dictionary_size,
             block_count,
         } in meta_file.entries
         {
             println!(
-                "  {} SST {sequence_number:08}.sst: {min_hash:016x} - {max_hash:016x} (p = 1/{})",
-                if cold { "COLD" } else { "HOT" },
+                "  SST {sequence_number:08}.sst: {} {min_hash:016x} - {max_hash:016x} (p = 1/{})",
+                flags,
                 u64::MAX / (max_hash - min_hash + 1)
             );
             println!("    AMQF {amqf_entries} entries = {} KiB", amqf_size / 1024);

--- a/turbopack/crates/turbo-persistence-tools/src/main.rs
+++ b/turbopack/crates/turbo-persistence-tools/src/main.rs
@@ -34,12 +34,14 @@ fn main() -> Result<()> {
             amqf_size,
             amqf_entries,
             sst_size,
+            cold,
             key_compression_dictionary_size,
             block_count,
         } in meta_file.entries
         {
             println!(
-                "  SST {sequence_number:08}.sst: {min_hash:016x} - {max_hash:016x} (p = 1/{})",
+                "  {} SST {sequence_number:08}.sst: {min_hash:016x} - {max_hash:016x} (p = 1/{})",
+                if cold { "COLD" } else { "HOT" },
                 u64::MAX / (max_hash - min_hash + 1)
             );
             println!("    AMQF {amqf_entries} entries = {} KiB", amqf_size / 1024);

--- a/turbopack/crates/turbo-persistence-tools/src/main.rs
+++ b/turbopack/crates/turbo-persistence-tools/src/main.rs
@@ -16,7 +16,7 @@ fn main() -> Result<()> {
         bail!("The provided path does not exist: {}", path.display());
     }
 
-    let db: TurboPersistence<SerialScheduler> = TurboPersistence::open_read_only(path)?;
+    let db: TurboPersistence<SerialScheduler, 0> = TurboPersistence::open_read_only(path)?;
     let meta_info = db
         .meta_info()
         .context("Failed to retrieve meta information")?;

--- a/turbopack/crates/turbo-persistence-tools/src/main.rs
+++ b/turbopack/crates/turbo-persistence-tools/src/main.rs
@@ -40,8 +40,8 @@ fn main() -> Result<()> {
         } in meta_file.entries
         {
             println!(
-                "  SST {sequence_number:08}.sst: {} {min_hash:016x} - {max_hash:016x} (p = 1/{})",
-                flags,
+                "  SST {sequence_number:08}.sst: {flags} {min_hash:016x} - {max_hash:016x} (p = \
+                 1/{})",
                 u64::MAX / (max_hash - min_hash + 1)
             );
             println!("    AMQF {amqf_entries} entries = {} KiB", amqf_size / 1024);

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -14,6 +14,7 @@ verbose_log = []
 
 [dependencies]
 anyhow = { workspace = true }
+bitfield = { workspace = true }
 dashmap = { workspace = true}
 either = { workspace = true }
 pot = "3.0.0"

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -14,12 +14,14 @@ verbose_log = []
 
 [dependencies]
 anyhow = { workspace = true }
+dashmap = { workspace = true}
 either = { workspace = true }
 pot = "3.0.0"
 byteorder = { workspace = true }
 jiff = "0.2.10"
 lzzzz = "1.1.0"
 memmap2 = "0.9.5"
+nohash-hasher = { workspace = true }
 parking_lot = { workspace = true }
 qfilter = { version = "0.2.4", features = ["serde"] }
 quick_cache = { workspace = true }

--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -50,8 +50,10 @@ A meta file can contain metadata about multiple SST files. The metadata is store
     - 8 bytes max hash
     - 8 bytes SST file size
     - 4 bytes end of AMQF offset relative to start of all AMQF data
+  - 4 bytes end of AMQF offset relative to start of all AMQF data of the "used key hashes" AMQF
 - foreach described SST file
   - serialized AMQF
+- serialized "used key hashes" AMQF
 
 ### SST file
 

--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -49,6 +49,7 @@ A meta file can contain metadata about multiple SST files. The metadata is store
     - 8 bytes min hash
     - 8 bytes max hash
     - 8 bytes SST file size
+    - 4 bytes flags (bit 0: cold)
     - 4 bytes end of AMQF offset relative to start of all AMQF data
   - 4 bytes end of AMQF offset relative to start of all AMQF data of the "used key hashes" AMQF
 - foreach described SST file
@@ -171,7 +172,7 @@ Compaction chooses a few SST files and runs the merge step of merge sort on tham
 
 Example:
 
-```
+``` text
 key hash range: | 0    ...    u64::MAX |
 SST 1:             |----------------|
 SST 2:                |----------------|
@@ -180,7 +181,7 @@ SST 3:            |-----|
 
 can be compacted into:
 
-```
+``` text
 key hash range: | 0    ...    u64::MAX |
 SST 1':           |-------|
 SST 2':                   |------|
@@ -208,7 +209,7 @@ Full example:
 
 Example:
 
-```
+``` text
 key hash range: | 0    ...    u64::MAX | Family
 SST 1:             |-|                   1
 SST 2:             |----------------|    1
@@ -236,7 +237,7 @@ Then we delete SST files 2, 3, 6 and 4, 5, 8 and 7, 9. The
 
 SST files 1 stays unchanged.
 
-```
+``` text
 key hash range: | 0    ...    u64::MAX | Family
 SST 1:             |-|                   1
 SST 10:            |-----|               1

--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -49,7 +49,9 @@ A meta file can contain metadata about multiple SST files. The metadata is store
     - 8 bytes min hash
     - 8 bytes max hash
     - 8 bytes SST file size
-    - 4 bytes flags (bit 0: cold)
+    - 4 bytes flags
+      - bit 0: cold (compacted and not recently accessed)
+      - bit 1: fresh (not yet compacted)
     - 4 bytes end of AMQF offset relative to start of all AMQF data
   - 4 bytes end of AMQF offset relative to start of all AMQF data of the "used key hashes" AMQF
 - foreach described SST file

--- a/turbopack/crates/turbo-persistence/src/compaction/selector.rs
+++ b/turbopack/crates/turbo-persistence/src/compaction/selector.rs
@@ -37,6 +37,7 @@ fn extend_range(a: &mut RangeInclusive<u64>, b: &RangeInclusive<u64>) -> bool {
     extended
 }
 
+#[cfg(test)]
 #[derive(Debug)]
 pub struct CompactableMetrics {
     /// The total coverage of the compactables.
@@ -53,6 +54,7 @@ pub struct CompactableMetrics {
 }
 
 /// Computes metrics about the compactables.
+#[cfg(test)]
 pub fn compute_metrics<T: Compactable>(
     compactables: &[T],
     full_range: RangeInclusive<u64>,
@@ -167,6 +169,7 @@ impl DuplicationInfo {
     }
 
     /// The estimated size (in bytes) of a database segment containing `range` keys.
+    #[cfg(test)]
     fn size(&self, range: &RangeInclusive<u64>) -> u64 {
         if self.total_size == 0 {
             return 0;
@@ -633,13 +636,16 @@ mod tests {
 
                 let new_metrics = compute_metrics(&containers, 0..=KEY_RANGE);
                 println!(
-                    "Compaction done: coverage: {} ({}), overlap: {} ({}), duplication: {} ({})",
+                    "Compaction done: coverage: {} ({}), overlap: {} ({}), duplication: {} ({}), \
+                     duplicated_size: {} ({})",
                     new_metrics.coverage,
                     new_metrics.coverage - metrics.coverage,
                     new_metrics.overlap,
                     new_metrics.overlap - metrics.overlap,
                     new_metrics.duplication,
-                    new_metrics.duplication - metrics.duplication
+                    new_metrics.duplication - metrics.duplication,
+                    new_metrics.duplicated_size,
+                    (new_metrics.duplicated_size as f32) - metrics.duplicated_size as f32,
                 );
             } else {
                 println!("No compaction needed");

--- a/turbopack/crates/turbo-persistence/src/compression.rs
+++ b/turbopack/crates/turbo-persistence/src/compression.rs
@@ -3,7 +3,6 @@ use std::{mem::MaybeUninit, sync::Arc};
 use anyhow::{Context, Result};
 use lzzzz::lz4::{ACC_LEVEL_DEFAULT, decompress, decompress_with_dict};
 
-#[tracing::instrument(level = "trace", skip_all, name = "decompress database block")]
 pub fn decompress_into_arc(
     uncompressed_length: u32,
     block: &[u8],

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -846,6 +846,8 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             }
 
             fn category(&self) -> u8 {
+                // Cold and non-cold files are placed separately so we pass different category
+                // values to ensure they are not merged together.
                 if self.flags.cold() { 1 } else { 0 }
             }
         }
@@ -1335,6 +1337,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     /// Get a value from the database. Returns None if the key is not found. The returned value
     /// might hold onto a block of the database and it should not be hold long-term.
     pub fn get<K: QueryKey>(&self, family: usize, key: &K) -> Result<Option<ArcSlice<u8>>> {
+        debug_assert!(family < FAMILIES, "Family index out of bounds");
         let hash = hash_key(key);
         let inner = self.inner.read();
         for meta in inner.meta_files.iter().rev() {

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -470,7 +470,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             let set = &inner.accessed_key_hashes[family as usize];
             // len is only a snapshot at that time and it can change while we create the filter.
             // So we give it 5% more space to make resizes less likely.
-            let initial_capacity = set.len() * 19 / 20;
+            let initial_capacity = set.len() * 20 / 19;
             let mut amqf =
                 qfilter::Filter::with_fingerprint_size(initial_capacity as u64, u64::BITS as u8)
                     .unwrap();

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1102,6 +1102,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                             collector.entries.push(current);
                                         } else {
                                             // Override value
+                                            // TODO delete blob file
                                         }
                                     }
                                     current = Some(entry);

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -833,6 +833,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             seq: u32,
             range: StaticSortedFileRange,
             size: u64,
+            flags: MetaEntryFlags,
         }
 
         impl Compactable for SstWithRange {
@@ -842,6 +843,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
             fn size(&self) -> u64 {
                 self.size
+            }
+
+            fn category(&self) -> u8 {
+                if self.flags.cold() { 1 } else { 0 }
             }
         }
 
@@ -858,6 +863,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                         seq: entry.sequence_number(),
                         range: entry.range(),
                         size: entry.size(),
+                        flags: entry.flags(),
                     })
             })
             .collect::<Vec<_>>();

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1045,9 +1045,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     // Remove duplicates
                                     if let Some(current) = current.take() {
                                         if current.key != entry.key {
-                                            let is_used = used_key_hashes[family as usize]
-                                                .iter()
-                                                .any(|amqf| amqf.contains(current.hash));
+                                            let is_used =
+                                                used_key_hashes[family as usize].iter().any(
+                                                    |amqf| amqf.contains_fingerprint(current.hash),
+                                                );
                                             let collector = if is_used {
                                                 &mut used_collector
                                             } else {
@@ -1104,7 +1105,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                 if let Some(entry) = current {
                                     let is_used = used_key_hashes[family as usize]
                                         .iter()
-                                        .any(|amqf| amqf.contains(entry.hash));
+                                        .any(|amqf| amqf.contains_fingerprint(entry.hash));
                                     let collector = if is_used {
                                         &mut used_collector
                                     } else {

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -183,6 +183,12 @@ pub struct MetaFile {
     obsolete_entries: Vec<u32>,
     /// The obsolete SST files.
     obsolete_sst_files: Vec<u32>,
+    /// The offset of the start of the "used keys" AMQF data in the meta file relative to the end
+    /// of the header.
+    start_of_used_keys_amqf_data_offset: u32,
+    /// The offset of the end of the "used keys" AMQF data in the the meta file relative to the end
+    /// of the header.
+    end_of_used_keys_amqf_data_offset: u32,
     /// The memory mapped file.
     mmap: Mmap,
 }
@@ -232,6 +238,9 @@ impl MetaFile {
             start_of_amqf_data_offset = entry.end_of_amqf_data_offset;
             entries.push(entry);
         }
+        let start_of_used_keys_amqf_data_offset = start_of_amqf_data_offset;
+        let end_of_used_keys_amqf_data_offset = file.read_u32::<BE>()?;
+
         let offset = file.stream_position()?;
         let file = file.into_inner();
         let mut options = MmapOptions::new();
@@ -246,6 +255,8 @@ impl MetaFile {
             entries,
             obsolete_entries: Vec::new(),
             obsolete_sst_files,
+            start_of_used_keys_amqf_data_offset,
+            end_of_used_keys_amqf_data_offset,
             mmap,
         };
         Ok(file)

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -283,6 +283,20 @@ impl MetaFile {
         &self.mmap
     }
 
+    pub fn deserialize_used_key_hashes_amqf(&self) -> Result<Option<qfilter::Filter>> {
+        if self.start_of_used_keys_amqf_data_offset == self.end_of_used_keys_amqf_data_offset {
+            return Ok(None);
+        }
+        let amqf = &self.amqf_data()[self.start_of_used_keys_amqf_data_offset as usize
+            ..self.end_of_used_keys_amqf_data_offset as usize];
+        Ok(Some(pot::from_slice(amqf).with_context(|| {
+            format!(
+                "Failed to deserialize used key hashes AMQF from {:08}.meta",
+                self.sequence_number
+            )
+        })?))
+    }
+
     pub fn retain_entries(&mut self, mut predicate: impl FnMut(u32) -> bool) -> bool {
         let old_len = self.entries.len();
         self.entries.retain(|entry| {

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -42,6 +42,8 @@ pub struct MetaEntry {
     max_hash: u64,
     /// The size of the SST file in bytes.
     size: u64,
+    /// If the file is cold or warm.
+    cold: bool,
     /// The offset of the start of the AMQF data in the meta file relative to the end of the
     /// header.
     start_of_amqf_data_offset: u32,
@@ -62,6 +64,10 @@ impl MetaEntry {
 
     pub fn size(&self) -> u64 {
         self.size
+    }
+
+    pub fn cold(&self) -> bool {
+        self.cold
     }
 
     pub fn amqf_size(&self) -> u32 {
@@ -230,6 +236,7 @@ impl MetaFile {
                 min_hash: file.read_u64::<BE>()?,
                 max_hash: file.read_u64::<BE>()?,
                 size: file.read_u64::<BE>()?,
+                cold: file.read_u32::<BE>()? != 0,
                 start_of_amqf_data_offset,
                 end_of_amqf_data_offset: file.read_u32::<BE>()?,
                 amqf: OnceLock::new(),

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -53,11 +53,11 @@ impl MetaEntryFlags {
 impl Display for MetaEntryFlags {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.fresh() {
-            write!(f, "fresh")
+            f.pad_integral(true, "", "fresh")
         } else if self.cold() {
-            write!(f, "cold")
+            f.pad_integral(true, "", "cold")
         } else {
-            write!(f, "warm")
+            f.pad_integral(true, "", "warm")
         }
     }
 }

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -70,6 +70,7 @@ impl<'a> MetaFileBuilder<'a> {
             file.write_u64::<BE>(sst.min_hash)?;
             file.write_u64::<BE>(sst.max_hash)?;
             file.write_u64::<BE>(sst.size)?;
+            file.write_u32::<BE>(if sst.cold { 1 } else { 0 })?;
             amqf_offset += sst.amqf.len();
             file.write_u32::<BE>(amqf_offset as u32)?;
         }

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -70,7 +70,7 @@ impl<'a> MetaFileBuilder<'a> {
             file.write_u64::<BE>(sst.min_hash)?;
             file.write_u64::<BE>(sst.max_hash)?;
             file.write_u64::<BE>(sst.size)?;
-            file.write_u32::<BE>(if sst.cold { 1 } else { 0 })?;
+            file.write_u32::<BE>(sst.flags.0)?;
             amqf_offset += sst.amqf.len();
             file.write_u32::<BE>(amqf_offset as u32)?;
         }

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use byteorder::{BE, WriteBytesExt};
+use qfilter::Filter;
 
 use crate::static_sorted_file_builder::StaticSortedFileBuilderMeta;
 
@@ -15,6 +16,8 @@ pub struct MetaFileBuilder<'a> {
     entries: Vec<(u32, StaticSortedFileBuilderMeta<'a>)>,
     /// Obsolete SST files, represented by their sequence numbers
     obsolete_sst_files: Vec<u32>,
+    /// Optional AMQF for used key hashes
+    used_key_hashes_amqf: Option<Filter>,
 }
 
 impl<'a> MetaFileBuilder<'a> {
@@ -23,6 +26,7 @@ impl<'a> MetaFileBuilder<'a> {
             family,
             entries: Vec::new(),
             obsolete_sst_files: Vec::new(),
+            used_key_hashes_amqf: None,
         }
     }
 
@@ -32,6 +36,10 @@ impl<'a> MetaFileBuilder<'a> {
 
     pub fn add_obsolete_sst_file(&mut self, sequence_number: u32) {
         self.obsolete_sst_files.push(sequence_number);
+    }
+
+    pub fn set_used_key_hashes_amqf(&mut self, amqf: Filter) {
+        self.used_key_hashes_amqf = Some(amqf);
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
@@ -65,9 +73,21 @@ impl<'a> MetaFileBuilder<'a> {
             amqf_offset += sst.amqf.len();
             file.write_u32::<BE>(amqf_offset as u32)?;
         }
+        let serialized_used_key_hashes = self
+            .used_key_hashes_amqf
+            .as_ref()
+            .map(|f| pot::to_vec(f).expect("AMQF serialization failed"));
+        amqf_offset += serialized_used_key_hashes
+            .as_ref()
+            .map(|bytes| bytes.len())
+            .unwrap_or(0);
+        file.write_u32::<BE>(amqf_offset as u32)?;
 
         for (_, sst) in &self.entries {
             file.write_all(&sst.amqf)?;
+        }
+        if let Some(bytes) = &serialized_used_key_hashes {
+            file.write_all(bytes)?;
         }
         Ok(file.into_inner()?)
     }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -88,6 +88,8 @@ pub struct StaticSortedFileBuilderMeta<'a> {
     pub block_count: u16,
     /// The file size of the SST file
     pub size: u64,
+    /// If the file is cold or warm
+    pub cold: bool,
     /// The number of entries in the SST file
     pub entries: u64,
 }
@@ -96,6 +98,7 @@ pub fn write_static_stored_file<E: Entry>(
     entries: &[E],
     total_key_size: usize,
     file: &Path,
+    cold: bool,
 ) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
     debug_assert!(entries.iter().map(|e| e.key_hash()).is_sorted());
 
@@ -141,6 +144,7 @@ pub fn write_static_stored_file<E: Entry>(
         key_compression_dictionary_length: key_dict.len().try_into().unwrap(),
         block_count,
         size: file.stream_position()?,
+        cold,
         entries: entries.len() as u64,
     };
     Ok((meta, file.into_inner()?))

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -11,6 +11,7 @@ use byteorder::{BE, ByteOrder, WriteBytesExt};
 
 use crate::{
     compression::compress_into_buffer,
+    meta_file::MetaEntryFlags,
     static_sorted_file::{
         BLOCK_TYPE_INDEX, BLOCK_TYPE_KEY, KEY_BLOCK_ENTRY_TYPE_BLOB, KEY_BLOCK_ENTRY_TYPE_DELETED,
         KEY_BLOCK_ENTRY_TYPE_MEDIUM, KEY_BLOCK_ENTRY_TYPE_SMALL,
@@ -88,8 +89,8 @@ pub struct StaticSortedFileBuilderMeta<'a> {
     pub block_count: u16,
     /// The file size of the SST file
     pub size: u64,
-    /// If the file is cold or warm
-    pub cold: bool,
+    /// The status flags for this SST file
+    pub flags: MetaEntryFlags,
     /// The number of entries in the SST file
     pub entries: u64,
 }
@@ -98,7 +99,7 @@ pub fn write_static_stored_file<E: Entry>(
     entries: &[E],
     total_key_size: usize,
     file: &Path,
-    cold: bool,
+    flags: MetaEntryFlags,
 ) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
     debug_assert!(entries.iter().map(|e| e.key_hash()).is_sorted());
 
@@ -144,7 +145,7 @@ pub fn write_static_stored_file<E: Entry>(
         key_compression_dictionary_length: key_dict.len().try_into().unwrap(),
         block_count,
         size: file.stream_position()?,
-        cold,
+        flags,
         entries: entries.len() as u64,
     };
     Ok((meta, file.into_inner()?))

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -420,7 +420,7 @@ impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
         let path = self.db_path.join(format!("{seq:08}.sst"));
         let (meta, file) = self
             .parallel_scheduler
-            .block_in_place(|| write_static_stored_file(entries, total_key_size, &path))
+            .block_in_place(|| write_static_stored_file(entries, total_key_size, &path, true))
             .with_context(|| format!("Unable to write SST file {seq:08}.sst"))?;
 
         #[cfg(feature = "verify_sst_content")]

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -21,6 +21,7 @@ use crate::{
     compression::compress_into_buffer,
     constants::{MAX_MEDIUM_VALUE_SIZE, THREAD_LOCAL_SIZE_SHIFT},
     key::StoreKey,
+    meta_file::MetaEntryFlags,
     meta_file_builder::MetaFileBuilder,
     parallel_scheduler::ParallelScheduler,
     static_sorted_file_builder::{StaticSortedFileBuilderMeta, write_static_stored_file},
@@ -420,7 +421,9 @@ impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
         let path = self.db_path.join(format!("{seq:08}.sst"));
         let (meta, file) = self
             .parallel_scheduler
-            .block_in_place(|| write_static_stored_file(entries, total_key_size, &path, true))
+            .block_in_place(|| {
+                write_static_stored_file(entries, total_key_size, &path, MetaEntryFlags::FRESH)
+            })
             .with_context(|| format!("Unable to write SST file {seq:08}.sst"))?;
 
         #[cfg(feature = "verify_sst_content")]

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -21,6 +21,9 @@ use crate::database::{
 
 mod parallel_scheduler;
 
+/// Number of key families, see KeySpace enum for their numbers.
+const FAMILIES: usize = 5;
+
 const MB: u64 = 1024 * 1024;
 const COMPACT_CONFIG: CompactConfig = CompactConfig {
     min_merge_count: 3,
@@ -33,7 +36,7 @@ const COMPACT_CONFIG: CompactConfig = CompactConfig {
 };
 
 pub struct TurboKeyValueDatabase {
-    db: Arc<TurboPersistence<TurboTasksParallelScheduler>>,
+    db: Arc<TurboPersistence<TurboTasksParallelScheduler, FAMILIES>>,
     compact_join_handle: Mutex<Option<JoinHandle<Result<()>>>>,
     is_ci: bool,
     is_short_session: bool,
@@ -129,7 +132,7 @@ impl KeyValueDatabase for TurboKeyValueDatabase {
 }
 
 fn do_compact(
-    db: &TurboPersistence<TurboTasksParallelScheduler>,
+    db: &TurboPersistence<TurboTasksParallelScheduler, FAMILIES>,
     message: &'static str,
     max_merge_segment_count: usize,
 ) -> Result<()> {
@@ -151,8 +154,9 @@ fn do_compact(
 }
 
 pub struct TurboWriteBatch<'a> {
-    batch: turbo_persistence::WriteBatch<WriteBuffer<'static>, TurboTasksParallelScheduler, 5>,
-    db: &'a Arc<TurboPersistence<TurboTasksParallelScheduler>>,
+    batch:
+        turbo_persistence::WriteBatch<WriteBuffer<'static>, TurboTasksParallelScheduler, FAMILIES>,
+    db: &'a Arc<TurboPersistence<TurboTasksParallelScheduler, FAMILIES>>,
     compact_join_handle: Option<&'a Mutex<Option<JoinHandle<Result<()>>>>>,
 }
 


### PR DESCRIPTION
### What?

* capture used key hashes and store them in the meta file
* During compaction separate used and unused entries

This eventually leads to a state where frequently used entries are stored in separate files, which makes it faster to restore. This improves db restore performance after a few runs. 