### PR TITLE
Turbopack: chore: Update anyhow, remove old backtrace feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,12 +244,9 @@ checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-dependencies = [
- "backtrace",
-]
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "approx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -371,7 +371,7 @@ tungstenite = "0.20.1"
 allsorts = { version = "0.14.0", default-features = false, features = [
   "flate2_rust",
 ] }
-anyhow = "1.0.98"
+anyhow = "1.0.100"
 async-compression = { version = "0.3.13", default-features = false, features = [
   "gzip",
   "tokio",

--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true, features = ["backtrace"] }
+anyhow = { workspace = true }
 byteorder = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1533,10 +1533,8 @@ pub async fn rebase(
         let base_path = [&old_base.path, "/"].concat();
         if !fs_path.path.starts_with(&base_path) {
             bail!(
-                "rebasing {} from {} onto {} doesn't work because it's not part of the source path",
-                fs_path.to_string(),
-                old_base.to_string(),
-                new_base.to_string()
+                "rebasing {fs_path} from {old_base} onto {new_base} doesn't work because it's not \
+                 part of the source path",
             );
         }
         if new_base.path.is_empty() {

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -124,7 +124,7 @@ async fn resolve_symlink_safely(entry: DirectoryEntry) -> Result<DirectoryEntry>
         if source_path.is_inside_or_equal(&resolved_entry.clone().path().unwrap()) {
             bail!(
                 "'{}' is a symlink causes that causes an infinite loop!",
-                source_path.path.to_string()
+                source_path.path,
             )
         }
     }

--- a/turbopack/crates/turbopack-bench/Cargo.toml
+++ b/turbopack/crates/turbopack-bench/Cargo.toml
@@ -17,7 +17,7 @@ harness = false
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true, features = ["backtrace"] }
+anyhow = { workspace = true }
 chromiumoxide = { workspace = true, features = [
   "tokio-runtime",
 ], default-features = false }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -84,11 +84,7 @@ impl EcmascriptBrowserChunkContent {
                 let chunk_server_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
                     path
                 } else {
-                    bail!(
-                        "chunk path {} is not in output root {}",
-                        chunk_path.to_string(),
-                        output_root.to_string()
-                    );
+                    bail!("chunk path {chunk_path} is not in output root {output_root}");
                 };
                 Either::Left(StringifyJs(chunk_server_path))
             }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -99,11 +99,7 @@ impl EcmascriptBrowserEvaluateChunk {
                 let chunk_server_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
                     path
                 } else {
-                    bail!(
-                        "chunk path {} is not in output root {}",
-                        chunk_path.to_string(),
-                        output_root.to_string()
-                    );
+                    bail!("chunk path {chunk_path} is not in output root {output_root}");
                 };
                 Either::Left(StringifyJs(chunk_server_path))
             }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
@@ -27,11 +27,7 @@ impl EcmascriptBrowserChunkVersion {
         let chunk_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path
         } else {
-            bail!(
-                "chunk path {} is not in client root {}",
-                chunk_path.to_string(),
-                output_root.to_string()
-            );
+            bail!("chunk path {chunk_path} is not in client root {output_root}");
         };
         let entries = EcmascriptBrowserChunkContentEntries::new(content).await?;
         let mut entries_hashes =

--- a/turbopack/crates/turbopack-cli/Cargo.toml
+++ b/turbopack/crates/turbopack-cli/Cargo.toml
@@ -37,7 +37,7 @@ custom_allocator = ["turbo-tasks-malloc/custom_allocator"]
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true, features = ["backtrace"] }
+anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 console-subscriber = { workspace = true, optional = true }
 dunce = { workspace = true }

--- a/turbopack/crates/turbopack-nft/Cargo.toml
+++ b/turbopack/crates/turbopack-nft/Cargo.toml
@@ -18,7 +18,7 @@ bench = false
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true, features = ["backtrace"] }
+anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 console-subscriber = { workspace = true, optional = true }
 rustc-hash = { workspace = true }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -69,19 +69,14 @@ impl EcmascriptBuildNodeEntryChunk {
                 path
             } else {
                 bail!(
-                    "cannot find a relative path from the chunk ({}) to the runtime chunk ({})",
-                    chunk_path.to_string(),
-                    runtime_path.to_string(),
+                    "cannot find a relative path from the chunk ({chunk_path}) to the runtime \
+                     chunk ({runtime_path})",
                 );
             };
         let chunk_public_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path
         } else {
-            bail!(
-                "chunk path ({}) is not in output root ({})",
-                chunk_path.to_string(),
-                output_root.to_string()
-            );
+            bail!("chunk path ({chunk_path}) is not in output root ({output_root})");
         };
 
         let mut code = CodeBuilder::default();

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -46,11 +46,7 @@ impl EcmascriptBuildNodeRuntimeChunk {
         let runtime_public_path = if let Some(path) = output_root.get_path_to(&runtime_path) {
             path
         } else {
-            bail!(
-                "runtime path {} is not in output root {}",
-                runtime_path.to_string(),
-                output_root.to_string()
-            );
+            bail!("runtime path {runtime_path} is not in output root {output_root}");
         };
 
         let mut code = CodeBuilder::default();

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
@@ -27,11 +27,7 @@ impl EcmascriptBuildNodeChunkVersion {
         let chunk_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path
         } else {
-            bail!(
-                "chunk path {} is not in client root {}",
-                chunk_path.to_string(),
-                output_root.to_string()
-            );
+            bail!("chunk path {chunk_path} is not in client root {output_root}");
         };
         let chunk_items = content.await?.chunk_item_code_and_ids().await?;
         Ok(EcmascriptBuildNodeChunkVersion {

--- a/turbopack/crates/turbopack-trace-server/Cargo.toml
+++ b/turbopack/crates/turbopack-trace-server/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 bench = false
 
 [dependencies]
-anyhow = { workspace = true, features = ["backtrace"] }
+anyhow = { workspace = true }
 either = { workspace = true }
 flate2 = { workspace = true }
 hashbrown = { workspace = true, features = ["raw"] }


### PR DESCRIPTION
- `anyhow` now causes `cargo clippy` to warn about `.to_string()` in `bail!(...)` calls. I also inlined most of these format string variables while I was at it. https://github.com/dtolnay/anyhow/pull/426
- The `backtrace` feature isn't needed (and is a no-op) since Rust 1.65. https://github.com/dtolnay/anyhow/blob/master/Cargo.toml#L19-L22

