### PR TITLE
Honour `NEXT_TEST_PREFER_OFFLINE` in `install-native.mjs`

### DIFF
--- a/scripts/install-native.mjs
+++ b/scripts/install-native.mjs
@@ -10,6 +10,9 @@ import fsp from 'fs/promises'
     )
     return
   }
+
+  const preferOffline = process.env.NEXT_TEST_PREFER_OFFLINE === '1'
+
   let cwd = process.cwd()
   const { version: nextVersion } = JSON.parse(
     fs.readFileSync(path.join(cwd, 'packages', 'next', 'package.json'))
@@ -57,9 +60,11 @@ import fsp from 'fs/promises'
     fs.writeFileSync(path.join(tmpdir, 'package.json'), JSON.stringify(pkgJson))
     fs.writeFileSync(path.join(tmpdir, '.npmrc'), 'node-linker=hoisted')
 
-    let { stdout } = await execa('pnpm', ['add', `next@${nextVersion}`], {
-      cwd: tmpdir,
-    })
+    const args = ['add', `next@${nextVersion}`]
+    if (preferOffline) {
+      args.push('--prefer-offline')
+    }
+    let { stdout } = await execa('pnpm', args, { cwd: tmpdir })
     console.log(stdout)
 
     let pkgs = fs.readdirSync(path.join(tmpdir, 'node_modules/@next'))


### PR DESCRIPTION
The `scripts/install-native.mjs` script is run in the postinstall step of the Next.js monorepo to install the published binary packages of the latest Next.js canary version. This change makes the script respect the `NEXT_TEST_PREFER_OFFLINE` environment variable, allowing it to prefer installing previously downloaded packages from the local cache. This is useful for scenarios where network access is limited or unavailable.