### PR TITLE
Turbopack: remove duplicate traversal implementations

### DIFF
--- a/crates/next-api/src/analyze.rs
+++ b/crates/next-api/src/analyze.rs
@@ -419,10 +419,10 @@ pub async fn analyze_module_graphs(module_graphs: Vc<ModuleGraphs>) -> Result<Vc
         module_graph.traverse_all_edges_unordered(|(parent_node, reference), node| {
             match reference.chunking_type {
                 ChunkingType::Async => {
-                    all_async_edges.insert((parent_node.module, node.module));
+                    all_async_edges.insert((parent_node, node));
                 }
                 _ => {
-                    all_edges.insert((parent_node.module, node.module));
+                    all_edges.insert((parent_node, node));
                 }
             }
             Ok(())

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -34,9 +34,7 @@ pub async fn map_client_references(
     let graph = graph.await?;
     let manifest = graph
         .iter_nodes()
-        .map(|node| async move {
-            let module = node.module;
-
+        .map(|module| async move {
             if let Some(client_reference_module) =
                 ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module)
             {

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -135,20 +135,20 @@ pub async fn map_next_dynamic(graph: Vc<SingleModuleGraph>) -> Result<Vc<Dynamic
                 .as_ref()
                 .is_some_and(|layer| layer.name() == "app-client" || layer.name() == "client")
                 && let Some(dynamic_entry_module) =
-                    ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(*module)
+                    ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(module)
             {
                 return Ok(Some((
-                    *module,
+                    module,
                     DynamicImportEntriesMapType::DynamicEntry(dynamic_entry_module),
                 )));
             }
             // TODO add this check once these modules have the correct layer
             // if layer.is_some_and(|layer| &**layer == "app-rsc") {
             if let Some(client_reference_module) =
-                ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(*module)
+                ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module)
             {
                 return Ok(Some((
-                    *module,
+                    module,
                     DynamicImportEntriesMapType::ClientReference(client_reference_module),
                 )));
             }

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -35,7 +35,7 @@ use turbopack_core::{
         availability_info::AvailabilityInfo,
     },
     module::Module,
-    module_graph::{ModuleGraph, SingleModuleGraph, SingleModuleGraphModuleNode},
+    module_graph::{ModuleGraph, SingleModuleGraph},
     output::OutputAssets,
 };
 
@@ -125,9 +125,7 @@ pub async fn map_next_dynamic(graph: Vc<SingleModuleGraph>) -> Result<Vc<Dynamic
     let actions = graph
         .await?
         .iter_nodes()
-        .map(|node| async move {
-            let SingleModuleGraphModuleNode { module } = node;
-
+        .map(|module| async move {
             if module
                 .ident()
                 .await?

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -74,7 +74,7 @@ impl NextDynamicGraph {
         let span = tracing::info_span!("collect next/dynamic imports for endpoint");
         async move {
             let data = &*self.data.await?;
-            let graph = &*self.graph.await?;
+            let graph = self.graph.await?;
 
             #[derive(Clone, PartialEq, Eq)]
             enum VisitState {
@@ -96,48 +96,56 @@ impl NextDynamicGraph {
 
             // module -> the client reference entry (if any)
             let mut state_map = FxHashMap::default();
-            graph.traverse_edges_from_entries(entries, |parent_info, node| {
-                let module = node.module;
-                let Some((parent_node, _)) = parent_info else {
-                    state_map.insert(module, VisitState::Entry);
-                    return GraphTraversalAction::Continue;
-                };
-                let parent_module = parent_node.module;
-
-                let module_type = data.get(&module);
-                let parent_state = state_map.get(&parent_module).unwrap().clone();
-                let parent_client_reference =
-                    if let Some(DynamicImportEntriesMapType::ClientReference(module)) = module_type
-                    {
-                        Some(ClientReferenceType::EcmascriptClientReference(*module))
-                    } else if let VisitState::InClientReference(ty) = parent_state {
-                        Some(ty)
-                    } else {
-                        None
+            graph.read().traverse_edges_from_entries_dfs(
+                entries,
+                &mut (),
+                |parent_info, node, _| {
+                    let module = node.module;
+                    let Some((parent_node, _)) = parent_info else {
+                        state_map.insert(module, VisitState::Entry);
+                        return Ok(GraphTraversalAction::Continue);
                     };
+                    let parent_module = parent_node.module;
 
-                match module_type {
-                    Some(DynamicImportEntriesMapType::DynamicEntry(dynamic_entry)) => {
-                        result.push((*dynamic_entry, parent_client_reference));
+                    let module_type = data.get(&module);
+                    let parent_state = state_map.get(&parent_module).unwrap().clone();
+                    let parent_client_reference =
+                        if let Some(DynamicImportEntriesMapType::ClientReference(module)) =
+                            module_type
+                        {
+                            Some(ClientReferenceType::EcmascriptClientReference(*module))
+                        } else if let VisitState::InClientReference(ty) = parent_state {
+                            Some(ty)
+                        } else {
+                            None
+                        };
 
-                        state_map.insert(module, parent_state);
-                        GraphTraversalAction::Skip
-                    }
-                    Some(DynamicImportEntriesMapType::ClientReference(client_reference)) => {
-                        state_map.insert(
-                            module,
-                            VisitState::InClientReference(
-                                ClientReferenceType::EcmascriptClientReference(*client_reference),
-                            ),
-                        );
-                        GraphTraversalAction::Continue
-                    }
-                    None => {
-                        state_map.insert(module, parent_state);
-                        GraphTraversalAction::Continue
-                    }
-                }
-            })?;
+                    Ok(match module_type {
+                        Some(DynamicImportEntriesMapType::DynamicEntry(dynamic_entry)) => {
+                            result.push((*dynamic_entry, parent_client_reference));
+
+                            state_map.insert(module, parent_state);
+                            GraphTraversalAction::Skip
+                        }
+                        Some(DynamicImportEntriesMapType::ClientReference(client_reference)) => {
+                            state_map.insert(
+                                module,
+                                VisitState::InClientReference(
+                                    ClientReferenceType::EcmascriptClientReference(
+                                        *client_reference,
+                                    ),
+                                ),
+                            );
+                            GraphTraversalAction::Continue
+                        }
+                        None => {
+                            state_map.insert(module, parent_state);
+                            GraphTraversalAction::Continue
+                        }
+                    })
+                },
+                |_, _, _| Ok(()),
+            )?;
             Ok(Vc::cell(result))
         }
         .instrument(span)
@@ -184,7 +192,7 @@ impl ServerActionsGraph {
                 Cow::Borrowed(data)
             } else {
                 // The graph contains the whole app, traverse and collect all reachable imports.
-                let graph = &*self.graph.await?;
+                let graph = self.graph.await?;
 
                 if !graph.has_entry_module(entry) {
                     // the graph doesn't contain the entry, e.g. for the additional module graph
@@ -192,11 +200,17 @@ impl ServerActionsGraph {
                 }
 
                 let mut result = FxIndexMap::default();
-                graph.traverse_from_entry(entry, |node| {
-                    if let Some(node_data) = data.get(&node.module) {
-                        result.insert(node.module, *node_data);
-                    }
-                })?;
+                graph.read().traverse_nodes_from_entries_dfs(
+                    vec![entry],
+                    &mut result,
+                    |node, result| {
+                        if let Some(node_data) = data.get(&node.module) {
+                            result.insert(node.module, *node_data);
+                        }
+                        Ok(GraphTraversalAction::Continue)
+                    },
+                    |_, _| Ok(()),
+                )?;
                 Cow::Owned(result)
             };
 
@@ -274,7 +288,7 @@ impl ClientReferencesGraph {
         let span = tracing::info_span!("collect client references for endpoint");
         async move {
             let data = &*self.data.await?;
-            let graph = &*self.graph.await?;
+            let graph = self.graph.await?;
 
             let entries = if !self.is_single_page {
                 if !graph.has_entry_module(entry) {
@@ -293,8 +307,9 @@ impl ClientReferencesGraph {
 
             let mut server_components = FxIndexSet::default();
 
+            let graph = graph.read();
             // Perform a DFS traversal to find all server components included by this page.
-            graph.traverse_nodes_from_entries(
+            graph.traverse_nodes_from_entries_dfs(
                 entries,
                 &mut (),
                 |node, _| {
@@ -350,7 +365,7 @@ impl ClientReferencesGraph {
             // necessarily rendered at the same time (not-found, or parallel routes), we need to
             // determine the order of client references individually for each server component.
             for sc in server_components.iter().copied() {
-                graph.traverse_nodes_from_entries(
+                graph.traverse_nodes_from_entries_dfs(
                     std::iter::once(ResolvedVc::upcast(sc)),
                     &mut (),
                     |node, _| {
@@ -506,7 +521,7 @@ async fn validate_pages_css_imports(
     entry: Vc<Box<dyn Module>>,
     app_module: ResolvedVc<Box<dyn Module>>,
 ) -> Result<()> {
-    let graph = &*graph.await?;
+    let graph = graph.await?;
     let entry = entry.to_resolved().await?;
 
     let entries = if !is_single_page {
@@ -521,47 +536,52 @@ async fn validate_pages_css_imports(
 
     let mut candidates = vec![];
 
-    graph.traverse_edges_from_entries(entries, |parent_info, node| {
-        let module = node.module;
+    graph.read().traverse_edges_from_entries_dfs(
+        entries,
+        &mut (),
+        |parent_info, node, _| {
+            let module = node.module;
 
-        // If we're at a root node, there is nothing importing this module and we can skip
-        // any further validations.
-        let Some((parent_node, _)) = parent_info else {
-            return GraphTraversalAction::Continue;
-        };
-        let parent_module = parent_node.module;
+            // If we're at a root node, there is nothing importing this module and we can skip
+            // any further validations.
+            let Some((parent_node, _)) = parent_info else {
+                return Ok(GraphTraversalAction::Continue);
+            };
+            let parent_module = parent_node.module;
 
-        // Importing CSS from _app.js is always allowed.
-        if parent_module == app_module {
-            return GraphTraversalAction::Continue;
-        }
+            // Importing CSS from _app.js is always allowed.
+            if parent_module == app_module {
+                return Ok(GraphTraversalAction::Continue);
+            }
 
-        // If the module being imported isn't a global css module, there is nothing to validate.
-        let module_is_global_css =
-            ResolvedVc::try_downcast_type::<CssModuleAsset>(module).is_some();
+            // If the module being imported isn't a global css module, there is nothing to validate.
+            let module_is_global_css =
+                ResolvedVc::try_downcast_type::<CssModuleAsset>(module).is_some();
 
-        if !module_is_global_css {
-            return GraphTraversalAction::Continue;
-        }
+            if !module_is_global_css {
+                return Ok(GraphTraversalAction::Continue);
+            }
 
-        let parent_is_css_module = ResolvedVc::try_downcast_type::<ModuleCssAsset>(parent_module)
-            .is_some()
-            || ResolvedVc::try_downcast_type::<CssModuleAsset>(parent_module).is_some();
+            let parent_is_css_module =
+                ResolvedVc::try_downcast_type::<ModuleCssAsset>(parent_module).is_some()
+                    || ResolvedVc::try_downcast_type::<CssModuleAsset>(parent_module).is_some();
 
-        // We also always allow .module css/scss/sass files to import global css files as well.
-        if parent_is_css_module {
-            return GraphTraversalAction::Continue;
-        }
+            // We also always allow .module css/scss/sass files to import global css files as well.
+            if parent_is_css_module {
+                return Ok(GraphTraversalAction::Continue);
+            }
 
-        // If all of the above invariants have been checked, we look to see if the parent module is
-        // the same as the app module. If it isn't we know it isn't a valid place to import global
-        // css.
-        if parent_module != app_module {
-            candidates.push(CssGlobalImportIssue::new(parent_module, module))
-        }
+            // If all of the above invariants have been checked, we look to see if the parent module
+            // is the same as the app module. If it isn't we know it isn't a valid place
+            // to import global css.
+            if parent_module != app_module {
+                candidates.push(CssGlobalImportIssue::new(parent_module, module))
+            }
 
-        GraphTraversalAction::Continue
-    })?;
+            Ok(GraphTraversalAction::Continue)
+        },
+        |_, _, _| Ok(()),
+    )?;
 
     candidates
         .into_iter()

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -100,12 +100,12 @@ impl NextDynamicGraph {
                 entries,
                 &mut (),
                 |parent_info, node, _| {
-                    let module = node.module;
+                    let module = node;
                     let Some((parent_node, _)) = parent_info else {
                         state_map.insert(module, VisitState::Entry);
                         return Ok(GraphTraversalAction::Continue);
                     };
-                    let parent_module = parent_node.module;
+                    let parent_module = parent_node;
 
                     let module_type = data.get(&module);
                     let parent_state = state_map.get(&parent_module).unwrap().clone();
@@ -204,8 +204,8 @@ impl ServerActionsGraph {
                     vec![entry],
                     &mut result,
                     |node, result| {
-                        if let Some(node_data) = data.get(&node.module) {
-                            result.insert(node.module, *node_data);
+                        if let Some(node_data) = data.get(&node) {
+                            result.insert(node, *node_data);
                         }
                         Ok(GraphTraversalAction::Continue)
                     },
@@ -313,7 +313,7 @@ impl ClientReferencesGraph {
                 entries,
                 &mut (),
                 |node, _| {
-                    let module_type = data.get(&node.module);
+                    let module_type = data.get(&node);
                     Ok(match module_type {
                         Some(
                             ClientManifestEntryType::EcmascriptClientReference { .. }
@@ -325,14 +325,14 @@ impl ClientReferencesGraph {
                 },
                 |node, _| {
                     if let Some(server_util_module) =
-                        ResolvedVc::try_downcast_type::<NextServerUtilityModule>(node.module)
+                        ResolvedVc::try_downcast_type::<NextServerUtilityModule>(node)
                     {
                         // Server utility used by the template, not a server component
                         server_utils.insert(server_util_module);
                         return Ok(());
                     }
 
-                    let module_type = data.get(&node.module);
+                    let module_type = data.get(&node);
 
                     let ty = match module_type {
                         Some(ClientManifestEntryType::EcmascriptClientReference {
@@ -369,7 +369,7 @@ impl ClientReferencesGraph {
                     std::iter::once(ResolvedVc::upcast(sc)),
                     &mut (),
                     |node, _| {
-                        let module = node.module;
+                        let module = node;
                         let module_type = data.get(&module);
 
                         Ok(match module_type {
@@ -381,7 +381,7 @@ impl ClientReferencesGraph {
                         })
                     },
                     |node, _| {
-                        let module = node.module;
+                        let module = node;
                         if let Some(server_util_module) =
                             ResolvedVc::try_downcast_type::<NextServerUtilityModule>(module)
                         {
@@ -540,14 +540,14 @@ async fn validate_pages_css_imports(
         entries,
         &mut (),
         |parent_info, node, _| {
-            let module = node.module;
+            let module = node;
 
             // If we're at a root node, there is nothing importing this module and we can skip
             // any further validations.
             let Some((parent_node, _)) = parent_info else {
                 return Ok(GraphTraversalAction::Continue);
             };
-            let parent_module = parent_node.module;
+            let parent_module = parent_node;
 
             // Importing CSS from _app.js is always allowed.
             if parent_module == app_module {

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -30,10 +30,7 @@ use turbopack_core::{
     file_source::FileSource,
     ident::AssetIdent,
     module::Module,
-    module_graph::{
-        ModuleGraph, SingleModuleGraph, SingleModuleGraphModuleNode,
-        async_module_info::AsyncModulesInfo,
-    },
+    module_graph::{ModuleGraph, SingleModuleGraph, async_module_info::AsyncModulesInfo},
     output::OutputAsset,
     reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
     resolve::ModulePart,
@@ -454,24 +451,21 @@ pub async fn map_server_actions(graph: Vc<SingleModuleGraph>) -> Result<Vc<AllMo
     let actions = graph
         .await?
         .iter_nodes()
-        .map(|node| {
-            async move {
-                let SingleModuleGraphModuleNode { module } = node;
-                // TODO: compare module contexts instead?
-                let layer = match module.ident().await?.layer.as_ref() {
-                    Some(layer) if layer.name() == "app-rsc" || layer.name() == "app-edge-rsc" => {
-                        ActionLayer::Rsc
-                    }
-                    Some(layer) if layer.name() == "app-client" => ActionLayer::ActionBrowser,
-                    // TODO really ignore SSR?
-                    _ => return Ok(None),
-                };
-                // TODO the old implementation did parse_actions(to_rsc_context(module))
-                // is that really necessary?
-                Ok(parse_actions(*module)
-                    .await?
-                    .map(|action_map| (module, (layer, action_map))))
-            }
+        .map(async |module| {
+            // TODO: compare module contexts instead?
+            let layer = match module.ident().await?.layer.as_ref() {
+                Some(layer) if layer.name() == "app-rsc" || layer.name() == "app-edge-rsc" => {
+                    ActionLayer::Rsc
+                }
+                Some(layer) if layer.name() == "app-client" => ActionLayer::ActionBrowser,
+                // TODO really ignore SSR?
+                _ => return Ok(None),
+            };
+            // TODO the old implementation did parse_actions(to_rsc_context(module))
+            // is that really necessary?
+            Ok(parse_actions(*module)
+                .await?
+                .map(|action_map| (module, (layer, action_map))))
         })
         .try_flat_join()
         .await?;

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -468,9 +468,9 @@ pub async fn map_server_actions(graph: Vc<SingleModuleGraph>) -> Result<Vc<AllMo
                 };
                 // TODO the old implementation did parse_actions(to_rsc_context(module))
                 // is that really necessary?
-                Ok(parse_actions(**module)
+                Ok(parse_actions(*module)
                     .await?
-                    .map(|action_map| (*module, (layer, action_map))))
+                    .map(|action_map| (module, (layer, action_map))))
             }
         })
         .try_flat_join()

--- a/crates/next-api/src/webpack_stats.rs
+++ b/crates/next-api/src/webpack_stats.rs
@@ -60,9 +60,9 @@ where
         let mut edges = vec![];
         module_graph.traverse_all_edges_unordered(|(parent_node, r), current| {
             edges.push((
-                parent_node.module,
+                parent_node,
                 RcStr::from(format!("{}: {}", r.chunking_type, r.export)),
-                current.module,
+                current,
             ));
             Ok(())
         })?;

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -83,8 +83,6 @@ async fn compute_async_module_info_single(
                 // An entry module
                 return Ok(());
             };
-            let module = module.module;
-            let parent_module = parent_module.module;
 
             if ref_data.chunking_type.is_inherit_async() && async_modules.contains(&module) {
                 async_modules.insert(parent_module);

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -57,7 +57,7 @@ async fn compute_async_module_info_single(
 
     let self_async_modules = graph
         .iter_nodes()
-        .map(async |node| Ok((node.module, *node.module.is_self_async().await?)))
+        .map(async |node| Ok((node, *node.is_self_async().await?)))
         .try_join()
         .await?
         .into_iter()
@@ -94,13 +94,8 @@ async fn compute_async_module_info_single(
     graph_ref.traverse_cycles(
         |ref_data| ref_data.chunking_type.is_inherit_async(),
         |cycle| {
-            if cycle
-                .iter()
-                .any(|node| async_modules.contains(&node.module))
-            {
-                for &node in cycle {
-                    async_modules.insert(node.module);
-                }
+            if cycle.iter().any(|node| async_modules.contains(node)) {
+                async_modules.extend(cycle.iter().map(|n| **n));
             }
             Ok(())
         },

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -73,7 +73,8 @@ async fn compute_async_module_info_single(
     // modules in the SCC is async.
 
     let mut async_modules = self_async_modules;
-    graph.traverse_edges_from_entries_dfs(
+    let graph_ref = graph.read();
+    graph_ref.traverse_edges_from_entries_dfs(
         graph.entry_modules(),
         &mut (),
         |_, _, _| Ok(GraphTraversalAction::Continue),
@@ -82,7 +83,7 @@ async fn compute_async_module_info_single(
                 // An entry module
                 return Ok(());
             };
-            let module = module.module();
+            let module = module.module;
             let parent_module = parent_module.module;
 
             if ref_data.chunking_type.is_inherit_async() && async_modules.contains(&module) {
@@ -92,7 +93,7 @@ async fn compute_async_module_info_single(
         },
     )?;
 
-    graph.traverse_cycles(
+    graph_ref.traverse_cycles(
         |ref_data| ref_data.chunking_type.is_inherit_async(),
         |cycle| {
             if cycle
@@ -103,8 +104,9 @@ async fn compute_async_module_info_single(
                     async_modules.insert(node.module);
                 }
             }
+            Ok(())
         },
-    );
+    )?;
 
     Ok(Vc::cell(async_modules))
 }

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -507,8 +507,8 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraphRef) -> Result<Vc<Chunk
                 })
                 .collect::<Result<Vec<_>>>()?,
             &mut module_chunk_groups,
-            |parent_info: Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
-             node: &'_ SingleModuleGraphModuleNode,
+            |parent_info: Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
+             node: SingleModuleGraphModuleNode,
              module_chunk_groups: &mut FxHashMap<
                 ResolvedVc<Box<dyn Module>>,
                 RoaringBitmapWrapper,

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -19,7 +19,7 @@ use turbo_tasks::{
 use crate::{
     chunk::ChunkingType,
     module::Module,
-    module_graph::{GraphTraversalAction, ModuleGraphRef, RefData, SingleModuleGraphModuleNode},
+    module_graph::{GraphTraversalAction, ModuleGraphRef, RefData},
 };
 
 #[derive(
@@ -412,14 +412,14 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraphRef) -> Result<Vc<Chunk
                 |parent, node| {
                     if let Some((parent, _)) = parent {
                         let parent_depth = *module_depth
-                            .get(&parent.module)
+                            .get(&parent)
                             .context("Module depth not found")?;
-                        module_depth.entry(node.module).or_insert(parent_depth + 1);
+                        module_depth.entry(node).or_insert(parent_depth + 1);
                     } else {
-                        module_depth.insert(node.module, 0);
+                        module_depth.insert(node, 0);
                     };
 
-                    module_chunk_groups.insert(node.module, RoaringBitmapWrapper::default());
+                    module_chunk_groups.insert(node, RoaringBitmapWrapper::default());
 
                     Ok(GraphTraversalAction::Continue)
                 },
@@ -507,8 +507,8 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraphRef) -> Result<Vc<Chunk
                 })
                 .collect::<Result<Vec<_>>>()?,
             &mut module_chunk_groups,
-            |parent_info: Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
-             node: SingleModuleGraphModuleNode,
+            |parent_info: Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
+             node: ResolvedVc<Box<dyn Module>>,
              module_chunk_groups: &mut FxHashMap<
                 ResolvedVc<Box<dyn Module>>,
                 RoaringBitmapWrapper,
@@ -520,28 +520,26 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraphRef) -> Result<Vc<Chunk
                 }
                 let chunk_groups = if let Some((parent, ref_data)) = parent_info {
                     match &ref_data.chunking_type {
-                        ChunkingType::Parallel { .. } => {
-                            ChunkGroupInheritance::Inherit(parent.module)
-                        }
+                        ChunkingType::Parallel { .. } => ChunkGroupInheritance::Inherit(parent),
                         ChunkingType::Async => ChunkGroupInheritance::ChunkGroup(Either::Left(
-                            std::iter::once(ChunkGroupKey::Async(node.module)),
+                            std::iter::once(ChunkGroupKey::Async(node)),
                         )),
                         ChunkingType::Isolated {
                             merge_tag: None, ..
                         } => ChunkGroupInheritance::ChunkGroup(Either::Left(std::iter::once(
-                            ChunkGroupKey::Isolated(node.module),
+                            ChunkGroupKey::Isolated(node),
                         ))),
                         ChunkingType::Shared {
                             merge_tag: None, ..
                         } => ChunkGroupInheritance::ChunkGroup(Either::Left(std::iter::once(
-                            ChunkGroupKey::Shared(node.module),
+                            ChunkGroupKey::Shared(node),
                         ))),
                         ChunkingType::Isolated {
                             merge_tag: Some(merge_tag),
                             ..
                         } => {
                             let parents = module_chunk_groups
-                                .get(&parent.module)
+                                .get(&parent)
                                 .context("Module chunk group not found")?;
                             let chunk_groups =
                                 parents.iter().map(|parent| ChunkGroupKey::IsolatedMerged {
@@ -557,7 +555,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraphRef) -> Result<Vc<Chunk
                             ..
                         } => {
                             let parents = module_chunk_groups
-                                .get(&parent.module)
+                                .get(&parent)
                                 .context("Module chunk group not found")?;
                             let chunk_groups =
                                 parents.iter().map(|parent| ChunkGroupKey::SharedMerged {
@@ -577,7 +575,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraphRef) -> Result<Vc<Chunk
                     ChunkGroupInheritance::ChunkGroup(Either::Left(std::iter::once(
                         // TODO remove clone
                         entry_chunk_group_keys
-                            .get(&node.module)
+                            .get(&node)
                             .context("Module chunk group not found")?
                             .clone(),
                     )))
@@ -597,7 +595,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraphRef) -> Result<Vc<Chunk
                                 Entry::Occupied(mut e) => {
                                     let (id, merged_entries) = e.get_mut();
                                     if is_merged {
-                                        merged_entries.insert(node.module);
+                                        merged_entries.insert(node);
                                     }
                                     **id
                                 }
@@ -605,7 +603,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraphRef) -> Result<Vc<Chunk
                                     let chunk_group_id = len as u32;
                                     let mut set = FxIndexSet::default();
                                     if is_merged {
-                                        set.insert(node.module);
+                                        set.insert(node);
                                     }
                                     e.insert((ChunkGroupId(chunk_group_id), set));
                                     chunk_group_id
@@ -618,7 +616,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraphRef) -> Result<Vc<Chunk
 
                         // Assign chunk group to the target node (the entry of the chunk group)
                         let bitset = module_chunk_groups
-                            .get_mut(&node.module)
+                            .get_mut(&node)
                             .context("Module chunk group not found")?;
                         if chunk_groups.is_proper_superset(bitset) {
                             // Add bits from parent, and continue traversal because changed
@@ -634,12 +632,12 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraphRef) -> Result<Vc<Chunk
                         // Inherit chunk groups from parent, merge parent chunk groups into
                         // current
 
-                        if parent == node.module {
+                        if parent == node {
                             // A self-reference
                             GraphTraversalAction::Skip
                         } else {
                             let [Some(parent_chunk_groups), Some(current_chunk_groups)] =
-                                module_chunk_groups.get_disjoint_mut([&parent, &node.module])
+                                module_chunk_groups.get_disjoint_mut([&parent, &node])
                             else {
                                 // All modules are inserted in the previous iteration
                                 // Technically unreachable, but could be reached due to eventual
@@ -673,10 +671,10 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraphRef) -> Result<Vc<Chunk
             |successor, module_chunk_groups| {
                 Ok(TraversalPriority {
                     depth: *module_depth
-                        .get(&successor.module)
+                        .get(&successor)
                         .context("Module depth not found")?,
                     chunk_group_len: module_chunk_groups
-                        .get(&successor.module)
+                        .get(&successor)
                         .context("Module chunk group not found")?
                         .len(),
                 })

--- a/turbopack/crates/turbopack-core/src/module_graph/export_usage.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/export_usage.rs
@@ -15,7 +15,7 @@ pub async fn compute_export_usage_info(
     let mut used_exports = FxHashMap::<_, ModuleExportUsageInfo>::default();
     let graph = graph.read_graphs().await?;
     graph.traverse_all_edges_unordered(|(_, ref_data), target| {
-        let e = used_exports.entry(target.module).or_default();
+        let e = used_exports.entry(target).or_default();
 
         e.add(&ref_data.export);
 

--- a/turbopack/crates/turbopack-core/src/module_graph/export_usage.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/export_usage.rs
@@ -41,6 +41,7 @@ pub async fn compute_export_usage_info(
             // (or 1.2% of all modules).  So with this analysis we could potentially drop 80% of
             // the cycle breaker modules.
             circuit_breakers.extend(cycle.iter().map(|n| n.module));
+            Ok(())
         },
     )?;
 

--- a/turbopack/crates/turbopack-core/src/module_graph/export_usage.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/export_usage.rs
@@ -40,7 +40,7 @@ pub async fn compute_export_usage_info(
             // rare.  For vercel-site on 8/22/2025 there were 106 cycles covering 800 modules
             // (or 1.2% of all modules).  So with this analysis we could potentially drop 80% of
             // the cycle breaker modules.
-            circuit_breakers.extend(cycle.iter().map(|n| n.module));
+            circuit_breakers.extend(cycle.iter().map(|n| **n));
             Ok(())
         },
     )?;

--- a/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
@@ -150,8 +150,8 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
                 .map(|e| Ok((*e, -*module_depth.get(e).context("Module depth not found")?)))
                 .collect::<Result<Vec<_>>>()?,
             &mut (),
-            |parent_info: Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
-             node: &'_ SingleModuleGraphModuleNode,
+            |parent_info: Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
+             node: SingleModuleGraphModuleNode,
              _|
              -> Result<GraphTraversalAction> {
                 // On the down traversal, establish which edges are mergeable and set the list

--- a/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
@@ -124,8 +124,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
         let mergeable = graphs
             .iter()
             .flat_map(|g| g.iter_nodes())
-            .map(async |n| {
-                let module = n.module;
+            .map(async |module| {
                 if let Some(mergeable) =
                     ResolvedVc::try_downcast::<Box<dyn MergeableModule>>(module)
                     && *mergeable.is_mergeable().await?

--- a/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
@@ -12,8 +12,7 @@ use crate::{
     },
     module::Module,
     module_graph::{
-        GraphTraversalAction, ModuleGraph, RefData, SingleModuleGraphModuleNode,
-        chunk_group_info::RoaringBitmapWrapper,
+        GraphTraversalAction, ModuleGraph, RefData, chunk_group_info::RoaringBitmapWrapper,
     },
     resolve::ExportUsage,
 };
@@ -99,11 +98,11 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
                 |parent, node| {
                     if let Some((parent, _)) = parent {
                         let parent_depth = *module_depth
-                            .get(&parent.module)
+                            .get(&parent)
                             .context("Module depth not found")?;
-                        module_depth.entry(node.module).or_insert(parent_depth + 1);
+                        module_depth.entry(node).or_insert(parent_depth + 1);
                     } else {
-                        module_depth.insert(node.module, 0);
+                        module_depth.insert(node, 0);
                     };
 
                     Ok(GraphTraversalAction::Continue)
@@ -150,22 +149,22 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
                 .map(|e| Ok((*e, -*module_depth.get(e).context("Module depth not found")?)))
                 .collect::<Result<Vec<_>>>()?,
             &mut (),
-            |parent_info: Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
-             node: SingleModuleGraphModuleNode,
+            |parent_info: Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
+             node: ResolvedVc<Box<dyn Module>>,
              _|
              -> Result<GraphTraversalAction> {
                 // On the down traversal, establish which edges are mergeable and set the list
                 // indices.
                 let (parent_module, hoisted) = parent_info.map_or((None, false), |(node, ty)| {
                     (
-                        Some(node.module),
+                        Some(node),
                         match &ty.chunking_type {
                             ChunkingType::Parallel { hoisted, .. } => *hoisted,
                             _ => false,
                         },
                     )
                 });
-                let module = node.module;
+                let module = node;
 
                 Ok(if parent_module.is_some_and(|p| p == module) {
                     // A self-reference
@@ -181,9 +180,9 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
 
                     // A hoisted reference from a mergeable module to a non-async mergeable
                     // module, inherit bitmaps from parent.
-                    module_merged_groups.entry(node.module).or_default();
+                    module_merged_groups.entry(node).or_default();
                     let [Some(parent_merged_groups), Some(current_merged_groups)] =
-                        module_merged_groups.get_disjoint_mut([&parent_module, &node.module])
+                        module_merged_groups.get_disjoint_mut([&parent_module, &node])
                     else {
                         // All modules are inserted in the previous iteration
                         bail!("unreachable except for eventual consistency");
@@ -227,7 +226,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
                 // Invert the ordering here. High priority values get visited first, and we want to
                 // visit the low-depth nodes first, as we are propagating bitmaps downwards.
                 Ok(-*module_depth
-                    .get(&successor.module)
+                    .get(&successor)
                     .context("Module depth not found")?)
             },
         )?;
@@ -332,7 +331,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
                             &mut (),
                             |parent_info, node, _| {
                                 if parent_info.is_none_or(|(_, r)| r.chunking_type.is_parallel())
-                                    && visited.insert(node.module)
+                                    && visited.insert(node)
                                 {
                                     Ok(GraphTraversalAction::Continue)
                                 } else {
@@ -340,7 +339,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
                                 }
                             },
                             |parent_info, node, _| {
-                                let module = node.module;
+                                let module = node;
                                 let bitmap = module_merged_groups
                                     .get(&module)
                                     .context("every module should have a bitmap at this point")?;
@@ -383,15 +382,14 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
                                 }
 
                                 if let Some((parent, _)) = parent_info {
-                                    let same_bitmap =
-                                        module_merged_groups.get(&parent.module).unwrap()
-                                            == module_merged_groups.get(&module).unwrap();
+                                    let same_bitmap = module_merged_groups.get(&parent).unwrap()
+                                        == module_merged_groups.get(&module).unwrap();
 
                                     if same_bitmap {
                                         intra_group_references_rev
                                             .entry(module)
                                             .or_default()
-                                            .insert(parent.module);
+                                            .insert(parent);
                                     }
                                 }
                                 Ok(())
@@ -469,22 +467,22 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
             &mut (),
             |_, _, _| Ok(GraphTraversalAction::Continue),
             |parent_info, node, _| {
-                let module = node.module;
+                let module = node;
 
                 if let Some((parent, _)) = parent_info {
-                    let same_bitmap = module_merged_groups.get(&parent.module).unwrap()
+                    let same_bitmap = module_merged_groups.get(&parent).unwrap()
                         == module_merged_groups.get(&module).unwrap();
 
                     if same_bitmap {
                         intra_group_references
-                            .entry(parent.module)
+                            .entry(parent)
                             .or_default()
                             .insert(module);
                     }
                 }
 
                 if parent_info.is_none_or(|(parent, _)| {
-                    module_merged_groups.get(&parent.module).unwrap()
+                    module_merged_groups.get(&parent).unwrap()
                         != module_merged_groups.get(&module).unwrap()
                 }) {
                     // This module needs to be exposed:

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1,3 +1,4 @@
+use core::panic;
 use std::{
     collections::{BinaryHeap, VecDeque, hash_map::Entry},
     future::Future,
@@ -871,6 +872,14 @@ impl ModuleGraphRef {
             .context("Expected graph node")
     }
 
+    fn should_visit_node(&self, node: &SingleModuleGraphNode) -> bool {
+        if self.skip_visited_module_children {
+            !matches!(node, SingleModuleGraphNode::VisitedModule { .. })
+        } else {
+            true
+        }
+    }
+
     /// Returns a map of all modules in the graphs to their identifiers.
     /// This is primarily useful for debugging.
     pub async fn get_ids(&self) -> Result<FxHashMap<ResolvedVc<Box<dyn Module>>, ReadRef<RcStr>>> {
@@ -887,10 +896,12 @@ impl ModuleGraphRef {
 
     /// Traverses all reachable nodes exactly once and calls the visitor.
     ///
-    /// * `entry` - The entry module to start the traversal from
-    /// * `visitor` - Called before visiting the children of a node.
-    ///    - Receives &SingleModuleGraphNode
+    /// * `entries` - The entry modules to start the traversal from
+    /// * `state` mutable state to be shared across the visitors
+    /// * `visit_preorder` - Called before visiting the children of a node.
+    ///    - Receives the module and the `state`
     ///    - Can return [GraphTraversalAction]s to control the traversal
+    /// * `visit_postorder` - Called after visiting children of a node.
     pub fn traverse_nodes_from_entries_dfs<S>(
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
@@ -899,7 +910,6 @@ impl ModuleGraphRef {
         mut visit_postorder: impl FnMut(ResolvedVc<Box<dyn Module>>, &mut S) -> Result<()>,
     ) -> Result<()> {
         let graphs = &self.graphs;
-        let skip_visited_module_children = self.skip_visited_module_children;
 
         let entries = entries.into_iter().collect::<Vec<_>>();
 
@@ -928,8 +938,7 @@ impl ModuleGraphRef {
                     }
                     stack.push((Pass::Visit, current));
                     if action == GraphTraversalAction::Continue
-                        && !(skip_visited_module_children
-                            && matches!(current_node, SingleModuleGraphNode::VisitedModule { .. }))
+                        && self.should_visit_node(current_node)
                     {
                         let current = current_node.target_idx().unwrap_or(current);
                         stack.extend(
@@ -963,7 +972,6 @@ impl ModuleGraphRef {
         ) -> Result<GraphTraversalAction>,
     ) -> Result<()> {
         let graphs = &self.graphs;
-        let skip_visited_module_children = self.skip_visited_module_children;
 
         let mut queue = VecDeque::from(
             entries
@@ -986,9 +994,7 @@ impl ModuleGraphRef {
                         Some((node_weight.module(), edge_weight)),
                         succ_weight.module(),
                     )?;
-                    if skip_visited_module_children
-                        && matches!(succ_weight, SingleModuleGraphNode::VisitedModule { .. })
-                    {
+                    if !self.should_visit_node(succ_weight) {
                         continue;
                     }
                     let succ = succ_weight.target_idx().unwrap_or(succ);
@@ -1021,7 +1027,6 @@ impl ModuleGraphRef {
         ) -> GraphTraversalAction,
     ) -> Result<()> {
         let graphs = &self.graphs;
-        let skip_visited_module_children = self.skip_visited_module_children;
 
         let mut stack = entries
             .into_iter()
@@ -1042,9 +1047,7 @@ impl ModuleGraphRef {
                         Some((node_weight.module(), edge_weight)),
                         succ_weight.module(),
                     );
-                    if skip_visited_module_children
-                        && matches!(succ_weight, SingleModuleGraphNode::VisitedModule { .. })
-                    {
+                    if !self.should_visit_node(succ_weight) {
                         continue;
                     }
                     let succ = succ_weight.target_idx().unwrap_or(succ);
@@ -1102,7 +1105,6 @@ impl ModuleGraphRef {
     /// * `visit_postorder` - Called after visiting the children of a node. Return
     ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode, state &S
-    ///    - Can return [GraphTraversalAction]s to control the traversal
     pub fn traverse_edges_from_entries_dfs<S>(
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
@@ -1119,7 +1121,6 @@ impl ModuleGraphRef {
         ) -> Result<()>,
     ) -> Result<()> {
         let graphs = &self.graphs;
-        let skip_visited_module_children = self.skip_visited_module_children;
 
         let entries = entries.into_iter().collect::<Vec<_>>();
 
@@ -1158,8 +1159,7 @@ impl ModuleGraphRef {
                     stack.push((Pass::Visit, parent, current));
                     if action == GraphTraversalAction::Continue
                         && expanded.insert(current)
-                        && !(skip_visited_module_children
-                            && matches!(current_node, SingleModuleGraphNode::VisitedModule { .. }))
+                        && self.should_visit_node(current_node)
                     {
                         let current = current_node.target_idx().unwrap_or(current);
                         stack.extend(iter_graphs_neighbors_rev(graphs, current).map(
@@ -1220,7 +1220,9 @@ impl ModuleGraphRef {
     ) -> Result<usize> {
         let graphs = &self.graphs;
         if self.skip_visited_module_children {
-            bail!("traverse_edges_fixed_point_with_priority musn't be called on individual graphs");
+            panic!(
+                "traverse_edges_fixed_point_with_priority musn't be called on individual graphs"
+            );
         }
 
         #[derive(PartialEq, Eq)]

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -32,7 +32,7 @@ use crate::{
         merged_modules::{MergedModuleInfo, compute_merged_modules},
         module_batches::{ModuleBatchesGraph, compute_module_batches},
         style_groups::{StyleGroups, StyleGroupsConfig, compute_style_groups},
-        traced_di_graph::{TracedDiGraph, iter_graphs_neighbors_rev},
+        traced_di_graph::TracedDiGraph,
     },
     reference::primary_chunkable_referenced_modules,
     resolve::ExportUsage,
@@ -406,7 +406,7 @@ impl SingleModuleGraph {
     pub fn read(self: &ReadRef<SingleModuleGraph>) -> ModuleGraphRef {
         ModuleGraphRef {
             graphs: vec![self.clone()],
-            ignore_visited_module: true,
+            skip_visited_module_children: true,
         }
     }
 
@@ -807,7 +807,7 @@ impl ModuleGraph {
         let async_modules_info = self.async_module_info().await?;
 
         let entry = graph_ref.get_entry(module)?;
-        let referenced_modules = iter_graphs_neighbors_rev(&graphs[entry.graph_idx()].graph, entry)
+        let referenced_modules = iter_graphs_neighbors_rev(graphs, entry)
             .filter(|(edge_idx, _)| {
                 let ty = graphs[entry.graph_idx()]
                     .graph
@@ -831,7 +831,7 @@ impl ModuleGraph {
     pub async fn read_graphs(self: Vc<ModuleGraph>) -> Result<ModuleGraphRef> {
         Ok(ModuleGraphRef {
             graphs: self.await?.graphs.iter().try_join().await?,
-            ignore_visited_module: false,
+            skip_visited_module_children: false,
         })
     }
 }
@@ -842,7 +842,7 @@ pub struct ModuleGraphRef {
     pub graphs: Vec<ReadRef<SingleModuleGraph>>,
     // Whether to simply ignore SingleModuleGraphNode::VisitedModule during traversals. For single
     // module graph usecases, this is what you want. For the whole graph, there should be an error.
-    ignore_visited_module: bool,
+    skip_visited_module_children: bool,
 }
 
 impl ModuleGraphRef {
@@ -899,7 +899,7 @@ impl ModuleGraphRef {
         mut visit_postorder: impl FnMut(ResolvedVc<Box<dyn Module>>, &mut S) -> Result<()>,
     ) -> Result<()> {
         let graphs = &self.graphs;
-        let ignore_visited_module = self.ignore_visited_module;
+        let skip_visited_module_children = self.skip_visited_module_children;
 
         let entries = entries.into_iter().collect::<Vec<_>>();
 
@@ -928,20 +928,14 @@ impl ModuleGraphRef {
                     }
                     stack.push((Pass::Visit, current));
                     if action == GraphTraversalAction::Continue
-                        && !(ignore_visited_module
+                        && !(skip_visited_module_children
                             && matches!(current_node, SingleModuleGraphNode::VisitedModule { .. }))
                     {
-                        let graph = &graphs[current.graph_idx()].graph;
-                        let neighbors_rev = match graph.node_weight(current.node_idx).unwrap() {
-                            SingleModuleGraphNode::Module(_) => {
-                                iter_graphs_neighbors_rev(graph, current)
-                            }
-                            SingleModuleGraphNode::VisitedModule { idx, .. } => {
-                                // We switch graphs
-                                iter_graphs_neighbors_rev(&graphs[idx.graph_idx()].graph, *idx)
-                            }
-                        };
-                        stack.extend(neighbors_rev.map(|(_, child)| (Pass::ExpandAndVisit, child)));
+                        let current = current_node.target_idx().unwrap_or(current);
+                        stack.extend(
+                            iter_graphs_neighbors_rev(graphs, current)
+                                .map(|(_, child)| (Pass::ExpandAndVisit, child)),
+                        );
                     }
                 }
             }
@@ -969,7 +963,7 @@ impl ModuleGraphRef {
         ) -> Result<GraphTraversalAction>,
     ) -> Result<()> {
         let graphs = &self.graphs;
-        let ignore_visited_module = self.ignore_visited_module;
+        let skip_visited_module_children = self.skip_visited_module_children;
 
         let mut queue = VecDeque::from(
             entries
@@ -985,18 +979,18 @@ impl ModuleGraphRef {
             if visited.insert(node) {
                 let node_weight = self.get_node(node)?;
                 let graph = &graphs[node.graph_idx()].graph;
-                for (edge, succ) in iter_graphs_neighbors_rev(graph, node) {
+                for (edge, succ) in iter_graphs_neighbors_rev(graphs, node) {
                     let succ_weight = self.get_node(succ)?;
-                    if ignore_visited_module
-                        && matches!(succ_weight, SingleModuleGraphNode::VisitedModule { .. })
-                    {
-                        continue;
-                    }
                     let edge_weight = graph.edge_weight(edge).unwrap();
                     let action = visitor(
                         Some((node_weight.module(), edge_weight)),
                         succ_weight.module(),
                     )?;
+                    if skip_visited_module_children
+                        && matches!(succ_weight, SingleModuleGraphNode::VisitedModule { .. })
+                    {
+                        continue;
+                    }
                     let succ = succ_weight.target_idx().unwrap_or(succ);
                     if !visited.contains(&succ) && action == GraphTraversalAction::Continue {
                         queue.push_back(succ);
@@ -1027,7 +1021,7 @@ impl ModuleGraphRef {
         ) -> GraphTraversalAction,
     ) -> Result<()> {
         let graphs = &self.graphs;
-        let ignore_visited_module = self.ignore_visited_module;
+        let skip_visited_module_children = self.skip_visited_module_children;
 
         let mut stack = entries
             .into_iter()
@@ -1041,18 +1035,18 @@ impl ModuleGraphRef {
             if visited.insert(node) {
                 let node_weight = self.get_node(node)?;
                 let graph = &graphs[node.graph_idx()].graph;
-                for (edge, succ) in iter_graphs_neighbors_rev(graph, node) {
+                for (edge, succ) in iter_graphs_neighbors_rev(graphs, node) {
                     let succ_weight = self.get_node(succ)?;
-                    if ignore_visited_module
-                        && matches!(succ_weight, SingleModuleGraphNode::VisitedModule { .. })
-                    {
-                        continue;
-                    }
                     let edge_weight = graph.edge_weight(edge).unwrap();
                     let action = visitor(
                         Some((node_weight.module(), edge_weight)),
                         succ_weight.module(),
                     );
+                    if skip_visited_module_children
+                        && matches!(succ_weight, SingleModuleGraphNode::VisitedModule { .. })
+                    {
+                        continue;
+                    }
                     let succ = succ_weight.target_idx().unwrap_or(succ);
                     if !visited.contains(&succ) && action == GraphTraversalAction::Continue {
                         stack.push(succ);
@@ -1125,7 +1119,7 @@ impl ModuleGraphRef {
         ) -> Result<()>,
     ) -> Result<()> {
         let graphs = &self.graphs;
-        let ignore_visited_module = self.ignore_visited_module;
+        let skip_visited_module_children = self.skip_visited_module_children;
 
         let entries = entries.into_iter().collect::<Vec<_>>();
 
@@ -1164,12 +1158,11 @@ impl ModuleGraphRef {
                     stack.push((Pass::Visit, parent, current));
                     if action == GraphTraversalAction::Continue
                         && expanded.insert(current)
-                        && !(ignore_visited_module
+                        && !(skip_visited_module_children
                             && matches!(current_node, SingleModuleGraphNode::VisitedModule { .. }))
                     {
-                        let graph = &graphs[current.graph_idx()].graph;
                         let current = current_node.target_idx().unwrap_or(current);
-                        stack.extend(iter_graphs_neighbors_rev(graph, current).map(
+                        stack.extend(iter_graphs_neighbors_rev(graphs, current).map(
                             |(edge, child)| (Pass::ExpandAndVisit, Some((current, edge)), child),
                         ));
                     }
@@ -1226,7 +1219,9 @@ impl ModuleGraphRef {
         priority: impl Fn(ResolvedVc<Box<dyn Module>>, &mut S) -> Result<P>,
     ) -> Result<usize> {
         let graphs = &self.graphs;
-        let ignore_visited_module = self.ignore_visited_module;
+        if self.skip_visited_module_children {
+            bail!("traverse_edges_fixed_point_with_priority musn't be called on individual graphs");
+        }
 
         #[derive(PartialEq, Eq)]
         struct NodeWithPriority<T: Ord> {
@@ -1275,7 +1270,7 @@ impl ModuleGraphRef {
             visit_count += 1;
 
             let graph = &graphs[node.graph_idx()].graph;
-            for (edge, succ) in iter_graphs_neighbors_rev(graph, node) {
+            for (edge, succ) in iter_graphs_neighbors_rev(graphs, node) {
                 let succ_weight = self.get_node(succ)?;
 
                 let edge_weight = graph.edge_weight(edge).unwrap();
@@ -1286,11 +1281,7 @@ impl ModuleGraphRef {
                 )?;
 
                 let succ = succ_weight.target_idx().unwrap_or(succ);
-                if action == GraphTraversalAction::Continue
-                    && queue_set.insert(succ)
-                    && !(ignore_visited_module
-                        && matches!(succ_weight, SingleModuleGraphNode::VisitedModule { .. }))
-                {
+                if action == GraphTraversalAction::Continue && queue_set.insert(succ) {
                     queue.push(NodeWithPriority {
                         node: succ,
                         priority: priority(succ_weight.module(), state)?,
@@ -1301,6 +1292,34 @@ impl ModuleGraphRef {
 
         Ok(visit_count)
     }
+}
+
+/// Iterate the edges of a node REVERSED!
+fn iter_graphs_neighbors_rev(
+    graphs: &[ReadRef<SingleModuleGraph>],
+    node: GraphNodeIndex,
+) -> impl Iterator<Item = (EdgeIndex, GraphNodeIndex)> + '_ {
+    let graph = &*graphs[node.graph_idx()].graph;
+
+    if cfg!(debug_assertions) {
+        let node_weight = graph.node_weight(node.node_idx).unwrap();
+        if let SingleModuleGraphNode::VisitedModule { .. } = node_weight {
+            panic!("iter_graphs_neighbors_rev called on VisitedModule node");
+        }
+    }
+
+    let mut walker = graph.neighbors(node.node_idx).detach();
+    std::iter::from_fn(move || {
+        walker.next(graph).map(|(edge_idx, succ_idx)| {
+            (
+                edge_idx,
+                GraphNodeIndex {
+                    graph_idx: node.graph_idx,
+                    node_idx: succ_idx,
+                },
+            )
+        })
+    })
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result, bail};
 use auto_hash_map::AutoSet;
 use petgraph::{
     graph::{DiGraph, EdgeIndex, NodeIndex},
-    visit::{Dfs, EdgeRef, IntoNeighbors, IntoNodeReferences, NodeIndexable, Reversed},
+    visit::{EdgeRef, IntoNeighbors, IntoNodeReferences, NodeIndexable, Reversed},
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
@@ -92,9 +92,7 @@ impl VisitedModules {
                 .await?
                 .enumerate_nodes()
                 .flat_map(|(node_idx, module)| match module {
-                    SingleModuleGraphNode::Module(SingleModuleGraphModuleNode {
-                        module, ..
-                    }) => Some((
+                    SingleModuleGraphNode::Module(module) => Some((
                         *module,
                         GraphNodeIndex {
                             graph_idx: 0,
@@ -129,10 +127,7 @@ impl VisitedModules {
                 graph
                     .enumerate_nodes()
                     .flat_map(|(node_idx, module)| match module {
-                        SingleModuleGraphNode::Module(SingleModuleGraphModuleNode {
-                            module,
-                            ..
-                        }) => Some((
+                        SingleModuleGraphNode::Module(module) => Some((
                             *module,
                             GraphNodeIndex {
                                 graph_idx: self.next_graph_idx,
@@ -284,9 +279,7 @@ impl SingleModuleGraph {
                         let current_idx = if let Some(current_idx) = modules.get(&module) {
                             *current_idx
                         } else {
-                            let idx = graph.add_node(SingleModuleGraphNode::Module(
-                                SingleModuleGraphModuleNode { module },
-                            ));
+                            let idx = graph.add_node(SingleModuleGraphNode::Module(module));
                             number_of_modules += 1;
                             modules.insert(module, idx);
                             idx
@@ -327,11 +320,7 @@ impl SingleModuleGraph {
                                     idx: *idx,
                                     module: target,
                                 },
-                                None => {
-                                    SingleModuleGraphNode::Module(SingleModuleGraphModuleNode {
-                                        module: target,
-                                    })
-                                }
+                                None => SingleModuleGraphNode::Module(target),
                             });
                             modules.insert(target, idx);
                             idx
@@ -382,15 +371,8 @@ impl SingleModuleGraph {
         Ok(graph)
     }
 
-    fn get_module(&self, module: ResolvedVc<Box<dyn Module>>) -> Result<NodeIndex> {
-        self.modules
-            .get(&module)
-            .copied()
-            .context("Couldn't find module in graph")
-    }
-
     /// Iterate over all nodes in the graph
-    pub fn iter_nodes(&self) -> impl Iterator<Item = SingleModuleGraphModuleNode> + '_ {
+    pub fn iter_nodes(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Module>>> + '_ {
         self.graph.node_weights().filter_map(|n| match n {
             SingleModuleGraphNode::Module(node) => Some(*node),
             SingleModuleGraphNode::VisitedModule { .. } => None,
@@ -421,25 +403,6 @@ impl SingleModuleGraph {
         self.graph.node_references()
     }
 
-    /// Traverses all reachable nodes (once)
-    pub fn traverse_from_entryx<'a>(
-        &'a self,
-        entry: ResolvedVc<Box<dyn Module>>,
-        mut visitor: impl FnMut(&'a SingleModuleGraphModuleNode),
-    ) -> Result<()> {
-        let entry_node = self.get_module(entry)?;
-
-        let mut dfs = Dfs::new(&*self.graph, entry_node);
-        while let Some(nx) = dfs.next(&*self.graph) {
-            let SingleModuleGraphNode::Module(weight) = self.graph.node_weight(nx).unwrap() else {
-                return Ok(());
-            };
-            // weight.emit_issues();
-            visitor(weight);
-        }
-        Ok(())
-    }
-
     pub fn read(self: &ReadRef<SingleModuleGraph>) -> ModuleGraphRef {
         ModuleGraphRef {
             graphs: vec![self.clone()],
@@ -450,7 +413,7 @@ impl SingleModuleGraph {
     fn traverse_cycles<'l>(
         &'l self,
         edge_filter: impl Fn(&'l RefData) -> bool,
-        mut visit_cycle: impl FnMut(&[&'l SingleModuleGraphModuleNode]) -> Result<()>,
+        mut visit_cycle: impl FnMut(&[&'l ResolvedVc<Box<dyn Module>>]) -> Result<()>,
     ) -> Result<()> {
         // see https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
         // but iteratively instead of recursively
@@ -915,7 +878,7 @@ impl ModuleGraphRef {
             .graphs
             .iter()
             .flat_map(|g| g.iter_nodes())
-            .map(async |n| Ok((n.module, n.module.ident().to_string().await?)))
+            .map(async |n| Ok((n, n.ident().to_string().await?)))
             .try_join()
             .await?
             .into_iter()
@@ -1055,8 +1018,7 @@ impl ModuleGraphRef {
     ///    - Receives (originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode, state &S
     ///    - Can return [GraphTraversalAction]s to control the traversal
-    // TODO this is actually traverse_edges_from_entries_dfs
-    pub fn traverse_edges_from_entry(
+    pub fn traverse_edges_from_entry_dfs(
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         mut visitor: impl FnMut(
@@ -1223,7 +1185,7 @@ impl ModuleGraphRef {
     pub fn traverse_cycles(
         &self,
         edge_filter: impl Fn(&RefData) -> bool,
-        mut visit_cycle: impl FnMut(&[&SingleModuleGraphModuleNode]) -> Result<()>,
+        mut visit_cycle: impl FnMut(&[&ResolvedVc<Box<dyn Module>>]) -> Result<()>,
     ) -> Result<()> {
         for graph in &self.graphs {
             graph.traverse_cycles(&edge_filter, &mut visit_cycle)?;
@@ -1377,15 +1339,9 @@ impl SingleModuleGraph {
     }
 }
 
-// TODO get rid of this wrapper type
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
-pub struct SingleModuleGraphModuleNode {
-    pub module: ResolvedVc<Box<dyn Module>>,
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
 pub enum SingleModuleGraphNode {
-    Module(SingleModuleGraphModuleNode),
+    Module(ResolvedVc<Box<dyn Module>>),
     // Models a module that is referenced but has already been visited by an earlier graph.
     VisitedModule {
         idx: GraphNodeIndex,
@@ -1396,7 +1352,7 @@ pub enum SingleModuleGraphNode {
 impl SingleModuleGraphNode {
     pub fn module(&self) -> ResolvedVc<Box<dyn Module>> {
         match self {
-            SingleModuleGraphNode::Module(SingleModuleGraphModuleNode { module }) => *module,
+            SingleModuleGraphNode::Module(module) => *module,
             SingleModuleGraphNode::VisitedModule { module, .. } => *module,
         }
     }

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -7,10 +7,7 @@ use anyhow::{Context, Result, bail};
 use auto_hash_map::AutoSet;
 use petgraph::{
     graph::{DiGraph, EdgeIndex, NodeIndex},
-    visit::{
-        Dfs, EdgeRef, IntoNeighbors, IntoNodeReferences, NodeIndexable, Reversed, VisitMap,
-        Visitable,
-    },
+    visit::{Dfs, EdgeRef, IntoNeighbors, IntoNodeReferences, NodeIndexable, Reversed},
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
@@ -425,7 +422,7 @@ impl SingleModuleGraph {
     }
 
     /// Traverses all reachable nodes (once)
-    pub fn traverse_from_entry<'a>(
+    pub fn traverse_from_entryx<'a>(
         &'a self,
         entry: ResolvedVc<Box<dyn Module>>,
         mut visitor: impl FnMut(&'a SingleModuleGraphModuleNode),
@@ -443,334 +440,17 @@ impl SingleModuleGraph {
         Ok(())
     }
 
-    /// Traverses all reachable nodes once
-    pub fn traverse_nodes_from_entries<'a, S>(
-        &'a self,
-        entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
-        state: &mut S,
-        visit_preorder: impl Fn(&'a SingleModuleGraphModuleNode, &mut S) -> Result<GraphTraversalAction>,
-        mut visit_postorder: impl FnMut(&'a SingleModuleGraphModuleNode, &mut S) -> Result<()>,
-    ) -> Result<()> {
-        let graph = &self.graph;
-        let entries = entries.into_iter().map(|e| self.get_module(e).unwrap());
-
-        enum Pass {
-            Visit,
-            ExpandAndVisit,
+    pub fn read(self: &ReadRef<SingleModuleGraph>) -> ModuleGraphRef {
+        ModuleGraphRef {
+            graphs: vec![self.clone()],
         }
-
-        let mut stack: Vec<(Pass, NodeIndex)> =
-            entries.map(|e| (Pass::ExpandAndVisit, e)).collect();
-        let mut expanded = FxHashSet::default();
-        while let Some((pass, current)) = stack.pop() {
-            match pass {
-                Pass::Visit => {
-                    if let SingleModuleGraphNode::Module(current_node) =
-                        graph.node_weight(current).unwrap()
-                    {
-                        visit_postorder(current_node, state)?;
-                    }
-                }
-                Pass::ExpandAndVisit => {
-                    if expanded.insert(current)
-                        && let SingleModuleGraphNode::Module(current_node) =
-                            graph.node_weight(current).unwrap()
-                    {
-                        let action = visit_preorder(current_node, state)?;
-                        if action == GraphTraversalAction::Exclude {
-                            continue;
-                        }
-                        stack.push((Pass::Visit, current));
-                        if action == GraphTraversalAction::Continue {
-                            stack.extend(
-                                iter_neighbors_rev(graph, current)
-                                    .map(|(_, child)| (Pass::ExpandAndVisit, child)),
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(())
     }
 
-    /// Traverses all reachable edges exactly once and calls the visitor with the edge source and
-    /// target.
-    ///
-    /// This means that target nodes can be revisited (once per incoming edge).
-    ///
-    /// * `entry` - The entry module to start the traversal from
-    /// * `visitor` - Called before visiting the children of a node.
-    ///    - Receives (originating &SingleModuleGraphNode, edge &ChunkingType), target
-    ///      &SingleModuleGraphNode, state &S
-    ///    - Can return [GraphTraversalAction]s to control the traversal
-    pub fn traverse_edges_from_entries<'a>(
-        &'a self,
-        entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
-        mut visitor: impl FnMut(
-            Option<(&'a SingleModuleGraphModuleNode, &'a RefData)>,
-            &'a SingleModuleGraphModuleNode,
-        ) -> GraphTraversalAction,
-    ) -> Result<()> {
-        let graph = &self.graph;
-        let entries = entries.into_iter().map(|e| self.get_module(e).unwrap());
-
-        let mut stack = entries.collect::<Vec<_>>();
-        let mut discovered = graph.visit_map();
-        // entry_weight.emit_issues();
-        for entry_node in &stack {
-            let SingleModuleGraphNode::Module(entry_weight) =
-                graph.node_weight(*entry_node).unwrap()
-            else {
-                continue;
-            };
-            visitor(None, entry_weight);
-        }
-
-        while let Some(node) = stack.pop() {
-            let SingleModuleGraphNode::Module(node_weight) = graph.node_weight(node).unwrap()
-            else {
-                continue;
-            };
-            if discovered.visit(node) {
-                let neighbors = {
-                    let mut neighbors = vec![];
-                    let mut walker = graph.neighbors(node).detach();
-                    while let Some((edge, succ)) = walker.next(graph) {
-                        neighbors.push((edge, succ));
-                    }
-                    neighbors
-                };
-
-                for (edge, succ) in neighbors {
-                    let SingleModuleGraphNode::Module(succ_weight) =
-                        graph.node_weight(succ).unwrap()
-                    else {
-                        continue;
-                    };
-                    let edge_weight = graph.edge_weight(edge).unwrap();
-                    let action = visitor(Some((node_weight, edge_weight)), succ_weight);
-                    if !discovered.is_visited(&succ) && action == GraphTraversalAction::Continue {
-                        stack.push(succ);
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Traverses all edges exactly once and calls the visitor with the edge source and
-    /// target.
-    ///
-    /// This means that target nodes can be revisited (once per incoming edge).
-    pub fn traverse_edges<'a>(
-        &'a self,
-        mut visitor: impl FnMut(
-            (
-                Option<(&'a SingleModuleGraphModuleNode, &'a RefData)>,
-                &'a SingleModuleGraphModuleNode,
-            ),
-        ) -> GraphTraversalAction,
-    ) -> Result<()> {
-        let graph = &self.graph;
-        let mut stack: Vec<NodeIndex> = self
-            .entries
-            .iter()
-            .flat_map(|e| e.entries())
-            .map(|e| *self.modules.get(&e).unwrap())
-            .collect();
-        let mut discovered = graph.visit_map();
-        for entry_node in &stack {
-            let SingleModuleGraphNode::Module(entry_node) = graph.node_weight(*entry_node).unwrap()
-            else {
-                continue;
-            };
-            visitor((None, entry_node));
-        }
-
-        while let Some(node) = stack.pop() {
-            if discovered.visit(node) {
-                let SingleModuleGraphNode::Module(node_weight) = graph.node_weight(node).unwrap()
-                else {
-                    continue;
-                };
-                for edge in graph.edges(node).collect::<Vec<_>>() {
-                    let edge_weight = edge.weight();
-                    let succ = edge.target();
-                    let SingleModuleGraphNode::Module(succ_weight) =
-                        graph.node_weight(succ).unwrap()
-                    else {
-                        continue;
-                    };
-                    let action = visitor((Some((node_weight, edge_weight)), succ_weight));
-                    if !discovered.is_visited(&succ) && action == GraphTraversalAction::Continue {
-                        stack.push(succ);
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Traverses all reachable nodes and also continue revisiting them as long the visitor returns
-    /// GraphTraversalAction::Continue. The visitor is responsible for the runtime complexity and
-    /// eventual termination of the traversal. This corresponds to computing a fixed point state for
-    /// the graph.
-    ///
-    /// It is guaranteed that the parent node passed to the `visit` function, if any, has
-    /// already been passed to `visit`.
-    ///
-    /// * `entries` - The entry modules to start the traversal from
-    /// * `visit` - Called for a specific edge
-    ///    - Receives: Option(originating &SingleModuleGraphNode, edge &ChunkingType), target
-    ///      &SingleModuleGraphNode
-    ///    - Return [GraphTraversalAction]s to control the traversal
-    ///
-    /// Returns the number of node visits (i.e. higher than the node
-    /// count if there are retraversals).
-    pub fn traverse_edges_from_entries_fixed_point<'a>(
-        &'a self,
-        entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
-        mut visit: impl FnMut(
-            Option<(&'a SingleModuleGraphModuleNode, &'a RefData)>,
-            &'a SingleModuleGraphNode,
-        ) -> Result<GraphTraversalAction>,
-    ) -> Result<usize> {
-        let mut queue = VecDeque::default();
-        let mut queue_set = FxHashSet::default();
-
-        for module in entries {
-            let index = self.get_module(module).unwrap();
-            let action = visit(None, self.graph.node_weight(index).unwrap())?;
-            if action == GraphTraversalAction::Continue && queue_set.insert(index) {
-                queue.push_back(index);
-            }
-        }
-
-        let mut visit_count = 0;
-        while let Some(index) = queue.pop_front() {
-            queue_set.remove(&index);
-            let node = match self.graph.node_weight(index).unwrap() {
-                SingleModuleGraphNode::Module(single_module_graph_module_node) => {
-                    single_module_graph_module_node
-                }
-                _ => {
-                    continue; // we don't traverse into parent graphs
-                }
-            };
-            visit_count += 1;
-            for edge in self
-                .graph
-                .edges_directed(index, petgraph::Direction::Outgoing)
-            {
-                let refdata = edge.weight();
-                let target_index = edge.target();
-                let target = self.graph.node_weight(edge.target()).unwrap();
-                let action = visit(Some((node, refdata)), target)?;
-                if action == GraphTraversalAction::Continue && queue_set.insert(target_index) {
-                    queue.push_back(target_index);
-                }
-            }
-        }
-
-        Ok(visit_count)
-    }
-
-    /// Traverses all reachable edges in dfs order. The preorder visitor can be used to
-    /// forward state down the graph, and to skip subgraphs.
-    ///
-    /// Use this to collect modules in evaluation order.
-    ///
-    /// Target nodes can be revisited (once per incoming edge) in the preorder_visitor, in the post
-    /// order visitor they are visited exactly once with the first edge they were discovered with.
-    /// Edges are traversed in normal order, so should correspond to reference order.
-    ///
-    /// * `entries` - The entry modules to start the traversal from
-    /// * `state` - The state to be passed to the visitors
-    /// * `visit_preorder` - Called before visiting the children of a node.
-    ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
-    ///      &SingleModuleGraphNode, state &S
-    ///    - Can return [GraphTraversalAction]s to control the traversal
-    /// * `visit_postorder` - Called after visiting the children of a node. Return
-    ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
-    ///      &SingleModuleGraphNode, state &S
-    pub fn traverse_edges_from_entries_dfs<'a, S>(
-        &'a self,
-        entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
-        state: &mut S,
-        mut visit_preorder: impl FnMut(
-            Option<(&'a SingleModuleGraphModuleNode, &'a RefData)>,
-            &'a SingleModuleGraphNode,
-            &mut S,
-        ) -> Result<GraphTraversalAction>,
-        mut visit_postorder: impl FnMut(
-            Option<(&'a SingleModuleGraphModuleNode, &'a RefData)>,
-            &'a SingleModuleGraphNode,
-            &mut S,
-        ) -> Result<()>,
-    ) -> Result<()> {
-        let graph = &self.graph;
-        let entries = entries.into_iter().map(|e| self.get_module(e).unwrap());
-
-        enum Pass {
-            Visit,
-            ExpandAndVisit,
-        }
-
-        #[allow(clippy::type_complexity)] // This is a temporary internal structure
-        let mut stack: Vec<(Pass, Option<(NodeIndex, EdgeIndex)>, NodeIndex)> =
-            entries.map(|e| (Pass::ExpandAndVisit, None, e)).collect();
-        let mut expanded = FxHashSet::default();
-        while let Some((pass, parent, current)) = stack.pop() {
-            let parent_arg = parent.map(|parent| {
-                (
-                    match graph.node_weight(parent.0).unwrap() {
-                        SingleModuleGraphNode::Module(node) => node,
-                        SingleModuleGraphNode::VisitedModule { .. } => {
-                            unreachable!()
-                        }
-                    },
-                    graph.edge_weight(parent.1).unwrap(),
-                )
-            });
-            match pass {
-                Pass::Visit => {
-                    visit_postorder(parent_arg, graph.node_weight(current).unwrap(), state)?;
-                }
-                Pass::ExpandAndVisit => match graph.node_weight(current).unwrap() {
-                    current_node @ SingleModuleGraphNode::Module(_) => {
-                        let action = visit_preorder(parent_arg, current_node, state)?;
-                        if action == GraphTraversalAction::Exclude {
-                            continue;
-                        }
-                        stack.push((Pass::Visit, parent, current));
-                        if action == GraphTraversalAction::Continue && expanded.insert(current) {
-                            stack.extend(iter_neighbors_rev(graph, current).map(
-                                |(edge, child)| {
-                                    (Pass::ExpandAndVisit, Some((current, edge)), child)
-                                },
-                            ));
-                        }
-                    }
-                    current_node @ SingleModuleGraphNode::VisitedModule { .. } => {
-                        visit_preorder(parent_arg, current_node, state)?;
-                        visit_postorder(parent_arg, current_node, state)?;
-                    }
-                },
-            }
-        }
-
-        Ok(())
-    }
-
-    pub fn traverse_cycles<'l>(
+    fn traverse_cycles<'l>(
         &'l self,
         edge_filter: impl Fn(&'l RefData) -> bool,
-        mut visit_cycle: impl FnMut(&[&'l SingleModuleGraphModuleNode]),
-    ) {
+        mut visit_cycle: impl FnMut(&[&'l SingleModuleGraphModuleNode]) -> Result<()>,
+    ) -> Result<()> {
         // see https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
         // but iteratively instead of recursively
 
@@ -853,7 +533,7 @@ impl SingleModuleGraph {
                                 }
                             }
                             if scc.len() > 1 {
-                                visit_cycle(&scc);
+                                visit_cycle(&scc)?;
                             }
                             scc.clear();
                         }
@@ -861,6 +541,7 @@ impl SingleModuleGraph {
                 }
             }
         }
+        Ok(())
     }
 
     /// For each issue computes a (possibly empty) list of traces from the file that produced the
@@ -1288,6 +969,79 @@ impl ModuleGraphRef {
             .collect::<FxHashMap<_, _>>())
     }
 
+    /// Traverses all reachable nodes exactly once and calls the visitor.
+    ///
+    /// * `entry` - The entry module to start the traversal from
+    /// * `visitor` - Called before visiting the children of a node.
+    ///    - Receives &SingleModuleGraphNode
+    ///    - Can return [GraphTraversalAction]s to control the traversal
+    pub fn traverse_nodes_from_entries_dfs<'a, S>(
+        &'a self,
+        entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
+        state: &mut S,
+        visit_preorder: impl Fn(&'a SingleModuleGraphModuleNode, &mut S) -> Result<GraphTraversalAction>,
+        mut visit_postorder: impl FnMut(&'a SingleModuleGraphModuleNode, &mut S) -> Result<()>,
+    ) -> Result<()> {
+        let graphs = &self.graphs;
+
+        let entries = entries.into_iter().collect::<Vec<_>>();
+
+        enum Pass {
+            Visit,
+            ExpandAndVisit,
+        }
+        let mut stack: Vec<(Pass, GraphNodeIndex)> = Vec::with_capacity(entries.len());
+        for entry in entries.into_iter().rev() {
+            stack.push((Pass::ExpandAndVisit, self.get_entry(entry)?));
+        }
+        let mut expanded = HashSet::new();
+        while let Some((pass, current)) = stack.pop() {
+            let current_node = get_node!(graphs, current)?;
+            match pass {
+                Pass::Visit => {
+                    visit_postorder(current_node, state)?;
+                }
+                Pass::ExpandAndVisit => {
+                    if !expanded.insert(current) {
+                        continue;
+                    }
+                    let action = visit_preorder(current_node, state)?;
+                    if action == GraphTraversalAction::Exclude {
+                        continue;
+                    }
+                    stack.push((Pass::Visit, current));
+                    if action == GraphTraversalAction::Continue {
+                        let graph = &graphs[current.graph_idx()].graph;
+                        let (neighbors_rev, current) = match graph
+                            .node_weight(current.node_idx)
+                            .unwrap()
+                        {
+                            SingleModuleGraphNode::Module(_) => {
+                                (iter_neighbors_rev(graph, current.node_idx), current)
+                            }
+                            SingleModuleGraphNode::VisitedModule { idx, .. } => (
+                                // We switch graphs
+                                iter_neighbors_rev(&graphs[idx.graph_idx()].graph, idx.node_idx),
+                                *idx,
+                            ),
+                        };
+                        stack.extend(neighbors_rev.map(|(_, child)| {
+                            (
+                                Pass::ExpandAndVisit,
+                                GraphNodeIndex {
+                                    graph_idx: current.graph_idx,
+                                    node_idx: child,
+                                },
+                            )
+                        }));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Traverses all reachable edges exactly once and calls the visitor with the edge source and
     /// target.
     ///
@@ -1352,6 +1106,7 @@ impl ModuleGraphRef {
     ///    - Receives (originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode, state &S
     ///    - Can return [GraphTraversalAction]s to control the traversal
+    // TODO this is actually traverse_edges_from_entries_dfs
     pub fn traverse_edges_from_entry(
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
@@ -1362,11 +1117,10 @@ impl ModuleGraphRef {
     ) -> Result<()> {
         let graphs = &self.graphs;
 
-        let entries = entries.into_iter();
-        let mut stack = Vec::with_capacity(entries.size_hint().0);
-        for entry in entries {
-            stack.push(self.get_entry(entry)?);
-        }
+        let mut stack = entries
+            .into_iter()
+            .map(|e| self.get_entry(e))
+            .collect::<Result<Vec<_>>>()?;
         let mut visited = HashSet::new();
         for entry_node in &stack {
             visitor(None, get_node!(graphs, entry_node)?);
@@ -1539,10 +1293,10 @@ impl ModuleGraphRef {
     pub fn traverse_cycles(
         &self,
         edge_filter: impl Fn(&RefData) -> bool,
-        mut visit_cycle: impl FnMut(&[&SingleModuleGraphModuleNode]),
+        mut visit_cycle: impl FnMut(&[&SingleModuleGraphModuleNode]) -> Result<()>,
     ) -> Result<()> {
         for graph in &self.graphs {
-            graph.traverse_cycles(&edge_filter, &mut visit_cycle);
+            graph.traverse_cycles(&edge_filter, &mut visit_cycle)?;
         }
         Ok(())
     }
@@ -1956,7 +1710,7 @@ pub mod tests {
     use anyhow::Result;
     use rustc_hash::FxHashMap;
     use turbo_rcstr::{RcStr, rcstr};
-    use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, Vc};
+    use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
     use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
     use turbo_tasks_fs::{FileSystem, FileSystemPath, VirtualFileSystem};
 
@@ -1965,7 +1719,7 @@ pub mod tests {
         ident::AssetIdent,
         module::Module,
         module_graph::{
-            GraphEntries, GraphTraversalAction, SingleModuleGraph,
+            GraphEntries, GraphTraversalAction, ModuleGraphRef, SingleModuleGraph,
             chunk_group_info::ChunkGroupEntry,
         },
         reference::{ModuleReference, ModuleReferences, SingleChunkableModuleReference},
@@ -1973,7 +1727,7 @@ pub mod tests {
     };
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn traverse_dfs_from_entries_diamond() {
+    async fn test_traverse_dfs_from_entries_diamond() {
         run_graph_test(
             vec![rcstr!("a.js")],
             {
@@ -1995,7 +1749,7 @@ pub mod tests {
                         preorder_visits.push((
                             parent
                                 .map(|(node, _)| module_to_name.get(&node.module).unwrap().clone()),
-                            module_to_name.get(&target.module()).unwrap().clone(),
+                            module_to_name.get(&target.module).unwrap().clone(),
                         ));
                         Ok(GraphTraversalAction::Continue)
                     },
@@ -2003,7 +1757,7 @@ pub mod tests {
                         postorder_visits.push((
                             parent
                                 .map(|(node, _)| module_to_name.get(&node.module).unwrap().clone()),
-                            module_to_name.get(&target.module()).unwrap().clone(),
+                            module_to_name.get(&target.module).unwrap().clone(),
                         ));
                         Ok(())
                     },
@@ -2035,7 +1789,7 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn traverse_dfs_from_entries_cycle() {
+    async fn test_traverse_dfs_from_entries_cycle() {
         run_graph_test(
             vec![rcstr!("a.js")],
             {
@@ -2057,7 +1811,7 @@ pub mod tests {
                         preorder_visits.push((
                             parent
                                 .map(|(node, _)| module_to_name.get(&node.module).unwrap().clone()),
-                            module_to_name.get(&target.module()).unwrap().clone(),
+                            module_to_name.get(&target.module).unwrap().clone(),
                         ));
                         Ok(GraphTraversalAction::Continue)
                     },
@@ -2065,7 +1819,7 @@ pub mod tests {
                         postorder_visits.push((
                             parent
                                 .map(|(node, _)| module_to_name.get(&node.module).unwrap().clone()),
-                            module_to_name.get(&target.module()).unwrap().clone(),
+                            module_to_name.get(&target.module).unwrap().clone(),
                         ));
                         Ok(())
                     },
@@ -2095,7 +1849,7 @@ pub mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn traverse_edges_from_entries_fixed_point_cycle() {
+    async fn test_traverse_edges_fixed_point_with_priority_cycle() {
         run_graph_test(
             vec![rcstr!("a.js")],
             {
@@ -2110,13 +1864,14 @@ pub mod tests {
                 let mut visits = Vec::new();
                 let mut count = 0;
 
-                graph.traverse_edges_from_entries_fixed_point(
-                    entry_modules,
-                    |parent, target| {
+                graph.traverse_edges_fixed_point_with_priority(
+                    entry_modules.into_iter().map(|m| (m, 0)),
+                    &mut (),
+                    |parent, target, _| {
                         visits.push((
                             parent
                                 .map(|(node, _)| module_to_name.get(&node.module).unwrap().clone()),
-                            module_to_name.get(&target.module()).unwrap().clone(),
+                            module_to_name.get(&target.module).unwrap().clone(),
                         ));
                         count += 1;
 
@@ -2127,6 +1882,7 @@ pub mod tests {
                             GraphTraversalAction::Skip
                         })
                     },
+                    |_, _| Ok(0),
                 )?;
                 assert_eq!(
                     vec![
@@ -2221,7 +1977,7 @@ pub mod tests {
         entries: Vec<RcStr>,
         graph: FxHashMap<RcStr, Vec<RcStr>>,
         test_fn: impl FnOnce(
-            ReadRef<SingleModuleGraph>,
+            ModuleGraphRef,
             Vec<ResolvedVc<Box<dyn Module>>>,
             FxHashMap<ResolvedVc<Box<dyn Module>>, RcStr>,
         ) -> Result<()>
@@ -2276,7 +2032,7 @@ pub mod tests {
                 .await?
                 .into_iter()
                 .collect();
-            test_fn(graph, entry_modules, module_to_name)
+            test_fn(graph.read(), entry_modules, module_to_name)
         })
         .await
         .unwrap();

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BinaryHeap, HashSet, VecDeque, hash_map::Entry},
+    collections::{BinaryHeap, VecDeque, hash_map::Entry},
     future::Future,
 };
 
@@ -32,7 +32,7 @@ use crate::{
         merged_modules::{MergedModuleInfo, compute_merged_modules},
         module_batches::{ModuleBatchesGraph, compute_module_batches},
         style_groups::{StyleGroups, StyleGroupsConfig, compute_style_groups},
-        traced_di_graph::{TracedDiGraph, iter_neighbors_rev},
+        traced_di_graph::{TracedDiGraph, iter_graphs_neighbors_rev},
     },
     reference::primary_chunkable_referenced_modules,
     resolve::ExportUsage,
@@ -756,93 +756,6 @@ impl ImportTracer for ModuleGraphImportTracer {
     }
 }
 
-macro_rules! get_node {
-    ($graphs:expr, $node:expr, $ignore_visited_module:expr) => {{
-        let node_idx = $node;
-        match $graphs[node_idx.graph_idx()]
-            .graph
-            .node_weight(node_idx.node_idx)
-        {
-            Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok(*node),
-            Some(SingleModuleGraphNode::VisitedModule {
-                idx,
-                module: visited_module,
-            }) => {
-                if cfg!(debug_assertions) {
-                    match $graphs[idx.graph_idx()].graph.node_weight(idx.node_idx) {
-                        Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok(*node),
-                        Some(SingleModuleGraphNode::VisitedModule { .. }) => Err(
-                            ::anyhow::anyhow!("Expected visited target node to be module"),
-                        ),
-                        None => {
-                            if $ignore_visited_module {
-                                // TODO just expose the Module as opposed to the newtype
-                                ::anyhow::Ok(SingleModuleGraphModuleNode {
-                                    module: *visited_module,
-                                })
-                            } else {
-                                Err(::anyhow::anyhow!("Expected visited target node"))
-                            }
-                        }
-                    }
-                } else {
-                    // TODO just expose the Module as opposed to the newtype
-                    ::anyhow::Ok(SingleModuleGraphModuleNode {
-                        module: *visited_module,
-                    })
-                }
-            }
-            None => Err(::anyhow::anyhow!("Expected graph node")),
-        }
-    }};
-}
-macro_rules! get_node_idx {
-    ($graphs:expr, $node:expr, $ignore_visited_module:expr) => {{
-        let node_idx = $node;
-        match $graphs[node_idx.graph_idx()]
-            .graph
-            .node_weight(node_idx.node_idx)
-        {
-            Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok((*node, node_idx)),
-            Some(SingleModuleGraphNode::VisitedModule {
-                idx,
-                module: visited_module,
-            }) => {
-                if cfg!(debug_assertions) {
-                    match $graphs[idx.graph_idx()].graph.node_weight(idx.node_idx) {
-                        Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok((*node, *idx)),
-                        Some(SingleModuleGraphNode::VisitedModule { .. }) => Err(
-                            ::anyhow::anyhow!("Expected visited target node to be module"),
-                        ),
-                        None => {
-                            if $ignore_visited_module {
-                                // TODO just expose the Module as opposed to the newtype
-                                ::anyhow::Ok((
-                                    SingleModuleGraphModuleNode {
-                                        module: *visited_module,
-                                    },
-                                    *idx,
-                                ))
-                            } else {
-                                Err(::anyhow::anyhow!("Expected visited target node"))
-                            }
-                        }
-                    }
-                } else {
-                    // TODO just expose the Module as opposed to the newtype
-                    ::anyhow::Ok((
-                        SingleModuleGraphModuleNode {
-                            module: *visited_module,
-                        },
-                        *idx,
-                    ))
-                }
-            }
-            None => Err(::anyhow::anyhow!("Expected graph node")),
-        }
-    }};
-}
-
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Default)]
 pub struct ModuleGraph {
@@ -931,34 +844,21 @@ impl ModuleGraph {
         let async_modules_info = self.async_module_info().await?;
 
         let entry = graph_ref.get_entry(module)?;
-        let referenced_modules =
-            iter_neighbors_rev(&graphs[entry.graph_idx()].graph, entry.node_idx)
-                .filter(|(edge_idx, _)| {
-                    let ty = graphs[entry.graph_idx()]
-                        .graph
-                        .edge_weight(*edge_idx)
-                        .unwrap();
-                    ty.chunking_type.is_inherit_async()
-                })
-                .map(|(_, child_idx)| {
-                    anyhow::Ok(
-                        get_node!(
-                            graphs,
-                            GraphNodeIndex {
-                                graph_idx: entry.graph_idx,
-                                node_idx: child_idx
-                            },
-                            false
-                        )?
-                        .module,
-                    )
-                })
-                .collect::<Result<Vec<_>>>()?
-                .into_iter()
-                .rev()
-                .filter(|m| async_modules_info.contains(m))
-                .map(|m| *m)
-                .collect();
+        let referenced_modules = iter_graphs_neighbors_rev(&graphs[entry.graph_idx()].graph, entry)
+            .filter(|(edge_idx, _)| {
+                let ty = graphs[entry.graph_idx()]
+                    .graph
+                    .edge_weight(*edge_idx)
+                    .unwrap();
+                ty.chunking_type.is_inherit_async()
+            })
+            .map(|(_, child_idx)| anyhow::Ok(graph_ref.get_node(child_idx)?.module()))
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .rev()
+            .filter(|m| async_modules_info.contains(m))
+            .map(|m| *m)
+            .collect();
 
         Ok(AsyncModuleInfo::new(referenced_modules))
     }
@@ -1000,6 +900,14 @@ impl ModuleGraphRef {
         Ok(idx)
     }
 
+    fn get_node(&self, entry: GraphNodeIndex) -> Result<&SingleModuleGraphNode> {
+        let graph = &self.graphs[entry.graph_idx()];
+        graph
+            .graph
+            .node_weight(entry.node_idx)
+            .context("Expected graph node")
+    }
+
     /// Returns a map of all modules in the graphs to their identifiers.
     /// This is primarily useful for debugging.
     pub async fn get_ids(&self) -> Result<FxHashMap<ResolvedVc<Box<dyn Module>>, ReadRef<RcStr>>> {
@@ -1024,8 +932,8 @@ impl ModuleGraphRef {
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         state: &mut S,
-        visit_preorder: impl Fn(SingleModuleGraphModuleNode, &mut S) -> Result<GraphTraversalAction>,
-        mut visit_postorder: impl FnMut(SingleModuleGraphModuleNode, &mut S) -> Result<()>,
+        visit_preorder: impl Fn(ResolvedVc<Box<dyn Module>>, &mut S) -> Result<GraphTraversalAction>,
+        mut visit_postorder: impl FnMut(ResolvedVc<Box<dyn Module>>, &mut S) -> Result<()>,
     ) -> Result<()> {
         let graphs = &self.graphs;
         let ignore_visited_module = self.ignore_visited_module;
@@ -1040,46 +948,37 @@ impl ModuleGraphRef {
         for entry in entries.into_iter().rev() {
             stack.push((Pass::ExpandAndVisit, self.get_entry(entry)?));
         }
-        let mut expanded = HashSet::new();
+        let mut expanded = FxHashSet::default();
         while let Some((pass, current)) = stack.pop() {
-            let current_node = get_node!(graphs, current, ignore_visited_module)?;
+            let current_node = self.get_node(current)?;
             match pass {
                 Pass::Visit => {
-                    visit_postorder(current_node, state)?;
+                    visit_postorder(current_node.module(), state)?;
                 }
                 Pass::ExpandAndVisit => {
                     if !expanded.insert(current) {
                         continue;
                     }
-                    let action = visit_preorder(current_node, state)?;
+                    let action = visit_preorder(current_node.module(), state)?;
                     if action == GraphTraversalAction::Exclude {
                         continue;
                     }
                     stack.push((Pass::Visit, current));
-                    if action == GraphTraversalAction::Continue {
+                    if action == GraphTraversalAction::Continue
+                        && !(ignore_visited_module
+                            && matches!(current_node, SingleModuleGraphNode::VisitedModule { .. }))
+                    {
                         let graph = &graphs[current.graph_idx()].graph;
-                        let (neighbors_rev, current) = match graph
-                            .node_weight(current.node_idx)
-                            .unwrap()
-                        {
+                        let neighbors_rev = match graph.node_weight(current.node_idx).unwrap() {
                             SingleModuleGraphNode::Module(_) => {
-                                (iter_neighbors_rev(graph, current.node_idx), current)
+                                iter_graphs_neighbors_rev(graph, current)
                             }
-                            SingleModuleGraphNode::VisitedModule { idx, .. } => (
+                            SingleModuleGraphNode::VisitedModule { idx, .. } => {
                                 // We switch graphs
-                                iter_neighbors_rev(&graphs[idx.graph_idx()].graph, idx.node_idx),
-                                *idx,
-                            ),
+                                iter_graphs_neighbors_rev(&graphs[idx.graph_idx()].graph, *idx)
+                            }
                         };
-                        stack.extend(neighbors_rev.map(|(_, child)| {
-                            (
-                                Pass::ExpandAndVisit,
-                                GraphNodeIndex {
-                                    graph_idx: current.graph_idx,
-                                    node_idx: child,
-                                },
-                            )
-                        }));
+                        stack.extend(neighbors_rev.map(|(_, child)| (Pass::ExpandAndVisit, child)));
                     }
                 }
             }
@@ -1102,8 +1001,8 @@ impl ModuleGraphRef {
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         mut visitor: impl FnMut(
-            Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
-            SingleModuleGraphModuleNode,
+            Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
+            ResolvedVc<Box<dyn Module>>,
         ) -> Result<GraphTraversalAction>,
     ) -> Result<()> {
         let graphs = &self.graphs;
@@ -1115,24 +1014,27 @@ impl ModuleGraphRef {
                 .map(|e| self.get_entry(e))
                 .collect::<Result<Vec<_>>>()?,
         );
-        let mut visited = HashSet::new();
+        let mut visited = FxHashSet::default();
         for entry_node in &queue {
-            visitor(None, get_node!(graphs, entry_node, ignore_visited_module)?)?;
+            visitor(None, self.get_node(*entry_node)?.module())?;
         }
         while let Some(node) = queue.pop_front() {
-            let graph = &graphs[node.graph_idx()].graph;
-            let node_weight = get_node!(graphs, node, ignore_visited_module)?;
             if visited.insert(node) {
-                let neighbors = iter_neighbors_rev(graph, node.node_idx);
-
-                for (edge, succ) in neighbors {
-                    let succ = GraphNodeIndex {
-                        graph_idx: node.graph_idx,
-                        node_idx: succ,
-                    };
-                    let succ_weight = get_node!(graphs, succ, ignore_visited_module)?;
+                let node_weight = self.get_node(node)?;
+                let graph = &graphs[node.graph_idx()].graph;
+                for (edge, succ) in iter_graphs_neighbors_rev(graph, node) {
+                    let succ_weight = self.get_node(succ)?;
+                    if ignore_visited_module
+                        && matches!(succ_weight, SingleModuleGraphNode::VisitedModule { .. })
+                    {
+                        continue;
+                    }
                     let edge_weight = graph.edge_weight(edge).unwrap();
-                    let action = visitor(Some((node_weight, edge_weight)), succ_weight)?;
+                    let action = visitor(
+                        Some((node_weight.module(), edge_weight)),
+                        succ_weight.module(),
+                    )?;
+                    let succ = succ_weight.target_idx().unwrap_or(succ);
                     if !visited.contains(&succ) && action == GraphTraversalAction::Continue {
                         queue.push_back(succ);
                     }
@@ -1158,8 +1060,8 @@ impl ModuleGraphRef {
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         mut visitor: impl FnMut(
-            Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
-            SingleModuleGraphModuleNode,
+            Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
+            ResolvedVc<Box<dyn Module>>,
         ) -> GraphTraversalAction,
     ) -> Result<()> {
         let graphs = &self.graphs;
@@ -1169,24 +1071,27 @@ impl ModuleGraphRef {
             .into_iter()
             .map(|e| self.get_entry(e))
             .collect::<Result<Vec<_>>>()?;
-        let mut visited = HashSet::new();
+        let mut visited = FxHashSet::default();
         for entry_node in &stack {
-            visitor(None, get_node!(graphs, entry_node, ignore_visited_module)?);
+            visitor(None, self.get_node(*entry_node)?.module());
         }
         while let Some(node) = stack.pop() {
-            let graph = &graphs[node.graph_idx()].graph;
-            let node_weight = get_node!(graphs, node, ignore_visited_module)?;
             if visited.insert(node) {
-                let neighbors = iter_neighbors_rev(graph, node.node_idx);
-
-                for (edge, succ) in neighbors {
-                    let succ = GraphNodeIndex {
-                        graph_idx: node.graph_idx,
-                        node_idx: succ,
-                    };
-                    let succ_weight = get_node!(graphs, succ, ignore_visited_module)?;
+                let node_weight = self.get_node(node)?;
+                let graph = &graphs[node.graph_idx()].graph;
+                for (edge, succ) in iter_graphs_neighbors_rev(graph, node) {
+                    let succ_weight = self.get_node(succ)?;
+                    if ignore_visited_module
+                        && matches!(succ_weight, SingleModuleGraphNode::VisitedModule { .. })
+                    {
+                        continue;
+                    }
                     let edge_weight = graph.edge_weight(edge).unwrap();
-                    let action = visitor(Some((node_weight, edge_weight)), succ_weight);
+                    let action = visitor(
+                        Some((node_weight.module(), edge_weight)),
+                        succ_weight.module(),
+                    );
+                    let succ = succ_weight.target_idx().unwrap_or(succ);
                     if !visited.contains(&succ) && action == GraphTraversalAction::Continue {
                         stack.push(succ);
                     }
@@ -1208,30 +1113,18 @@ impl ModuleGraphRef {
     pub fn traverse_all_edges_unordered(
         &self,
         mut visitor: impl FnMut(
-            (SingleModuleGraphModuleNode, &'_ RefData),
-            SingleModuleGraphModuleNode,
+            (ResolvedVc<Box<dyn Module>>, &'_ RefData),
+            ResolvedVc<Box<dyn Module>>,
         ) -> Result<()>,
     ) -> Result<()> {
-        let graphs = &self.graphs;
-        let ignore_visited_module = self.ignore_visited_module;
-
-        for graph in graphs {
+        for graph in &self.graphs {
             let graph = &graph.graph;
             for edge in graph.edge_references() {
-                let source = match graph.node_weight(edge.source()).unwrap() {
-                    SingleModuleGraphNode::Module(node) => *node,
-                    SingleModuleGraphNode::VisitedModule { .. } => unreachable!(),
-                };
-                let target = match graph.node_weight(edge.target()).unwrap() {
-                    SingleModuleGraphNode::Module(node) => *node,
-                    SingleModuleGraphNode::VisitedModule { idx, .. } => {
-                        get_node!(graphs, idx, ignore_visited_module)?
-                    }
-                };
+                let source = graph.node_weight(edge.source()).unwrap().module();
+                let target = graph.node_weight(edge.target()).unwrap().module();
                 visitor((source, edge.weight()), target)?;
             }
         }
-
         Ok(())
     }
 
@@ -1259,13 +1152,13 @@ impl ModuleGraphRef {
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         state: &mut S,
         mut visit_preorder: impl FnMut(
-            Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
-            SingleModuleGraphModuleNode,
+            Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
+            ResolvedVc<Box<dyn Module>>,
             &mut S,
         ) -> Result<GraphTraversalAction>,
         mut visit_postorder: impl FnMut(
-            Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
-            SingleModuleGraphModuleNode,
+            Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
+            ResolvedVc<Box<dyn Module>>,
             &mut S,
         ) -> Result<()>,
     ) -> Result<()> {
@@ -1284,11 +1177,11 @@ impl ModuleGraphRef {
         for entry in entries.into_iter().rev() {
             stack.push((Pass::ExpandAndVisit, None, self.get_entry(entry)?));
         }
-        let mut expanded = HashSet::new();
+        let mut expanded = FxHashSet::default();
         while let Some((pass, parent, current)) = stack.pop() {
             let parent_arg = match parent {
                 Some((parent_node, parent_edge)) => Some((
-                    get_node!(graphs, parent_node, ignore_visited_module)?,
+                    self.get_node(parent_node)?.module(),
                     graphs[parent_node.graph_idx()]
                         .graph
                         .edge_weight(parent_edge)
@@ -1296,42 +1189,27 @@ impl ModuleGraphRef {
                 )),
                 None => None,
             };
-            let current_node = get_node!(graphs, current, ignore_visited_module)?;
+            let current_node = self.get_node(current)?;
             match pass {
                 Pass::Visit => {
-                    visit_postorder(parent_arg, current_node, state)?;
+                    visit_postorder(parent_arg, current_node.module(), state)?;
                 }
                 Pass::ExpandAndVisit => {
-                    let action = visit_preorder(parent_arg, current_node, state)?;
+                    let action = visit_preorder(parent_arg, current_node.module(), state)?;
                     if action == GraphTraversalAction::Exclude {
                         continue;
                     }
                     stack.push((Pass::Visit, parent, current));
-                    if action == GraphTraversalAction::Continue && expanded.insert(current) {
+                    if action == GraphTraversalAction::Continue
+                        && expanded.insert(current)
+                        && !(ignore_visited_module
+                            && matches!(current_node, SingleModuleGraphNode::VisitedModule { .. }))
+                    {
                         let graph = &graphs[current.graph_idx()].graph;
-                        let (neighbors_rev, current) = match graph
-                            .node_weight(current.node_idx)
-                            .unwrap()
-                        {
-                            SingleModuleGraphNode::Module(_) => {
-                                (iter_neighbors_rev(graph, current.node_idx), current)
-                            }
-                            SingleModuleGraphNode::VisitedModule { idx, .. } => (
-                                // We switch graphs
-                                iter_neighbors_rev(&graphs[idx.graph_idx()].graph, idx.node_idx),
-                                *idx,
-                            ),
-                        };
-                        stack.extend(neighbors_rev.map(|(edge, child)| {
-                            (
-                                Pass::ExpandAndVisit,
-                                Some((current, edge)),
-                                GraphNodeIndex {
-                                    graph_idx: current.graph_idx,
-                                    node_idx: child,
-                                },
-                            )
-                        }));
+                        let current = current_node.target_idx().unwrap_or(current);
+                        stack.extend(iter_graphs_neighbors_rev(graph, current).map(
+                            |(edge, child)| (Pass::ExpandAndVisit, Some((current, edge)), child),
+                        ));
                     }
                 }
             }
@@ -1379,11 +1257,11 @@ impl ModuleGraphRef {
         entries: impl IntoIterator<Item = (ResolvedVc<Box<dyn Module>>, P)>,
         state: &mut S,
         mut visit: impl FnMut(
-            Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
-            SingleModuleGraphModuleNode,
+            Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
+            ResolvedVc<Box<dyn Module>>,
             &mut S,
         ) -> Result<GraphTraversalAction>,
-        priority: impl Fn(SingleModuleGraphModuleNode, &mut S) -> Result<P>,
+        priority: impl Fn(ResolvedVc<Box<dyn Module>>, &mut S) -> Result<P>,
     ) -> Result<usize> {
         let graphs = &self.graphs;
         let ignore_visited_module = self.ignore_visited_module;
@@ -1423,35 +1301,37 @@ impl ModuleGraphRef {
         );
 
         for entry_node in &queue {
-            visit(
-                None,
-                get_node!(graphs, entry_node.node, ignore_visited_module)?,
-                state,
-            )?;
+            visit(None, self.get_node(entry_node.node)?.module(), state)?;
         }
 
         let mut visit_count = 0usize;
         while let Some(NodeWithPriority { node, .. }) = queue.pop() {
             queue_set.remove(&node);
-            let (node_weight, node) = get_node_idx!(graphs, node, ignore_visited_module)?;
-            let graph = &graphs[node.graph_idx()].graph;
-            let neighbors = iter_neighbors_rev(graph, node.node_idx);
+            let node_weight = self.get_node(node)?;
+            let node = node_weight.target_idx().unwrap_or(node);
 
             visit_count += 1;
 
-            for (edge, succ) in neighbors {
-                let succ = GraphNodeIndex {
-                    graph_idx: node.graph_idx,
-                    node_idx: succ,
-                };
-                let (succ_weight, succ) = get_node_idx!(graphs, succ, ignore_visited_module)?;
-                let edge_weight = graph.edge_weight(edge).unwrap();
-                let action = visit(Some((node_weight, edge_weight)), succ_weight, state)?;
+            let graph = &graphs[node.graph_idx()].graph;
+            for (edge, succ) in iter_graphs_neighbors_rev(graph, node) {
+                let succ_weight = self.get_node(succ)?;
 
-                if action == GraphTraversalAction::Continue && queue_set.insert(succ) {
+                let edge_weight = graph.edge_weight(edge).unwrap();
+                let action = visit(
+                    Some((node_weight.module(), edge_weight)),
+                    succ_weight.module(),
+                    state,
+                )?;
+
+                let succ = succ_weight.target_idx().unwrap_or(succ);
+                if action == GraphTraversalAction::Continue
+                    && queue_set.insert(succ)
+                    && !(ignore_visited_module
+                        && matches!(succ_weight, SingleModuleGraphNode::VisitedModule { .. }))
+                {
                     queue.push(NodeWithPriority {
                         node: succ,
-                        priority: priority(succ_weight, state)?,
+                        priority: priority(succ_weight.module(), state)?,
                     });
                 }
             }
@@ -1518,6 +1398,12 @@ impl SingleModuleGraphNode {
         match self {
             SingleModuleGraphNode::Module(SingleModuleGraphModuleNode { module }) => *module,
             SingleModuleGraphNode::VisitedModule { module, .. } => *module,
+        }
+    }
+    pub fn target_idx(&self) -> Option<GraphNodeIndex> {
+        match self {
+            SingleModuleGraphNode::VisitedModule { idx, .. } => Some(*idx),
+            SingleModuleGraphNode::Module(_) => None,
         }
     }
 }
@@ -1805,17 +1691,15 @@ pub mod tests {
                     &mut (),
                     |parent, target, _| {
                         preorder_visits.push((
-                            parent
-                                .map(|(node, _)| module_to_name.get(&node.module).unwrap().clone()),
-                            module_to_name.get(&target.module).unwrap().clone(),
+                            parent.map(|(node, _)| module_to_name.get(&node).unwrap().clone()),
+                            module_to_name.get(&target).unwrap().clone(),
                         ));
                         Ok(GraphTraversalAction::Continue)
                     },
                     |parent, target, _| {
                         postorder_visits.push((
-                            parent
-                                .map(|(node, _)| module_to_name.get(&node.module).unwrap().clone()),
-                            module_to_name.get(&target.module).unwrap().clone(),
+                            parent.map(|(node, _)| module_to_name.get(&node).unwrap().clone()),
+                            module_to_name.get(&target).unwrap().clone(),
                         ));
                         Ok(())
                     },
@@ -1867,17 +1751,15 @@ pub mod tests {
                     &mut (),
                     |parent, target, _| {
                         preorder_visits.push((
-                            parent
-                                .map(|(node, _)| module_to_name.get(&node.module).unwrap().clone()),
-                            module_to_name.get(&target.module).unwrap().clone(),
+                            parent.map(|(node, _)| module_to_name.get(&node).unwrap().clone()),
+                            module_to_name.get(&target).unwrap().clone(),
                         ));
                         Ok(GraphTraversalAction::Continue)
                     },
                     |parent, target, _| {
                         postorder_visits.push((
-                            parent
-                                .map(|(node, _)| module_to_name.get(&node.module).unwrap().clone()),
-                            module_to_name.get(&target.module).unwrap().clone(),
+                            parent.map(|(node, _)| module_to_name.get(&node).unwrap().clone()),
+                            module_to_name.get(&target).unwrap().clone(),
                         ));
                         Ok(())
                     },
@@ -1927,9 +1809,8 @@ pub mod tests {
                     &mut (),
                     |parent, target, _| {
                         visits.push((
-                            parent
-                                .map(|(node, _)| module_to_name.get(&node.module).unwrap().clone()),
-                            module_to_name.get(&target.module).unwrap().clone(),
+                            parent.map(|(node, _)| module_to_name.get(&node).unwrap().clone()),
+                            module_to_name.get(&target).unwrap().clone(),
                         ));
                         count += 1;
 

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -390,9 +390,9 @@ impl SingleModuleGraph {
     }
 
     /// Iterate over all nodes in the graph
-    pub fn iter_nodes(&self) -> impl Iterator<Item = &'_ SingleModuleGraphModuleNode> + '_ {
+    pub fn iter_nodes(&self) -> impl Iterator<Item = SingleModuleGraphModuleNode> + '_ {
         self.graph.node_weights().filter_map(|n| match n {
-            SingleModuleGraphNode::Module(node) => Some(node),
+            SingleModuleGraphNode::Module(node) => Some(*node),
             SingleModuleGraphNode::VisitedModule { .. } => None,
         })
     }
@@ -443,6 +443,7 @@ impl SingleModuleGraph {
     pub fn read(self: &ReadRef<SingleModuleGraph>) -> ModuleGraphRef {
         ModuleGraphRef {
             graphs: vec![self.clone()],
+            ignore_visited_module: true,
         }
     }
 
@@ -755,6 +756,93 @@ impl ImportTracer for ModuleGraphImportTracer {
     }
 }
 
+macro_rules! get_node {
+    ($graphs:expr, $node:expr, $ignore_visited_module:expr) => {{
+        let node_idx = $node;
+        match $graphs[node_idx.graph_idx()]
+            .graph
+            .node_weight(node_idx.node_idx)
+        {
+            Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok(*node),
+            Some(SingleModuleGraphNode::VisitedModule {
+                idx,
+                module: visited_module,
+            }) => {
+                if cfg!(debug_assertions) {
+                    match $graphs[idx.graph_idx()].graph.node_weight(idx.node_idx) {
+                        Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok(*node),
+                        Some(SingleModuleGraphNode::VisitedModule { .. }) => Err(
+                            ::anyhow::anyhow!("Expected visited target node to be module"),
+                        ),
+                        None => {
+                            if $ignore_visited_module {
+                                // TODO just expose the Module as opposed to the newtype
+                                ::anyhow::Ok(SingleModuleGraphModuleNode {
+                                    module: *visited_module,
+                                })
+                            } else {
+                                Err(::anyhow::anyhow!("Expected visited target node"))
+                            }
+                        }
+                    }
+                } else {
+                    // TODO just expose the Module as opposed to the newtype
+                    ::anyhow::Ok(SingleModuleGraphModuleNode {
+                        module: *visited_module,
+                    })
+                }
+            }
+            None => Err(::anyhow::anyhow!("Expected graph node")),
+        }
+    }};
+}
+macro_rules! get_node_idx {
+    ($graphs:expr, $node:expr, $ignore_visited_module:expr) => {{
+        let node_idx = $node;
+        match $graphs[node_idx.graph_idx()]
+            .graph
+            .node_weight(node_idx.node_idx)
+        {
+            Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok((*node, node_idx)),
+            Some(SingleModuleGraphNode::VisitedModule {
+                idx,
+                module: visited_module,
+            }) => {
+                if cfg!(debug_assertions) {
+                    match $graphs[idx.graph_idx()].graph.node_weight(idx.node_idx) {
+                        Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok((*node, *idx)),
+                        Some(SingleModuleGraphNode::VisitedModule { .. }) => Err(
+                            ::anyhow::anyhow!("Expected visited target node to be module"),
+                        ),
+                        None => {
+                            if $ignore_visited_module {
+                                // TODO just expose the Module as opposed to the newtype
+                                ::anyhow::Ok((
+                                    SingleModuleGraphModuleNode {
+                                        module: *visited_module,
+                                    },
+                                    *idx,
+                                ))
+                            } else {
+                                Err(::anyhow::anyhow!("Expected visited target node"))
+                            }
+                        }
+                    }
+                } else {
+                    // TODO just expose the Module as opposed to the newtype
+                    ::anyhow::Ok((
+                        SingleModuleGraphModuleNode {
+                            module: *visited_module,
+                        },
+                        *idx,
+                    ))
+                }
+            }
+            None => Err(::anyhow::anyhow!("Expected graph node")),
+        }
+    }};
+}
+
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Default)]
 pub struct ModuleGraph {
@@ -859,7 +947,8 @@ impl ModuleGraph {
                             GraphNodeIndex {
                                 graph_idx: entry.graph_idx,
                                 node_idx: child_idx
-                            }
+                            },
+                            false
                         )?
                         .module,
                     )
@@ -875,58 +964,11 @@ impl ModuleGraph {
     }
 }
 
-// fn get_node<T>(
-//     graphs: Vec<ReadRef<SingleModuleGraph>>,
-//     node: GraphNodeIndex,
-// ) -> Result<&'static SingleModuleGraphModuleNode> {
-macro_rules! get_node {
-    ($graphs:expr, $node:expr) => {{
-        let node_idx = $node;
-        match $graphs[node_idx.graph_idx()]
-            .graph
-            .node_weight(node_idx.node_idx)
-        {
-            Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok(node),
-            Some(SingleModuleGraphNode::VisitedModule { idx, .. }) => {
-                match $graphs[idx.graph_idx()].graph.node_weight(idx.node_idx) {
-                    Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok(node),
-                    Some(SingleModuleGraphNode::VisitedModule { .. }) => Err(::anyhow::anyhow!(
-                        "Expected visited target node to be module"
-                    )),
-                    None => Err(::anyhow::anyhow!("Expected visited target node")),
-                }
-            }
-            None => Err(::anyhow::anyhow!("Expected graph node")),
-        }
-    }};
-}
-pub(crate) use get_node;
-macro_rules! get_node_idx {
-    ($graphs:expr, $node:expr) => {{
-        let node_idx = $node;
-        match $graphs[node_idx.graph_idx()]
-            .graph
-            .node_weight(node_idx.node_idx)
-        {
-            Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok((node, node_idx)),
-            Some(SingleModuleGraphNode::VisitedModule { idx, .. }) => {
-                match $graphs[idx.graph_idx()].graph.node_weight(idx.node_idx) {
-                    Some(SingleModuleGraphNode::Module(node)) => ::anyhow::Ok((node, *idx)),
-                    Some(SingleModuleGraphNode::VisitedModule { .. }) => Err(::anyhow::anyhow!(
-                        "Expected visited target node to be module"
-                    )),
-                    None => Err(::anyhow::anyhow!("Expected visited target node")),
-                }
-            }
-            None => Err(::anyhow::anyhow!("Expected graph node")),
-        }
-    }};
-}
-
 impl ModuleGraph {
     pub async fn read_graphs(self: Vc<ModuleGraph>) -> Result<ModuleGraphRef> {
         Ok(ModuleGraphRef {
             graphs: self.await?.graphs.iter().try_join().await?,
+            ignore_visited_module: false,
         })
     }
 }
@@ -935,6 +977,9 @@ impl ModuleGraph {
 /// aren't awaited multiple times within the same task.
 pub struct ModuleGraphRef {
     pub graphs: Vec<ReadRef<SingleModuleGraph>>,
+    // Whether to simply ignore SingleModuleGraphNode::VisitedModule during traversals. For single
+    // module graph usecases, this is what you want. For the whole graph, there should be an error.
+    ignore_visited_module: bool,
 }
 
 impl ModuleGraphRef {
@@ -975,14 +1020,15 @@ impl ModuleGraphRef {
     /// * `visitor` - Called before visiting the children of a node.
     ///    - Receives &SingleModuleGraphNode
     ///    - Can return [GraphTraversalAction]s to control the traversal
-    pub fn traverse_nodes_from_entries_dfs<'a, S>(
-        &'a self,
+    pub fn traverse_nodes_from_entries_dfs<S>(
+        &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         state: &mut S,
-        visit_preorder: impl Fn(&'a SingleModuleGraphModuleNode, &mut S) -> Result<GraphTraversalAction>,
-        mut visit_postorder: impl FnMut(&'a SingleModuleGraphModuleNode, &mut S) -> Result<()>,
+        visit_preorder: impl Fn(SingleModuleGraphModuleNode, &mut S) -> Result<GraphTraversalAction>,
+        mut visit_postorder: impl FnMut(SingleModuleGraphModuleNode, &mut S) -> Result<()>,
     ) -> Result<()> {
         let graphs = &self.graphs;
+        let ignore_visited_module = self.ignore_visited_module;
 
         let entries = entries.into_iter().collect::<Vec<_>>();
 
@@ -996,7 +1042,7 @@ impl ModuleGraphRef {
         }
         let mut expanded = HashSet::new();
         while let Some((pass, current)) = stack.pop() {
-            let current_node = get_node!(graphs, current)?;
+            let current_node = get_node!(graphs, current, ignore_visited_module)?;
             match pass {
                 Pass::Visit => {
                     visit_postorder(current_node, state)?;
@@ -1056,11 +1102,12 @@ impl ModuleGraphRef {
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         mut visitor: impl FnMut(
-            Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
-            &'_ SingleModuleGraphModuleNode,
+            Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
+            SingleModuleGraphModuleNode,
         ) -> Result<GraphTraversalAction>,
     ) -> Result<()> {
         let graphs = &self.graphs;
+        let ignore_visited_module = self.ignore_visited_module;
 
         let mut queue = VecDeque::from(
             entries
@@ -1070,11 +1117,11 @@ impl ModuleGraphRef {
         );
         let mut visited = HashSet::new();
         for entry_node in &queue {
-            visitor(None, get_node!(graphs, entry_node)?)?;
+            visitor(None, get_node!(graphs, entry_node, ignore_visited_module)?)?;
         }
         while let Some(node) = queue.pop_front() {
             let graph = &graphs[node.graph_idx()].graph;
-            let node_weight = get_node!(graphs, node)?;
+            let node_weight = get_node!(graphs, node, ignore_visited_module)?;
             if visited.insert(node) {
                 let neighbors = iter_neighbors_rev(graph, node.node_idx);
 
@@ -1083,7 +1130,7 @@ impl ModuleGraphRef {
                         graph_idx: node.graph_idx,
                         node_idx: succ,
                     };
-                    let succ_weight = get_node!(graphs, succ)?;
+                    let succ_weight = get_node!(graphs, succ, ignore_visited_module)?;
                     let edge_weight = graph.edge_weight(edge).unwrap();
                     let action = visitor(Some((node_weight, edge_weight)), succ_weight)?;
                     if !visited.contains(&succ) && action == GraphTraversalAction::Continue {
@@ -1111,11 +1158,12 @@ impl ModuleGraphRef {
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         mut visitor: impl FnMut(
-            Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
-            &'_ SingleModuleGraphModuleNode,
+            Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
+            SingleModuleGraphModuleNode,
         ) -> GraphTraversalAction,
     ) -> Result<()> {
         let graphs = &self.graphs;
+        let ignore_visited_module = self.ignore_visited_module;
 
         let mut stack = entries
             .into_iter()
@@ -1123,11 +1171,11 @@ impl ModuleGraphRef {
             .collect::<Result<Vec<_>>>()?;
         let mut visited = HashSet::new();
         for entry_node in &stack {
-            visitor(None, get_node!(graphs, entry_node)?);
+            visitor(None, get_node!(graphs, entry_node, ignore_visited_module)?);
         }
         while let Some(node) = stack.pop() {
             let graph = &graphs[node.graph_idx()].graph;
-            let node_weight = get_node!(graphs, node)?;
+            let node_weight = get_node!(graphs, node, ignore_visited_module)?;
             if visited.insert(node) {
                 let neighbors = iter_neighbors_rev(graph, node.node_idx);
 
@@ -1136,7 +1184,7 @@ impl ModuleGraphRef {
                         graph_idx: node.graph_idx,
                         node_idx: succ,
                     };
-                    let succ_weight = get_node!(graphs, succ)?;
+                    let succ_weight = get_node!(graphs, succ, ignore_visited_module)?;
                     let edge_weight = graph.edge_weight(edge).unwrap();
                     let action = visitor(Some((node_weight, edge_weight)), succ_weight);
                     if !visited.contains(&succ) && action == GraphTraversalAction::Continue {
@@ -1160,22 +1208,25 @@ impl ModuleGraphRef {
     pub fn traverse_all_edges_unordered(
         &self,
         mut visitor: impl FnMut(
-            (&'_ SingleModuleGraphModuleNode, &'_ RefData),
-            &'_ SingleModuleGraphModuleNode,
+            (SingleModuleGraphModuleNode, &'_ RefData),
+            SingleModuleGraphModuleNode,
         ) -> Result<()>,
     ) -> Result<()> {
         let graphs = &self.graphs;
+        let ignore_visited_module = self.ignore_visited_module;
 
         for graph in graphs {
             let graph = &graph.graph;
             for edge in graph.edge_references() {
                 let source = match graph.node_weight(edge.source()).unwrap() {
-                    SingleModuleGraphNode::Module(node) => node,
+                    SingleModuleGraphNode::Module(node) => *node,
                     SingleModuleGraphNode::VisitedModule { .. } => unreachable!(),
                 };
                 let target = match graph.node_weight(edge.target()).unwrap() {
-                    SingleModuleGraphNode::Module(node) => node,
-                    SingleModuleGraphNode::VisitedModule { idx, .. } => get_node!(graphs, idx)?,
+                    SingleModuleGraphNode::Module(node) => *node,
+                    SingleModuleGraphNode::VisitedModule { idx, .. } => {
+                        get_node!(graphs, idx, ignore_visited_module)?
+                    }
                 };
                 visitor((source, edge.weight()), target)?;
             }
@@ -1208,17 +1259,18 @@ impl ModuleGraphRef {
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         state: &mut S,
         mut visit_preorder: impl FnMut(
-            Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
-            &'_ SingleModuleGraphModuleNode,
+            Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
+            SingleModuleGraphModuleNode,
             &mut S,
         ) -> Result<GraphTraversalAction>,
         mut visit_postorder: impl FnMut(
-            Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
-            &'_ SingleModuleGraphModuleNode,
+            Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
+            SingleModuleGraphModuleNode,
             &mut S,
         ) -> Result<()>,
     ) -> Result<()> {
         let graphs = &self.graphs;
+        let ignore_visited_module = self.ignore_visited_module;
 
         let entries = entries.into_iter().collect::<Vec<_>>();
 
@@ -1236,7 +1288,7 @@ impl ModuleGraphRef {
         while let Some((pass, parent, current)) = stack.pop() {
             let parent_arg = match parent {
                 Some((parent_node, parent_edge)) => Some((
-                    get_node!(graphs, parent_node)?,
+                    get_node!(graphs, parent_node, ignore_visited_module)?,
                     graphs[parent_node.graph_idx()]
                         .graph
                         .edge_weight(parent_edge)
@@ -1244,7 +1296,7 @@ impl ModuleGraphRef {
                 )),
                 None => None,
             };
-            let current_node = get_node!(graphs, current)?;
+            let current_node = get_node!(graphs, current, ignore_visited_module)?;
             match pass {
                 Pass::Visit => {
                     visit_postorder(parent_arg, current_node, state)?;
@@ -1327,13 +1379,14 @@ impl ModuleGraphRef {
         entries: impl IntoIterator<Item = (ResolvedVc<Box<dyn Module>>, P)>,
         state: &mut S,
         mut visit: impl FnMut(
-            Option<(&'_ SingleModuleGraphModuleNode, &'_ RefData)>,
-            &'_ SingleModuleGraphModuleNode,
+            Option<(SingleModuleGraphModuleNode, &'_ RefData)>,
+            SingleModuleGraphModuleNode,
             &mut S,
         ) -> Result<GraphTraversalAction>,
-        priority: impl Fn(&'_ SingleModuleGraphModuleNode, &mut S) -> Result<P>,
+        priority: impl Fn(SingleModuleGraphModuleNode, &mut S) -> Result<P>,
     ) -> Result<usize> {
         let graphs = &self.graphs;
+        let ignore_visited_module = self.ignore_visited_module;
 
         #[derive(PartialEq, Eq)]
         struct NodeWithPriority<T: Ord> {
@@ -1370,13 +1423,17 @@ impl ModuleGraphRef {
         );
 
         for entry_node in &queue {
-            visit(None, get_node!(graphs, entry_node.node)?, state)?;
+            visit(
+                None,
+                get_node!(graphs, entry_node.node, ignore_visited_module)?,
+                state,
+            )?;
         }
 
         let mut visit_count = 0usize;
         while let Some(NodeWithPriority { node, .. }) = queue.pop() {
             queue_set.remove(&node);
-            let (node_weight, node) = get_node_idx!(graphs, node)?;
+            let (node_weight, node) = get_node_idx!(graphs, node, ignore_visited_module)?;
             let graph = &graphs[node.graph_idx()].graph;
             let neighbors = iter_neighbors_rev(graph, node.node_idx);
 
@@ -1387,7 +1444,7 @@ impl ModuleGraphRef {
                     graph_idx: node.graph_idx,
                     node_idx: succ,
                 };
-                let (succ_weight, succ) = get_node_idx!(graphs, succ)?;
+                let (succ_weight, succ) = get_node_idx!(graphs, succ, ignore_visited_module)?;
                 let edge_weight = graph.edge_weight(edge).unwrap();
                 let action = visit(Some((node_weight, edge_weight)), succ_weight, state)?;
 
@@ -1440,7 +1497,8 @@ impl SingleModuleGraph {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
+// TODO get rid of this wrapper type
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
 pub struct SingleModuleGraphModuleNode {
     pub module: ResolvedVc<Box<dyn Module>>,
 }

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1638,7 +1638,7 @@ pub mod tests {
         ident::AssetIdent,
         module::Module,
         module_graph::{
-            GraphEntries, GraphTraversalAction, ModuleGraphRef, SingleModuleGraph,
+            GraphEntries, GraphTraversalAction, ModuleGraph, ModuleGraphRef, SingleModuleGraph,
             chunk_group_info::ChunkGroupEntry,
         },
         reference::{ModuleReference, ModuleReferences, SingleChunkableModuleReference},
@@ -1931,14 +1931,13 @@ pub mod tests {
                     entry_modules.clone(),
                 )])),
                 false,
-            )
-            .await?;
+            );
 
             // Create a simple name mapping to make analyzing the visitors easier.
             // Technically they could always pull this name off of the
-            // `module.ident().await?.path.path` themselves but that `await` is trick in the
-            // visitors so precomputing this helps.
+            // `module.ident().await?.path.path` themselves but you cannot `await` in visitors.
             let module_to_name = graph
+                .await?
                 .modules
                 .keys()
                 .map(|m| async move { Ok((*m, m.ident().await?.path.path.clone())) })
@@ -1946,7 +1945,11 @@ pub mod tests {
                 .await?
                 .into_iter()
                 .collect();
-            test_fn(graph.read(), entry_modules, module_to_name)
+            test_fn(
+                ModuleGraph::from_single_graph(graph).read_graphs().await?,
+                entry_modules,
+                module_to_name,
+            )
         })
         .await
         .unwrap();

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -295,7 +295,7 @@ impl PreBatches {
                     },
                     |(_, ty)| &ty.chunking_type,
                 );
-                let module = node.module;
+                let module = node;
                 if !ty.is_parallel() {
                     state.items.push(PreBatchItem::NonParallelEdge(
                         ty.without_inherit_async(),
@@ -319,7 +319,7 @@ impl PreBatches {
                 }
             },
             |_, node, state| {
-                let item = PreBatchItem::ParallelModule(node.module);
+                let item = PreBatchItem::ParallelModule(node);
                 state.items.push(item);
                 Ok(())
             },
@@ -352,7 +352,7 @@ pub async fn compute_module_batches(
         // different chunk group bitmap)
         module_graph.traverse_all_edges_unordered(|(parent, ty), node| {
             let std::collections::hash_set::Entry::Vacant(entry) =
-                pre_batches.boundary_modules.entry(node.module)
+                pre_batches.boundary_modules.entry(node)
             else {
                 // Already a boundary module, can skip check
                 return Ok(());
@@ -360,11 +360,11 @@ pub async fn compute_module_batches(
             if ty.chunking_type.is_parallel() {
                 let parent_chunk_groups = chunk_group_info
                     .module_chunk_groups
-                    .get(&parent.module)
+                    .get(&parent)
                     .context("all modules need to have chunk group info")?;
                 let chunk_groups = chunk_group_info
                     .module_chunk_groups
-                    .get(&node.module)
+                    .get(&node)
                     .context("all modules need to have chunk group info")?;
                 if parent_chunk_groups != chunk_groups {
                     // This is a boundary module

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -390,11 +390,11 @@ pub async fn compute_module_batches(
             |cycle| {
                 if cycle
                     .iter()
-                    .any(|node| pre_batches.boundary_modules.contains(&node.module))
+                    .any(|node| pre_batches.boundary_modules.contains(node))
                 {
                     pre_batches
                         .boundary_modules
-                        .extend(cycle.iter().map(|node| node.module));
+                        .extend(cycle.iter().map(|node| **node));
                 }
                 Ok(())
             },

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -396,6 +396,7 @@ pub async fn compute_module_batches(
                         .boundary_modules
                         .extend(cycle.iter().map(|node| node.module));
                 }
+                Ok(())
             },
         )?;
 

--- a/turbopack/crates/turbopack-core/src/module_graph/traced_di_graph.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/traced_di_graph.rs
@@ -8,8 +8,6 @@ use turbo_tasks::{
     trace::{TraceRawVcs, TraceRawVcsContext},
 };
 
-use crate::module_graph::GraphNodeIndex;
-
 #[derive(Clone, Debug, ValueDebugFormat, Serialize, Deserialize)]
 pub struct TracedDiGraph<N, E>(pub DiGraph<N, E>);
 impl<N, E> Default for TracedDiGraph<N, E> {
@@ -60,24 +58,4 @@ pub fn iter_neighbors_rev<N, E>(
 ) -> impl Iterator<Item = (EdgeIndex, NodeIndex)> + '_ {
     let mut walker = graph.neighbors(node).detach();
     std::iter::from_fn(move || walker.next(graph))
-}
-
-/// Iterate the edges of a node REVERSED!
-pub fn iter_graphs_neighbors_rev<N, E>(
-    graph: &DiGraph<N, E>,
-    node: GraphNodeIndex,
-) -> impl Iterator<Item = (EdgeIndex, GraphNodeIndex)> + '_ {
-    // TODO assert that `node` is never SingleModuleGraphNode::VisitedModule
-    let mut walker = graph.neighbors(node.node_idx).detach();
-    std::iter::from_fn(move || {
-        walker.next(graph).map(|(edge_idx, succ_idx)| {
-            (
-                edge_idx,
-                GraphNodeIndex {
-                    graph_idx: node.graph_idx,
-                    node_idx: succ_idx,
-                },
-            )
-        })
-    })
 }

--- a/turbopack/crates/turbopack-core/src/module_graph/traced_di_graph.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/traced_di_graph.rs
@@ -8,6 +8,8 @@ use turbo_tasks::{
     trace::{TraceRawVcs, TraceRawVcsContext},
 };
 
+use crate::module_graph::GraphNodeIndex;
+
 #[derive(Clone, Debug, ValueDebugFormat, Serialize, Deserialize)]
 pub struct TracedDiGraph<N, E>(pub DiGraph<N, E>);
 impl<N, E> Default for TracedDiGraph<N, E> {
@@ -58,4 +60,24 @@ pub fn iter_neighbors_rev<N, E>(
 ) -> impl Iterator<Item = (EdgeIndex, NodeIndex)> + '_ {
     let mut walker = graph.neighbors(node).detach();
     std::iter::from_fn(move || walker.next(graph))
+}
+
+/// Iterate the edges of a node REVERSED!
+pub fn iter_graphs_neighbors_rev<N, E>(
+    graph: &DiGraph<N, E>,
+    node: GraphNodeIndex,
+) -> impl Iterator<Item = (EdgeIndex, GraphNodeIndex)> + '_ {
+    // TODO assert that `node` is never SingleModuleGraphNode::VisitedModule
+    let mut walker = graph.neighbors(node.node_idx).detach();
+    std::iter::from_fn(move || {
+        walker.next(graph).map(|(edge_idx, succ_idx)| {
+            (
+                edge_idx,
+                GraphNodeIndex {
+                    graph_idx: node.graph_idx,
+                    node_idx: succ_idx,
+                },
+            )
+        })
+    })
 }

--- a/turbopack/crates/turbopack/src/global_module_ids.rs
+++ b/turbopack/crates/turbopack/src/global_module_ids.rs
@@ -39,7 +39,7 @@ pub async fn get_global_module_id_strategy(
                 },
             ) = parent
             {
-                let module = ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(current.module)
+                let module = ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(current)
                     .context("expected chunkable module for async reference")?;
                 async_idents.push(AsyncLoaderModule::asset_ident_for(*module));
             }

--- a/turbopack/crates/turbopack/src/global_module_ids.rs
+++ b/turbopack/crates/turbopack/src/global_module_ids.rs
@@ -26,7 +26,7 @@ pub async fn get_global_module_id_strategy(
         let module_idents = graphs
             .iter()
             .flat_map(|graph| graph.iter_nodes())
-            .map(|m| m.module.ident());
+            .map(|m| m.ident());
 
         // And additionally, all the modules that are inserted by chunking (i.e. async loaders)
         let mut async_idents = vec![];


### PR DESCRIPTION
We had two implementations of various traversals: first for the SingleModuleGraph, and then also the more general version that can cross module graphs. Let's just use the second for everything (with just a single graph in the case of `SingleModuleGraph`)

This turned out to be a much bigger change than I had anticipated, but this was long overdue anyway.