### PR TITLE
Allow serializable overrides in defineServer

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -343,7 +343,7 @@ export function getDefineEnv({
   if (isNodeServer || isEdgeServer) {
     const userDefinesServer = config.compiler?.defineServer ?? {}
     for (const key in userDefinesServer) {
-      if (defineEnv.hasOwnProperty(key)) {
+      if (defineEnv.hasOwnProperty(key) && !userDefines.hasOwnProperty(key)) {
         throw new Error(
           `The \`compiler.defineServer\` option is configured to replace the \`${key}\` variable. This variable is either part of a Next.js built-in or is already configured.`
         )

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -443,8 +443,8 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
             useLightningcss: z.boolean().optional(),
           }),
         ]),
-        define: z.record(z.string(), z.string()).optional(),
-        defineServer: z.record(z.string(), z.string()).optional(),
+        define: z.record(z.string(), z.any()).optional(),
+        defineServer: z.record(z.string(), z.any()).optional(),
         runAfterProductionCompile: z
           .function()
           .returns(z.promise(z.void()))

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1173,13 +1173,13 @@ export interface NextConfig {
      * Replaces variables in your code during compile time. Each key will be
      * replaced with the respective values.
      */
-    define?: Record<string, string>
+    define?: Record<string, any>
 
     /**
      * Replaces server-only (Node.js and Edge) variables in your code during compile time.
      * Each key will be replaced with the respective values.
      */
-    defineServer?: Record<string, string>
+    defineServer?: Record<string, any>
 
     /**
      * A hook function that executes after production build compilation finishes,

--- a/test/e2e/define/app/with-server-only/client-component.js
+++ b/test/e2e/define/app/with-server-only/client-component.js
@@ -28,3 +28,14 @@ export function ClientExpr() {
 
   return <>{serverExpr}</>
 }
+
+export function ClientFlag() {
+  const [clientFlag, setClientFlag] = useState('<loading>')
+  useEffect(() => {
+    setClientFlag(
+      typeof IS_CLIENT === 'boolean' ? String(IS_CLIENT) : 'not set'
+    )
+  }, [setClientFlag])
+
+  return <>{clientFlag}</>
+}

--- a/test/e2e/define/app/with-server-only/page.js
+++ b/test/e2e/define/app/with-server-only/page.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import { ClientValue, ClientExpr } from './client-component'
+import { ClientValue, ClientExpr, ClientFlag } from './client-component'
 
 export default function Page() {
   return (
@@ -21,6 +21,13 @@ export default function Page() {
       </li>
       <li>
         Client expr: <ClientExpr />
+      </li>
+      <li>
+        Server flag:{' '}
+        {typeof IS_CLIENT === 'boolean' ? String(IS_CLIENT) : 'not set'}
+      </li>
+      <li>
+        Client flag: <ClientFlag />
       </li>
     </ul>
   )

--- a/test/e2e/define/define.test.ts
+++ b/test/e2e/define/define.test.ts
@@ -14,21 +14,17 @@ describe('compiler.define', () => {
 
     it('should render the magic variable on server side', async () => {
       expect(loadedText).toContain('Server value: foobar')
-      expect(loadedText).toContain('Client value: foobar')
     })
 
     it('should render the magic variable on client side', async () => {
-      expect(loadedText).toContain('Server value: foobar')
       expect(loadedText).toContain('Client value: foobar')
     })
 
     it('should render the magic expression on server side', async () => {
       expect(loadedText).toContain('Server expr: barbaz')
-      expect(loadedText).toContain('Client expr: barbaz')
     })
 
     it('should render the magic expression on client side', async () => {
-      expect(loadedText).toContain('Server expr: barbaz')
       expect(loadedText).toContain('Client expr: barbaz')
     })
   })

--- a/test/e2e/define/define.test.ts
+++ b/test/e2e/define/define.test.ts
@@ -55,5 +55,13 @@ describe('compiler.define', () => {
     it('should not render the inlined expression on client side', async () => {
       expect(loadedText).toContain('Client expr: not set')
     })
+
+    it('should render the inlined client flag on server side', async () => {
+      expect(loadedText).toContain('Server flag: false')
+    })
+
+    it('should render the inlined client flag on client side', async () => {
+      expect(loadedText).toContain('Client flag: true')
+    })
   })
 })

--- a/test/e2e/define/next.config.js
+++ b/test/e2e/define/next.config.js
@@ -3,10 +3,12 @@ module.exports = {
     define: {
       MY_MAGIC_VARIABLE: 'foobar',
       'process.env.MY_MAGIC_EXPR': 'barbaz',
+      IS_CLIENT: true,
     },
     defineServer: {
       MY_SERVER_VARIABLE: 'server',
       'process.env.MY_MAGIC_SERVER_EXPR': 'serverbarbaz',
+      IS_CLIENT: false,
     },
   },
 }


### PR DESCRIPTION
## What

- Enables override of `compiler.define` with `compiler.defineServer`.
- Supports serializable values in `compiler.define` and `compiler.defineServer`, not only strings.
- Removes duplicated (I think) tests.

## Why

When using webpack, it was possible to statically replace globals using a plugin in `next.config.ts`:

```js
webpack: (config, { isServer, webpack, dev }) => {
    config.plugins.push(
        new webpack.DefinePlugin({
            __IS_DEV__: dev,
            __IS_CLIENT__: !isServer,
        }),
    )

    return config
},
```

#79225 added a similar capability to turbopack using `compiler.define` and `compiler.defineServer`, but seems to have left unintentional behaviour:

1. `compiler.defineServer` is not allowed to override variables defined in `compiler.define`, which is an unnecessary limitation. Imagine something like this:

```js
compiler: {
    define: {
        __IS_DEV__: phase === PHASE_DEVELOPMENT_SERVER,
        __IS_CLIENT__: true,
    },
    defineServer: {
        __IS_CLIENT__: false,
    },
}
```

2. Where `DefinePlugin` [allows](https://github.com/webpack/webpack/blob/4cfe0088ee4ec3a920f1c3e35c29cf31df3b3620/types.d.ts#L2016) a wide range of values, `compiler.define` and `compiler.defineServer` only allowed `string`, even though they're all serialized [here](https://github.com/vercel/next.js/blob/f7b4a8f4a8697ff6324c2b2f5e8933ee7754b9e7/packages/next/src/build/define-env.ts#L355). This made the example above impossible, as `__IS_CLIENT__: JSON.stringify(false)` would still be evaluated as truthy.

Using `any` was merely a placeholder. Unlike in webpack, there is currently no check if the value is in fact serializable, other than `JSON.stringify` crashing I guess. Let me know if it makes more sense to limit it to something like `string | number | boolean | null`.

This is not about enabling flags like `__IS_CLIENT__` specifically, which could be circumvented with things like `typeof window !== 'undefined'`. I'm sure there are other scenarios that could benefit from lifting the limitations above.

I wasn't sure if this is intentional behaviour, but the docs don't mention this limitation, so I assumed not.

> The define option allows you to statically replace variables in your code at build-time. The option takes an object as key-value pairs, where the keys are the variables that should be replaced with the corresponding values.

Tested with https://github.com/arvidede/next-example-app