### PR TITLE
Build: Share StaticWorker between static check and static generation

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -871,6 +871,9 @@ async function writeFullyStaticExport(
   configOutDir: string,
   nextBuildSpan: Span,
   appDirOnly: boolean
+  // TODO: Reusing the worker seems to break finding if it's `.html` or a JS page.
+  // Because writeFullyStaticExport is called after `exportApp` has been called before
+  // worker: StaticWorker | undefined
 ): Promise<void> {
   const exportApp = (require('../export') as typeof import('../export'))
     .default as typeof import('../export').default
@@ -887,6 +890,7 @@ async function writeFullyStaticExport(
       appDirOnly,
     },
     nextBuildSpan
+    // worker
   )
 }
 
@@ -925,6 +929,7 @@ export default async function build(
   const buildStartTime = Date.now()
 
   let loadedConfig: NextConfigComplete | undefined
+  let staticWorker: StaticWorker
   try {
     const nextBuildSpan = trace('next-build', undefined, {
       buildMode: experimentalBuildMode,
@@ -1966,7 +1971,7 @@ export default async function build(
 
       process.env.NEXT_PHASE = PHASE_PRODUCTION_BUILD
 
-      const worker = createStaticWorker(config, {
+      staticWorker = createStaticWorker(config, {
         numberOfWorkers,
         debuggerPortOffset: -1,
       })
@@ -2004,7 +2009,7 @@ export default async function build(
           nonStaticErrorPageSpan.traceAsyncFn(
             async () =>
               hasCustomErrorPage &&
-              (await worker.hasCustomGetInitialProps({
+              (await staticWorker.hasCustomGetInitialProps({
                 page: '/_error',
                 distDir,
                 checkingApp: false,
@@ -2015,7 +2020,7 @@ export default async function build(
         const errorPageStaticResult = nonStaticErrorPageSpan.traceAsyncFn(
           async () =>
             hasCustomErrorPage &&
-            worker.isPageStatic({
+            staticWorker.isPageStatic({
               dir,
               page: '/_error',
               distDir,
@@ -2037,7 +2042,7 @@ export default async function build(
         const appPageToCheck = '/_app'
 
         const customAppGetInitialPropsPromise = hasUserPagesRoutes
-          ? worker.hasCustomGetInitialProps({
+          ? staticWorker.hasCustomGetInitialProps({
               page: appPageToCheck,
               distDir,
               checkingApp: true,
@@ -2046,7 +2051,7 @@ export default async function build(
           : Promise.resolve(false)
 
         const namedExportsPromise = hasUserPagesRoutes
-          ? worker.getDefinedNamedExports({
+          ? staticWorker.getDefinedNamedExports({
               page: appPageToCheck,
               distDir,
               sriEnabled,
@@ -2226,7 +2231,7 @@ export default async function build(
                         checkPageSpan.traceChild('is-page-static')
                       let workerResult = await isPageStaticSpan.traceAsyncFn(
                         () => {
-                          return worker.isPageStatic({
+                          return staticWorker.isPageStatic({
                             dir,
                             page,
                             originalAppPath,
@@ -3078,7 +3083,8 @@ export default async function build(
               numWorkers: numberOfWorkers,
               appDirOnly,
             },
-            nextBuildSpan
+            nextBuildSpan,
+            staticWorker
           )
 
           // If there was no result, there's nothing more to do.
@@ -4007,8 +4013,12 @@ export default async function build(
         buildTracesSpinner = createSpinner('Collecting build traces')
       }
 
-      // ensure the worker is not left hanging
-      worker.end()
+      // When output: export we want to end the worker later as it's still used for writeFullyStaticExport
+      if (config.output !== 'export') {
+        // ensure the worker is not left hanging
+        staticWorker?.end()
+        staticWorker = undefined! // Reset staticWorker to make sure it does not end in `finally`
+      }
 
       const analysisEnd = process.hrtime(analysisBegin)
       telemetry.record(
@@ -4183,6 +4193,11 @@ export default async function build(
       }
 
       if (config.output === 'export') {
+        // TODO: When writeFullyStaticExport doesn't fail when staticWorker is passed moved this after writeFullyStaticExport.
+        // End the worker here when it's output: export.
+        staticWorker.end()
+        staticWorker = undefined! // Reset staticWorker to make sure it does not end in `finally`
+
         await nextBuildSpan
           .traceChild('output-export-full-static-export')
           .traceAsyncFn(async () => {
@@ -4193,6 +4208,7 @@ export default async function build(
               configOutDir,
               nextBuildSpan,
               appDirOnly
+              // staticWorker
             )
           })
       }
@@ -4300,6 +4316,10 @@ export default async function build(
     }
     throw e
   } finally {
+    // @ts-expect-error Existence of staticWorker is checked here intentionally.
+    if (staticWorker) {
+      staticWorker.end()
+    }
     // Ensure we wait for lockfile patching if present
     await lockfilePatchPromise.cur
 

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -12,6 +12,7 @@ import type {
 import type { FetchMetrics } from '../server/base-http'
 import type { RouteMetadata } from './routes/types'
 import type { RenderResumeDataCache } from '../server/resume-data-cache/resume-data-cache'
+import type { StaticWorker } from '../build'
 
 export type ExportPathEntry = ExportPathMap[keyof ExportPathMap] & {
   path: string
@@ -89,6 +90,7 @@ export type WorkerRenderOpts = WorkerRenderOptsPartial &
   LoadComponentsReturnType
 
 export interface ExportAppOptions {
+  staticWorker?: StaticWorker
   outdir: string
   enabledDirectories: NextEnabledDirectories
   silent?: boolean

--- a/test/e2e/app-dir/refresh/app/refresh/page.tsx
+++ b/test/e2e/app-dir/refresh/app/refresh/page.tsx
@@ -1,6 +1,9 @@
 import { triggerRefresh } from './actions'
+import { connection } from 'next/server'
 
 export default function Page() {
+  connection()
+
   const timestamp = performance.now()
 
   return (

--- a/test/e2e/app-dir/refresh/app/refresh/page.tsx
+++ b/test/e2e/app-dir/refresh/app/refresh/page.tsx
@@ -1,8 +1,8 @@
 import { triggerRefresh } from './actions'
 import { connection } from 'next/server'
 
-export default function Page() {
-  connection()
+export default async function Page() {
+  await connection()
 
   const timestamp = performance.now()
 

--- a/test/e2e/app-dir/refresh/refresh.test.ts
+++ b/test/e2e/app-dir/refresh/refresh.test.ts
@@ -27,7 +27,6 @@ describe('app-dir refresh', () => {
       const newServerTimestamp = await browser
         .elementById('server-timestamp')
         .text()
-      console.log({ newServerTimestamp, initialServerTimestamp })
       expect(newServerTimestamp).not.toBe(initialServerTimestamp)
       expect(Number(newServerTimestamp)).toBeGreaterThan(
         Number(initialServerTimestamp)

--- a/test/e2e/app-dir/refresh/refresh.test.ts
+++ b/test/e2e/app-dir/refresh/refresh.test.ts
@@ -27,6 +27,7 @@ describe('app-dir refresh', () => {
       const newServerTimestamp = await browser
         .elementById('server-timestamp')
         .text()
+      console.log({ newServerTimestamp, initialServerTimestamp })
       expect(newServerTimestamp).not.toBe(initialServerTimestamp)
       expect(Number(newServerTimestamp)).toBeGreaterThan(
         Number(initialServerTimestamp)


### PR DESCRIPTION
## What?

Shares `static check` and `static generation` workers.

On hello-world:

Before:

```
next build test/e2e/app-dir/hello-world  7.58s user 1.07s system 332% cpu 2.603 total
```

After:

```
next build test/e2e/app-dir/hello-world  7.18s user 0.87s system 308% cpu 2.612 total
```
