### PR TITLE
Fix telemetry event loss on build failures and server shutdown

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -905,5 +905,7 @@
   "904": "The file \"%s\" must export a function, either as a default export or as a named \"%s\" export.",
   "905": "Page \"%s\" cannot use \\`export const unstable_prefetch = ...\\` without enabling \\`cacheComponents\\`.",
   "906": "Bindings not loaded yet, but they are being loaded, did you forget to await?",
-  "907": "bindings not loaded yet.  Either call `loadBindings` to wait for them to be available or ensure that `installBindings` has already been called."
+  "907": "bindings not loaded yet.  Either call `loadBindings` to wait for them to be available or ensure that `installBindings` has already been called.",
+  "908": "Invalid flags should be run as node detached-flush dev ./path-to/project [eventsFile]",
+  "909": "Failed to load SWC binary for %s/%s, see more info here: https://nextjs.org/docs/messages/failed-loading-swc"
 }

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -245,15 +245,20 @@ export async function workerMain(workerData: {
   // Install bindings early so we can access synchronously later
   await installBindings(config.experimental?.useWasmBinary)
 
-  const {
-    shutdownPromise: resultShutdownPromise,
-    buildTraceContext,
-    duration,
-  } = await turbopackBuild()
-  shutdownPromise = resultShutdownPromise
-  return {
-    buildTraceContext,
-    duration,
+  try {
+    const {
+      shutdownPromise: resultShutdownPromise,
+      buildTraceContext,
+      duration,
+    } = await turbopackBuild()
+    shutdownPromise = resultShutdownPromise
+    return {
+      buildTraceContext,
+      duration,
+    }
+  } finally {
+    // Always flush telemetry before worker exits (waits for async operations like setTimeout in debug mode)
+    await telemetry.flush()
   }
 }
 

--- a/packages/next/src/lib/verify-partytown-setup.ts
+++ b/packages/next/src/lib/verify-partytown-setup.ts
@@ -91,7 +91,8 @@ export async function verifyPartytownSetup(
     // Don't show a stack trace when there is an error due to missing dependencies
     if (err instanceof FatalError) {
       console.error(err.message)
-      process.exit(1)
+      // Throw to allow finally blocks to run (e.g., telemetry flush)
+      throw err
     }
     throw err
   }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -417,7 +417,10 @@ export async function startServer(
                     >
                   | undefined
                 if (telemetry) {
-                  await telemetry.flush()
+                  // Use flushDetached to avoid blocking process exit
+                  // Each process writes to a unique file (_events_${pid}.json)
+                  // to avoid race conditions with the parent process
+                  telemetry.flushDetached('dev', dir)
                 }
               } catch (_) {
                 // Ignore telemetry errors during cleanup

--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -216,7 +216,9 @@ export class Telemetry {
     return prom
   }
 
-  flush = async () => Promise.all(this.queue).catch(() => null)
+  flush = async () => {
+    return Promise.all(this.queue).catch(() => null)
+  }
 
   // writes current events to disk and spawns separate
   // detached process to submit the records without blocking
@@ -232,9 +234,17 @@ export class Telemetry {
         // if we fail to abort ignore this event
       }
     })
+
+    if (allEvents.length === 0) {
+      // No events to flush
+      return
+    }
+
     fs.mkdirSync(this.distDir, { recursive: true })
+    // Use unique filename per process to avoid race conditions between parent/child
+    const eventsFile = `_events_${process.pid}.json`
     fs.writeFileSync(
-      path.join(this.distDir, '_events.json'),
+      path.join(this.distDir, eventsFile),
       JSON.stringify(allEvents)
     )
 
@@ -249,16 +259,20 @@ export class Telemetry {
       ? child_process.spawnSync
       : child_process.spawn
 
-    spawn(process.execPath, [require.resolve('./detached-flush'), mode, dir], {
-      detached: !this.NEXT_TELEMETRY_DEBUG,
-      windowsHide: true,
-      shell: false,
-      ...(this.NEXT_TELEMETRY_DEBUG
-        ? {
-            stdio: 'inherit',
-          }
-        : {}),
-    })
+    spawn(
+      process.execPath,
+      [require.resolve('./detached-flush'), mode, dir, eventsFile],
+      {
+        detached: !this.NEXT_TELEMETRY_DEBUG,
+        windowsHide: true,
+        shell: false,
+        ...(this.NEXT_TELEMETRY_DEBUG
+          ? {
+              stdio: 'inherit',
+            }
+          : {}),
+      }
+    )
   }
 
   private submitRecord = async (
@@ -276,15 +290,19 @@ export class Telemetry {
     }
 
     if (this.NEXT_TELEMETRY_DEBUG) {
-      // Print to standard error to simplify selecting the output
-      events.forEach(({ eventName, payload }) =>
-        console.error(
-          `[telemetry] ` + JSON.stringify({ eventName, payload }, null, 2)
-        )
-      )
-      // Do not send the telemetry data if debugging. Users may use this feature
-      // to preview what data would be sent.
-      return Promise.resolve()
+      // Return a promise that resolves after logging to ensure the output
+      // is captured before the process exits (e.g., during flushDetached)
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          // Print to standard error to simplify selecting the output
+          events.forEach(({ eventName, payload }) =>
+            console.error(
+              `[telemetry] ` + JSON.stringify({ eventName, payload }, null, 2)
+            )
+          )
+          resolve(undefined)
+        }, 1000)
+      })
     }
 
     // Skip recording telemetry if the feature is disabled

--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -301,7 +301,7 @@ export class Telemetry {
             )
           )
           resolve(undefined)
-        }, 1000)
+        }, 100)
       })
     }
 


### PR DESCRIPTION
## Problem

Telemetry events were not being captured in three scenarios:

### 1. MCP Telemetry Lost on Dev Server Shutdown

Two telemetry instances were created during dev server startup. MCP events were recorded to one instance but shutdown flushed a different instance.

**Fix:** Reuse the existing telemetry instance from `traceGlobals`.

### 2. Process Exit Timeout Killing Async Telemetry

The CLI force-kills child processes after 100ms (`NEXT_EXIT_TIMEOUT_MS`). Async telemetry operations were interrupted before completion.

**Fix:** Use `flushDetached()` to write events to disk and spawn a detached process for async submission, allowing immediate parent exit.

### 3. Build Errors Calling `process.exit()` Before Telemetry Flush

`process.exit()` calls in error handlers (SWC failures, missing dependencies, route conflicts) bypassed finally blocks and killed processes before telemetry completed.

**Fix:** Throw errors instead of calling `process.exit()`, add finally blocks with `await telemetry.flush()` in critical paths.

## Changes

**Core:**
- `server/dev/next-dev-server.ts`: Reuse telemetry instance
- `server/lib/start-server.ts`: Use `flushDetached()` for shutdown
- `build/swc/index.ts`: Remove `process.exit()` calls
- `build/turbopack-build/impl.ts`: Add telemetry flush in worker finally block
- `build/index.ts`: Add telemetry flush in finally block, throw instead of exit
- `lib/verify-partytown-setup.ts`: Throw instead of exit

**Supporting:**
- `telemetry/storage.ts`: Generate unique event files per PID
- `telemetry/detached-flush.ts`: Accept optional eventsFile parameter
- `errors.json`: Update detached-flush error message

## Testing

All telemetry tests now pass:
- MCP telemetry on dev server shutdown
- SWC load failures in worker threads
- Build configuration errors

✅ Non-blocking shutdown  
✅ Timeout-independent  
✅ No race conditions  
✅ Works in worker threads
