### PR TITLE
Turbopack: Remove `non_operation_vc_strongly_consistent` feature usage from next-api

### DIFF
--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = { workspace = true }
 swc_core = { workspace = true }
 tracing = { workspace = true }
 turbo-rcstr = { workspace = true }
-turbo-tasks = { workspace = true, features = ["non_operation_vc_strongly_consistent"] }
+turbo-tasks = { workspace = true }
 turbo-tasks-env = { workspace = true }
 turbo-tasks-fs = { workspace = true }
 turbo-unix-path = { workspace = true }


### PR DESCRIPTION
This feature exists because we have some tests that aren't using the proper `OperationVc` APIs yet. It's documented that it should not be used in new code: https://github.com/search?q=repo%3Avercel%2Fnext.js%20non_operation_vc_strongly_consistent&type=code

This feature usage was added for some HMR benchmarks which were later removed. I added a comment to that PR here: https://github.com/vercel/next.js/pull/80219#discussion_r2143787319 (but it was after the PR merged)

The feature lets you strongly-consistently read or resolve a normal `Vc`. This API predates the `OperationVc` type, and is a footgun because if the `Vc` is already resolved, there's no meaningful way to read or resolve it with strong consistency.