### PR TITLE
Fix false-positive build error for `cacheLife` & `cacheTag`

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -76,7 +76,6 @@ struct ModuleImports {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ModuleDirective {
-    None,
     UseClient,
     UseServer,
     UseCache,
@@ -134,7 +133,7 @@ impl<C: Comments> VisitMut for ReactServerComponents<C> {
 
         module.visit_with(&mut validator);
 
-        let is_client_entry = validator.module_directive == ModuleDirective::UseClient;
+        let is_client_entry = validator.module_directive == Some(ModuleDirective::UseClient);
         let export_names = validator.export_names;
 
         self.remove_top_level_directive(module);
@@ -366,7 +365,7 @@ fn collect_module_info(
     app_dir: &Option<PathBuf>,
     filepath: &str,
     module: &Module,
-) -> (ModuleDirective, Vec<ModuleImports>, Vec<Atom>) {
+) -> (Option<ModuleDirective>, Vec<ModuleImports>, Vec<Atom>) {
     let mut imports: Vec<ModuleImports> = vec![];
     let mut finished_directives = false;
     let mut is_client_entry = false;
@@ -566,13 +565,13 @@ fn collect_module_info(
     });
 
     let directive = if is_client_entry {
-        ModuleDirective::UseClient
+        Some(ModuleDirective::UseClient)
     } else if is_action_file {
-        ModuleDirective::UseServer
+        Some(ModuleDirective::UseServer)
     } else if is_cache_file {
-        ModuleDirective::UseCache
+        Some(ModuleDirective::UseCache)
     } else {
-        ModuleDirective::None
+        None
     };
 
     (directive, imports, export_names)
@@ -590,7 +589,7 @@ struct ReactServerComponentValidator {
     deprecated_apis_mapping: FxHashMap<&'static str, Vec<&'static str>>,
     invalid_client_imports: Vec<Atom>,
     invalid_client_lib_apis_mapping: FxHashMap<&'static str, Vec<&'static str>>,
-    pub module_directive: ModuleDirective,
+    pub module_directive: Option<ModuleDirective>,
     pub export_names: Vec<Atom>,
     imports: ImportMap,
 }
@@ -609,7 +608,7 @@ impl ReactServerComponentValidator {
             use_cache_enabled,
             filepath: filename,
             app_dir,
-            module_directive: ModuleDirective::None,
+            module_directive: None,
             export_names: vec![],
             // react -> [apis]
             // react-dom -> [apis]
@@ -1052,7 +1051,7 @@ impl Visit for ReactServerComponentValidator {
         self.export_names = export_names;
 
         if self.is_react_server_layer {
-            if directive == ModuleDirective::UseClient {
+            if directive == Some(ModuleDirective::UseClient) {
                 return;
             } else {
                 // Only assert server graph if file's bundle target is "server", e.g.
@@ -1067,7 +1066,9 @@ impl Visit for ReactServerComponentValidator {
             // and bundle target is "client" e.g.
             // * client components pages
             // * pages bundles on browser layer
-            if directive != ModuleDirective::UseServer && directive != ModuleDirective::UseCache {
+            if directive != Some(ModuleDirective::UseServer)
+                && directive != Some(ModuleDirective::UseCache)
+            {
                 self.assert_client_graph(&imports);
                 self.assert_invalid_api(module, true);
             }

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -66,7 +66,6 @@ struct ReactServerComponents<C: Comments> {
     filepath: String,
     app_dir: Option<PathBuf>,
     comments: C,
-    directive_import_collection: Option<(bool, bool, RcVec<ModuleImports>, RcVec<Atom>)>,
 }
 
 #[derive(Clone, Debug)]
@@ -75,10 +74,17 @@ struct ModuleImports {
     specifiers: Vec<(Atom, Span)>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ModuleDirective {
+    None,
+    UseClient,
+    UseServer,
+    UseCache,
+}
+
 enum RSCErrorKind {
-    /// When `use client` and `use server` are in the same file.
-    /// It's not possible to have both directives in the same file.
-    RedundantDirectives(Span),
+    UseClientWithUseServer(Span),
+    UseClientWithUseCache(Span),
     NextRscErrServerImport((String, Span)),
     NextRscErrClientImport((String, Span)),
     NextRscErrClientDirective(Span),
@@ -127,13 +133,9 @@ impl<C: Comments> VisitMut for ReactServerComponents<C> {
         );
 
         module.visit_with(&mut validator);
-        self.directive_import_collection = validator.directive_import_collection;
 
-        let is_client_entry = self
-            .directive_import_collection
-            .as_ref()
-            .expect("directive_import_collection must be set")
-            .0;
+        let is_client_entry = validator.module_directive == ModuleDirective::UseClient;
+        let export_names = validator.export_names;
 
         self.remove_top_level_directive(module);
 
@@ -141,11 +143,11 @@ impl<C: Comments> VisitMut for ReactServerComponents<C> {
 
         if self.is_react_server_layer {
             if is_client_entry {
-                self.to_module_ref(module, is_cjs);
+                self.to_module_ref(module, is_cjs, &export_names);
                 return;
             }
         } else if is_client_entry {
-            self.prepend_comment_node(module, is_cjs);
+            self.prepend_comment_node(module, is_cjs, &export_names);
         }
         module.visit_mut_children_with(self)
     }
@@ -171,7 +173,7 @@ impl<C: Comments> ReactServerComponents<C> {
 
     // Convert the client module to the module reference code and add a special
     // comment to the top of the file.
-    fn to_module_ref(&self, module: &mut Module, is_cjs: bool) {
+    fn to_module_ref(&self, module: &mut Module, is_cjs: bool, export_names: &[Atom]) {
         // Clear all the statements and module declarations.
         module.body.clear();
 
@@ -229,16 +231,10 @@ impl<C: Comments> ReactServerComponents<C> {
             .into_iter(),
         );
 
-        self.prepend_comment_node(module, is_cjs);
+        self.prepend_comment_node(module, is_cjs, export_names);
     }
 
-    fn prepend_comment_node(&self, module: &Module, is_cjs: bool) {
-        let export_names = &self
-            .directive_import_collection
-            .as_ref()
-            .expect("directive_import_collection must be set")
-            .3;
-
+    fn prepend_comment_node(&self, module: &Module, is_cjs: bool, export_names: &[Atom]) {
         // Prepend a special comment to the top of the file that contains
         // module export names and the detected module type.
         self.comments.add_leading(
@@ -269,8 +265,14 @@ fn join_atoms(atoms: &[Atom]) -> String {
 /// errors.
 fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorKind) {
     let (msg, spans) = match error_kind {
-        RSCErrorKind::RedundantDirectives(span) => (
-            "It's not possible to have both `use client` and `use server` directives in the \
+        RSCErrorKind::UseClientWithUseServer(span) => (
+            "It's not possible to have both \"use client\" and \"use server\" directives in the \
+             same file."
+                .to_string(),
+            vec![span],
+        ),
+        RSCErrorKind::UseClientWithUseCache(span) => (
+            "It's not possible to have both \"use client\" and \"use cache\" directives in the \
              same file."
                 .to_string(),
             vec![span],
@@ -359,16 +361,17 @@ fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorK
     HANDLER.with(|handler| handler.struct_span_err(spans, msg.as_str()).emit())
 }
 
-/// Collects top level directives and imports
-fn collect_top_level_directives_and_imports(
+/// Collects module directive, imports, and exports from top-level statements
+fn collect_module_info(
     app_dir: &Option<PathBuf>,
     filepath: &str,
     module: &Module,
-) -> (bool, bool, Vec<ModuleImports>, Vec<Atom>) {
+) -> (ModuleDirective, Vec<ModuleImports>, Vec<Atom>) {
     let mut imports: Vec<ModuleImports> = vec![];
     let mut finished_directives = false;
     let mut is_client_entry = false;
     let mut is_action_file = false;
+    let mut is_cache_file = false;
 
     let mut export_names = vec![];
 
@@ -392,7 +395,15 @@ fn collect_top_level_directives_and_imports(
                                             report_error(
                                                 app_dir,
                                                 filepath,
-                                                RSCErrorKind::RedundantDirectives(expr_stmt.span),
+                                                RSCErrorKind::UseClientWithUseServer(
+                                                    expr_stmt.span,
+                                                ),
+                                            );
+                                        } else if is_cache_file {
+                                            report_error(
+                                                app_dir,
+                                                filepath,
+                                                RSCErrorKind::UseClientWithUseCache(expr_stmt.span),
                                             );
                                         }
                                     } else {
@@ -409,7 +420,20 @@ fn collect_top_level_directives_and_imports(
                                         report_error(
                                             app_dir,
                                             filepath,
-                                            RSCErrorKind::RedundantDirectives(expr_stmt.span),
+                                            RSCErrorKind::UseClientWithUseServer(expr_stmt.span),
+                                        );
+                                    }
+                                } else if (&**value == "use cache"
+                                    || value.starts_with("use cache: "))
+                                    && !finished_directives
+                                {
+                                    is_cache_file = true;
+
+                                    if is_client_entry {
+                                        report_error(
+                                            app_dir,
+                                            filepath,
+                                            RSCErrorKind::UseClientWithUseCache(expr_stmt.span),
                                         );
                                     }
                                 }
@@ -541,7 +565,17 @@ fn collect_top_level_directives_and_imports(
         }
     });
 
-    (is_client_entry, is_action_file, imports, export_names)
+    let directive = if is_client_entry {
+        ModuleDirective::UseClient
+    } else if is_action_file {
+        ModuleDirective::UseServer
+    } else if is_cache_file {
+        ModuleDirective::UseCache
+    } else {
+        ModuleDirective::None
+    };
+
+    (directive, imports, export_names)
 }
 
 /// A visitor to assert given module file is a valid React server component.
@@ -556,12 +590,10 @@ struct ReactServerComponentValidator {
     deprecated_apis_mapping: FxHashMap<&'static str, Vec<&'static str>>,
     invalid_client_imports: Vec<Atom>,
     invalid_client_lib_apis_mapping: FxHashMap<&'static str, Vec<&'static str>>,
-    pub directive_import_collection: Option<(bool, bool, RcVec<ModuleImports>, RcVec<Atom>)>,
+    pub module_directive: ModuleDirective,
+    pub export_names: Vec<Atom>,
     imports: ImportMap,
 }
-
-// A type to workaround a clippy warning.
-type RcVec<T> = Rc<Vec<T>>;
 
 impl ReactServerComponentValidator {
     pub fn new(
@@ -577,7 +609,8 @@ impl ReactServerComponentValidator {
             use_cache_enabled,
             filepath: filename,
             app_dir,
-            directive_import_collection: None,
+            module_directive: ModuleDirective::None,
+            export_names: vec![],
             // react -> [apis]
             // react-dom -> [apis]
             // next/navigation -> [apis]
@@ -1011,20 +1044,15 @@ impl Visit for ReactServerComponentValidator {
     fn visit_module(&mut self, module: &Module) {
         self.imports = ImportMap::analyze(module);
 
-        let (is_client_entry, is_action_file, imports, export_names) =
-            collect_top_level_directives_and_imports(&self.app_dir, &self.filepath, module);
+        let (directive, imports, export_names) =
+            collect_module_info(&self.app_dir, &self.filepath, module);
         let imports = Rc::new(imports);
-        let export_names = Rc::new(export_names);
 
-        self.directive_import_collection = Some((
-            is_client_entry,
-            is_action_file,
-            imports.clone(),
-            export_names,
-        ));
+        self.module_directive = directive;
+        self.export_names = export_names;
 
         if self.is_react_server_layer {
-            if is_client_entry {
+            if directive == ModuleDirective::UseClient {
                 return;
             } else {
                 // Only assert server graph if file's bundle target is "server", e.g.
@@ -1035,11 +1063,11 @@ impl Visit for ReactServerComponentValidator {
                 self.assert_server_graph(&imports, module);
             }
         } else {
-            // Only assert client graph if the file is not an action file,
+            // Only assert client graph if the file is not an action or cache file,
             // and bundle target is "client" e.g.
             // * client components pages
             // * pages bundles on browser layer
-            if !is_action_file {
+            if directive != ModuleDirective::UseServer && directive != ModuleDirective::UseCache {
                 self.assert_client_graph(&imports);
                 self.assert_invalid_api(module, true);
             }
@@ -1115,6 +1143,5 @@ pub fn server_components<C: Comments>(
             _ => filename.to_string(),
         },
         app_dir,
-        directive_import_collection: None,
     })
 }

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -74,6 +74,7 @@ struct ModuleImports {
     specifiers: Vec<(Atom, Span)>,
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ModuleDirective {
     UseClient,

--- a/crates/next-custom-transforms/tests/errors.rs
+++ b/crates/next-custom-transforms/tests/errors.rs
@@ -158,6 +158,8 @@ fn react_server_actions_errors(input: PathBuf) {
         syntax(),
         &|tr| {
             (
+                // The transforms are intentionally declared in the same order as in
+                // crates/next-custom-transforms/src/chain_transforms.rs
                 resolver(Mark::new(), Mark::new(), false),
                 server_components(
                     FileName::Real(PathBuf::from("/app/item.js")).into(),
@@ -222,6 +224,8 @@ fn use_cache_not_allowed(input: PathBuf) {
         syntax(),
         &|tr| {
             (
+                // The transforms are intentionally declared in the same order as in
+                // crates/next-custom-transforms/src/chain_transforms.rs
                 resolver(Mark::new(), Mark::new(), false),
                 server_components(
                     FileName::Real(PathBuf::from("/app/item.js")).into(),

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/12/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/12/output.stderr
@@ -1,4 +1,4 @@
-  x It's not possible to have both `use client` and `use server` directives in the same file.
+  x It's not possible to have both "use client" and "use server" directives in the same file.
    ,-[input.js:2:1]
  1 | 'use server'
  2 | 'use client'

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/13/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/13/output.stderr
@@ -1,4 +1,4 @@
-  x It's not possible to have both `use client` and `use server` directives in the same file.
+  x It's not possible to have both "use client" and "use server" directives in the same file.
    ,-[input.js:6:1]
  5 | 
  6 | 'use server'

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/29/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/29/input.js
@@ -1,0 +1,4 @@
+'use cache'
+'use client'
+
+export async function foo() {}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/29/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/29/output.js
@@ -1,0 +1,2 @@
+/* __next_internal_client_entry_do_not_use__ foo auto */ const { createProxy } = require("private-next-rsc-mod-ref-proxy");
+module.exports = createProxy("/app/item.js");

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/29/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/29/output.stderr
@@ -1,0 +1,6 @@
+  x It's not possible to have both "use client" and "use cache" directives in the same file.
+   ,-[input.js:2:1]
+ 1 | 'use cache'
+ 2 | 'use client'
+   : ^^^^^^^^^^^^
+   `----

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/30/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/30/input.js
@@ -1,0 +1,4 @@
+'use client'
+'use cache'
+
+export async function foo() {}

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/30/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/30/output.js
@@ -1,0 +1,2 @@
+/* __next_internal_client_entry_do_not_use__ foo auto */ const { createProxy } = require("private-next-rsc-mod-ref-proxy");
+module.exports = createProxy("/app/item.js");

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/30/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/30/output.stderr
@@ -1,0 +1,6 @@
+  x It's not possible to have both "use client" and "use cache" directives in the same file.
+   ,-[input.js:2:1]
+ 1 | 'use client'
+ 2 | 'use cache'
+   : ^^^^^^^^^^^
+   `----

--- a/crates/next-custom-transforms/tests/fixture/react-server-components/client-graph/actions/input.js
+++ b/crates/next-custom-transforms/tests/fixture/react-server-components/client-graph/actions/input.js
@@ -3,3 +3,7 @@
 // It should be allowed to import server APIs here.
 import 'server-only'
 import { cookies } from 'next/headers'
+
+export async function test() {
+  await cookies()
+}

--- a/crates/next-custom-transforms/tests/fixture/react-server-components/client-graph/actions/output.js
+++ b/crates/next-custom-transforms/tests/fixture/react-server-components/client-graph/actions/output.js
@@ -1,4 +1,2 @@
-'use server';
-// It should be allowed to import server APIs here.
-import 'server-only';
-import { cookies } from 'next/headers';
+/* __next_internal_action_entry_do_not_use__ {"00a275d5b08d0553a04df65d28075d3cad57073dca":"test"} */ import { createServerReference, callServer, findSourceMapURL } from "private-next-rsc-action-client-wrapper";
+export var test = /*#__PURE__*/ createServerReference("00a275d5b08d0553a04df65d28075d3cad57073dca", callServer, void 0, findSourceMapURL, "test");

--- a/crates/next-custom-transforms/tests/fixture/react-server-components/client-graph/cache-life/input.js
+++ b/crates/next-custom-transforms/tests/fixture/react-server-components/client-graph/cache-life/input.js
@@ -1,0 +1,8 @@
+'use cache'
+
+import { cacheLife } from 'next/cache'
+
+export async function test() {
+  cacheLife('days')
+  return null
+}

--- a/crates/next-custom-transforms/tests/fixture/react-server-components/client-graph/cache-life/output.js
+++ b/crates/next-custom-transforms/tests/fixture/react-server-components/client-graph/cache-life/output.js
@@ -1,0 +1,2 @@
+/* __next_internal_action_entry_do_not_use__ {"80a275d5b08d0553a04df65d28075d3cad57073dca":"test"} */ import { createServerReference, callServer, findSourceMapURL } from "private-next-rsc-action-client-wrapper";
+export var test = /*#__PURE__*/ createServerReference("80a275d5b08d0553a04df65d28075d3cad57073dca", callServer, void 0, findSourceMapURL, "test");

--- a/crates/next-custom-transforms/tests/fixture/react-server-components/client-graph/cache-tag/input.js
+++ b/crates/next-custom-transforms/tests/fixture/react-server-components/client-graph/cache-tag/input.js
@@ -1,0 +1,8 @@
+'use cache'
+
+import { cacheTag } from 'next/cache'
+
+export async function test() {
+  cacheTag('test')
+  return null
+}

--- a/crates/next-custom-transforms/tests/fixture/react-server-components/client-graph/cache-tag/output.js
+++ b/crates/next-custom-transforms/tests/fixture/react-server-components/client-graph/cache-tag/output.js
@@ -1,0 +1,2 @@
+/* __next_internal_action_entry_do_not_use__ {"80a275d5b08d0553a04df65d28075d3cad57073dca":"test"} */ import { createServerReference, callServer, findSourceMapURL } from "private-next-rsc-action-client-wrapper";
+export var test = /*#__PURE__*/ createServerReference("80a275d5b08d0553a04df65d28075d3cad57073dca", callServer, void 0, findSourceMapURL, "test");

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/imported-from-client/cached.ts
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/imported-from-client/cached.ts
@@ -1,5 +1,7 @@
 'use cache'
 
+import { cacheLife, cacheTag } from 'next/cache'
+
 function getRandomValue() {
   const v = Math.random()
   console.log(v)
@@ -7,10 +9,12 @@ function getRandomValue() {
 }
 
 export async function foo() {
+  cacheLife('days')
   return getRandomValue()
 }
 
 export const bar = async function () {
+  cacheTag('bar')
   return getRandomValue()
 }
 


### PR DESCRIPTION
When functions exported from a module with a top-level `'use cache'` directive are imported into client modules, the compiler should allow `cacheLife` and `cacheTag` usage within those functions.

This PR updates the `react_server_components` transform to properly track module directives (`'use client'`, `'use server'`, `'use cache'`) and skip client graph validation for modules with `'use cache'`, identical to how modules with `'use server'` are already handled. Those modules are transformed anyway for the client graph by the `server_actions` transform, which is applied after the `react_server_components` transform, in which their implementation is replaced by server function references.

closes NAR-498