### PR TITLE
fix: middleware header encoding for non-ASCII characters

### DIFF
--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -15,7 +15,7 @@ import { getCloneableBody } from '../../body-streams'
 import { filterReqHeaders, ipcForbiddenHeaders } from '../server-ipc/utils'
 import { stringifyQuery } from '../../server-route-utils'
 import { formatHostname } from '../format-hostname'
-import { toNodeOutgoingHttpHeaders } from '../../web/utils'
+import { toNodeOutgoingHttpHeaders, decodeHeaderValue } from '../../web/utils'
 import { isAbortError } from '../../pipe-readable'
 import { getHostname } from '../../../shared/lib/get-hostname'
 import {
@@ -611,7 +611,8 @@ export function getResolveRoutes(
               // Update or add headers.
               for (const key of overriddenHeaders.keys()) {
                 const valueKey = 'x-middleware-request-' + key
-                const newValue = middlewareHeaders[valueKey]
+                const encodedValue = middlewareHeaders[valueKey]
+                const newValue = encodedValue === null ? null : decodeHeaderValue(encodedValue)
                 const oldValue = req.headers[key]
 
                 if (oldValue !== newValue) {

--- a/packages/next/src/server/web/spec-extension/response.ts
+++ b/packages/next/src/server/web/spec-extension/response.ts
@@ -1,7 +1,7 @@
 import { stringifyCookie } from '../../web/spec-extension/cookies'
 import type { I18NConfig } from '../../config-shared'
 import { NextURL } from '../next-url'
-import { toNodeOutgoingHttpHeaders, validateURL } from '../utils'
+import { toNodeOutgoingHttpHeaders, validateURL, encodeHeaderValue } from '../utils'
 import { ReflectAdapter } from './adapters/reflect'
 
 import { ResponseCookies } from './cookies'
@@ -20,7 +20,7 @@ function handleMiddlewareField(
 
     const keys = []
     for (const [key, value] of init.request.headers) {
-      headers.set('x-middleware-request-' + key, value)
+      headers.set('x-middleware-request-' + key, encodeHeaderValue(value))
       keys.push(key)
     }
 

--- a/packages/next/src/server/web/utils.test.ts
+++ b/packages/next/src/server/web/utils.test.ts
@@ -1,4 +1,4 @@
-import { toNodeOutgoingHttpHeaders } from './utils'
+import { toNodeOutgoingHttpHeaders, encodeHeaderValue, decodeHeaderValue } from './utils'
 
 describe('toNodeHeaders', () => {
   it('should handle multiple set-cookie headers correctly', () => {
@@ -47,5 +47,74 @@ describe('toNodeHeaders', () => {
     expect(toNodeOutgoingHttpHeaders(headers)).toEqual({
       'set-cookie': ['foo=bar', 'bar=foo'],
     })
+  })
+})
+
+describe('encodeHeaderValue', () => {
+  it('should return ASCII values unchanged', () => {
+    expect(encodeHeaderValue('hello-world')).toBe('hello-world')
+    expect(encodeHeaderValue('test_value')).toBe('test_value')
+    expect(encodeHeaderValue('123')).toBe('123')
+  })
+
+  it('should encode non-ASCII characters', () => {
+    expect(encodeHeaderValue('Montréal')).toBe('Montr%C3%A9al')
+    expect(encodeHeaderValue('café')).toBe('caf%C3%A9')
+    expect(encodeHeaderValue('北京')).toBe('%E5%8C%97%E4%BA%AC')
+    expect(encodeHeaderValue('русский')).toBe('%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9')
+  })
+
+  it('should preserve spaces', () => {
+    expect(encodeHeaderValue('hello world')).toBe('hello world')
+    expect(encodeHeaderValue('Montréal city')).toBe('Montr%C3%A9al city')
+  })
+
+  it('should handle mixed ASCII and non-ASCII', () => {
+    expect(encodeHeaderValue('City: Montréal')).toBe('City: Montr%C3%A9al')
+  })
+})
+
+describe('decodeHeaderValue', () => {
+  it('should return unencoded values unchanged', () => {
+    expect(decodeHeaderValue('hello-world')).toBe('hello-world')
+    expect(decodeHeaderValue('test_value')).toBe('test_value')
+    expect(decodeHeaderValue('123')).toBe('123')
+  })
+
+  it('should decode percent-encoded values', () => {
+    expect(decodeHeaderValue('Montr%C3%A9al')).toBe('Montréal')
+    expect(decodeHeaderValue('caf%C3%A9')).toBe('café')
+    expect(decodeHeaderValue('%E5%8C%97%E4%BA%AC')).toBe('北京')
+    expect(decodeHeaderValue('%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9')).toBe('русский')
+  })
+
+  it('should handle spaces correctly', () => {
+    expect(decodeHeaderValue('hello world')).toBe('hello world')
+    expect(decodeHeaderValue('Montr%C3%A9al city')).toBe('Montréal city')
+  })
+
+  it('should handle mixed encoded and unencoded values', () => {
+    expect(decodeHeaderValue('City: Montr%C3%A9al')).toBe('City: Montréal')
+  })
+
+  it('should return original value if decoding fails', () => {
+    expect(decodeHeaderValue('invalid%')).toBe('invalid%')
+    expect(decodeHeaderValue('invalid%2')).toBe('invalid%2')
+    expect(decodeHeaderValue('%XX')).toBe('%XX')
+  })
+
+  it('should round-trip encode/decode correctly', () => {
+    const testValues = [
+      'Montréal',
+      'café',
+      '北京',
+      'русский',
+      'hello world',
+      'mixed: Montréal café 北京',
+    ]
+
+    for (const value of testValues) {
+      expect(decodeHeaderValue(encodeHeaderValue(value))).toBe(value)
+    }
   })
 })

--- a/packages/next/src/server/web/utils.ts
+++ b/packages/next/src/server/web/utils.ts
@@ -164,3 +164,44 @@ export function normalizeNextQueryParam(key: string): null | string {
   }
   return null
 }
+
+/**
+ * Encodes header values containing non-ASCII characters for safe HTTP transmission.
+ * HTTP headers must be ASCII-safe, so non-ASCII characters are percent-encoded.
+ *
+ * @param value - The header value to encode
+ * @returns The encoded header value
+ */
+export function encodeHeaderValue(value: string): string {
+  // Check if the value contains non-ASCII characters
+  if (/[^\x00-\x7F]/.test(value)) {
+    // Use encodeURIComponent but preserve spaces and common header-safe characters
+    return encodeURIComponent(value)
+      .replace(/%20/g, ' ')  // Preserve spaces
+      .replace(/%3A/g, ':')  // Preserve colons (common in headers)
+      .replace(/%2D/g, '-')  // Preserve hyphens
+      .replace(/%2E/g, '.')  // Preserve dots
+      .replace(/%5F/g, '_')  // Preserve underscores
+  }
+  return value
+}
+
+/**
+ * Decodes header values that were encoded with encodeHeaderValue.
+ *
+ * @param value - The header value to decode
+ * @returns The decoded header value
+ */
+export function decodeHeaderValue(value: string): string {
+  try {
+    // decodeURIComponent will throw if the value is not properly encoded
+    // Only attempt to decode if the value contains percent-encoded sequences
+    if (/%[0-9A-Fa-f]{2}/.test(value)) {
+      return decodeURIComponent(value.replace(/ /g, '%20'))
+    }
+    return value
+  } catch {
+    // If decoding fails, return the original value
+    return value
+  }
+}


### PR DESCRIPTION
### What?
Fixes middleware header encoding issue where non-ASCII characters (like "Montréal") in request headers cause "Header contains non-ASCII characters" errors in Vercel deployments.

### Why?
HTTP headers must be ASCII-safe. Middleware was passing non-ASCII characters without encoding, causing deployment failures.

### How?
- Added `encodeHeaderValue()`/`decodeHeaderValue()` utilities for safe encoding/decoding
- Modified middleware response handling to encode headers
- Modified route resolution to decode headers  
- Added comprehensive tests

Fixes #85631