### PR TITLE
Docs: Add the version history in refresh, unstable-rethrow, and updateTag APIs.

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/refresh.mdx
+++ b/docs/01-app/03-api-reference/04-functions/refresh.mdx
@@ -67,3 +67,9 @@ export async function POST() {
   refresh()
 }
 ```
+
+## Version History
+
+| Version   | Changes               |
+| --------- | --------------------- |
+| `v16.0.0` | `refresh` introduced. |

--- a/docs/01-app/03-api-reference/04-functions/unstable_rethrow.mdx
+++ b/docs/01-app/03-api-reference/04-functions/unstable_rethrow.mdx
@@ -68,4 +68,4 @@ If a route segment is marked to throw an error unless it's static, a Dynamic API
 
 | Version   | Changes                        |
 | --------- | ------------------------------ |
-| `v15.0.0` | `unstable_noStore` introduced. |
+| `v15.0.0` | `unstable_rethrow` introduced. |

--- a/docs/01-app/03-api-reference/04-functions/unstable_rethrow.mdx
+++ b/docs/01-app/03-api-reference/04-functions/unstable_rethrow.mdx
@@ -63,3 +63,9 @@ If a route segment is marked to throw an error unless it's static, a Dynamic API
 > - You may be able to avoid using `unstable_rethrow` if you encapsulate your API calls that throw and let the **caller** handle the exception.
 > - Only use `unstable_rethrow` if your caught exceptions may include both application errors and framework-controlled exceptions (like `redirect()` or `notFound()`).
 > - Any resource cleanup (like clearing intervals, timers, etc) would have to either happen prior to the call to `unstable_rethrow` or within a `finally` block.
+
+## Version History
+
+| Version   | Changes                        |
+| --------- | ------------------------------ |
+| `v15.0.0` | `unstable_noStore` introduced. |

--- a/docs/01-app/03-api-reference/04-functions/updateTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/updateTag.mdx
@@ -52,7 +52,6 @@ async function getData() {
 While both `updateTag` and `revalidateTag` invalidate cached data, they serve different purposes:
 
 - **`updateTag`**:
-
   - Can only be used in Server Actions
   - Next request waits for fresh data (no stale content served)
   - Designed for read-your-own-writes scenarios

--- a/docs/01-app/03-api-reference/04-functions/updateTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/updateTag.mdx
@@ -151,3 +151,9 @@ Use `revalidateTag` instead when:
 
 - [`revalidateTag`](/docs/app/api-reference/functions/revalidateTag) - For invalidating tags in Route Handlers
 - [`revalidatePath`](/docs/app/api-reference/functions/revalidatePath) - For invalidating specific paths
+
+## Version History
+
+| Version   | Changes                 |
+| --------- | ----------------------- |
+| `v16.0.0` | `updateTag` introduced. |

--- a/docs/01-app/03-api-reference/04-functions/updateTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/updateTag.mdx
@@ -52,6 +52,7 @@ async function getData() {
 While both `updateTag` and `revalidateTag` invalidate cached data, they serve different purposes:
 
 - **`updateTag`**:
+
   - Can only be used in Server Actions
   - Next request waits for fresh data (no stale content served)
   - Designed for read-your-own-writes scenarios


### PR DESCRIPTION
## For Contributors

## Improving Documentation

Add the version history in refresh, unstable-rethrow, and updateTag APIs in the documentation. 

#### Change in the following documentation page:

- https://nextjs.org/docs/app/api-reference/functions/unstable_rethrow
- https://nextjs.org/docs/app/api-reference/functions/refresh
- https://nextjs.org/docs/app/api-reference/functions/updateTag
