### PR TITLE
fix: trace context propagation from middleware → server 

### DIFF
--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -235,6 +235,9 @@ export async function adapter(
   })
   let response
   let cookiesFromResponse
+  let middlewareTraceContext: ReturnType<
+    ReturnType<typeof getTracer>['getTracePropagationData']
+  > = []
 
   response = await propagator(request, () => {
     // we only care to make async storage available for middleware
@@ -306,7 +309,7 @@ export async function adapter(
               previouslyRevalidatedTags: [],
             })
 
-            return await workAsyncStorage.run(workStore, () =>
+            const result = await workAsyncStorage.run(workStore, () =>
               workUnitAsyncStorage.run(
                 requestStore,
                 params.handler,
@@ -314,6 +317,12 @@ export async function adapter(
                 event
               )
             )
+
+            // Capture trace context while middleware span is still active
+            // This ensures the server span becomes a child of the middleware span
+            middlewareTraceContext = getTracer().getTracePropagationData()
+
+            return result
           } finally {
             // middleware cannot stream, so we can consider the response closed
             // as soon as the handler returns.
@@ -469,23 +478,37 @@ export async function adapter(
 
   const finalResponse = response ? response : NextResponse.next()
 
-  // Flight headers are not overridable / removable so they are applied at the end.
+  const overwrittenHeaders: string[] = []
+
+  if (middlewareTraceContext.length > 0) {
+    // Inject trace context headers (traceparent, tracestate) so the Node.js server
+    // can continue the trace started by middleware
+    for (const { key, value } of middlewareTraceContext) {
+      finalResponse.headers.set(`x-middleware-request-${key}`, value)
+      if (!overwrittenHeaders.includes(key)) {
+        overwrittenHeaders.push(key)
+      }
+    }
+  }
+
+  // Get existing override headers list
   const middlewareOverrideHeaders = finalResponse.headers.get(
     'x-middleware-override-headers'
   )
-  const overwrittenHeaders: string[] = []
+  // Flight headers are not overridable / removable so they are applied at the end.
   if (middlewareOverrideHeaders) {
     for (const [key, value] of flightHeaders) {
       finalResponse.headers.set(`x-middleware-request-${key}`, value)
       overwrittenHeaders.push(key)
     }
+  }
 
-    if (overwrittenHeaders.length > 0) {
-      finalResponse.headers.set(
-        'x-middleware-override-headers',
-        middlewareOverrideHeaders + ',' + overwrittenHeaders.join(',')
-      )
-    }
+  // Update the override headers list if we added any headers
+  if (overwrittenHeaders.length > 0) {
+    finalResponse.headers.set(
+      'x-middleware-override-headers',
+      middlewareOverrideHeaders + ',' + overwrittenHeaders.join(',')
+    )
   }
 
   return {

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -463,23 +463,22 @@ describe('opentelemetry', () => {
                   'next.span_type': 'Middleware.execute',
                 },
                 status: { code: 0 },
-                spans: [],
-              },
-
-              {
-                runtime: 'nodejs',
-                traceId: env.span.traceId,
-                parentId: env.span.rootParentId,
-                name: 'GET /behind-middleware',
-                attributes: {
-                  'http.method': 'GET',
-                  'http.route': '/behind-middleware',
-                  'http.status_code': 200,
-                  'http.target': '/behind-middleware',
-                  'next.route': '/behind-middleware',
-                  'next.span_name': 'GET /behind-middleware',
-                  'next.span_type': 'BaseServer.handleRequest',
-                },
+                spans: [
+                  {
+                    runtime: 'nodejs',
+                    traceId: env.span.traceId,
+                    name: 'GET /behind-middleware',
+                    attributes: {
+                      'http.method': 'GET',
+                      'http.route': '/behind-middleware',
+                      'http.status_code': 200,
+                      'http.target': '/behind-middleware',
+                      'next.route': '/behind-middleware',
+                      'next.span_name': 'GET /behind-middleware',
+                      'next.span_type': 'BaseServer.handleRequest',
+                    },
+                  },
+                ],
               },
             ])
           })


### PR DESCRIPTION
### What?
This PR fixes OpenTelemetry trace context propagation when requests pass through Next.js middleware. Previously, middleware traces (edge runtime) and server traces (Node.js runtime) were created as separate, independent traces. Now they are properly connected as parent-child spans within a single unified trace.

**Changes:**
- Modified `packages/next/src/server/web/adapter.ts` to capture and propagate trace context from middleware spans to server requests
- Updated test expectations in `test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts` to verify the correct span hierarchy

### Why?

When a request goes through middleware in Next.js, two separate runtime environments are involved:
1. **Edge runtime** - Where middleware/proxy executes
2. **Node.js runtime** - Where the actual route handlers execute

Before this fix, these two environments created **disconnected traces**:

```
Trace 1: [traceId: abc123]
└─ Middleware.execute [spanId: 111, parentId: root]

Trace 2: [traceId: abc123]  ❌ Disconnected!
└─ BaseServer.handleRequest [spanId: 222, parentId: root]
```
**After the fix:**
```
Trace: [traceId: abc123]
└─ Middleware.execute [spanId: 111, parentId: root]
   └─ BaseServer.handleRequest [spanId: 222, parentId: 111]  ✅ Connected!
```

**The Problem:**
- Both spans share the same `traceId` (if an external `traceparent` header was provided)
- But they have **no parent-child relationship** - both point to the same root parent
- The W3C Trace Context headers (`traceparent`, `tracestate`) were not being propagated from middleware to the server

### How?

The fix implements W3C Trace Context propagation across the edge → Node.js runtime boundary by leveraging Next.js's existing header propagation mechanism (`x-middleware-request-*` headers).

