### PR TITLE
[Segment Cache] perf: stream read partial static exported html

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -89,6 +89,7 @@ import { pingVisibleLinks } from '../links'
 import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 import {
   DOC_PREFETCH_RANGE_HEADER_VALUE,
+  DOC_PREFETCH_MAX_BYTE_LENGTH,
   doesExportedHtmlMatchBuildId,
 } from '../../../shared/lib/segment-cache/output-export-prefetch-encoding'
 import { FetchStrategy } from './types'
@@ -1338,12 +1339,50 @@ export async function fetchRouteOnCacheMiss(
       // NOTE: We could embed the route tree into the HTML document, to avoid
       // a second request. We're not doing that currently because it would make
       // the HTML document larger and affect normal page loads.
+
+      // Not all static hosting providers support "Range" requests. if they don't they will return full HTML instead of a partial response
+      // To save bandwidth, we still manually read bytes up to the specified range and ignore the rest.
+      const abortController = new AbortController()
       const htmlResponse = await fetch(url, {
         headers: {
           Range: DOC_PREFETCH_RANGE_HEADER_VALUE,
         },
+        signal: abortController.signal,
       })
-      const partialHtml = await htmlResponse.text()
+
+      if (!htmlResponse.body) {
+        // Server responded with no body, we should reject the entry
+        rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+        return null
+      }
+
+      let partialHtml = ''
+
+      // use TextDecoderStream to get UTF-8 string then read first 64 bytes
+      const stream = htmlResponse.body.pipeThrough(
+        new TextDecoderStream('utf-8')
+      )
+      const reader = stream.getReader()
+      try {
+        while (partialHtml.length < DOC_PREFETCH_MAX_BYTE_LENGTH) {
+          // Limit to first 64 bytes
+          const { done, value } = await reader.read()
+          if (done) break
+          if (!value) continue
+          partialHtml += value
+        }
+      } catch {
+        // error happened during reading the stream, we should reject the entry
+        rejectRouteCacheEntry(entry, Date.now() + 10 * 1000)
+        return null
+      } finally {
+        reader.cancel()
+        // technically if we cancel the readablestream, it should close the original body stream too.
+        // but this is never described in the fetch spec. let's just abort the fetch request to prevent
+        // any potential leaks.
+        abortController.abort()
+      }
+
       if (!doesExportedHtmlMatchBuildId(partialHtml, getAppBuildId())) {
         // The target page is not part of this app, or it belongs to a
         // different build.

--- a/packages/next/src/shared/lib/segment-cache/output-export-prefetch-encoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/output-export-prefetch-encoding.ts
@@ -18,6 +18,7 @@ const MAX_BUILD_ID_LENGTH = 24
 
 // Request the first 64 bytes. The Range header is inclusive of the end value.
 export const DOC_PREFETCH_RANGE_HEADER_VALUE = 'bytes=0-63'
+export const DOC_PREFETCH_MAX_BYTE_LENGTH = 64
 
 function escapeBuildId(buildId: string) {
   // If the build id is longer than the given limit, it's OK for our purposes


### PR DESCRIPTION
Not all static hosting providers support the `Range` request:

- GitHub Pages: full support
- Netlify: full support

- GitLab Pages: require extra non-default configurations (something like `FF_USE_FASTZIP: "true"` and `ARTIFACT_COMPRESSION_LEVEL: "fastest"`) that most of GitLab Pages projects do not enable
- Cloudflare Pages: no support at all
- Render.com: no support at all

In case the `Range` request is not supported, those static hosting providers will always return full HTML instead of a partial response. With `await .text()` downloading full HTML, this would greatly waste bandwidth (and hurt performance).

The PR introduces the following changes:

- Replace `await .text()` usage with reading from `htmlResponse.body` via `TextDecoderStream` and `ReadableStream#getReader`
  - `TextDecoderStream` is supported by Chrome 71+, Edge 79+, Firefox 105+, and Safari 14.1+, all within the Next.js 16 supported browsers range.
  - `ReadableStream#getReader` is supported by Chrome 43+, Edge 14+, Firefox 65+, and Safari 10.1+, all within the Next.js 16 supported browsers range.
- Use `AbortController` to abort the prefetch request after we read at least 64 bytes of the HTML
  - `AbortController` is supported by Chrome 66+, Edge 16+, Firefox 57+, and Safari 12.1+, all within the Next.js 16 supported browsers range.
  - Technically, if we use `ReadableStream#cancel` API to cancel the prefetch stream, the request should automatically be cancelled as well. However, this is not in the fetch spec, let's just use `AbortController` to abort.