### PR TITLE
[test] Increase response timeout in `next.browserWithResponse()`

### DIFF
--- a/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
+++ b/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
@@ -19,7 +19,7 @@ describe('fallback-shells', () => {
       }
 
       // If we didn't use the fallback shell, then we didn't postpone the
-      // response and therefore shouldn't have sent the postponed header.
+      // response, and therefore shouldn't have sent the postponed header.
       expect(headers['x-nextjs-postponed']).not.toBe('1')
     })
   })

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -784,7 +784,7 @@ export class NextInstance {
     const responsePromise = new Promise<Response>((resolve, reject) => {
       const timer = setTimeout(() => {
         reject(`Timed out waiting for the response of ${url}`)
-      }, 10_000)
+      }, 30_000)
 
       resolveResponse = (response: Response) => {
         clearTimeout(timer)


### PR DESCRIPTION
The `next.browserWithResponse()` test helper is currently only used in the `fallback-shells` test suite, which frequently times out after 10 seconds in CI, because the initial compilation for the first request can take quite a while when there's resource contention. Increasing the timeout to 30 seconds should help mitigate these issues. We could also consider removing the timeout entirely. Playwright also doesn't use a timeout per default for the `page.goto()` method, which we use for `next.browser()` and `next.browserWithResponse()` under the hood.