### PR TITLE
Fix prefetch redirect loop

### DIFF
--- a/packages/next/src/server/normalizers/request/segment-prefix-rsc.test.ts
+++ b/packages/next/src/server/normalizers/request/segment-prefix-rsc.test.ts
@@ -9,4 +9,42 @@ describe('SegmentPrefixRSCPathnameNormalizer', () => {
       segmentPath: '/_tree',
     })
   })
+
+  it('should handle doubled segment suffixes without creating infinite loops', () => {
+    const normalizer = new SegmentPrefixRSCPathnameNormalizer()
+
+    // This test demonstrates the bug: when a path already contains .segments/_tree.segment.rsc,
+    // the greedy regex fails to properly strip it, leading to infinite redirect loops
+    const doubledPath =
+      '/app/poggio-dogfood.segments/_tree.segment.rsc.segments/_tree.segment.rsc'
+
+    const result = normalizer.extract(doubledPath)
+
+    // With the fixed non-greedy regex, this should properly extract the clean pathname
+    // The key fix: originalPathname should NOT contain any .segments suffixes
+    expect(result).toEqual({
+      originalPathname: '/app/poggio-dogfood',
+      segmentPath: '/_tree.segment.rsc.segments/_tree',
+    })
+
+    // This prevents infinite redirect loops by ensuring the original pathname is clean
+  })
+
+  it('should handle complex nested segment suffixes', () => {
+    const normalizer = new SegmentPrefixRSCPathnameNormalizer()
+
+    // Even more complex case that would happen after multiple redirects
+    const tripleNestedPath =
+      '/app/test.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc'
+
+    const result = normalizer.extract(tripleNestedPath)
+
+    // Should always extract the clean original pathname, regardless of nesting depth
+    // The non-greedy regex captures everything after the first .segments in segmentPath
+    expect(result).toEqual({
+      originalPathname: '/app/test',
+      segmentPath:
+        '/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree',
+    })
+  })
 })

--- a/packages/next/src/server/normalizers/request/segment-prefix-rsc.ts
+++ b/packages/next/src/server/normalizers/request/segment-prefix-rsc.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../lib/constants'
 
 const PATTERN = new RegExp(
-  `^(/.*)${RSC_SEGMENTS_DIR_SUFFIX}(/.*)${RSC_SEGMENT_SUFFIX}$`
+  `^(/.*?)${RSC_SEGMENTS_DIR_SUFFIX}(/.*)${RSC_SEGMENT_SUFFIX}$`
 )
 
 export class SegmentPrefixRSCPathnameNormalizer implements PathnameNormalizer {

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
@@ -140,4 +140,42 @@ describe('segment cache (CDN cache busting)', () => {
       }, 'no-requests')
     }
   )
+
+  it(
+    'prevent infinite redirect loops when segment prefetch URLs contain ' +
+      'doubled segment suffixes',
+    async () => {
+      const browser = await webdriver(port, '/')
+
+      // Test the scenario that was causing infinite redirect loops on Vercel
+      // This simulates what happens when a URL gets processed multiple times
+      // and accumulates .segments/_tree.segment.rsc suffixes
+      const doubledSegmentPath =
+        '/target-page.segments/_tree.segment.rsc.segments/_tree.segment.rsc'
+
+      const { status, redirected } = await browser.eval(
+        async (path: string) => {
+          // This request would previously cause an infinite loop because the
+          // greedy regex in SegmentPrefixRSCPathnameNormalizer failed to
+          // properly strip the segment suffixes
+          const res = await fetch(path, {
+            headers: {
+              rsc: '1',
+              'next-router-prefetch': '1',
+              'next-router-segment-prefetch': '/_tree',
+            },
+          })
+          return {
+            status: res.status,
+            redirected: res.redirected,
+          }
+        },
+        doubledSegmentPath
+      )
+
+      // Should handle the doubled path gracefully without infinite loops
+      expect(status).toBe(200)
+      expect(redirected).toBe(true) // Should redirect to clean up the URL
+    }
+  )
 })


### PR DESCRIPTION
We recently upgraded to nextjs 16, but had to rollback after noticing a bunch of failed redirects happening all the time in the background.

Here is an example of a url we saw:
```https://my-app.com/app/slug.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc.segments/_tree.segment.rsc?_rsc=vo3ju```

After some investigation, I believe these are prefetch requests that aren't being handled correctly. Our app has a base path of `/app', and the path for all logged in routes start with `app/[workspaceslug]`. Because of a bad regex in the segment path normalizer, the `_tree.segment.rsc` is duplicated each time the request comes in. I believe this only happens if the first route segment (excluding basePath) is dynamic, which is why it hasn't been reported yet.

This bug only manifests in production builds, so I have not attempted to test this fix with a real app. It's possible I'm barking up the wrong tree here, but this is a real bug we ran into and this seems like a plausible fix.