### PR TITLE
[turbopack] Enable the filesystem cache for dev in canary builds

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -415,6 +415,8 @@ export interface ExperimentalConfig {
 
   /**
    * Enable filesystem cache for the turbopack dev server.
+   *
+   * Defaults to `true` in canary releases.
    */
   turbopackFileSystemCacheForDev?: boolean
 
@@ -1532,6 +1534,8 @@ export const defaultConfig = Object.freeze({
     proxyClientMaxBodySize: 10_485_760, // 10MB
     hideLogsAfterAbort: false,
     mcpServer: true,
+    turbopackFileSystemCacheForDev: !isStableBuild(),
+    turbopackFileSystemCacheForBuild: false,
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -400,7 +400,7 @@ function assignDefaultsAndValidate(
 
   if (isStableBuild()) {
     // Prevents usage of certain experimental features outside of canary
-    if (result.experimental?.turbopackFileSystemCacheForBuild) {
+    if (result.experimental.turbopackFileSystemCacheForBuild) {
       throw new CanaryOnlyConfigError({
         feature: 'experimental.turbopackFileSystemCacheForBuild',
       })

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -1,297 +1,271 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 
-describe('filesystem-caching', () => {
-  process.env.NEXT_PUBLIC_ENV_VAR = 'hello world'
-  // Make it easier to run in development, test directories are cleared between runs already so this is safe.
-  process.env.TURBO_ENGINE_IGNORE_DIRTY = '1'
-  // decrease the idle timeout to make the test more reliable
-  process.env.TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS = '1000'
-  process.env.ENABLE_CACHING = '1'
-  const { skipped, next, isTurbopack } = nextTestSetup({
-    files: __dirname,
-    skipDeployment: true,
-    // We need to use npm here as pnpms symlinks trigger a weird bug (kernel bug?)
-    installCommand: 'npm i',
-    buildCommand: 'npm exec next build',
-    startCommand: isNextDev ? 'npm exec next dev' : 'npm exec next start',
-  })
+process.env.NEXT_PUBLIC_ENV_VAR = 'hello world'
+// Make it easier to run in development, test directories are cleared between runs already so this is safe.
+process.env.TURBO_ENGINE_IGNORE_DIRTY = '1'
+// decrease the idle timeout to make the test more reliable
+process.env.TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS = '1000'
 
-  if (skipped) {
-    return
-  }
+for (const cacheEnabled of [false, true]) {
+  describe(`filesystem-caching with cache ${cacheEnabled ? 'enabled' : 'disabled'}`, () => {
+    const { skipped, next, isTurbopack } = nextTestSetup({
+      files: __dirname,
+      skipDeployment: true,
+      packageJson: {
+        scripts: {
+          build: `ENABLE_CACHING=${cacheEnabled ? '1' : ''} next build`,
+          dev: `ENABLE_CACHING=${cacheEnabled ? '1' : ''} next dev`,
+          start: 'next start',
+        },
+      },
+      // We need to use npm here as pnpms symlinks trigger a weird bug (kernel bug?)
+      installCommand: 'npm i',
+      // Next is always started with caching, but this can disable it for the followup restarts
+      buildCommand: `npm run build`,
+      startCommand: isNextDev ? 'npm run dev' : 'npm run start',
+    })
 
-  beforeAll(() => {
-    // We can skip the dev watch delay since this is not an HMR test
-    ;(next as any).handleDevWatchDelayBeforeChange = () => {}
-    ;(next as any).handleDevWatchDelayAfterChange = () => {}
-  })
-
-  async function restartCycle() {
-    await stop()
-    await start()
-  }
-
-  async function stop() {
-    if (isNextDev) {
-      // Give FileSystem Cache time to write to disk
-      // Turbopack is configured to wait 1s above.
-      // Webpack has an idle timeout (after large changes) of 1s
-      // and we give time a bit more to allow writing to disk
-      await waitFor(3000)
+    if (skipped) {
+      return
     }
-    await next.stop()
-  }
 
-  async function start() {
-    await next.start()
-  }
+    beforeAll(() => {
+      // We can skip the dev watch delay since this is not an HMR test
+      ;(next as any).handleDevWatchDelayBeforeChange = () => {}
+      ;(next as any).handleDevWatchDelayAfterChange = () => {}
+    })
 
-  for (const cacheEnabled of [false, true]) {
-    describe(`with cache ${cacheEnabled ? 'enabled' : 'disabled'}`, () => {
-      it('should cache or not cache loaders', async () => {
-        let appTimestamp, unchangedTimestamp, appClientTimestamp, pagesTimestamp
-        {
-          const browser = await next.browser('/')
-          appTimestamp = await browser.elementByCss('main').text()
-          expect(appTimestamp).toMatch(/Timestamp = \d+$/)
-          await browser.close()
+    async function restartCycle() {
+      await stop()
+      await start()
+    }
+
+    async function stop() {
+      if (isNextDev) {
+        // Give FileSystem Cache time to write to disk
+        // Turbopack is configured to wait 1s above.
+        // Webpack has an idle timeout (after large changes) of 1s
+        // and we give time a bit more to allow writing to disk
+        await waitFor(3000)
+      }
+      await next.stop()
+    }
+
+    async function start() {
+      await next.start()
+    }
+
+    it('should cache or not cache loaders', async () => {
+      let appTimestamp, unchangedTimestamp, appClientTimestamp, pagesTimestamp
+      {
+        const browser = await next.browser('/')
+        appTimestamp = await browser.elementByCss('main').text()
+        expect(appTimestamp).toMatch(/Timestamp = \d+$/)
+        await browser.close()
+      }
+      {
+        const browser = await next.browser('/unchanged')
+        unchangedTimestamp = await browser.elementByCss('main').text()
+        expect(unchangedTimestamp).toMatch(/Timestamp = \d+$/)
+        await browser.close()
+      }
+      {
+        const browser = await next.browser('/client')
+        appClientTimestamp = await browser.elementByCss('main').text()
+        expect(appClientTimestamp).toMatch(/Timestamp = \d+$/)
+        await browser.close()
+      }
+      {
+        const browser = await next.browser('/pages')
+        pagesTimestamp = await browser.elementByCss('main').text()
+        expect(pagesTimestamp).toMatch(/Timestamp = \d+$/)
+        await browser.close()
+      }
+      await restartCycle()
+
+      {
+        const browser = await next.browser('/')
+        const newTimestamp = await browser.elementByCss('main').text()
+        expect(newTimestamp).toMatch(/Timestamp = \d+$/)
+        if (cacheEnabled) {
+          expect(newTimestamp).toBe(appTimestamp)
+        } else {
+          expect(newTimestamp).not.toBe(appTimestamp)
         }
-        {
+        await browser.close()
+      }
+      {
+        const browser = await next.browser('/unchanged')
+        const newTimestamp = await browser.elementByCss('main').text()
+        expect(newTimestamp).toMatch(/Timestamp = \d+$/)
+        if (cacheEnabled) {
+          expect(newTimestamp).toBe(unchangedTimestamp)
+        } else {
+          expect(newTimestamp).not.toBe(unchangedTimestamp)
+        }
+        await browser.close()
+      }
+      {
+        const browser = await next.browser('/client')
+        const newTimestamp = await browser.elementByCss('main').text()
+        expect(newTimestamp).toMatch(/Timestamp = \d+$/)
+        if (cacheEnabled) {
+          expect(newTimestamp).toBe(appClientTimestamp)
+        } else {
+          expect(newTimestamp).not.toBe(appClientTimestamp)
+        }
+        await browser.close()
+      }
+      {
+        const browser = await next.browser('/pages')
+        const newTimestamp = await browser.elementByCss('main').text()
+        expect(newTimestamp).toMatch(/Timestamp = \d+$/)
+        if (cacheEnabled) {
+          expect(newTimestamp).toBe(pagesTimestamp)
+        } else {
+          expect(newTimestamp).not.toBe(pagesTimestamp)
+        }
+        await browser.close()
+      }
+    })
+
+    function makeTextCheck(url: string, text: string) {
+      return textCheck.bind(null, url, text)
+    }
+
+    async function textCheck(url: string, text: string) {
+      const browser = await next.browser(url)
+      expect(await browser.elementByCss('p').text()).toBe(text)
+      await browser.close()
+    }
+
+    function makeFileEdit(file: string) {
+      return async (inner: () => Promise<void>) => {
+        await next.patchFile(
+          file,
+          (content) => {
+            return content.replace('hello world', 'hello filesystem cache')
+          },
+          inner
+        )
+      }
+    }
+
+    interface Change {
+      checkInitial(): Promise<void>
+      withChange(previous: () => Promise<void>): Promise<void>
+      checkChanged(): Promise<void>
+      fullInvalidation?: boolean
+    }
+    const POTENTIAL_CHANGES: Record<string, Change> = {
+      'RSC change': {
+        checkInitial: makeTextCheck('/', 'hello world'),
+        withChange: makeFileEdit('app/page.tsx'),
+        checkChanged: makeTextCheck('/', 'hello filesystem cache'),
+      },
+      'RCC change': {
+        checkInitial: makeTextCheck('/client', 'hello world'),
+        withChange: makeFileEdit('app/client/page.tsx'),
+        checkChanged: makeTextCheck('/client', 'hello filesystem cache'),
+      },
+      'Pages change': {
+        checkInitial: makeTextCheck('/pages', 'hello world'),
+        withChange: makeFileEdit('pages/pages.tsx'),
+        checkChanged: makeTextCheck('/pages', 'hello filesystem cache'),
+      },
+      'rename app page': {
+        checkInitial: makeTextCheck('/remove-me', 'hello world'),
+        async withChange(inner) {
+          await next.renameFolder('app/remove-me', 'app/add-me')
+          try {
+            await inner()
+          } finally {
+            await next.renameFolder('app/add-me', 'app/remove-me')
+          }
+        },
+        checkChanged: makeTextCheck('/add-me', 'hello world'),
+      },
+      // TODO fix this case with Turbopack
+      ...(isTurbopack
+        ? {}
+        : {
+            'loader change': {
+              async checkInitial() {
+                await textCheck('/loader', 'hello world')
+                await textCheck('/loader/client', 'hello world')
+              },
+              withChange: makeFileEdit('my-loader.js'),
+              async checkChanged() {
+                await textCheck('/loader', 'hello filesystem cache')
+                await textCheck('/loader/client', 'hello filesystem cache')
+              },
+              fullInvalidation: !isTurbopack,
+            },
+          }),
+      'next config change': {
+        async checkInitial() {
+          await textCheck('/next-config', 'hello world')
+          await textCheck('/next-config/client', 'hello world')
+        },
+        withChange: makeFileEdit('next.config.js'),
+        async checkChanged() {
+          await textCheck('/next-config', 'hello filesystem cache')
+          await textCheck('/next-config/client', 'hello filesystem cache')
+        },
+        fullInvalidation: !isTurbopack,
+      },
+      'env var change': {
+        async checkInitial() {
+          await textCheck('/env', 'hello world')
+          await textCheck('/env/client', 'hello world')
+        },
+        async withChange(inner) {
+          process.env.NEXT_PUBLIC_ENV_VAR = 'hello filesystem cache'
+          try {
+            await inner()
+          } finally {
+            process.env.NEXT_PUBLIC_ENV_VAR = 'hello world'
+          }
+        },
+        async checkChanged() {
+          await textCheck('/env', 'hello filesystem cache')
+          await textCheck('/env/client', 'hello filesystem cache')
+        },
+      },
+    } as const
+
+    // Checking only single change and all combined for performance reasons.
+    const combinations = Object.entries(POTENTIAL_CHANGES).map(([k, v]) => [
+      k,
+      [v],
+    ]) as Array<[string, Array<Change>]>
+    combinations.push([
+      Object.keys(POTENTIAL_CHANGES).join(', '),
+      Object.values(POTENTIAL_CHANGES),
+    ])
+
+    for (const [name, changes] of combinations) {
+      it(`should allow to change files while stopped (${name})`, async () => {
+        let fullInvalidation = !cacheEnabled
+        for (const change of changes) {
+          await change.checkInitial()
+          if (change.fullInvalidation) {
+            fullInvalidation = true
+          }
+        }
+
+        let unchangedTimestamp: string
+        if (!fullInvalidation) {
           const browser = await next.browser('/unchanged')
           unchangedTimestamp = await browser.elementByCss('main').text()
           expect(unchangedTimestamp).toMatch(/Timestamp = \d+$/)
           await browser.close()
         }
-        {
-          const browser = await next.browser('/client')
-          appClientTimestamp = await browser.elementByCss('main').text()
-          expect(appClientTimestamp).toMatch(/Timestamp = \d+$/)
-          await browser.close()
-        }
-        {
-          const browser = await next.browser('/pages')
-          pagesTimestamp = await browser.elementByCss('main').text()
-          expect(pagesTimestamp).toMatch(/Timestamp = \d+$/)
-          await browser.close()
-        }
-        await restartCycle()
 
-        {
-          const browser = await next.browser('/')
-          const newTimestamp = await browser.elementByCss('main').text()
-          if (cacheEnabled) {
-            expect(newTimestamp).toBe(appTimestamp)
-          } else {
-            expect(newTimestamp).not.toBe(appTimestamp)
-          }
-          await browser.close()
-        }
-        {
-          const browser = await next.browser('/unchanged')
-          const newTimestamp = await browser.elementByCss('main').text()
-          if (cacheEnabled) {
-            expect(newTimestamp).toBe(unchangedTimestamp)
-          } else {
-            expect(newTimestamp).not.toBe(unchangedTimestamp)
-          }
-          await browser.close()
-        }
-        {
-          const browser = await next.browser('/client')
-          const newTimestamp = await browser.elementByCss('main').text()
-          if (cacheEnabled) {
-            expect(newTimestamp).toBe(appClientTimestamp)
-          } else {
-            expect(newTimestamp).not.toBe(appClientTimestamp)
-          }
-          await browser.close()
-        }
-        {
-          const browser = await next.browser('/pages')
-          const newTimestamp = await browser.elementByCss('main').text()
-          if (cacheEnabled) {
-            expect(newTimestamp).toBe(pagesTimestamp)
-          } else {
-            expect(newTimestamp).not.toBe(pagesTimestamp)
-          }
-          await browser.close()
-        }
-      })
-
-      function makeTextCheck(url: string, text: string) {
-        return textCheck.bind(null, url, text)
-      }
-
-      async function textCheck(url: string, text: string) {
-        const browser = await next.browser(url)
-        expect(await browser.elementByCss('p').text()).toBe(text)
-        await browser.close()
-      }
-
-      function makeFileEdit(file: string) {
-        return async (inner: () => Promise<void>) => {
-          await next.patchFile(
-            file,
-            (content) => {
-              return content.replace('hello world', 'hello filesystem cache')
-            },
-            inner
-          )
-        }
-      }
-
-      interface Change {
-        checkInitial(): Promise<void>
-        withChange(previous: () => Promise<void>): Promise<void>
-        checkChanged(): Promise<void>
-        fullInvalidation?: boolean
-      }
-      const POTENTIAL_CHANGES: Record<string, Change> = {
-        'RSC change': {
-          checkInitial: makeTextCheck('/', 'hello world'),
-          withChange: makeFileEdit('app/page.tsx'),
-          checkChanged: makeTextCheck('/', 'hello filesystem cache'),
-        },
-        'RCC change': {
-          checkInitial: makeTextCheck('/client', 'hello world'),
-          withChange: makeFileEdit('app/client/page.tsx'),
-          checkChanged: makeTextCheck('/client', 'hello filesystem cache'),
-        },
-        'Pages change': {
-          checkInitial: makeTextCheck('/pages', 'hello world'),
-          withChange: makeFileEdit('pages/pages.tsx'),
-          checkChanged: makeTextCheck('/pages', 'hello filesystem cache'),
-        },
-        'rename app page': {
-          checkInitial: makeTextCheck('/remove-me', 'hello world'),
-          async withChange(inner) {
-            await next.renameFolder('app/remove-me', 'app/add-me')
-            try {
-              await inner()
-            } finally {
-              await next.renameFolder('app/add-me', 'app/remove-me')
-            }
-          },
-          checkChanged: makeTextCheck('/add-me', 'hello world'),
-        },
-        // TODO fix this case with Turbopack
-        ...(isTurbopack
-          ? {}
-          : {
-              'loader change': {
-                async checkInitial() {
-                  await textCheck('/loader', 'hello world')
-                  await textCheck('/loader/client', 'hello world')
-                },
-                withChange: makeFileEdit('my-loader.js'),
-                async checkChanged() {
-                  await textCheck('/loader', 'hello filesystem cache')
-                  await textCheck('/loader/client', 'hello filesystem cache')
-                },
-                fullInvalidation: !isTurbopack,
-              },
-            }),
-        'next config change': {
-          async checkInitial() {
-            await textCheck('/next-config', 'hello world')
-            await textCheck('/next-config/client', 'hello world')
-          },
-          withChange: makeFileEdit('next.config.js'),
-          async checkChanged() {
-            await textCheck('/next-config', 'hello filesystem cache')
-            await textCheck('/next-config/client', 'hello filesystem cache')
-          },
-          fullInvalidation: !isTurbopack,
-        },
-        'env var change': {
-          async checkInitial() {
-            await textCheck('/env', 'hello world')
-            await textCheck('/env/client', 'hello world')
-          },
-          async withChange(inner) {
-            process.env.NEXT_PUBLIC_ENV_VAR = 'hello filesystem cache'
-            try {
-              await inner()
-            } finally {
-              process.env.NEXT_PUBLIC_ENV_VAR = 'hello world'
-            }
-          },
-          async checkChanged() {
-            await textCheck('/env', 'hello filesystem cache')
-            await textCheck('/env/client', 'hello filesystem cache')
-          },
-        },
-      } as const
-
-      // Checking only single change and all combined for performance reasons.
-      const combinations = Object.entries(POTENTIAL_CHANGES).map(([k, v]) => [
-        k,
-        [v],
-      ]) as Array<[string, Array<Change>]>
-      combinations.push([
-        Object.keys(POTENTIAL_CHANGES).join(', '),
-        Object.values(POTENTIAL_CHANGES),
-      ])
-
-      beforeAll(() => {
-        // Next is always started with caching, but this can disable it for the followup restarts
-        process.env.ENABLE_CACHING = cacheEnabled ? '1' : '0'
-      })
-      for (const [name, changes] of combinations) {
-        it(`should allow to change files while stopped (${name})`, async () => {
-          let fullInvalidation = false
+        async function checkChanged() {
           for (const change of changes) {
-            await change.checkInitial()
-            if (change.fullInvalidation) {
-              fullInvalidation = true
-            }
-          }
-
-          let unchangedTimestamp: string
-          if (!fullInvalidation) {
-            const browser = await next.browser('/unchanged')
-            unchangedTimestamp = await browser.elementByCss('main').text()
-            expect(unchangedTimestamp).toMatch(/Timestamp = \d+$/)
-            await browser.close()
-          }
-
-          async function checkChanged() {
-            for (const change of changes) {
-              await change.checkChanged()
-            }
-
-            if (!fullInvalidation) {
-              const browser = await next.browser('/unchanged')
-              const timestamp = await browser.elementByCss('main').text()
-              expect(unchangedTimestamp).toEqual(timestamp)
-              await browser.close()
-            }
-          }
-
-          await stop()
-
-          async function inner() {
-            await start()
-            await checkChanged()
-            // Some no-op change builds
-            for (let i = 0; i < 2; i++) {
-              await restartCycle()
-              await checkChanged()
-            }
-            await stop()
-          }
-
-          let current = inner
-          for (const change of changes) {
-            const prev = current
-            current = () => change.withChange(prev)
-          }
-          await current()
-
-          await start()
-          for (const change of changes) {
-            await change.checkInitial()
+            await change.checkChanged()
           }
 
           if (!fullInvalidation) {
@@ -300,8 +274,40 @@ describe('filesystem-caching', () => {
             expect(unchangedTimestamp).toEqual(timestamp)
             await browser.close()
           }
-        }, 200000)
-      }
-    })
-  }
-})
+        }
+
+        await stop()
+
+        async function inner() {
+          await start()
+          await checkChanged()
+          // Some no-op change builds
+          for (let i = 0; i < 2; i++) {
+            await restartCycle()
+            await checkChanged()
+          }
+          await stop()
+        }
+
+        let current = inner
+        for (const change of changes) {
+          const prev = current
+          current = () => change.withChange(prev)
+        }
+        await current()
+
+        await start()
+        for (const change of changes) {
+          await change.checkInitial()
+        }
+
+        if (!fullInvalidation) {
+          const browser = await next.browser('/unchanged')
+          const timestamp = await browser.elementByCss('main').text()
+          expect(unchangedTimestamp).toEqual(timestamp)
+          await browser.close()
+        }
+      }, 200000)
+    }
+  })
+}

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -47,172 +47,193 @@ describe('filesystem-caching', () => {
     await next.start()
   }
 
-  it('should filesystem cache loaders', async () => {
-    let appTimestamp, unchangedTimestamp, appClientTimestamp, pagesTimestamp
-    {
-      const browser = await next.browser('/')
-      appTimestamp = await browser.elementByCss('main').text()
-      expect(appTimestamp).toMatch(/Timestamp = \d+$/)
-      await browser.close()
-    }
-    {
-      const browser = await next.browser('/unchanged')
-      unchangedTimestamp = await browser.elementByCss('main').text()
-      expect(unchangedTimestamp).toMatch(/Timestamp = \d+$/)
-      await browser.close()
-    }
-    {
-      const browser = await next.browser('/client')
-      appClientTimestamp = await browser.elementByCss('main').text()
-      expect(appClientTimestamp).toMatch(/Timestamp = \d+$/)
-      await browser.close()
-    }
-    {
-      const browser = await next.browser('/pages')
-      pagesTimestamp = await browser.elementByCss('main').text()
-      expect(pagesTimestamp).toMatch(/Timestamp = \d+$/)
-      await browser.close()
-    }
-    await restartCycle()
-
-    {
-      const browser = await next.browser('/')
-      expect(await browser.elementByCss('main').text()).toBe(appTimestamp)
-      await browser.close()
-    }
-    {
-      const browser = await next.browser('/unchanged')
-      expect(await browser.elementByCss('main').text()).toBe(unchangedTimestamp)
-      await browser.close()
-    }
-    {
-      const browser = await next.browser('/client')
-      expect(await browser.elementByCss('main').text()).toBe(appClientTimestamp)
-      await browser.close()
-    }
-    {
-      const browser = await next.browser('/pages')
-      expect(await browser.elementByCss('main').text()).toBe(pagesTimestamp)
-      await browser.close()
-    }
-  })
-
-  function makeTextCheck(url: string, text: string) {
-    return textCheck.bind(null, url, text)
-  }
-
-  async function textCheck(url: string, text: string) {
-    const browser = await next.browser(url)
-    expect(await browser.elementByCss('p').text()).toBe(text)
-    await browser.close()
-  }
-
-  function makeFileEdit(file: string) {
-    return async (inner: () => Promise<void>) => {
-      await next.patchFile(
-        file,
-        (content) => {
-          return content.replace('hello world', 'hello filesystem cache')
-        },
-        inner
-      )
-    }
-  }
-
-  interface Change {
-    checkInitial(): Promise<void>
-    withChange(previous: () => Promise<void>): Promise<void>
-    checkChanged(): Promise<void>
-    fullInvalidation?: boolean
-  }
-  const POTENTIAL_CHANGES: Record<string, Change> = {
-    'RSC change': {
-      checkInitial: makeTextCheck('/', 'hello world'),
-      withChange: makeFileEdit('app/page.tsx'),
-      checkChanged: makeTextCheck('/', 'hello filesystem cache'),
-    },
-    'RCC change': {
-      checkInitial: makeTextCheck('/client', 'hello world'),
-      withChange: makeFileEdit('app/client/page.tsx'),
-      checkChanged: makeTextCheck('/client', 'hello filesystem cache'),
-    },
-    'Pages change': {
-      checkInitial: makeTextCheck('/pages', 'hello world'),
-      withChange: makeFileEdit('pages/pages.tsx'),
-      checkChanged: makeTextCheck('/pages', 'hello filesystem cache'),
-    },
-    'rename app page': {
-      checkInitial: makeTextCheck('/remove-me', 'hello world'),
-      async withChange(inner) {
-        await next.renameFolder('app/remove-me', 'app/add-me')
-        try {
-          await inner()
-        } finally {
-          await next.renameFolder('app/add-me', 'app/remove-me')
-        }
-      },
-      checkChanged: makeTextCheck('/add-me', 'hello world'),
-    },
-    // TODO fix this case with Turbopack
-    ...(isTurbopack
-      ? {}
-      : {
-          'loader change': {
-            async checkInitial() {
-              await textCheck('/loader', 'hello world')
-              await textCheck('/loader/client', 'hello world')
-            },
-            withChange: makeFileEdit('my-loader.js'),
-            async checkChanged() {
-              await textCheck('/loader', 'hello filesystem cache')
-              await textCheck('/loader/client', 'hello filesystem cache')
-            },
-            fullInvalidation: !isTurbopack,
-          },
-        }),
-    'next config change': {
-      async checkInitial() {
-        await textCheck('/next-config', 'hello world')
-        await textCheck('/next-config/client', 'hello world')
-      },
-      withChange: makeFileEdit('next.config.js'),
-      async checkChanged() {
-        await textCheck('/next-config', 'hello filesystem cache')
-        await textCheck('/next-config/client', 'hello filesystem cache')
-      },
-      fullInvalidation: !isTurbopack,
-    },
-    'env var change': {
-      async checkInitial() {
-        await textCheck('/env', 'hello world')
-        await textCheck('/env/client', 'hello world')
-      },
-      async withChange(inner) {
-        process.env.NEXT_PUBLIC_ENV_VAR = 'hello filesystem cache'
-        try {
-          await inner()
-        } finally {
-          process.env.NEXT_PUBLIC_ENV_VAR = 'hello world'
-        }
-      },
-      async checkChanged() {
-        await textCheck('/env', 'hello filesystem cache')
-        await textCheck('/env/client', 'hello filesystem cache')
-      },
-    },
-  } as const
-
-  // Checking only single change and all combined for performance reasons.
-  const combinations = Object.entries(POTENTIAL_CHANGES).map(([k, v]) => [
-    k,
-    [v],
-  ]) as Array<[string, Array<Change>]>
-  combinations.push([
-    Object.keys(POTENTIAL_CHANGES).join(', '),
-    Object.values(POTENTIAL_CHANGES),
-  ])
-  for (const cacheEnabled of [true, false]) {
+  for (const cacheEnabled of [false, true]) {
     describe(`with cache ${cacheEnabled ? 'enabled' : 'disabled'}`, () => {
+      it('should cache or not cache loaders', async () => {
+        let appTimestamp, unchangedTimestamp, appClientTimestamp, pagesTimestamp
+        {
+          const browser = await next.browser('/')
+          appTimestamp = await browser.elementByCss('main').text()
+          expect(appTimestamp).toMatch(/Timestamp = \d+$/)
+          await browser.close()
+        }
+        {
+          const browser = await next.browser('/unchanged')
+          unchangedTimestamp = await browser.elementByCss('main').text()
+          expect(unchangedTimestamp).toMatch(/Timestamp = \d+$/)
+          await browser.close()
+        }
+        {
+          const browser = await next.browser('/client')
+          appClientTimestamp = await browser.elementByCss('main').text()
+          expect(appClientTimestamp).toMatch(/Timestamp = \d+$/)
+          await browser.close()
+        }
+        {
+          const browser = await next.browser('/pages')
+          pagesTimestamp = await browser.elementByCss('main').text()
+          expect(pagesTimestamp).toMatch(/Timestamp = \d+$/)
+          await browser.close()
+        }
+        await restartCycle()
+
+        {
+          const browser = await next.browser('/')
+          const newTimestamp = await browser.elementByCss('main').text()
+          if (cacheEnabled) {
+            expect(newTimestamp).toBe(appTimestamp)
+          } else {
+            expect(newTimestamp).not.toBe(appTimestamp)
+          }
+          await browser.close()
+        }
+        {
+          const browser = await next.browser('/unchanged')
+          const newTimestamp = await browser.elementByCss('main').text()
+          if (cacheEnabled) {
+            expect(newTimestamp).toBe(unchangedTimestamp)
+          } else {
+            expect(newTimestamp).not.toBe(unchangedTimestamp)
+          }
+          await browser.close()
+        }
+        {
+          const browser = await next.browser('/client')
+          const newTimestamp = await browser.elementByCss('main').text()
+          if (cacheEnabled) {
+            expect(newTimestamp).toBe(appClientTimestamp)
+          } else {
+            expect(newTimestamp).not.toBe(appClientTimestamp)
+          }
+          await browser.close()
+        }
+        {
+          const browser = await next.browser('/pages')
+          const newTimestamp = await browser.elementByCss('main').text()
+          if (cacheEnabled) {
+            expect(newTimestamp).toBe(pagesTimestamp)
+          } else {
+            expect(newTimestamp).not.toBe(pagesTimestamp)
+          }
+          await browser.close()
+        }
+      })
+
+      function makeTextCheck(url: string, text: string) {
+        return textCheck.bind(null, url, text)
+      }
+
+      async function textCheck(url: string, text: string) {
+        const browser = await next.browser(url)
+        expect(await browser.elementByCss('p').text()).toBe(text)
+        await browser.close()
+      }
+
+      function makeFileEdit(file: string) {
+        return async (inner: () => Promise<void>) => {
+          await next.patchFile(
+            file,
+            (content) => {
+              return content.replace('hello world', 'hello filesystem cache')
+            },
+            inner
+          )
+        }
+      }
+
+      interface Change {
+        checkInitial(): Promise<void>
+        withChange(previous: () => Promise<void>): Promise<void>
+        checkChanged(): Promise<void>
+        fullInvalidation?: boolean
+      }
+      const POTENTIAL_CHANGES: Record<string, Change> = {
+        'RSC change': {
+          checkInitial: makeTextCheck('/', 'hello world'),
+          withChange: makeFileEdit('app/page.tsx'),
+          checkChanged: makeTextCheck('/', 'hello filesystem cache'),
+        },
+        'RCC change': {
+          checkInitial: makeTextCheck('/client', 'hello world'),
+          withChange: makeFileEdit('app/client/page.tsx'),
+          checkChanged: makeTextCheck('/client', 'hello filesystem cache'),
+        },
+        'Pages change': {
+          checkInitial: makeTextCheck('/pages', 'hello world'),
+          withChange: makeFileEdit('pages/pages.tsx'),
+          checkChanged: makeTextCheck('/pages', 'hello filesystem cache'),
+        },
+        'rename app page': {
+          checkInitial: makeTextCheck('/remove-me', 'hello world'),
+          async withChange(inner) {
+            await next.renameFolder('app/remove-me', 'app/add-me')
+            try {
+              await inner()
+            } finally {
+              await next.renameFolder('app/add-me', 'app/remove-me')
+            }
+          },
+          checkChanged: makeTextCheck('/add-me', 'hello world'),
+        },
+        // TODO fix this case with Turbopack
+        ...(isTurbopack
+          ? {}
+          : {
+              'loader change': {
+                async checkInitial() {
+                  await textCheck('/loader', 'hello world')
+                  await textCheck('/loader/client', 'hello world')
+                },
+                withChange: makeFileEdit('my-loader.js'),
+                async checkChanged() {
+                  await textCheck('/loader', 'hello filesystem cache')
+                  await textCheck('/loader/client', 'hello filesystem cache')
+                },
+                fullInvalidation: !isTurbopack,
+              },
+            }),
+        'next config change': {
+          async checkInitial() {
+            await textCheck('/next-config', 'hello world')
+            await textCheck('/next-config/client', 'hello world')
+          },
+          withChange: makeFileEdit('next.config.js'),
+          async checkChanged() {
+            await textCheck('/next-config', 'hello filesystem cache')
+            await textCheck('/next-config/client', 'hello filesystem cache')
+          },
+          fullInvalidation: !isTurbopack,
+        },
+        'env var change': {
+          async checkInitial() {
+            await textCheck('/env', 'hello world')
+            await textCheck('/env/client', 'hello world')
+          },
+          async withChange(inner) {
+            process.env.NEXT_PUBLIC_ENV_VAR = 'hello filesystem cache'
+            try {
+              await inner()
+            } finally {
+              process.env.NEXT_PUBLIC_ENV_VAR = 'hello world'
+            }
+          },
+          async checkChanged() {
+            await textCheck('/env', 'hello filesystem cache')
+            await textCheck('/env/client', 'hello filesystem cache')
+          },
+        },
+      } as const
+
+      // Checking only single change and all combined for performance reasons.
+      const combinations = Object.entries(POTENTIAL_CHANGES).map(([k, v]) => [
+        k,
+        [v],
+      ]) as Array<[string, Array<Change>]>
+      combinations.push([
+        Object.keys(POTENTIAL_CHANGES).join(', '),
+        Object.values(POTENTIAL_CHANGES),
+      ])
+
       beforeAll(() => {
         // Next is always started with caching, but this can disable it for the followup restarts
         process.env.ENABLE_CACHING = cacheEnabled ? '1' : '0'

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -1,8 +1,12 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 
-describe('persistent-caching', () => {
+describe('filesystem-caching', () => {
   process.env.NEXT_PUBLIC_ENV_VAR = 'hello world'
+  // Make it easier to run in development, test directories are cleared between runs already so this is safe.
+  process.env.TURBO_ENGINE_DISABLE_VERSIONING = '1'
+  // decrease the idle timeout to make the test more reliable
+  process.env.TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS = '1000'
   const { skipped, next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
@@ -30,7 +34,7 @@ describe('persistent-caching', () => {
   async function stop() {
     if (isNextDev) {
       // Give FileSystem Cache time to write to disk
-      // Turbopack has an idle timeout of 2s
+      // Turbopack is configured to wait 1s above.
       // Webpack has an idle timeout (after large changes) of 1s
       // and we give time a bit more to allow writing to disk
       await waitFor(3000)
@@ -43,6 +47,7 @@ describe('persistent-caching', () => {
   }
 
   it('should filesystem cache loaders', async () => {
+    process.env.ENABLE_CACHING = '1'
     let appTimestamp, unchangedTimestamp, appClientTimestamp, pagesTimestamp
     {
       const browser = await next.browser('/')
@@ -114,7 +119,13 @@ describe('persistent-caching', () => {
     }
   }
 
-  const POTENTIAL_CHANGES = {
+  interface Change {
+    checkInitial(): Promise<void>
+    withChange(previous: () => Promise<void>): Promise<void>
+    checkChanged(): Promise<void>
+    fullInvalidation?: boolean
+  }
+  const POTENTIAL_CHANGES: Record<string, Change> = {
     'RSC change': {
       checkInitial: makeTextCheck('/', 'hello world'),
       withChange: makeFileEdit('app/page.tsx'),
@@ -189,80 +200,86 @@ describe('persistent-caching', () => {
         await textCheck('/env/client', 'hello filesystem cache')
       },
     },
-  }
+  } as const
 
-  const KEYS = Object.keys(POTENTIAL_CHANGES)
-  for (let bitset = 1; bitset < 1 << KEYS.length; bitset++) {
-    let combination = []
-    for (let i = 0; i < KEYS.length; i++) {
-      if (bitset & (1 << i)) {
-        combination.push(KEYS[i])
+  // Checking only single change and all combined for performance reasons.
+  const combinations = Object.entries(POTENTIAL_CHANGES).map(([k, v]) => [
+    k,
+    [v],
+  ]) as Array<[string, Array<Change>]>
+  combinations.push([
+    Object.keys(POTENTIAL_CHANGES).join(', '),
+    Object.values(POTENTIAL_CHANGES),
+  ])
+  for (const cacheEnabled of [true, false]) {
+    describe(`with cache ${cacheEnabled ? 'enabled' : 'disabled'}`, () => {
+      beforeAll(() => {
+        process.env.ENABLE_CACHING = cacheEnabled ? '1' : '0'
+      })
+      for (const [name, changes] of combinations) {
+        it(`should allow to change files while stopped (${name})`, async () => {
+          let fullInvalidation = false
+          for (const change of changes) {
+            await change.checkInitial()
+            if (change.fullInvalidation) {
+              fullInvalidation = true
+            }
+          }
+
+          let unchangedTimestamp: string
+          if (!fullInvalidation) {
+            const browser = await next.browser('/unchanged')
+            unchangedTimestamp = await browser.elementByCss('main').text()
+            expect(unchangedTimestamp).toMatch(/Timestamp = \d+$/)
+            await browser.close()
+          }
+
+          async function checkChanged() {
+            for (const change of changes) {
+              await change.checkChanged()
+            }
+
+            if (!fullInvalidation) {
+              const browser = await next.browser('/unchanged')
+              const timestamp = await browser.elementByCss('main').text()
+              expect(unchangedTimestamp).toEqual(timestamp)
+              await browser.close()
+            }
+          }
+
+          await stop()
+
+          async function inner() {
+            await start()
+            await checkChanged()
+            // Some no-op change builds
+            for (let i = 0; i < 2; i++) {
+              await restartCycle()
+              await checkChanged()
+            }
+            await stop()
+          }
+
+          let current = inner
+          for (const change of changes) {
+            const prev = current
+            current = () => change.withChange(prev)
+          }
+          await current()
+
+          await start()
+          for (const change of changes) {
+            await change.checkInitial()
+          }
+
+          if (!fullInvalidation) {
+            const browser = await next.browser('/unchanged')
+            const timestamp = await browser.elementByCss('main').text()
+            expect(unchangedTimestamp).toEqual(timestamp)
+            await browser.close()
+          }
+        }, 200000)
       }
-    }
-    // Checking only single change and all combined for performance reasons.
-    if (combination.length !== 1 && combination.length !== KEYS.length) continue
-
-    it(`should allow to change files while stopped (${combination.join(', ')})`, async () => {
-      let fullInvalidation = false
-      for (const key of combination) {
-        await POTENTIAL_CHANGES[key].checkInitial()
-        if (POTENTIAL_CHANGES[key].fullInvalidation) {
-          fullInvalidation = true
-        }
-      }
-
-      let unchangedTimestamp
-      if (!fullInvalidation) {
-        const browser = await next.browser('/unchanged')
-        unchangedTimestamp = await browser.elementByCss('main').text()
-        expect(unchangedTimestamp).toMatch(/Timestamp = \d+$/)
-        await browser.close()
-      }
-
-      async function checkChanged() {
-        for (const key of combination) {
-          await POTENTIAL_CHANGES[key].checkChanged()
-        }
-
-        if (!fullInvalidation) {
-          const browser = await next.browser('/unchanged')
-          const timestamp = await browser.elementByCss('main').text()
-          expect(unchangedTimestamp).toEqual(timestamp)
-          await browser.close()
-        }
-      }
-
-      await stop()
-
-      async function inner() {
-        await start()
-        await checkChanged()
-        // Some no-op change builds
-        for (let i = 0; i < 2; i++) {
-          await restartCycle()
-          await checkChanged()
-        }
-        await stop()
-      }
-
-      let current = inner
-      for (const key of combination) {
-        const prev = current
-        current = () => POTENTIAL_CHANGES[key].withChange(prev)
-      }
-      await current()
-
-      await start()
-      for (const key of combination) {
-        await POTENTIAL_CHANGES[key].checkInitial()
-      }
-
-      if (!fullInvalidation) {
-        const browser = await next.browser('/unchanged')
-        const timestamp = await browser.elementByCss('main').text()
-        expect(unchangedTimestamp).toEqual(timestamp)
-        await browser.close()
-      }
-    }, 200000)
+    })
   }
 })

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -4,9 +4,10 @@ import { waitFor } from 'next-test-utils'
 describe('filesystem-caching', () => {
   process.env.NEXT_PUBLIC_ENV_VAR = 'hello world'
   // Make it easier to run in development, test directories are cleared between runs already so this is safe.
-  process.env.TURBO_ENGINE_DISABLE_VERSIONING = '1'
+  process.env.TURBO_ENGINE_IGNORE_DIRTY = '1'
   // decrease the idle timeout to make the test more reliable
   process.env.TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS = '1000'
+  process.env.ENABLE_CACHING = '1'
   const { skipped, next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
@@ -47,7 +48,6 @@ describe('filesystem-caching', () => {
   }
 
   it('should filesystem cache loaders', async () => {
-    process.env.ENABLE_CACHING = '1'
     let appTimestamp, unchangedTimestamp, appClientTimestamp, pagesTimestamp
     {
       const browser = await next.browser('/')
@@ -214,6 +214,7 @@ describe('filesystem-caching', () => {
   for (const cacheEnabled of [true, false]) {
     describe(`with cache ${cacheEnabled ? 'enabled' : 'disabled'}`, () => {
       beforeAll(() => {
+        // Next is always started with caching, but this can disable it for the followup restarts
         process.env.ENABLE_CACHING = cacheEnabled ? '1' : '0'
       })
       for (const [name, changes] of combinations) {

--- a/test/e2e/filesystem-cache/next.config.js
+++ b/test/e2e/filesystem-cache/next.config.js
@@ -1,3 +1,5 @@
+const enableCaching = !!process.env.ENABLE_CACHING
+
 /**
  * @type {import('next').NextConfig}
  */
@@ -16,8 +18,8 @@ const nextConfig = {
     },
   },
   experimental: {
-    turbopackFileSystemCacheForDev: true,
-    turbopackFileSystemCacheForBuild: true,
+    turbopackFileSystemCacheForDev: enableCaching,
+    turbopackFileSystemCacheForBuild: enableCaching,
   },
   env: {
     NEXT_PUBLIC_CONFIG_ENV: 'hello world',
@@ -30,6 +32,9 @@ const nextConfig = {
     config.module.rules.push({
       test: /app\/loader(?:\/client)?\/page\.tsx/,
       use: ['./my-loader.js'],
+    })
+    config.cache = Object.freeze({
+      type: enableCaching ? 'filesystem' : 'memory',
     })
     if (dev) {
       // Make webpack consider the build as large change which makes it filesystem cache it sooner

--- a/test/e2e/filesystem-cache/next.config.js
+++ b/test/e2e/filesystem-cache/next.config.js
@@ -17,10 +17,14 @@ const nextConfig = {
       },
     },
   },
-  experimental: {
-    turbopackFileSystemCacheForDev: enableCaching,
-    turbopackFileSystemCacheForBuild: enableCaching,
-  },
+  experimental: enableCaching
+    ? {
+        turbopackFileSystemCacheForBuild: true,
+      }
+    : {
+        turbopackFileSystemCacheForDev: false,
+        turbopackFileSystemCacheForBuild: false,
+      },
   env: {
     NEXT_PUBLIC_CONFIG_ENV: 'hello world',
   },
@@ -33,9 +37,11 @@ const nextConfig = {
       test: /app\/loader(?:\/client)?\/page\.tsx/,
       use: ['./my-loader.js'],
     })
-    config.cache = Object.freeze({
-      type: enableCaching ? 'filesystem' : 'memory',
-    })
+    if (enableCaching) {
+      config.cache = Object.freeze({
+        type: 'memory',
+      })
+    }
     if (dev) {
       // Make webpack consider the build as large change which makes it filesystem cache it sooner
       config.plugins.push((compiler) => {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -12,7 +12,7 @@ use std::{
     ops::Range,
     pin::Pin,
     sync::{
-        Arc,
+        Arc, LazyLock,
         atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     },
 };
@@ -71,6 +71,16 @@ use crate::{
 };
 
 const SNAPSHOT_REQUESTED_BIT: usize = 1 << (usize::BITS - 1);
+
+/// Configurable idle timeout for snapshot persistence.
+/// Defaults to 2 seconds if not set or if the value is invalid.
+static IDLE_TIMEOUT: LazyLock<Duration> = LazyLock::new(|| {
+    std::env::var("TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(Duration::from_secs(2))
+});
 
 struct SnapshotRequest {
     snapshot_requested: bool,
@@ -2467,8 +2477,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     loop {
                         const FIRST_SNAPSHOT_WAIT: Duration = Duration::from_secs(300);
                         const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(120);
-                        const IDLE_TIMEOUT: Duration = Duration::from_secs(2);
-
+                        let idle_timeout = *IDLE_TIMEOUT;
                         let (time, mut reason) =
                             if matches!(job, TurboTasksBackendJob::InitialSnapshot) {
                                 (FIRST_SNAPSHOT_WAIT, "initial snapshot timeout")
@@ -2485,7 +2494,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                             let mut idle_start_listener = self.idle_start_event.listen();
                             let mut idle_end_listener = self.idle_end_event.listen();
                             let mut idle_time = if turbo_tasks.is_idle() {
-                                Instant::now() + IDLE_TIMEOUT
+                                Instant::now() + idle_timeout
                             } else {
                                 far_future()
                             };
@@ -2495,11 +2504,11 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                                         return;
                                     },
                                     _ = &mut idle_start_listener => {
-                                        idle_time = Instant::now() + IDLE_TIMEOUT;
+                                        idle_time = Instant::now() + idle_timeout;
                                         idle_start_listener = self.idle_start_event.listen()
                                     },
                                     _ = &mut idle_end_listener => {
-                                        idle_time = until + IDLE_TIMEOUT;
+                                        idle_time = until + idle_timeout;
                                         idle_end_listener = self.idle_end_event.listen()
                                     },
                                     _ = tokio::time::sleep_until(until) => {


### PR DESCRIPTION
Enable the filesystem cache in canary builds in preparation for enabling it by default in the next release.

It can still be disabled by explicitly setting the option to `false`.

Flipping it for all users is deferred to #85975 so as not to interfere with potential patch releases.

Also fix the filesystem caching test that was accidentally disabled in #84632 due to the file rename.