### PR TITLE
Turbopack: remove referenced_assets field

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1816,7 +1816,7 @@ impl AppEndpoint {
                             .await?;
                     }
 
-                    let current_referenced_assets = current_chunk_group.referenced_assets();
+                    let current_references = current_chunk_group.references();
                     let chunk_group = current_chunk_group.await?;
                     let current_availability_info = chunk_group.availability_info;
                     let current_chunks = chunk_group.assets;
@@ -1833,13 +1833,12 @@ impl AppEndpoint {
                                         evaluatable_assets,
                                         module_graph,
                                         *current_chunks,
-                                        current_referenced_assets,
+                                        current_references,
                                         current_availability_info,
                                     )
                                     .to_resolved()
                                     .await?,
                             ]),
-                            referenced_assets: ResolvedVc::cell(vec![]),
                             references: ResolvedVc::cell(vec![]),
                         }
                         .cell(),

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -19,7 +19,7 @@ use turbopack_core::{
         GraphEntries,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
     },
-    output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
+    output::{OutputAsset, OutputAssets, OutputAssetsReferences, OutputAssetsWithReferenced},
     reference_type::{EntryReferenceSubType, ReferenceType},
     source::Source,
     virtual_output::VirtualOutputAsset,
@@ -133,7 +133,7 @@ impl InstrumentationEndpoint {
                 Vc::cell(vec![module]),
                 module_graph,
                 OutputAssets::empty(),
-                OutputAssets::empty(),
+                OutputAssetsReferences::empty(),
                 AvailabilityInfo::root(),
             )
             .await?;

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -24,7 +24,7 @@ use turbopack_core::{
         GraphEntries,
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
     },
-    output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
+    output::{OutputAsset, OutputAssets, OutputAssetsReferences, OutputAssetsWithReferenced},
     reference_type::{EntryReferenceSubType, ReferenceType},
     source::Source,
     virtual_output::VirtualOutputAsset,
@@ -146,7 +146,7 @@ impl MiddlewareEndpoint {
                 Vc::cell(vec![module]),
                 module_graph,
                 OutputAssets::empty(),
-                OutputAssets::empty(),
+                OutputAssetsReferences::empty(),
                 AvailabilityInfo::root(),
             )
             .await?;

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -160,7 +160,6 @@ pub async fn get_app_client_references_chunks(
 
             let mut current_client_chunk_group = ChunkGroupResult {
                 assets: ResolvedVc::cell(vec![]),
-                referenced_assets: ResolvedVc::cell(vec![]),
                 references: ResolvedVc::cell(vec![]),
                 availability_info: client_availability_info,
             }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -117,7 +117,6 @@ impl OutputAssetsReference for EcmascriptBrowserChunk {
 
         Ok(OutputAssetsWithReferenced {
             assets: ResolvedVc::cell(assets),
-            referenced_assets: chunk_references.referenced_assets,
             references: chunk_references.references,
         }
         .cell())

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -36,7 +36,7 @@ use turbopack_core::{
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
         export_usage::compute_export_usage_info,
     },
-    output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
+    output::{OutputAsset, OutputAssets, OutputAssetsReferences, OutputAssetsWithReferenced},
     reference_type::{EntryReferenceSubType, ReferenceType},
     resolve::{
         origin::{PlainResolveOrigin, ResolveOriginExt},
@@ -464,13 +464,12 @@ async fn build_internal(
                                             EvaluatableAssets::one(*ecmascript),
                                             module_graph,
                                             OutputAssets::empty(),
-                                            OutputAssets::empty(),
+                                            OutputAssetsReferences::empty(),
                                             AvailabilityInfo::root(),
                                         )
                                         .await?
                                         .asset,
                                 ]),
-                                referenced_assets: ResolvedVc::cell(vec![]),
                                 references: ResolvedVc::cell(vec![]),
                             }
                             .cell(),

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -26,8 +26,7 @@ use crate::{
         module_batches::{BatchingConfig, ModuleBatchesGraphEdge},
     },
     output::{
-        OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsReferences,
-        OutputAssetsWithReferenced,
+        OutputAsset, OutputAssetsReference, OutputAssetsReferences, OutputAssetsWithReferenced,
     },
     reference::ModuleReference,
     traced_asset::TracedAsset,
@@ -185,7 +184,6 @@ pub async fn references_to_output_assets(
         .collect::<Vec<_>>();
     Ok(OutputAssetsWithReferenced {
         assets: ResolvedVc::cell(output_assets),
-        referenced_assets: OutputAssets::empty_resolved(),
         references: OutputAssetsReferences::empty_resolved(),
     }
     .cell())

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -273,12 +273,7 @@ impl OutputAssetsReference for CssChunk {
                 } else {
                     None
                 };
-                Ok((
-                    refs.assets.await?,
-                    single_css_chunk,
-                    refs.referenced_assets.await?,
-                    refs.references.await?,
-                ))
+                Ok((refs.assets.await?, single_css_chunk, refs.references.await?))
             })
             .try_join()
             .await?;
@@ -298,7 +293,7 @@ impl OutputAssetsReference for CssChunk {
             assets: ResolvedVc::cell(
                 references
                     .iter()
-                    .flat_map(|(assets, single_css_chunk, _, _)| {
+                    .flat_map(|(assets, single_css_chunk, _)| {
                         assets
                             .iter()
                             .copied()
@@ -307,16 +302,10 @@ impl OutputAssetsReference for CssChunk {
                     .chain(source_map.into_iter())
                     .collect(),
             ),
-            referenced_assets: ResolvedVc::cell(
-                references
-                    .iter()
-                    .flat_map(|(_, _, referenced_assets, _)| referenced_assets.iter().copied())
-                    .collect(),
-            ),
             references: ResolvedVc::cell(
                 references
                     .iter()
-                    .flat_map(|(_, _, _, references)| references.iter().copied())
+                    .flat_map(|(_, _, references)| references.iter().copied())
                     .collect(),
             ),
         }

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -178,7 +178,6 @@ impl DevHtmlAsset {
 
                 Ok((
                     asset_with_referenced.assets.await?,
-                    asset_with_referenced.referenced_assets.await?,
                     asset_with_referenced.references.await?,
                 ))
             })
@@ -186,17 +185,14 @@ impl DevHtmlAsset {
             .await?;
 
         let mut all_assets = Vec::new();
-        let mut all_referenced_assets = Vec::new();
         let mut all_references = Vec::new();
-        for (asset, referenced_asset, reference) in all_chunk_groups {
+        for (asset, reference) in all_chunk_groups {
             all_assets.extend(asset);
-            all_referenced_assets.extend(referenced_asset);
             all_references.extend(reference);
         }
 
         Ok(OutputAssetsWithReferenced {
             assets: ResolvedVc::cell(all_assets),
-            referenced_assets: ResolvedVc::cell(all_referenced_assets),
             references: ResolvedVc::cell(all_references),
         }
         .cell())

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -155,11 +155,7 @@ async fn expand(
         for &reference in refs.references.await?.iter() {
             queue.push_back(reference);
         }
-        let ref_assets = refs
-            .assets
-            .await?
-            .into_iter()
-            .chain(refs.referenced_assets.await?.into_iter());
+        let ref_assets = refs.assets.await?;
         for &asset in ref_assets {
             if assets_set.insert(asset) {
                 let path = asset.path().await?;

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -49,7 +49,6 @@ impl AsyncLoaderChunkItem {
             {
                 return Ok(OutputAssetsWithReferenced {
                     assets: ResolvedVc::cell(vec![]),
-                    referenced_assets: ResolvedVc::cell(vec![]),
                     references: ResolvedVc::cell(vec![]),
                 }
                 .cell());

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/batch.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/batch.rs
@@ -71,18 +71,15 @@ impl EcmascriptChunkBatchWithAsyncInfo {
     #[turbo_tasks::function]
     pub async fn references(&self) -> Result<Vc<OutputAssetsWithReferenced>> {
         let mut output_assets = Vec::new();
-        let mut referenced_output_assets = Vec::new();
         let mut references = Vec::new();
         // We expect most references to be empty, and avoiding try_join to avoid allocating the Vec
         for item in &self.chunk_items {
             let r = item.chunk_item.references().await?;
             output_assets.extend(r.assets.await?);
-            referenced_output_assets.extend(r.referenced_assets.await?);
             references.extend(r.references.await?);
         }
         Ok(OutputAssetsWithReferenced {
             assets: ResolvedVc::cell(output_assets),
-            referenced_assets: ResolvedVc::cell(referenced_output_assets),
             references: ResolvedVc::cell(references),
         }
         .cell())

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -76,11 +76,7 @@ impl OutputAssetsReference for EcmascriptChunk {
             .iter()
             .map(async |with_info| {
                 let r = with_info.references().await?;
-                Ok((
-                    r.assets.await?,
-                    r.referenced_assets.await?,
-                    r.references.await?,
-                ))
+                Ok((r.assets.await?, r.references.await?))
             })
             .try_join()
             .await?;
@@ -88,19 +84,13 @@ impl OutputAssetsReference for EcmascriptChunk {
             assets: ResolvedVc::cell(
                 references
                     .iter()
-                    .flat_map(|(assets, _, _)| assets.into_iter().copied())
-                    .collect(),
-            ),
-            referenced_assets: ResolvedVc::cell(
-                references
-                    .iter()
-                    .flat_map(|(_, referenced_assets, _)| referenced_assets.into_iter().copied())
+                    .flat_map(|(assets, _)| assets.into_iter().copied())
                     .collect(),
             ),
             references: ResolvedVc::cell(
                 references
                     .iter()
-                    .flat_map(|(_, _, references)| references.into_iter().copied())
+                    .flat_map(|(_, references)| references.into_iter().copied())
                     .collect(),
             ),
         }

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -82,7 +82,6 @@ impl ManifestAsyncModule {
             {
                 return Ok(OutputAssetsWithReferenced {
                     assets: ResolvedVc::cell(vec![]),
-                    referenced_assets: ResolvedVc::cell(vec![]),
                     references: ResolvedVc::cell(vec![]),
                 }
                 .cell());

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -25,7 +25,7 @@ use turbopack_core::{
     },
     module::Module,
     module_graph::{GraphEntries, ModuleGraph, chunk_group_info::ChunkGroupEntry},
-    output::{OutputAsset, OutputAssets},
+    output::{OutputAsset, OutputAssets, OutputAssetsReferences},
     reference_type::{InnerAssets, ReferenceType},
     source::Source,
     virtual_source::VirtualSource,
@@ -94,7 +94,7 @@ async fn emit_evaluate_pool_assets_operation(
         Vc::cell(entries.clone()),
         *module_graph,
         OutputAssets::empty(),
-        OutputAssets::empty(),
+        OutputAssetsReferences::empty(),
     );
 
     let output_root = chunking_context.output_root().owned().await?;

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -16,7 +16,10 @@ use turbopack_core::{
     chunk::{ChunkingContext, ChunkingContextExt, EvaluatableAsset, EvaluatableAssets},
     module::Module,
     module_graph::{ModuleGraph, chunk_group_info::ChunkGroupEntry},
-    output::{ExpandOutputAssetsInput, OutputAsset, OutputAssets, expand_output_assets},
+    output::{
+        ExpandOutputAssetsInput, OutputAsset, OutputAssets, OutputAssetsReferences,
+        expand_output_assets,
+    },
     source_map::GenerateSourceMap,
     virtual_output::VirtualOutputAsset,
 };
@@ -192,7 +195,7 @@ pub async fn get_intermediate_asset(
             false,
         ),
         OutputAssets::empty(),
-        OutputAssets::empty(),
+        OutputAssetsReferences::empty(),
     ))
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -96,7 +96,6 @@ impl OutputAssetsReference for EcmascriptBuildNodeChunk {
 
         Ok(OutputAssetsWithReferenced {
             assets: ResolvedVc::cell(assets),
-            referenced_assets: chunk_references.referenced_assets,
             references: chunk_references.references,
         }
         .cell())

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -29,7 +29,6 @@ pub(crate) struct EcmascriptBuildNodeEntryChunk {
     other_chunks: ResolvedVc<OutputAssets>,
     evaluatable_assets: ResolvedVc<EvaluatableAssets>,
     exported_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
-    referenced_output_assets: ResolvedVc<OutputAssets>,
     references: ResolvedVc<OutputAssetsReferences>,
     module_graph: ResolvedVc<ModuleGraph>,
     chunking_context: ResolvedVc<NodeJsChunkingContext>,
@@ -44,7 +43,6 @@ impl EcmascriptBuildNodeEntryChunk {
         other_chunks: ResolvedVc<OutputAssets>,
         evaluatable_assets: ResolvedVc<EvaluatableAssets>,
         exported_module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
-        referenced_output_assets: ResolvedVc<OutputAssets>,
         references: ResolvedVc<OutputAssetsReferences>,
         module_graph: ResolvedVc<ModuleGraph>,
         chunking_context: ResolvedVc<NodeJsChunkingContext>,
@@ -54,7 +52,6 @@ impl EcmascriptBuildNodeEntryChunk {
             other_chunks,
             evaluatable_assets,
             exported_module,
-            referenced_output_assets,
             references,
             module_graph,
             chunking_context,
@@ -192,7 +189,6 @@ impl OutputAssetsReference for EcmascriptBuildNodeEntryChunk {
 
         Ok(OutputAssetsWithReferenced {
             assets: ResolvedVc::cell(assets),
-            referenced_assets: this.referenced_output_assets,
             references: this.references,
         }
         .cell())

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -50,7 +50,10 @@ use turbopack_core::{
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
         export_usage::compute_export_usage_info,
     },
-    output::{OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsWithReferenced},
+    output::{
+        OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsReferences,
+        OutputAssetsWithReferenced,
+    },
     reference_type::{EntryReferenceSubType, ReferenceType},
     source::Source,
 };
@@ -536,13 +539,12 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                             evaluatable_assets,
                             module_graph,
                             OutputAssets::empty(),
-                            OutputAssets::empty(),
+                            OutputAssetsReferences::empty(),
                             AvailabilityInfo::root(),
                         )
                         .await?
                         .asset,
                 ]),
-                referenced_assets: ResolvedVc::cell(vec![]),
                 references: ResolvedVc::cell(vec![]),
             }
             .cell()


### PR DESCRIPTION
### What?

remove the unused `referenced_output_assets` field that is passed through everywhere, but actually never used.