### PR TITLE
[turbopack] Enable filesystem cache by default for development

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackFileSystemCache.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackFileSystemCache.mdx
@@ -8,7 +8,7 @@ description: Learn how to enable FileSystem Caching for Turbopack builds
 
 Turbopack FileSystem Cache enables Turbopack to reduce work across `next dev` or `next build` commands. When enabled, Turbopack will save and restore data to the `.next` folder between builds, which can greatly speed up subsequent builds and dev sessions.
 
-> **Good to know:** The FileSystem Cache feature is Beta and is still under development. Users adopting should expect some stability issues. We recommend first adopting it for development.
+> **Good to know:** The FileSystem Cache feature is considered stable for development and experimental for production builds
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
@@ -43,5 +43,6 @@ module.exports = nextConfig
 
 | Version   | Changes                                                        |
 | --------- | -------------------------------------------------------------- |
+| `v16.1.0` | FileSystem caching is enabled by default for development       |
 | `v16.0.0` | Beta release with separate flags for build and dev             |
 | `v15.5.0` | Persistent caching released as experimental on canary releases |

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -190,12 +190,12 @@ We are planning to offer an equivalent to the Inner Graph Optimization in Turbop
 
 ### Build Caching
 
-Webpack supports [disk build caching](https://webpack.js.org/configuration/cache/#cache) to improve build performance. Turbopack provides a similar opt-in feature, currently in beta. Starting with Next 16, you can enable Turbopack’s filesystem cache by setting the following experimental flags:
+Webpack supports [disk build caching](https://webpack.js.org/configuration/cache/#cache) to improve build performance. Turbopack provides a similar feature, currently in beta. Starting with Next 16, you can enable Turbopack’s filesystem cache by setting the following experimental flags:
 
-- [`experimental.turbopackFileSystemCacheForDev`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache)
-- [`experimental.turbopackFileSystemCacheForBuild`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache)
+- [`experimental.turbopackFileSystemCacheForDev`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) is enabled by default
+- [`experimental.turbopackFileSystemCacheForBuild`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) is currently opt-in
 
-> **Good to know:** For this reason, when comparing webpack and Turbopack performance, make sure to delete the `.next` folder between builds to see a fair comparison or enable the turbopack filesystem cache feature.
+> **Good to know:** For this reason, when comparing webpack and Turbopack performance, make sure to delete the `.next` folder between builds to see a fair cold build comparison or enable the turbopack filesystem cache feature to compare warm builds.
 
 ### Webpack plugins
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -434,6 +434,8 @@ export interface ExperimentalConfig {
 
   /**
    * Enable filesystem cache for the turbopack build.
+   *
+   * Defaults to `false`.
    */
   turbopackFileSystemCacheForBuild?: boolean
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -428,7 +428,7 @@ export interface ExperimentalConfig {
   /**
    * Enable filesystem cache for the turbopack dev server.
    *
-   * Defaults to `true` in canary releases.
+   * Defaults to `true`.
    */
   turbopackFileSystemCacheForDev?: boolean
 
@@ -1555,7 +1555,7 @@ export const defaultConfig = Object.freeze({
     proxyClientMaxBodySize: 10_485_760, // 10MB
     hideLogsAfterAbort: false,
     mcpServer: true,
-    turbopackFileSystemCacheForDev: !isStableBuild(),
+    turbopackFileSystemCacheForDev: true,
     turbopackFileSystemCacheForBuild: false,
   },
   htmlLimitedBots: undefined,

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -95,22 +95,7 @@ describe('loadConfig', () => {
         /`experimental\.ppr` has been merged into `cacheComponents`/
       )
     })
-
-    it('errors when using persistentCachingForBuild if not in canary', async () => {
-      await expect(
-        loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
-          customConfig: {
-            experimental: {
-              turbopackFileSystemCacheForBuild: true,
-            },
-          },
-        })
-      ).rejects.toThrow(
-        /The experimental feature "experimental.turbopackFileSystemCacheForBuild" can only be enabled when using the latest canary version of Next.js./
-      )
-    })
   })
-
   describe('with a canary version', () => {
     beforeAll(() => {
       process.env.__NEXT_VERSION = '15.4.0-canary.35'

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -38,10 +38,6 @@ import { dset } from '../shared/lib/dset'
 import { normalizeZodErrors } from '../shared/lib/zod'
 import { HTML_LIMITED_BOT_UA_RE_STRING } from '../shared/lib/router/utils/is-bot'
 import { findDir } from '../lib/find-pages-dir'
-import {
-  CanaryOnlyConfigError,
-  isStableBuild,
-} from '../shared/lib/errors/canary-only-config-error'
 import { interopDefault } from '../lib/interop-default'
 import { djb2Hash } from '../shared/lib/hash'
 import type { NextAdapter } from '../build/adapter/build-complete'
@@ -396,15 +392,6 @@ function assignDefaultsAndValidate(
         `Custom Sass functions are only available with webpack. ` +
         `Please remove the "functions" property from your sassOptions in ${configFileName}.`
     )
-  }
-
-  if (isStableBuild()) {
-    // Prevents usage of certain experimental features outside of canary
-    if (result.experimental.turbopackFileSystemCacheForBuild) {
-      throw new CanaryOnlyConfigError({
-        feature: 'experimental.turbopackFileSystemCacheForBuild',
-      })
-    }
   }
 
   if (result.experimental.ppr) {


### PR DESCRIPTION
Enable Turbopack filesystem cache for dev by default

Remove the canary block on the option for builds, but that remains false by default