### PR TITLE
Enable React's default Transition indicator behind a flag

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -870,6 +870,7 @@ pub struct ExperimentalConfig {
     /// Enables source maps generation for the server production bundle.
     server_source_maps: Option<bool>,
     swc_trace_profiling: Option<bool>,
+    transition_indicator: Option<bool>,
     /// @internal Used by the Next.js internals only.
     trust_host_header: Option<bool>,
 
@@ -1672,6 +1673,11 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn enable_taint(&self) -> Vc<bool> {
         Vc::cell(self.experimental.taint.unwrap_or(false))
+    }
+
+    #[turbo_tasks::function]
+    pub fn enable_transition_indicator(&self) -> Vc<bool> {
+        Vc::cell(self.experimental.transition_indicator.unwrap_or(false))
     }
 
     #[turbo_tasks::function]

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -328,6 +328,8 @@ export function getDefineEnv({
       (config.experimental.turbopackFileSystemCacheForDev ?? false),
     'process.env.__NEXT_REACT_DEBUG_CHANNEL':
       config.experimental.reactDebugChannel ?? false,
+    'process.env.__NEXT_TRANSITION_INDICATOR':
+      config.experimental.transitionIndicator ?? false,
   }
 
   const userDefines = config.compiler?.define ?? {}

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -270,14 +270,17 @@ function Root({ children }: React.PropsWithChildren<{}>) {
   return children
 }
 
-function onDefaultTransitionIndicator() {
-  // TODO: Compose default with user-configureable (e.g. nprogress)
-  // TODO: Use React's default once we figure out hanging indicators: https://codesandbox.io/p/sandbox/charming-moon-hktkp6?file=%2Fsrc%2Findex.js%3A106%2C30
+const enableTransitionIndicator = process.env.__NEXT_TRANSITION_INDICATOR
+
+function noDefaultTransitionIndicator() {
   return () => {}
 }
 
 const reactRootOptions: ReactDOMClient.RootOptions = {
-  onDefaultTransitionIndicator: onDefaultTransitionIndicator,
+  onDefaultTransitionIndicator: enableTransitionIndicator
+    ? // TODO: Compose default with user-configureable (e.g. nprogress)
+      undefined
+    : noDefaultTransitionIndicator,
   onRecoverableError,
   onCaughtError,
   onUncaughtError,

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -70,6 +70,7 @@ function HistoryUpdater({
       renderedSearch,
     }
 
+    // TODO: Use Navigation API if available
     const historyState = {
       ...(pushRef.preserveCustomHistoryState ? window.history.state : {}),
       // Identifier is shortened intentionally.
@@ -328,6 +329,7 @@ function Router({
       _unused: string,
       url?: string | URL | null
     ): void {
+      // TODO: Warn when Navigation API is available (navigation.navigate() should be used)
       // Avoid a loop when Next.js internals trigger pushState/replaceState
       if (data?.__NA || data?._N) {
         return originalPushState(data, _unused, url)
@@ -352,6 +354,7 @@ function Router({
       _unused: string,
       url?: string | URL | null
     ): void {
+      // TODO: Warn when Navigation API is available (navigation.navigate() should be used)
       // Avoid a loop when Next.js internals trigger pushState/replaceState
       if (data?.__NA || data?._N) {
         return originalReplaceState(data, _unused, url)

--- a/packages/next/src/lib/needs-experimental-react.ts
+++ b/packages/next/src/lib/needs-experimental-react.ts
@@ -2,6 +2,6 @@ import type { NextConfig } from '../server/config-shared'
 
 // Keep in sync with Turbopack's experimental React switch: file://./../../../../crates/next-core/src/next_import_map.rs
 export function needsExperimentalReact(config: NextConfig) {
-  const { taint } = config.experimental || {}
-  return Boolean(taint)
+  const { taint, transitionIndicator } = config.experimental || {}
+  return Boolean(taint || transitionIndicator)
 }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -289,6 +289,7 @@ export const experimentalSchema = {
       }),
     ])
     .optional(),
+  transitionIndicator: z.boolean().optional(),
   typedRoutes: z.boolean().optional(),
   webpackBuildWorker: z.boolean().optional(),
   webpackMemoryOptimizations: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -388,6 +388,12 @@ export interface ExperimentalConfig {
   optimizeServerReact?: boolean
 
   /**
+   * Displays an indicator when a React Transition has no other indicator rendered.
+   * This includes displaying an indicator on client-side navigations.
+   */
+  transitionIndicator?: boolean
+
+  /**
    * A target memory limit for turbo, in bytes.
    */
   turbopackMemoryLimit?: number
@@ -1515,6 +1521,7 @@ export const defaultConfig = Object.freeze({
     serverComponentsHmrCache: true,
     staticGenerationMaxConcurrency: 8,
     staticGenerationMinPagesPerWorker: 25,
+    transitionIndicator: false,
     inlineCss: false,
     useCache: undefined,
     slowModuleDetection: undefined,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1864,6 +1864,24 @@ function enforceExperimentalFeatures(
   }
 
   if (
+    process.env.__NEXT_EXPERIMENTAL_TRANSITION_INDICATOR === 'true' &&
+    // We do respect an explicit value in the user config.
+    (config.experimental.transitionIndicator === undefined ||
+      (isDefaultConfig && !config.experimental.transitionIndicator))
+  ) {
+    config.experimental.transitionIndicator = true
+
+    if (configuredExperimentalFeatures) {
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        'transitionIndicator',
+        true,
+        'enabled by `__NEXT_EXPERIMENTAL_TRANSITION_INDICATOR`'
+      )
+    }
+  }
+
+  if (
     process.env.__NEXT_ENABLE_REACT_COMPILER === 'true' &&
     // We do respect an explicit value in the user config.
     (config.reactCompiler === undefined ||

--- a/test/e2e/app-dir/transition-indicator/app/layout.tsx
+++ b/test/e2e/app-dir/transition-indicator/app/layout.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+import { ReactNode, Suspense } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <ul>
+          <li>
+            <Link href="/">Home</Link>
+          </li>
+          <li>
+            <Link href="/slow-without-fallback">
+              Slow Page without fallback
+            </Link>
+          </li>
+          <li>
+            <Link href="/slow-with-fallback">Slow Page with fallback</Link>
+          </li>
+        </ul>
+        <main>
+          <Suspense>{children}</Suspense>
+        </main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/transition-indicator/app/page.tsx
+++ b/test/e2e/app-dir/transition-indicator/app/page.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { startTransition, useReducer } from 'react'
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export default function Page() {
+  const [counter, increment] = useReducer((n) => n + 1, 0)
+
+  function handleClick() {
+    startTransition(async () => {
+      await sleep(1000)
+      startTransition(() => {
+        increment()
+      })
+    })
+  }
+  return (
+    <>
+      <p>Count: {counter}</p>
+      <button onClick={handleClick}>Increment</button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/transition-indicator/app/slow-with-fallback/loading.tsx
+++ b/test/e2e/app-dir/transition-indicator/app/slow-with-fallback/loading.tsx
@@ -1,0 +1,3 @@
+export default function SlowFallback() {
+  return <p>While waiting, enjoy Next.js' navigation indicator.</p>
+}

--- a/test/e2e/app-dir/transition-indicator/app/slow-with-fallback/page.tsx
+++ b/test/e2e/app-dir/transition-indicator/app/slow-with-fallback/page.tsx
@@ -1,0 +1,7 @@
+import { setTimeout } from 'timers/promises'
+
+export default async function SlowPage() {
+  await setTimeout(2000)
+
+  return <p>Hello, Dave!</p>
+}

--- a/test/e2e/app-dir/transition-indicator/app/slow-without-fallback/page.tsx
+++ b/test/e2e/app-dir/transition-indicator/app/slow-without-fallback/page.tsx
@@ -1,0 +1,7 @@
+import { setTimeout } from 'timers/promises'
+
+export default async function SlowPage() {
+  await setTimeout(2000)
+
+  return <p>Hello, Dave!</p>
+}

--- a/test/e2e/app-dir/transition-indicator/next.config.js
+++ b/test/e2e/app-dir/transition-indicator/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    transitionIndicator: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/transition-indicator/transition-indicator.test.ts
+++ b/test/e2e/app-dir/transition-indicator/transition-indicator.test.ts
@@ -1,0 +1,36 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('transition-indicator', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // TODO: Find testing pattern to assert that the browser's pending indicator is shown
+  // These tests are just instructions for manual testing
+
+  it('displays while loading content without fallback', async () => {
+    const browser = await next.browser('/')
+
+    await browser.elementByCss('a[href="/slow-without-fallback"]').click()
+
+    // shows pending indicator in browser tab while loading
+    // Gets stuck due to usage of history.pushState
+  })
+
+  it('does not display while loading content with fallback', async () => {
+    const browser = await next.browser('/')
+
+    await browser.elementByCss('a[href="/slow-with-fallback"]').click()
+
+    // fallback is shown, no pending indicator in browser tab
+  })
+
+  it('displays during any Transition that does not commit a pending state', async () => {
+    const browser = await next.browser('/')
+
+    const button = await browser.elementByCss('button')
+    await button.click()
+
+    // shows pending indicator in browser tab until increment is committed
+  })
+})


### PR DESCRIPTION
This has known bugs (e.g. [crbug#457939331](https://issues.chromium.org/u/1/issues/457939331)).

The flag (`config.experimental.transitionIndicator`) will be used in a follow-up to switch to `navigation.navigate()` where available to work around the known bugs.

Part of https://linear.app/vercel/issue/NAR-499/