### PR TITLE
docs: cacheHandlers use object instead of class

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx
@@ -91,7 +91,7 @@ Returns a `CacheEntry` object if found, or `undefined` if not found or expired.
 Your `get` method should retrieve the cache entry from storage, check if it has expired based on the `revalidate` time, and return `undefined` for missing or expired entries.
 
 ```js
-class CacheHandler {
+const cacheHandler = {
   async get(cacheKey, softTags) {
     const entry = cache.get(cacheKey)
     if (!entry) return undefined
@@ -127,7 +127,7 @@ Returns `Promise<void>`.
 Your `set` method must await the `pendingEntry` promise before storing it, since the cache entry may still be generating when this method is called. Once resolved, store the entry in your cache system.
 
 ```js
-class CacheHandler {
+const cacheHandler = {
   async set(cacheKey, pendingEntry) {
     // Wait for the entry to be ready
     const entry = await pendingEntry
@@ -153,7 +153,7 @@ Returns `Promise<void>`.
 For in-memory caches, this can be a no-op. For distributed caches, use this to sync tag state from an external service or database before processing requests.
 
 ```js
-class CacheHandler {
+const cacheHandler = {
   async refreshTags() {
     // For in-memory cache, no action needed
     // For distributed cache, sync tag state from external service
@@ -182,7 +182,7 @@ Returns:
 If you're not tracking tag revalidation timestamps, return `0`. Otherwise, find the most recent revalidation timestamp across all the provided tags. Return `Infinity` if you prefer to handle soft tag checking in the `get` method.
 
 ```js
-class CacheHandler {
+const cacheHandler = {
   async getExpiration(tags) {
     // Return 0 if not tracking tag revalidation
     return 0
@@ -213,7 +213,7 @@ Returns `Promise<void>`.
 When tags are revalidated, your handler should invalidate all cache entries that have any of those tags. Iterate through your cache and remove entries whose tags match the provided list.
 
 ```js
-class CacheHandler {
+const cacheHandler = {
   async updateTags(tags, durations) {
     // Invalidate all cache entries with matching tags
     for (const [key, entry] of cache.entries()) {
@@ -264,7 +264,7 @@ Here's a minimal implementation using a `Map` for storage. This example demonstr
 const cache = new Map()
 const pendingSets = new Map()
 
-module.exports = class MemoryCacheHandler {
+module.exports = {
   async get(cacheKey, softTags) {
     // Wait for any pending set operation to complete
     const pendingPromise = pendingSets.get(cacheKey)
@@ -333,7 +333,7 @@ For durable storage like Redis or a database, you'll need to serialize the cache
 ```js filename="cache-handlers/redis-handler.js"
 const { createClient } = require('redis')
 
-module.exports = class RedisCacheHandler {
+module.exports = {
   constructor() {
     this.client = createClient({ url: process.env.REDIS_URL })
     this.client.connect()

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx
@@ -41,8 +41,8 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   cacheHandlers: {
-    default: './cache-handlers/default-handler.js',
-    remote: './cache-handlers/remote-handler.js',
+    default: require.resolve('./cache-handlers/default-handler.js'),
+    remote: require.resolve('./cache-handlers/remote-handler.js'),
   },
 }
 
@@ -52,8 +52,8 @@ export default nextConfig
 ```js filename="next.config.js" switcher
 module.exports = {
   cacheHandlers: {
-    default: './cache-handlers/default-handler.js',
-    remote: './cache-handlers/remote-handler.js',
+    default: require.resolve('./cache-handlers/default-handler.js'),
+    remote: require.resolve('./cache-handlers/remote-handler.js'),
   },
 }
 ```

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx
@@ -41,8 +41,8 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   cacheHandlers: {
-    default: require.resolve('./cache-handlers/default-handler.js'),
-    remote: require.resolve('./cache-handlers/remote-handler.js'),
+    default: './cache-handlers/default-handler.js',
+    remote: './cache-handlers/remote-handler.js',
   },
 }
 
@@ -52,8 +52,8 @@ export default nextConfig
 ```js filename="next.config.js" switcher
 module.exports = {
   cacheHandlers: {
-    default: require.resolve('./cache-handlers/default-handler.js'),
-    remote: require.resolve('./cache-handlers/remote-handler.js'),
+    default: './cache-handlers/default-handler.js',
+    remote: './cache-handlers/remote-handler.js',
   },
 }
 ```
@@ -103,7 +103,7 @@ const cacheHandler = {
     }
 
     return entry
-  }
+  },
 }
 ```
 
@@ -134,7 +134,7 @@ const cacheHandler = {
 
     // Store in your cache system
     cache.set(cacheKey, entry)
-  }
+  },
 }
 ```
 
@@ -157,7 +157,7 @@ const cacheHandler = {
   async refreshTags() {
     // For in-memory cache, no action needed
     // For distributed cache, sync tag state from external service
-  }
+  },
 }
 ```
 
@@ -189,7 +189,7 @@ const cacheHandler = {
 
     // Or return the most recent revalidation timestamp
     // return Math.max(...tags.map(tag => tagTimestamps.get(tag) || 0));
-  }
+  },
 }
 ```
 
@@ -221,7 +221,7 @@ const cacheHandler = {
         cache.delete(key)
       }
     }
-  }
+  },
 }
 ```
 
@@ -284,7 +284,7 @@ module.exports = {
     }
 
     return entry
-  }
+  },
 
   async set(cacheKey, pendingEntry) {
     // Create a promise to track this set operation
@@ -304,16 +304,16 @@ module.exports = {
       resolvePending()
       pendingSets.delete(cacheKey)
     }
-  }
+  },
 
   async refreshTags() {
     // No-op for in-memory cache
-  }
+  },
 
   async getExpiration(tags) {
     // Return 0 to indicate no tags have been revalidated
     return 0
-  }
+  },
 
   async updateTags(tags, durations) {
     // Implement tag-based invalidation
@@ -322,7 +322,7 @@ module.exports = {
         cache.delete(key)
       }
     }
-  }
+  },
 }
 ```
 
@@ -333,15 +333,13 @@ For durable storage like Redis or a database, you'll need to serialize the cache
 ```js filename="cache-handlers/redis-handler.js"
 const { createClient } = require('redis')
 
-module.exports = {
-  constructor() {
-    this.client = createClient({ url: process.env.REDIS_URL })
-    this.client.connect()
-  }
+const client = createClient({ url: process.env.REDIS_URL })
+client.connect()
 
+module.exports = {
   async get(cacheKey, softTags) {
     // Retrieve from Redis
-    const stored = await this.client.get(cacheKey)
+    const stored = await client.get(cacheKey)
     if (!stored) return undefined
 
     // Deserialize the entry
@@ -361,7 +359,7 @@ module.exports = {
       expire: data.expire,
       revalidate: data.revalidate,
     }
-  }
+  },
 
   async set(cacheKey, pendingEntry) {
     const entry = await pendingEntry
@@ -383,7 +381,7 @@ module.exports = {
     // Combine chunks and serialize for Redis storage
     const data = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)))
 
-    await this.client.set(
+    await client.set(
       cacheKey,
       JSON.stringify({
         value: data.toString('base64'),
@@ -395,23 +393,23 @@ module.exports = {
       }),
       { EX: entry.expire } // Use Redis TTL for automatic expiration
     )
-  }
+  },
 
   async refreshTags() {
     // No-op for basic Redis implementation
     // Could sync with external tag service if needed
-  }
+  },
 
   async getExpiration(tags) {
     // Return 0 to indicate no tags have been revalidated
     // Could query Redis for tag expiration timestamps if tracking them
     return 0
-  }
+  },
 
   async updateTags(tags, durations) {
     // Implement tag-based invalidation if needed
     // Could iterate over keys with matching tags and delete them
-  }
+  },
 }
 ```
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

This PR fixes the docs' example where it used class (like cacheHandler (no s)), but cacheHandlers expect an object.






