### PR TITLE
Remove invalid MDN link for placeholder prop in Image docs

### DIFF
--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -327,8 +327,6 @@ Specifies a placeholder to use while the image is loading, improving the perceiv
 - [Shimmer effect with data URL `placeholder` prop](https://image-component.nextjs.gallery/shimmer)
 - [Color effect with `blurDataURL` prop](https://image-component.nextjs.gallery/color)
 
-> Learn more about the [`placeholder` attribute](https://developer.mozilla.org/docs/Web/HTML/Element/img#placeholder).
-
 #### `blurDataURL`
 
 A [Data URL](https://developer.mozilla.org/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) to


### PR DESCRIPTION
This PR fixes an issue in the API reference documentation for the Image component. You can view this issue on the live documentation site [here](https://nextjs.org/docs/app/api-reference/components/image#placeholder).

At the bottom of the section it says: _"Learn more about the [placeholder attribute](https://developer.mozilla.org/docs/Web/HTML/Element/img#placeholder)."_ This incorrectly implies that `placeholder` is a valid attribute of the `<img>` element, and the link points to a non-existent anchor on the MDN  `<img>` reference page. 

This PR remove this entire line in the documentation. Alternatively, it could be helpful to add a brief explanation of how the `placeholder` prop works behind the scenes, to avoid confusion for readers who may think it is a real `<img>` attribute, similar to `loading`.