### PR TITLE
Turbopack: expose used export info in tests

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/code_gen.rs
@@ -16,6 +16,7 @@ use turbopack_core::{chunk::ChunkingContext, reference::ModuleReference};
 
 use crate::{
     ScopeHoistingContext,
+    chunk::{EcmascriptChunkPlaceable, EcmascriptExports},
     references::{
         AstPath,
         amd::AmdDefineWithDependenciesCodeGen,
@@ -31,6 +32,7 @@ use crate::{
             dynamic::EsmAsyncAssetReferenceCodeGen, module_id::EsmModuleIdAssetReferenceCodeGen,
             url::UrlAssetReferenceCodeGen,
         },
+        exports_info::{ExportsInfoBinding, ExportsInfoRef},
         ident::IdentReplacement,
         member::MemberReplacement,
         require_context::RequireContextAssetReferenceCodeGen,
@@ -181,6 +183,8 @@ pub enum CodeGen {
     DynamicExpression(DynamicExpression),
     EsmBinding(EsmBinding),
     EsmModuleItem(EsmModuleItem),
+    ExportsInfoBinding(ExportsInfoBinding),
+    ExportsInfoRef(ExportsInfoRef),
     IdentReplacement(IdentReplacement),
     ImportMetaBinding(ImportMetaBinding),
     ImportMetaRef(ImportMetaRef),
@@ -200,6 +204,8 @@ impl CodeGen {
         &self,
         ctx: Vc<Box<dyn ChunkingContext>>,
         scope_hoisting_context: ScopeHoistingContext<'_>,
+        module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+        exports: ResolvedVc<EcmascriptExports>,
     ) -> Result<CodeGeneration> {
         match self {
             Self::AmdDefineWithDependenciesCodeGen(v) => v.code_generation(ctx).await,
@@ -209,6 +215,8 @@ impl CodeGen {
             Self::DynamicExpression(v) => v.code_generation(ctx).await,
             Self::EsmBinding(v) => v.code_generation(ctx, scope_hoisting_context).await,
             Self::EsmModuleItem(v) => v.code_generation(ctx).await,
+            Self::ExportsInfoBinding(v) => v.code_generation(ctx, module, exports).await,
+            Self::ExportsInfoRef(v) => v.code_generation(ctx).await,
             Self::IdentReplacement(v) => v.code_generation(ctx).await,
             Self::ImportMetaBinding(v) => v.code_generation(ctx).await,
             Self::ImportMetaRef(v) => v.code_generation(ctx).await,

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -270,6 +270,8 @@ pub struct EcmascriptOptions {
     // node_modules.
     /// Whether to replace `typeof window` with some constant value.
     pub enable_typeof_window_inlining: Option<TypeofWindow>,
+    /// Whether to allow accessing exports info via `__webpack_exports_info__`.
+    pub enable_exports_info_inlining: bool,
 
     pub inline_helpers: bool,
 }
@@ -1025,7 +1027,14 @@ impl EcmascriptModuleContentOptions {
             let code_gens = code_generation
                 .await?
                 .iter()
-                .map(|c| c.code_generation(**chunking_context, scope_hoisting_context))
+                .map(|c| {
+                    c.code_generation(
+                        **chunking_context,
+                        scope_hoisting_context,
+                        *module,
+                        *exports,
+                    )
+                })
                 .try_join()
                 .await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/exports_info.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/exports_info.rs
@@ -1,0 +1,126 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use swc_core::{
+    common::DUMMY_SP,
+    ecma::ast::{Expr, Ident, KeyValueProp, ObjectLit, PropName, PropOrSpread},
+    quote,
+};
+use turbo_rcstr::rcstr;
+use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, debug::ValueDebugFormat, trace::TraceRawVcs};
+use turbopack_core::chunk::ChunkingContext;
+
+use crate::{
+    chunk::{EcmascriptChunkPlaceable, EcmascriptExports},
+    code_gen::{CodeGen, CodeGeneration},
+    create_visitor, magic_identifier,
+    references::AstPath,
+};
+
+/// Responsible for initializing the `ExportsInfoBinding` object binding, so that it may be
+/// referenced in the the file.
+///
+/// There can be many references, and they appear at any nesting in the file. But we must only
+/// initialize the binding a single time.
+///
+/// This singleton behavior must be enforced by the caller!
+#[derive(PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue)]
+pub struct ExportsInfoBinding {}
+
+impl ExportsInfoBinding {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        ExportsInfoBinding {}
+    }
+
+    pub async fn code_generation(
+        &self,
+        chunking_context: Vc<Box<dyn ChunkingContext>>,
+        module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
+        exports: ResolvedVc<EcmascriptExports>,
+    ) -> Result<CodeGeneration> {
+        let export_usage_info = chunking_context
+            .module_export_usage(*ResolvedVc::upcast(module))
+            .await?;
+        let export_usage_info = export_usage_info.export_usage.await?;
+
+        let props = if let EcmascriptExports::EsmExports(exports) = &*exports.await? {
+            exports
+                .await?
+                .exports
+                .keys()
+                .map(|e| {
+                    let used: Expr = export_usage_info.is_export_used(e).into();
+                    PropOrSpread::Prop(Box::new(swc_core::ecma::ast::Prop::KeyValue(
+                        KeyValueProp {
+                            key: PropName::Str(e.as_str().into()),
+                            value: quote!("{ used: $v }" as Box<Expr>, v: Expr = used),
+                        },
+                    )))
+                })
+                .collect()
+        } else {
+            vec![]
+        };
+
+        let data = Expr::Object(ObjectLit {
+            props,
+            span: DUMMY_SP,
+        });
+
+        Ok(CodeGeneration::hoisted_stmt(
+            rcstr!("__webpack_exports_info__"),
+            quote!(
+                "const $name = $data;" as Stmt,
+                name = exports_ident(),
+                data: Expr = data
+            ),
+        ))
+    }
+}
+
+impl From<ExportsInfoBinding> for CodeGen {
+    fn from(val: ExportsInfoBinding) -> Self {
+        CodeGen::ExportsInfoBinding(val)
+    }
+}
+
+/// Handles rewriting `__webpack_exports_info__` references into the injected binding created by
+/// ExportsInfoBinding.
+///
+/// There can be many references, and they appear at any nesting in the file. But all references
+/// refer to the same mutable object.
+#[derive(PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, ValueDebugFormat, NonLocalValue)]
+pub struct ExportsInfoRef {
+    ast_path: AstPath,
+}
+
+impl ExportsInfoRef {
+    pub fn new(ast_path: AstPath) -> Self {
+        ExportsInfoRef { ast_path }
+    }
+
+    pub async fn code_generation(
+        &self,
+        _chunking_context: Vc<Box<dyn ChunkingContext>>,
+    ) -> Result<CodeGeneration> {
+        let visitor = create_visitor!(self.ast_path, visit_mut_expr, |expr: &mut Expr| {
+            *expr = Expr::Ident(exports_ident());
+        });
+
+        Ok(CodeGeneration::visitors(vec![visitor]))
+    }
+}
+
+impl From<ExportsInfoRef> for CodeGen {
+    fn from(val: ExportsInfoRef) -> Self {
+        CodeGen::ExportsInfoRef(val)
+    }
+}
+
+fn exports_ident() -> Ident {
+    Ident::new(
+        magic_identifier::mangle("__webpack_exports_info__").into(),
+        DUMMY_SP,
+        Default::default(),
+    )
+}

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -403,6 +403,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
                     TypescriptTransformOptions::default().resolved_cell(),
                 ),
                 import_externals: true,
+                enable_exports_info_inlining: true,
                 ..Default::default()
             },
             environment: Some(env),

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/code-gen/exports-info/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/code-gen/exports-info/input/index.js
@@ -1,0 +1,9 @@
+import { foo, usage } from './module.js'
+
+it('should expose __webpack_exports_info__ in tests', () => {
+  expect(foo).toBe('foo')
+
+  expect(usage.foo.used).toBe(true)
+  expect(usage.bar.used).toBe(false)
+  expect(usage.usage.used).toBe(true)
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/code-gen/exports-info/input/module.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/code-gen/exports-info/input/module.js
@@ -1,0 +1,4 @@
+export const foo = 'foo'
+export const bar = 'bar'
+
+export const usage = __webpack_exports_info__

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -355,6 +355,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                     ..Default::default()
                 })),
                 ignore_dynamic_requests: true,
+                enable_exports_info_inlining: true,
                 ..Default::default()
             },
             environment: Some(env),

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -208,6 +208,7 @@ impl ModuleOptions {
                     import_externals,
                     esm_url_rewrite_behavior,
                     enable_typeof_window_inlining,
+                    enable_exports_info_inlining,
                     source_maps: ecmascript_source_maps,
                     inline_helpers,
                     ..
@@ -283,6 +284,7 @@ impl ModuleOptions {
             keep_last_successful_parse,
             analyze_mode,
             enable_typeof_window_inlining,
+            enable_exports_info_inlining,
             inline_helpers,
             ..Default::default()
         };

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -239,6 +239,9 @@ pub struct EcmascriptOptionsContext {
     /// Specifies how Source Maps are handled.
     pub source_maps: SourceMapsType,
 
+    /// Whether to allow accessing exports info via `__webpack_exports_info__`.
+    pub enable_exports_info_inlining: bool,
+
     // TODO should this be a part of Environment instead?
     pub inline_helpers: bool,
 


### PR DESCRIPTION
This will allow us to reuse more Webpack tests soon
```js
module.exports = [
"[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/code-gen/exports-info/input/index.js [test] (ecmascript)", ((__turbopack_context__) => {
"use strict";

// MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/code-gen/exports-info/input/module.js [test] (ecmascript)
;
const __TURBOPACK__$5f$_webpack_exports_info_$5f$__ = {
    "bar": {
        used: false
    },
    "foo": {
        used: true
    },
    "usage": {
        used: true
    }
};
const foo = 'foo';
const bar = 'bar';
const usage = __TURBOPACK__$5f$_webpack_exports_info_$5f$__;
// MERGED MODULE: [project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/code-gen/exports-info/input/index.js [test] (ecmascript)
;
;
it('should expose __webpack_exports_info__ in tests', ()=>{
    expect(foo).toBe('foo');
    expect(usage.foo.used).toBe(true);
    expect(usage.bar.used).toBe(false);
    expect(usage.usage.used).toBe(true);
});
__turbopack_context__.s([], "[project]/turbopack/crates/turbopack-tests/tests/execution/turbopack/code-gen/exports-info/input/index.js [test] (ecmascript)");
}),
];
```