### PR TITLE
update routes-manifest to include whether app has pages routes

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -435,6 +435,7 @@ type ManifestDataRoute = {
 export type RoutesManifest = {
   version: number
   pages404: boolean
+  appType: 'app' | 'pages' | 'hybrid'
   basePath: string
   redirects: Array<ManifestRedirectRoute>
   rewrites: {
@@ -923,6 +924,7 @@ export default async function build(
   NextBuildContext.isCompileMode = isCompileMode
   NextBuildContext.analyze = experimentalAnalyze
   const buildStartTime = Date.now()
+  let appType: RoutesManifest['appType']
 
   let loadedConfig: NextConfigComplete | undefined
   try {
@@ -1076,6 +1078,14 @@ export default async function build(
 
       const publicDir = path.join(dir, 'public')
       const { pagesDir, appDir } = findPagesDir(dir)
+
+      if (pagesDir && appDir) {
+        appType = 'hybrid'
+      } else if (pagesDir) {
+        appType = 'pages'
+      } else if (appDir) {
+        appType = 'app'
+      }
 
       if (!appDirOnly && !pagesDir) {
         appDirOnly = true
@@ -1619,6 +1629,7 @@ export default async function build(
           return {
             version: 3,
             pages404: true,
+            appType,
             caseSensitive: !!config.experimental.caseSensitiveRoutes,
             basePath: config.basePath,
             redirects: redirects.map((r) =>

--- a/test/integration/custom-routes/test/index.test.ts
+++ b/test/integration/custom-routes/test/index.test.ts
@@ -1500,6 +1500,7 @@ const runTests = (isDev = false) => {
         ])
       ).toMatchInlineSnapshot(`
        {
+         "appType": "pages",
          "basePath": "",
          "caseSensitive": true,
          "dataRoutes": [

--- a/test/integration/dynamic-routing/test/index.test.ts
+++ b/test/integration/dynamic-routing/test/index.test.ts
@@ -1257,6 +1257,7 @@ function runTests({ dev }) {
       expect(normalizeManifest(manifest, [[buildId, 'BUILD_ID']]))
         .toMatchInlineSnapshot(`
        {
+         "appType": "pages",
          "basePath": "",
          "caseSensitive": false,
          "dataRoutes": [

--- a/test/production/app-type/app-type.test.ts
+++ b/test/production/app-type/app-type.test.ts
@@ -1,0 +1,46 @@
+import { nextTestSetup } from 'e2e-utils'
+import path from 'path'
+
+describe('app-type', () => {
+  describe('app-only', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures', 'app-only'),
+    })
+
+    it('should have the app-only app type', async () => {
+      const requiredServerFiles = JSON.parse(
+        await next.readFile('.next/routes-manifest.json')
+      )
+
+      expect(requiredServerFiles.appType).toBe('app')
+    })
+  })
+
+  describe('pages-only', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures', 'pages-only'),
+    })
+
+    it('should have the pages-only app type', async () => {
+      const requiredServerFiles = JSON.parse(
+        await next.readFile('.next/routes-manifest.json')
+      )
+
+      expect(requiredServerFiles.appType).toBe('pages')
+    })
+  })
+
+  describe('hybrid', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures', 'hybrid'),
+    })
+
+    it('should have the hybrid app type', async () => {
+      const requiredServerFiles = JSON.parse(
+        await next.readFile('.next/routes-manifest.json')
+      )
+
+      expect(requiredServerFiles.appType).toBe('hybrid')
+    })
+  })
+})

--- a/test/production/app-type/fixtures/app-only/app/layout.tsx
+++ b/test/production/app-type/fixtures/app-only/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-type/fixtures/app-only/app/page.tsx
+++ b/test/production/app-type/fixtures/app-only/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Hello, world!</div>
+}

--- a/test/production/app-type/fixtures/hybrid/app/layout.tsx
+++ b/test/production/app-type/fixtures/hybrid/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-type/fixtures/hybrid/app/page.tsx
+++ b/test/production/app-type/fixtures/hybrid/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Hello, world!</div>
+}

--- a/test/production/app-type/fixtures/hybrid/pages/other.tsx
+++ b/test/production/app-type/fixtures/hybrid/pages/other.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Hello, world!</div>
+}

--- a/test/production/app-type/fixtures/pages-only/pages/index.tsx
+++ b/test/production/app-type/fixtures/pages-only/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Hello, world!</div>
+}


### PR DESCRIPTION
The Vercel CLI produces a lot of `/_next/data` routes regardless of if pages router is in-use. There's a lot of different metadata we emit but nothing concretely tells us if an app has pages router enabled. For app router, we rely on the presence of `app-paths-manifest`, but in pages router, we always emit a `pages-manifest`.

Rather than trying to cobble together something in the CLI, this updates the routes manifest to explicitly output the app type (pages, app, or hybrid).