### PR TITLE
feat: add UnsafeUnwrappedCookies and UnsafeUnwrappedHeaders to next 14

### DIFF
--- a/packages/next/src/client/components/headers.ts
+++ b/packages/next/src/client/components/headers.ts
@@ -2,13 +2,19 @@ import {
   type ReadonlyRequestCookies,
   RequestCookiesAdapter,
 } from '../../server/web/spec-extension/adapters/request-cookies'
-import { HeadersAdapter } from '../../server/web/spec-extension/adapters/headers'
+import {
+  HeadersAdapter,
+  type ReadonlyHeaders,
+} from '../../server/web/spec-extension/adapters/headers'
 import { RequestCookies } from '../../server/web/spec-extension/cookies'
 import { actionAsyncStorage } from './action-async-storage.external'
 import { DraftMode } from './draft-mode'
 import { trackDynamicDataAccessed } from '../../server/app-render/dynamic-rendering'
 import { staticGenerationAsyncStorage } from './static-generation-async-storage.external'
 import { getExpectedRequestStore } from './request-async-storage.external'
+
+export type UnsafeUnwrappedHeaders = ReadonlyHeaders
+export type UnsafeUnwrappedCookies = ReadonlyRequestCookies
 
 /**
  * This function allows you to read the HTTP incoming request headers in


### PR DESCRIPTION
### What?
`UnsafeUnwrappedCookies` and `UnsafeUnwrappedHeaders` added to `next/headers` next v14

### Why?
We have a codemod which updates a codebase and uses the Unsafe types in case it is not able to modify code properly.
Such cases requires manual resolution from a developer. It would be nice to be able to run codemod staying on next.js v14 and being able to migrate gradually.

### How?
Just adding types required =)

