### PR TITLE
perf: revert to use the light safe stringify for is-error

### DIFF
--- a/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
+++ b/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
@@ -19,7 +19,7 @@ describe('serialize-circular-error', () => {
     `)
     const output = next.cliOutput
     expect(output).toContain(
-      'Error: {"objA":{"other":{"a":"[Circular]"}},"objB":{"a":{"other":"[Circular]"}}}'
+      'Error: {"objA":{"other":{"a":"[Circular]"}},"objB":"[Circular]"}'
     )
   })
 
@@ -44,7 +44,7 @@ describe('serialize-circular-error', () => {
 
     const output = next.cliOutput
     expect(output).toContain(
-      'Error: {"objC":{"other":{"a":"[Circular]"}},"objD":{"a":{"other":"[Circular]"}}}'
+      'Error: {"objC":{"other":{"a":"[Circular]"}},"objD":"[Circular]"}'
     )
   })
 })

--- a/test/production/app-dir/browser-chunks/browser-chunks.test.ts
+++ b/test/production/app-dir/browser-chunks/browser-chunks.test.ts
@@ -48,4 +48,18 @@ describe('browser-chunks', () => {
       )
     }
   })
+
+  it('must not include heavy dependencies into browser chunks', () => {
+    const heavyDependencies = sources.filter((source) => {
+      return source.includes('next/dist/compiled/safe-stable-stringify')
+    })
+
+    if (heavyDependencies.length > 0) {
+      const message = `Found the following heavy dependencies:\n  ${heavyDependencies.join('\n  ')}`
+
+      throw new Error(
+        'Did not expect any heavy dependencies in browser chunks.\n' + message
+      )
+    }
+  })
 })


### PR DESCRIPTION
`is-error` is a helper that being used accorss client and server now, in #84909 we switched the underlying safe stringify error implementation to the precompiled dependency `safe-stable-stringify`. But it increased the client bundle size a bit.

The change in #84909 was only for applying the `safe-stable-stringify` for client file logger with mcp, not  really necessary need to change for is-error helper

Note: Save minified around 12kb. it's actually 7.5kb on bundlephobia, but because we're using ncc to compile it to cjs dependency that the size seems slightly larger than their metrics. The saved gzip size would be around 2-3.x kb