### PR TITLE
Add quoteblock to proxy docs

### DIFF
--- a/docs/01-app/01-getting-started/16-proxy.mdx
+++ b/docs/01-app/01-getting-started/16-proxy.mdx
@@ -28,7 +28,7 @@ For simple redirects, consider using the [`redirects`](/docs/app/api-reference/c
 
 Proxy is _not_ intended for slow data fetching. While Proxy can be helpful for [optimistic checks](/docs/app/guides/authentication#optimistic-checks-with-proxy-optional) such as permission-based redirects, it should not be used as a full session management or authorization solution.
 
-Using fetch with `options.cache`, `options.next.revalidate`, or `options.next.tags`, has no effect in Proxy.
+> **Good to know**: Using fetch with `options.cache`, `options.next.revalidate`, or `options.next.tags`, has no effect in Proxy.
 
 ### Convention
 


### PR DESCRIPTION
### What?

Wrapped the statement about `fetch` options having no effect in Proxy within a "Good to know" quoteblock.

### Why?

To improve the visibility of important information regarding `fetch` options in the Proxy documentation, ensuring users easily notice this detail.

### How?

The line "Using fetch with `options.cache`, `options.next.revalidate`, or `options.next.tags`, has no effect in Proxy." in `docs/01-app/01-getting-started/16-proxy.mdx` was updated to `> **Good to know**: Using fetch with \`options.cache\`, \`options.next.revalidate\`, or \`options.next.tags\`, has no effect in Proxy.`.

---
[Slack Thread](https://vercel.slack.com/archives/C09P3BYAD7W/p1762962491114569?thread_ts=1762962491.114569&cid=C09P3BYAD7W)

<a href="https://cursor.com/background-agent?bcId=bc-0b9e2776-1825-45b8-a5f4-a1b61685732b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b9e2776-1825-45b8-a5f4-a1b61685732b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

