### PR TITLE
next analyze: annotate polyfill modules in UI

### DIFF
--- a/apps/bundle-analyzer/app/globals.css
+++ b/apps/bundle-analyzer/app/globals.css
@@ -32,6 +32,8 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --polyfill: #5f707f;
+  --polyfill-foreground: #ffffff;
 }
 
 .dark {
@@ -62,6 +64,8 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(0.269 0 0);
   --sidebar-ring: oklch(0.439 0 0);
+  --polyfill: #5f707f;
+  --polyfill-foreground: #ffffff;
 }
 
 @theme inline {
@@ -98,6 +102,8 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-polyfill: var(--polyfill);
+  --color-polyfill-foreground: var(--polyfill-foreground);
 }
 
 @layer base {

--- a/apps/bundle-analyzer/app/page.tsx
+++ b/apps/bundle-analyzer/app/page.tsx
@@ -321,8 +321,8 @@ export default function Home() {
                               {specialModuleType ===
                               SpecialModule.POLYFILL_NOMODULE ? (
                                 <>
-                                  . <pre>polyfill-nomodule.js</pre> is only sent
-                                  to legacy browsers.
+                                  . <code>polyfill-nomodule.js</code> is only
+                                  sent to legacy browsers.
                                 </>
                               ) : null}
                             </dd>

--- a/apps/bundle-analyzer/app/page.tsx
+++ b/apps/bundle-analyzer/app/page.tsx
@@ -14,6 +14,8 @@ import { Input } from '@/components/ui/input'
 import { Skeleton, TreemapSkeleton } from '@/components/ui/skeleton'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { AnalyzeData, ModulesData } from '@/lib/analyze-data'
+import { SpecialModule } from '@/lib/types'
+import { getSpecialModuleType } from '@/lib/utils'
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B'
@@ -136,6 +138,11 @@ export default function Home() {
   const error = analyzeError || modulesError
   const isAnyLoading = isAnalyzeLoading || isModulesLoading
   const rootSourceIndex = getRootSourceIndex(analyzeData)
+
+  const specialModuleType = getSpecialModuleType(
+    analyzeData,
+    selectedSourceIndex
+  )
 
   return (
     <main
@@ -289,12 +296,39 @@ export default function Home() {
                 {selectedSourceIndex != null &&
                   analyzeData.source(selectedSourceIndex) && (
                     <>
-                      <p className="text-xs text-muted-foreground mt-2">
-                        Output Size:{' '}
-                        {formatBytes(
-                          analyzeData.getSourceOutputSize(selectedSourceIndex)
+                      <dl className="space-y-2">
+                        <div>
+                          <dt className="text-xs text-muted-foreground inline">
+                            Output Size:{' '}
+                          </dt>
+                          <dd className="text-xs text-muted-foreground inline">
+                            {formatBytes(
+                              analyzeData.getSourceOutputSize(
+                                selectedSourceIndex
+                              )
+                            )}
+                          </dd>
+                        </div>
+                        {(specialModuleType === SpecialModule.POLYFILL_MODULE ||
+                          specialModuleType ===
+                            SpecialModule.POLYFILL_NOMODULE) && (
+                          <div className="flex items-center gap-2">
+                            <dt className="inline-flex items-center rounded-md bg-polyfill/10 dark:bg-polyfill/30 px-2 py-1 text-xs font-medium text-polyfill dark:text-polyfill-foreground ring-1 ring-inset ring-polyfill/20 shrink-0">
+                              Polyfill
+                            </dt>
+                            <dd className="text-xs text-muted-foreground">
+                              Next.js built-in polyfills
+                              {specialModuleType ===
+                              SpecialModule.POLYFILL_NOMODULE ? (
+                                <>
+                                  . <pre>polyfill-nomodule.js</pre> is only sent
+                                  to legacy browsers.
+                                </>
+                              ) : null}
+                            </dd>
+                          </div>
                         )}
-                      </p>
+                      </dl>
                       {modulesData && (
                         <ImportChain
                           key={selectedSourceIndex}

--- a/apps/bundle-analyzer/lib/analyze-data.ts
+++ b/apps/bundle-analyzer/lib/analyze-data.ts
@@ -388,6 +388,20 @@ export class AnalyzeData {
     return { client, server, traced, js, css, json, asset }
   }
 
+  isPolyfillModule(index: number): boolean {
+    const fullSourcePath = this.getFullSourcePath(index)
+    return fullSourcePath.endsWith(
+      'node_modules/next/dist/build/polyfills/polyfill-module.js'
+    )
+  }
+
+  isPolyfillNoModule(index: number): boolean {
+    const fullSourcePath = this.getFullSourcePath(index)
+    return fullSourcePath.endsWith(
+      'node_modules/next/dist/build/polyfills/polyfill-nomodule.js'
+    )
+  }
+
   // Get the raw header for debugging
   getRawAnalyzeHeader(): AnalyzeDataHeader {
     return this.analyzeHeader

--- a/apps/bundle-analyzer/lib/treemap-layout.ts
+++ b/apps/bundle-analyzer/lib/treemap-layout.ts
@@ -1,5 +1,7 @@
 import type { AnalyzeData } from './analyze-data'
 import { layoutTreemap } from './layout-treemap'
+import { SpecialModule } from './types'
+import { getSpecialModuleType } from './utils'
 
 export interface LayoutRect {
   x: number
@@ -18,6 +20,7 @@ export interface LayoutNode extends LayoutNodeInfo {
   size: number
   rect: LayoutRect
   type: 'file' | 'directory' | 'collapsed-directory'
+  specialModuleType: SpecialModule | null
   titleBarHeight?: number
   children?: LayoutNode[]
   itemCount?: number
@@ -141,6 +144,7 @@ function computeTreemapLayoutFromAnalyzeInternal(
       type: 'file',
       rect,
       sourceIndex,
+      specialModuleType: getSpecialModuleType(analyzeData, sourceIndex),
       ...analyzeData.getSourceFlags(sourceIndex),
     }
   }
@@ -178,6 +182,7 @@ function computeTreemapLayoutFromAnalyzeInternal(
       itemCount: countDescendants(sourceIndex),
       children: [],
       sourceIndex,
+      specialModuleType: null,
     }
   }
 
@@ -211,6 +216,7 @@ function computeTreemapLayoutFromAnalyzeInternal(
       titleBarHeight,
       children: [],
       sourceIndex,
+      specialModuleType: null,
     }
   }
 
@@ -240,6 +246,7 @@ function computeTreemapLayoutFromAnalyzeInternal(
     titleBarHeight,
     children: layoutChildren,
     sourceIndex,
+    specialModuleType: null,
   }
 }
 

--- a/apps/bundle-analyzer/lib/types.ts
+++ b/apps/bundle-analyzer/lib/types.ts
@@ -33,3 +33,8 @@ export interface RouteManifest {
   staticRoutes: Array<Route>
   dynamicRoutes: Array<Route>
 }
+
+export enum SpecialModule {
+  POLYFILL_MODULE,
+  POLYFILL_NOMODULE,
+}

--- a/apps/bundle-analyzer/lib/utils.ts
+++ b/apps/bundle-analyzer/lib/utils.ts
@@ -1,5 +1,7 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
+import { SpecialModule } from './types'
+import { AnalyzeData } from './analyze-data'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -7,4 +9,20 @@ export function cn(...inputs: ClassValue[]) {
 
 export function jsonFetcher<T>(url: string): Promise<T> {
   return fetch(url).then((res) => res.json())
+}
+
+export function getSpecialModuleType(
+  analyzeData: AnalyzeData | undefined,
+  sourceIndex: number | null
+): SpecialModule | null {
+  if (!analyzeData || sourceIndex == null) return null
+
+  const path = analyzeData.source(sourceIndex)?.path || ''
+  if (path.endsWith('polyfill-module.js')) {
+    return SpecialModule.POLYFILL_MODULE
+  } else if (path.endsWith('polyfill-nomodule.js')) {
+    return SpecialModule.POLYFILL_NOMODULE
+  }
+
+  return null
 }

--- a/apps/bundle-analyzer/styles/globals.css
+++ b/apps/bundle-analyzer/styles/globals.css
@@ -21,6 +21,8 @@
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
+  --polyfill: oklch(0.478 0.0185 252.37);
+  --polyfill-foreground: oklch(0.99 0 0);
   --radius: 0.625rem;
 }
 
@@ -42,6 +44,8 @@
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.439 0 0);
+  --polyfill: oklch(0.478 0.0185 252.37);
+  --polyfill-foreground: oklch(0.99 0 0);
 }
 
 @theme inline {
@@ -64,6 +68,8 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-polyfill: var(--polyfill);
+  --color-polyfill-foreground: var(--polyfill-foreground);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);

--- a/crates/next-api/src/analyze.rs
+++ b/crates/next-api/src/analyze.rs
@@ -367,6 +367,7 @@ pub async fn analyze_output_assets(output_assets: Vc<OutputAssets>) -> Result<Vc
             // Skip source maps.
             continue;
         }
+
         let output_file_index = builder.add_output_file(AnalyzeOutputFile { filename });
         let chunk_parts = split_output_asset_into_parts(*asset).await?;
         for chunk_part in chunk_parts {

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -9,7 +9,7 @@ use turbo_tasks::{
 };
 use turbopack_core::{
     module_graph::{GraphEntries, ModuleGraph},
-    output::OutputAssets,
+    output::{OptionOutputAsset, OutputAssets},
 };
 
 use crate::{operation::OptionEndpoint, paths::ServerPath, project::Project};
@@ -72,6 +72,10 @@ pub trait Endpoint {
     }
     #[turbo_tasks::function]
     fn module_graphs(self: Vc<Self>) -> Vc<ModuleGraphs>;
+    #[turbo_tasks::function]
+    fn polyfill_asset(self: Vc<Self>) -> Vc<OptionOutputAsset> {
+        Vc::cell(None)
+    }
 }
 
 #[derive(

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -24,6 +24,7 @@ mod path_visitor;
 pub mod references;
 pub mod runtime_functions;
 pub mod side_effect_optimization;
+pub mod single_file_ecmascript_output;
 pub mod source_map;
 pub(crate) mod static_code;
 mod swc_comments;

--- a/turbopack/crates/turbopack-ecmascript/src/single_file_ecmascript_output.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/single_file_ecmascript_output.rs
@@ -1,0 +1,99 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use swc_core::common::{BytePos, FileName, LineCol, SourceMap};
+use tokio::io::AsyncReadExt;
+use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks_fs::{FileContent, FileSystemPath, rope::Rope};
+use turbopack_core::{
+    asset::{Asset, AssetContent},
+    output::{OutputAsset, OutputAssetsReference},
+    source::Source,
+    source_map::{GenerateSourceMap, OptionStringifiedSourceMap},
+};
+
+use crate::parse::generate_js_source_map;
+
+/// An EcmaScript OutputAsset composed of one file, no parsing and no references. Includes a source
+/// map to the original file.
+#[turbo_tasks::value]
+pub struct SingleFileEcmascriptOutput {
+    output_path: FileSystemPath,
+    source_path: FileSystemPath,
+    source: ResolvedVc<Box<dyn Source>>,
+}
+
+#[turbo_tasks::value_impl]
+impl OutputAsset for SingleFileEcmascriptOutput {
+    #[turbo_tasks::function]
+    fn path(&self) -> Vc<FileSystemPath> {
+        self.output_path.clone().cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl OutputAssetsReference for SingleFileEcmascriptOutput {}
+
+#[turbo_tasks::value_impl]
+impl Asset for SingleFileEcmascriptOutput {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl SingleFileEcmascriptOutput {
+    #[turbo_tasks::function]
+    pub fn new(
+        output_path: FileSystemPath,
+        source_path: FileSystemPath,
+        source: ResolvedVc<Box<dyn Source>>,
+    ) -> Vc<SingleFileEcmascriptOutput> {
+        SingleFileEcmascriptOutput {
+            output_path,
+            source_path,
+            source,
+        }
+        .cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl GenerateSourceMap for SingleFileEcmascriptOutput {
+    #[turbo_tasks::function]
+    pub async fn generate_source_map(&self) -> Result<Vc<OptionStringifiedSourceMap>> {
+        let FileContent::Content(file) = &*self.source.content().file_content().await? else {
+            return Ok(Vc::cell(None));
+        };
+
+        let file_source = {
+            let mut s = String::new();
+            file.read().read_to_string(&mut s).await?;
+            s
+        };
+
+        let mut mappings = vec![];
+        // Start from 1 because 0 is reserved for dummy spans in SWC.
+        let mut pos: u32 = 1;
+        for (index, line) in file_source.split_inclusive('\n').enumerate() {
+            mappings.push((
+                BytePos(pos),
+                LineCol {
+                    line: index as u32,
+                    col: 0,
+                },
+            ));
+            pos += line.len() as u32;
+        }
+
+        let sm: Arc<SourceMap> = Default::default();
+        sm.new_source_file(
+            FileName::Custom(self.source_path.to_string()).into(),
+            file_source,
+        );
+
+        let map = generate_js_source_map(&*sm, mappings, None::<&Rope>, true, true)?;
+        Ok(Vc::cell(Some(map)))
+    }
+}


### PR DESCRIPTION
For small routes, it can appear like the polyfill chunk takes up a sizable amount of data, but `polyfill-nomodule.js` is only sent to legacy browsers. This makes it clearer.

This PR enhances the bundle analyzer by adding visual indicators for polyfill chunks, and noting they're conditionally sent to modern or legacy browsers. The changes include:

- Adds a source map to polyfill chunks (for the large pre-bundled input only)
- Visually distinguished polyfill chunks in the treemap by lightening their color
- Added a "Polyfill" badge (other badges coming soon!) with text when viewing polyfill chunk details

<img width="388" height="227" alt="image" src="https://github.com/user-attachments/assets/bcebfba6-1e10-459a-9364-b6b8197cd3df" />

Fixes PACK-5826