### PR TITLE
Turbopack: Avoid that session-dependent tasks write to DB on every build

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -27,8 +27,8 @@ use tokio::time::{Duration, Instant};
 use tracing::{Span, trace_span};
 use turbo_tasks::{
     CellId, FxDashMap, FxIndexMap, KeyValuePair, RawVc, ReadCellOptions, ReadConsistency,
-    ReadOutputOptions, ReadTracking, SessionId, TRANSIENT_TASK_BIT, TaskExecutionReason, TaskId,
-    TraitTypeId, TurboTasksBackendApi, ValueTypeId,
+    ReadOutputOptions, ReadTracking, TRANSIENT_TASK_BIT, TaskExecutionReason, TaskId, TraitTypeId,
+    TurboTasksBackendApi, ValueTypeId,
     backend::{
         Backend, CachedTaskType, CellContent, TaskExecutionSpec, TransientTaskRoot,
         TransientTaskType, TurboTasksExecutionError, TypedCellContent, VerificationMode,
@@ -180,7 +180,6 @@ struct TurboTasksBackendInner<B: BackingStorage> {
     options: BackendOptions,
 
     start_time: Instant,
-    session_id: SessionId,
 
     persisted_task_id_factory: IdFactoryWithReuse<TaskId>,
     transient_task_id_factory: IdFactoryWithReuse<TaskId>,
@@ -254,9 +253,6 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         Self {
             options,
             start_time: Instant::now(),
-            session_id: backing_storage
-                .next_session_id()
-                .expect("Failed get session id"),
             persisted_task_id_factory: IdFactoryWithReuse::new(
                 next_task_id,
                 TaskId::try_from(TRANSIENT_TASK_BIT - 1).unwrap(),
@@ -293,10 +289,6 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         turbo_tasks: &'a dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> impl ExecuteContext<'a> {
         ExecuteContextImpl::new(self, turbo_tasks)
-    }
-
-    fn session_id(&self) -> SessionId {
-        self.session_id
     }
 
     /// # Safety
@@ -1196,7 +1188,6 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let _span = tracing::info_span!(parent: parent_span, "persist", reason = reason).entered();
         {
             if let Err(err) = self.backing_storage.save_snapshot(
-                self.session_id,
                 suspended_operations,
                 persisted_task_cache_log,
                 task_snapshots,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -567,10 +567,10 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 }
             }
 
-            let is_dirty = task.is_dirty(self.session_id);
+            let is_dirty = task.is_dirty();
 
             // Check the dirty count of the root node
-            let has_dirty_containers = task.has_dirty_containers(self.session_id);
+            let has_dirty_containers = task.has_dirty_containers();
             if has_dirty_containers || is_dirty {
                 let activeness = get_mut!(task, Activeness);
                 let mut task_ids_to_schedule: Vec<_> = Vec::new();
@@ -589,7 +589,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                         .set_active_until_clean();
                     if ctx.should_track_activeness() {
                         // A newly added Activeness need to make sure to schedule the tasks
-                        task_ids_to_schedule = task.dirty_containers(self.session_id).collect();
+                        task_ids_to_schedule = task.dirty_containers().collect();
                         task_ids_to_schedule.push(task_id);
                     }
                     get!(task, Activeness).unwrap()
@@ -613,7 +613,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                             visited: &mut FxHashSet<TaskId>,
                         ) -> String {
                             let task = ctx.task(task_id, TaskDataCategory::All);
-                            let is_dirty = task.is_dirty(ctx.session_id());
+                            let is_dirty = task.is_dirty();
                             let in_progress =
                                 get!(task, InProgress).map_or("not in progress", |p| match p {
                                     InProgressState::InProgress(_) => "in progress",
@@ -634,7 +634,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                             };
 
                             // Check the dirty count of the root node
-                            let has_dirty_containers = task.has_dirty_containers(ctx.session_id());
+                            let has_dirty_containers = task.has_dirty_containers();
 
                             let task_description = ctx.get_task_description(task_id);
                             let is_dirty_label = if is_dirty { ", dirty" } else { "" };
@@ -653,8 +653,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                                  {in_progress}, \
                                  {activeness}{is_dirty_label}{has_dirty_containers_label})",
                             );
-                            let children: Vec<_> =
-                                task.dirty_containers_with_count(ctx.session_id()).collect();
+                            let children: Vec<_> = task.dirty_containers_with_count().collect();
                             drop(task);
 
                             if missing_upper {
@@ -2365,32 +2364,21 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         // Grab the old dirty state
         let old_dirtyness = get!(task, Dirty).cloned();
-        let (old_self_dirty, old_current_session_self_clean, old_clean_in_session) =
-            match old_dirtyness {
-                None => (false, false, None),
-                Some(Dirtyness::Dirty) => (true, false, None),
-                Some(Dirtyness::SessionDependent) => {
-                    let clean_in_session = get!(task, CleanInSession).copied();
-                    (
-                        true,
-                        clean_in_session == Some(self.session_id),
-                        clean_in_session,
-                    )
-                }
-            };
+        let (old_self_dirty, old_current_session_self_clean) = match old_dirtyness {
+            None => (false, false),
+            Some(Dirtyness::Dirty) => (true, false),
+            Some(Dirtyness::SessionDependent) => {
+                let clean_in_current_session = get!(task, CurrentSessionClean).is_some();
+                (true, clean_in_current_session)
+            }
+        };
 
         // Compute the new dirty state
-        let (new_dirtyness, new_clean_in_session, new_self_dirty, new_current_session_self_clean) =
-            if session_dependent {
-                (
-                    Some(Dirtyness::SessionDependent),
-                    Some(self.session_id),
-                    true,
-                    true,
-                )
-            } else {
-                (None, None, false, false)
-            };
+        let (new_dirtyness, new_self_dirty, new_current_session_self_clean) = if session_dependent {
+            (Some(Dirtyness::SessionDependent), true, true)
+        } else {
+            (None, false, false)
+        };
 
         // Update the dirty state
         if old_dirtyness != new_dirtyness {
@@ -2400,11 +2388,11 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 task.remove(&CachedDataItemKey::Dirty {});
             }
         }
-        if old_clean_in_session != new_clean_in_session {
-            if let Some(session_id) = new_clean_in_session {
-                task.insert(CachedDataItem::CleanInSession { value: session_id });
-            } else if old_clean_in_session.is_some() {
-                task.remove(&CachedDataItemKey::CleanInSession {});
+        if old_current_session_self_clean != new_current_session_self_clean {
+            if new_current_session_self_clean {
+                task.insert(CachedDataItem::CurrentSessionClean { value: () });
+            } else if old_current_session_self_clean {
+                task.remove(&CachedDataItemKey::CurrentSessionClean {});
             }
         }
 
@@ -2415,14 +2403,10 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             let dirty_container_count = get!(task, AggregatedDirtyContainerCount)
                 .cloned()
                 .unwrap_or_default();
-            let current_session_clean_container_count = get!(
-                task,
-                AggregatedSessionDependentCleanContainerCount {
-                    session_id: self.session_id
-                }
-            )
-            .copied()
-            .unwrap_or_default();
+            let current_session_clean_container_count =
+                get!(task, AggregatedCurrentSessionCleanContainerCount)
+                    .copied()
+                    .unwrap_or_default();
             let result = ComputeDirtyAndCleanUpdate {
                 old_dirty_container_count: dirty_container_count,
                 new_dirty_container_count: dirty_container_count,
@@ -2914,8 +2898,8 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         let mut ctx = self.execute_context(turbo_tasks);
         let mut task = ctx.task(task_id, TaskDataCategory::All);
-        let is_dirty = task.is_dirty(self.session_id);
-        let has_dirty_containers = task.has_dirty_containers(self.session_id);
+        let is_dirty = task.is_dirty();
+        let has_dirty_containers = task.has_dirty_containers();
         if is_dirty || has_dirty_containers {
             if let Some(activeness_state) = get_mut!(task, Activeness) {
                 // We will finish the task, but it would be removed after the task is done
@@ -3005,7 +2989,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 }
 
                 let is_dirty = get!(task, Dirty).is_some();
-                let has_dirty_container = task.has_dirty_containers(self.session_id);
+                let has_dirty_container = task.has_dirty_containers();
                 let should_be_in_upper = is_dirty || has_dirty_container;
 
                 let aggregation_number = get_aggregation_number(&task);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-use turbo_tasks::{FxIndexMap, KeyValuePair, SessionId, TaskId, TurboTasksBackendApi};
+use turbo_tasks::{FxIndexMap, KeyValuePair, TaskId, TurboTasksBackendApi};
 
 use crate::{
     backend::{
@@ -51,7 +51,6 @@ pub trait ExecuteContext<'e>: Sized {
     fn child_context<'l, 'r>(&'r self) -> impl ChildExecuteContext<'l> + use<'e, 'l, Self>
     where
         'e: 'l;
-    fn session_id(&self) -> SessionId;
     fn task(&mut self, task_id: TaskId, category: TaskDataCategory) -> Self::TaskGuardImpl;
     fn is_once_task(&self, task_id: TaskId) -> bool;
     fn task_pair(
@@ -179,10 +178,6 @@ where
             backend: self.backend,
             turbo_tasks: self.turbo_tasks,
         }
-    }
-
-    fn session_id(&self) -> SessionId {
-        self.backend.session_id()
     }
 
     fn task(&mut self, task_id: TaskId, category: TaskDataCategory) -> Self::TaskGuardImpl {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -415,49 +415,40 @@ pub trait TaskGuard: Debug {
     fn invalidate_serialization(&mut self);
     fn prefetch(&mut self) -> Option<FxIndexMap<TaskId, bool>>;
     fn is_immutable(&self) -> bool;
-    fn is_dirty(&self, session_id: SessionId) -> bool {
+    fn is_dirty(&self) -> bool {
         get!(self, Dirty).is_some_and(|dirtyness| match dirtyness {
             Dirtyness::Dirty => true,
-            Dirtyness::SessionDependent => get!(self, CleanInSession).copied() != Some(session_id),
+            Dirtyness::SessionDependent => get!(self, CurrentSessionClean).is_none(),
         })
     }
-    fn dirtyness_and_session(&self) -> Option<(Dirtyness, Option<SessionId>)> {
+    fn dirtyness_and_session(&self) -> Option<(Dirtyness, bool)> {
         match get!(self, Dirty)? {
-            Dirtyness::Dirty => Some((Dirtyness::Dirty, None)),
+            Dirtyness::Dirty => Some((Dirtyness::Dirty, false)),
             Dirtyness::SessionDependent => Some((
                 Dirtyness::SessionDependent,
-                get!(self, CleanInSession).copied(),
+                get!(self, CurrentSessionClean).is_some(),
             )),
         }
     }
     /// Returns (is_dirty, is_clean_in_current_session)
-    fn dirty(&self, session_id: SessionId) -> (bool, bool) {
+    fn dirty(&self) -> (bool, bool) {
         match get!(self, Dirty) {
             None => (false, false),
             Some(Dirtyness::Dirty) => (true, false),
-            Some(Dirtyness::SessionDependent) => (
-                true,
-                get!(self, CleanInSession).copied() == Some(session_id),
-            ),
+            Some(Dirtyness::SessionDependent) => (true, get!(self, CurrentSessionClean).is_some()),
         }
     }
-    fn dirty_containers(&self, session_id: SessionId) -> impl Iterator<Item = TaskId> {
-        self.dirty_containers_with_count(session_id)
+    fn dirty_containers(&self) -> impl Iterator<Item = TaskId> {
+        self.dirty_containers_with_count()
             .map(|(task_id, _)| task_id)
     }
-    fn dirty_containers_with_count(
-        &self,
-        session_id: SessionId,
-    ) -> impl Iterator<Item = (TaskId, i32)> {
+    fn dirty_containers_with_count(&self) -> impl Iterator<Item = (TaskId, i32)> {
         iter_many!(self, AggregatedDirtyContainer { task } count => (task, *count)).filter(
             move |&(task_id, count)| {
                 if count > 0 {
                     let clean_count = get!(
                         self,
-                        AggregatedSessionDependentCleanContainer {
-                            task: task_id,
-                            session_id
-                        }
+                        AggregatedCurrentSessionCleanContainer { task: task_id }
                     )
                     .copied()
                     .unwrap_or_default();
@@ -469,19 +460,16 @@ pub trait TaskGuard: Debug {
         )
     }
 
-    fn has_dirty_containers(&self, session_id: SessionId) -> bool {
+    fn has_dirty_containers(&self) -> bool {
         let dirty_count = get!(self, AggregatedDirtyContainerCount)
             .copied()
             .unwrap_or_default();
         if dirty_count <= 0 {
             return false;
         }
-        let clean_count = get!(
-            self,
-            AggregatedSessionDependentCleanContainerCount { session_id }
-        )
-        .copied()
-        .unwrap_or_default();
+        let clean_count = get!(self, AggregatedCurrentSessionCleanContainerCount)
+            .copied()
+            .unwrap_or_default();
         dirty_count > clean_count
     }
 }

--- a/turbopack/crates/turbo-tasks/src/id.rs
+++ b/turbopack/crates/turbo-tasks/src/id.rs
@@ -122,7 +122,6 @@ define_id!(TaskId: u32, derive(Serialize, Deserialize), serde(transparent));
 define_id!(FunctionId: u16);
 define_id!(ValueTypeId: u16);
 define_id!(TraitTypeId: u16);
-define_id!(SessionId: u32, derive(Debug, Serialize, Deserialize), serde(transparent));
 define_id!(
     LocalTaskId: u32,
     derive(Debug, Serialize, Deserialize),

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -96,9 +96,7 @@ pub use collectibles::CollectiblesSource;
 pub use completion::{Completion, Completions};
 pub use display::ValueToString;
 pub use effect::{ApplyEffectsContext, Effects, apply_effects, effect, get_effects};
-pub use id::{
-    ExecutionId, LocalTaskId, SessionId, TRANSIENT_TASK_BIT, TaskId, TraitTypeId, ValueTypeId,
-};
+pub use id::{ExecutionId, LocalTaskId, TRANSIENT_TASK_BIT, TaskId, TraitTypeId, ValueTypeId};
 pub use invalidation::{
     InvalidationReason, InvalidationReasonKind, InvalidationReasonSet, Invalidator, get_invalidator,
 };


### PR DESCRIPTION
### What?

Refactor session-dependent tasks to avoid session ids. This way session-dependent tasks no longer "change" on very run and dump duplicate data into the database.