### PR TITLE
Docs: Mention npm link with Turbopack root

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -119,7 +119,9 @@ module.exports = {
 }
 ```
 
-When using `npm link` where the package linked is outside of the project root, those files would not be resolved. For that case you can set the root to the parent directory of both the project and the linked package.
+To resolve files from linked dependencies outside the project root (via `npm link`, `yarn link`, `pnpm link`, etc.), you must configure the `turbopack.root` to the parent directory of both the project and the linked dependencies.
+
+While this expands the scope of filesystem watching, it's typically only necessary during development when actively working on linked packages.
 
 ### Configuring webpack loaders
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -98,6 +98,8 @@ If you have a loader that is critically dependent upon one of these features ple
 
 Turbopack uses the root directory to resolve modules. Files outside of the project root are not resolved.
 
+The reason files are not resolved outside of the project root is to improve cache validation, filesystem watching, and to reduce the number of resolving steps needed.
+
 Next.js automatically detects the root directory of your project. It does so by looking for one of these files:
 
 - `pnpm-lock.yaml`

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -98,7 +98,7 @@ If you have a loader that is critically dependent upon one of these features ple
 
 Turbopack uses the root directory to resolve modules. Files outside of the project root are not resolved.
 
-The reason files are not resolved outside of the project root is to improve cache validation, filesystem watching, and to reduce the number of resolving steps needed.
+The reason files are not resolved outside of the project root is to improve cache validation, reduce filesystem watching overhead, and reduce the number of resolving steps needed.
 
 Next.js automatically detects the root directory of your project. It does so by looking for one of these files:
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -117,6 +117,8 @@ module.exports = {
 }
 ```
 
+When using `npm link` where the package linked is outside of the project root, those files would not be resolved. For that case you can set the root to the parent directory of both the project and the linked package.
+
 ### Configuring webpack loaders
 
 If you need loader support beyond what's built in, many webpack loaders already work with Turbopack. There are currently some limitations:

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -114,7 +114,7 @@ There are a number of non-trivial behavior differences between webpack and Turbo
 
 Turbopack uses the root directory to resolve modules. Files outside of the project root are not resolved.
 
-For example when using `npm link` where the package linked is outside of the project root, those files would then not be resolved. For that case you can set the root option to the parent directory of both the project and the linked package.
+For example, when linking dependencies outside the project root (via `npm link`, `yarn link`, `pnpm link`, etc.), those linked files will not be resolved by default. To resolve these files, you must configure the root option to the parent directory of both the project and the linked dependencies.
 
 You can configure the filesystem root using [turbopack.root](/docs/app/api-reference/config/next-config-js/turbopack#root-directory) option in `next.config.js`.
 

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -110,6 +110,14 @@ Turbopack in Next.js has **zero-configuration** for the common use cases. Below 
 
 There are a number of non-trivial behavior differences between webpack and Turbopack that are important to be aware of when migrating an application. Generally, these are less of a concern for new applications.
 
+### Filesystem Root
+
+Turbopack uses the root directory to resolve modules. Files outside of the project root are not resolved.
+
+For example when using `npm link` where the package linked is outside of the project root, those files would then not be resolved. For that case you can set the root option to the parent directory of both the project and the linked package.
+
+You can configure the filesystem root using [turbopack.root](/docs/app/api-reference/config/next-config-js/turbopack#root-directory) option in `next.config.js`.
+
 ### CSS Module Ordering
 
 Turbopack will follow JS import order to order [CSS modules](/docs/app/getting-started/css#css-modules) which are not otherwise ordered. For example:


### PR DESCRIPTION
## What?

Mention `npm link` case for the Turbopack root for when the package is outside of the project directory.

Based on feedback here: https://x.com/stevenaharrison/status/1988781488738070962.