### PR TITLE
Allow attaching a debugger when `next dev` is already running

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -924,5 +924,6 @@
   "923": "%s is being parsed as a normalized route, but it has a route group or parallel route segment.",
   "924": "Invalid interception route: %s",
   "925": "You cannot define a route with the same specificity as an optional catch-all route (\"%s\" and \"/[[...%s]]\").",
-  "926": "Optional route parameters are not yet supported (\"[%s]\") in route \"%s\"."
+  "926": "Optional route parameters are not yet supported (\"[%s]\") in route \"%s\".",
+  "927": "No debug targets found"
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
@@ -23,7 +23,8 @@ export function ErrorOverlayToolbar({
       <CopyErrorButton error={error} generateErrorInfo={generateErrorInfo} />
       <DocsLinkButton errorMessage={error.message} />
       <NodejsInspectorButton
-        devtoolsFrontendUrl={debugInfo?.devtoolsFrontendUrl}
+        key={debugInfo?.devtoolsFrontendUrl}
+        defaultDevtoolsFrontendUrl={debugInfo?.devtoolsFrontendUrl}
       />
     </span>
   )
@@ -71,6 +72,10 @@ export const styles = `
       background-color: var(--color-gray-100);
       cursor: not-allowed;
     }
+  }
+
+  .nodejs-inspector-button[data-pending='true'] {
+    cursor: wait;
   }
 
   .error-overlay-toolbar-button-icon {

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/nodejs-inspector-button.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/nodejs-inspector-button.stories.tsx
@@ -15,12 +15,13 @@ type Story = StoryObj<typeof NodejsInspectorButton>
 
 export const WithDevtoolsUrl: Story = {
   args: {
-    devtoolsFrontendUrl: 'chrome-devtools://devtools/bundled/inspector.html',
+    defaultDevtoolsFrontendUrl:
+      'chrome-devtools://devtools/bundled/inspector.html',
   },
 }
 
 export const WithoutDevtoolsUrl: Story = {
   args: {
-    devtoolsFrontendUrl: undefined,
+    defaultDevtoolsFrontendUrl: undefined,
   },
 }

--- a/packages/next/src/next-devtools/server/attach-nodejs-debugger-middleware.ts
+++ b/packages/next/src/next-devtools/server/attach-nodejs-debugger-middleware.ts
@@ -1,0 +1,48 @@
+import { middlewareResponse } from './middleware-response'
+import type { ServerResponse, IncomingMessage } from 'http'
+import * as inspector from 'inspector'
+
+export function getAttachNodejsDebuggerMiddleware() {
+  return async function (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: () => void
+  ): Promise<void> {
+    const { pathname } = new URL(`http://n${req.url}`)
+
+    if (pathname !== '/__nextjs_attach-nodejs-inspector') {
+      return next()
+    }
+
+    try {
+      const isInspecting = inspector.url() !== undefined
+      const debugPort = process.debugPort
+      if (!isInspecting) {
+        // Node.js will already log that the inspector is listening.
+        inspector.open(debugPort)
+      }
+
+      const inspectorURLRaw = inspector.url()
+      if (inspectorURLRaw === undefined) {
+        // could not open, possibly because already in use.
+        return middlewareResponse.badRequest(
+          res,
+          `Failed to open port "${debugPort}". Address may be already in use.`
+        )
+      }
+      const inspectorURL = new URL(inspectorURLRaw)
+
+      const debugInfoListResponse = await fetch(
+        `http://${inspectorURL.host}/json/list`
+      )
+      const debugInfoList = await debugInfoListResponse.json()
+      if (!Array.isArray(debugInfoList) || debugInfoList.length === 0) {
+        throw new Error('No debug targets found')
+      }
+
+      return middlewareResponse.json(res, debugInfoList[0].devtoolsFrontendUrl)
+    } catch (error) {
+      return middlewareResponse.internalServerError(res)
+    }
+  }
+}

--- a/packages/next/src/next-devtools/server/middleware-response.ts
+++ b/packages/next/src/next-devtools/server/middleware-response.ts
@@ -6,9 +6,14 @@ export const middlewareResponse = {
     res.statusCode = 204
     res.end('No Content')
   },
-  badRequest(res: ServerResponse) {
+  badRequest(res: ServerResponse, reason?: string) {
     res.statusCode = 400
-    res.end('Bad Request')
+    if (reason !== undefined) {
+      res.setHeader('Content-Type', 'text/plain')
+      res.end(reason)
+    } else {
+      res.end()
+    }
   },
   notFound(res: ServerResponse) {
     res.statusCode = 404

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -107,6 +107,7 @@ import {
   devToolsConfigMiddleware,
   getDevToolsConfig,
 } from '../../next-devtools/server/devtools-config-middleware'
+import { getAttachNodejsDebuggerMiddleware } from '../../next-devtools/server/attach-nodejs-debugger-middleware'
 import {
   connectReactDebugChannel,
   connectReactDebugChannelForHtmlRequest,
@@ -773,6 +774,7 @@ export async function createHotReloaderTurbopack(
         })
       },
     }),
+    getAttachNodejsDebuggerMiddleware(),
     ...(nextConfig.experimental.mcpServer
       ? [
           getMcpMiddleware({

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -96,6 +96,7 @@ import {
   devToolsConfigMiddleware,
   getDevToolsConfig,
 } from '../../next-devtools/server/devtools-config-middleware'
+import { getAttachNodejsDebuggerMiddleware } from '../../next-devtools/server/attach-nodejs-debugger-middleware'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import {
   connectReactDebugChannel,
@@ -1667,6 +1668,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
           })
         },
       }),
+      getAttachNodejsDebuggerMiddleware(),
       ...(this.config.experimental.mcpServer
         ? [
             getMcpMiddleware({

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -423,6 +423,7 @@ export default class DevServer extends Server {
        */
       if (
         request.url.includes('/_next/static') ||
+        request.url.includes('/__nextjs_attach-nodejs-inspector') ||
         request.url.includes('/__nextjs_original-stack-frame') ||
         request.url.includes('/__nextjs_source-map') ||
         request.url.includes('/__nextjs_error_feedback')

--- a/test/development/app-dir/devtool-copy-button/devtool-copy-button.test.ts
+++ b/test/development/app-dir/devtool-copy-button/devtool-copy-button.test.ts
@@ -15,6 +15,6 @@ describe('app-dir - devtool-copy-button', () => {
       await browser
         .elementByCss('[data-nextjs-data-runtime-error-copy-devtools-url]')
         .getAttribute('aria-label')
-    ).toBe('Copy Chrome DevTools URL')
+    ).toBe('Copy DevTools URL for Chrome')
   })
 })


### PR DESCRIPTION
The icon when no debugger was attached linking to docs is now a button that, when clicked, opens a debugger port on the default port.

We need a separate icon in the NDT menu so that this affordance is available even without errors in the Redbox. The preferences should also allow to specify a different port. Both of these items can be handled in a follow-up.

https://github.com/user-attachments/assets/23ec31fc-66e5-400a-b23b-ae3ad4396b7e

