### PR TITLE
[Cache Components] Atomic setTimeouts

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -932,5 +932,6 @@
   "931": "Unexpected empty path segments match for a route \"%s\" with param \"%s\" of type \"%s\"",
   "932": "Could not resolve param value for segment: %s",
   "933": "An unexpected error occurred while adjusting `_idleStart` on an atomic timer",
-  "934": "createAtomicTimerGroup cannot be called in the edge runtime"
+  "934": "createAtomicTimerGroup cannot be called in the edge runtime",
+  "935": "Cannot schedule more timers into a group that already executed"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -930,5 +930,7 @@
   "929": "No pages or app directory found.",
   "930": "Expected a dynamic route, but got a static route: %s",
   "931": "Unexpected empty path segments match for a route \"%s\" with param \"%s\" of type \"%s\"",
-  "932": "Could not resolve param value for segment: %s"
+  "932": "Could not resolve param value for segment: %s",
+  "933": "An unexpected error occurred while adjusting `_idleStart` on an atomic timer",
+  "934": "createAtomicTimerGroup cannot be called in the edge runtime"
 }

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -1,4 +1,5 @@
 import { InvariantError } from '../../shared/lib/invariant-error'
+import { createAtomicTimerGroup } from './app-render-scheduling'
 
 /**
  * This is a utility function to make scheduling sequential tasks that run back to back easier.
@@ -14,19 +15,22 @@ export function prerenderAndAbortInSequentialTasks<R>(
     )
   } else {
     return new Promise((resolve, reject) => {
+      const scheduleTimeout = createAtomicTimerGroup()
+
       let pendingResult: Promise<R>
-      setTimeout(() => {
+      scheduleTimeout(() => {
         try {
           pendingResult = prerender()
           pendingResult.catch(() => {})
         } catch (err) {
           reject(err)
         }
-      }, 0)
-      setTimeout(() => {
+      })
+
+      scheduleTimeout(() => {
         abort()
         resolve(pendingResult)
-      }, 0)
+      })
     })
   }
 }
@@ -46,22 +50,26 @@ export function prerenderAndAbortInSequentialTasksWithStages<R>(
     )
   } else {
     return new Promise((resolve, reject) => {
+      const scheduleTimeout = createAtomicTimerGroup()
+
       let pendingResult: Promise<R>
-      setTimeout(() => {
+      scheduleTimeout(() => {
         try {
           pendingResult = prerender()
           pendingResult.catch(() => {})
         } catch (err) {
           reject(err)
         }
-      }, 0)
-      setTimeout(() => {
+      })
+
+      scheduleTimeout(() => {
         advanceStage()
-      }, 0)
-      setTimeout(() => {
+      })
+
+      scheduleTimeout(() => {
         abort()
         resolve(pendingResult)
-      }, 0)
+      })
     })
   }
 }

--- a/packages/next/src/server/app-render/app-render-scheduling.ts
+++ b/packages/next/src/server/app-render/app-render-scheduling.ts
@@ -74,12 +74,12 @@ When this occurs, `_idleStart` is reliably different between `t1` and `t2`.
 We can guarantee that multiple timers (with the same delay, usually `0`)
 run together without any delays by making sure that their `_idleStart`s are the same,
 because that's what's used to determine if a timer should be deferred or not.
-Luckily, this is property is currently exposed to userland and mutable,
+Luckily, this property is currently exposed to userland and mutable,
 so we can patch it.
 
 Another related trick we could potentially apply is making
 a timer immediately be considered expired by doing  `timer._idleStart -= 2`.
-(the value must be more `1`, the delay that actually gets set for `setTimeout(cb, 0)`).
+(the value must be more than `1`, the delay that actually gets set for `setTimeout(cb, 0)`).
 This makes node view this timer as "a 1ms timer scheduled 2ms ago",
 meaning that it should definitely run in the next timer phase.
 However, I'm not confident we know all the side effects of doing this,
@@ -156,7 +156,7 @@ export function createAtomicTimerGroup(delayMs = 0) {
         return timer
       }
 
-      // NodeJS timers to have a `_idleStart` property, but it doesn't exist e.g. in Bun.
+      // NodeJS timers have a `_idleStart` property, but it doesn't exist e.g. in Bun.
       // If it's not present, we'll warn and try to continue.
       try {
         if ('_idleStart' in timer && typeof timer._idleStart === 'number') {

--- a/packages/next/src/server/app-render/app-render-scheduling.ts
+++ b/packages/next/src/server/app-render/app-render-scheduling.ts
@@ -88,6 +88,12 @@ so for now, simply ensuring coordination is enough.
 
 let cannotGuaranteeAtomicTimers = false
 
+function warnAboutTimers() {
+  console.warn(
+    "Next.js cannot guarantee that Cache Components will run as expected due to the current runtime's implementation of `setTimeout()`.\nPlease report a github issue here: https://github.com/vercel/next.js/issues/new/"
+  )
+}
+
 /**
  * Allows scheduling multiple timers (equivalent to `setTimeout(cb, delayMs)`)
  * that are guaranteed to run in the same iteration of the event loop.
@@ -102,14 +108,47 @@ export function createAtomicTimerGroup(delayMs = 0) {
     )
   } else {
     let firstTimerIdleStart: number | null = null
+    let didFirstTimerRun = false
+
+    // As a sanity check, we schedule an immediate from the first timeout
+    // to check if the execution was interrupted.
+    let didImmediateRun = false
+    function runFirstCallback(callback: () => void) {
+      didFirstTimerRun = true
+      setImmediate(() => {
+        didImmediateRun = true
+      })
+      return callback()
+    }
+
+    function runSubsequentCallback(callback: () => void) {
+      if (didImmediateRun) {
+        // If the immediate managed to run between the timers, then we're not
+        // able to provide the guarantees that we're supposed to
+        cannotGuaranteeAtomicTimers = true
+        warnAboutTimers()
+      }
+      return callback()
+    }
 
     return function scheduleTimeout(callback: () => void) {
-      const timer = setTimeout(callback, delayMs)
+      if (didFirstTimerRun) {
+        throw new InvariantError(
+          'Cannot schedule more timers into a group that already executed'
+        )
+      }
+
       if (cannotGuaranteeAtomicTimers) {
         // We already tried patching some timers, and it didn't work.
         // No point trying again.
-        return timer
+        return setTimeout(callback, delayMs)
       }
+
+      const timer = setTimeout(
+        firstTimerIdleStart === null ? runFirstCallback : runSubsequentCallback,
+        delayMs,
+        callback
+      )
 
       // NodeJS timers to have a `_idleStart` property, but it doesn't exist e.g. in Bun.
       // If it's not present, we'll warn and try to continue.
@@ -125,10 +164,8 @@ export function createAtomicTimerGroup(delayMs = 0) {
             timer._idleStart = firstTimerIdleStart
           }
         } else {
-          console.warn(
-            "Next.js cannot guarantee that Cache Components will run as expected due to the current runtime's implementation of `setTimeout()`.\nPlease report a github issue here: https://github.com/vercel/next.js/issues/new/"
-          )
           cannotGuaranteeAtomicTimers = true
+          warnAboutTimers()
         }
       } catch (err) {
         // This should never fail in current Node, but it might start failing in the future.

--- a/packages/next/src/server/app-render/app-render-scheduling.ts
+++ b/packages/next/src/server/app-render/app-render-scheduling.ts
@@ -1,0 +1,148 @@
+import { InvariantError } from '../../shared/lib/invariant-error'
+
+/*
+==========================
+| Background             |
+==========================
+
+Node.js does not guarantee that two timers scheduled back to back will run
+on the same iteration of the event loop:
+
+```ts
+setTimeout(one, 0)
+setTimeout(two, 0)
+```
+
+Internally, each timer is assigned a `_idleStart` property that holds
+an internal libuv timestamp in millisecond resolution.
+This will be used to determine if the timer is already "expired" and should be executed.
+However, even in sync code, it's possible for two timers to get different `_idleStart` values.
+This can cause one of the timers to be executed, and the other to be delayed until the next timer phase.
+
+The delaying happens [here](https://github.com/nodejs/node/blob/c208ffc66bb9418ff026c4e3fa82e5b4387bd147/lib/internal/timers.js#L556-L564).
+and can be debugged by running node with `NODE_DEBUG=timer`.
+
+The easiest way to observe it is to run this program in a loop until it exits with status 1:
+
+```
+// test.js
+
+let immediateRan = false
+const t1 = setTimeout(() => {
+  console.log('timeout 1')
+  setImmediate(() => {
+    console.log('immediate 1')
+    immediateRan = true
+  })
+})
+
+const t2 = setTimeout(() => {
+  console.log('timeout 2')
+  if (immediateRan) {
+    console.log('immediate ran before the second timeout!')
+    console.log(
+      `t1._idleStart: ${t1._idleStart}, t2_idleStart: ${t2._idleStart}`
+    );
+    process.exit(1)
+  }
+})
+```
+
+```bash
+#!/usr/bin/env bash
+
+i=1;
+while true; do
+  output="$(NODE_DEBUG=timer node test.js 2>&1)";
+  if [ "$?" -eq 1 ]; then
+    echo "failed after $i iterations";
+    echo "$output";
+    break;
+  fi;
+  i=$((i+1));
+done
+```
+
+If `t2` is deferred to the next iteration of the event loop,
+then the immediate scheduled from inside `t1` will run first.
+When this occurs, `_idleStart` is reliably different between `t1` and `t2`.
+
+==========================
+| Solution               |
+==========================
+
+We can guarantee that multiple timers (with the same delay, usually `0`)
+run together without any delays by making sure that their `_idleStart`s are the same,
+because that's what's used to determine if a timer should be deferred or not.
+Luckily, this is property is currently exposed to userland and mutable,
+so we can patch it.
+
+Another related trick we could potentially apply is making
+a timer immediately be considered expired by doing  `timer._idleStart -= 2`.
+(the value must be more `1`, the delay that actually gets set for `setTimeout(cb, 0)`).
+This makes node view this timer as "a 1ms timer scheduled 2ms ago",
+meaning that it should definitely run in the next timer phase.
+However, I'm not confident we know all the side effects of doing this,
+so for now, simply ensuring coordination is enough.
+*/
+
+let cannotGuaranteeAtomicTimers = false
+
+/**
+ * Allows scheduling multiple timers (equivalent to `setTimeout(cb, delayMs)`)
+ * that are guaranteed to run in the same iteration of the event loop.
+ *
+ * @param delayMs - the delay to pass to `setTimeout`. (default: 0)
+ *
+ * */
+export function createAtomicTimerGroup(delayMs = 0) {
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    throw new InvariantError(
+      'createAtomicTimerGroup cannot be called in the edge runtime'
+    )
+  } else {
+    let firstTimerIdleStart: number | null = null
+
+    return function scheduleTimeout(callback: () => void) {
+      const timer = setTimeout(callback, delayMs)
+      if (cannotGuaranteeAtomicTimers) {
+        // We already tried patching some timers, and it didn't work.
+        // No point trying again.
+        return timer
+      }
+
+      // NodeJS timers to have a `_idleStart` property, but it doesn't exist e.g. in Bun.
+      // If it's not present, we'll warn and try to continue.
+      try {
+        if ('_idleStart' in timer && typeof timer._idleStart === 'number') {
+          // If this is the first timer that was scheduled, save its `_idleStart`.
+          // We'll copy it onto subsequent timers to guarantee that they'll all be
+          // considered expired in the same iteration of the event loop
+          // and thus will all be executed in the same timer phase.
+          if (firstTimerIdleStart === null) {
+            firstTimerIdleStart = timer._idleStart
+          } else {
+            timer._idleStart = firstTimerIdleStart
+          }
+        } else {
+          console.warn(
+            "Next.js cannot guarantee that Cache Components will run as expected due to the current runtime's implementation of `setTimeout()`.\nPlease report a github issue here: https://github.com/vercel/next.js/issues/new/"
+          )
+          cannotGuaranteeAtomicTimers = true
+        }
+      } catch (err) {
+        // This should never fail in current Node, but it might start failing in the future.
+        // We might be okay even without tweaking the timers, so warn and try to continue.
+        console.error(
+          new InvariantError(
+            'An unexpected error occurred while adjusting `_idleStart` on an atomic timer',
+            { cause: err }
+          )
+        )
+        cannotGuaranteeAtomicTimers = true
+      }
+
+      return timer
+    }
+  }
+}

--- a/packages/next/src/server/app-render/app-render-scheduling.ts
+++ b/packages/next/src/server/app-render/app-render-scheduling.ts
@@ -86,7 +86,7 @@ However, I'm not confident we know all the side effects of doing this,
 so for now, simply ensuring coordination is enough.
 */
 
-let cannotGuaranteeAtomicTimers = false
+let shouldAttemptPatching = true
 
 function warnAboutTimers() {
   console.warn(
@@ -116,7 +116,7 @@ export function createAtomicTimerGroup(delayMs = 0) {
     let didImmediateRun = false
     function runFirstCallback(callback: () => void) {
       didFirstTimerRun = true
-      if (!cannotGuaranteeAtomicTimers) {
+      if (shouldAttemptPatching) {
         setImmediate(() => {
           didImmediateRun = true
         })
@@ -125,11 +125,11 @@ export function createAtomicTimerGroup(delayMs = 0) {
     }
 
     function runSubsequentCallback(callback: () => void) {
-      if (!cannotGuaranteeAtomicTimers) {
+      if (shouldAttemptPatching) {
         if (didImmediateRun) {
           // If the immediate managed to run between the timers, then we're not
           // able to provide the guarantees that we're supposed to
-          cannotGuaranteeAtomicTimers = true
+          shouldAttemptPatching = false
           warnAboutTimers()
         }
       }
@@ -150,7 +150,7 @@ export function createAtomicTimerGroup(delayMs = 0) {
       )
       isFirstCallback = false
 
-      if (cannotGuaranteeAtomicTimers) {
+      if (!shouldAttemptPatching) {
         // We already tried patching some timers, and it didn't work.
         // No point trying again.
         return timer
@@ -170,7 +170,7 @@ export function createAtomicTimerGroup(delayMs = 0) {
             timer._idleStart = firstTimerIdleStart
           }
         } else {
-          cannotGuaranteeAtomicTimers = true
+          shouldAttemptPatching = false
           warnAboutTimers()
         }
       } catch (err) {
@@ -182,7 +182,8 @@ export function createAtomicTimerGroup(delayMs = 0) {
             { cause: err }
           )
         )
-        cannotGuaranteeAtomicTimers = true
+        shouldAttemptPatching = false
+        warnAboutTimers()
       }
 
       return timer

--- a/packages/next/src/server/app-render/app-render-scheduling.ts
+++ b/packages/next/src/server/app-render/app-render-scheduling.ts
@@ -107,6 +107,7 @@ export function createAtomicTimerGroup(delayMs = 0) {
       'createAtomicTimerGroup cannot be called in the edge runtime'
     )
   } else {
+    let isFirstCallback = true
     let firstTimerIdleStart: number | null = null
     let didFirstTimerRun = false
 
@@ -115,18 +116,22 @@ export function createAtomicTimerGroup(delayMs = 0) {
     let didImmediateRun = false
     function runFirstCallback(callback: () => void) {
       didFirstTimerRun = true
-      setImmediate(() => {
-        didImmediateRun = true
-      })
+      if (!cannotGuaranteeAtomicTimers) {
+        setImmediate(() => {
+          didImmediateRun = true
+        })
+      }
       return callback()
     }
 
     function runSubsequentCallback(callback: () => void) {
-      if (didImmediateRun) {
-        // If the immediate managed to run between the timers, then we're not
-        // able to provide the guarantees that we're supposed to
-        cannotGuaranteeAtomicTimers = true
-        warnAboutTimers()
+      if (!cannotGuaranteeAtomicTimers) {
+        if (didImmediateRun) {
+          // If the immediate managed to run between the timers, then we're not
+          // able to provide the guarantees that we're supposed to
+          cannotGuaranteeAtomicTimers = true
+          warnAboutTimers()
+        }
       }
       return callback()
     }
@@ -138,17 +143,18 @@ export function createAtomicTimerGroup(delayMs = 0) {
         )
       }
 
-      if (cannotGuaranteeAtomicTimers) {
-        // We already tried patching some timers, and it didn't work.
-        // No point trying again.
-        return setTimeout(callback, delayMs)
-      }
-
       const timer = setTimeout(
-        firstTimerIdleStart === null ? runFirstCallback : runSubsequentCallback,
+        isFirstCallback ? runFirstCallback : runSubsequentCallback,
         delayMs,
         callback
       )
+      isFirstCallback = false
+
+      if (cannotGuaranteeAtomicTimers) {
+        // We already tried patching some timers, and it didn't work.
+        // No point trying again.
+        return timer
+      }
 
       // NodeJS timers to have a `_idleStart` property, but it doesn't exist e.g. in Bun.
       // If it's not present, we'll warn and try to continue.


### PR DESCRIPTION
This PR exploits some Node internals to make sure that, if we schedule some timeouts back to back to perform staged rendering, they'll actually run in the same iteration of the event loop.

If we cannot patch the timeouts correctly (due to runtime differences in e.g. Bun, or changes in future node versions), we'll warn that Cache Components may not function correctly, and run the timers normally. timer/immediate interleaving is rare in practice, and we'll usually be fine even without this patch, so it's better to warn and try to carry on rather than to error out.

(h/t to @sokra for finding this trick)