### PR TITLE
Un-skip tests in prefetch-runtime.test.ts

### DIFF
--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
@@ -2,6 +2,11 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
 export default async function Page() {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
@@ -2,6 +2,11 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
 export default async function Page() {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
@@ -2,6 +2,11 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
 export default async function Page() {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
@@ -2,6 +2,11 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
 export default async function Page() {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
@@ -2,6 +2,11 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
 export default async function Page() {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
@@ -3,6 +3,11 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { ErrorBoundary } from '../../../../components/error-boundary'
 
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
 export default async function Page() {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/page.tsx
@@ -8,50 +8,29 @@ export default async function Page() {
       <h2>thrown errors</h2>
       <ul>
         <li>
-          <DebugLinkAccordion
-            href="/errors/error-after-cookies"
-            prefetch={true}
-          />
+          <DebugLinkAccordion href="/errors/error-after-cookies" />
         </li>
       </ul>
 
       <h2>sync IO</h2>
       <ul>
         <li>
-          <DebugLinkAccordion
-            href="/errors/sync-io-after-runtime-api/cookies"
-            prefetch={true}
-          />
+          <DebugLinkAccordion href="/errors/sync-io-after-runtime-api/cookies" />
         </li>
         <li>
-          <DebugLinkAccordion
-            href="/errors/sync-io-after-runtime-api/headers"
-            prefetch={true}
-          />
+          <DebugLinkAccordion href="/errors/sync-io-after-runtime-api/headers" />
         </li>
         <li>
-          <DebugLinkAccordion
-            href="/errors/sync-io-after-runtime-api/dynamic-params/123"
-            prefetch={true}
-          />
+          <DebugLinkAccordion href="/errors/sync-io-after-runtime-api/dynamic-params/123" />
         </li>
         <li>
-          <DebugLinkAccordion
-            href="/errors/sync-io-after-runtime-api/search-params?foo=bar"
-            prefetch={true}
-          />
+          <DebugLinkAccordion href="/errors/sync-io-after-runtime-api/search-params?foo=bar" />
         </li>
         <li>
-          <DebugLinkAccordion
-            href="/errors/sync-io-after-runtime-api/private-cache"
-            prefetch={true}
-          />
+          <DebugLinkAccordion href="/errors/sync-io-after-runtime-api/private-cache" />
         </li>
         <li>
-          <DebugLinkAccordion
-            href="/errors/sync-io-after-runtime-api/quickly-expiring-public-cache"
-            prefetch={true}
-          />
+          <DebugLinkAccordion href="/errors/sync-io-after-runtime-api/quickly-expiring-public-cache" />
         </li>
       </ul>
     </main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
@@ -2,6 +2,11 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { DebugRenderKind } from '../../../../shared'
 
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
 export default async function Page() {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
@@ -4,6 +4,11 @@ import { workUnitAsyncStorage } from 'next/dist/server/app-render/work-unit-asyn
 
 type Params = { id: string }
 
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
 export default async function Page({ params }: { params: Promise<Params> }) {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
@@ -2,6 +2,11 @@ import { headers } from 'next/headers'
 import { Suspense } from 'react'
 import { DebugRenderKind } from '../../../../shared'
 
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
 export default async function Page() {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
@@ -1,6 +1,11 @@
 import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../../shared'
 
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
 export default async function Page() {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
@@ -2,6 +2,11 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../../shared'
 import { cacheLife } from 'next/cache'
 
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
 export default async function Page() {
   return (
     <main>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
@@ -3,6 +3,11 @@ import { DebugRenderKind } from '../../../../shared'
 
 type AnySearchParams = { [key: string]: string | string[] | undefined }
 
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
 export default async function Page({
   searchParams,
 }: {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/page.tsx
@@ -175,16 +175,7 @@ export default async function Page() {
           private, short stale
           <ul>
             <li>
-              <DebugLinkAccordion
-                href="/caches/private-short-stale"
-                prefetch={'auto'}
-              />
-            </li>
-            <li>
-              <DebugLinkAccordion
-                href="/caches/private-short-stale"
-                prefetch={true}
-              />
+              <DebugLinkAccordion href="/caches/private-short-stale" />
             </li>
           </ul>
         </li>
@@ -192,16 +183,7 @@ export default async function Page() {
           public, short expire, long enough stale
           <ul>
             <li>
-              <DebugLinkAccordion
-                href="/caches/public-short-expire-long-stale"
-                prefetch={'auto'}
-              />
-            </li>
-            <li>
-              <DebugLinkAccordion
-                href="/caches/public-short-expire-long-stale"
-                prefetch={true}
-              />
+              <DebugLinkAccordion href="/caches/public-short-expire-long-stale" />
             </li>
           </ul>
         </li>
@@ -209,16 +191,7 @@ export default async function Page() {
           public, short expire, short stale
           <ul>
             <li>
-              <DebugLinkAccordion
-                href="/caches/public-short-expire-short-stale"
-                prefetch={'auto'}
-              />
-            </li>
-            <li>
-              <DebugLinkAccordion
-                href="/caches/public-short-expire-short-stale"
-                prefetch={true}
-              />
+              <DebugLinkAccordion href="/caches/public-short-expire-short-stale" />
             </li>
           </ul>
         </li>
@@ -226,16 +199,7 @@ export default async function Page() {
           public, cacheLife("seconds")
           <ul>
             <li>
-              <DebugLinkAccordion
-                href="/caches/public-seconds"
-                prefetch={'auto'}
-              />
-            </li>
-            <li>
-              <DebugLinkAccordion
-                href="/caches/public-seconds"
-                prefetch={true}
-              />
+              <DebugLinkAccordion href="/caches/public-seconds" />
             </li>
           </ul>
         </li>
@@ -243,16 +207,7 @@ export default async function Page() {
           private, cacheLife("seconds")
           <ul>
             <li>
-              <DebugLinkAccordion
-                href="/caches/private-seconds"
-                prefetch={'auto'}
-              />
-            </li>
-            <li>
-              <DebugLinkAccordion
-                href="/caches/private-seconds"
-                prefetch={true}
-              />
+              <DebugLinkAccordion href="/caches/private-seconds" />
             </li>
           </ul>
         </li>

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/components/link-accordion.tsx
@@ -54,7 +54,7 @@ function getPrefetchKind(prefetch: LinkProps['prefetch']) {
     case 'auto':
       return 'auto'
     case true:
-      return 'full'
+      return 'true'
     default:
       prefetch satisfies never
   }


### PR DESCRIPTION
These were temporarily disabled when removed the Link level opt-in for runtime prefetching. I fixed the tests by switching to the file-based API.

prefetch-layout-sharing.test.ts still needs to be updated, in a similar way.