### PR TITLE
test: improve router prefetch test reliability

### DIFF
--- a/test/e2e/app-dir/interception-dynamic-segment/app/page.client.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/page.client.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({ href }: { href: string }) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div
+      data-testid="link-accordion"
+      data-href={href}
+      style={{
+        border: '1px solid #e5e7eb',
+        borderRadius: '12px',
+        padding: '16px',
+        margin: '12px 0',
+        backgroundColor: 'white',
+        boxShadow:
+          '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+        transition: 'all 0.2s ease',
+        cursor: 'pointer',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: '12px',
+        }}
+      >
+        <div
+          style={{
+            fontFamily: 'monospace',
+            fontSize: '14px',
+            color: '#374151',
+            fontWeight: '500',
+            flex: 1,
+          }}
+        >
+          {href}
+        </div>
+        {!isOpen && (
+          <button
+            onClick={() => setIsOpen(true)}
+            style={{
+              padding: '8px 16px',
+              borderRadius: '8px',
+              border: 'none',
+              backgroundColor: '#3b82f6',
+              color: 'white',
+              fontSize: '14px',
+              fontWeight: '600',
+              cursor: 'pointer',
+              transition: 'all 0.2s ease',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
+            }}
+          >
+            <span>▶</span>
+            Open
+          </button>
+        )}
+      </div>
+      {isOpen && (
+        <div
+          style={{
+            marginTop: '16px',
+            paddingTop: '16px',
+            borderTop: '1px solid #e5e7eb',
+          }}
+        >
+          <Link
+            href={href}
+            style={{
+              display: 'inline-block',
+              padding: '10px 20px',
+              backgroundColor: '#10b981',
+              color: 'white',
+              textDecoration: 'none',
+              borderRadius: '8px',
+              fontSize: '14px',
+              fontWeight: '600',
+            }}
+          >
+            Navigate to {href}
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/interception-dynamic-segment/app/page.tsx
+++ b/test/e2e/app-dir/interception-dynamic-segment/app/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link'
+import { LinkAccordion } from './page.client'
 
 export default function Page() {
   return (
@@ -8,9 +8,7 @@ export default function Page() {
 
         <div>
           <h3>Test Case 1a: Simple page (no parallel routes)</h3>
-          <Link href="/simple-page" style={{ color: 'blue', fontSize: '16px' }}>
-            → /simple-page
-          </Link>
+          <LinkAccordion href="/simple-page" />
           <p>
             Interception route with just a page.tsx, no parallel routes at all.
           </p>
@@ -18,7 +16,7 @@ export default function Page() {
 
         <div>
           <h3>Test Case 1b: Has page.tsx</h3>
-          <Link href="/has-page">→ /has-page</Link>
+          <LinkAccordion href="/has-page" />
           <p>
             Interception route has page.tsx at root level. No children slot
             exists.
@@ -27,15 +25,13 @@ export default function Page() {
 
         <div>
           <h3>Test Case 2: No parallel routes</h3>
-          <Link href="/no-parallel-routes/deeper">
-            → /no-parallel-routes/deeper
-          </Link>
+          <LinkAccordion href="/no-parallel-routes/deeper" />
           <p>No @parallel routes exist, so no implicit layout created.</p>
         </div>
 
         <div>
           <h3>Test Case 3: Has both @sidebar AND page.tsx</h3>
-          <Link href="/has-both">→ /has-both</Link>
+          <LinkAccordion href="/has-both" />
           <p>
             Has @sidebar parallel route BUT page.tsx fills the children slot.
           </p>
@@ -47,14 +43,14 @@ export default function Page() {
 
         <div>
           <h3>Test Case 4a: Has @sidebar but NO page.tsx (implicit layout)</h3>
-          <Link href="/test-nested">→ /test-nested</Link>
+          <LinkAccordion href="/test-nested" />
           <p>Has @sidebar (creates implicit layout) but NO page.tsx.</p>
           <p>✓ Auto-uses null default (no explicit files needed)</p>
         </div>
 
         <div>
           <h3>Test Case 4b: Has explicit layout.tsx but NO parallel routes</h3>
-          <Link href="/explicit-layout/deeper">→ /explicit-layout/deeper</Link>
+          <LinkAccordion href="/explicit-layout/deeper" />
           <p>
             Has explicit layout.tsx with children slot, but NO parallel routes
             like @sidebar.
@@ -69,18 +65,16 @@ export default function Page() {
         <h2>Original Tests</h2>
         <ul>
           <li>
-            <Link href="/foo/1">/foo/1</Link>
+            <LinkAccordion href="/foo/1" />
           </li>
           <li>
-            <Link href="/bar/1">/bar/1</Link>
+            <LinkAccordion href="/bar/1" />
           </li>
           <li>
-            <Link href="/test-nested/deeper">/test-nested/deeper</Link>
+            <LinkAccordion href="/test-nested/deeper" />
           </li>
           <li>
-            <Link href="/generate-static-params/foo">
-              /generate-static-params/foo
-            </Link>
+            <LinkAccordion href="/generate-static-params/foo" />
           </li>
         </ul>
       </section>


### PR DESCRIPTION
This updates the tests to use the accordion style link reveal technique to ensure that prefetches occur within the act and do not hang waiting for requests to be initiated.