### PR TITLE
fix: ENAMETOOLONG error by ETag handling in image optimizer #85978

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -125,9 +125,10 @@ export function extractEtag(
   imageBuffer: Buffer
 ) {
   if (etag) {
-    // upstream etag needs to be base64url encoded due to weak etag signature
-    // as we store this in the cache-entry file name.
-    return Buffer.from(etag).toString('base64url')
+    // Hash the upstream ETag to produce a short, filesystem-safe identifier.
+    // This preserves change detection while avoiding overly long or unsafe values
+    // in the cache-entry filename.
+    return getHash([etag])
   }
   return getImageEtag(imageBuffer)
 }


### PR DESCRIPTION
Replaced the base64url encoding of the upstream ETag with getHash function to create a short, filesystem-safe identifier.

### What & Why?

If the upstream server sends a very long ETag, the encoded string becomes very long. The full file path exceeded the OS filename length limit (~255 characters). Then Node throws, ENAMETOOLONG.

### How?

changed upstream ETag processing from: ```Buffer.from(etag).toString('base64url')``` to, ```getHash([etag])```. This transforms, the ETag string into one fixed-size SHA-256 hash.

Fixes #85978