### PR TITLE
[next-upgrade] Force install of dev dependencies

### DIFF
--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -121,11 +121,20 @@ export function runInstallation(
   options: { cwd: string }
 ) {
   try {
-    execa.sync(packageManager, ['install'], {
-      cwd: options.cwd,
-      stdio: 'inherit',
-      shell: true,
-    })
+    execa.sync(
+      packageManager,
+      [
+        'install',
+        // In case NODE_ENV=production is set, we still want dev dependencies to
+        // be installed. Otherwise we won't be able to check for peer dependencies.
+        '--production=false',
+      ],
+      {
+        cwd: options.cwd,
+        stdio: 'inherit',
+        shell: true,
+      }
+    )
   } catch (error) {
     throw new Error('Failed to install dependencies', { cause: error })
   }

--- a/packages/next-codemod/lib/handle-package.ts
+++ b/packages/next-codemod/lib/handle-package.ts
@@ -121,20 +121,18 @@ export function runInstallation(
   options: { cwd: string }
 ) {
   try {
-    execa.sync(
-      packageManager,
-      [
-        'install',
+    execa.sync(packageManager, ['install'], {
+      cwd: options.cwd,
+      env: {
+        ...process.env,
         // In case NODE_ENV=production is set, we still want dev dependencies to
         // be installed. Otherwise we won't be able to check for peer dependencies.
-        '--production=false',
-      ],
-      {
-        cwd: options.cwd,
-        stdio: 'inherit',
-        shell: true,
-      }
-    )
+        // --production=false is not implemented by every package manager.
+        NODE_ENV: 'development',
+      },
+      stdio: 'inherit',
+      shell: true,
+    })
   } catch (error) {
     throw new Error('Failed to install dependencies', { cause: error })
   }


### PR DESCRIPTION
When `NODE_ENV=production` is set, `install` will default to installing production dependencies. However, we need all dependencies to be present after we upgraded Next.js. `--production=false` is not implemented by every package manager (e.g. later Yarn versions)

`NODE_ENV=production` may be set from the parent process e.g. in the upcoming `next upgrade`.