### PR TITLE
[next-upgrade] Add `next upgrade`

### DIFF
--- a/docs/01-app/01-getting-started/18-upgrading.mdx
+++ b/docs/01-app/01-getting-started/18-upgrading.mdx
@@ -12,10 +12,16 @@ related:
 
 ## Latest version
 
-To update to the latest version of Next.js, you can use the `upgrade` codemod:
+To update to the latest version of Next.js, you can use the `upgrade` command:
 
 ```bash filename="Terminal"
-npx @next/codemod@latest upgrade latest
+next upgrade
+```
+
+Next.js 15 and earlier do not support the `upgrade` command and need to use a separate package instead:
+
+```bash filename="Terminal"
+npx @next/codemod@canary upgrade latest
 ```
 
 If you prefer to upgrade manually, install the latest Next.js and React versions:

--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -34,6 +34,7 @@ The following commands are available:
 | [`info`](#next-info-options)           | Prints relevant details about the current system which can be used to report Next.js bugs.                    |
 | [`telemetry`](#next-telemetry-options) | Allows you to enable or disable Next.js' completely anonymous telemetry collection.                           |
 | [`typegen`](#next-typegen-options)     | Generates TypeScript definitions for routes, pages, layouts, and route handlers without running a full build. |
+| [`upgrade`](#next-upgrade-options)     | Upgrades your Next.js application to the latest version.                                                      |
 
 > **Good to know**: Running `next` without a command is an alias for `next dev`.
 
@@ -185,6 +186,19 @@ The `next-env.d.ts` file is included into your `tsconfig.json` file, to make Nex
 To ensure `next-env.d.ts` is present before type-checking run `next typegen`. The commands `next dev` and `next build` also generate the `next-env.d.ts` file, but it is often undesirable to run these just to type-check, for example in CI/CD environments.
 
 > **Good to know**: `next typegen` loads your Next.js config (`next.config.js`, `next.config.mjs`, or `next.config.ts`) using the production build phase. Ensure any required environment variables and dependencies are available so the config can load correctly.
+
+## `next upgrade` options
+
+`next upgrade` upgrades your Next.js application to the latest version.
+
+The following options are available for the `next upgrade` command:
+
+| Option                  | Description                                                                                                                                        |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-h, --help`            | Show all available options.                                                                                                                        |
+| `[directory]`           | A directory with the Next.js application to upgrade. If not provided, the current directory will be used.                                          |
+| `--revision <revision>` | Specify a Next.js version or tag to upgrade to (e.g., `latest`, `canary`, `15.0.0`). Defaults to the release channel you have currently installed. |
+| `--verbose`             | Show verbose output during the upgrade process.                                                                                                    |
 
 ## Examples
 

--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -58,6 +58,8 @@ program
   .description(
     'Upgrade Next.js apps to desired versions with a single command.'
   )
+  // The CLI interface must be backwards compatible at all times so that older
+  // versions of Next.js can still run the codemod successfully.
   .argument(
     '[revision]',
     'Specify the target Next.js version using an NPM dist tag (e.g. "latest", "canary", "rc", "beta") or an exact version number (e.g. "15.0.0").',

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -411,6 +411,36 @@ program
   )
   .usage('[directory] [options]')
 
+const nextVersion = process.env.__NEXT_VERSION || 'unknown'
+program
+  .command('upgrade')
+  .description(
+    'Upgrade Next.js apps to desired versions with a single command.'
+  )
+  .argument(
+    '[directory]',
+    `A Next.js project directory to upgrade. ${italic(
+      'If no directory is provided, the current directory will be used.'
+    )}`
+  )
+  .usage('[directory] [options]')
+  .option(
+    '--revision <revision>',
+    'Specify the target Next.js version using an NPM dist tag (e.g. "latest", "canary", "rc", "beta") or an exact version number (e.g. "15.0.0").',
+    nextVersion.includes('-canary.')
+      ? 'canary'
+      : nextVersion.includes('-rc.')
+        ? 'rc'
+        : nextVersion.includes('-beta.')
+          ? 'beta'
+          : 'latest'
+  )
+  .option('--verbose', 'Verbose output', false)
+  .action(async (directory, options) => {
+    const mod = await import('../cli/next-upgrade.js')
+    mod.spawnNextUpgrade(directory, options)
+  })
+
 program
   .command('experimental-test')
   .description(

--- a/packages/next/src/cli/next-upgrade.ts
+++ b/packages/next/src/cli/next-upgrade.ts
@@ -32,7 +32,6 @@ export function spawnNextUpgrade(
     {
       stdio: 'inherit',
       cwd: baseDir,
-      shell: true,
     }
   )
 

--- a/packages/next/src/cli/next-upgrade.ts
+++ b/packages/next/src/cli/next-upgrade.ts
@@ -1,0 +1,42 @@
+import { spawn } from 'child_process'
+import { getProjectDir } from '../lib/get-project-dir'
+import { getNpxCommand } from '../lib/helpers/get-npx-command'
+
+interface NextUpgradeOptions {
+  revision: string
+  verbose: boolean
+}
+
+export function spawnNextUpgrade(
+  directory: string | undefined,
+  options: NextUpgradeOptions
+) {
+  const baseDir = getProjectDir(directory)
+  const [upgradeProcessCommand, ...upgradeProcessDefaultArgs] =
+    getNpxCommand(baseDir).split(' ')
+
+  const upgradeProcessCommandArgs = [
+    ...upgradeProcessDefaultArgs,
+    // Needs to be bleeding edge (canary) to pick up latest codemods.
+    '@next/codemod@canary',
+    'upgrade',
+    options.revision,
+  ]
+  if (options.verbose) {
+    upgradeProcessCommandArgs.push('--verbose')
+  }
+
+  const upgradeProcess = spawn(
+    upgradeProcessCommand,
+    upgradeProcessCommandArgs,
+    {
+      stdio: 'inherit',
+      cwd: baseDir,
+      shell: true,
+    }
+  )
+
+  upgradeProcess.on('close', (code) => {
+    process.exitCode = code ?? 0
+  })
+}

--- a/packages/next/src/lib/helpers/get-npx-command.ts
+++ b/packages/next/src/lib/helpers/get-npx-command.ts
@@ -3,13 +3,13 @@ import { getPkgManager } from './get-pkg-manager'
 
 export function getNpxCommand(baseDir: string) {
   const pkgManager = getPkgManager(baseDir)
-  let command = 'npx'
+  let command = 'npx --yes'
   if (pkgManager === 'pnpm') {
-    command = 'pnpm dlx'
+    command = 'pnpm --silent dlx'
   } else if (pkgManager === 'yarn') {
     try {
       execSync('yarn dlx --help', { stdio: 'ignore' })
-      command = 'yarn dlx'
+      command = 'yarn --quiet dlx'
     } catch {}
   }
 


### PR DESCRIPTION
This is just a convenience alias to `@next/codemod@canary upgrade` using the package manager you called `next upgrade` with e.g. `pnpm next upgrade` is just `pnpm --quiet dlx @next/codemod@canary upgrade latest`.

`@next/codemod@canary` will default to upgrading to Canary which is undesired. We do want people to use the Codemod canary though. We consider `@next/codemod@canary` as stable.

Closes https://linear.app/vercel/issue/NDX-420/

## test plan

`pnpm next upgrade /Users/sebbie/repos/vercel-packages/`

