### PR TITLE
[telemetry] Rename `experimental/cacheComponents` to `cacheComponents`

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2672,7 +2672,7 @@ export default async function build(
 
       const features: EventBuildFeatureUsage[] = [
         {
-          featureName: 'experimental/cacheComponents',
+          featureName: 'cacheComponents',
           invocationCount: config.cacheComponents ? 1 : 0,
         },
         {

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -193,7 +193,7 @@ export type EventBuildFeatureUsage = {
     | 'next/font/google'
     | 'next/font/local'
     | 'experimental/nextScriptWorkers'
-    | 'experimental/cacheComponents'
+    | 'cacheComponents'
     | 'experimental/optimizeCss'
     | 'experimental/ppr'
     | 'swcLoader'

--- a/test/integration/telemetry/next.config.cache-components
+++ b/test/integration/telemetry/next.config.cache-components
@@ -1,5 +1,3 @@
 module.exports = {
-  experimental: {
-    cacheComponents: true
-  }
+  cacheComponents: true
 }

--- a/test/integration/telemetry/test/config.test.ts
+++ b/test/integration/telemetry/test/config.test.ts
@@ -260,7 +260,7 @@ describe('config telemetry', () => {
         }
       )
 
-      it('emits telemetry for usage of `experimental/cacheComponents`', async () => {
+      it('emits telemetry for usage of `cacheComponents`', async () => {
         await fs.rename(
           path.join(appDir, 'next.config.cache-components'),
           path.join(appDir, 'next.config.js')
@@ -281,7 +281,7 @@ describe('config telemetry', () => {
           'NEXT_BUILD_FEATURE_USAGE'
         )
         expect(events).toContainEqual({
-          featureName: 'experimental/cacheComponents',
+          featureName: 'cacheComponents',
           invocationCount: 1,
         })
       })

--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -20701,7 +20701,7 @@
       "config telemetry production mode emits telemetry for middleware related options",
       "config telemetry production mode emits telemetry for transpilePackages",
       "config telemetry production mode emits telemetry for usage of @vercel/og",
-      "config telemetry production mode emits telemetry for usage of `experimental/cacheComponents`",
+      "config telemetry production mode emits telemetry for usage of `cacheComponents`",
       "config telemetry production mode emits telemetry for usage of `nextScriptWorkers`",
       "config telemetry production mode emits telemetry for usage of `optimizeCss`",
       "config telemetry production mode emits telemetry for usage of middleware",

--- a/test/rspack-dev-tests-manifest.json
+++ b/test/rspack-dev-tests-manifest.json
@@ -22938,7 +22938,7 @@
       "config telemetry production mode emits telemetry for middleware related options",
       "config telemetry production mode emits telemetry for transpilePackages",
       "config telemetry production mode emits telemetry for usage of @vercel/og",
-      "config telemetry production mode emits telemetry for usage of `experimental/cacheComponents`",
+      "config telemetry production mode emits telemetry for usage of `cacheComponents`",
       "config telemetry production mode emits telemetry for usage of `nextScriptWorkers`",
       "config telemetry production mode emits telemetry for usage of `optimizeCss`",
       "config telemetry production mode emits telemetry for usage of middleware",

--- a/test/turbopack-build-tests-manifest.json
+++ b/test/turbopack-build-tests-manifest.json
@@ -17694,7 +17694,7 @@
       "config telemetry production mode emits telemetry for lint during build when 'ignoreDuringBuilds' is specified",
       "config telemetry production mode emits telemetry for filesystem cache in build mode",
       "config telemetry production mode emits telemetry for filesystem cache in dev mode",
-      "config telemetry production mode emits telemetry for usage of `experimental/cacheComponents`",
+      "config telemetry production mode emits telemetry for usage of `cacheComponents`",
       "config telemetry production mode emits telemetry for usage of `nextScriptWorkers`",
       "config telemetry production mode emits telemetry for usage of `optimizeCss`",
       "config telemetry production mode emits telemetry for usage of middleware",

--- a/test/turbopack-dev-tests-manifest.json
+++ b/test/turbopack-dev-tests-manifest.json
@@ -21231,7 +21231,7 @@
       "config telemetry production mode emits telemetry for filesystem cache in dev mode",
       "config telemetry production mode emits telemetry for transpilePackages",
       "config telemetry production mode emits telemetry for usage of @vercel/og",
-      "config telemetry production mode emits telemetry for usage of `experimental/cacheComponents`",
+      "config telemetry production mode emits telemetry for usage of `cacheComponents`",
       "config telemetry production mode emits telemetry for usage of `nextScriptWorkers`",
       "config telemetry production mode emits telemetry for usage of `optimizeCss`",
       "config telemetry production mode emits telemetry for usage of middleware",


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/issues/85035

The feature is no longer experimental so we shouldn't log it. Queries would need adjustment.