### PR TITLE
[build] Remove `layers` experiment flag from next-runtime webpack config

### DIFF
--- a/packages/next/next-runtime.webpack-config.js
+++ b/packages/next/next-runtime.webpack-config.js
@@ -297,9 +297,6 @@ module.exports = ({ dev, turbo, bundleType, experimental, ...rest }) => {
       externalsMap,
       externalHandler,
     ],
-    experiments: {
-      layers: true,
-    },
     ...rest,
   }
 }


### PR DESCRIPTION
The `layers` feature is now enabled by default in Rspack.

<img width="1490" height="580" alt="layers-warning" src="https://github.com/user-attachments/assets/42fd6575-f0d3-4249-a6b2-6073bbd7935d" />
