### PR TITLE
Turbopack: scope hoisting bug with reexport-self-star

### DIFF
--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -416,7 +416,7 @@ impl SingleModuleGraph {
         // See https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm, but
         // implemented iteratively instead of recursively.
         //
-        // Compared to the stadnard Tarjan's, this also treated self-references (via
+        // Compared to the standard Tarjan's, this also treated self-references (via
         // `has_self_loop`) as SCCs.
 
         #[derive(Clone)]

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -413,14 +413,18 @@ impl SingleModuleGraph {
         graph_idx: u32,
         binding_usage: &'l Option<ReadRef<BindingUsageInfo>>,
     ) -> Result<()> {
-        // see https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
-        // but iteratively instead of recursively
+        // See https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm, but
+        // implemented iteratively instead of recursively.
+        //
+        // Compared to the stadnard Tarjan's, this also treated self-references (via
+        // `has_self_loop`) as SCCs.
 
         #[derive(Clone)]
         struct NodeState {
             index: u32,
             lowlink: u32,
             on_stack: bool,
+            has_self_loop: bool,
         }
         enum VisitStep {
             UnvisitedNode(NodeIndex),
@@ -445,6 +449,7 @@ impl SingleModuleGraph {
                             index,
                             lowlink: index,
                             on_stack: true,
+                            has_self_loop: false,
                         });
                         index += 1;
                         stack.push(node);
@@ -468,6 +473,9 @@ impl SingleModuleGraph {
                                     let index = node_state.index;
                                     let parent_state = node_states[node.index()].as_mut().unwrap();
                                     parent_state.lowlink = parent_state.lowlink.min(index);
+                                    if succ == node {
+                                        parent_state.has_self_loop = true;
+                                    }
                                 }
                             } else {
                                 visit_stack.push(VisitStep::EdgeAfterVisit {
@@ -487,6 +495,7 @@ impl SingleModuleGraph {
                     }
                     VisitStep::AfterVisit(node) => {
                         let node_state = node_states[node.index()].as_ref().unwrap();
+                        let node_has_self_loop = node_state.has_self_loop;
                         if node_state.lowlink == node_state.index {
                             loop {
                                 let poppped = stack.pop().unwrap();
@@ -501,7 +510,7 @@ impl SingleModuleGraph {
                                     break;
                                 }
                             }
-                            if scc.len() > 1 {
+                            if scc.len() > 1 || node_has_self_loop {
                                 visit_cycle(&scc)?;
                             }
                             scc.clear();
@@ -1341,6 +1350,7 @@ impl ModuleGraphRef {
 
     /// Traverse all cycles in the graph (where the edge filter returns true for the whole cycle)
     /// and call the visitor with the nodes in the cycle.
+    /// Notably, module self-references are also treated as cycles.
     pub fn traverse_cycles(
         &self,
         edge_filter: impl Fn(&RefData) -> bool,
@@ -1989,6 +1999,58 @@ pub mod tests {
                         (Some(rcstr!("c.js")), rcstr!("e.js")),
                     ],
                     visits
+                );
+
+                Ok(())
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_traverse_cycles() {
+        run_graph_test(
+            vec![rcstr!("a.js")],
+            {
+                let mut deps = FxHashMap::default();
+                // The cycles are: (i, j, k), and (s) which a self-import
+                //          a
+                //      /   |    \
+                //     /i   s-\   x
+                //     |j   \-/
+                //     \k
+                deps.insert(
+                    rcstr!("a.js"),
+                    vec![rcstr!("i.js"), rcstr!("s.js"), rcstr!("x.js")],
+                );
+                deps.insert(rcstr!("i.js"), vec![rcstr!("j.js")]);
+                deps.insert(rcstr!("j.js"), vec![rcstr!("k.js")]);
+                deps.insert(rcstr!("k.js"), vec![rcstr!("i.js")]);
+                deps.insert(rcstr!("s.js"), vec![rcstr!("s.js")]);
+                deps
+            },
+            |graph, _, module_to_name| {
+                let mut cycles = vec![];
+
+                graph.traverse_cycles(
+                    |_| true,
+                    |cycle| {
+                        cycles.push(
+                            cycle
+                                .iter()
+                                .map(|n| module_to_name.get(*n).unwrap().clone())
+                                .collect::<Vec<_>>(),
+                        );
+                        Ok(())
+                    },
+                )?;
+
+                assert_eq!(
+                    cycles,
+                    vec![
+                        vec![rcstr!("k.js"), rcstr!("j.js"), rcstr!("i.js")],
+                        vec![rcstr!("s.js")]
+                    ],
                 );
 
                 Ok(())

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -395,9 +395,10 @@ pub async fn compute_module_batches(
         module_graph.traverse_cycles(
             |ref_data| ref_data.chunking_type.is_parallel(),
             |cycle| {
-                if cycle
-                    .iter()
-                    .any(|node| pre_batches.boundary_modules.contains(node))
+                if cycle.len() > 1
+                    && cycle
+                        .iter()
+                        .any(|node| pre_batches.boundary_modules.contains(node))
                 {
                     pre_batches
                         .boundary_modules

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/self-reexport-star/input/data.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/self-reexport-star/input/data.js
@@ -1,0 +1,9 @@
+export function foo() {
+  return 'foo'
+}
+
+export function bar() {
+  return 'bar'
+}
+
+export * as Data from './data'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/self-reexport-star/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/self-reexport-star/input/index.js
@@ -1,0 +1,6 @@
+import { Data } from './data'
+
+it('should re-export own namespace correctly', () => {
+  expect(Data.foo()).toBe('foo')
+  expect(Data.bar()).toBe('bar')
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/self-reexport-star/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/self-reexport-star/options.json
@@ -1,0 +1,3 @@
+{
+  "scopeHoisting": true
+}


### PR DESCRIPTION
Closes PACK-5850
Closes https://github.com/vercel/next.js/issues/86132
Closes #86714

The problem was that you get this with scope hoisting:

```js
"index.js": () => {

// foo.js

// exports object read here
const self_import = turbopack_import("foo.js")

// exports object created here
__turbopack_esm__([...], "foo.js")

// index.js

....
}
```

without scope hoisting, that exports object is already initialized before the module factory runs
```js
"foo.js": () => { // exports initialized here

const self_import = turbopack_import("foo.js")


__turbopack_esm__([....]);
}
....
```

so let's fix it by making it hoist the `__turbopack_esm__` statement (just as we did before always) in the case of self-imports


---


This bug is actually very similar to https://github.com/vercel/next.js/pull/82827. It also executes `data.js` twice.

The problem is that if a module imports itself,
```js
"[project]/input/data.js [test] (ecmascript)", ((__turbopack_context__) => {
"use strict";

var __TURBOPACK__imported__module__$5b$project$2f$input$2f$data$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$locals$3e$__ = __turbopack_context__.i("[project]/input/data.js [test] (ecmascript) <locals>");
var __TURBOPACK__imported__module__$5b$project$2f$input$2f$data$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/input/data.js [test] (ecmascript)");
__turbopack_context__.s([
    "Data",
    0,
    __TURBOPACK__imported__module__$5b$project$2f$input$2f$data$2e$js__$5b$test$5d$__$28$ecmascript$29$__,
    "bar",
    ()=>__TURBOPACK__imported__module__$5b$project$2f$input$2f$data$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$locals$3e$__["bar"],
    "foo",
    ()=>__TURBOPACK__imported__module__$5b$project$2f$input$2f$data$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$locals$3e$__["foo"]
]);
}),
```
and with scope hoisting, the `import("id")` happens before the `esm_export(..., "id")`:
```js
module.exports = [
"[project]/index.js [test] (ecmascript)", ((__turbopack_context__) => {
"use strict";

// MERGED MODULE: [project]/index.js [test] (ecmascript)
;
// MERGED MODULE: [project]/data.js [test] (ecmascript) <locals>
;
function foo() {
    return 'foo';
}
function bar() {
    return 'bar';
}
;
__turbopack_context__.s([
    "bar",
    ()=>bar,
    "foo",
    ()=>foo
], "[project]/data.js [test] (ecmascript) <locals>");
// MERGED MODULE: [project]/data.js [test] (ecmascript) <export * as Data>
;
// MERGED MODULE: [project]/data.js [test] (ecmascript)
;
var __TURBOPACK__imported__module__$5b$project$2f$input$2f$data$2e$js__$5b$test$5d$__$28$ecmascript$29$__$3c$locals$3e$__ = __turbopack_context__.i("[project]/data.js [test] (ecmascript) <locals>");
var __TURBOPACK__imported__module__$5b$project$2f$input$2f$data$2e$js__$5b$test$5d$__$28$ecmascript$29$__ = __turbopack_context__.i("[project]/data.js [test] (ecmascript)");
__turbopack_context__.s([
    "Data",
    0,
    __TURBOPACK__imported__module__$5b$project$2f$input$2f$data$2e$js__$5b$test$5d$__$28$ecmascript$29$__,
    "bar",
    ()=>bar,
    "foo",
    ()=>foo
], "[project]/data.js [test] (ecmascript)");
```