### PR TITLE
Stop adding additional padding to Next.js logs

### DIFF
--- a/packages/next/src/build/output/log.ts
+++ b/packages/next/src/build/output/log.ts
@@ -35,18 +35,15 @@ function prefixedLog(prefixType: keyof typeof prefixes, ...message: any[]) {
     // Ensure if there's ANSI escape codes it's concatenated into one string.
     // Chrome DevTool can only handle color if it's in one string.
     if (message.length === 1 && typeof message[0] === 'string') {
-      console[consoleMethod](' ' + prefix + ' ' + message[0])
+      console[consoleMethod](prefix + ' ' + message[0])
     } else {
-      console[consoleMethod](' ' + prefix, ...message)
+      console[consoleMethod](prefix, ...message)
     }
   }
 }
 
-export function bootstrap(...message: string[]) {
-  // logging format: ' <prefix> <message>'
-  // e.g. ' ✓ Compiled successfully'
-  // Add spaces to align with the indent of other logs
-  console.log('   ' + message.join(' '))
+export function bootstrap(message: string) {
+  console.log(message)
 }
 
 export function wait(...message: any[]) {

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.test.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.test.ts
@@ -97,28 +97,28 @@ describe('writeConfigurationDefaults()', () => {
       expect(stripAnsi(consoleLogSpy.mock.calls.flat().join('\n')))
         .toMatchInlineSnapshot(`
        "
-          We detected TypeScript in your project and reconfigured your tsconfig.json file for you. Strict-mode is set to false by default.
-          The following suggested values were added to your tsconfig.json. These values can be changed to fit your project's needs:
+         We detected TypeScript in your project and reconfigured your tsconfig.json file for you. Strict-mode is set to false by default.
+         The following suggested values were added to your tsconfig.json. These values can be changed to fit your project's needs:
 
-          	- target was set to ES2017 (For top-level \`await\`. Note: Next.js only polyfills for the esmodules target.)
-          	- lib was set to dom,dom.iterable,esnext
-          	- allowJs was set to true
-          	- skipLibCheck was set to true
-          	- strict was set to false
-          	- noEmit was set to true
-          	- incremental was set to true
-          	- include was set to ['next-env.d.ts', '.next/types/**/*.ts', '.next/dev/types/**/*.ts', '**/*.mts', '**/*.ts', '**/*.tsx']
-          	- plugins was updated to add { name: 'next' }
-          	- exclude was set to ['node_modules']
+         	- target was set to ES2017 (For top-level \`await\`. Note: Next.js only polyfills for the esmodules target.)
+         	- lib was set to dom,dom.iterable,esnext
+         	- allowJs was set to true
+         	- skipLibCheck was set to true
+         	- strict was set to false
+         	- noEmit was set to true
+         	- incremental was set to true
+         	- include was set to ['next-env.d.ts', '.next/types/**/*.ts', '.next/dev/types/**/*.ts', '**/*.mts', '**/*.ts', '**/*.tsx']
+         	- plugins was updated to add { name: 'next' }
+         	- exclude was set to ['node_modules']
 
-          The following mandatory changes were made to your tsconfig.json:
+         The following mandatory changes were made to your tsconfig.json:
 
-          	- module was set to esnext (for dynamic import() support)
-          	- esModuleInterop was set to true (requirement for SWC / babel)
-          	- moduleResolution was set to node (to match webpack resolution)
-          	- resolveJsonModule was set to true (to match webpack resolution)
-          	- isolatedModules was set to true (requirement for SWC / Babel)
-          	- jsx was set to react-jsx (next.js uses the React automatic runtime)
+         	- module was set to esnext (for dynamic import() support)
+         	- esModuleInterop was set to true (requirement for SWC / babel)
+         	- moduleResolution was set to node (to match webpack resolution)
+         	- resolveJsonModule was set to true (to match webpack resolution)
+         	- isolatedModules was set to true (requirement for SWC / Babel)
+         	- jsx was set to react-jsx (next.js uses the React automatic runtime)
        "
       `)
     })

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -33,11 +33,11 @@ describe('middleware - development errors', () => {
       })
       expect(stripAnsi(next.cliOutput)).toContain(
         isTurbopack
-          ? '\n ⨯ Error: boom' +
+          ? '\n⨯ Error: boom' +
               // TODO(veil): Sourcemap to original name i.e. "default"
               '\n    at __TURBOPACK__default__export__ (middleware.js:3:15)' +
               '\n  1 |'
-          : '\n ⨯ Error: boom' +
+          : '\n⨯ Error: boom' +
               '\n    at default (middleware.js:3:15)' +
               '\n  1 |'
       )
@@ -129,12 +129,12 @@ describe('middleware - development errors', () => {
       })
       expect(stripAnsi(next.cliOutput)).toContain(
         isTurbopack
-          ? ' ⨯ unhandledRejection:  Error: async boom!' +
+          ? '⨯ unhandledRejection:  Error: async boom!' +
               '\n    at throwError (middleware.js:4:15)' +
               // TODO(veil): Sourcemap to original name i.e. "default"
               '\n    at __TURBOPACK__default__export__ (middleware.js:7:9)' +
               "\n  2 |       import { NextResponse } from 'next/server'"
-          : '\n ⨯ unhandledRejection:  Error: async boom!' +
+          : '\n⨯ unhandledRejection:  Error: async boom!' +
               '\n    at throwError (middleware.js:4:15)' +
               '\n    at default (middleware.js:7:9)' +
               "\n  2 |       import { NextResponse } from 'next/server'"
@@ -184,12 +184,12 @@ describe('middleware - development errors', () => {
       }
       expect(stripAnsi(next.cliOutput)).toContain(
         isTurbopack
-          ? '\n ⨯ Error [ReferenceError]: test is not defined' +
+          ? '\n⨯ Error [ReferenceError]: test is not defined' +
               '\n    at eval (middleware.js:4:9)' +
               '\n    at <unknown> (middleware.js:4:9)' +
               // TODO(veil): Should be sourcemapped
               '\n    at __TURBOPACK__default__export__ ('
-          : '\n ⨯ Error [ReferenceError]: test is not defined' +
+          : '\n⨯ Error [ReferenceError]: test is not defined' +
               // TODO(veil): Redundant and not clickable
               '\n    at eval (file://webpack-internal:///(middleware)/./middleware.js)' +
               '\n    at eval (middleware.js:4:9)' +
@@ -198,11 +198,11 @@ describe('middleware - development errors', () => {
       )
       expect(stripAnsi(next.cliOutput)).toContain(
         isTurbopack
-          ? "\n ⚠ DynamicCodeEvaluationWarning: Dynamic Code Evaluation (e. g. 'eval', 'new Function') not allowed in Edge Runtime" +
+          ? "\n⚠ DynamicCodeEvaluationWarning: Dynamic Code Evaluation (e. g. 'eval', 'new Function') not allowed in Edge Runtime" +
               '\nLearn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation' +
               // TODO(veil): Should be sourcemapped
               '\n    at __TURBOPACK__default__export__ ('
-          : "\n ⚠ DynamicCodeEvaluationWarning: Dynamic Code Evaluation (e. g. 'eval', 'new Function') not allowed in Edge Runtime" +
+          : "\n⚠ DynamicCodeEvaluationWarning: Dynamic Code Evaluation (e. g. 'eval', 'new Function') not allowed in Edge Runtime" +
               '\nLearn More: https://nextjs.org/docs/messages/edge-dynamic-code-evaluation' +
               '\n    at default (middleware.js:4:9)' +
               "\n  2 |       import { NextResponse } from 'next/server'"
@@ -294,10 +294,10 @@ describe('middleware - development errors', () => {
       })
       expect(stripAnsi(next.cliOutput)).toContain(
         isTurbopack
-          ? '\n ⨯ Error: booooom!' +
+          ? '\n⨯ Error: booooom!' +
               // TODO(veil): Should be sourcemapped
               '\n    at module evaluation (middleware.js:3:13)'
-          : '\n ⨯ Error: booooom!' +
+          : '\n⨯ Error: booooom!' +
               // TODO: Should be anonymous method without a method name
               '\n    at <unknown> (middleware.js:3)' +
               // TODO: Should be ignore-listed

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -4965,7 +4965,7 @@ describe('Cache Components Errors', () => {
                ],
              },
              {
-               "description": " ⨯ "unhandledRejection:" "BOOM"",
+               "description": "⨯ "unhandledRejection:" "BOOM"",
                "environmentLabel": "Prerender",
                "label": "Console Error",
                "source": null,
@@ -4974,7 +4974,7 @@ describe('Cache Components Errors', () => {
                ],
              },
              {
-               "description": " ⨯ "unhandledRejection: " "BOOM"",
+               "description": "⨯ "unhandledRejection: " "BOOM"",
                "environmentLabel": "Prerender",
                "label": "Console Error",
                "source": null,
@@ -4992,7 +4992,7 @@ describe('Cache Components Errors', () => {
                ],
              },
              {
-               "description": " ⨯ "unhandledRejection:" "BAM"",
+               "description": "⨯ "unhandledRejection:" "BAM"",
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": null,
@@ -5001,7 +5001,7 @@ describe('Cache Components Errors', () => {
                ],
              },
              {
-               "description": " ⨯ "unhandledRejection: " "BAM"",
+               "description": "⨯ "unhandledRejection: " "BAM"",
                "environmentLabel": "Server",
                "label": "Console Error",
                "source": null,

--- a/test/e2e/app-dir/server-source-maps/server-source-maps-edge.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps-edge.test.ts
@@ -57,7 +57,7 @@ describe('app-dir - server source maps edge runtime', () => {
 
       const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
       expect(cliOutput).toContain(
-        ' ⨯ Error: ssr-throw' +
+        '⨯ Error: ssr-throw' +
           '\n    at throwError (app/ssr-throw/page.js:4:9)' +
           '\n    at Page (app/ssr-throw/page.js:8:3)' +
           '\n  2 |' +
@@ -87,7 +87,7 @@ describe('app-dir - server source maps edge runtime', () => {
 
       const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
       expect(cliOutput).toContain(
-        ' ⨯ Error: rsc-throw' +
+        '⨯ Error: rsc-throw' +
           '\n    at throwError (app/rsc-throw/page.js:2:9)' +
           '\n    at Page (app/rsc-throw/page.js:6:3)' +
           '\n  1 | function throwError() {' +

--- a/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
+++ b/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
@@ -40,7 +40,7 @@ describe('fetch failures have good stack traces in edge runtime', () => {
             '\n  7 | }' +
             '\n  8 |' +
             // TODO(veil): Why double error?
-            '\n ⨯ Error [TypeError]: fetch failed'
+            '\n⨯ Error [TypeError]: fetch failed'
         )
 
         // Turbopack produces incorrect mappings in the sourcemap.

--- a/test/e2e/legacy-link-behavior/validations.console.test.ts
+++ b/test/e2e/legacy-link-behavior/validations.console.test.ts
@@ -105,7 +105,7 @@ describe('Validations for <Link legacyBehavior>', () => {
 
           expect(output).toMatchInlineSnapshot(`
            "Using a Server Component as a direct child of \`<Link legacyBehavior>\` is not supported. If you need legacyBehavior, wrap your Server Component in a Client Component that renders the Link's \`<a>\` tag.
-            ⨯ Error: \`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag."
+           ⨯ Error: \`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag."
           `)
         }
       })
@@ -175,7 +175,7 @@ describe('Validations for <Link legacyBehavior>', () => {
           })
           expect(output).toMatchInlineSnapshot(`
            "Using a Lazy Component as a direct child of \`<Link legacyBehavior>\` from a Server Component is not supported. If you need legacyBehavior, wrap your Lazy Component in a Client Component that renders the Link's \`<a>\` tag.
-            ⨯ Error: \`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag."
+           ⨯ Error: \`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag."
           `)
         }
       })
@@ -221,7 +221,7 @@ describe('Validations for <Link legacyBehavior>', () => {
           })
 
           expect(output).toMatchInlineSnapshot(
-            `" ⨯ Error: \`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag."`
+            `"⨯ Error: \`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag."`
           )
         }
       })
@@ -279,7 +279,7 @@ describe('Validations for <Link legacyBehavior>', () => {
         })
 
         expect(output).toMatchInlineSnapshot(
-          `" ⨯ Error: React.Children.only expected to receive a single React element child."`
+          `"⨯ Error: React.Children.only expected to receive a single React element child."`
         )
       }
     })
@@ -311,7 +311,7 @@ describe('Validations for <Link legacyBehavior>', () => {
         })
 
         expect(output).toMatchInlineSnapshot(
-          `" ⨯ Error: React.Children.only expected to receive a single React element child."`
+          `"⨯ Error: React.Children.only expected to receive a single React element child."`
         )
       }
     })
@@ -350,7 +350,7 @@ describe('Validations for <Link legacyBehavior>', () => {
         })
 
         expect(output).toMatchInlineSnapshot(
-          `" ⨯ Error: \`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag."`
+          `"⨯ Error: \`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag."`
         )
       }
     })

--- a/test/integration/config-experimental-warning/test/index.test.ts
+++ b/test/integration/config-experimental-warning/test/index.test.ts
@@ -16,7 +16,7 @@ const appDir = join(__dirname, '..')
 const configFile = new File(join(appDir, '/next.config.js'))
 const configFileMjs = new File(join(appDir, '/next.config.mjs'))
 
-const experimentalHeader = ' - Experiments (use with caution):'
+const experimentalHeader = '- Experiments (use with caution):'
 
 let app
 async function collectStdoutFromDev(appDir) {

--- a/test/integration/server-side-dev-errors/test/index.test.ts
+++ b/test/integration/server-side-dev-errors/test/index.test.ts
@@ -34,7 +34,7 @@ describe('server-side dev errors', () => {
         // All tests cause Runtime ReferenceErrors which may lead to this message which
         // is not relevant to this test.
         stderr = stderr.replace(
-          ' ⚠ Fast Refresh had to perform a full reload due to a Runtime ReferenceError.',
+          '⚠ Fast Refresh had to perform a full reload due to a Runtime ReferenceError.',
           ''
         )
       },
@@ -362,7 +362,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ unhandledRejection: Error: catch this rejection
+       ⨯ unhandledRejection: Error: catch this rejection
            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-rejection.js:7:20)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {
@@ -371,7 +371,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ unhandledRejection:  Error: catch this rejection
+       ⨯ unhandledRejection:  Error: catch this rejection
            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-rejection.js:7:20)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {
@@ -393,7 +393,7 @@ describe('server-side dev errors', () => {
            8 |   }, 10)
            9 |   return {
           10 |     props: {},
-         ⨯ unhandledRejection: Error: catch this rejection
+        ⨯ unhandledRejection: Error: catch this rejection
             at Timeout.eval [as _onTimeout] (../../test/integration/server-side-dev-errors/pages/uncaught-rejection.js:7:20)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
@@ -402,7 +402,7 @@ describe('server-side dev errors', () => {
            8 |   }, 10)
            9 |   return {
           10 |     props: {},
-         ⨯ unhandledRejection:  Error: catch this rejection
+        ⨯ unhandledRejection:  Error: catch this rejection
             at Timeout.eval [as _onTimeout] (../../test/integration/server-side-dev-errors/pages/uncaught-rejection.js:7:20)
            5 | export async function getServerSideProps() {
            6 |   setTimeout(() => {
@@ -441,7 +441,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ unhandledRejection: Error: 
+       ⨯ unhandledRejection: Error: 
            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-empty-rejection.js:7:20)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {
@@ -450,7 +450,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ unhandledRejection:  Error: 
+       ⨯ unhandledRejection:  Error: 
            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-empty-rejection.js:7:20)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {
@@ -471,7 +471,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ unhandledRejection: Error: 
+       ⨯ unhandledRejection: Error: 
            at Timeout.eval [as _onTimeout] (../../test/integration/server-side-dev-errors/pages/uncaught-empty-rejection.js:7:20)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {
@@ -480,7 +480,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ unhandledRejection:  Error: 
+       ⨯ unhandledRejection:  Error: 
            at Timeout.eval [as _onTimeout] (../../test/integration/server-side-dev-errors/pages/uncaught-empty-rejection.js:7:20)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {
@@ -519,7 +519,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ uncaughtException: Error: catch this exception
+       ⨯ uncaughtException: Error: catch this exception
            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-exception.js:7:11)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {
@@ -528,7 +528,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ uncaughtException:  Error: catch this exception
+       ⨯ uncaughtException:  Error: catch this exception
            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-exception.js:7:11)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {
@@ -549,7 +549,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ uncaughtException: Error: catch this exception
+       ⨯ uncaughtException: Error: catch this exception
            at Timeout.eval [as _onTimeout] (../../test/integration/server-side-dev-errors/pages/uncaught-exception.js:7:11)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {
@@ -558,7 +558,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ uncaughtException:  Error: catch this exception
+       ⨯ uncaughtException:  Error: catch this exception
            at Timeout.eval [as _onTimeout] (../../test/integration/server-side-dev-errors/pages/uncaught-exception.js:7:11)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {
@@ -597,7 +597,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ uncaughtException: Error: 
+       ⨯ uncaughtException: Error: 
            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-empty-exception.js:7:11)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {
@@ -606,7 +606,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ uncaughtException:  Error: 
+       ⨯ uncaughtException:  Error: 
            at Timeout._onTimeout (../../test/integration/server-side-dev-errors/pages/uncaught-empty-exception.js:7:11)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {
@@ -627,7 +627,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ uncaughtException: Error: 
+       ⨯ uncaughtException: Error: 
            at Timeout.eval [as _onTimeout] (../../test/integration/server-side-dev-errors/pages/uncaught-empty-exception.js:7:11)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {
@@ -636,7 +636,7 @@ describe('server-side dev errors', () => {
           8 |   }, 10)
           9 |   return {
          10 |     props: {},
-        ⨯ uncaughtException:  Error: 
+       ⨯ uncaughtException:  Error: 
            at Timeout.eval [as _onTimeout] (../../test/integration/server-side-dev-errors/pages/uncaught-empty-exception.js:7:11)
           5 | export async function getServerSideProps() {
           6 |   setTimeout(() => {

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -93,7 +93,7 @@ export class NextInstance {
   public forcedPort?: string
   public subDir: string = ''
   public startServerTimeout: number = 10_000 // 10 seconds
-  public serverReadyPattern: RegExp = / ✓ Ready in /
+  public serverReadyPattern: RegExp = /✓ Ready in /
   patchFileDelay: number = 0
 
   constructor(opts: NextInstanceOpts) {

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -21,28 +21,28 @@ describe('build-output-prerender', () => {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (Turbopack, Cache Components)
-                - Experiments (use with caution):
-                  ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
+             - Experiments (use with caution):
+               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (webpack, Cache Components)
-                - Experiments (use with caution):
-                  ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
+             - Experiments (use with caution):
+               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
             `)
           }
         } else if (pprEnabled) {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (Turbopack, Cache Components)
-                - Experiments (use with caution):
-                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+              - Experiments (use with caution):
+                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (webpack, Cache Components)
-                - Experiments (use with caution):
-                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+              - Experiments (use with caution):
+                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
             `)
           }
         } else {
@@ -108,73 +108,73 @@ describe('build-output-prerender', () => {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (Turbopack, Cache Components)
-                - Experiments (use with caution):
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
-                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
+             ▲ Next.js x.y.z (Turbopack, Cache Components)
+             - Experiments (use with caution):
+               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
+               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+               ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (webpack, Cache Components)
-                - Experiments (use with caution):
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
-                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
+             ▲ Next.js x.y.z (webpack, Cache Components)
+             - Experiments (use with caution):
+               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
+               ⨯ serverMinification (disabled by \`--debug-prerender\`)
+               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
           }
         } else if (pprEnabled) {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (Turbopack, Cache Components)
-                - Experiments (use with caution):
-                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
-                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
+             ▲ Next.js x.y.z (Turbopack, Cache Components)
+             - Experiments (use with caution):
+               ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+               ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (webpack, Cache Components)
-                - Experiments (use with caution):
-                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
+             ▲ Next.js x.y.z (webpack, Cache Components)
+             - Experiments (use with caution):
+               ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+               ⨯ serverMinification (disabled by \`--debug-prerender\`)
+               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
           }
         } else {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (Turbopack, Cache Components)
-                - Experiments (use with caution):
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
-                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
+             ▲ Next.js x.y.z (Turbopack, Cache Components)
+             - Experiments (use with caution):
+               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+               ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
             `)
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (Rspack, Cache Components)
-                - Experiments (use with caution):
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
+             ▲ Next.js x.y.z (Rspack, Cache Components)
+             - Experiments (use with caution):
+               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+               ⨯ serverMinification (disabled by \`--debug-prerender\`)
+               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (webpack, Cache Components)
-                - Experiments (use with caution):
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
+             ▲ Next.js x.y.z (webpack, Cache Components)
+             - Experiments (use with caution):
+               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+               ⨯ serverMinification (disabled by \`--debug-prerender\`)
+               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
           }
         }
@@ -255,28 +255,28 @@ describe('build-output-prerender', () => {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (Turbopack, Cache Components)
-                - Experiments (use with caution):
-                  ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
+             - Experiments (use with caution):
+               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (webpack, Cache Components)
-                - Experiments (use with caution):
-                  ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
+             - Experiments (use with caution):
+               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
             `)
           }
         } else if (pprEnabled) {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (Turbopack)
-                - Experiments (use with caution):
-                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+              - Experiments (use with caution):
+                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (webpack)
-                - Experiments (use with caution):
-                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+              - Experiments (use with caution):
+                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
             `)
           }
         } else {
@@ -311,73 +311,73 @@ describe('build-output-prerender', () => {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (Turbopack, Cache Components)
-                - Experiments (use with caution):
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
-                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
+             ▲ Next.js x.y.z (Turbopack, Cache Components)
+             - Experiments (use with caution):
+               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
+               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+               ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (webpack, Cache Components)
-                - Experiments (use with caution):
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
-                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
+             ▲ Next.js x.y.z (webpack, Cache Components)
+             - Experiments (use with caution):
+               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
+               ⨯ serverMinification (disabled by \`--debug-prerender\`)
+               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
           }
         } else if (pprEnabled) {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (Turbopack)
-                - Experiments (use with caution):
-                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
-                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
+              ▲ Next.js x.y.z (Turbopack)
+              - Experiments (use with caution):
+                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (webpack)
-                - Experiments (use with caution):
-                  ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
+              ▲ Next.js x.y.z (webpack)
+              - Experiments (use with caution):
+                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                ⨯ serverMinification (disabled by \`--debug-prerender\`)
+                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
           }
         } else {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (Turbopack)
-                - Experiments (use with caution):
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
-                  ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
+             ▲ Next.js x.y.z (Turbopack)
+             - Experiments (use with caution):
+               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+               ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
             `)
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (Rspack)
-                - Experiments (use with caution):
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
+              ▲ Next.js x.y.z (Rspack)
+              - Experiments (use with caution):
+                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                ⨯ serverMinification (disabled by \`--debug-prerender\`)
+                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-                ▲ Next.js x.y.z (webpack)
-                - Experiments (use with caution):
-                  ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                  ⨯ serverMinification (disabled by \`--debug-prerender\`)
-                  ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
+             ▲ Next.js x.y.z (webpack)
+             - Experiments (use with caution):
+               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+               ⨯ serverMinification (disabled by \`--debug-prerender\`)
+               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
           }
         }

--- a/test/unit/warn-removed-experimental-config.test.ts
+++ b/test/unit/warn-removed-experimental-config.test.ts
@@ -53,7 +53,7 @@ describe('warnOptionHasBeenMovedOutOfExperimental', () => {
 
     expect(spy).toHaveBeenCalledWith(
       expect.stringContaining(
-        ' ⚠ `experimental.skipTrailingSlashRedirect` has been moved to `skipTrailingSlashRedirect`. Please update your next.config.js file accordingly.'
+        '⚠ `experimental.skipTrailingSlashRedirect` has been moved to `skipTrailingSlashRedirect`. Please update your next.config.js file accordingly.'
       )
     )
   })
@@ -73,7 +73,7 @@ describe('warnOptionHasBeenMovedOutOfExperimental', () => {
 
     expect(spy).toHaveBeenCalledWith(
       expect.stringContaining(
-        ' ⚠ `experimental.relay` has been moved to `compiler.relay`. Please update your next.config.js file accordingly.'
+        '⚠ `experimental.relay` has been moved to `compiler.relay`. Please update your next.config.js file accordingly.'
       )
     )
   })
@@ -131,7 +131,7 @@ describe('warnOptionHasBeenMovedOutOfExperimental', () => {
 
     expect(spy).toHaveBeenCalledWith(
       expect.stringContaining(
-        ' ⚠ `experimental.bundlePagesExternals` has been moved to `bundlePagesRouterDependencies`. Please update your next.config.js file accordingly.'
+        '⚠ `experimental.bundlePagesExternals` has been moved to `bundlePagesRouterDependencies`. Please update your next.config.js file accordingly.'
       )
     )
   })


### PR DESCRIPTION
:aligned:

Before
```
   ▲ Next.js 16.0.2-canary.14 (Turbopack, Cache Components)
   - Local:         http://localhost:3000/
   - Network:       http://192.168.178.36:3000/
   - Debugger port: 9229
   - Environments: .env.local
   - Experiments (use with caution):
     ✓ reactDebugChannel
     ✓ taint

 ✓ Starting...
 ✓ Ready in 355ms
some message from console.log
```

After
```
▲ Next.js 16.0.2-canary.14 (Turbopack, Cache Components)
- Local:         http://localhost:3000/
- Network:       http://192.168.178.36:3000/
- Debugger port: 9229
- Environments: .env.local
- Experiments (use with caution):
  ✓ reactDebugChannel
  ✓ taint

✓ Starting...
✓ Ready in 355ms
some message from console.log
```