### PR TITLE
docs: Update manifest page to add more details

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/manifest.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/manifest.mdx
@@ -21,7 +21,7 @@ Add or generate a `manifest.(json|webmanifest)` file that matches the [Web Manif
 
 Add a `manifest.js` or `manifest.ts` file that returns a [`Manifest` object](#manifest-object).
 
-> Good to know: `manifest.js` is a special Route Handler that is cached by default unless it uses a [Dynamic API](/docs/app/guides/caching#dynamic-apis) or [dynamic config](/docs/app/guides/caching#segment-config-options) option. The final file name will be `manifest.webmanifest`.
+> Good to know: `manifest.js` is a special Route Handler that is cached by default unless it uses a [Dynamic API](/docs/app/guides/caching#dynamic-apis) or [dynamic config](/docs/app/guides/caching#segment-config-options) option. The manifest link tag is automatically injected in the HTML. Dynamic files are served as `/manifest.webmanifest` while static files keep their original names.
 
 ```ts filename="app/layout.tsx"
 ...

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/manifest.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/manifest.mdx
@@ -21,7 +21,7 @@ Add or generate a `manifest.(json|webmanifest)` file that matches the [Web Manif
 
 Add a `manifest.js` or `manifest.ts` file that returns a [`Manifest` object](#manifest-object).
 
-> Good to know: `manifest.js` is special Route Handlers that is cached by default unless it uses a [Dynamic API](/docs/app/guides/caching#dynamic-apis) or [dynamic config](/docs/app/guides/caching#segment-config-options) option. The final file name will be `manifest.webmanifest`.
+> Good to know: `manifest.js` is a special Route Handler that is cached by default unless it uses a [Dynamic API](/docs/app/guides/caching#dynamic-apis) or [dynamic config](/docs/app/guides/caching#segment-config-options) option. The final file name will be `manifest.webmanifest`.
 
 ```ts filename="app/layout.tsx"
 ...

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/manifest.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/manifest.mdx
@@ -21,7 +21,17 @@ Add or generate a `manifest.(json|webmanifest)` file that matches the [Web Manif
 
 Add a `manifest.js` or `manifest.ts` file that returns a [`Manifest` object](#manifest-object).
 
-> Good to know: `manifest.js` is special Route Handlers that is cached by default unless it uses a [Dynamic API](/docs/app/guides/caching#dynamic-apis) or [dynamic config](/docs/app/guides/caching#segment-config-options) option.
+> Good to know: `manifest.js` is special Route Handlers that is cached by default unless it uses a [Dynamic API](/docs/app/guides/caching#dynamic-apis) or [dynamic config](/docs/app/guides/caching#segment-config-options) option. The final file name will be `manifest.webmanifest`.
+
+```ts filename="app/layout.tsx"
+...
+  <head>
+    ...
+    <link rel="manifest" href="/manifest.webmanifest" />
+  </head>
+...
+
+```
 
 ```ts filename="app/manifest.ts" switcher
 import type { MetadataRoute } from 'next'


### PR DESCRIPTION
Current version of this page does not explain how to add it into HTML and dynamic manifest file name is missing, for example I had to run `npm run build` to see the final file name of this dynamic manifest