### PR TITLE
Fix telemetry event race condition in webpack worker for @vercel/og detection

### DIFF
--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -414,5 +414,7 @@ export async function workerMain(workerData: {
     result.buildTraceContext!.chunksTrace!.entryNameFilesMap = entryNameFilesMap
   }
   NextBuildContext.nextBuildSpan.stop()
+  await telemetry.flush()
+
   return { ...result, debugTraceEvents: getTraceEvents() }
 }

--- a/test/integration/telemetry/test/config.test.ts
+++ b/test/integration/telemetry/test/config.test.ts
@@ -441,6 +441,7 @@ describe('config telemetry', () => {
       ;(process.env.IS_TURBOPACK_TEST ? it.skip : it)(
         'emits telemetry for usage of @vercel/og',
         async () => {
+          // Test vercelImageGeneration telemetry tracking
           const { stderr } = await nextBuild(appDir, [], {
             stderr: true,
             env: { NEXT_TELEMETRY_DEBUG: '1' },


### PR DESCRIPTION
Follow up to https://github.com/vercel/next.js/pull/85867

The webpack build uses separate worker processes for edge server compilation. The worker creates its own telemetry instance and the MiddlewarePlugin records `vercelImageGeneration` events to it during the `finishModules` hook.

When `NEXT_TELEMETRY_DEBUG=1`, telemetry logging uses `setTimeout(100ms)` before calling `console.error()` to ensure output is captured. However, the worker was returning immediately after recording telemetry without waiting for the setTimeout to fire. The parent process then terminates the worker, canceling the pending setTimeout and losing the telemetry events.

This adds `await telemetry.flush()` before the worker returns to ensure all queued telemetry promises (including their setTimeout delays) complete before the worker exits. This ensures telemetry is logged to stderr before the worker terminates.

Fixes flaky `test/integration/telemetry/test/config.test.ts` failure for @vercel/og detection.
