### PR TITLE
Fix streaming server actions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -730,12 +730,13 @@ export async function handleAction({
                 // Only warn if it's a server action, otherwise skip for other post requests
                 warnBadServerActionRequest()
 
-                const actionReturnedState =
+                const { returnVal: actionReturnedState } =
                   await executeActionAndPrepareForRender(
                     action as () => Promise<unknown>,
                     [],
                     workStore,
-                    requestStore
+                    requestStore,
+                    actionWasForwarded
                   )
 
                 const formState = await decodeFormState(
@@ -924,12 +925,13 @@ export async function handleAction({
                 // Only warn if it's a server action, otherwise skip for other post requests
                 warnBadServerActionRequest()
 
-                const actionReturnedState =
+                const { returnVal: actionReturnedState } =
                   await executeActionAndPrepareForRender(
                     action as () => Promise<unknown>,
                     [],
                     workStore,
-                    requestStore
+                    requestStore,
+                    actionWasForwarded
                   )
 
                 const formState = await decodeFormState(
@@ -1023,20 +1025,16 @@ export async function handleAction({
             actionId!
           ]
 
-        // If the page was not revalidated, or if the action was forwarded from
-        // another worker, we can skip rendering the page.
-        const skipPageRendering =
-          !workStore.pathWasRevalidated || actionWasForwarded
-
-        const returnVal = await executeActionAndPrepareForRender(
-          actionHandler,
-          boundActionArguments,
-          workStore,
-          requestStore,
-          skipPageRendering
-        ).finally(() => {
-          addRevalidationHeader(res, { workStore, requestStore })
-        })
+        const { returnVal, skipPageRendering } =
+          await executeActionAndPrepareForRender(
+            actionHandler,
+            boundActionArguments,
+            workStore,
+            requestStore,
+            actionWasForwarded
+          ).finally(() => {
+            addRevalidationHeader(res, { workStore, requestStore })
+          })
 
         // For form actions, we need to continue rendering the page.
         if (isFetchAction) {
@@ -1170,13 +1168,24 @@ async function executeActionAndPrepareForRender<
   args: Parameters<TFn>,
   workStore: WorkStore,
   requestStore: RequestStore,
-  skipPageRendering: boolean = false
-): Promise<Awaited<ReturnType<TFn>>> {
+  actionWasForwarded: boolean
+): Promise<{
+  returnVal: Awaited<ReturnType<TFn>>
+  skipPageRendering: boolean
+}> {
   requestStore.phase = 'action'
+  let skipPageRendering = actionWasForwarded
+
   try {
-    return await workUnitAsyncStorage.run(requestStore, () =>
+    const returnVal = await workUnitAsyncStorage.run(requestStore, () =>
       action.apply(null, args)
     )
+
+    // If the page was not revalidated, or if the action was forwarded from
+    // another worker, we can skip rendering the page.
+    skipPageRendering ||= !workStore.pathWasRevalidated
+
+    return { returnVal, skipPageRendering }
   } finally {
     if (!skipPageRendering) {
       requestStore.phase = 'render'

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -617,8 +617,9 @@ export async function handleAction({
           type: 'done',
           result: await generateFlight(req, ctx, requestStore, {
             actionResult: promise,
-            // We didn't execute an action, so no revalidations could have occurred. We can skip rendering the page.
-            skipFlight: true,
+            // We didn't execute an action, so no revalidations could have
+            // occurred. We can skip rendering the page.
+            skipPageRendering: true,
             temporaryReferences,
           }),
         }
@@ -1022,11 +1023,17 @@ export async function handleAction({
             actionId!
           ]
 
+        // If the page was not revalidated, or if the action was forwarded from
+        // another worker, we can skip rendering the page.
+        const skipPageRendering =
+          !workStore.pathWasRevalidated || actionWasForwarded
+
         const returnVal = await executeActionAndPrepareForRender(
           actionHandler,
           boundActionArguments,
           workStore,
-          requestStore
+          requestStore,
+          skipPageRendering
         ).finally(() => {
           addRevalidationHeader(res, { workStore, requestStore })
         })
@@ -1035,9 +1042,14 @@ export async function handleAction({
         if (isFetchAction) {
           const actionResult = await generateFlight(req, ctx, requestStore, {
             actionResult: Promise.resolve(returnVal),
-            // if the page was not revalidated, or if the action was forwarded from another worker, we can skip the rendering the flight tree
-            skipFlight: !workStore.pathWasRevalidated || actionWasForwarded,
+            skipPageRendering,
             temporaryReferences,
+            // If we skip page rendering, we need to ensure pending revalidates
+            // are awaited before closing the response. Otherwise, this will be
+            // done after rendering the page.
+            waitUntil: skipPageRendering
+              ? executeRevalidates(workStore)
+              : undefined,
           })
 
           return {
@@ -1101,7 +1113,7 @@ export async function handleAction({
         return {
           type: 'done',
           result: await generateFlight(req, ctx, requestStore, {
-            skipFlight: false,
+            skipPageRendering: false,
             actionResult: promise,
             temporaryReferences,
           }),
@@ -1139,7 +1151,8 @@ export async function handleAction({
         result: await generateFlight(req, ctx, requestStore, {
           actionResult: promise,
           // if the page was not revalidated, or if the action was forwarded from another worker, we can skip the rendering the flight tree
-          skipFlight: !workStore.pathWasRevalidated || actionWasForwarded,
+          skipPageRendering:
+            !workStore.pathWasRevalidated || actionWasForwarded,
           temporaryReferences,
         }),
       }
@@ -1156,7 +1169,8 @@ async function executeActionAndPrepareForRender<
   action: TFn,
   args: Parameters<TFn>,
   workStore: WorkStore,
-  requestStore: RequestStore
+  requestStore: RequestStore,
+  skipPageRendering: boolean = false
 ): Promise<Awaited<ReturnType<TFn>>> {
   requestStore.phase = 'action'
   try {
@@ -1164,21 +1178,25 @@ async function executeActionAndPrepareForRender<
       action.apply(null, args)
     )
   } finally {
-    requestStore.phase = 'render'
+    if (!skipPageRendering) {
+      requestStore.phase = 'render'
 
-    // When we switch to the render phase, cookies() will return
-    // `workUnitStore.cookies` instead of `workUnitStore.userspaceMutableCookies`.
-    // We want the render to see any cookie writes that we performed during the action,
-    // so we need to update the immutable cookies to reflect the changes.
-    synchronizeMutableCookies(requestStore)
+      // When we switch to the render phase, cookies() will return
+      // `workUnitStore.cookies` instead of
+      // `workUnitStore.userspaceMutableCookies`. We want the render to see any
+      // cookie writes that we performed during the action, so we need to update
+      // the immutable cookies to reflect the changes.
+      synchronizeMutableCookies(requestStore)
 
-    // The server action might have toggled draft mode, so we need to reflect
-    // that in the work store to be up-to-date for subsequent rendering.
-    workStore.isDraftMode = requestStore.draftMode.isEnabled
+      // The server action might have toggled draft mode, so we need to reflect
+      // that in the work store to be up-to-date for subsequent rendering.
+      workStore.isDraftMode = requestStore.draftMode.isEnabled
 
-    // If the action called revalidateTag/revalidatePath, then that might affect data used by the subsequent render,
-    // so we need to make sure all revalidations are applied before that
-    await executeRevalidates(workStore)
+      // If the action called revalidateTag/revalidatePath, then that might
+      // affect data used by the subsequent render, so we need to make sure all
+      // revalidations are applied before that
+      await executeRevalidates(workStore)
+    }
   }
 }
 

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -1200,7 +1200,7 @@ async function executeActionAndPrepareForRender<
 
       // If the action called revalidateTag/revalidatePath, then that might
       // affect data used by the subsequent render, so we need to make sure all
-      // revalidations are applied before that
+      // revalidations are applied before that.
       await executeRevalidates(workStore)
     }
   }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -730,17 +730,16 @@ export async function handleAction({
                 // Only warn if it's a server action, otherwise skip for other post requests
                 warnBadServerActionRequest()
 
-                const { returnVal: actionReturnedState } =
-                  await executeActionAndPrepareForRender(
-                    action as () => Promise<unknown>,
-                    [],
-                    workStore,
-                    requestStore,
-                    actionWasForwarded
-                  )
+                const { actionResult } = await executeActionAndPrepareForRender(
+                  action as () => Promise<unknown>,
+                  [],
+                  workStore,
+                  requestStore,
+                  actionWasForwarded
+                )
 
                 const formState = await decodeFormState(
-                  actionReturnedState,
+                  actionResult,
                   formData,
                   serverModuleMap
                 )
@@ -925,17 +924,16 @@ export async function handleAction({
                 // Only warn if it's a server action, otherwise skip for other post requests
                 warnBadServerActionRequest()
 
-                const { returnVal: actionReturnedState } =
-                  await executeActionAndPrepareForRender(
-                    action as () => Promise<unknown>,
-                    [],
-                    workStore,
-                    requestStore,
-                    actionWasForwarded
-                  )
+                const { actionResult } = await executeActionAndPrepareForRender(
+                  action as () => Promise<unknown>,
+                  [],
+                  workStore,
+                  requestStore,
+                  actionWasForwarded
+                )
 
                 const formState = await decodeFormState(
-                  actionReturnedState,
+                  actionResult,
                   formData,
                   serverModuleMap
                 )
@@ -1025,7 +1023,7 @@ export async function handleAction({
             actionId!
           ]
 
-        const { returnVal, skipPageRendering } =
+        const { actionResult, skipPageRendering } =
           await executeActionAndPrepareForRender(
             actionHandler,
             boundActionArguments,
@@ -1038,21 +1036,19 @@ export async function handleAction({
 
         // For form actions, we need to continue rendering the page.
         if (isFetchAction) {
-          const actionResult = await generateFlight(req, ctx, requestStore, {
-            actionResult: Promise.resolve(returnVal),
-            skipPageRendering,
-            temporaryReferences,
-            // If we skip page rendering, we need to ensure pending revalidates
-            // are awaited before closing the response. Otherwise, this will be
-            // done after rendering the page.
-            waitUntil: skipPageRendering
-              ? executeRevalidates(workStore)
-              : undefined,
-          })
-
           return {
             type: 'done',
-            result: actionResult,
+            result: await generateFlight(req, ctx, requestStore, {
+              actionResult: Promise.resolve(actionResult),
+              skipPageRendering,
+              temporaryReferences,
+              // If we skip page rendering, we need to ensure pending
+              // revalidates are awaited before closing the response. Otherwise,
+              // this will be done after rendering the page.
+              waitUntil: skipPageRendering
+                ? executeRevalidates(workStore)
+                : undefined,
+            }),
           }
         } else {
           // TODO: this shouldn't be reachable, because all non-fetch codepaths return early.
@@ -1148,7 +1144,8 @@ export async function handleAction({
         type: 'done',
         result: await generateFlight(req, ctx, requestStore, {
           actionResult: promise,
-          // if the page was not revalidated, or if the action was forwarded from another worker, we can skip the rendering the flight tree
+          // If the page was not revalidated, or if the action was forwarded
+          // from another worker, we can skip rendering the page.
           skipPageRendering:
             !workStore.pathWasRevalidated || actionWasForwarded,
           temporaryReferences,
@@ -1170,14 +1167,14 @@ async function executeActionAndPrepareForRender<
   requestStore: RequestStore,
   actionWasForwarded: boolean
 ): Promise<{
-  returnVal: Awaited<ReturnType<TFn>>
+  actionResult: Awaited<ReturnType<TFn>>
   skipPageRendering: boolean
 }> {
   requestStore.phase = 'action'
   let skipPageRendering = actionWasForwarded
 
   try {
-    const returnVal = await workUnitAsyncStorage.run(requestStore, () =>
+    const actionResult = await workUnitAsyncStorage.run(requestStore, () =>
       action.apply(null, args)
     )
 
@@ -1185,7 +1182,7 @@ async function executeActionAndPrepareForRender<
     // another worker, we can skip rendering the page.
     skipPageRendering ||= !workStore.pathWasRevalidated
 
-    return { returnVal, skipPageRendering }
+    return { actionResult, skipPageRendering }
   } finally {
     if (!skipPageRendering) {
       requestStore.phase = 'render'

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -453,7 +453,7 @@ async function generateDynamicRSCPayload(
   ctx: AppRenderContext,
   options?: {
     actionResult?: ActionResult
-    skipFlight?: boolean
+    skipPageRendering?: boolean
     runtimePrefetchSentinel?: number
   }
 ): Promise<RSCPayload> {
@@ -485,7 +485,7 @@ async function generateDynamicRSCPayload(
 
   const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
 
-  if (!options?.skipFlight) {
+  if (!options?.skipPageRendering) {
     const preloadCallbacks: PreloadCallbacks = []
 
     const { Viewport, Metadata, MetadataOutlet } = createMetadataComponents({
@@ -588,10 +588,11 @@ async function generateDynamicFlightRenderResult(
   requestStore: RequestStore,
   options?: {
     actionResult: ActionResult
-    skipFlight: boolean
+    skipPageRendering: boolean
     componentTree?: CacheNodeSeedData
     preloadCallbacks?: PreloadCallbacks
     temporaryReferences?: WeakMap<any, string>
+    waitUntil?: Promise<unknown>
   }
 ): Promise<RenderResult> {
   const {
@@ -649,9 +650,11 @@ async function generateDynamicFlightRenderResult(
     }
   )
 
-  return new FlightRenderResult(flightReadableStream, {
-    fetchMetrics: workStore.fetchMetrics,
-  })
+  return new FlightRenderResult(
+    flightReadableStream,
+    { fetchMetrics: workStore.fetchMetrics },
+    options?.waitUntil
+  )
 }
 
 type RenderToReadableStreamServerOptions = NonNullable<

--- a/packages/next/src/server/app-render/flight-render-result.ts
+++ b/packages/next/src/server/app-render/flight-render-result.ts
@@ -7,8 +7,13 @@ import RenderResult, { type RenderResultMetadata } from '../render-result'
 export class FlightRenderResult extends RenderResult {
   constructor(
     response: string | ReadableStream<Uint8Array>,
-    metadata: RenderResultMetadata = {}
+    metadata: RenderResultMetadata = {},
+    waitUntil?: Promise<unknown>
   ) {
-    super(response, { contentType: RSC_CONTENT_TYPE_HEADER, metadata })
+    super(response, {
+      contentType: RSC_CONTENT_TYPE_HEADER,
+      metadata,
+      waitUntil,
+    })
   }
 }

--- a/test/e2e/app-dir/actions-streaming/actions-streaming.test.ts
+++ b/test/e2e/app-dir/actions-streaming/actions-streaming.test.ts
@@ -1,0 +1,44 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+
+describe('actions-streaming', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  describe('actions returning a ReadableStream', () => {
+    it('should properly stream the response without buffering', async () => {
+      const browser = await next.browser('/readable-stream')
+      await browser.elementById('stream-button').click()
+
+      expect(await browser.elementById('stream-button').text()).toBe(
+        'Streaming...'
+      )
+
+      // If we're streaming properly, we should see the first chunks arrive
+      // quickly.
+      expect(await browser.elementByCss('h3').text()).toMatch(
+        /Received \d+ chunks/
+      )
+      expect(await browser.elementById('chunks').text()).toInclude(
+        'Lorem ipsum dolor sit'
+      )
+
+      // Finally, wait for the response to finish streaming.
+      await waitFor(5000)
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('h3').text()).toBe(
+            'Received 50 chunks'
+          )
+
+          expect(await browser.elementById('stream-button').text()).toBe(
+            'Start Stream'
+          )
+        },
+        10000,
+        1000
+      )
+    })
+  })
+})

--- a/test/e2e/app-dir/actions-streaming/actions-streaming.test.ts
+++ b/test/e2e/app-dir/actions-streaming/actions-streaming.test.ts
@@ -31,7 +31,6 @@ describe('actions-streaming', () => {
           expect(await browser.elementByCss('h3').text()).toBe(
             'Received 50 chunks'
           )
-
           expect(await browser.elementById('stream-button').text()).toBe(
             'Start Stream'
           )

--- a/test/e2e/app-dir/actions-streaming/app/layout.tsx
+++ b/test/e2e/app-dir/actions-streaming/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/actions-streaming/app/page.tsx
+++ b/test/e2e/app-dir/actions-streaming/app/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <p>
+      <Link href="/readable-stream">Readable Stream</Link>
+    </p>
+  )
+}

--- a/test/e2e/app-dir/actions-streaming/app/readable-stream/actions.ts
+++ b/test/e2e/app-dir/actions-streaming/app/readable-stream/actions.ts
@@ -1,0 +1,7 @@
+'use server'
+
+export async function streamData(origin: string) {
+  const response = await fetch(new URL('/readable-stream/api', origin))
+
+  return response.body!
+}

--- a/test/e2e/app-dir/actions-streaming/app/readable-stream/api/route.ts
+++ b/test/e2e/app-dir/actions-streaming/app/readable-stream/api/route.ts
@@ -12,7 +12,6 @@ export async function GET() {
         await setTimeout(100)
         controller.enqueue(encoder.encode(loremIpsum))
       }
-
       controller.close()
     },
   })

--- a/test/e2e/app-dir/actions-streaming/app/readable-stream/api/route.ts
+++ b/test/e2e/app-dir/actions-streaming/app/readable-stream/api/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
     async start(controller) {
       for (let i = 0; i < 50; i++) {
         await setTimeout(100)
-        controller.enqueue(encoder.encode(`${i} ${loremIpsum}`))
+        controller.enqueue(encoder.encode(loremIpsum))
       }
 
       controller.close()

--- a/test/e2e/app-dir/actions-streaming/app/readable-stream/api/route.ts
+++ b/test/e2e/app-dir/actions-streaming/app/readable-stream/api/route.ts
@@ -1,0 +1,21 @@
+import { setTimeout } from 'timers/promises'
+
+const loremIpsum =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.\n'
+
+export async function GET() {
+  const encoder = new TextEncoder()
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      for (let i = 0; i < 50; i++) {
+        await setTimeout(100)
+        controller.enqueue(encoder.encode(`${i} ${loremIpsum}`))
+      }
+
+      controller.close()
+    },
+  })
+
+  return new Response(stream, { headers: { 'Content-Type': 'text/plain' } })
+}

--- a/test/e2e/app-dir/actions-streaming/app/readable-stream/page.tsx
+++ b/test/e2e/app-dir/actions-streaming/app/readable-stream/page.tsx
@@ -39,11 +39,11 @@ export default function Page() {
       {chunks && (
         <>
           <h3>Received {chunks.length} chunks</h3>
-          <div id="chunks">
+          <ol id="chunks">
             {chunks.map((chunk, i) => (
-              <div key={i}>{chunk}</div>
+              <li key={i}>{chunk}</li>
             ))}
-          </div>
+          </ol>
         </>
       )}
     </div>

--- a/test/e2e/app-dir/actions-streaming/app/readable-stream/page.tsx
+++ b/test/e2e/app-dir/actions-streaming/app/readable-stream/page.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useState } from 'react'
+import { streamData } from './actions'
+
+export default function Page() {
+  const [chunks, setChunks] = useState<string[] | null>(null)
+  const [isStreaming, setIsStreaming] = useState(false)
+
+  const handleClick = async () => {
+    setChunks(null)
+    setIsStreaming(true)
+
+    const stream = await streamData(window.location.origin)
+    const reader = stream.getReader()
+    const decoder = new TextDecoder()
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) {
+          break
+        }
+        const chunk = decoder.decode(value, { stream: true })
+        setChunks((prev) => (prev ? [...prev, chunk] : [chunk]))
+      }
+    } finally {
+      reader.releaseLock()
+      setIsStreaming(false)
+    }
+  }
+
+  return (
+    <div style={{ marginTop: '1rem' }}>
+      <button disabled={isStreaming} onClick={handleClick} id="stream-button">
+        {isStreaming ? 'Streaming...' : 'Start Stream'}
+      </button>
+
+      {chunks && (
+        <>
+          <h3>Received {chunks.length} chunks</h3>
+          <div id="chunks">
+            {chunks.map((chunk, i) => (
+              <div key={i}>{chunk}</div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/actions-streaming/app/readable-stream/page.tsx
+++ b/test/e2e/app-dir/actions-streaming/app/readable-stream/page.tsx
@@ -31,7 +31,7 @@ export default function Page() {
   }
 
   return (
-    <div style={{ marginTop: '1rem' }}>
+    <div>
       <button disabled={isStreaming} onClick={handleClick} id="stream-button">
         {isStreaming ? 'Streaming...' : 'Start Stream'}
       </button>

--- a/test/e2e/app-dir/actions-streaming/next.config.js
+++ b/test/e2e/app-dir/actions-streaming/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
By accident, the responses for server actions that fetch something and don't revalidate are currently not streamed to the browser until the `fetch` calls are fully resolved. In the simplest case this happens when a server action returns the response body of a `fetch` call. This is especially critical if that response is itself streaming, for example for a chat app. In that case the client didn't see any updates until the whole stream was resolved. It affected mostly dev mode (due to the HMR fetch cache), but also prod if the fetch was explicitly marked as cacheable.

The cause of the issue is that we are awaiting `pendingRevalidates` (in which the cache-writing promise is stored) after executing the action and before rendering. However, when we skip rendering and return the action directly this is unnecessary and blocks the response. Instead, we can defer awaiting the `pendingRevalidates` using `waitUntil`, as we do after rendering. This is executed at the very end, before the response is closed.