### PR TITLE
[test] Use `next-data-api-endpoint` for Middleware HTTP method tests

### DIFF
--- a/test/e2e/middleware-fetches-with-any-http-method/index.test.ts
+++ b/test/e2e/middleware-fetches-with-any-http-method/index.test.ts
@@ -19,7 +19,7 @@ describe('Middleware fetches with any HTTP method', () => {
         'middleware.js': `
           import { NextResponse } from 'next/server';
 
-          const HTTP_ECHO_URL = 'https://http-echo-kou029w.vercel.app/';
+          const HTTP_ECHO_URL = 'https://next-data-api-endpoint.vercel.app/api/echo-headers';
 
           export default async (req) => {
             const kind = req.nextUrl.searchParams.get('kind')


### PR DESCRIPTION
We use `https://next-data-api-endpoint.vercel.app` for most of our e2e test API calls. The `middleware-fetches-with-any-http-method` test suite was using `https://http-echo-kou029w.vercel.app`, which was soft-deleted recently, and that caused the tests to fail. Now we're using the `next-data-api-endpoint` for this test suite as well.