### PR TITLE
fix(template): improve mobile spacing in Tailwind starter layout

### DIFF
--- a/packages/create-next-app/templates/app-tw/ts/app/page.tsx
+++ b/packages/create-next-app/templates/app-tw/ts/app/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 export default function Home() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
+      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center gap-6 justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
         <Image
           className="dark:invert"
           src="/next.svg"


### PR DESCRIPTION
This PR improves the mobile spacing in the App Router + Tailwind starter template by adding `gap-6` to the `<main>` element. The logo and heading currently appear visually crowded on smaller screens. This small adjustment provides more breathing room, improves readability, and creates a more balanced layout without affecting the desktop experience.

### Before
<img width="335" height="583" alt="image" src="https://github.com/user-attachments/assets/fb1c45ee-dc6a-4c86-a238-4b4bce6888c7" />

### After
<img width="331" height="581" alt="image" src="https://github.com/user-attachments/assets/30d0c457-c771-4292-84c4-17bb8cabc3d5" />

### What changed

```diff
- <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
+ <main className="flex min-h-screen w-full max-w-3xl flex-col items-center gap-6 justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">

