### PR TITLE
Bump `@capsizecss/metrics` from 3.4.0 -> 3.6.2

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -152,7 +152,7 @@
     "@babel/traverse": "7.27.0",
     "@babel/types": "7.27.0",
     "@base-ui-components/react": "1.0.0-beta.2",
-    "@capsizecss/metrics": "3.4.0",
+    "@capsizecss/metrics": "3.6.2",
     "@edge-runtime/cookies": "6.0.0",
     "@edge-runtime/ponyfill": "4.0.0",
     "@edge-runtime/primitives": "6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1168,8 +1168,8 @@ importers:
         specifier: 1.0.0-beta.2
         version: 1.0.0-beta.2(@types/react@19.2.2)(react-dom@19.3.0-canary-fb2177c1-20251114(react@19.3.0-canary-fb2177c1-20251114))(react@19.3.0-canary-fb2177c1-20251114)
       '@capsizecss/metrics':
-        specifier: 3.4.0
-        version: 3.4.0
+        specifier: 3.6.2
+        version: 3.6.2
       '@edge-runtime/cookies':
         specifier: 6.0.0
         version: 6.0.0
@@ -2894,8 +2894,8 @@ packages:
   '@bundled-es-modules/statuses@1.0.1':
     resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
 
-  '@capsizecss/metrics@3.4.0':
-    resolution: {integrity: sha512-hIn8MAHxLvwyUh6ZvLQHDt2GPShBz6+gxBs1JTD9GleBkht1AZvtCFo0adr7bQvYYuQzUJeKi69zqlAwgKMHNA==}
+  '@capsizecss/metrics@3.6.2':
+    resolution: {integrity: sha512-5uL1EIhAlfg0dvWsR1DGfqIsyiPBUsD/qlra15B82Ik28BcH7ScYEHLA4F34fZA0KamlpYcappvt2n1pTuDUfw==}
 
   '@csstools/postcss-color-function@1.1.0':
     resolution: {integrity: sha512-5D5ND/mZWcQoSfYnSPsXtuiFxhzmhxt6pcjrFLJyldj+p0ZN2vvRpYNX+lahFTtMhAYOa2WmkdGINr0yP0CvGA==}
@@ -19655,7 +19655,7 @@ snapshots:
     dependencies:
       statuses: 2.0.1
 
-  '@capsizecss/metrics@3.4.0': {}
+  '@capsizecss/metrics@3.6.2': {}
 
   '@csstools/postcss-color-function@1.1.0(postcss@8.4.31)':
     dependencies:


### PR DESCRIPTION
### What?

I've bumped the `@capsizecss/metrics` dependency from version 3.4.0 to version 3.6.2.

I've generated a changelog of the `entireMetricsCollection.json` file in the `metrics` package from `3.4.0` -> `3.6.0`. 
[font_changelog.txt](https://github.com/user-attachments/files/23564459/font_changelog.txt)

### Why?

I was facing a similar issue with Cascadia Mono as https://github.com/vercel/next.js/issues/82079.

### How?

- Bump `@capsizecss/metrics` to 3.6.2