### PR TITLE
fix broken extend implementation on DynamicStorage

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/dynamic_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/dynamic_storage.rs
@@ -61,14 +61,9 @@ impl DynamicStorage {
     pub fn extend(
         &mut self,
         ty: CachedDataItemType,
-        item: impl Iterator<Item = CachedDataItem>,
+        iterator: impl Iterator<Item = CachedDataItem>,
     ) -> bool {
-        let map = self.get_or_create_map_mut(ty);
-        let mut added = true;
-        for item in item {
-            added = map.add(item) && added;
-        }
-        added
+        self.get_or_create_map_mut(ty).extend(iterator)
     }
 
     pub fn insert(&mut self, item: CachedDataItem) -> Option<CachedDataItemValue> {

--- a/turbopack/crates/turbo-tasks-macros/src/derive/key_value_pair_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/key_value_pair_macro.rs
@@ -360,6 +360,20 @@ pub fn derive_key_value_pair(input: TokenStream) -> TokenStream {
                 }
             }
 
+            pub fn extend(&mut self, iterator: impl Iterator<Item = #ident>) -> bool {
+                match self {
+                    #(
+                        #storage_name::#variant_names { storage } => {
+                            storage.extend(iterator.map(|item| match item {
+                                #storage_pattern => (#storage_key, value),
+                                _ => unreachable!(),
+                            }))
+                        }
+                    )*
+                    _ => unreachable!(),
+                }
+            }
+
             pub fn remove(&mut self, key: &#key_name) -> Option<#value_name> {
                 match (self, *key) {
                     #(


### PR DESCRIPTION
### What?

This implementation was broken. It did call `add` instead of `insert` and that doesn't override existing values as it should.

It could also be a bit more efficient by using `extend`.