### PR TITLE
fix: Rename proxy.js to middleware.js in NFT file

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4079,6 +4079,34 @@ export default async function build(
           path.join(distDir, SERVER_DIRECTORY, 'proxy.js.nft.json'),
           path.join(distDir, SERVER_DIRECTORY, 'middleware.js.nft.json')
         )
+
+        const middlewareNft = JSON.parse(
+          await fs.readFile(
+            path.join(distDir, SERVER_DIRECTORY, 'middleware.js.nft.json'),
+            'utf8'
+          )
+        )
+
+        // When Proxy self-reference itself e.g. __filename, it is traced to
+        // the NFT file. However, since we rename 'proxy.js' to 'middleware.js',
+        // the files in NFT will differ from the actual outputs, which will fail
+        // for the providers like Vercel that uses NFT. Therefore also rename
+        // the 'proxy.js' to 'middleware.js' in the NFT file.
+        let hasProxyJsInNft = false
+        middlewareNft.files = middlewareNft.files.map((file: string) => {
+          if (file === 'proxy.js') {
+            hasProxyJsInNft = true
+            return 'middleware.js'
+          }
+          return file
+        })
+
+        if (hasProxyJsInNft) {
+          await fs.writeFile(
+            path.join(distDir, SERVER_DIRECTORY, 'middleware.js.nft.json'),
+            JSON.stringify(middlewareNft)
+          )
+        }
       }
 
       if (isCompileMode) {

--- a/test/e2e/app-dir/proxy-nfc-traced/app/layout.tsx
+++ b/test/e2e/app-dir/proxy-nfc-traced/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/proxy-nfc-traced/app/page.tsx
+++ b/test/e2e/app-dir/proxy-nfc-traced/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/proxy-nfc-traced/next.config.js
+++ b/test/e2e/app-dir/proxy-nfc-traced/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/proxy-nfc-traced/proxy-nfc-traced.test.ts
+++ b/test/e2e/app-dir/proxy-nfc-traced/proxy-nfc-traced.test.ts
@@ -1,0 +1,16 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// This test verifies a case when the "proxy.ts" bundle is being traced into the NFT file as "proxy.js".
+// As Next.js renames "proxy.js" to "middleware.js" during webpack build, the files in NFT will differ
+// from the actual outputs, which will fail for the providers like Vercel that checks for the files in NFT.
+
+describe('proxy-nfc-traced', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should successfully build and be redirected from proxy', async () => {
+    const $ = await next.render$('/home')
+    expect($('p').text()).toBe('hello world')
+  })
+})

--- a/test/e2e/app-dir/proxy-nfc-traced/proxy-nfc-traced.test.ts
+++ b/test/e2e/app-dir/proxy-nfc-traced/proxy-nfc-traced.test.ts
@@ -1,4 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
+import fs from 'fs'
+import path from 'path'
 
 // This test verifies a case when the "proxy.ts" bundle is being traced into the NFT file as "proxy.js".
 // As Next.js renames "proxy.js" to "middleware.js" during webpack build, the files in NFT will differ
@@ -7,6 +9,16 @@ import { nextTestSetup } from 'e2e-utils'
 describe('proxy-nfc-traced', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+  })
+
+  it('should have renamed trace file as middleware instead of proxy', async () => {
+    const nfc = JSON.parse(
+      fs.readFileSync(
+        path.join(next.testDir, '.next/server/middleware.js.nft.json'),
+        'utf-8'
+      )
+    )
+    expect(nfc.files).toContain('middleware.js')
   })
 
   it('should successfully build and be redirected from proxy', async () => {

--- a/test/e2e/app-dir/proxy-nfc-traced/proxy-nfc-traced.test.ts
+++ b/test/e2e/app-dir/proxy-nfc-traced/proxy-nfc-traced.test.ts
@@ -7,21 +7,25 @@ import path from 'path'
 // from the actual outputs, which will fail for the providers like Vercel that checks for the files in NFT.
 
 describe('proxy-nfc-traced', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack, isNextStart } = nextTestSetup({
     files: __dirname,
   })
 
-  it('should have renamed trace file as middleware instead of proxy', async () => {
-    const nfc = JSON.parse(
-      fs.readFileSync(
-        path.join(next.testDir, '.next/server/middleware.js.nft.json'),
-        'utf-8'
+  // 'middleware.js' won't be traced because Turbopack doesn't bundle all code to .next/server/middleware.js
+  if (isNextStart && !isTurbopack) {
+    it('should have renamed trace file as middleware instead of proxy', async () => {
+      const nfc = JSON.parse(
+        fs.readFileSync(
+          path.join(next.testDir, '.next/server/middleware.js.nft.json'),
+          'utf-8'
+        )
       )
-    )
-    expect(nfc.files).toContain('middleware.js')
-    expect(nfc.files).not.toContain('proxy.js')
-  })
+      expect(nfc.files).toContain('middleware.js')
+      expect(nfc.files).not.toContain('proxy.js')
+    })
+  }
 
+  // Previously, the deployment tests failed because of the traced file name mismatch.
   it('should successfully build and be redirected from proxy', async () => {
     const $ = await next.render$('/home')
     expect($('p').text()).toBe('hello world')

--- a/test/e2e/app-dir/proxy-nfc-traced/proxy-nfc-traced.test.ts
+++ b/test/e2e/app-dir/proxy-nfc-traced/proxy-nfc-traced.test.ts
@@ -19,6 +19,7 @@ describe('proxy-nfc-traced', () => {
       )
     )
     expect(nfc.files).toContain('middleware.js')
+    expect(nfc.files).not.toContain('proxy.js')
   })
 
   it('should successfully build and be redirected from proxy', async () => {

--- a/test/e2e/app-dir/proxy-nfc-traced/proxy.ts
+++ b/test/e2e/app-dir/proxy-nfc-traced/proxy.ts
@@ -1,0 +1,17 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export default function proxy(request: NextRequest) {
+  if (request.nextUrl.pathname === '/home') {
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+
+  // `__filename` included in the bundle makes the NFT to trace it.
+  // This will result creating "proxy.js" to be traced into the NFT file.
+  // However, as Next.js renames "proxy.js" to "middleware.js" during build,
+  // the files in NFT will differ from the actual outputs, which will fail for
+  // the providers like Vercel that checks for the files in NFT.
+  console.log(__filename)
+
+  return NextResponse.next()
+}


### PR DESCRIPTION
### Why?

When Proxy self-references itself, e.g., `__filename`, it is traced to the NFT file. However, since Next.js renames 'proxy.js' to 'middleware.js' during webpack build, the files in NFT will differ from the actual outputs. This can cause a problem when verifying the NFT.

Current Behavior:

https://github.com/vercel/next.js/actions/runs/19483162554/job/55760669267?pr=86214#step:34:91

### How?

Therefore, also rename the self-reference of `'proxy.js'` in `middleware.js.nft.json` to `'middleware.js'`.

I don't expect other modules to be referencing the build output of Proxy, that is not recommended.

Closes NEXT-4777
Closes NAR-518