### PR TITLE
`next analyze`: Make ipv6 server links valid and normalize localhost

### DIFF
--- a/packages/next/src/build/analyze/index.ts
+++ b/packages/next/src/build/analyze/index.ts
@@ -77,9 +77,11 @@ export default async function analyze({
       await turbopackAnalyze(analyzeContext)
 
     const durationString = durationToString(analyzeDuration)
-    Log.event(
-      `Analyze data created successfully in ${durationString}. To explore it, run \`next experimental-analyze --serve\`.`
-    )
+    let logMessage = `Analyze completed in ${durationString}.`
+    if (!serve) {
+      logMessage += ` To explore the analyze results, run \`next experimental-analyze --serve\`.`
+    }
+    Log.event(logMessage)
 
     await shutdownPromise
 
@@ -238,8 +240,15 @@ function startServer(dir: string, port: number): Promise<void> {
       let addressString
       if (typeof address === 'string') {
         addressString = address
+      } else if (
+        address.family === 'IPv6' &&
+        (address.address === '::' || address.address === '::1')
+      ) {
+        addressString = `localhost:${address.port}`
+      } else if (address.family === 'IPv6') {
+        addressString = `[${address.address}]:${address.port}`
       } else {
-        addressString = `${address.address === '::' ? 'localhost' : address.address}:${address.port}`
+        addressString = `${address.address}:${address.port}`
       }
 
       Log.info(`Bundle analyzer available at http://${addressString}`)


### PR DESCRIPTION
The current implementation doesn't properly format IPv6 addresses, which means URLs aren't valid. 

- Added specific handling for IPv6 localhost addresses (`::`/`::1`) to display as `localhost:port` for display
- Added proper IPv6 address formatting with square brackets: `[IPv6Address]:port`
- Maintained existing handling for IPv4 addresses and string addresses

Fixes PACK-5874