### PR TITLE
next-analyze: improve network error visuals

### DIFF
--- a/apps/bundle-analyzer/components/error-state.tsx
+++ b/apps/bundle-analyzer/components/error-state.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { RefreshCw, AlertTriangle } from 'lucide-react'
+import { NetworkError } from '@/lib/errors'
+
+interface ErrorStateProps {
+  error: unknown
+  onRetry?: () => void
+}
+
+export function ErrorState({ error }: ErrorStateProps) {
+  const isNetwork = error instanceof NetworkError
+  const title = isNetwork ? 'Server Connection Lost' : 'Error'
+  const message = isNetwork
+    ? 'Unable to connect to the bundle analyzer server. Please ensure the server is running and try again.'
+    : ((error as any)?.message ?? 'An unexpected error occurred.')
+
+  return (
+    <div className="flex-1 flex items-center justify-center">
+      <div className="text-center space-y-4 max-w-md px-6">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-destructive/10 text-destructive mb-2">
+          <AlertTriangle className="w-8 h-8" />
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold text-foreground mb-2">
+            {title}
+          </h3>
+          <p className="text-sm text-muted-foreground mb-4">{message}</p>
+          <button
+            onClick={() => {
+              window.location.reload()
+            }}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors text-sm font-medium"
+          >
+            <RefreshCw className="w-4 h-4" />
+            Retry Connection
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/bundle-analyzer/components/index.ts
+++ b/apps/bundle-analyzer/components/index.ts
@@ -1,3 +1,4 @@
 export { ImportChain } from './import-chain'
 export { RouteTypeahead } from './route-typeahead'
 export { TreemapVisualizer } from './treemap-visualizer'
+export { ErrorState } from './error-state'

--- a/apps/bundle-analyzer/components/route-typeahead.tsx
+++ b/apps/bundle-analyzer/components/route-typeahead.tsx
@@ -18,6 +18,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover'
 import { cn, jsonFetcher } from '@/lib/utils'
+import { NetworkError } from '@/lib/errors'
 
 interface RouteTypeaheadProps {
   selectedRoute: string | null
@@ -55,8 +56,13 @@ export const RouteTypeahead = forwardRef<
 
   if (error) {
     return (
-      <div className="flex max-w-full text-red-600">
-        Failed to load routes manifest: {error.message}
+      <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-destructive/10 border border-destructive/20 text-destructive text-sm max-w-full">
+        <span className="font-medium">⚠</span>
+        <span className="truncate">
+          {error instanceof NetworkError
+            ? 'Unable to connect to server'
+            : error.message}
+        </span>
       </div>
     )
   }

--- a/apps/bundle-analyzer/lib/errors.ts
+++ b/apps/bundle-analyzer/lib/errors.ts
@@ -1,0 +1,10 @@
+export class NetworkError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message)
+    this.name = 'NetworkError'
+    // Preserve error cause when supported
+    if (options && 'cause' in options) {
+      ;(this as any).cause = options.cause
+    }
+  }
+}

--- a/apps/bundle-analyzer/lib/utils.ts
+++ b/apps/bundle-analyzer/lib/utils.ts
@@ -1,14 +1,30 @@
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 import { SpecialModule } from './types'
+import { NetworkError } from './errors'
 import { AnalyzeData } from './analyze-data'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function jsonFetcher<T>(url: string): Promise<T> {
-  return fetch(url).then((res) => res.json())
+export async function fetchStrict(url: string): Promise<Response> {
+  let res: Response
+  try {
+    res = await fetch(url)
+  } catch (err) {
+    throw new NetworkError(`Failed to fetch ${url}`, { cause: err })
+  }
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`)
+  }
+  return res
+}
+
+export async function jsonFetcher<T>(url: string): Promise<T> {
+  const res = await fetchStrict(url)
+  return res.json() as Promise<T>
 }
 
 export function getSpecialModuleType(


### PR DESCRIPTION
This improves how network errors (such as when the bundle analyzer error server is shut down) are shown.

Fixes PACK-5877

![image.png](https://app.graphite.com/user-attachments/assets/69e57bb7-03ca-45ec-9816-f4bc512bfd58.png)

![image.png](https://app.graphite.com/user-attachments/assets/450ed52c-5368-49ee-a149-e7b17a8c21db.png)