### PR TITLE
Add flag to show ignore listed frames

### DIFF
--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -327,8 +327,7 @@ function parseAndSourceMap(
   error: Error,
   inspectOptions: util.InspectOptions
 ): string {
-  // TODO(veil): Expose as CLI arg or config option. Useful for local debugging.
-  const showIgnoreListed = false
+  const showIgnoreListed = process.env.__NEXT_SHOW_IGNORE_LISTED === 'true'
   // We overwrote Error.prepareStackTrace earlier so error.stack is not sourcemapped.
   let unparsedStack = String(error.stack)
   // We could just read it from `error.stack`.


### PR DESCRIPTION
Since there's no way to show ignore-listed frames in the terminal, added `__NEXT_SHOW_IGNORE_LISTED` flag to show them. This should only be a concern for the maintainers/contributors who debug internals and can't attach a debugger.