### PR TITLE
[ts-plugin] fix: do not overwrite the prior quickInfo values

### DIFF
--- a/packages/next/src/server/typescript/index.ts
+++ b/packages/next/src/server/typescript/index.ts
@@ -135,10 +135,17 @@ export const createTSPlugin: tsModule.server.PluginModuleFactory = ({
     }
 
     // Quick info
-    proxy.getQuickInfoAtPosition = (fileName: string, position: number) => {
+    proxy.getQuickInfoAtPosition = (
+      fileName: string,
+      position: number,
+      // Pass all args to the getQuickInfoAtPosition function to prevent missing out.
+      // https://github.com/microsoft/vscode/issues/259321#issuecomment-3168667334
+      ...args: any[]
+    ) => {
       const prior = info.languageService.getQuickInfoAtPosition(
         fileName,
-        position
+        position,
+        ...args
       )
       if (!isAppEntryFile(fileName)) return prior
 
@@ -157,7 +164,11 @@ export const createTSPlugin: tsModule.server.PluginModuleFactory = ({
         }
       }
 
-      const overridden = entryConfig.getQuickInfoAtPosition(fileName, position)
+      const overridden = entryConfig.getQuickInfoAtPosition(
+        fileName,
+        position,
+        prior
+      )
       if (overridden) return overridden
 
       return prior

--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -307,7 +307,7 @@ const config = {
       ...(prior.documentation ?? []),
     ]
 
-    let overridden: tsModule.QuickInfo = prior
+    let overridden: tsModule.QuickInfo = { ...prior }
 
     // TODO: Do we have to walk the AST, or can we populate the values we need
     // from the prior?


### PR DESCRIPTION
TS plugin `getQuickInfo` was overwriting the prior info, not overriding. Therefore, it swallowed Type, JSDoc, and VSCode Expandable Hovers added in TS 5.9.

This PR correctly adds documentation on top of the prior quick info, ensuring all values are persisted.

| Before | After |
|--------|--------|
| <img width="1656" height="390" alt="CleanShot 2025-11-19 at 12 19 50@2x" src="https://github.com/user-attachments/assets/ed39a851-7096-448b-bffe-55c5320c1713" /> | <img width="1668" height="384" alt="CleanShot 2025-11-19 at 12 18 47@2x" src="https://github.com/user-attachments/assets/0a3a0cbc-5c75-4b6f-90fc-bbcef028d06b" /> |

x-ref: https://github.com/microsoft/vscode/issues/232685#issuecomment-3484167019