### PR TITLE
Fix log log alignment in spinners

### DIFF
--- a/packages/next/src/build/spinner.ts
+++ b/packages/next/src/build/spinner.ts
@@ -13,7 +13,7 @@ export default function createSpinner(
 ) {
   let spinner: undefined | (ora.Ora & { setText: (text: string) => void })
 
-  let prefixText = ` ${Log.prefixes.info} ${text} `
+  let prefixText = `${Log.prefixes.info} ${text} `
 
   if (process.stdout.isTTY) {
     spinner = ora({
@@ -60,7 +60,7 @@ export default function createSpinner(
     }
     spinner.setText = (newText) => {
       text = newText
-      prefixText = ` ${Log.prefixes.info} ${newText} `
+      prefixText = `${Log.prefixes.info} ${newText} `
       spinner!.prefixText = prefixText
       return spinner!
     }
@@ -71,7 +71,7 @@ export default function createSpinner(
     }
     spinner.stopAndPersist = () => {
       // Add \r at beginning to reset the current line of loading status text
-      const suffixText = `\r ${Log.prefixes.event} ${text} `
+      const suffixText = `\r${Log.prefixes.event} ${text} `
       if (spinner) {
         spinner.text = suffixText
       } else {

--- a/test/e2e/app-dir/cache-components-errors/cache-components-console-patch.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-console-patch.test.ts
@@ -70,11 +70,11 @@ describe('Cache Components Errors', () => {
             `)
           } else {
             expect(output).toMatchInlineSnapshot(`
-                        "[<timestamp>] This is a console log from a server component page
-                        [<timestamp>] This is a console log from a server component page
-                        [<timestamp>]    Collecting build traces ...
-                        [<timestamp>]"
-                      `)
+             "[<timestamp>] This is a console log from a server component page
+             [<timestamp>] This is a console log from a server component page
+             [<timestamp>]   Collecting build traces ...
+             [<timestamp>]"
+            `)
           }
         })
       }


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/86139

Forgot to check other usages of these prefixes which added their own padding.

Before
```
✓ Compiled successfully in 2.3s
   Running TypeScript ...
   Collecting page data using 10 workers ...
   Generating static pages using 10 workers (0/2) ...
✓ Generating static pages using 10 workers (2/2) in 227.0ms
   Finalizing page optimization ...
   Collecting build traces ..
```

after
```
✓ Compiled successfully in 2.3s
  Running TypeScript ...
  Collecting page data using 10 workers ...
  Generating static pages using 10 workers (0/2) ...
✓ Generating static pages using 10 workers (2/2) in 227.0ms
  Finalizing page optimization ...
  Collecting build traces ..
```