### PR TITLE
[test] Let pending test finish on abort

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -795,16 +795,15 @@ ${ENDGROUP}`)
       // once CI runs with Node.js 24+.
       if (dirSema) await dirSema.acquire()
       await sema.acquire()
-      if (testSignal.aborted) {
-        // We already logged the abort reason. No need to include it in cause.
-        const error = new Error(`Skipped due to abort.`)
-        error.name = test.file
-        if (dirSema) dirSema.release()
-        sema.release()
-        throw error
-      }
 
       try {
+        if (testSignal.aborted) {
+          // We already logged the abort reason. No need to include it in cause.
+          const error = new Error(`Skipped due to abort.`)
+          error.name = test.file
+          throw error
+        }
+
         await runTest(test)
       } finally {
         sema.release()

--- a/run-tests.js
+++ b/run-tests.js
@@ -819,8 +819,8 @@ ${ENDGROUP}`)
     }
   }
 
-  if (hadFailures) {
-    // TODO: Does it make sense to update timings if there were failures?
+  if (hadFailures && !shouldContinueTestsOnError) {
+    // TODO: Does it make sense to update timings if there were failures if without shouldContinueTestsOnError?
     return hadFailures
   }
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -501,8 +501,17 @@ ${ENDGROUP}`)
     `jest${process.platform === 'win32' ? '.CMD' : ''}`
   )
   let firstError = true
-  let killed = false
+  const testController = new AbortController()
+  const testSignal = testController.signal
   let hadFailures = false
+
+  async function yourTurn() {
+    await sema.acquire()
+    if (testSignal.aborted) {
+      sema.release()
+      throw testSignal.reason
+    }
+  }
 
   const runTest = (/** @type {TestFile} */ test, isFinalRun, isRetry) =>
     new Promise((resolve, reject) => {
@@ -618,11 +627,11 @@ ${ENDGROUP}`)
           if (hideOutput) {
             await outputSema.acquire()
             const isExpanded =
-              firstError && !killed && !shouldContinueTestsOnError
+              firstError && !testSignal.aborted && !shouldContinueTestsOnError
             if (isExpanded) {
               firstError = false
               process.stdout.write(`❌ ${test.file} output:\n`)
-            } else if (killed) {
+            } else if (testSignal.aborted) {
               process.stdout.write(`${GROUP}${test.file} output (killed)\n`)
             } else {
               process.stdout.write(`${GROUP}❌ ${test.file} output\n`)
@@ -636,7 +645,7 @@ ${ENDGROUP}`)
               output += chunk.toString()
             }
 
-            if (process.env.CI && !killed) {
+            if (process.env.CI && !testSignal.aborted) {
               errorsPerTests.set(test.file, output)
             }
 
@@ -685,7 +694,7 @@ ${ENDGROUP}`)
   const directorySemas = new Map()
 
   const originalRetries = numRetries
-  await Promise.all(
+  const results = await Promise.allSettled(
     tests.map(async (test) => {
       const dirName = path.dirname(test.file)
       let dirSema = directorySemas.get(dirName)
@@ -697,7 +706,12 @@ ${ENDGROUP}`)
       }
       if (dirSema) await dirSema.acquire()
 
-      await sema.acquire()
+      try {
+        await yourTurn()
+      } catch (err) {
+        throw new Error(`Skipping ${test.file} due to abort.`, { cause: err })
+      }
+
       let passed = false
 
       const shouldSkipRetries = skipRetryTestManifest.find((t) =>
@@ -750,16 +764,16 @@ ${ENDGROUP}`)
       }
 
       if (!passed) {
-        console.error(
-          `${test.file} failed to pass within ${numRetries} retries`
+        hadFailures = true
+        const error = new Error(
+          // "failed to pass within" is a keyword parsed by next-pr-webhook
+          `Test ${test.file} failed to pass within ${numRetries} retries`
         )
+        console.error(error.message)
 
         if (!shouldContinueTestsOnError) {
-          killed = true
-          children.forEach((child) => child.kill())
-          cleanUpAndExit(1)
+          testController.abort(error)
         } else {
-          hadFailures = true
           console.log(
             `CONTINUE_ON_ERROR enabled, continuing tests after ${test.file} failed`
           )
@@ -797,6 +811,18 @@ ${ENDGROUP}`)
       if (dirSema) dirSema.release()
     })
   )
+
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      hadFailures = true
+      console.error(result.reason)
+    }
+  }
+
+  if (hadFailures) {
+    // TODO: Does it make sense to update timings if there were failures?
+    return hadFailures
+  }
 
   if (options.timings) {
     const curTimings = {}
@@ -857,7 +883,6 @@ ${ENDGROUP}`)
     }
   }
 
-  // Return whether there were any failures
   return hadFailures
 }
 
@@ -865,12 +890,13 @@ main()
   .then((hadFailures) => {
     if (hadFailures) {
       console.error('Some tests failed')
-      cleanUpAndExit(1)
+      return cleanUpAndExit(1)
     } else {
-      cleanUpAndExit(0)
+      return cleanUpAndExit(0)
     }
   })
   .catch((err) => {
     console.error(err)
-    cleanUpAndExit(1)
+    // Retry cleanup one more time.
+    return cleanUpAndExit(1)
   })

--- a/run-tests.js
+++ b/run-tests.js
@@ -505,15 +505,7 @@ ${ENDGROUP}`)
   const testSignal = testController.signal
   let hadFailures = false
 
-  async function yourTurn() {
-    await sema.acquire()
-    if (testSignal.aborted) {
-      sema.release()
-      throw testSignal.reason
-    }
-  }
-
-  const runTest = (/** @type {TestFile} */ test, isFinalRun, isRetry) =>
+  const runTestOnce = (/** @type {TestFile} */ test, isFinalRun, isRetry) =>
     new Promise((resolve, reject) => {
       const start = new Date().getTime()
       let outputChunks = []
@@ -691,6 +683,101 @@ ${ENDGROUP}`)
       })
     })
 
+  const runTest = async (/** @type {TestFile} */ test) => {
+    let passed = false
+
+    const shouldSkipRetries = skipRetryTestManifest.find((t) =>
+      t.includes(test.file)
+    )
+    const numRetries = shouldSkipRetries ? 0 : originalRetries
+    if (shouldSkipRetries) {
+      console.log(
+        `Skipping retry for ${test.file} due to skipRetryTestManifest`
+      )
+    }
+
+    for (let i = 0; i < numRetries + 1; i++) {
+      try {
+        console.log(`Starting ${test.file} retry ${i}/${numRetries}`)
+        const time = await runTestOnce(
+          test,
+          shouldSkipRetries || i === numRetries,
+          shouldSkipRetries || i > 0
+        )
+        timings.push({
+          file: test.file,
+          time,
+        })
+        passed = true
+        console.log(
+          `${test.file} finished on retry ${i}/${numRetries} in ${time / 1000}s`
+        )
+        break
+      } catch (err) {
+        if (i < numRetries) {
+          try {
+            let testDir = path.dirname(path.join(__dirname, test.file))
+
+            // if test is nested in a test folder traverse up a dir to ensure
+            // we clean up relevant test files
+            if (testDir.endsWith('/test') || testDir.endsWith('\\test')) {
+              testDir = path.join(testDir, '..')
+            }
+            console.log('Cleaning test files at', testDir)
+            await exec(`git clean -fdx "${testDir}"`)
+            await exec(`git checkout "${testDir}"`)
+          } catch (err) {}
+        } else {
+          console.error(`${test.file} failed due to ${err}`)
+        }
+      }
+    }
+
+    if (!passed) {
+      hadFailures = true
+      const error = new Error(
+        // "failed to pass within" is a keyword parsed by next-pr-webhook
+        `${test.file} failed to pass within ${numRetries} retries`
+      )
+      console.error(error.message)
+
+      if (!shouldContinueTestsOnError) {
+        testController.abort(error)
+      } else {
+        console.log(
+          `CONTINUE_ON_ERROR enabled, continuing tests after ${test.file} failed`
+        )
+      }
+    }
+
+    // Emit test output if test failed or if we're continuing tests on error
+    // This is parsed by the commenter webhook to notify about failing tests
+    if ((!passed || shouldContinueTestsOnError) && isTestJob) {
+      try {
+        const testsOutput = await fsp.readFile(
+          `${test.file}${RESULTS_EXT}`,
+          'utf8'
+        )
+        const obj = JSON.parse(testsOutput)
+        obj.processEnv = {
+          NEXT_TEST_MODE: process.env.NEXT_TEST_MODE,
+          HEADLESS: process.env.HEADLESS,
+        }
+        await outputSema.acquire()
+        if (GROUP) console.log(`${GROUP}Result as JSON for tooling`)
+        console.log(
+          `--test output start--`,
+          JSON.stringify(obj),
+          `--test output end--`
+        )
+        if (ENDGROUP) console.log(ENDGROUP)
+        outputSema.release()
+      } catch (err) {
+        console.log(`Failed to load test output`, err)
+      }
+    }
+  }
+
   const directorySemas = new Map()
 
   const originalRetries = numRetries
@@ -704,113 +791,25 @@ ${ENDGROUP}`)
       if (/^test[/\\]integration/.test(test.file) && dirSema === undefined) {
         directorySemas.set(dirName, (dirSema = new Sema(1)))
       }
+      // TODO: Use explicit resource managment instead of this acquire/release pattern
+      // once CI runs with Node.js 24+.
       if (dirSema) await dirSema.acquire()
-
-      try {
-        await yourTurn()
-      } catch (cause) {
-        const error = new Error(`Skipped due to abort.`, { cause })
+      await sema.acquire()
+      if (testSignal.aborted) {
+        // We already logged the abort reason. No need to include it in cause.
+        const error = new Error(`Skipped due to abort.`)
         error.name = test.file
+        if (dirSema) dirSema.release()
+        sema.release()
         throw error
       }
 
-      let passed = false
-
-      const shouldSkipRetries = skipRetryTestManifest.find((t) =>
-        t.includes(test.file)
-      )
-      const numRetries = shouldSkipRetries ? 0 : originalRetries
-      if (shouldSkipRetries) {
-        console.log(
-          `Skipping retry for ${test.file} due to skipRetryTestManifest`
-        )
+      try {
+        await runTest(test)
+      } finally {
+        sema.release()
+        if (dirSema) dirSema.release()
       }
-
-      for (let i = 0; i < numRetries + 1; i++) {
-        try {
-          console.log(`Starting ${test.file} retry ${i}/${numRetries}`)
-          const time = await runTest(
-            test,
-            shouldSkipRetries || i === numRetries,
-            shouldSkipRetries || i > 0
-          )
-          timings.push({
-            file: test.file,
-            time,
-          })
-          passed = true
-          console.log(
-            `${test.file} finished on retry ${i}/${numRetries} in ${
-              time / 1000
-            }s`
-          )
-          break
-        } catch (err) {
-          if (i < numRetries) {
-            try {
-              let testDir = path.dirname(path.join(__dirname, test.file))
-
-              // if test is nested in a test folder traverse up a dir to ensure
-              // we clean up relevant test files
-              if (testDir.endsWith('/test') || testDir.endsWith('\\test')) {
-                testDir = path.join(testDir, '..')
-              }
-              console.log('Cleaning test files at', testDir)
-              await exec(`git clean -fdx "${testDir}"`)
-              await exec(`git checkout "${testDir}"`)
-            } catch (err) {}
-          } else {
-            console.error(`${test.file} failed due to ${err}`)
-          }
-        }
-      }
-
-      if (!passed) {
-        hadFailures = true
-        const error = new Error(
-          // "failed to pass within" is a keyword parsed by next-pr-webhook
-          `${test.file} failed to pass within ${numRetries} retries`
-        )
-        console.error(error.message)
-
-        if (!shouldContinueTestsOnError) {
-          testController.abort(error)
-        } else {
-          console.log(
-            `CONTINUE_ON_ERROR enabled, continuing tests after ${test.file} failed`
-          )
-        }
-      }
-
-      // Emit test output if test failed or if we're continuing tests on error
-      // This is parsed by the commenter webhook to notify about failing tests
-      if ((!passed || shouldContinueTestsOnError) && isTestJob) {
-        try {
-          const testsOutput = await fsp.readFile(
-            `${test.file}${RESULTS_EXT}`,
-            'utf8'
-          )
-          const obj = JSON.parse(testsOutput)
-          obj.processEnv = {
-            NEXT_TEST_MODE: process.env.NEXT_TEST_MODE,
-            HEADLESS: process.env.HEADLESS,
-          }
-          await outputSema.acquire()
-          if (GROUP) console.log(`${GROUP}Result as JSON for tooling`)
-          console.log(
-            `--test output start--`,
-            JSON.stringify(obj),
-            `--test output end--`
-          )
-          if (ENDGROUP) console.log(ENDGROUP)
-          outputSema.release()
-        } catch (err) {
-          console.log(`Failed to load test output`, err)
-        }
-      }
-
-      sema.release()
-      if (dirSema) dirSema.release()
     })
   )
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -886,17 +886,17 @@ ${ENDGROUP}`)
   return hadFailures
 }
 
-main()
-  .then((hadFailures) => {
+main().then(
+  (hadFailures) => {
     if (hadFailures) {
       console.error('Some tests failed')
       return cleanUpAndExit(1)
     } else {
       return cleanUpAndExit(0)
     }
-  })
-  .catch((err) => {
-    console.error(err)
-    // Retry cleanup one more time.
+  },
+  (reason) => {
+    console.error(reason)
     return cleanUpAndExit(1)
-  })
+  }
+)

--- a/run-tests.js
+++ b/run-tests.js
@@ -708,8 +708,10 @@ ${ENDGROUP}`)
 
       try {
         await yourTurn()
-      } catch (err) {
-        throw new Error(`Skipping ${test.file} due to abort.`, { cause: err })
+      } catch (cause) {
+        const error = new Error(`Skipped due to abort.`, { cause })
+        error.name = test.file
+        throw error
       }
 
       let passed = false
@@ -738,7 +740,7 @@ ${ENDGROUP}`)
           })
           passed = true
           console.log(
-            `Finished ${test.file} on retry ${i}/${numRetries} in ${
+            `${test.file} finished on retry ${i}/${numRetries} in ${
               time / 1000
             }s`
           )
@@ -767,7 +769,7 @@ ${ENDGROUP}`)
         hadFailures = true
         const error = new Error(
           // "failed to pass within" is a keyword parsed by next-pr-webhook
-          `Test ${test.file} failed to pass within ${numRetries} retries`
+          `${test.file} failed to pass within ${numRetries} retries`
         )
         console.error(error.message)
 

--- a/test/development/acceptance-app/app-hmr-changes.test.ts
+++ b/test/development/acceptance-app/app-hmr-changes.test.ts
@@ -22,6 +22,10 @@ describe('Error overlay - RSC build errors', () => {
     skipStart: true,
   })
 
+  it('fails', () => {
+    throw new Error('simulated test failure')
+  })
+
   // TODO: The error overlay is not closed when restoring the working code.
   ;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
     'Skipped in webpack',

--- a/test/development/acceptance-app/app-hmr-changes.test.ts
+++ b/test/development/acceptance-app/app-hmr-changes.test.ts
@@ -22,10 +22,6 @@ describe('Error overlay - RSC build errors', () => {
     skipStart: true,
   })
 
-  it('fails', () => {
-    throw new Error('simulated test failure')
-  })
-
   // TODO: The error overlay is not closed when restoring the working code.
   ;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
     'Skipped in webpack',


### PR DESCRIPTION
When a test fails its final attempt, we used to forcefully exit the process. This could lead to cascading test failures that end up in the test reports uploaded to Datadog. These abort failures pollute our flakiness metrics because it's not the test itself that is problematic but the batch the test ran in.

Instead, we now abort the test runner which lets pending test finish. Scheduled test will not start and instead log that they're skipped. This will help debugging why a test only started failing when you fixed a prior one.

## test plan

```console
# on a version of this branch with the simulated test failure (before 'Revert "REVERT OR YOU WILL BE FIRED simulate failing test"'
$ node run-tests.js --timings -g 1/300 --type development
test/development/acceptance-app/app-hmr-changes.test.ts failed due to Error: failed with code: 1
test/development/acceptance-app/app-hmr-changes.test.ts failed to pass within 2 retries
test/e2e/app-dir/cache-components/cache-components.search.test.ts finished on retry 0/2 in 25.701s
test/e2e/app-dir/revalidate-dynamic/revalidate-dynamic.test.ts: Skipped due to abort.
    at /Users/sebbie/repos/next.js/run-tests.js:801:25
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Promise.allSettled (index 2)
    at async main (/Users/sebbie/repos/next.js/run-tests.js:783:19)
test/e2e/repeated-forward-slashes-error/repeated-forward-slashes-error.test.ts: Skipped due to abort.
    at /Users/sebbie/repos/next.js/run-tests.js:801:25
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Promise.allSettled (index 3)
    at async main (/Users/sebbie/repos/next.js/run-tests.js:783:19)
```
