### PR TITLE
create-next-app: Add `ignoreScripts` for `unrs-resolver` on bun

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -340,6 +340,19 @@ export const installTemplate = async ({
     );
   }
 
+  if (packageManager === "bun") {
+    // Equivalent to pnpm's `ignoredBuiltDependencies`, added in bun 1.3.2.
+    // - https://bun.com/blog/bun-v1.3.2#faster-bun-install
+    // - https://github.com/oven-sh/bun/pull/24283
+    // Bun ignores `sharp` by default, but does not ignore `unrs-resolver`
+    // unless configured.
+    packageJson.ignoreScripts = ["sharp", "unrs-resolver"];
+    // The script must be in *both* `ignoreScripts` and `trustedDependencies` to
+    // suppress the warning. This could change in future versions of Bun.
+    // https://vercel.slack.com/archives/C06DNAH5LSG/p1763582930218709?thread_ts=1763580178.004169&cid=C06DNAH5LSG
+    packageJson.trustedDependencies = ["sharp", "unrs-resolver"];
+  }
+
   await fs.writeFile(
     path.join(root, "package.json"),
     JSON.stringify(packageJson, null, 2) + os.EOL,


### PR DESCRIPTION
`unrs-resolver`'s postinstall script is only needed for legacy versions of npm, so it's safe to ignore: https://github.com/unrs/unrs-resolver/issues/193#issuecomment-3295510146

Without this, bun blocks the postinstall script (okay) and logs a warning (not ideal, confusing to end users). This prevents it from running and suppresses the warning. This matches what we now do in `pnpm` (https://github.com/vercel/next.js/pull/83168) but for `bun`.

Context:
- https://vercel.slack.com/archives/C03KAR5DCKC/p1763570835510729
- https://vercel.slack.com/archives/C06DNAH5LSG/p1763580178004169

## Before

![CleanShot 2025-11-19 at 08.46.56@2x.png](https://app.graphite.com/user-attachments/assets/4979ca3c-0a05-4c05-831a-93c358832ed4.png)

## After

![Screenshot 2025-11-19 at 1.02.01 PM.png](https://app.graphite.com/user-attachments/assets/f99b419b-a30e-449a-9118-77621b15fcd9.png)