### PR TITLE
Turbopack: remove Asset supertrait from Module trait. Modules don't have content

### DIFF
--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -4,9 +4,9 @@ use anyhow::{Context, Result, bail};
 use indoc::writedoc;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{IntoTraitRef, ResolvedVc, ValueToString, Vc};
-use turbo_tasks_fs::{File, FileContent};
+use turbo_tasks_fs::File;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
+    asset::AssetContent,
     chunk::{
         AsyncModuleInfo, ChunkGroupType, ChunkItem, ChunkType, ChunkableModule,
         ChunkableModuleReference, ChunkingContext, ChunkingType, ChunkingTypeOption,
@@ -240,18 +240,6 @@ impl Module for EcmascriptClientReferenceModule {
             .collect();
 
         Ok(Vc::cell(references))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for EcmascriptClientReferenceModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        AssetContent::File(
-            FileContent::Content("// This is a proxy module for Next.js client references.".into())
-                .resolved_cell(),
-        )
-        .cell()
     }
 }
 

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -4,9 +4,7 @@ use anyhow::Result;
 use indoc::formatdoc;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::FileContent;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     ident::AssetIdent,
     module::Module,
@@ -70,18 +68,6 @@ impl Module for NextDynamicEntryModule {
             .to_resolved()
             .await?,
         )]))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for NextDynamicEntryModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        AssetContent::File(
-            FileContent::Content("// This is a marker module for Next.js dynamic.".into())
-                .resolved_cell(),
-        )
-        .cell()
     }
 }
 

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -4,9 +4,8 @@ use anyhow::Result;
 use indoc::formatdoc;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{FileContent, FileSystemPath};
+use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     ident::AssetIdent,
     module::Module,
@@ -66,20 +65,6 @@ impl Module for NextServerComponentModule {
                 .to_resolved()
                 .await?,
         )]))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for NextServerComponentModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        AssetContent::File(
-            FileContent::Content(
-                "// This is a marker module for Next.js server components.".into(),
-            )
-            .resolved_cell(),
-        )
-        .cell()
     }
 }
 

--- a/crates/next-core/src/next_server_utility/server_utility_module.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_module.rs
@@ -4,9 +4,8 @@ use anyhow::Result;
 use indoc::formatdoc;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{FileContent, FileSystemPath};
+use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     ident::AssetIdent,
     module::Module,
@@ -66,18 +65,6 @@ impl Module for NextServerUtilityModule {
                 .to_resolved()
                 .await?,
         )]))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for NextServerUtilityModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        AssetContent::File(
-            FileContent::Content("// This is a marker module for Next.js server utilities.".into())
-                .resolved_cell(),
-        )
-        .cell()
     }
 }
 

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -36,11 +36,12 @@ pub async fn get_swc_ecma_transform_rule_impl(
     enable_mdx_rs: bool,
 ) -> Result<Option<ModuleRule>> {
     use anyhow::bail;
-    use turbo_tasks::TryFlatJoinIterExt;
+    use turbo_tasks::{TryFlatJoinIterExt, ValueToString};
     use turbo_tasks_fs::FileContent;
     use turbopack::{resolve_options, resolve_options_context::ResolveOptionsContext};
     use turbopack_core::{
         asset::Asset,
+        module::Module,
         reference_type::{CommonJsReferenceSubType, ReferenceType},
         resolve::{handle_resolve_error, parse::Request, resolve},
     };
@@ -99,7 +100,16 @@ pub async fn get_swc_ecma_transform_rule_impl(
                     return Ok(None);
                 };
 
-                let content = &*plugin_module.content().file_content().await?;
+                let Some(plugin_source) = &*plugin_module.source().await? else {
+                    use anyhow::bail;
+
+                    bail!(
+                        "Expected source for plugin module: {}",
+                        plugin_module.ident().to_string().await?
+                    );
+                };
+
+                let content = &*plugin_source.content().file_content().await?;
                 let FileContent::Content(file) = content else {
                     bail!("Expected file content for plugin module");
                 };

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -10,7 +10,7 @@ use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt, ValueToStr
 use turbo_tasks_fs::{FileContent, glob::Glob, rope::Rope};
 use turbopack::{ModuleAssetContext, module_options::CustomModuleType};
 use turbopack_core::{
-    asset::{Asset, AssetContent},
+    asset::Asset,
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     code_builder::CodeBuilder,
     compile_time_info::{
@@ -104,14 +104,6 @@ impl Module for RawEcmascriptModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(false)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for RawEcmascriptModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/changed.rs
+++ b/turbopack/crates/turbopack-core/src/changed.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use turbo_tasks::{
     Completion, Completions, ResolvedVc, TryJoinIterExt, Vc,
     graph::{AdjacencyMap, GraphTraversal},
@@ -33,7 +33,7 @@ pub async fn any_content_changed_of_module(
         .completed()?
         .into_inner()
         .into_postorder_topological()
-        .map(|m| content_changed(*ResolvedVc::upcast(m)))
+        .map(|m| source_changed(*m))
         .map(|v| v.to_resolved())
         .try_join()
         .await?;
@@ -83,5 +83,18 @@ pub async fn any_content_changed_of_output_assets(
 pub async fn content_changed(asset: Vc<Box<dyn Asset>>) -> Result<Vc<Completion>> {
     // Reading the file content is enough to add as dependency
     asset.content().file_content().await?;
+    Ok(Completion::new())
+}
+
+/// Returns a completion that changes when the content of the given asset
+/// changes.
+#[turbo_tasks::function]
+pub async fn source_changed(asset: Vc<Box<dyn Module>>) -> Result<Vc<Completion>> {
+    if let Some(source) = *asset.source().await? {
+        // Reading the file content is enough to add as dependency
+        source.content().file_content().await?;
+    } else {
+        bail!("Module has no source")
+    }
     Ok(Completion::new())
 }

--- a/turbopack/crates/turbopack-core/src/changed.rs
+++ b/turbopack/crates/turbopack-core/src/changed.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, bail};
 use turbo_tasks::{
-    Completion, Completions, ResolvedVc, TryJoinIterExt, Vc,
+    Completion, Completions, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
     graph::{AdjacencyMap, GraphTraversal},
 };
 
@@ -94,7 +94,7 @@ pub async fn source_changed(asset: Vc<Box<dyn Module>>) -> Result<Vc<Completion>
         // Reading the file content is enough to add as dependency
         source.content().file_content().await?;
     } else {
-        bail!("Module has no source")
+        bail!("Module {} has no source", asset.ident().to_string().await?)
     }
     Ok(Completion::new())
 }

--- a/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
@@ -3,7 +3,6 @@ use turbo_tasks::{ResolvedVc, Upcast, ValueToString, Vc};
 
 use super::ChunkableModule;
 use crate::{
-    asset::Asset,
     context::AssetContext,
     module::Module,
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -15,7 +14,7 @@ use crate::{
 /// The chunking context implementation will resolve the dynamic entry to a
 /// well-known value or trait object.
 #[turbo_tasks::value_trait]
-pub trait EvaluatableAsset: Asset + Module + ChunkableModule {}
+pub trait EvaluatableAsset: Module + ChunkableModule {}
 
 pub trait EvaluatableAssetExt {
     fn to_evaluatable(

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -90,7 +90,7 @@ pub struct ModuleIds(Vec<ResolvedVc<ModuleId>>);
 
 /// A [Module] that can be converted into a [Chunk].
 #[turbo_tasks::value_trait]
-pub trait ChunkableModule: Module + Asset {
+pub trait ChunkableModule: Module {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: Vc<Self>,
@@ -115,7 +115,7 @@ impl ChunkableModules {
 // with other module types (as a MergeableModule cannot prevent itself from being merged with other
 // module types)
 #[turbo_tasks::value_trait]
-pub trait MergeableModule: Module + Asset {
+pub trait MergeableModule: Module {
     /// Even though MergeableModule is implemented, this allows a dynamic condition to determine
     /// mergeability
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/introspect/module.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/module.rs
@@ -33,8 +33,12 @@ impl Introspectable for IntrospectableModule {
     }
 
     #[turbo_tasks::function]
-    fn details(&self) -> Vc<RcStr> {
-        content_to_details(self.0.content())
+    async fn details(&self) -> Result<Vc<RcStr>> {
+        if let Some(source) = *self.0.source().await? {
+            Ok(content_to_details(source.content()))
+        } else {
+            Ok(Vc::cell("No source".into()))
+        }
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -14,7 +14,7 @@ pub enum StyleType {
 /// A module. This usually represents parsed source code, which has references
 /// to other modules.
 #[turbo_tasks::value_trait]
-pub trait Module: Asset {
+pub trait Module {
     /// The identifier of the [Module]. It's expected to be unique and capture
     /// all properties of the [Module].
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -2,7 +2,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, TaskInput, ValueToString, Vc};
 use turbo_tasks_fs::glob::Glob;
 
-use crate::{asset::Asset, ident::AssetIdent, reference::ModuleReferences, source::OptionSource};
+use crate::{ident::AssetIdent, reference::ModuleReferences, source::OptionSource};
 
 #[derive(Clone, Copy, Debug, TaskInput, Hash)]
 #[turbo_tasks::value(shared)]
@@ -55,7 +55,7 @@ pub trait Module {
 }
 
 #[turbo_tasks::value_trait]
-pub trait StyleModule: Module + Asset {
+pub trait StyleModule: Module {
     /// The style type of the module.
     #[turbo_tasks::function]
     fn style_type(&self) -> Vc<StyleType>;

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -7,7 +7,6 @@ use turbo_tasks::{FxIndexSet, ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::{FileSystemEntryType, FileSystemPath};
 
 use crate::{
-    asset::{Asset, AssetContent},
     file_source::FileSource,
     ident::AssetIdent,
     module::Module,
@@ -99,14 +98,6 @@ impl Module for NodeAddonModule {
 
         // Most addon modules don't have references to other modules.
         Ok(ModuleReferences::empty())
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for NodeAddonModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/raw_module.rs
+++ b/turbopack/crates/turbopack-core/src/raw_module.rs
@@ -1,7 +1,6 @@
 use turbo_tasks::{ResolvedVc, Vc};
 
 use crate::{
-    asset::{Asset, AssetContent},
     ident::AssetIdent,
     module::Module,
     source::{OptionSource, Source},
@@ -24,14 +23,6 @@ impl Module for RawModule {
     #[turbo_tasks::function]
     fn source(&self) -> Vc<OptionSource> {
         Vc::cell(Some(self.source))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for RawModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/rebase.rs
+++ b/turbopack/crates/turbopack-core/src/rebase.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
 use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
@@ -78,7 +78,10 @@ impl Asset for RebasedAsset {
         if let Some(source) = *self.module.source().await? {
             Ok(source.content())
         } else {
-            bail!("Module has no source")
+            bail!(
+                "Module {} has no source",
+                self.module.ident().to_string().await?
+            )
         }
     }
 }

--- a/turbopack/crates/turbopack-core/src/rebase.rs
+++ b/turbopack/crates/turbopack-core/src/rebase.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
@@ -74,7 +74,11 @@ impl OutputAsset for RebasedAsset {
 #[turbo_tasks::value_impl]
 impl Asset for RebasedAsset {
     #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.module.content()
+    async fn content(&self) -> Result<Vc<AssetContent>> {
+        if let Some(source) = *self.module.source().await? {
+            Ok(source.content())
+        } else {
+            bail!("Module has no source")
+        }
     }
 }

--- a/turbopack/crates/turbopack-core/src/traced_asset.rs
+++ b/turbopack/crates/turbopack-core/src/traced_asset.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
@@ -54,7 +54,11 @@ impl OutputAsset for TracedAsset {
 #[turbo_tasks::value_impl]
 impl Asset for TracedAsset {
     #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.module.content()
+    async fn content(&self) -> Result<Vc<AssetContent>> {
+        if let Some(source) = *self.module.source().await? {
+            Ok(source.content())
+        } else {
+            bail!("Module has no source")
+        }
     }
 }

--- a/turbopack/crates/turbopack-core/src/traced_asset.rs
+++ b/turbopack/crates/turbopack-core/src/traced_asset.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
@@ -58,7 +58,10 @@ impl Asset for TracedAsset {
         if let Some(source) = *self.module.source().await? {
             Ok(source.content())
         } else {
-            bail!("Module has no source")
+            bail!(
+                "Module {} has no source",
+                self.module.ident().to_string().await?,
+            )
         }
     }
 }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -3,7 +3,6 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{IntoTraitRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, MinifyType},
     context::AssetContext,
     environment::Environment,
@@ -163,14 +162,6 @@ impl StyleModule for CssModuleAsset {
             CssModuleAssetType::Default => StyleType::GlobalStyle.cell(),
             CssModuleAssetType::Module => StyleType::IsolatedStyle.cell(),
         }
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for CssModuleAsset {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -437,7 +437,7 @@ impl GenerateSourceMap for CssChunk {
 
 // TODO: remove
 #[turbo_tasks::value_trait]
-pub trait CssChunkPlaceable: ChunkableModule + Module + Asset {}
+pub trait CssChunkPlaceable: ChunkableModule + Module {}
 
 #[derive(Clone, Debug)]
 #[turbo_tasks::value(shared)]

--- a/turbopack/crates/turbopack-css/src/embed.rs
+++ b/turbopack/crates/turbopack-css/src/embed.rs
@@ -1,8 +1,8 @@
 use turbo_tasks::Vc;
-use turbopack_core::{asset::Asset, chunk::ChunkingContext, module::Module, output::OutputAsset};
+use turbopack_core::{chunk::ChunkingContext, module::Module, output::OutputAsset};
 
 #[turbo_tasks::value_trait]
-pub trait CssEmbed: Module + Asset {
+pub trait CssEmbed: Module {
     #[turbo_tasks::function]
     fn embedded_asset(
         self: Vc<Self>,

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -8,7 +8,6 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, IntoTraitRef, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileSystemPath, rope::Rope};
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     context::{AssetContext, ProcessResult},
     ident::AssetIdent,
@@ -110,14 +109,6 @@ impl Module for ModuleCssAsset {
             .collect();
 
         Ok(Vc::cell(references))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for ModuleCssAsset {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -3,7 +3,6 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{ChunkableModule, ChunkingContext, availability_info::AvailabilityInfo},
     ident::AssetIdent,
     module::Module,
@@ -73,14 +72,6 @@ impl Module for AsyncLoaderModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for AsyncLoaderModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        panic!("content() should not be called");
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -24,7 +24,7 @@ use crate::references::{
 };
 
 #[turbo_tasks::value_trait]
-pub trait EcmascriptChunkPlaceable: ChunkableModule + Module + Asset {
+pub trait EcmascriptChunkPlaceable: ChunkableModule + Module {
     #[turbo_tasks::function]
     fn get_exports(self: Vc<Self>) -> Vc<EcmascriptExports>;
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/inlined_bytes_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/inlined_bytes_module.rs
@@ -5,7 +5,7 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileContent, glob::Glob, rope::RopeBuilder};
 use turbopack_core::{
-    asset::{Asset, AssetContent},
+    asset::Asset,
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
     module::Module,
@@ -56,14 +56,6 @@ impl Module for InlinedBytesJsModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for InlinedBytesJsModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 
@@ -128,7 +120,7 @@ impl ChunkItem for InlinedBytesJsChunkItem {
 impl EcmascriptChunkItem for InlinedBytesJsChunkItem {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
-        let content = self.module.content().file_content().await?;
+        let content = self.module.await?.source.content().file_content().await?;
         match &*content {
             FileContent::Content(data) => {
                 let mut inner_code = RopeBuilder::default();

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -90,7 +90,6 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::{FileJsonContent, FileSystemPath, glob::Glob, rope::Rope};
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{
         AsyncModuleInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext, EvaluatableAsset,
         MergeableModule, MergeableModuleExposure, MergeableModules, MergeableModulesExposed,
@@ -403,7 +402,7 @@ pub trait EcmascriptParsable {
 }
 
 #[turbo_tasks::value_trait]
-pub trait EcmascriptAnalyzable: Module + Asset {
+pub trait EcmascriptAnalyzable: Module {
     #[turbo_tasks::function]
     fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult>;
 
@@ -771,14 +770,6 @@ impl Module for EcmascriptModuleAsset {
         } else {
             Vc::cell(self.analyze().await?.has_side_effect_free_directive)
         })
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for EcmascriptModuleAsset {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -3,7 +3,6 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{
         ChunkableModule, ChunkingContext, ChunkingContextExt, availability_info::AvailabilityInfo,
     },
@@ -159,14 +158,6 @@ impl Module for ManifestAsyncModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for ManifestAsyncModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        panic!("content() should not be called");
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/merged_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/merged_module.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{
         AsyncModuleInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext,
         MergeableModuleExposure, MergeableModules, MergeableModulesExposed,
@@ -57,14 +56,6 @@ impl MergedEcmascriptModule {
             options,
         }
         .resolved_cell())
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for MergedEcmascriptModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        panic!("content() should not be called");
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -4,9 +4,8 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, Vc, trace::TraceRawVcs};
-use turbo_tasks_fs::{FileContent, FileSystem, VirtualFileSystem, glob::Glob, rope::RopeBuilder};
+use turbo_tasks_fs::{FileSystem, VirtualFileSystem, glob::Glob, rope::RopeBuilder};
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{AsyncModuleInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     ident::{AssetIdent, Layer},
     module::Module,
@@ -314,15 +313,6 @@ impl Module for CachedExternalModule {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for CachedExternalModule {
-    #[turbo_tasks::function]
-    fn content(self: Vc<Self>) -> Vc<AssetContent> {
-        // should be `NotFound` as this function gets called to detect source changes
-        AssetContent::file(FileContent::NotFound.cell())
-    }
-}
-
-#[turbo_tasks::value_impl]
 impl ChunkableModule for CachedExternalModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
@@ -454,7 +444,7 @@ impl Module for ModuleWithoutSelfAsync {
 
     #[turbo_tasks::function]
     fn source(&self) -> Vc<turbopack_core::source::OptionSource> {
-        Vc::cell(None)
+        self.module.source()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -446,14 +446,6 @@ impl ModuleWithoutSelfAsync {
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for ModuleWithoutSelfAsync {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.module.content()
-    }
-}
-
-#[turbo_tasks::value_impl]
 impl Module for ModuleWithoutSelfAsync {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -21,7 +21,6 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath, glob::Glob};
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{
         ChunkItem, ChunkType, ChunkableModule, ChunkableModuleReference, ChunkingContext,
         MinifyType, ModuleChunkItemIdExt,
@@ -433,14 +432,6 @@ impl Module for RequireContextAsset {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for RequireContextAsset {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        unimplemented!()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -2,9 +2,8 @@ use std::collections::BTreeMap;
 
 use anyhow::{Result, bail};
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{File, FileContent, glob::Glob};
+use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{
         AsyncModuleInfo, ChunkableModule, ChunkingContext, EvaluatableAsset, MergeableModule,
         MergeableModules, MergeableModulesExposed,
@@ -195,16 +194,6 @@ impl Module for EcmascriptModuleFacadeModule {
             }
             _ => bail!("Unexpected ModulePart for EcmascriptModuleFacadeModule"),
         })
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for EcmascriptModuleFacadeModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        let f = File::from("");
-
-        AssetContent::file(FileContent::Content(f).cell())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -4,7 +4,6 @@ use anyhow::{Result, bail};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{
         AsyncModuleInfo, ChunkableModule, ChunkingContext, MergeableModule, MergeableModules,
         MergeableModulesExposed,
@@ -76,14 +75,6 @@ impl Module for EcmascriptModuleLocalsModule {
     fn is_marked_as_side_effect_free(&self, side_effect_free_packages: Vc<Glob>) -> Vc<bool> {
         self.module
             .is_marked_as_side_effect_free(side_effect_free_packages)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for EcmascriptModuleLocalsModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.module.content()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -3,7 +3,6 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext, EvaluatableAsset},
     context::AssetContext,
     ident::AssetIdent,
@@ -363,14 +362,6 @@ impl Module for EcmascriptModulePartAsset {
                 .full_module
                 .is_marked_as_side_effect_free(side_effect_free_packages)),
         }
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for EcmascriptModulePartAsset {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.full_module.content()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
@@ -1,9 +1,8 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
-use turbo_tasks_fs::{FileContent, glob::Glob};
+use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{ChunkableModule, ChunkingContext, EvaluatableAsset},
     ident::AssetIdent,
     module::Module,
@@ -116,21 +115,6 @@ impl Module for SideEffectsModule {
     #[turbo_tasks::function]
     fn is_marked_as_side_effect_free(self: Vc<Self>, _: Vc<Glob>) -> Vc<bool> {
         Vc::cell(true)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for SideEffectsModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        AssetContent::File(
-            FileContent::Content(
-                "// This is a proxy module for reexportings a module with additional side effects."
-                    .into(),
-            )
-            .resolved_cell(),
-        )
-        .cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -4,7 +4,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::DirectoryContent;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
+    asset::Asset,
     ident::AssetIdent,
     module::Module,
     raw_module::RawModule,
@@ -177,14 +177,6 @@ impl Module for TsConfigModuleAsset {
             }
         }
         Ok(Vc::cell(references))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for TsConfigModuleAsset {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -3,7 +3,6 @@ use swc_core::ecma::ast::Lit;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     file_source::FileSource,
     ident::AssetIdent,
     module::Module,
@@ -63,14 +62,6 @@ impl Module for WebpackModuleAsset {
     #[turbo_tasks::function]
     fn references(&self) -> Vc<ModuleReferences> {
         module_references(*self.source, *self.runtime, *self.transforms)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for WebpackModuleAsset {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -3,7 +3,6 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{
         ChunkGroupType, ChunkableModule, ChunkableModuleReference, ChunkingContext, ChunkingType,
         ChunkingTypeOption,
@@ -64,14 +63,6 @@ impl Module for WorkerLoaderModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for WorkerLoaderModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        panic!("content() should not be called");
     }
 }
 

--- a/turbopack/crates/turbopack-json/src/lib.rs
+++ b/turbopack/crates/turbopack-json/src/lib.rs
@@ -16,7 +16,7 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileContent, FileJsonContent, glob::Glob};
 use turbopack_core::{
-    asset::{Asset, AssetContent},
+    asset::Asset,
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     code_builder::CodeBuilder,
     ident::AssetIdent,
@@ -64,14 +64,6 @@ impl Module for JsonModuleAsset {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for JsonModuleAsset {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 
@@ -138,7 +130,7 @@ impl EcmascriptChunkItem for JsonChunkItem {
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
         // We parse to JSON and then stringify again to ensure that the
         // JSON is valid.
-        let content = self.module.content().file_content();
+        let content = self.module.await?.source.content().file_content();
         let data = content.parse_json().await?;
         match &*data {
             FileJsonContent::Content(data) => {

--- a/turbopack/crates/turbopack-static/src/css.rs
+++ b/turbopack/crates/turbopack-static/src/css.rs
@@ -2,12 +2,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
-    chunk::ChunkingContext,
-    ident::AssetIdent,
-    module::Module,
-    output::OutputAsset,
-    source::Source,
+    chunk::ChunkingContext, ident::AssetIdent, module::Module, output::OutputAsset, source::Source,
 };
 use turbopack_css::embed::CssEmbed;
 
@@ -58,14 +53,6 @@ impl Module for StaticUrlCssModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for StaticUrlCssModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -3,7 +3,6 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
     module::Module,
@@ -70,14 +69,6 @@ impl Module for StaticUrlJsModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for StaticUrlJsModule {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -3,7 +3,6 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{IntoTraitRef, ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{
         AsyncModuleInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext,
         chunk_group::references_to_output_assets,
@@ -143,14 +142,6 @@ impl Module for WebAssemblyModuleAsset {
     #[turbo_tasks::function]
     fn is_self_async(self: Vc<Self>) -> Vc<bool> {
         Vc::cell(true)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for WebAssemblyModuleAsset {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -2,7 +2,6 @@ use anyhow::{Result, bail};
 use turbo_rcstr::rcstr;
 use turbo_tasks::{IntoTraitRef, ResolvedVc, Vc};
 use turbopack_core::{
-    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     context::AssetContext,
     ident::AssetIdent,
@@ -63,14 +62,6 @@ impl Module for RawWebAssemblyModuleAsset {
     #[turbo_tasks::function]
     fn source(&self) -> Vc<OptionSource> {
         Vc::cell(Some(ResolvedVc::upcast(self.source)))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl Asset for RawWebAssemblyModuleAsset {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<AssetContent> {
-        self.source.content()
     }
 }
 


### PR DESCRIPTION
Turbopack: remove Asset supertrait from Module trait. Modules don't have content

remove unneeded Asset implementation

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
