### PR TITLE
Turbopack: fix import chain by determining depth locally per route

### DIFF
--- a/apps/bundle-analyzer/app/page.tsx
+++ b/apps/bundle-analyzer/app/page.tsx
@@ -15,6 +15,7 @@ import { Input } from '@/components/ui/input'
 import { Skeleton, TreemapSkeleton } from '@/components/ui/skeleton'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { AnalyzeData, ModulesData } from '@/lib/analyze-data'
+import { computeActiveEntries, computeModuleDepthMap } from '@/lib/module-graph'
 import { SpecialModule } from '@/lib/types'
 import { getSpecialModuleType, fetchStrict } from '@/lib/utils'
 
@@ -99,6 +100,14 @@ export default function Home() {
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [])
+
+  // Compute module depth map from active entries
+  const moduleDepthMap = useMemo(() => {
+    if (!modulesData || !analyzeData) return new Map()
+
+    const activeEntries = computeActiveEntries(modulesData, analyzeData)
+    return computeModuleDepthMap(modulesData, activeEntries)
+  }, [modulesData, analyzeData])
 
   const filterSource = useMemo(() => {
     if (!analyzeData) return undefined
@@ -332,6 +341,7 @@ export default function Home() {
                           startFileId={selectedSourceIndex}
                           analyzeData={analyzeData}
                           modulesData={modulesData}
+                          depthMap={moduleDepthMap}
                           filterSource={filterSource}
                         />
                       )}

--- a/apps/bundle-analyzer/app/page.tsx
+++ b/apps/bundle-analyzer/app/page.tsx
@@ -30,7 +30,9 @@ function formatBytes(bytes: number): string {
 
 export default function Home() {
   const [selectedRoute, setSelectedRoute] = useState<string | null>(null)
-  const [environmentFilter, setEnvironmentFilter] = useState<string>('client')
+  const [environmentFilter, setEnvironmentFilter] = useState<
+    'client' | 'server'
+  >('client')
   const [typeFilter, setTypeFilter] = useState<string[]>(['js', 'css', 'json'])
   const [selectedSourceIndex, setSelectedSourceIndex] = useState<number | null>(
     null
@@ -181,7 +183,7 @@ export default function Home() {
                 className="mr-4"
                 value={environmentFilter}
                 onValueChange={(value) => {
-                  if (value) setEnvironmentFilter(value)
+                  if (value) setEnvironmentFilter(value as 'client' | 'server')
                 }}
                 size="sm"
               >
@@ -342,7 +344,7 @@ export default function Home() {
                           analyzeData={analyzeData}
                           modulesData={modulesData}
                           depthMap={moduleDepthMap}
-                          filterSource={filterSource}
+                          environmentFilter={environmentFilter}
                         />
                       )}
                       {(() => {

--- a/apps/bundle-analyzer/components/import-chain.tsx
+++ b/apps/bundle-analyzer/components/import-chain.tsx
@@ -20,6 +20,7 @@ import type {
   SourceIndex,
 } from '@/lib/analyze-data'
 import { splitIdent } from '@/lib/utils'
+import clsx from 'clsx'
 
 interface ImportChainProps {
   startFileId: number
@@ -53,52 +54,61 @@ interface DependentInfo {
   depth: number
 }
 
-function getPathDifference(currentPath: string, previousPath: string | null) {
-  if (!previousPath) {
-    return { common: '', different: currentPath }
-  }
+type PathPart = {
+  segment: string
+  isCommon: boolean
+  isLastCommon: boolean
+  isPackageName: boolean
+  isInfrastructure: boolean
+}
 
-  const currentSegments = currentPath.split('/')
-  const previousSegments = previousPath.split('/')
+function spitPathSegments(path: string): string[] {
+  return Array.from(path.matchAll(/(.+?(?:\/|$))/g)).map(([i]) => i)
+}
+
+function getPathParts(
+  currentPath: string,
+  previousPath: string | null
+): PathPart[] {
+  const currentSegments = spitPathSegments(currentPath)
 
   let commonCount = 0
-  const minLength = Math.min(currentSegments.length, previousSegments.length)
+  if (previousPath) {
+    const previousSegments = spitPathSegments(previousPath)
 
-  for (let i = 0; i < minLength; i++) {
-    if (currentSegments[i] === previousSegments[i]) {
-      commonCount++
-    } else {
-      break
+    const minLength = Math.min(currentSegments.length, previousSegments.length)
+
+    for (let i = 0; i < minLength; i++) {
+      if (currentSegments[i] === previousSegments[i]) {
+        commonCount++
+      } else {
+        break
+      }
     }
   }
 
-  const commonSegments = currentSegments.slice(0, commonCount)
-  const differentSegments = currentSegments.slice(commonCount)
-
-  const common =
-    commonSegments.length === 0
-      ? ''
-      : differentSegments.length === 0
-        ? `${commonSegments.join('/')}`
-        : `${commonSegments.join('/')}/`
-  return {
-    common,
-    different: differentSegments.join('/'),
+  let infrastructureCount = 0
+  let packageNameCount = 0
+  let nodeModulesIndex = currentSegments.lastIndexOf('node_modules/')
+  if (nodeModulesIndex === -1) {
+    nodeModulesIndex = currentSegments.length
+  } else {
+    infrastructureCount = nodeModulesIndex + 1
+    if (currentSegments[nodeModulesIndex + 1]?.startsWith('@')) {
+      packageNameCount = 2
+    } else {
+      packageNameCount = 1
+    }
   }
-}
 
-const insertLineBreaks = (path: string) => {
-  const segments = path.split('/')
-  return segments.map((segment, i) => (
-    <span
-      key={`${segment}-${i}`}
-      className={segment.length > 20 ? 'break-all' : ''}
-    >
-      {segment}
-      {i < segments.length - 1 && '/'}
-      <wbr />
-    </span>
-  ))
+  return currentSegments.map((segment, i) => ({
+    segment,
+    isCommon: i < commonCount,
+    isLastCommon: i === commonCount - 1,
+    isInfrastructure: i < infrastructureCount,
+    isPackageName:
+      i >= infrastructureCount && i < infrastructureCount + packageNameCount,
+  }))
 }
 
 function getTitle(level: ChainLevel) {
@@ -330,10 +340,7 @@ export function ImportChain({
       <div className="space-y-0">
         {chain.map((level, index) => {
           const previousPath = index > 0 ? chain[index - 1].path : null
-          const { common, different } = getPathDifference(
-            level.path,
-            previousPath
-          )
+          const parts = getPathParts(level.path, previousPath)
 
           const flags =
             level.sourceIndex !== undefined
@@ -402,21 +409,35 @@ export function ImportChain({
                     className="font-mono text-xs text-foreground text-center block break-words"
                     title={getTitle(level)}
                   >
-                    {index === 0 ? (
-                      <span className="font-normal">
-                        {insertLineBreaks(level.path)}
-                      </span>
-                    ) : (
-                      <>
-                        {common && (
-                          <span className="font-normal text-muted-foreground/60">
-                            {insertLineBreaks(common)}
-                          </span>
-                        )}
-                        <span className="font-bold">
-                          {insertLineBreaks(different)}
+                    {parts.map(
+                      (
+                        {
+                          segment,
+                          isCommon,
+                          isLastCommon,
+                          isInfrastructure,
+                          isPackageName,
+                        },
+                        i
+                      ) => (
+                        <span
+                          key={i}
+                          className={clsx(
+                            segment.length > 20 && 'break-all',
+                            isCommon &&
+                              !isLastCommon &&
+                              !isPackageName &&
+                              !isInfrastructure &&
+                              'text-muted-foreground/80',
+                            !isCommon && !isInfrastructure && 'font-bold',
+                            isInfrastructure && 'text-muted-foreground/50',
+                            isPackageName && 'text-orange-500'
+                          )}
+                        >
+                          {segment}
+                          <wbr />
                         </span>
-                      </>
+                      )
                     )}
                   </span>
                 </div>

--- a/apps/bundle-analyzer/components/import-chain.tsx
+++ b/apps/bundle-analyzer/components/import-chain.tsx
@@ -4,30 +4,45 @@ import {
   ArrowUp,
   ChevronLeft,
   ChevronRight,
-  Monitor,
-  Route,
+  Box,
+  File,
+  PanelTop,
+  SquareFunction,
   Server,
+  Globe,
+  MessageCircleQuestion,
 } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import type { AnalyzeData, ModulesData } from '@/lib/analyze-data'
+import type {
+  AnalyzeData,
+  ModuleIndex,
+  ModulesData,
+  SourceIndex,
+} from '@/lib/analyze-data'
+import { splitIdent } from '@/lib/utils'
 
 interface ImportChainProps {
   startFileId: number
   analyzeData: AnalyzeData
   modulesData: ModulesData
+  depthMap: Map<ModuleIndex, number>
   filterSource?: (sourceIndex: number) => boolean
 }
 
 interface ChainLevel {
-  fileId: number
-  filePath: string
-  fileDepth: number
+  moduleIndex: ModuleIndex
+  sourceIndex: SourceIndex | undefined
+  path: string
+  depth: number
+  fullPath?: string
+  templateArgs?: string
+  layer?: string
+  moduleType?: string
+  treeShaking?: string
   selectedIndex: number
   totalCount: number
   // Info about this level's relationship to parent (undefined for root)
   info?: DependentInfo
-  // All available dependents at this level
-  allDependents?: DependentInfo[]
 }
 
 interface DependentInfo {
@@ -35,17 +50,6 @@ interface DependentInfo {
   sourceIndex: number | undefined
   isAsync: boolean
   depth: number
-  flags:
-    | {
-        client: boolean
-        server: boolean
-        traced: boolean
-        js: boolean
-        css: boolean
-        json: boolean
-        asset: boolean
-      }
-    | undefined
 }
 
 function getPathDifference(currentPath: string, previousPath: string | null) {
@@ -70,8 +74,14 @@ function getPathDifference(currentPath: string, previousPath: string | null) {
   const commonSegments = currentSegments.slice(0, commonCount)
   const differentSegments = currentSegments.slice(commonCount)
 
+  const common =
+    commonSegments.length === 0
+      ? ''
+      : differentSegments.length === 0
+        ? `${commonSegments.join('/')}`
+        : `${commonSegments.join('/')}/`
   return {
-    common: commonSegments.length > 0 ? `${commonSegments.join('/')}/` : '',
+    common,
     different: differentSegments.join('/'),
   }
 }
@@ -90,18 +100,33 @@ const insertLineBreaks = (path: string) => {
   ))
 }
 
+function getTitle(level: ChainLevel) {
+  const parts = []
+  if (level.fullPath) parts.push(`Full Path: ${level.fullPath}`)
+  else parts.push(`Path: ${level.path}`)
+  if (level.layer) parts.push(`Layer: ${level.layer}`)
+  if (level.moduleType) parts.push(`Module Type: ${level.moduleType}`)
+  if (level.treeShaking) parts.push(`Tree Shaking: ${level.treeShaking}`)
+  if (level.templateArgs) parts.push(`Template Args: ${level.templateArgs}`)
+  return parts.join('\n')
+}
+
 export function ImportChain({
   startFileId,
   analyzeData,
   modulesData,
+  depthMap,
 }: ImportChainProps) {
+  // Filter to include only the current route
+  const [showAll, setShowAll] = useState(false)
+
   // Track which dependent is selected at each level
   const [selectedIndices, setSelectedIndices] = useState<number[]>([])
 
-  // Helper function to get module index from source path
-  const getModuleIndexFromSourceIndex = (sourceIndex: number) => {
+  // Helper function to get module indices from source path
+  const getModuleIndicesFromSourceIndex = (sourceIndex: number) => {
     const path = analyzeData.getFullSourcePath(sourceIndex)
-    return modulesData.getModuleIndexFromPath(path)
+    return modulesData.getModuleIndiciesFromPath(path)
   }
 
   // Helper function to get source index from module path
@@ -127,22 +152,35 @@ export function ImportChain({
     const startPath = analyzeData.getFullSourcePath(startFileId)
     if (!startPath) return result
 
-    // Get the module index for the starting source
-    const startModuleIndex = getModuleIndexFromSourceIndex(startFileId)
-    if (startModuleIndex === undefined) return result
+    // Get all module indices for the starting source
+    const startModuleIndices = getModuleIndicesFromSourceIndex(
+      startFileId
+    ).filter((moduleIndex) => showAll || depthMap.has(moduleIndex))
+    if (startModuleIndices.length === 0) return result
+
+    // Get the selected index for the start modules (default to 0)
+    const selectedStartIdx = selectedIndices[0] ?? 0
+    const actualStartIdx = Math.min(
+      selectedStartIdx,
+      startModuleIndices.length - 1
+    )
+    const startModuleIndex = startModuleIndices[actualStartIdx]
+    const startIdent = modulesData.module(startModuleIndex)?.ident ?? ''
 
     result.push({
-      fileId: startFileId,
-      filePath: startPath,
-      fileDepth: modulesData.module(startModuleIndex)?.depth ?? Infinity,
-      selectedIndex: 0,
-      totalCount: 1,
+      moduleIndex: startModuleIndex,
+      sourceIndex: startFileId,
+      path: startPath,
+      ...splitIdent(startIdent),
+      depth: depthMap.get(startModuleIndex) ?? Infinity,
+      selectedIndex: actualStartIdx,
+      totalCount: startModuleIndices.length,
     })
 
     visitedModules.add(startModuleIndex)
 
     // Build chain by following selected dependents
-    let levelIndex = 0
+    let levelIndex = 1
     let currentModuleIndex = startModuleIndex
 
     while (true) {
@@ -150,15 +188,24 @@ export function ImportChain({
       const dependentModuleIndices = [
         ...modulesData
           .moduleDependents(currentModuleIndex)
-          .map((index: number) => ({ index, async: false })),
+          .map((index: number) => ({
+            index,
+            async: false,
+            depth: depthMap.get(index) ?? Infinity,
+          })),
         ...modulesData
           .asyncModuleDependents(currentModuleIndex)
-          .map((index: number) => ({ index, async: true })),
+          .map((index: number) => ({
+            index,
+            async: true,
+            depth: depthMap.get(index) ?? Infinity,
+          })),
       ]
 
       // Filter out dependents that would create a cycle
       const validDependents = dependentModuleIndices.filter(
-        ({ index }) => !visitedModules.has(index)
+        ({ index, depth }) =>
+          !visitedModules.has(index) && (isFinite(depth) || showAll)
       )
 
       if (validDependents.length === 0) {
@@ -168,37 +215,19 @@ export function ImportChain({
 
       // Build info for each dependent
       const dependentsInfo: DependentInfo[] = validDependents.map(
-        ({ index: moduleIndex, async: isAsync }) => {
-          const module = modulesData.module(moduleIndex)
+        ({ index: moduleIndex, async: isAsync, depth }) => {
           const sourceIndex = getSourceIndexFromModuleIndex(moduleIndex)
-          const flags =
-            sourceIndex !== undefined
-              ? analyzeData.getSourceFlags(sourceIndex)
-              : undefined
           return {
             moduleIndex,
             sourceIndex,
             isAsync,
-            depth: module?.depth ?? Infinity,
-            flags,
+            depth,
           }
         }
       )
 
       // Sort: sync first, async second, then by source presence, then by depth
       dependentsInfo.sort((a, b) => {
-        // First sort by async state (sync before async)
-        if (a.isAsync !== b.isAsync) {
-          return a.isAsync ? 1 : -1
-        }
-
-        // Then sort by source presence (with source before without)
-        const aHasSource = a.sourceIndex !== undefined
-        const bHasSource = b.sourceIndex !== undefined
-        if (aHasSource !== bHasSource) {
-          return aHasSource ? -1 : 1
-        }
-
         // Finally sort by depth (smallest first)
         return a.depth - b.depth
       })
@@ -213,13 +242,14 @@ export function ImportChain({
       if (!selectedDepModule) break
 
       result.push({
-        fileId: selectedDepInfo.moduleIndex,
-        filePath: selectedDepModule.path,
-        fileDepth: selectedDepModule.depth,
+        moduleIndex: selectedDepInfo.moduleIndex,
+        sourceIndex: selectedDepInfo.sourceIndex,
+        path: selectedDepModule.path,
+        depth: depthMap.get(selectedDepInfo.moduleIndex) ?? Infinity,
+        ...splitIdent(selectedDepModule.ident),
         selectedIndex: actualIdx,
         totalCount: dependentsInfo.length,
         info: selectedDepInfo,
-        allDependents: dependentsInfo,
       })
 
       visitedModules.add(selectedDepInfo.moduleIndex)
@@ -232,13 +262,20 @@ export function ImportChain({
 
     return result
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [startFileId, analyzeData, modulesData, selectedIndices])
+  }, [
+    startFileId,
+    analyzeData,
+    modulesData,
+    selectedIndices,
+    showAll,
+    depthMap,
+  ])
 
   const handlePrevious = (levelIndex: number) => {
     setSelectedIndices((prev) => {
       const newIndices = [...prev]
       const currentIdx = newIndices[levelIndex] ?? 0
-      const level = chain[levelIndex + 1] // Fixed: use levelIndex + 1 to get the correct level
+      const level = chain[levelIndex]
       newIndices[levelIndex] =
         currentIdx > 0 ? currentIdx - 1 : level.totalCount - 1
       return newIndices.slice(0, levelIndex + 1)
@@ -249,7 +286,7 @@ export function ImportChain({
     setSelectedIndices((prev) => {
       const newIndices = [...prev]
       const currentIdx = newIndices[levelIndex] ?? 0
-      const level = chain[levelIndex + 1] // Fixed: use levelIndex + 1 to get the correct level
+      const level = chain[levelIndex]
       newIndices[levelIndex] =
         currentIdx < level.totalCount - 1 ? currentIdx + 1 : 0
       return newIndices.slice(0, levelIndex + 1)
@@ -264,26 +301,82 @@ export function ImportChain({
       <h3 className="text-xs font-semibold text-foreground">Import chain</h3>
       <div className="space-y-0">
         {chain.map((level, index) => {
-          const previousPath = index > 0 ? chain[index - 1].filePath : null
+          const previousPath = index > 0 ? chain[index - 1].path : null
           const { common, different } = getPathDifference(
-            level.filePath,
+            level.path,
             previousPath
           )
+
+          const flags =
+            level.sourceIndex !== undefined
+              ? analyzeData.getSourceFlags(level.sourceIndex)
+              : undefined
 
           // Get the current item's info from the level itself
           const currentItemInfo = level.info
 
           return (
-            <div key={`${level.filePath}-${index}`}>
+            <div key={`${level.path}-${index}`}>
+              {currentItemInfo?.isAsync && <div className="h-8" />}
+              <div className="flex items-center justify-center gap-2 py-1">
+                {currentItemInfo?.isAsync && (
+                  <span className="text-xs text-muted-foreground italic">
+                    (async)
+                  </span>
+                )}
+                {index > 0 ? (
+                  <ArrowUp className="w-4 h-4 text-muted-foreground" />
+                ) : undefined}
+                {level.totalCount > 1 && (
+                  <div className="flex items-center gap-1 flex-none">
+                    <button
+                      type="button"
+                      onClick={() => handlePrevious(index)}
+                      className="p-0.5 hover:bg-accent rounded transition-colors cursor-pointer"
+                      title="Previous dependent"
+                    >
+                      <ChevronLeft className="w-3 h-3" />
+                    </button>
+                    <span className="text-muted-foreground text-xs min-w-[3ch] text-center">
+                      {level.selectedIndex + 1}/{level.totalCount}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => handleNext(index)}
+                      className="p-0.5 hover:bg-accent rounded transition-colors cursor-pointer"
+                      title="Next dependent"
+                    >
+                      <ChevronRight className="w-3 h-3" />
+                    </button>
+                  </div>
+                )}
+              </div>
+              {currentItemInfo?.isAsync && <div className="h-8" />}
               <div className="flex items-center gap-2">
+                <div className="flex flex-col gap-1 items-center">
+                  {!level.layer ? (
+                    <div title="Unknown">
+                      <MessageCircleQuestion className="w-3 h-3 text-gray-500" />
+                    </div>
+                  ) : /app/.test(level.layer || '') ? (
+                    <div title="App Router">
+                      <Box className="w-3 h-3 text-green-500" />
+                    </div>
+                  ) : (
+                    <div title="Pages Router">
+                      <File className="w-3 h-3 text-purple-500" />
+                    </div>
+                  )}
+                </div>
+
                 <div className="flex-1 border border-border rounded px-2 py-1 bg-background">
                   <span
                     className="font-mono text-xs text-foreground text-center block break-words"
-                    title={level.filePath}
+                    title={getTitle(level)}
                   >
                     {index === 0 ? (
                       <span className="font-normal">
-                        {insertLineBreaks(level.filePath)}
+                        {insertLineBreaks(level.path)}
                       </span>
                     ) : (
                       <>
@@ -301,66 +394,62 @@ export function ImportChain({
                 </div>
 
                 {/* Show icons for current item if we have flag info or no source */}
-                {currentItemInfo && (
-                  <div className="flex flex-col gap-1 items-center">
-                    {currentItemInfo.sourceIndex === undefined && (
-                      <div title="Used only on different route">
-                        <Route className="w-3 h-3 text-amber-500" />
+                <div className="flex flex-col gap-1 items-center">
+                  {/client/.test(level.layer || '') &&
+                    (flags?.client ? (
+                      <div title="Included on client-side of this route">
+                        <PanelTop className="w-3 h-3 text-green-500" />
                       </div>
-                    )}
-                    {currentItemInfo.flags?.client ? (
-                      <div title="Client Component">
-                        <Monitor className="w-3 h-3 text-green-500" />
+                    ) : (
+                      <div title="On client layer, but not included on client-side of this route (might be tree shaken)">
+                        <PanelTop className="w-3 h-3 text-gray-500" />
                       </div>
-                    ) : currentItemInfo.flags?.server ? (
-                      <div title="Server Component">
-                        <Server className="w-3 h-3 text-blue-500" />
+                    ))}
+                  {/ssr/.test(level.layer || '') &&
+                    (flags?.server ? (
+                      <div title="Included on server-side of this route for server-side rendering">
+                        <Globe className="w-3 h-3 text-blue-500" />
                       </div>
-                    ) : null}
+                    ) : (
+                      <div title="On server-side rendering layer, but not included on server-side of this route (might be tree shaken)">
+                        <Globe className="w-3 h-3 text-gray-500" />
+                      </div>
+                    ))}
+                  {/rsc/.test(level.layer || '') &&
+                    (flags?.server ? (
+                      <div title="Included on server-side of this route as Server Component">
+                        <Server className="w-3 h-3 text-orange-500" />
+                      </div>
+                    ) : (
+                      <div title="On Server Component layer, but not included on server-side of this route (might be tree shaken)">
+                        <Server className="w-3 h-3 text-gray-500" />
+                      </div>
+                    ))}
+                  {/route|api/.test(level.layer || '') &&
+                    (flags?.server ? (
+                      <div title="Included on server-side of this route for API routes">
+                        <SquareFunction className="w-3 h-3 text-red-500" />
+                      </div>
+                    ) : (
+                      <div title="On API route layer, but not included on server-side of this route (might be tree shaken)">
+                        <SquareFunction className="w-3 h-3 text-gray-500" />
+                      </div>
+                    ))}
+                </div>
+              </div>
+
+              <div className="block text-center">
+                {level.treeShaking && (
+                  <div className="text-xs text-foreground text-center">
+                    {level.treeShaking === 'locals'
+                      ? '(only the local declarations of the module)'
+                      : level.treeShaking ===
+                          '(only the module evaluation part of the module)'
+                        ? ''
+                        : `(only the ${level.treeShaking} part of the module)`}
                   </div>
                 )}
               </div>
-
-              {index < chain.length - 1 &&
-                (() => {
-                  // Get the info for the next item (the one the arrow points to)
-                  const nextItemInfo = chain[index + 1].info
-
-                  return (
-                    <div className="flex items-center justify-center gap-2 py-1">
-                      <ArrowUp
-                        className="w-4 h-4 text-muted-foreground"
-                        strokeDasharray={
-                          nextItemInfo?.isAsync ? '4,4' : undefined
-                        }
-                      />
-                      {chain[index + 1].totalCount > 1 && (
-                        <div className="flex items-center gap-1 flex-none">
-                          <button
-                            type="button"
-                            onClick={() => handlePrevious(index)}
-                            className="p-0.5 hover:bg-accent rounded transition-colors cursor-pointer"
-                            title="Previous dependent"
-                          >
-                            <ChevronLeft className="w-3 h-3" />
-                          </button>
-                          <span className="text-muted-foreground text-xs min-w-[3ch] text-center">
-                            {chain[index + 1].selectedIndex + 1}/
-                            {chain[index + 1].totalCount}
-                          </span>
-                          <button
-                            type="button"
-                            onClick={() => handleNext(index)}
-                            className="p-0.5 hover:bg-accent rounded transition-colors cursor-pointer"
-                            title="Next dependent"
-                          >
-                            <ChevronRight className="w-3 h-3" />
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                  )
-                })()}
             </div>
           )
         })}
@@ -369,6 +458,19 @@ export function ImportChain({
             No dependents found
           </p>
         )}
+      </div>
+      <div className="pt-2">
+        <label className="inline-flex items-center space-x-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            className="form-checkbox h-4 w-4 text-primary"
+            checked={showAll}
+            onChange={() => setShowAll((prev) => !prev)}
+          />
+          <span>
+            Show all dependents (including those outside current route)
+          </span>
+        </label>
       </div>
     </div>
   )

--- a/apps/bundle-analyzer/components/import-chain.tsx
+++ b/apps/bundle-analyzer/components/import-chain.tsx
@@ -26,7 +26,7 @@ interface ImportChainProps {
   analyzeData: AnalyzeData
   modulesData: ModulesData
   depthMap: Map<ModuleIndex, number>
-  filterSource?: (sourceIndex: number) => boolean
+  environmentFilter: 'client' | 'server'
 }
 
 interface ChainLevel {
@@ -48,6 +48,7 @@ interface ChainLevel {
 interface DependentInfo {
   moduleIndex: number
   sourceIndex: number | undefined
+  ident: string
   isAsync: boolean
   depth: number
 }
@@ -116,6 +117,7 @@ export function ImportChain({
   analyzeData,
   modulesData,
   depthMap,
+  environmentFilter,
 }: ImportChainProps) {
   // Filter to include only the current route
   const [showAll, setShowAll] = useState(false)
@@ -155,7 +157,22 @@ export function ImportChain({
     // Get all module indices for the starting source
     const startModuleIndices = getModuleIndicesFromSourceIndex(
       startFileId
-    ).filter((moduleIndex) => showAll || depthMap.has(moduleIndex))
+    ).filter((moduleIndex) => {
+      if (!showAll && !depthMap.has(moduleIndex)) {
+        return false
+      }
+      let module = modulesData.module(moduleIndex)
+      let layer = splitIdent(module?.ident || '').layer
+      if (layer) {
+        if (environmentFilter === 'client' && /ssr|rsc|route|api/.test(layer)) {
+          return false
+        }
+        if (environmentFilter === 'server' && /client/.test(layer)) {
+          return false
+        }
+      }
+      return true
+    })
     if (startModuleIndices.length === 0) return result
 
     // Get the selected index for the start modules (default to 0)
@@ -217,9 +234,11 @@ export function ImportChain({
       const dependentsInfo: DependentInfo[] = validDependents.map(
         ({ index: moduleIndex, async: isAsync, depth }) => {
           const sourceIndex = getSourceIndexFromModuleIndex(moduleIndex)
+          let ident = modulesData.module(moduleIndex)?.ident || ''
           return {
             moduleIndex,
             sourceIndex,
+            ident,
             isAsync,
             depth,
           }
@@ -228,8 +247,16 @@ export function ImportChain({
 
       // Sort: sync first, async second, then by source presence, then by depth
       dependentsInfo.sort((a, b) => {
-        // Finally sort by depth (smallest first)
-        return a.depth - b.depth
+        // Sort by depth (smallest first)
+        if (a.depth !== b.depth) {
+          return a.depth - b.depth
+        }
+        // Sort by ident length (shortest first)
+        if (a.ident.length !== b.ident.length) {
+          return a.ident.length - b.ident.length
+        }
+        // Sort by ident
+        return a.ident.localeCompare(b.ident)
       })
 
       // Get the selected index for this level (default to 0)
@@ -269,6 +296,7 @@ export function ImportChain({
     selectedIndices,
     showAll,
     depthMap,
+    environmentFilter,
   ])
 
   const handlePrevious = (levelIndex: number) => {
@@ -401,7 +429,7 @@ export function ImportChain({
                         <PanelTop className="w-3 h-3 text-green-500" />
                       </div>
                     ) : (
-                      <div title="On client layer, but not included on client-side of this route (might be tree shaken)">
+                      <div title="On client layer, but not included on client-side of this route (might be optimized away)">
                         <PanelTop className="w-3 h-3 text-gray-500" />
                       </div>
                     ))}
@@ -411,7 +439,7 @@ export function ImportChain({
                         <Globe className="w-3 h-3 text-blue-500" />
                       </div>
                     ) : (
-                      <div title="On server-side rendering layer, but not included on server-side of this route (might be tree shaken)">
+                      <div title="On server-side rendering layer, but not included on server-side of this route (might be optimized away)">
                         <Globe className="w-3 h-3 text-gray-500" />
                       </div>
                     ))}
@@ -421,7 +449,7 @@ export function ImportChain({
                         <Server className="w-3 h-3 text-orange-500" />
                       </div>
                     ) : (
-                      <div title="On Server Component layer, but not included on server-side of this route (might be tree shaken)">
+                      <div title="On Server Component layer, but not included on server-side of this route (might be optimized away)">
                         <Server className="w-3 h-3 text-gray-500" />
                       </div>
                     ))}
@@ -431,7 +459,7 @@ export function ImportChain({
                         <SquareFunction className="w-3 h-3 text-red-500" />
                       </div>
                     ) : (
-                      <div title="On API route layer, but not included on server-side of this route (might be tree shaken)">
+                      <div title="On API route layer, but not included on server-side of this route (might be optimized away)">
                         <SquareFunction className="w-3 h-3 text-gray-500" />
                       </div>
                     ))}
@@ -442,11 +470,10 @@ export function ImportChain({
                 {level.treeShaking && (
                   <div className="text-xs text-foreground text-center">
                     {level.treeShaking === 'locals'
-                      ? '(only the local declarations of the module)'
-                      : level.treeShaking ===
-                          '(only the module evaluation part of the module)'
-                        ? ''
-                        : `(only the ${level.treeShaking} part of the module)`}
+                      ? '(local declarations only)'
+                      : level.treeShaking === 'module evaluation'
+                        ? '(only the module evaluation part of the module)'
+                        : `(${level.treeShaking})`}
                   </div>
                 )}
               </div>

--- a/apps/bundle-analyzer/lib/module-graph.ts
+++ b/apps/bundle-analyzer/lib/module-graph.ts
@@ -72,27 +72,25 @@ export function computeModuleDepthMap(
   activeEntries: ModuleIndex[]
 ): Map<ModuleIndex, number> {
   const depthMap = new Map<ModuleIndex, number>()
-  const queue: Array<{ moduleIndex: ModuleIndex; depth: number }> = []
+  const delayedModules = new Array<{ depth: number; queue: ModuleIndex[] }>()
 
   // Initialize queue with active entries
   for (const moduleIndex of activeEntries) {
-    if (!depthMap.has(moduleIndex)) {
-      depthMap.set(moduleIndex, 0)
-      queue.push({ moduleIndex, depth: 0 })
-    }
+    depthMap.set(moduleIndex, 0)
   }
 
   // BFS to compute depth
-  while (queue.length > 0) {
-    const { moduleIndex, depth } = queue.shift()!
-
+  // We need to insert new entries into the depth map in monotonic increasing order of depth
+  // so that we always process shallower modules before deeper ones
+  // This is important to avoid visiting modules multiple times and needing to decrease their depth
+  let i = 0
+  for (const [moduleIndex, depth] of depthMap) {
+    const newDepth = depth + 1
     // Process regular dependencies
     const dependencies = modulesData.moduleDependencies(moduleIndex)
     for (const depIndex of dependencies) {
       if (!depthMap.has(depIndex)) {
-        const newDepth = depth + 1
         depthMap.set(depIndex, newDepth)
-        queue.push({ moduleIndex: depIndex, depth: newDepth })
       }
     }
 
@@ -101,10 +99,44 @@ export function computeModuleDepthMap(
     for (const depIndex of asyncDependencies) {
       if (!depthMap.has(depIndex)) {
         const newDepth = depth + 1000
-        depthMap.set(depIndex, newDepth)
-        queue.push({ moduleIndex: depIndex, depth: newDepth })
+        // We can't directly insert async dependencies into the depth map
+        // because they might be processed before their parent module
+        // leading to incorrect depth assignment.
+        // Instead, we queue them to be processed later.
+        let delayedQueue = delayedModules.find((dq) => dq.depth === newDepth)
+        if (!delayedQueue) {
+          delayedQueue = { depth: newDepth, queue: [] }
+          delayedModules.push(delayedQueue)
+          // Keep delayed queues sorted by depth descending
+          delayedModules.sort((a, b) => b.depth - a.depth)
+        }
+        delayedQueue.queue.push(depIndex)
       }
     }
+
+    i++
+
+    // Check if we need to process the next delayed queue to insert its items into the depth map
+    // This happens when we reach the end of the current queue
+    // or the next delayed queue has the same depth so its items need to be processed now
+    while (
+      delayedModules.length > 0 &&
+      (i === depthMap.size ||
+        newDepth === delayedModules[delayedModules.length - 1].depth)
+    ) {
+      const { depth, queue } = delayedModules.pop()!
+      for (const depIndex of queue) {
+        if (!depthMap.has(depIndex)) {
+          depthMap.set(depIndex, depth)
+        }
+      }
+    }
+  }
+
+  if (delayedModules.length > 0) {
+    throw new Error(
+      'Internal error: delayed modules remain after BFS processing'
+    )
   }
 
   return depthMap

--- a/apps/bundle-analyzer/lib/module-graph.ts
+++ b/apps/bundle-analyzer/lib/module-graph.ts
@@ -1,0 +1,111 @@
+import type { AnalyzeData, ModuleIndex, ModulesData } from './analyze-data'
+
+/**
+ * Compute active entries from the current route's sources.
+ *
+ * It's a heuristic approach that looks for known entry module idents
+ * and traces their dependencies to find active modules.
+ *
+ * I don't like it as it has too much assumptions about next.js internals.
+ * It would be better if the source map contains idents instead of only paths.
+ */
+export function computeActiveEntries(
+  modulesData: ModulesData,
+  analyzeData: AnalyzeData
+): ModuleIndex[] {
+  const potentialEntryDependents = [
+    'next/dist/esm/build/templates/pages.js',
+    'next/dist/esm/build/templates/pages-api.js',
+    'next/dist/esm/build/templates/pages-edge-api.js',
+    'next/dist/esm/build/templates/edge-ssr.js',
+    'next/dist/esm/build/templates/app-route.js',
+    'next/dist/esm/build/templates/edge-app-route.js',
+    'next/dist/esm/build/templates/app-page.js',
+    'next/dist/esm/build/templates/edge-ssr-app.js',
+    'next/dist/esm/build/templates/middleware.js',
+    '[next]/entry/page-loader.ts',
+  ]
+  const potentialEntries = [
+    'next/dist/client/app-next-turbopack.js',
+    'next/dist/client/next-turbopack.js',
+  ]
+
+  const activeEntries = new Set<ModuleIndex>()
+
+  for (
+    let moduleIndex = 0;
+    moduleIndex < modulesData.moduleCount();
+    moduleIndex++
+  ) {
+    const ident = modulesData.module(moduleIndex)!.ident
+
+    if (
+      potentialEntryDependents.some((entryIdent) => ident.includes(entryIdent))
+    ) {
+      const dependencies = modulesData.moduleDependencies(moduleIndex)
+      for (const dep of dependencies) {
+        const path = modulesData.module(dep)!.path
+        if (path.includes('next/dist/')) {
+          continue
+        }
+        const source = analyzeData.getSourceIndexFromPath(path)
+        if (source !== undefined) {
+          activeEntries.add(dep)
+        }
+      }
+    }
+    if (potentialEntries.some((entryIdent) => ident.includes(entryIdent))) {
+      activeEntries.add(moduleIndex)
+    }
+  }
+
+  return Array.from(activeEntries)
+}
+
+/**
+ * Compute module depth from active entries using BFS
+ * Returns a Map from ModuleIndex to depth
+ * Unreachable modules will not have an entry in the map
+ */
+export function computeModuleDepthMap(
+  modulesData: ModulesData,
+  activeEntries: ModuleIndex[]
+): Map<ModuleIndex, number> {
+  const depthMap = new Map<ModuleIndex, number>()
+  const queue: Array<{ moduleIndex: ModuleIndex; depth: number }> = []
+
+  // Initialize queue with active entries
+  for (const moduleIndex of activeEntries) {
+    if (!depthMap.has(moduleIndex)) {
+      depthMap.set(moduleIndex, 0)
+      queue.push({ moduleIndex, depth: 0 })
+    }
+  }
+
+  // BFS to compute depth
+  while (queue.length > 0) {
+    const { moduleIndex, depth } = queue.shift()!
+
+    // Process regular dependencies
+    const dependencies = modulesData.moduleDependencies(moduleIndex)
+    for (const depIndex of dependencies) {
+      if (!depthMap.has(depIndex)) {
+        const newDepth = depth + 1
+        depthMap.set(depIndex, newDepth)
+        queue.push({ moduleIndex: depIndex, depth: newDepth })
+      }
+    }
+
+    // Process async dependencies with higher depth penalty
+    const asyncDependencies = modulesData.asyncModuleDependencies(moduleIndex)
+    for (const depIndex of asyncDependencies) {
+      if (!depthMap.has(depIndex)) {
+        const newDepth = depth + 1000
+        depthMap.set(depIndex, newDepth)
+        queue.push({ moduleIndex: depIndex, depth: newDepth })
+      }
+    }
+  }
+
+  return depthMap
+}

--- a/apps/bundle-analyzer/lib/treemap-layout.ts
+++ b/apps/bundle-analyzer/lib/treemap-layout.ts
@@ -1,4 +1,4 @@
-import type { AnalyzeData } from './analyze-data'
+import type { AnalyzeData, SourceIndex } from './analyze-data'
 import { layoutTreemap } from './layout-treemap'
 import { SpecialModule } from './types'
 import { getSpecialModuleType } from './utils'
@@ -29,7 +29,7 @@ export interface LayoutNode extends LayoutNodeInfo {
   css?: boolean
   json?: boolean
   asset?: boolean
-  sourceIndex?: number // Track which source this node represents
+  sourceIndex?: SourceIndex // Track which source this node represents
 }
 
 interface SourceMetadata {
@@ -39,7 +39,7 @@ interface SourceMetadata {
 
 function precomputeSourceMetadata(
   analyzeData: AnalyzeData,
-  filterSource?: (sourceIndex: number) => boolean
+  filterSource?: (sourceIndex: SourceIndex) => boolean
 ): SourceMetadata[] {
   const sourceCount = analyzeData.sourceCount()
   const metadata: SourceMetadata[] = new Array(sourceCount)
@@ -65,7 +65,7 @@ function precomputeSourceMetadata(
   }
 
   // Top-down pass: aggregate child sizes and filtered status for directories
-  function processDirectory(idx: number) {
+  function processDirectory(idx: SourceIndex) {
     const children = analyzeData.sourceChildren(idx)
     if (children.length === 0) return // Already processed as leaf
 
@@ -97,11 +97,11 @@ function precomputeSourceMetadata(
 // Internal function that uses precomputed metadata
 function computeTreemapLayoutFromAnalyzeInternal(
   analyzeData: AnalyzeData,
-  sourceIndex: number,
+  sourceIndex: SourceIndex,
   foldedPath: string,
   rect: LayoutRect,
   metadata: SourceMetadata[],
-  filterSource?: (sourceIndex: number) => boolean
+  filterSource?: (sourceIndex: SourceIndex) => boolean
 ): LayoutNode {
   const source = analyzeData.source(sourceIndex)
   if (!source) {
@@ -164,7 +164,7 @@ function computeTreemapLayoutFromAnalyzeInternal(
 
   if (isCollapsed) {
     // Count all descendant files
-    function countDescendants(idx: number): number {
+    function countDescendants(idx: SourceIndex): number {
       const children = analyzeData.sourceChildren(idx)
       if (children.length === 0) return 1
       return children.reduce(
@@ -253,9 +253,9 @@ function computeTreemapLayoutFromAnalyzeInternal(
 // Public function that precomputes metadata and calls internal function
 export function computeTreemapLayoutFromAnalyze(
   analyzeData: AnalyzeData,
-  sourceIndex: number,
+  sourceIndex: SourceIndex,
   rect: LayoutRect,
-  filterSource?: (sourceIndex: number) => boolean
+  filterSource?: (sourceIndex: SourceIndex) => boolean
 ): LayoutNode {
   // Precompute metadata once for entire tree
   const metadata = precomputeSourceMetadata(analyzeData, filterSource)

--- a/apps/bundle-analyzer/lib/utils.ts
+++ b/apps/bundle-analyzer/lib/utils.ts
@@ -46,9 +46,15 @@ export function getSpecialModuleType(
 let IDENT_ATTRIBUTES_REGEXP =
   /^(.+?)(?: \{(.*)\})?(?: \[(.*)\])?(?: \((.*?)\))?(?: <(.*?)>)?$/
 
-export function splitIdent(ident: string) {
-  let [match, fullPath, extra, layer, moduleType, treeShaking] =
+export function splitIdent(ident: string): {
+  fullPath: string
+  templateArgs: string
+  layer: string
+  moduleType: string
+  treeShaking: string
+} {
+  let [match, fullPath, templateArgs, layer, moduleType, treeShaking] =
     IDENT_ATTRIBUTES_REGEXP.exec(ident) || ['']
   ident = ident.substring(0, ident.length - match.length)
-  return { fullPath, extra, layer, moduleType, treeShaking }
+  return { fullPath, templateArgs, layer, moduleType, treeShaking }
 }

--- a/apps/bundle-analyzer/lib/utils.ts
+++ b/apps/bundle-analyzer/lib/utils.ts
@@ -2,7 +2,7 @@ import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 import { SpecialModule } from './types'
 import { NetworkError } from './errors'
-import { AnalyzeData } from './analyze-data'
+import { AnalyzeData, SourceIndex } from './analyze-data'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -29,7 +29,7 @@ export async function jsonFetcher<T>(url: string): Promise<T> {
 
 export function getSpecialModuleType(
   analyzeData: AnalyzeData | undefined,
-  sourceIndex: number | null
+  sourceIndex: SourceIndex | null
 ): SpecialModule | null {
   if (!analyzeData || sourceIndex == null) return null
 
@@ -41,4 +41,14 @@ export function getSpecialModuleType(
   }
 
   return null
+}
+
+let IDENT_ATTRIBUTES_REGEXP =
+  /^(.+?)(?: \{(.*)\})?(?: \[(.*)\])?(?: \((.*?)\))?(?: <(.*?)>)?$/
+
+export function splitIdent(ident: string) {
+  let [match, fullPath, extra, layer, moduleType, treeShaking] =
+    IDENT_ATTRIBUTES_REGEXP.exec(ident) || ['']
+  ident = ident.substring(0, ident.length - match.length)
+  return { fullPath, extra, layer, moduleType, treeShaking }
 }

--- a/apps/bundle-analyzer/package.json
+++ b/apps/bundle-analyzer/package.json
@@ -17,7 +17,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",
-    "lucide-react": "^0.454.0",
+    "lucide-react": "^0.554.0",
     "next": "16.0.1",
     "next-themes": "^0.4.6",
     "polished": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -643,8 +643,8 @@ importers:
         specifier: 1.0.4
         version: 1.0.4(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-8ac5f4eb-20251119(react@19.3.0-canary-8ac5f4eb-20251119))(react@19.3.0-canary-8ac5f4eb-20251119)
       lucide-react:
-        specifier: ^0.454.0
-        version: 0.454.0(react@19.3.0-canary-8ac5f4eb-20251119)
+        specifier: ^0.554.0
+        version: 0.554.0(react@19.3.0-canary-8ac5f4eb-20251119)
       next:
         specifier: 16.0.1
         version: 16.0.1(@babel/core@7.26.10)(@opentelemetry/api@1.6.0)(@playwright/test@1.51.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@0.0.0-experimental-3fde738-20250918)(react-dom@19.3.0-canary-8ac5f4eb-20251119(react@19.3.0-canary-8ac5f4eb-20251119))(react@19.3.0-canary-8ac5f4eb-20251119)(sass@1.77.8)
@@ -12820,8 +12820,8 @@ packages:
     peerDependencies:
       react: 19.3.0-canary-8ac5f4eb-20251119
 
-  lucide-react@0.454.0:
-    resolution: {integrity: sha512-hw7zMDwykCLnEzgncEEjHeA6+45aeEzRYuKHuyRSOPkhko+J3ySGjGIzu+mmMfDFG1vazHepMaYFYHbTFAZAAQ==}
+  lucide-react@0.554.0:
+    resolution: {integrity: sha512-St+z29uthEJVx0Is7ellNkgTEhaeSoA42I7JjOCBCrc5X6LYMGSv0P/2uS5HDLTExP5tpiqRD2PyUEOS6s9UXA==}
     peerDependencies:
       react: 19.3.0-canary-8ac5f4eb-20251119
 
@@ -31817,7 +31817,7 @@ snapshots:
     dependencies:
       react: 19.3.0-canary-fb2177c1-20251114
 
-  lucide-react@0.454.0(react@19.3.0-canary-8ac5f4eb-20251119):
+  lucide-react@0.554.0(react@19.3.0-canary-8ac5f4eb-20251119):
     dependencies:
       react: 19.3.0-canary-8ac5f4eb-20251119
 


### PR DESCRIPTION
### What?

fix the import chain showing only modules relevant to the current route

fix module graph being merged by path. It's keyed by identifier now.

also add more info to import chain, e. g. layer info. and more details in tooltip.