### PR TITLE
docs: csr-bailout debugging

### DIFF
--- a/errors/missing-suspense-with-csr-bailout.mdx
+++ b/errors/missing-suspense-with-csr-bailout.mdx
@@ -188,3 +188,4 @@ This provides unminified stack traces with source maps, making it easier to pinp
 - [`useSearchParams`](/docs/app/api-reference/functions/use-search-params)
 - [`connection`](/docs/app/api-reference/functions/connection)
 - [Dynamic Rendering guide](/docs/app/guides/caching#dynamic-rendering)
+- [Debugging prerender errors](/docs/app/api-reference/cli/next#debugging-prerender-errors)

--- a/errors/missing-suspense-with-csr-bailout.mdx
+++ b/errors/missing-suspense-with-csr-bailout.mdx
@@ -173,6 +173,16 @@ module.exports = {
 
 This configuration option will be removed in a future major version.
 
+## Debugging
+
+If you're having trouble locating where `useSearchParams()` is being used without a Suspense boundary (for example, the error message is unclear or points to an incorrect route like `/404` or `/500`), you can get more detailed stack traces by running:
+
+```bash
+next build --debug-prerender
+```
+
+This provides unminified stack traces with source maps, making it easier to pinpoint the exact component and route causing the issue.
+
 ## Useful Links
 
 - [`useSearchParams`](/docs/app/api-reference/functions/use-search-params)

--- a/errors/missing-suspense-with-csr-bailout.mdx
+++ b/errors/missing-suspense-with-csr-bailout.mdx
@@ -175,7 +175,7 @@ This configuration option will be removed in a future major version.
 
 ## Debugging
 
-If you're having trouble locating where `useSearchParams()` is being used without a Suspense boundary (for example, the error message is unclear or points to an incorrect route like `/404` or `/500`), you can get more detailed stack traces by running:
+If you're having trouble locating where `useSearchParams()` is being used without a Suspense boundary, you can get more detailed stack traces by running:
 
 ```bash
 next build --debug-prerender

--- a/errors/prerender-error.mdx
+++ b/errors/prerender-error.mdx
@@ -145,5 +145,6 @@ This provides unminified stack traces with source maps, making it easier to pinp
 
 - [Handling Errors in Next.js](/docs/app/getting-started/error-handling)
 - [Data Fetching in Next.js](/docs/app/getting-started/fetching-data)
+- [Debugging prerender errors](/docs/app/api-reference/cli/next#debugging-prerender-errors)
 
 If you continue to experience issues after trying these solutions, consider checking your server logs for more detailed error messages or reaching out to the Next.js community for support.

--- a/errors/prerender-error.mdx
+++ b/errors/prerender-error.mdx
@@ -131,6 +131,16 @@ export default function Page() {
 }
 ```
 
+## Debugging
+
+For additional debugging information when troubleshooting prerender errors, you can run:
+
+```bash
+next build --debug-prerender
+```
+
+This provides unminified stack traces with source maps, making it easier to pinpoint the exact component and route causing the issue.
+
 ## Additional Resources
 
 - [Handling Errors in Next.js](/docs/app/getting-started/error-handling)


### PR DESCRIPTION
I think maybe these others need a hint too, let's get started with, `errors/missing-suspense-with-csr-bailout` and `errors/prerender-error`

- errors/blocking-route.mdx
- errors/deopted-into-client-rendering.mdx
- errors/dynamic-server-error.mdx
- errors/next-prerender-crypto.mdx
- errors/next-prerender-current-time.mdx
- errors/next-prerender-sync-headers.mdx
- errors/next-prerender-sync-params.mdx
- errors/sync-dynamic-apis.mdx