### PR TITLE
Re-implement Server Action reducer

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -161,12 +161,14 @@ export function navigateReducer(
   // implementation. Eventually we'll rewrite the router reducer to a
   // state machine.
   const currentUrl = new URL(state.canonicalUrl, location.origin)
+  const shouldRefreshDynamicData = false
   const result = navigateUsingSegmentCache(
     url,
     currentUrl,
     state.cache,
     state.tree,
     state.nextUrl,
+    shouldRefreshDynamicData,
     shouldScroll,
     mutable
   )

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -32,16 +32,8 @@ import type {
 } from '../router-reducer-types'
 import { assignLocation } from '../../../assign-location'
 import { createHrefFromUrl } from '../create-href-from-url'
-import { handleExternalUrl } from './navigate-reducer'
-import { applyRouterStatePatchToTree } from '../apply-router-state-patch-to-tree'
-import { isNavigatingToNewRootLayout } from '../is-navigating-to-new-root-layout'
-import type { CacheNode } from '../../../../shared/lib/app-router-types'
-import { handleMutable } from '../handle-mutable'
-import { fillLazyItemsTillLeafWithHead } from '../fill-lazy-items-till-leaf-with-head'
-import { createEmptyCacheNode } from '../../app-router'
+import { handleExternalUrl, handleNavigationResult } from './navigate-reducer'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
-import { handleSegmentMismatch } from '../handle-segment-mismatch'
-import { refreshInactiveParallelSegments } from '../refetch-inactive-parallel-segments'
 import {
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
@@ -57,6 +49,11 @@ import {
 } from '../../../../shared/lib/server-reference-info'
 import { revalidateEntireCache } from '../../segment-cache/cache'
 import { getDeploymentId } from '../../../../shared/lib/deployment-id'
+import {
+  navigateToSeededRoute,
+  navigate as navigateUsingSegmentCache,
+} from '../../segment-cache/navigation'
+import type { NormalizedSearch } from '../../segment-cache/cache-key'
 
 const createFromFetch =
   createFromFetchBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromFetch']
@@ -74,11 +71,16 @@ if (
   ).createDebugChannel
 }
 
+// TODO: Refactor to be a discriminated union. Or just get rid of it;
+// fetchServerAction only has one caller, no reason this intermediate type has
+// to exist.
 type FetchServerActionResult = {
   redirectLocation: URL | undefined
   redirectType: RedirectType | undefined
   actionResult: ActionResult | undefined
   actionFlightData: NormalizedFlightData[] | string | undefined
+  actionFlightDataRenderedSearch: NormalizedSearch | undefined
+  actionFlightDataCouldBeIntercepted: boolean | undefined
   isPrerender: boolean
   revalidatedParts: {
     tag: boolean
@@ -166,7 +168,7 @@ async function fetchServerAction(
     revalidatedParts = {
       paths: revalidatedHeader[0] || [],
       tag: !!revalidatedHeader[1],
-      cookie: revalidatedHeader[2],
+      cookie: !!revalidatedHeader[2],
     }
   } catch (e) {
     revalidatedParts = NO_REVALIDATED_PARTS
@@ -200,6 +202,8 @@ async function fetchServerAction(
 
   let actionResult: FetchServerActionResult['actionResult']
   let actionFlightData: FetchServerActionResult['actionFlightData']
+  let actionFlightDataRenderedSearch: FetchServerActionResult['actionFlightDataRenderedSearch']
+  let actionFlightDataCouldBeIntercepted: FetchServerActionResult['actionFlightDataCouldBeIntercepted']
 
   if (isRscResponse) {
     const response: ActionFlightResponse = await createFromFetch(
@@ -214,16 +218,25 @@ async function fetchServerAction(
 
     // An internal redirect can send an RSC response, but does not have a useful `actionResult`.
     actionResult = redirectLocation ? undefined : response.a
-    actionFlightData = normalizeFlightData(response.f)
+    const maybeFlightData = normalizeFlightData(response.f)
+    if (maybeFlightData !== '') {
+      actionFlightData = maybeFlightData
+      actionFlightDataRenderedSearch = response.q as NormalizedSearch
+      actionFlightDataCouldBeIntercepted = response.i
+    }
   } else {
     // An external redirect doesn't contain RSC data.
     actionResult = undefined
     actionFlightData = undefined
+    actionFlightDataRenderedSearch = undefined
+    actionFlightDataCouldBeIntercepted = undefined
   }
 
   return {
     actionResult,
     actionFlightData,
+    actionFlightDataRenderedSearch,
+    actionFlightDataCouldBeIntercepted,
     redirectLocation,
     redirectType,
     revalidatedParts,
@@ -248,8 +261,6 @@ export function serverActionReducer(
   const { resolve, reject } = action
   const mutable: ServerActionMutable = {}
 
-  let currentTree = state.tree
-
   mutable.preserveCustomHistoryState = false
 
   // only pass along the `nextUrl` param (used for interception routes) if the current route was intercepted.
@@ -267,161 +278,47 @@ export function serverActionReducer(
       ? state.previousNextUrl || state.nextUrl
       : null
 
-  const navigatedAt = Date.now()
-
   return fetchServerAction(state, nextUrl, action).then(
     async ({
       actionResult,
       actionFlightData: flightData,
+      actionFlightDataRenderedSearch: flightDataRenderedSearch,
+      actionFlightDataCouldBeIntercepted: flightDataCouldBeIntercepted,
       redirectLocation,
       redirectType,
       revalidatedParts,
     }) => {
-      let redirectHref: string | undefined
-
-      // honor the redirect type instead of defaulting to push in case of server actions.
-      if (redirectLocation) {
-        if (redirectType === RedirectType.replace) {
-          state.pushRef.pendingPush = false
-          mutable.pendingPush = false
-        } else {
-          state.pushRef.pendingPush = true
-          mutable.pendingPush = true
-        }
-
-        redirectHref = createHrefFromUrl(redirectLocation, false)
-        mutable.canonicalUrl = redirectHref
-      }
-
-      if (!flightData) {
-        resolve(actionResult)
-
-        // If there is a redirect but no flight data we need to do a mpaNavigation.
-        if (redirectLocation) {
-          return handleExternalUrl(
-            state,
-            mutable,
-            redirectLocation.href,
-            state.pushRef.pendingPush
-          )
-        }
-        return state
-      }
-
-      if (typeof flightData === 'string') {
-        // Handle case when navigating to page in `pages` from `app`
-        resolve(actionResult)
-
-        return handleExternalUrl(
-          state,
-          mutable,
-          flightData,
-          state.pushRef.pendingPush
-        )
-      }
-
-      const actionRevalidated =
+      const actionDidRevalidateCache =
         revalidatedParts.paths.length > 0 ||
         revalidatedParts.tag ||
         revalidatedParts.cookie
 
-      // Store whether this action triggered any revalidation
-      // The action queue will use this information to potentially
-      // trigger a refresh action if the action was discarded
-      // (ie, due to a navigation, before the action completed)
-      if (actionRevalidated) {
+      if (actionDidRevalidateCache) {
+        // Store whether this action triggered any revalidation
+        // The action queue will use this information to potentially
+        // trigger a refresh action if the action was discarded
+        // (ie, due to a navigation, before the action completed)
         action.didRevalidate = true
+
+        // If there was a revalidation, evict the entire prefetch cache.
+        // TODO: Evict only segments with matching tags and/or paths.
+        revalidateEntireCache(nextUrl, state.tree)
       }
 
-      for (const normalizedFlightData of flightData) {
-        const {
-          tree: treePatch,
-          seedData: cacheNodeSeedData,
-          head,
-          isRootRender,
-        } = normalizedFlightData
-
-        if (!isRootRender) {
-          // TODO-APP: handle this case better
-          console.log('SERVER ACTION APPLY FAILED')
-          resolve(actionResult)
-
-          return state
-        }
-
-        // Given the path can only have two items the items are only the router state and rsc for the root.
-        const newTree = applyRouterStatePatchToTree(
-          // TODO-APP: remove ''
-          [''],
-          currentTree,
-          treePatch,
-          redirectHref ? redirectHref : state.canonicalUrl
-        )
-
-        if (newTree === null) {
-          resolve(actionResult)
-
-          return handleSegmentMismatch(state, action, treePatch)
-        }
-
-        if (isNavigatingToNewRootLayout(currentTree, newTree)) {
-          resolve(actionResult)
-
-          return handleExternalUrl(
-            state,
-            mutable,
-            redirectHref || state.canonicalUrl,
-            state.pushRef.pendingPush
-          )
-        }
-
-        // The server sent back RSC data for the server action, so we need to apply it to the cache.
-        if (cacheNodeSeedData !== null) {
-          const rsc = cacheNodeSeedData[0]
-          const cache: CacheNode = createEmptyCacheNode()
-          cache.rsc = rsc
-          cache.prefetchRsc = null
-          cache.loading = cacheNodeSeedData[2]
-          fillLazyItemsTillLeafWithHead(
-            navigatedAt,
-            cache,
-            // Existing cache is not passed in as server actions have to invalidate the entire cache.
-            undefined,
-            treePatch,
-            cacheNodeSeedData,
-            head
-          )
-
-          mutable.cache = cache
-          revalidateEntireCache(state.nextUrl, newTree)
-          if (actionRevalidated) {
-            await refreshInactiveParallelSegments({
-              navigatedAt,
-              state,
-              updatedTree: newTree,
-              updatedCache: cache,
-              includeNextUrl: Boolean(nextUrl),
-              canonicalUrl: mutable.canonicalUrl || state.canonicalUrl,
-            })
-          }
-        }
-
-        mutable.patchedTree = newTree
-        currentTree = newTree
-      }
-
-      if (redirectLocation && redirectHref) {
+      if (redirectLocation !== undefined) {
         // If the action triggered a redirect, the action promise will be rejected with
         // a redirect so that it's handled by RedirectBoundary as we won't have a valid
         // action result to resolve the promise with. This will effectively reset the state of
         // the component that called the action as the error boundary will remount the tree.
         // The status code doesn't matter here as the action handler will have already sent
         // a response with the correct status code.
+        const redirectHref = createHrefFromUrl(redirectLocation, false)
+        const resolvedRedirectType = redirectType || RedirectType.push
         const redirectError = getRedirectError(
           hasBasePath(redirectHref)
             ? removeBasePath(redirectHref)
             : redirectHref,
-          redirectType || RedirectType.push
+          resolvedRedirectType
         )
         // We mark the error as handled because we don't want the redirect to be tried later by
         // the RedirectBoundary, in case the user goes back and `Activity` triggers the redirect
@@ -431,10 +328,125 @@ export function serverActionReducer(
         ;(redirectError as any).handled = true
         reject(redirectError)
       } else {
+        // If there's no redirect, resolve the action with the result.
         resolve(actionResult)
       }
 
-      return handleMutable(state, mutable)
+      const pendingPush = redirectType !== RedirectType.replace
+      state.pushRef.pendingPush = pendingPush
+      mutable.pendingPush = pendingPush
+
+      // Check if we can bail out without updating any state.
+      if (
+        // Did the action trigger a redirect?
+        redirectLocation === undefined &&
+        // Did the action revalidate any data?
+        !actionDidRevalidateCache &&
+        // Did the server render new data?
+        flightData === undefined
+      ) {
+        // The action did not trigger any revalidations or redirects. No
+        // navigation is required.
+        return state
+      }
+
+      if (flightData === undefined && redirectLocation !== undefined) {
+        // The server redirected, but did not send any Flight data. This implies
+        // an external redirect.
+        // TODO: We should refactor the action response type to be more explicit
+        // about the various response types.
+        return handleExternalUrl(
+          state,
+          mutable,
+          redirectLocation.href,
+          pendingPush
+        )
+      }
+
+      if (typeof flightData === 'string') {
+        // If the flight data is just a string, something earlier in the
+        // response handling triggered an external redirect.
+        return handleExternalUrl(state, mutable, flightData, pendingPush)
+      }
+
+      // The action triggered a navigation — either a redirect, a revalidation,
+      // or both.
+
+      // If there was no redirect, then the target URL is the same as the
+      // current URL.
+      const currentUrl = new URL(state.canonicalUrl, location.origin)
+      const redirectUrl =
+        redirectLocation !== undefined ? redirectLocation : currentUrl
+      const currentFlightRouterState = state.tree
+      const shouldScroll = true
+
+      // If the action triggered a revalidation of the cache, we should also
+      // refresh all the dynamic data.
+      const shouldRefreshDynamicData = actionDidRevalidateCache
+
+      // The server may have sent back new data. If so, we will perform a
+      // "seeded" navigation that uses the data from the response.
+      if (flightData !== undefined) {
+        const normalizedFlightData = flightData[0]
+        if (
+          normalizedFlightData !== undefined &&
+          // TODO: Currently the server always renders from the root in
+          // response to a Server Action. In the case of a normal redirect
+          // with no revalidation, it should skip over the shared layouts.
+          normalizedFlightData.isRootRender &&
+          flightDataRenderedSearch !== undefined &&
+          flightDataCouldBeIntercepted !== undefined
+        ) {
+          // The server sent back new route data as part of the response. We
+          // will use this to render the new page. If this happens to be only a
+          // subset of the data needed to render the new page, we'll initiate a
+          // new fetch, like we would for a normal navigation.
+          const seedFlightRouterState = normalizedFlightData.tree
+          const seedRenderedSearch = flightDataRenderedSearch
+          const seedData = normalizedFlightData.seedData
+          const seedHead = normalizedFlightData.head
+          const result = navigateToSeededRoute(
+            redirectUrl,
+            currentUrl,
+            state.cache,
+            currentFlightRouterState,
+            seedFlightRouterState,
+            seedRenderedSearch,
+            seedData,
+            seedHead,
+            shouldRefreshDynamicData,
+            nextUrl,
+            shouldScroll
+          )
+          return handleNavigationResult(
+            redirectUrl,
+            state,
+            mutable,
+            pendingPush,
+            result
+          )
+        }
+      }
+
+      // The server did not send back new data. We'll perform a regular, non-
+      // seeded navigation — effectively the same as <Link> or router.push().
+      const result = navigateUsingSegmentCache(
+        redirectUrl,
+        currentUrl,
+        state.cache,
+        currentFlightRouterState,
+        nextUrl,
+        shouldRefreshDynamicData,
+        shouldScroll,
+        mutable
+      )
+      return handleNavigationResult(
+        redirectUrl,
+        state,
+        mutable,
+        pendingPush,
+        result
+      )
     },
     (e: any) => {
       // When the server action is rejected we don't update the state and instead call the reject handler of the promise.

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -532,6 +532,10 @@ async function generateDynamicRSCPayload(
     ).map((path) => path.slice(1)) // remove the '' (root) segment
   }
 
+  const varyHeader = ctx.res.getHeader('vary')
+  const couldBeIntercepted =
+    typeof varyHeader === 'string' && varyHeader.includes(NEXT_URL)
+
   // If we have an action result, then this is a server action response.
   // We can rely on this because `ActionResult` will always be a promise, even if
   // the result is falsey.
@@ -540,6 +544,8 @@ async function generateDynamicRSCPayload(
       a: options.actionResult,
       f: flightData,
       b: ctx.sharedContext.buildId,
+      q: getRenderedSearch(query),
+      i: !!couldBeIntercepted,
     }
   }
 
@@ -547,6 +553,8 @@ async function generateDynamicRSCPayload(
   const baseResponse = {
     b: ctx.sharedContext.buildId,
     f: flightData,
+    q: getRenderedSearch(query),
+    i: !!couldBeIntercepted,
     S: workStore.isStaticGeneration,
   }
 

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -300,6 +300,10 @@ export type NavigationFlightResponse = {
   f: FlightData
   /** prerendered */
   S: boolean
+  /** renderedSearch */
+  q: string
+  /** couldBeIntercepted */
+  i: boolean
   /** runtimePrefetch - [isPartial, staleTime]. Only present in runtime prefetch responses. */
   rp?: [boolean, number]
 }
@@ -312,6 +316,10 @@ export type ActionFlightResponse = {
   b: string
   /** flightData */
   f: FlightData
+  /** renderedSearch */
+  q: string
+  /** couldBeIntercepted */
+  i: boolean
 }
 
 export type RSCPayload =


### PR DESCRIPTION
Based on:

- #86747 

---

Rewrite of the Server Action reducer to use the PPR/Segment Cache navigation implementation, rather than the old lazy fetch implementation.

Server Actions may trigger a revalidation, a redirect, or both. They may also invalidate the cache. The behavior could be naively implemented using router.refresh() and router.push(). Semantically, the routing behavior is equivalent.

The main difference is that the server that invokes the action may also send back new data for the page within the same response. Compared to a separate request, this data is more likely to be consistent with any data that may have been mutated by the action, due to global data propagation races. (It's also faster since it avoids an extra server waterfall.)

So, navigations initiated by a Server action must be able to "seed" the navigation with the data it just received from the server. I've added a new internal method, navigateToSeededRoute, that implements this behavior.