### PR TITLE
[next-upgrade] Fall back to `npx` if `yarn dlx` is not available

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -203,7 +203,7 @@ export async function runUpgrade(
 
   let shouldRunReactCodemods = false
   let shouldRunReactTypesCodemods = false
-  let execCommand = 'npx'
+  let execCommand = 'npx --yes'
   // The following React codemods are for React 19
   if (
     !shouldStayOnReact18 &&
@@ -213,13 +213,7 @@ export async function runUpgrade(
     shouldRunReactCodemods = await suggestReactCodemods()
     shouldRunReactTypesCodemods = await suggestReactTypesCodemods()
 
-    const execCommandMap = {
-      yarn: 'yarn dlx',
-      pnpm: 'pnpx',
-      bun: 'bunx',
-      npm: 'npx',
-    }
-    execCommand = execCommandMap[packageManager]
+    execCommand = getNpxCommand(packageManager)
   }
 
   fs.writeFileSync(appPackageJsonPath, JSON.stringify(appPackageJson, null, 2))
@@ -739,4 +733,20 @@ function warnDependenciesOutOfRange(
       })
     })
   }
+}
+
+function getNpxCommand(pkgManager: PackageManager) {
+  let command = 'npx --yes'
+  if (pkgManager === 'pnpm') {
+    command = 'pnpm --silent dlx'
+  } else if (pkgManager === 'yarn') {
+    try {
+      execSync('yarn dlx --help', { stdio: 'ignore', cwd })
+      command = 'yarn --quiet dlx'
+    } catch {}
+  } else if (pkgManager === 'bun') {
+    command = 'bunx'
+  }
+
+  return command
 }


### PR DESCRIPTION
Affected Yarn v1. This is the same logic we use in Next.js' CLI.