### PR TITLE
Turboopack: fix async module cycle

### DIFF
--- a/turbopack/crates/turbopack-core/src/module_graph/export_usage.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/export_usage.rs
@@ -40,7 +40,7 @@ pub async fn compute_export_usage_info(
             // rare.  For vercel-site on 8/22/2025 there were 106 cycles covering 800 modules
             // (or 1.2% of all modules).  So with this analysis we could potentially drop 80% of
             // the cycle breaker modules.
-            circuit_breakers.extend(cycle.iter().map(|n| **n));
+            circuit_breakers.extend(cycle.iter().copied());
             Ok(())
         },
     )?;

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -414,7 +414,7 @@ impl SingleModuleGraph {
     fn traverse_cycles<'l>(
         &'l self,
         edge_filter: impl Fn(&'l RefData) -> bool,
-        mut visit_cycle: impl FnMut(&[&'l ResolvedVc<Box<dyn Module>>]) -> Result<()>,
+        mut visit_cycle: impl FnMut(&[ResolvedVc<Box<dyn Module>>]) -> Result<()>,
     ) -> Result<()> {
         // see https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
         // but iteratively instead of recursively
@@ -491,7 +491,7 @@ impl SingleModuleGraph {
                                 if let SingleModuleGraphNode::Module(module) =
                                     self.graph.node_weight(poppped).unwrap()
                                 {
-                                    scc.push(module);
+                                    scc.push(*module);
                                 }
                                 if poppped == node {
                                     break;
@@ -1182,7 +1182,7 @@ impl ModuleGraphRef {
     pub fn traverse_cycles(
         &self,
         edge_filter: impl Fn(&RefData) -> bool,
-        mut visit_cycle: impl FnMut(&[&ResolvedVc<Box<dyn Module>>]) -> Result<()>,
+        mut visit_cycle: impl FnMut(&[ResolvedVc<Box<dyn Module>>]) -> Result<()>,
     ) -> Result<()> {
         for graph in &self.graphs {
             graph.traverse_cycles(&edge_filter, &mut visit_cycle)?;

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -392,9 +392,7 @@ pub async fn compute_module_batches(
                     .iter()
                     .any(|node| pre_batches.boundary_modules.contains(node))
                 {
-                    pre_batches
-                        .boundary_modules
-                        .extend(cycle.iter().map(|node| **node));
+                    pre_batches.boundary_modules.extend(cycle.iter().copied());
                 }
                 Ok(())
             },

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/A.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/A.ts
@@ -1,0 +1,7 @@
+import { B } from './B'
+
+export function A(n: number) {
+  if (n > 0) {
+    B(n - 1)
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/B.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/B.ts
@@ -1,0 +1,9 @@
+import { C } from './C'
+import { asyncImportFn } from './asyncImportFn'
+
+export function B(n: number) {
+  if (n > 0) {
+    C(n - 1)
+    asyncImportFn()
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/C.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/C.ts
@@ -1,0 +1,7 @@
+import { A } from './A'
+
+export function C(n: number) {
+  if (n > 0) {
+    A(n - 1)
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/D.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/D.ts
@@ -1,0 +1,7 @@
+import { C } from './C'
+
+export function D(n: number) {
+  if (n > 0) {
+    C(n - 1)
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/E.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/E.ts
@@ -1,0 +1,7 @@
+import { B } from './B'
+
+export function E(n: number) {
+  if (n > 0) {
+    B(n - 1)
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/asyncImportFn.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/asyncImportFn.js
@@ -1,0 +1,7 @@
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+await sleep(0)
+console.log('Imported asyncImportFn')
+
+export function asyncImportFn() {}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/index.js
@@ -1,0 +1,27 @@
+import { A } from './A'
+import { D } from './D'
+
+/*
+ * {A,B,C,D}.ts and asyncImportFn.ts have an import graph topology that
+ * exposes a bug in `compute_async_module_info_single` in turbopack. Requesting
+ * this page (localhost:3000/api/test) will fail with:
+ *   TypeError: (0 , t.C) is not a function
+ * This is because C has been marked as an async module, but D hasn't.
+ *
+ * route
+ * |   \
+ * v    v
+ * A<-  D
+ * |  \ |
+ * v   \v
+ * B--->C
+ * |
+ * v
+ * async
+ */
+
+it('should handle cycles in async modules', () => {
+  A(10)
+  D(10)
+  expect(true).toBe(true)
+})


### PR DESCRIPTION
Closes https://github.com/vercel/next.js/issues/85988
Closes PACK-5806

The previous approach didn't entirely work: the whole cycle was marked as async, but that wasn't then further propagated to importers of modules in the cycle.