### PR TITLE
failing test for circular references

### DIFF
--- a/test/production/app-dir/circular-reference-client-component/app/client.tsx
+++ b/test/production/app-dir/circular-reference-client-component/app/client.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+export default function ClientComp({ data }: { data: { title: string } }) {
+  return (
+    <pre>
+      <div>Hello World</div>
+      {data.title}
+    </pre>
+  )
+}

--- a/test/production/app-dir/circular-reference-client-component/app/layout.tsx
+++ b/test/production/app-dir/circular-reference-client-component/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/circular-reference-client-component/app/other/page.tsx
+++ b/test/production/app-dir/circular-reference-client-component/app/other/page.tsx
@@ -1,0 +1,9 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <p>
+      other page <Link href="/">home</Link>
+    </p>
+  )
+}

--- a/test/production/app-dir/circular-reference-client-component/app/page.tsx
+++ b/test/production/app-dir/circular-reference-client-component/app/page.tsx
@@ -1,0 +1,23 @@
+import ClientComp from './client'
+
+export default async function Page() {
+  const topic = { title: 'Topic', fields: { featured: [] } }
+  const guide = { title: 'Guide', fields: { topic: [topic] } }
+  const featured = {
+    title: 'Featured',
+    fields: {
+      content: [guide],
+      topic, // points back to the same topic
+    },
+  }
+
+  // Circular reference: topic -> featured[] -> content[] -> topic
+  topic.fields.featured.push(featured)
+
+  return (
+    <div>
+      <ClientComp data={topic} />
+      Other
+    </div>
+  )
+}

--- a/test/production/app-dir/circular-reference-client-component/circular-reference-client-component.test.ts
+++ b/test/production/app-dir/circular-reference-client-component/circular-reference-client-component.test.ts
@@ -1,0 +1,16 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('circular-reference-client-component', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    env: {
+      NEXT_DEBUG_BUILD: '1',
+    },
+  })
+
+  it('should not have errors when collecting segment data for a page with a circular reference to a client component', async () => {
+    expect(next.cliOutput).not.toContain(
+      'Error: Route / errored during segment collection'
+    )
+  })
+})

--- a/test/production/app-dir/circular-reference-client-component/next.config.js
+++ b/test/production/app-dir/circular-reference-client-component/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
Passing a circular reference to a client component is breaking `collectSegmentData` which results in the creation of a prefetch segment that errors. For now this is just a failing reproduction while we investigate a fix. 