### PR TITLE
Revert "Turbopack: remove Asset supertrait from Module trait. Modules don't have content"

### DIFF
--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -4,9 +4,9 @@ use anyhow::{Context, Result, bail};
 use indoc::writedoc;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{IntoTraitRef, ResolvedVc, ValueToString, Vc};
-use turbo_tasks_fs::File;
+use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{
-    asset::AssetContent,
+    asset::{Asset, AssetContent},
     chunk::{
         AsyncModuleInfo, ChunkGroupType, ChunkItem, ChunkType, ChunkableModule,
         ChunkableModuleReference, ChunkingContext, ChunkingType, ChunkingTypeOption,
@@ -240,6 +240,18 @@ impl Module for EcmascriptClientReferenceModule {
             .collect();
 
         Ok(Vc::cell(references))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for EcmascriptClientReferenceModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        AssetContent::File(
+            FileContent::Content("// This is a proxy module for Next.js client references.".into())
+                .resolved_cell(),
+        )
+        .cell()
     }
 }
 

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use indoc::formatdoc;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks_fs::FileContent;
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     ident::AssetIdent,
     module::Module,
@@ -68,6 +70,18 @@ impl Module for NextDynamicEntryModule {
             .to_resolved()
             .await?,
         )]))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for NextDynamicEntryModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        AssetContent::File(
+            FileContent::Content("// This is a marker module for Next.js dynamic.".into())
+                .resolved_cell(),
+        )
+        .cell()
     }
 }
 

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -4,8 +4,9 @@ use anyhow::Result;
 use indoc::formatdoc;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::FileSystemPath;
+use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     ident::AssetIdent,
     module::Module,
@@ -65,6 +66,20 @@ impl Module for NextServerComponentModule {
                 .to_resolved()
                 .await?,
         )]))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for NextServerComponentModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        AssetContent::File(
+            FileContent::Content(
+                "// This is a marker module for Next.js server components.".into(),
+            )
+            .resolved_cell(),
+        )
+        .cell()
     }
 }
 

--- a/crates/next-core/src/next_server_utility/server_utility_module.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_module.rs
@@ -4,8 +4,9 @@ use anyhow::Result;
 use indoc::formatdoc;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::FileSystemPath;
+use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     ident::AssetIdent,
     module::Module,
@@ -65,6 +66,18 @@ impl Module for NextServerUtilityModule {
                 .to_resolved()
                 .await?,
         )]))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for NextServerUtilityModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        AssetContent::File(
+            FileContent::Content("// This is a marker module for Next.js server utilities.".into())
+                .resolved_cell(),
+        )
+        .cell()
     }
 }
 

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -36,12 +36,11 @@ pub async fn get_swc_ecma_transform_rule_impl(
     enable_mdx_rs: bool,
 ) -> Result<Option<ModuleRule>> {
     use anyhow::bail;
-    use turbo_tasks::{TryFlatJoinIterExt, ValueToString};
+    use turbo_tasks::TryFlatJoinIterExt;
     use turbo_tasks_fs::FileContent;
     use turbopack::{resolve_options, resolve_options_context::ResolveOptionsContext};
     use turbopack_core::{
         asset::Asset,
-        module::Module,
         reference_type::{CommonJsReferenceSubType, ReferenceType},
         resolve::{handle_resolve_error, parse::Request, resolve},
     };
@@ -100,16 +99,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
                     return Ok(None);
                 };
 
-                let Some(plugin_source) = &*plugin_module.source().await? else {
-                    use anyhow::bail;
-
-                    bail!(
-                        "Expected source for plugin module: {}",
-                        plugin_module.ident().to_string().await?
-                    );
-                };
-
-                let content = &*plugin_source.content().file_content().await?;
+                let content = &*plugin_module.content().file_content().await?;
                 let FileContent::Content(file) = content else {
                     bail!("Expected file content for plugin module");
                 };

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -10,7 +10,7 @@ use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt, ValueToStr
 use turbo_tasks_fs::{FileContent, glob::Glob, rope::Rope};
 use turbopack::{ModuleAssetContext, module_options::CustomModuleType};
 use turbopack_core::{
-    asset::Asset,
+    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     code_builder::CodeBuilder,
     compile_time_info::{
@@ -104,6 +104,14 @@ impl Module for RawEcmascriptModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(false)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for RawEcmascriptModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
@@ -3,6 +3,7 @@ use turbo_tasks::{ResolvedVc, Upcast, ValueToString, Vc};
 
 use super::ChunkableModule;
 use crate::{
+    asset::Asset,
     context::AssetContext,
     module::Module,
     reference_type::{EntryReferenceSubType, ReferenceType},
@@ -14,7 +15,7 @@ use crate::{
 /// The chunking context implementation will resolve the dynamic entry to a
 /// well-known value or trait object.
 #[turbo_tasks::value_trait]
-pub trait EvaluatableAsset: Module + ChunkableModule {}
+pub trait EvaluatableAsset: Asset + Module + ChunkableModule {}
 
 pub trait EvaluatableAssetExt {
     fn to_evaluatable(

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -90,7 +90,7 @@ pub struct ModuleIds(Vec<ResolvedVc<ModuleId>>);
 
 /// A [Module] that can be converted into a [Chunk].
 #[turbo_tasks::value_trait]
-pub trait ChunkableModule: Module {
+pub trait ChunkableModule: Module + Asset {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: Vc<Self>,
@@ -115,7 +115,7 @@ impl ChunkableModules {
 // with other module types (as a MergeableModule cannot prevent itself from being merged with other
 // module types)
 #[turbo_tasks::value_trait]
-pub trait MergeableModule: Module {
+pub trait MergeableModule: Module + Asset {
     /// Even though MergeableModule is implemented, this allows a dynamic condition to determine
     /// mergeability
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/introspect/module.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/module.rs
@@ -33,12 +33,8 @@ impl Introspectable for IntrospectableModule {
     }
 
     #[turbo_tasks::function]
-    async fn details(&self) -> Result<Vc<RcStr>> {
-        if let Some(source) = *self.0.source().await? {
-            Ok(content_to_details(source.content()))
-        } else {
-            Ok(Vc::cell("No source".into()))
-        }
+    fn details(&self) -> Vc<RcStr> {
+        content_to_details(self.0.content())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -2,7 +2,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, TaskInput, ValueToString, Vc};
 use turbo_tasks_fs::glob::Glob;
 
-use crate::{ident::AssetIdent, reference::ModuleReferences, source::OptionSource};
+use crate::{asset::Asset, ident::AssetIdent, reference::ModuleReferences, source::OptionSource};
 
 #[derive(Clone, Copy, Debug, TaskInput, Hash)]
 #[turbo_tasks::value(shared)]
@@ -14,7 +14,7 @@ pub enum StyleType {
 /// A module. This usually represents parsed source code, which has references
 /// to other modules.
 #[turbo_tasks::value_trait]
-pub trait Module {
+pub trait Module: Asset {
     /// The identifier of the [Module]. It's expected to be unique and capture
     /// all properties of the [Module].
     #[turbo_tasks::function]
@@ -55,7 +55,7 @@ pub trait Module {
 }
 
 #[turbo_tasks::value_trait]
-pub trait StyleModule: Module {
+pub trait StyleModule: Module + Asset {
     /// The style type of the module.
     #[turbo_tasks::function]
     fn style_type(&self) -> Vc<StyleType>;

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -7,6 +7,7 @@ use turbo_tasks::{FxIndexSet, ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::{FileSystemEntryType, FileSystemPath};
 
 use crate::{
+    asset::{Asset, AssetContent},
     file_source::FileSource,
     ident::AssetIdent,
     module::Module,
@@ -98,6 +99,14 @@ impl Module for NodeAddonModule {
 
         // Most addon modules don't have references to other modules.
         Ok(ModuleReferences::empty())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for NodeAddonModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/raw_module.rs
+++ b/turbopack/crates/turbopack-core/src/raw_module.rs
@@ -1,6 +1,7 @@
 use turbo_tasks::{ResolvedVc, Vc};
 
 use crate::{
+    asset::{Asset, AssetContent},
     ident::AssetIdent,
     module::Module,
     source::{OptionSource, Source},
@@ -23,6 +24,14 @@ impl Module for RawModule {
     #[turbo_tasks::function]
     fn source(&self) -> Vc<OptionSource> {
         Vc::cell(Some(self.source))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for RawModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/rebase.rs
+++ b/turbopack/crates/turbopack-core/src/rebase.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
-use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
@@ -74,14 +74,7 @@ impl OutputAsset for RebasedAsset {
 #[turbo_tasks::value_impl]
 impl Asset for RebasedAsset {
     #[turbo_tasks::function]
-    async fn content(&self) -> Result<Vc<AssetContent>> {
-        if let Some(source) = *self.module.source().await? {
-            Ok(source.content())
-        } else {
-            bail!(
-                "Module {} has no source",
-                self.module.ident().to_string().await?
-            )
-        }
+    fn content(&self) -> Vc<AssetContent> {
+        self.module.content()
     }
 }

--- a/turbopack/crates/turbopack-core/src/traced_asset.rs
+++ b/turbopack/crates/turbopack-core/src/traced_asset.rs
@@ -1,5 +1,5 @@
-use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
@@ -54,14 +54,7 @@ impl OutputAsset for TracedAsset {
 #[turbo_tasks::value_impl]
 impl Asset for TracedAsset {
     #[turbo_tasks::function]
-    async fn content(&self) -> Result<Vc<AssetContent>> {
-        if let Some(source) = *self.module.source().await? {
-            Ok(source.content())
-        } else {
-            bail!(
-                "Module {} has no source",
-                self.module.ident().to_string().await?,
-            )
-        }
+    fn content(&self) -> Vc<AssetContent> {
+        self.module.content()
     }
 }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -3,6 +3,7 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{IntoTraitRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, MinifyType},
     context::AssetContext,
     environment::Environment,
@@ -162,6 +163,14 @@ impl StyleModule for CssModuleAsset {
             CssModuleAssetType::Default => StyleType::GlobalStyle.cell(),
             CssModuleAssetType::Module => StyleType::IsolatedStyle.cell(),
         }
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for CssModuleAsset {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -437,7 +437,7 @@ impl GenerateSourceMap for CssChunk {
 
 // TODO: remove
 #[turbo_tasks::value_trait]
-pub trait CssChunkPlaceable: ChunkableModule + Module {}
+pub trait CssChunkPlaceable: ChunkableModule + Module + Asset {}
 
 #[derive(Clone, Debug)]
 #[turbo_tasks::value(shared)]

--- a/turbopack/crates/turbopack-css/src/embed.rs
+++ b/turbopack/crates/turbopack-css/src/embed.rs
@@ -1,8 +1,8 @@
 use turbo_tasks::Vc;
-use turbopack_core::{chunk::ChunkingContext, module::Module, output::OutputAsset};
+use turbopack_core::{asset::Asset, chunk::ChunkingContext, module::Module, output::OutputAsset};
 
 #[turbo_tasks::value_trait]
-pub trait CssEmbed: Module {
+pub trait CssEmbed: Module + Asset {
     #[turbo_tasks::function]
     fn embedded_asset(
         self: Vc<Self>,

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -8,6 +8,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, IntoTraitRef, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileSystemPath, rope::Rope};
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     context::{AssetContext, ProcessResult},
     ident::AssetIdent,
@@ -109,6 +110,14 @@ impl Module for ModuleCssAsset {
             .collect();
 
         Ok(Vc::cell(references))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for ModuleCssAsset {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -3,6 +3,7 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{ChunkableModule, ChunkingContext, availability_info::AvailabilityInfo},
     ident::AssetIdent,
     module::Module,
@@ -72,6 +73,14 @@ impl Module for AsyncLoaderModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for AsyncLoaderModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        panic!("content() should not be called");
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -24,7 +24,7 @@ use crate::references::{
 };
 
 #[turbo_tasks::value_trait]
-pub trait EcmascriptChunkPlaceable: ChunkableModule + Module {
+pub trait EcmascriptChunkPlaceable: ChunkableModule + Module + Asset {
     #[turbo_tasks::function]
     fn get_exports(self: Vc<Self>) -> Vc<EcmascriptExports>;
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/inlined_bytes_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/inlined_bytes_module.rs
@@ -5,7 +5,7 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileContent, glob::Glob, rope::RopeBuilder};
 use turbopack_core::{
-    asset::Asset,
+    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
     module::Module,
@@ -56,6 +56,14 @@ impl Module for InlinedBytesJsModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for InlinedBytesJsModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 
@@ -120,7 +128,7 @@ impl ChunkItem for InlinedBytesJsChunkItem {
 impl EcmascriptChunkItem for InlinedBytesJsChunkItem {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
-        let content = self.module.await?.source.content().file_content().await?;
+        let content = self.module.content().file_content().await?;
         match &*content {
             FileContent::Content(data) => {
                 let mut inner_code = RopeBuilder::default();

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -90,6 +90,7 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::{FileJsonContent, FileSystemPath, glob::Glob, rope::Rope};
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{
         AsyncModuleInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext, EvaluatableAsset,
         MergeableModule, MergeableModuleExposure, MergeableModules, MergeableModulesExposed,
@@ -402,7 +403,7 @@ pub trait EcmascriptParsable {
 }
 
 #[turbo_tasks::value_trait]
-pub trait EcmascriptAnalyzable: Module {
+pub trait EcmascriptAnalyzable: Module + Asset {
     #[turbo_tasks::function]
     fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult>;
 
@@ -770,6 +771,14 @@ impl Module for EcmascriptModuleAsset {
         } else {
             Vc::cell(self.analyze().await?.has_side_effect_free_directive)
         })
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for EcmascriptModuleAsset {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -3,6 +3,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{
         ChunkableModule, ChunkingContext, ChunkingContextExt, availability_info::AvailabilityInfo,
     },
@@ -158,6 +159,14 @@ impl Module for ManifestAsyncModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for ManifestAsyncModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        panic!("content() should not be called");
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/merged_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/merged_module.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{
         AsyncModuleInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext,
         MergeableModuleExposure, MergeableModules, MergeableModulesExposed,
@@ -56,6 +57,14 @@ impl MergedEcmascriptModule {
             options,
         }
         .resolved_cell())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for MergedEcmascriptModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        panic!("content() should not be called");
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -21,6 +21,7 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath, glob::Glob};
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{
         ChunkItem, ChunkType, ChunkableModule, ChunkableModuleReference, ChunkingContext,
         MinifyType, ModuleChunkItemIdExt,
@@ -432,6 +433,14 @@ impl Module for RequireContextAsset {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for RequireContextAsset {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        unimplemented!()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -2,8 +2,9 @@ use std::collections::BTreeMap;
 
 use anyhow::{Result, bail};
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::glob::Glob;
+use turbo_tasks_fs::{File, FileContent, glob::Glob};
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{
         AsyncModuleInfo, ChunkableModule, ChunkingContext, EvaluatableAsset, MergeableModule,
         MergeableModules, MergeableModulesExposed,
@@ -194,6 +195,16 @@ impl Module for EcmascriptModuleFacadeModule {
             }
             _ => bail!("Unexpected ModulePart for EcmascriptModuleFacadeModule"),
         })
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for EcmascriptModuleFacadeModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        let f = File::from("");
+
+        AssetContent::file(FileContent::Content(f).cell())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -4,6 +4,7 @@ use anyhow::{Result, bail};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{
         AsyncModuleInfo, ChunkableModule, ChunkingContext, MergeableModule, MergeableModules,
         MergeableModulesExposed,
@@ -75,6 +76,14 @@ impl Module for EcmascriptModuleLocalsModule {
     fn is_marked_as_side_effect_free(&self, side_effect_free_packages: Vc<Glob>) -> Vc<bool> {
         self.module
             .is_marked_as_side_effect_free(side_effect_free_packages)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for EcmascriptModuleLocalsModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.module.content()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -3,6 +3,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext, EvaluatableAsset},
     context::AssetContext,
     ident::AssetIdent,
@@ -362,6 +363,14 @@ impl Module for EcmascriptModulePartAsset {
                 .full_module
                 .is_marked_as_side_effect_free(side_effect_free_packages)),
         }
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for EcmascriptModulePartAsset {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.full_module.content()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/side_effect_module.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
-use turbo_tasks_fs::glob::Glob;
+use turbo_tasks_fs::{FileContent, glob::Glob};
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{ChunkableModule, ChunkingContext, EvaluatableAsset},
     ident::AssetIdent,
     module::Module,
@@ -115,6 +116,21 @@ impl Module for SideEffectsModule {
     #[turbo_tasks::function]
     fn is_marked_as_side_effect_free(self: Vc<Self>, _: Vc<Glob>) -> Vc<bool> {
         Vc::cell(true)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for SideEffectsModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        AssetContent::File(
+            FileContent::Content(
+                "// This is a proxy module for reexportings a module with additional side effects."
+                    .into(),
+            )
+            .resolved_cell(),
+        )
+        .cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -4,7 +4,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::DirectoryContent;
 use turbopack_core::{
-    asset::Asset,
+    asset::{Asset, AssetContent},
     ident::AssetIdent,
     module::Module,
     raw_module::RawModule,
@@ -177,6 +177,14 @@ impl Module for TsConfigModuleAsset {
             }
         }
         Ok(Vc::cell(references))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for TsConfigModuleAsset {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -3,6 +3,7 @@ use swc_core::ecma::ast::Lit;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     file_source::FileSource,
     ident::AssetIdent,
     module::Module,
@@ -62,6 +63,14 @@ impl Module for WebpackModuleAsset {
     #[turbo_tasks::function]
     fn references(&self) -> Vc<ModuleReferences> {
         module_references(*self.source, *self.runtime, *self.transforms)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for WebpackModuleAsset {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -3,6 +3,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{
         ChunkGroupType, ChunkableModule, ChunkableModuleReference, ChunkingContext, ChunkingType,
         ChunkingTypeOption,
@@ -63,6 +64,14 @@ impl Module for WorkerLoaderModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for WorkerLoaderModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        panic!("content() should not be called");
     }
 }
 

--- a/turbopack/crates/turbopack-json/src/lib.rs
+++ b/turbopack/crates/turbopack-json/src/lib.rs
@@ -16,7 +16,7 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileContent, FileJsonContent, glob::Glob};
 use turbopack_core::{
-    asset::Asset,
+    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     code_builder::CodeBuilder,
     ident::AssetIdent,
@@ -64,6 +64,14 @@ impl Module for JsonModuleAsset {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for JsonModuleAsset {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 
@@ -130,7 +138,7 @@ impl EcmascriptChunkItem for JsonChunkItem {
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
         // We parse to JSON and then stringify again to ensure that the
         // JSON is valid.
-        let content = self.module.await?.source.content().file_content();
+        let content = self.module.content().file_content();
         let data = content.parse_json().await?;
         match &*data {
             FileJsonContent::Content(data) => {

--- a/turbopack/crates/turbopack-static/src/css.rs
+++ b/turbopack/crates/turbopack-static/src/css.rs
@@ -2,7 +2,12 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
-    chunk::ChunkingContext, ident::AssetIdent, module::Module, output::OutputAsset, source::Source,
+    asset::{Asset, AssetContent},
+    chunk::ChunkingContext,
+    ident::AssetIdent,
+    module::Module,
+    output::OutputAsset,
+    source::Source,
 };
 use turbopack_css::embed::CssEmbed;
 
@@ -53,6 +58,14 @@ impl Module for StaticUrlCssModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for StaticUrlCssModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -3,6 +3,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
     module::Module,
@@ -69,6 +70,14 @@ impl Module for StaticUrlJsModule {
         _side_effect_free_packages: Vc<Glob>,
     ) -> Vc<bool> {
         Vc::cell(true)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for StaticUrlJsModule {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -3,6 +3,7 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{IntoTraitRef, ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{
         AsyncModuleInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext,
         chunk_group::references_to_output_assets,
@@ -142,6 +143,14 @@ impl Module for WebAssemblyModuleAsset {
     #[turbo_tasks::function]
     fn is_self_async(self: Vc<Self>) -> Vc<bool> {
         Vc::cell(true)
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for WebAssemblyModuleAsset {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -2,6 +2,7 @@ use anyhow::{Result, bail};
 use turbo_rcstr::rcstr;
 use turbo_tasks::{IntoTraitRef, ResolvedVc, Vc};
 use turbopack_core::{
+    asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     context::AssetContext,
     ident::AssetIdent,
@@ -62,6 +63,14 @@ impl Module for RawWebAssemblyModuleAsset {
     #[turbo_tasks::function]
     fn source(&self) -> Vc<OptionSource> {
         Vc::cell(Some(ResolvedVc::upcast(self.source)))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for RawWebAssemblyModuleAsset {
+    #[turbo_tasks::function]
+    fn content(&self) -> Vc<AssetContent> {
+        self.source.content()
     }
 }
 


### PR DESCRIPTION
Reverts vercel/next.js#86339