### PR TITLE
[turbopack] Support traversing the graph in reverse order

### DIFF
--- a/contributing/core/testing.md
+++ b/contributing/core/testing.md
@@ -103,6 +103,19 @@ we attempt to capture traces of the playwright run to make debugging the failure
 A test-trace artifact should be uploaded after the workflow completes which can be downloaded, unzipped,
 and then inspected with `pnpm playwright show-trace ./path/to/trace`
 
+To attach the chrome debugger to next the easiest approach is to modify the `createNext` call in your test to pass `--inspect` to next.
+
+```js
+const next = await createNext({
+  ...
+  startArgs: =['--inspect'],
+})
+```
+
+Consider also sett `NEXT_E2E_TEST_TIMEOUT=0`
+
+To debug the test process itself you need to pass the `inspect` flag to the node process running jest. e.g. `IS_TURBOPACK_TEST=1 TURBOPACK_DEV=1 NEXT_TEST_MODE=dev node --inspect node_modules/jest/bin/jest.js ...`
+
 ### Profiling tests
 
 Add `NEXT_TEST_TRACE=1` to enable test profiling. It's useful for improving our testing infrastructure.

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -86,19 +86,18 @@ async fn compute_async_module_info_single(
         // child is the previously visited module which must be async
         // parent is a new module that depends on it
         |child, parent, _state| {
-            Ok(
-                if let Some((_, edge)) = child
-                    && edge.chunking_type.is_inherit_async()
-                {
+            Ok(if let Some((_, edge)) = child {
+                if edge.chunking_type.is_inherit_async() {
                     async_modules.insert(parent);
                     GraphTraversalAction::Continue
-                } else if child.is_none() {
-                    // These are our entry points, just continue
-                    GraphTraversalAction::Continue
                 } else {
+                    // Wrong edge type to follow
                     GraphTraversalAction::Exclude
-                },
-            )
+                }
+            } else {
+                // These are our entry points, just continue
+                GraphTraversalAction::Continue
+            })
         },
         |_, _, _| Ok(()),
     )?;

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -83,14 +83,16 @@ async fn compute_async_module_info_single(
     graph.traverse_edges_from_entries_dfs_reversed(
         self_async_modules,
         &mut (),
-        |parent, module, _state| {
+        // child is the previously visited module which must be async
+        // parent is a new module that depends on it
+        |child, parent, _state| {
             Ok(
-                if let Some((_, edge)) = parent
+                if let Some((_, edge)) = child
                     && edge.chunking_type.is_inherit_async()
                 {
-                    async_modules.insert(module);
+                    async_modules.insert(parent);
                     GraphTraversalAction::Continue
-                } else if parent.is_none() {
+                } else if child.is_none() {
                     // These are our entry points, just continue
                     GraphTraversalAction::Continue
                 } else {

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use rustc_hash::FxHashSet;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
+use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, Vc};
 
 use crate::{
     module::{Module, Modules},
@@ -57,52 +57,52 @@ async fn compute_async_module_info_single(
     let graph = graph.read().await?;
 
     let self_async_modules = graph
-        .graphs
-        .first()
-        .unwrap()
-        .iter_nodes()
-        .map(async |node| Ok((node, *node.is_self_async().await?)))
-        .try_join()
-        .await?
-        .into_iter()
-        .flat_map(|(k, v)| v.then_some(k))
-        .chain(parent_async_modules.iter().copied())
-        .collect::<FxHashSet<_>>();
+        .enumerate_nodes()
+        .map(async |(_, node)| {
+            Ok(match node {
+                super::SingleModuleGraphNode::Module(node) => {
+                    node.is_self_async().await?.then_some(*node)
+                }
+                super::SingleModuleGraphNode::VisitedModule { idx: _, module } => {
+                    // If a module is async in the parent then we need to mark reverse dependencies
+                    // async in this graph as well.
+                    parent_async_modules.contains(module).then_some(*module)
+                }
+            })
+        })
+        .try_flat_join()
+        .await?;
 
     // To determine which modules are async, we need to propagate the self-async flag to all
-    // importers, which is done using a postorder traversal of the graph.
-    //
-    // This however doesn't cover cycles of async modules, which are handled by determining all
-    // strongly-connected components, and then marking all the whole SCC as async if one of the
-    // modules in the SCC is async.
+    // importers, which is done using a reverse traversal over the graph
+    // Because we walk edges in the reverse direction we can trivially handle things like cycles
+    // without actually computing them.
+    let mut async_modules = FxHashSet::default();
+    async_modules.extend(self_async_modules.iter());
 
-    let mut async_modules = self_async_modules;
-    graph.traverse_edges_from_entries_dfs(
-        graph.graphs.first().unwrap().entry_modules(),
+    graph.traverse_edges_from_entries_dfs_reversed(
+        self_async_modules,
         &mut (),
-        |_, _, _| Ok(GraphTraversalAction::Continue),
-        |parent_info, module, _| {
-            let Some((parent_module, ref_data)) = parent_info else {
-                // An entry module
-                return Ok(());
-            };
-
-            if ref_data.chunking_type.is_inherit_async() && async_modules.contains(&module) {
-                async_modules.insert(parent_module);
-            }
-            Ok(())
+        |parent, module, _state| {
+            Ok(
+                if let Some((_, edge)) = parent
+                    && edge.chunking_type.is_inherit_async()
+                {
+                    async_modules.insert(module);
+                    GraphTraversalAction::Continue
+                } else if parent.is_none() {
+                    // These are our entry points, just continue
+                    GraphTraversalAction::Continue
+                } else {
+                    GraphTraversalAction::Exclude
+                },
+            )
         },
+        |_, _, _| Ok(()),
     )?;
 
-    graph.traverse_cycles(
-        |ref_data| ref_data.chunking_type.is_inherit_async(),
-        |cycle| {
-            if cycle.iter().any(|node| async_modules.contains(node)) {
-                async_modules.extend(cycle.iter().map(|n| **n));
-            }
-            Ok(())
-        },
-    )?;
+    // Accumulate the parent modules at the end. Not all parent async modules were in this graph
+    async_modules.extend(parent_async_modules);
 
     Ok(Vc::cell(async_modules))
 }

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1288,7 +1288,7 @@ impl ModuleGraphRef {
     }
 
     /// Traverses all reachable edges in dfs order over the reversed graph. The preorder visitor can
-    /// be used to forward state down the graph, and to skip subgraphs
+    /// be used to forward state up the graph, and to skip subgraphs
     ///
     /// Target nodes can be revisited (once per incoming edge) in the preorder_visitor, in the post
     /// order visitor they are visited exactly once with the first edge they were discovered with.
@@ -1300,7 +1300,7 @@ impl ModuleGraphRef {
     ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode, state &S
     ///    - Can return [GraphTraversalAction]s to control the traversal
-    /// * `visit_postorder` - Called after visiting the children of a node. Return
+    /// * `visit_postorder` - Called after visiting the parents of a node. Return
     ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode, state &S
     pub fn traverse_edges_from_entries_dfs_reversed<S>(

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -998,8 +998,8 @@ impl ModuleGraphRef {
             .context("Expected graph node")
     }
 
-    fn should_visit_node(&self, node: &SingleModuleGraphNode) -> bool {
-        if self.skip_visited_module_children {
+    fn should_visit_node(&self, node: &SingleModuleGraphNode, direction: Direction) -> bool {
+        if self.skip_visited_module_children && direction == Direction::Outgoing {
             !matches!(node, SingleModuleGraphNode::VisitedModule { .. })
         } else {
             true
@@ -1102,7 +1102,7 @@ impl ModuleGraphRef {
                     }
                     stack.push((Pass::Visit, current));
                     if action == GraphTraversalAction::Continue
-                        && self.should_visit_node(current_node)
+                        && self.should_visit_node(current_node, Direction::Outgoing)
                     {
                         let current = current_node.target_idx().unwrap_or(current);
                         stack.extend(
@@ -1154,7 +1154,7 @@ impl ModuleGraphRef {
                         Some((node_weight.module(), self.get_edge(edge)?)),
                         succ_weight.module(),
                     )?;
-                    if !self.should_visit_node(succ_weight) {
+                    if !self.should_visit_node(succ_weight, Direction::Outgoing) {
                         continue;
                     }
                     let succ = succ_weight.target_idx().unwrap_or(succ);
@@ -1203,7 +1203,7 @@ impl ModuleGraphRef {
                         Some((node_weight.module(), self.get_edge(edge)?)),
                         succ_weight.module(),
                     );
-                    if !self.should_visit_node(succ_weight) {
+                    if !self.should_visit_node(succ_weight, Direction::Outgoing) {
                         continue;
                     }
                     let succ = succ_weight.target_idx().unwrap_or(succ);
@@ -1380,7 +1380,7 @@ impl ModuleGraphRef {
                     stack.push((Pass::Visit, parent, current));
                     if action == GraphTraversalAction::Continue
                         && expanded.insert(current)
-                        && self.should_visit_node(current_node)
+                        && self.should_visit_node(current_node, direction)
                     {
                         let current = current_node.target_idx().unwrap_or(current);
                         stack.extend(self.iter_graphs_neighbors_rev(current, direction).map(

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1020,7 +1020,7 @@ impl ModuleGraphRef {
     ) -> impl Iterator<Item = (GraphEdgeIndex, GraphNodeIndex)> + 'a {
         let graph = &*self.get_graph(node.graph_idx).graph;
 
-        if cfg!(debug_assertions) {
+        if cfg!(debug_assertions) && direction == Direction::Outgoing {
             let node_weight = graph.node_weight(node.node_idx).unwrap();
             if let SingleModuleGraphNode::VisitedModule { .. } = node_weight {
                 panic!("iter_graphs_neighbors_rev called on VisitedModule node");

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -7,6 +7,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use auto_hash_map::AutoSet;
 use petgraph::{
+    Direction,
     graph::{DiGraph, EdgeIndex, NodeIndex},
     visit::{EdgeRef, IntoNeighbors, IntoNodeReferences, NodeIndexable, Reversed},
 };
@@ -412,7 +413,7 @@ impl SingleModuleGraph {
     pub fn has_entry_module(&self, module: ResolvedVc<Box<dyn Module>>) -> bool {
         if let Some(index) = self.modules.get(&module) {
             self.graph
-                .edges_directed(*index, petgraph::Direction::Incoming)
+                .edges_directed(*index, Direction::Incoming)
                 .next()
                 .is_none()
         } else {
@@ -845,7 +846,7 @@ impl ModuleGraph {
 
         let entry = graph_ref.get_entry(module)?;
         let referenced_modules = graph_ref
-            .iter_graphs_neighbors_rev(entry)
+            .iter_graphs_neighbors_rev(entry, Direction::Outgoing)
             .filter(|(edge_idx, _)| {
                 let ty = graph_ref.get_edge(*edge_idx).unwrap();
                 ty.chunking_type.is_inherit_async()
@@ -1005,10 +1006,17 @@ impl ModuleGraphRef {
         }
     }
 
+    pub fn enumerate_nodes(
+        &self,
+    ) -> impl Iterator<Item = (NodeIndex, &'_ SingleModuleGraphNode)> + '_ {
+        self.graphs.iter().flat_map(|g| g.enumerate_nodes())
+    }
+
     /// Iterate the edges of a node REVERSED!
     fn iter_graphs_neighbors_rev<'a>(
         &'a self,
         node: GraphNodeIndex,
+        direction: Direction,
     ) -> impl Iterator<Item = (GraphEdgeIndex, GraphNodeIndex)> + 'a {
         let graph = &*self.get_graph(node.graph_idx).graph;
 
@@ -1019,7 +1027,7 @@ impl ModuleGraphRef {
             }
         }
 
-        let mut walker = graph.neighbors(node.node_idx).detach();
+        let mut walker = graph.neighbors_directed(node.node_idx, direction).detach();
         std::iter::from_fn(move || {
             while let Some((edge_idx, succ_idx)) = walker.next(graph) {
                 let edge_idx = GraphEdgeIndex::new(node.graph_idx, edge_idx);
@@ -1098,7 +1106,7 @@ impl ModuleGraphRef {
                     {
                         let current = current_node.target_idx().unwrap_or(current);
                         stack.extend(
-                            self.iter_graphs_neighbors_rev(current)
+                            self.iter_graphs_neighbors_rev(current, Direction::Outgoing)
                                 .map(|(_, child)| (Pass::ExpandAndVisit, child)),
                         );
                     }
@@ -1140,7 +1148,7 @@ impl ModuleGraphRef {
         while let Some(node) = queue.pop_front() {
             if visited.insert(node) {
                 let node_weight = self.get_node(node)?;
-                for (edge, succ) in self.iter_graphs_neighbors_rev(node) {
+                for (edge, succ) in self.iter_graphs_neighbors_rev(node, Direction::Outgoing) {
                     let succ_weight = self.get_node(succ)?;
                     let action = visitor(
                         Some((node_weight.module(), self.get_edge(edge)?)),
@@ -1189,7 +1197,7 @@ impl ModuleGraphRef {
         while let Some(node) = stack.pop() {
             if visited.insert(node) {
                 let node_weight = self.get_node(node)?;
-                for (edge, succ) in self.iter_graphs_neighbors_rev(node) {
+                for (edge, succ) in self.iter_graphs_neighbors_rev(node, Direction::Outgoing) {
                     let succ_weight = self.get_node(succ)?;
                     let action = visitor(
                         Some((node_weight.module(), self.get_edge(edge)?)),
@@ -1259,6 +1267,70 @@ impl ModuleGraphRef {
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         state: &mut S,
+        visit_preorder: impl FnMut(
+            Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
+            ResolvedVc<Box<dyn Module>>,
+            &mut S,
+        ) -> Result<GraphTraversalAction>,
+        visit_postorder: impl FnMut(
+            Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
+            ResolvedVc<Box<dyn Module>>,
+            &mut S,
+        ) -> Result<()>,
+    ) -> Result<()> {
+        self.traverse_edges_from_entries_dfs_impl::<S>(
+            entries,
+            state,
+            visit_preorder,
+            visit_postorder,
+            Direction::Outgoing,
+        )
+    }
+
+    /// Traverses all reachable edges in dfs order over the reversed graph. The preorder visitor can
+    /// be used to forward state down the graph, and to skip subgraphs
+    ///
+    /// Target nodes can be revisited (once per incoming edge) in the preorder_visitor, in the post
+    /// order visitor they are visited exactly once with the first edge they were discovered with.
+    /// Edges are traversed in normal order, so should correspond to reference order.
+    ///
+    /// * `entries` - The entry modules to start the traversal from
+    /// * `state` - The state to be passed to the visitors
+    /// * `visit_preorder` - Called before visiting the children of a node.
+    ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
+    ///      &SingleModuleGraphNode, state &S
+    ///    - Can return [GraphTraversalAction]s to control the traversal
+    /// * `visit_postorder` - Called after visiting the children of a node. Return
+    ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
+    ///      &SingleModuleGraphNode, state &S
+    pub fn traverse_edges_from_entries_dfs_reversed<S>(
+        &self,
+        entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
+        state: &mut S,
+        visit_preorder: impl FnMut(
+            Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
+            ResolvedVc<Box<dyn Module>>,
+            &mut S,
+        ) -> Result<GraphTraversalAction>,
+        visit_postorder: impl FnMut(
+            Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
+            ResolvedVc<Box<dyn Module>>,
+            &mut S,
+        ) -> Result<()>,
+    ) -> Result<()> {
+        self.traverse_edges_from_entries_dfs_impl::<S>(
+            entries,
+            state,
+            visit_preorder,
+            visit_postorder,
+            Direction::Incoming,
+        )
+    }
+
+    fn traverse_edges_from_entries_dfs_impl<S>(
+        &self,
+        entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
+        state: &mut S,
         mut visit_preorder: impl FnMut(
             Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
             ResolvedVc<Box<dyn Module>>,
@@ -1269,6 +1341,7 @@ impl ModuleGraphRef {
             ResolvedVc<Box<dyn Module>>,
             &mut S,
         ) -> Result<()>,
+        direction: Direction,
     ) -> Result<()> {
         let entries = entries.into_iter().collect::<Vec<_>>();
 
@@ -1310,7 +1383,7 @@ impl ModuleGraphRef {
                         && self.should_visit_node(current_node)
                     {
                         let current = current_node.target_idx().unwrap_or(current);
-                        stack.extend(self.iter_graphs_neighbors_rev(current).map(
+                        stack.extend(self.iter_graphs_neighbors_rev(current, direction).map(
                             |(edge, child)| (Pass::ExpandAndVisit, Some((current, edge)), child),
                         ));
                     }
@@ -1423,7 +1496,7 @@ impl ModuleGraphRef {
 
             visit_count += 1;
 
-            for (edge, succ) in self.iter_graphs_neighbors_rev(node) {
+            for (edge, succ) in self.iter_graphs_neighbors_rev(node, Direction::Outgoing) {
                 let succ_weight = self.get_node(succ)?;
 
                 let action = visit(

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1104,7 +1104,9 @@ impl ModuleGraphRef {
                     if action == GraphTraversalAction::Continue
                         && self.should_visit_node(current_node, Direction::Outgoing)
                     {
-                        let current = current_node.target_idx().unwrap_or(current);
+                        let current = current_node
+                            .target_idx(Direction::Outgoing)
+                            .unwrap_or(current);
                         stack.extend(
                             self.iter_graphs_neighbors_rev(current, Direction::Outgoing)
                                 .map(|(_, child)| (Pass::ExpandAndVisit, child)),
@@ -1157,7 +1159,7 @@ impl ModuleGraphRef {
                     if !self.should_visit_node(succ_weight, Direction::Outgoing) {
                         continue;
                     }
-                    let succ = succ_weight.target_idx().unwrap_or(succ);
+                    let succ = succ_weight.target_idx(Direction::Outgoing).unwrap_or(succ);
                     if !visited.contains(&succ) && action == GraphTraversalAction::Continue {
                         queue.push_back(succ);
                     }
@@ -1206,7 +1208,7 @@ impl ModuleGraphRef {
                     if !self.should_visit_node(succ_weight, Direction::Outgoing) {
                         continue;
                     }
-                    let succ = succ_weight.target_idx().unwrap_or(succ);
+                    let succ = succ_weight.target_idx(Direction::Outgoing).unwrap_or(succ);
                     if !visited.contains(&succ) && action == GraphTraversalAction::Continue {
                         stack.push(succ);
                     }
@@ -1343,6 +1345,13 @@ impl ModuleGraphRef {
         ) -> Result<()>,
         direction: Direction,
     ) -> Result<()> {
+        if direction == Direction::Incoming {
+            debug_assert!(
+                self.skip_visited_module_children,
+                "Can only trace reverse edges in a single layer graph. We do not model cross \
+                 graph reverse edges"
+            );
+        }
         let entries = entries.into_iter().collect::<Vec<_>>();
 
         enum Pass {
@@ -1382,7 +1391,7 @@ impl ModuleGraphRef {
                         && expanded.insert(current)
                         && self.should_visit_node(current_node, direction)
                     {
-                        let current = current_node.target_idx().unwrap_or(current);
+                        let current = current_node.target_idx(direction).unwrap_or(current);
                         stack.extend(self.iter_graphs_neighbors_rev(current, direction).map(
                             |(edge, child)| (Pass::ExpandAndVisit, Some((current, edge)), child),
                         ));
@@ -1492,7 +1501,7 @@ impl ModuleGraphRef {
         while let Some(NodeWithPriority { node, .. }) = queue.pop() {
             queue_set.remove(&node);
             let node_weight = self.get_node(node)?;
-            let node = node_weight.target_idx().unwrap_or(node);
+            let node = node_weight.target_idx(Direction::Outgoing).unwrap_or(node);
 
             visit_count += 1;
 
@@ -1505,7 +1514,7 @@ impl ModuleGraphRef {
                     state,
                 )?;
 
-                let succ = succ_weight.target_idx().unwrap_or(succ);
+                let succ = succ_weight.target_idx(Direction::Outgoing).unwrap_or(succ);
                 if action == GraphTraversalAction::Continue && queue_set.insert(succ) {
                     queue.push(NodeWithPriority {
                         node: succ,
@@ -1572,9 +1581,12 @@ impl SingleModuleGraphNode {
             SingleModuleGraphNode::VisitedModule { module, .. } => *module,
         }
     }
-    pub fn target_idx(&self) -> Option<GraphNodeIndex> {
+    pub fn target_idx(&self, direction: Direction) -> Option<GraphNodeIndex> {
         match self {
-            SingleModuleGraphNode::VisitedModule { idx, .. } => Some(*idx),
+            SingleModuleGraphNode::VisitedModule { idx, .. } => match direction {
+                Direction::Outgoing => Some(*idx),
+                Direction::Incoming => None,
+            },
             SingleModuleGraphNode::Module(_) => None,
         }
     }
@@ -1866,7 +1878,7 @@ pub mod tests {
     use anyhow::Result;
     use rustc_hash::FxHashMap;
     use turbo_rcstr::{RcStr, rcstr};
-    use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
+    use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
     use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
     use turbo_tasks_fs::{FileSystem, FileSystemPath, VirtualFileSystem};
 
@@ -1876,7 +1888,7 @@ pub mod tests {
         module::Module,
         module_graph::{
             GraphEntries, GraphTraversalAction, ModuleGraph, ModuleGraphRef, SingleModuleGraph,
-            chunk_group_info::ChunkGroupEntry,
+            VisitedModules, chunk_group_info::ChunkGroupEntry,
         },
         reference::{ModuleReference, ModuleReferences, SingleChunkableModuleReference},
         resolve::ExportUsage,
@@ -2053,6 +2065,161 @@ pub mod tests {
         )
         .await;
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_reverse_edges_through_layered_graph() {
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        tt.run_once(async move {
+            let fs = VirtualFileSystem::new_with_name(rcstr!("test"));
+            let root = fs.root().await?;
+
+            // a simple linear graph a -> b ->c
+            // but b->c is in a parent graph and a is in the child
+            let graph = {
+                let mut deps = FxHashMap::default();
+
+                deps.insert(rcstr!("a.js"), vec![rcstr!("b.js"), rcstr!("d.js")]);
+                deps.insert(rcstr!("b.js"), vec![rcstr!("c.js")]);
+                deps
+            };
+            let repo = TestRepo {
+                repo: graph
+                    .iter()
+                    .map(|(k, v)| {
+                        (
+                            root.join(k).unwrap(),
+                            v.iter().map(|f| root.join(f).unwrap()).collect(),
+                        )
+                    })
+                    .collect(),
+            }
+            .cell();
+            let make_module = |name| {
+                Vc::upcast::<Box<dyn Module>>(MockModule::new(root.join(name).unwrap(), repo))
+                    .to_resolved()
+            };
+            let a_module = make_module("a.js").await?;
+            let b_module = make_module("b.js").await?;
+
+            let parent_graph = SingleModuleGraph::new_with_entries(
+                GraphEntries::cell(GraphEntries(vec![ChunkGroupEntry::Entry(vec![b_module])])),
+                false,
+            );
+
+            let module_graph = ModuleGraph::from_graphs(vec![
+                parent_graph,
+                SingleModuleGraph::new_with_entries_visited(
+                    GraphEntries::cell(GraphEntries(vec![ChunkGroupEntry::Entry(vec![a_module])])),
+                    VisitedModules::from_graph(parent_graph),
+                    false,
+                ),
+            ])
+            .await?;
+            let child_graph = module_graph.iter_graphs().nth(1).unwrap().read().await?;
+            // test traversing forward from a in the child graph
+            {
+                let mut visited_forward = Vec::new();
+                child_graph.traverse_edges_from_entries_dfs(
+                    vec![a_module],
+                    &mut (),
+                    |_parent, child, _state_| {
+                        visited_forward.push(child);
+                        Ok(GraphTraversalAction::Continue)
+                    },
+                    |_, _, _| Ok(()),
+                )?;
+
+                assert_eq!(
+                    visited_forward
+                        .iter()
+                        .map(|m| m.ident().to_string().owned())
+                        .try_join()
+                        .await?,
+                    vec![
+                        rcstr!("[test]/a.js"),
+                        rcstr!("[test]/b.js"),
+                        rcstr!("[test]/d.js")
+                    ]
+                );
+            }
+
+            // test traversing backwards from 'd' which is only in the child graph
+            {
+                use turbo_tasks::TryFlatJoinIterExt;
+                let d_module = child_graph
+                    .enumerate_nodes()
+                    .map(|(_index, module)| async move {
+                        Ok(match module {
+                            crate::module_graph::SingleModuleGraphNode::Module(module) => {
+                                if module.ident().to_string().owned().await.unwrap()
+                                    == "[test]/d.js"
+                                {
+                                    Some(*module)
+                                } else {
+                                    None
+                                }
+                            }
+                            crate::module_graph::SingleModuleGraphNode::VisitedModule {
+                                ..
+                            } => None,
+                        })
+                    })
+                    .try_flat_join()
+                    .await?
+                    .into_iter()
+                    .next()
+                    .unwrap();
+                let mut visited_reverse = Vec::new();
+                child_graph.traverse_edges_from_entries_dfs_reversed(
+                    vec![d_module],
+                    &mut (),
+                    |_parent, child, _state_| {
+                        visited_reverse.push(child);
+                        Ok(GraphTraversalAction::Continue)
+                    },
+                    |_, _, _| Ok(()),
+                )?;
+                assert_eq!(
+                    visited_reverse
+                        .iter()
+                        .map(|m| m.ident().to_string().owned())
+                        .try_join()
+                        .await?,
+                    vec![rcstr!("[test]/d.js"), rcstr!("[test]/a.js")]
+                );
+            }
+            // test traversing backwards from `b` which is in the parent graph and thus a
+            // VisitedModule in this graph
+            {
+                let mut visited_reverse = Vec::new();
+                child_graph.traverse_edges_from_entries_dfs_reversed(
+                    vec![b_module],
+                    &mut (),
+                    |_parent, child, _state_| {
+                        visited_reverse.push(child);
+                        Ok(GraphTraversalAction::Continue)
+                    },
+                    |_, _, _| Ok(()),
+                )?;
+                assert_eq!(
+                    visited_reverse
+                        .iter()
+                        .map(|m| m.ident().to_string().owned())
+                        .try_join()
+                        .await?,
+                    vec![rcstr!("[test]/b.js"), rcstr!("[test]/a.js")]
+                );
+            }
+
+            Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
     #[turbo_tasks::value(shared)]
     struct TestRepo {
         repo: FxHashMap<FileSystemPath, Vec<FileSystemPath>>,

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/A.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/A.ts
@@ -1,0 +1,7 @@
+import { B } from './B'
+
+export function A(n: number) {
+  if (n > 0) {
+    B(n - 1)
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/B.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/B.ts
@@ -1,0 +1,9 @@
+import { C } from './C'
+import { asyncImportFn } from './asyncImportFn'
+
+export function B(n: number) {
+  if (n > 0) {
+    C(n - 1)
+    asyncImportFn()
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/C.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/C.ts
@@ -1,0 +1,7 @@
+import { A } from './A'
+
+export function C(n: number) {
+  if (n > 0) {
+    A(n - 1)
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/D.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/D.ts
@@ -1,0 +1,7 @@
+import { C } from './C'
+
+export function D(n: number) {
+  if (n > 0) {
+    C(n - 1)
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/E.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/E.ts
@@ -1,0 +1,7 @@
+import { B } from './B'
+
+export function E(n: number) {
+  if (n > 0) {
+    B(n - 1)
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/asyncImportFn.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/asyncImportFn.js
@@ -1,0 +1,7 @@
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+await sleep(0)
+console.log('Imported asyncImportFn')
+
+export function asyncImportFn() {}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/async-modules/cycle-2/input/index.js
@@ -1,0 +1,27 @@
+import { A } from './A'
+import { D } from './D'
+
+/*
+ * {A,B,C,D}.ts and asyncImportFn.ts have an import graph topology that
+ * exposes a bug in `compute_async_module_info_single` in turbopack. Requesting
+ * this page (localhost:3000/api/test) will fail with:
+ *   TypeError: (0 , t.C) is not a function
+ * This is because C has been marked as an async module, but D hasn't.
+ *
+ * route
+ * |   \
+ * v    v
+ * A<-  D
+ * |  \ |
+ * v   \v
+ * B--->C
+ * |
+ * v
+ * async
+ */
+
+it('should handle cycles in async modules', () => {
+  A(10)
+  D(10)
+  expect(true).toBe(true)
+})


### PR DESCRIPTION
This makes certain aggregations trivial since we are are guaranteed to only traverse relevant edges.

Use it to fix a bug in the async module identification logic.  Previously we would aggregate async cycles after propagating 'asyncness' through the DFS post order traversal, but this could cause us to fail to propagate async to all reverse dependencies depending on which part of a cycle a node would happen to visit first.

By traversing starting from the async modules we just need to mark everything we find and not worry about cycles at all since the underlying DFS mechanism will ensure we don't loop.  In addition to only requiring a single pass, this is guaranteed to visit fewer nodes in that single pass.

One caveat is that reverse traversals only work within a single `SingleModuleGraph` so a debug assert was added to prevent misuse

Closes #85988
Closes #86391
Closes PACK-5806
