### PR TITLE
add info about url pattern possible requiring polyfill

### DIFF
--- a/errors/middleware-upgrade-guide.mdx
+++ b/errors/middleware-upgrade-guide.mdx
@@ -379,6 +379,8 @@ export function middleware(request: NextRequest) {
 }
 ```
 
+> **Good to know:** `URLPattern` may require a polyfill depending on your runtime environment.
+
 ## Executing Middleware on Internal Next.js Requests
 
 ### Summary of changes

--- a/errors/proxy-request-page.mdx
+++ b/errors/proxy-request-page.mdx
@@ -59,3 +59,5 @@ export function proxy(request: NextRequest) {
   }
 }
 ```
+
+> **Good to know:** `URLPattern` may require a polyfill depending on your runtime environment.


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

Closes NEXT-
Fixes #

-->


### What?

Adds add info segment noting that `URLPattern` may require a polyfill 

### Why?

URLPattern is only available through import from `node:url` since 23.8 and globally since 24 (neither Version is currently available on Vercel). With the switch of the runtime for middleware/proxy in 16 to Node this caused our deploy to fail. Since the usage of URLPattern is recommended in the docs for Middleware, and it's importable from `next-server`, the possible need for a polyfill deserves a callout. 


