### PR TITLE
Codemod/middleware-to-proxy: Rename middleware.ts even when no changes in the file detected

### DIFF
--- a/packages/next-codemod/transforms/middleware-to-proxy.ts
+++ b/packages/next-codemod/transforms/middleware-to-proxy.ts
@@ -74,16 +74,16 @@ export default function transformer(file: FileInfo) {
     hasChanges = hasChanges || hasConfigChanges
   }
 
+  // Need to write proxy file and unlink the original middleware file.
+  if (isMiddlewareFile) {
+    return handleMiddlewareFileRename(file, source)
+  }
+
   if (!hasChanges) {
     return file.source
   }
 
   const source = root.toSource()
-
-  // Need to write proxy file and unlink the original middleware file.
-  if (isMiddlewareFile) {
-    return handleMiddlewareFileRename(file, source)
-  }
 
   return source
 }


### PR DESCRIPTION
### What?

Currently the codemod does not perform rename of middleware.ts to proxy.ts, if there're no changes to the middleware content

### Why?

The rename seems like a desired behaviour in this case
