### PR TITLE
fix(turbopack): correct __dirname and __filename in CJS modules

### DIFF
--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -227,6 +227,14 @@ pub enum InputRelativeConstant {
     FileName,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, NonLocalValue)]
+pub enum CjsPathConstant {
+    // The project relative directory name of the source file
+    DirName,
+    // The project relative file name of the source file.
+    FileName,
+}
+
 #[turbo_tasks::value]
 #[derive(Debug, Clone)]
 pub enum FreeVarReference {
@@ -239,6 +247,7 @@ pub enum FreeVarReference {
     Member(RcStr, RcStr),
     Value(CompileTimeDefineValue),
     InputRelative(InputRelativeConstant),
+    CjsPath(CjsPathConstant),
     Error(RcStr),
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1555,9 +1555,15 @@ async fn compile_time_info_for_module_options(
         .or_insert(rcstr!("string").into());
     free_var_references
         .entry(vec![DefinableNameSegment::Name(dir_name)])
-        .or_insert(FreeVarReference::InputRelative(
-            InputRelativeConstant::DirName,
-        ));
+        .or_insert(if is_esm {
+            FreeVarReference::InputRelative(
+                InputRelativeConstant::DirName,
+            )
+        } else {
+            FreeVarReference::CjsPath(
+                CjsPathConstant::DirName,
+            )
+        });
     let file_name = rcstr!("__filename");
 
     free_var_references
@@ -1568,9 +1574,15 @@ async fn compile_time_info_for_module_options(
         .or_insert(rcstr!("string").into());
     free_var_references
         .entry(vec![DefinableNameSegment::Name(file_name)])
-        .or_insert(FreeVarReference::InputRelative(
-            InputRelativeConstant::FileName,
-        ));
+        .or_insert(if is_esm {
+            FreeVarReference::InputRelative(
+                InputRelativeConstant::FileName,
+            )
+        } else {
+            FreeVarReference::CjsPath(
+                CjsPathConstant::FileName,
+            )
+        });
 
     // Compiletime rewrite the nodejs `global` to `__turbopack_context_.g` which is a shortcut for
     // `globalThis` that cannot be shadowed by a local variable.
@@ -2891,6 +2903,17 @@ async fn handle_free_var_reference(
             let source_path = match kind {
                 InputRelativeConstant::DirName => source_path.parent(),
                 InputRelativeConstant::FileName => source_path,
+            };
+            analysis.add_code_gen(ConstantValueCodeGen::new(
+                as_abs_path(source_path).into(),
+                ast_path.to_vec().into(),
+            ));
+        }
+        FreeVarReference::CjsPath(kind) => {
+            let source_path = state.origin.origin_path().owned().await?;
+            let source_path = match kind {
+                CjsPathConstant::DirName => source_path.parent(),
+                CjsPathConstant::FileName => source_path,
             };
             analysis.add_code_gen(ConstantValueCodeGen::new(
                 as_abs_path(source_path).into(),


### PR DESCRIPTION
This commit fixes an issue where __dirname and __filename were not being correctly resolved in CommonJS modules when using Turbopack. The issue was that the origin of the requiring module was being used to resolve these variables, instead of the origin of the CJS module itself.

To fix this, I've introduced a new CjsPath variant to the FreeVarReference enum. This new variant is used to represent __dirname and __filename in CJS modules. The handle_free_var_reference function in 	urbopack/crates/turbopack-ecmascript/src/references/mod.rs has been updated to handle this new variant and resolve the path correctly using the origin of the CJS module.

This change ensures that __dirname and __filename have the correct values in CJS modules, which is important for compatibility with existing Node.js code.

Fixes #86476

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
