### PR TITLE
Fix typed routes test expectations

### DIFF
--- a/test/e2e/app-dir/typed-routes/typed-routes.test.ts
+++ b/test/e2e/app-dir/typed-routes/typed-routes.test.ts
@@ -6,7 +6,7 @@ type AppRoutes = "/" | "/_shop/[[...category]]" | "/dashboard" | "/dashboard/set
 type AppRouteHandlerRoutes = "/api-test" | "/api/docs/[...slug]" | "/api/shop/[[...category]]" | "/api/users/[id]"
 type PageRoutes = "/about" | "/users/[id]"
 type LayoutRoutes = "/" | "/dashboard"
-type RedirectRoutes = "/blog/[category]/[[...slug]]" | "/project/[slug]"
+type RedirectRoutes = "/blog/[category]/[[...slug]]"
 type RewriteRoutes = "/api-legacy/[version]/[[...endpoint]]" | "/docs-old/[...path]"
 type Routes = AppRoutes | PageRoutes | LayoutRoutes | RedirectRoutes | RewriteRoutes | AppRouteHandlerRoutes
 `


### PR DESCRIPTION
Follow up to https://github.com/vercel/next.js/pull/86273

The typed routes test was checking for `/project/[slug]` in the `RedirectRoutes` type, but this route doesn't actually exist in the test fixture anymore. The test fixture only has redirects defined for `/blog/[category]/[[...slug]]`.

When Next.js generates the typed routes during the build, it only includes routes that actually exist in the project structure. The test was expecting a route that wasn't present, which would cause the test to fail if the generated types were correct.

This removes `/project/[slug]` from the expected `RedirectRoutes` type so the test expectations match what's actually generated.

Also includes a minor formatting fix in `apps/bundle-analyzer/next-env.d.ts` to use consistent semicolons and double quotes per the project's style guidelines.