### PR TITLE
[test] Add test fixture for runtime error in `'use cache'`

### DIFF
--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-runtime-error/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-runtime-error/layout.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>
+          <Suspense>{children}</Suspense>
+        </main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-runtime-error/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-runtime-error/page.tsx
@@ -1,0 +1,24 @@
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+
+  return (
+    <>
+      <p>This page throws an error at runtime in `'use cache'`.</p>
+      <ThrowingComponent />
+    </>
+  )
+}
+
+function throwAnError() {
+  throw new Error('Kaputt!')
+}
+
+async function ThrowingComponent() {
+  'use cache: remote'
+
+  throwAnError()
+
+  return null
+}

--- a/test/e2e/app-dir/cache-components-errors/utils.ts
+++ b/test/e2e/app-dir/cache-components-errors/utils.ts
@@ -21,22 +21,28 @@ export function convertModuleFunctionSequenceExpression(
   return output.replace(/\(0 , \w+\.(\w+)\)\(\.\.\.\)/, '<module-function>()')
 }
 
-export function getPrerenderOutput(
+export function getDeterministicOutput(
   cliOutput: string,
-  { isMinified }: { isMinified: boolean }
+  {
+    isMinified,
+    startingLineMatch,
+  }: { isMinified: boolean; startingLineMatch?: string }
 ): string {
   const lines: string[] = []
-  let foundPrerenderingLine = false
+
+  // If no starting line match is provided, we start from the beginning.
+  let foundStartingLine = !startingLineMatch
   let a = 0
   let n = 0
 
-  const replaceNextDistStackFrame = () =>
-    `at ${abc[a++ % abc.length]} (<next-dist-dir>)`
+  const replaceNextDistStackFrame = (_m: string, name: string) =>
+    `at ${isMinified ? abc[a++ % abc.length] : name} (<next-dist-dir>)`
 
   const isLikelyLibraryInternalStackFrame = (line: string) => {
     return line.startsWith('    at InnerLayoutRouter (')
   }
-  const replaceAnonymousStackFrame = (_m, name) => {
+
+  const replaceAnonymousStackFrame = (_m: string, name: string) => {
     const deterministicName = hostElementsUsedInFixtures.includes(name)
       ? name
       : abc[a++ % abc.length]
@@ -73,8 +79,8 @@ export function getPrerenderOutput(
         isErrorWithStackTraceStartingInLibraryInternals = false
       }
     }
-    if (line.includes('Collecting page data')) {
-      foundPrerenderingLine = true
+    if (startingLineMatch && line.includes(startingLineMatch)) {
+      foundStartingLine = true
       continue
     }
 
@@ -87,7 +93,7 @@ export function getPrerenderOutput(
     }
 
     if (
-      foundPrerenderingLine &&
+      foundStartingLine &&
       !ignoredLines.some((ignoredLine) => line.includes(ignoredLine))
     ) {
       if (isMinified) {
@@ -103,7 +109,7 @@ export function getPrerenderOutput(
       }
 
       line = line
-        .replace(/at .+? \(.next[^)]+\)/, replaceNextDistStackFrame)
+        .replace(/at (.+?) \(.next[^)]+\)/, replaceNextDistStackFrame)
         .replace(
           // Single-letter lower-case names are likely minified.
           /at [a-z] \((?!(<next-dist-dir>|<anonymous>))/,
@@ -117,4 +123,14 @@ export function getPrerenderOutput(
   }
 
   return lines.join('\n').trim()
+}
+
+export function getPrerenderOutput(
+  cliOutput: string,
+  { isMinified }: { isMinified: boolean }
+): string {
+  return getDeterministicOutput(cliOutput, {
+    isMinified,
+    startingLineMatch: 'Collecting page data',
+  })
 }


### PR DESCRIPTION
In production, when throwing an error in `'use cache'` at runtime, we are currently logging the obfuscated error that React is producing when crossing the cache-server boundary. This is not ideal for investigating production issues so we're also logging the original error in the `'use cache'` wrapper. But this error does not have a digest, which makes it non-obvious that it's the same error as the obfuscated one.

This PR is just adding a test fixture for this case, so that we can see the changes when improving the error handling in the upstack PR.