### PR TITLE
Fix error logging for `'use cache'` runtime errors in production

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -606,11 +606,17 @@ export async function handler(
           },
           onAfterTaskError: () => {},
 
-          onInstrumentationRequestError: (error, _request, errorContext) =>
+          onInstrumentationRequestError: (
+            error,
+            _request,
+            errorContext,
+            silenceLog
+          ) =>
             routeModule.onRequestError(
               req,
               error,
               errorContext,
+              silenceLog,
               routerServerContext
             ),
           err: getRequestMeta(req, 'invokeError'),
@@ -1414,6 +1420,7 @@ export async function handler(
     }
   } catch (err) {
     if (!(err instanceof NoFallbackError)) {
+      const silenceLog = false
       await routeModule.onRequestError(
         req,
         err,
@@ -1426,6 +1433,7 @@ export async function handler(
             isOnDemandRevalidate,
           }),
         },
+        silenceLog,
         routerServerContext
       )
     }

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -180,11 +180,17 @@ async function requestHandler(
       },
       onAfterTaskError: () => {},
 
-      onInstrumentationRequestError: (error, _request, errorContext) =>
+      onInstrumentationRequestError: (
+        error,
+        _request,
+        errorContext,
+        silenceLog
+      ) =>
         pageRouteModule.onRequestError(
           baseReq,
           error,
           errorContext,
+          silenceLog,
           routerServerContext
         ),
       dev: pageRouteModule.isDev,
@@ -319,12 +325,18 @@ async function requestHandler(
 
       return renderResultToResponse(result)
     } catch (err) {
-      await pageRouteModule.onRequestError(baseReq, err, {
-        routerKind: 'App Router',
-        routePath: normalizedSrcPage,
-        routeType: 'render',
-        revalidateReason: undefined,
-      })
+      const silenceLog = false
+      await pageRouteModule.onRequestError(
+        baseReq,
+        err,
+        {
+          routerKind: 'App Router',
+          routePath: normalizedSrcPage,
+          routeType: 'render',
+          revalidateReason: undefined,
+        },
+        silenceLog
+      )
       // rethrow so that we can handle serving error page
       throw err
     }

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -301,12 +301,18 @@ async function requestHandler(
         throw err
       }
 
-      await errRouteModule.onRequestError(baseReq, err, {
-        routerKind: 'Pages Router',
-        routePath: srcPage,
-        routeType: 'render',
-        revalidateReason: undefined,
-      })
+      const silenceLog = false
+      await errRouteModule.onRequestError(
+        baseReq,
+        err,
+        {
+          routerKind: 'Pages Router',
+          routePath: srcPage,
+          routeType: 'render',
+          revalidateReason: undefined,
+        },
+        silenceLog
+      )
 
       const errResult = await errRouteModule.render(
         // @ts-expect-error we don't type this for edge

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -78,8 +78,7 @@ import { AppRenderSpan, NextNodeServerSpan } from '../lib/trace/constants'
 import { getTracer } from '../lib/trace/tracer'
 import { FlightRenderResult } from './flight-render-result'
 import {
-  createFlightReactServerErrorHandler,
-  createHTMLReactServerErrorHandler,
+  createReactServerErrorHandler,
   createHTMLErrorHandler,
   type DigestedError,
   isUserLandError,
@@ -615,6 +614,7 @@ async function generateDynamicFlightRenderResult(
     dev = false,
     onInstrumentationRequestError,
     setReactDebugChannel,
+    nextExport = false,
   } = renderOpts
 
   function onFlightDataRenderError(err: DigestedError) {
@@ -624,8 +624,13 @@ async function generateDynamicFlightRenderResult(
       createErrorContext(ctx, 'react-server-components-payload')
     )
   }
-  const onError = createFlightReactServerErrorHandler(
+
+  const silenceLogger = false
+  const onError = createReactServerErrorHandler(
     dev,
+    nextExport,
+    workStore.reactServerErrorsByDigest,
+    silenceLogger,
     onFlightDataRenderError
   )
 
@@ -770,6 +775,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
     setReactDebugChannel,
     setCacheStatus,
     clientReferenceManifest,
+    nextExport = false,
   } = renderOpts
   assertClientReferenceManifest(clientReferenceManifest)
 
@@ -780,8 +786,13 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
       createErrorContext(ctx, 'react-server-components-payload')
     )
   }
-  const onError = createFlightReactServerErrorHandler(
+
+  const silenceLogger = false
+  const onError = createReactServerErrorHandler(
     dev,
+    nextExport,
+    workStore.reactServerErrorsByDigest,
+    silenceLogger,
     onFlightDataRenderError
   )
 
@@ -913,19 +924,24 @@ async function generateRuntimePrefetchResult(
   ctx: AppRenderContext,
   requestStore: RequestStore
 ): Promise<RenderResult> {
-  const { workStore } = ctx
-  const renderOpts = ctx.renderOpts
+  const { workStore, renderOpts } = ctx
+  const { nextExport = false, onInstrumentationRequestError } = renderOpts
 
   function onFlightDataRenderError(err: DigestedError) {
-    return renderOpts.onInstrumentationRequestError?.(
+    return onInstrumentationRequestError?.(
       err,
       req,
       // TODO(runtime-ppr): should we use a different value?
       createErrorContext(ctx, 'react-server-components-payload')
     )
   }
-  const onError = createFlightReactServerErrorHandler(
+
+  const silenceLogger = false
+  const onError = createReactServerErrorHandler(
     false,
+    nextExport,
+    workStore.reactServerErrorsByDigest,
+    silenceLogger,
     onFlightDataRenderError
   )
 
@@ -2616,7 +2632,7 @@ async function renderToStream(
       ? `self.__next_r=${JSON.stringify(requestId)}`
       : undefined
 
-  const reactServerErrorsByDigest: Map<string, DigestedError> = new Map()
+  const { reactServerErrorsByDigest } = workStore
   const silenceLogger = false
   function onHTMLRenderRSCError(err: DigestedError) {
     return onInstrumentationRequestError?.(
@@ -2625,7 +2641,7 @@ async function renderToStream(
       createErrorContext(ctx, 'react-server-components')
     )
   }
-  const serverComponentsErrorHandler = createHTMLReactServerErrorHandler(
+  const serverComponentsErrorHandler = createReactServerErrorHandler(
     dev,
     nextExport,
     reactServerErrorsByDigest,
@@ -4160,7 +4176,7 @@ async function prerenderToStream(
     page
   )
 
-  const reactServerErrorsByDigest: Map<string, DigestedError> = new Map()
+  const { reactServerErrorsByDigest } = workStore
   // We don't report errors during prerendering through our instrumentation hooks
   const silenceLogger = !!experimental.isRoutePPREnabled
   function onHTMLRenderRSCError(err: DigestedError) {
@@ -4170,7 +4186,7 @@ async function prerenderToStream(
       createErrorContext(ctx, 'react-server-components')
     )
   }
-  const serverComponentsErrorHandler = createHTMLReactServerErrorHandler(
+  const serverComponentsErrorHandler = createReactServerErrorHandler(
     dev,
     nextExport,
     reactServerErrorsByDigest,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -617,20 +617,19 @@ async function generateDynamicFlightRenderResult(
     nextExport = false,
   } = renderOpts
 
-  function onFlightDataRenderError(err: DigestedError) {
+  function onFlightDataRenderError(err: DigestedError, silenceLog: boolean) {
     return onInstrumentationRequestError?.(
       err,
       req,
-      createErrorContext(ctx, 'react-server-components-payload')
+      createErrorContext(ctx, 'react-server-components-payload'),
+      silenceLog
     )
   }
 
-  const silenceLogger = false
   const onError = createReactServerErrorHandler(
     dev,
     nextExport,
     workStore.reactServerErrorsByDigest,
-    silenceLogger,
     onFlightDataRenderError
   )
 
@@ -779,20 +778,19 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
   } = renderOpts
   assertClientReferenceManifest(clientReferenceManifest)
 
-  function onFlightDataRenderError(err: DigestedError) {
+  function onFlightDataRenderError(err: DigestedError, silenceLog: boolean) {
     return onInstrumentationRequestError?.(
       err,
       req,
-      createErrorContext(ctx, 'react-server-components-payload')
+      createErrorContext(ctx, 'react-server-components-payload'),
+      silenceLog
     )
   }
 
-  const silenceLogger = false
   const onError = createReactServerErrorHandler(
     dev,
     nextExport,
     workStore.reactServerErrorsByDigest,
-    silenceLogger,
     onFlightDataRenderError
   )
 
@@ -927,21 +925,20 @@ async function generateRuntimePrefetchResult(
   const { workStore, renderOpts } = ctx
   const { nextExport = false, onInstrumentationRequestError } = renderOpts
 
-  function onFlightDataRenderError(err: DigestedError) {
+  function onFlightDataRenderError(err: DigestedError, silenceLog: boolean) {
     return onInstrumentationRequestError?.(
       err,
       req,
       // TODO(runtime-ppr): should we use a different value?
-      createErrorContext(ctx, 'react-server-components-payload')
+      createErrorContext(ctx, 'react-server-components-payload'),
+      silenceLog
     )
   }
 
-  const silenceLogger = false
   const onError = createReactServerErrorHandler(
     false,
     nextExport,
     workStore.reactServerErrorsByDigest,
-    silenceLogger,
     onFlightDataRenderError
   )
 
@@ -2633,27 +2630,30 @@ async function renderToStream(
       : undefined
 
   const { reactServerErrorsByDigest } = workStore
-  const silenceLogger = false
-  function onHTMLRenderRSCError(err: DigestedError) {
+  function onHTMLRenderRSCError(err: DigestedError, silenceLog: boolean) {
     return onInstrumentationRequestError?.(
       err,
       req,
-      createErrorContext(ctx, 'react-server-components')
+      createErrorContext(ctx, 'react-server-components'),
+      silenceLog
     )
   }
   const serverComponentsErrorHandler = createReactServerErrorHandler(
     dev,
     nextExport,
     reactServerErrorsByDigest,
-    silenceLogger,
     onHTMLRenderRSCError
   )
 
   function onHTMLRenderSSRError(err: DigestedError) {
+    // We don't need to silence logs here. onHTMLRenderSSRError won't be called
+    // at all if the error was logged before in the RSC error handler.
+    const silenceLog = false
     return onInstrumentationRequestError?.(
       err,
       req,
-      createErrorContext(ctx, 'server-rendering')
+      createErrorContext(ctx, 'server-rendering'),
+      silenceLog
     )
   }
 
@@ -2663,7 +2663,6 @@ async function renderToStream(
     nextExport,
     reactServerErrorsByDigest,
     allCapturedErrors,
-    silenceLogger,
     onHTMLRenderSSRError
   )
 
@@ -4178,28 +4177,36 @@ async function prerenderToStream(
 
   const { reactServerErrorsByDigest } = workStore
   // We don't report errors during prerendering through our instrumentation hooks
-  const silenceLogger = !!experimental.isRoutePPREnabled
-  function onHTMLRenderRSCError(err: DigestedError) {
-    return onInstrumentationRequestError?.(
-      err,
-      req,
-      createErrorContext(ctx, 'react-server-components')
-    )
+  const reportErrors = !experimental.isRoutePPREnabled
+  function onHTMLRenderRSCError(err: DigestedError, silenceLog: boolean) {
+    if (reportErrors) {
+      return onInstrumentationRequestError?.(
+        err,
+        req,
+        createErrorContext(ctx, 'react-server-components'),
+        silenceLog
+      )
+    }
   }
   const serverComponentsErrorHandler = createReactServerErrorHandler(
     dev,
     nextExport,
     reactServerErrorsByDigest,
-    silenceLogger,
     onHTMLRenderRSCError
   )
 
   function onHTMLRenderSSRError(err: DigestedError) {
-    return onInstrumentationRequestError?.(
-      err,
-      req,
-      createErrorContext(ctx, 'server-rendering')
-    )
+    if (reportErrors) {
+      // We don't need to silence logs here. onHTMLRenderSSRError won't be
+      // called at all if the error was logged before in the RSC error handler.
+      const silenceLog = false
+      return onInstrumentationRequestError?.(
+        err,
+        req,
+        createErrorContext(ctx, 'server-rendering'),
+        silenceLog
+      )
+    }
   }
   const allCapturedErrors: Array<unknown> = []
   const htmlRendererErrorHandler = createHTMLErrorHandler(
@@ -4207,7 +4214,6 @@ async function prerenderToStream(
     nextExport,
     reactServerErrorsByDigest,
     allCapturedErrors,
-    silenceLogger,
     onHTMLRenderSSRError
   )
 

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -52,8 +52,7 @@ export function createReactServerErrorHandler(
   shouldFormatError: boolean,
   isNextExport: boolean,
   reactServerErrors: Map<string, DigestedError>,
-  silenceLogger: boolean,
-  onReactServerRenderError: undefined | ((err: DigestedError) => void)
+  onReactServerRenderError: (err: DigestedError, silenceLog: boolean) => void
 ): RSCErrorHandler {
   return (thrownValue: unknown) => {
     if (typeof thrownValue === 'string') {
@@ -77,6 +76,7 @@ export function createReactServerErrorHandler(
     }
 
     let err = getProperError(thrownValue) as DigestedError
+    let silenceLog = false
 
     // If the error already has a digest, respect the original digest,
     // so it won't get re-generated into another new error.
@@ -86,8 +86,12 @@ export function createReactServerErrorHandler(
         reactServerErrors.has(err.digest)
       ) {
         // This error is likely an obfuscated error from another react-server
-        // environment (e.g. 'use cache'). We recover the original error here.
+        // environment (e.g. 'use cache'). We recover the original error here
+        // for reporting purposes.
         err = reactServerErrors.get(err.digest)!
+        // We don't log it again though, as it was already logged in the
+        // original environment.
+        silenceLog = true
       } else {
         // Either we're in development (where we want to keep the transported
         // error with environmentName), or the error is not in reactServerErrors
@@ -132,9 +136,7 @@ export function createReactServerErrorHandler(
         })
       }
 
-      if (!silenceLogger) {
-        onReactServerRenderError?.(err)
-      }
+      onReactServerRenderError(err, silenceLog)
     }
 
     return err.digest
@@ -146,7 +148,6 @@ export function createHTMLErrorHandler(
   isNextExport: boolean,
   reactServerErrors: Map<string, DigestedError>,
   allCapturedErrors: Array<unknown>,
-  silenceLogger: boolean,
   onHTMLRenderSSRError: (err: DigestedError, errorInfo?: ErrorInfo) => void
 ): SSRErrorHandler {
   return (thrownValue: unknown, errorInfo?: ErrorInfo) => {
@@ -170,6 +171,7 @@ export function createHTMLErrorHandler(
     }
 
     const err = getProperError(thrownValue) as DigestedError
+
     // If the error already has a digest, respect the original digest,
     // so it won't get re-generated into another new error.
     if (err.digest) {
@@ -216,11 +218,8 @@ export function createHTMLErrorHandler(
         })
       }
 
-      if (
-        !silenceLogger &&
-        // HTML errors contain RSC errors as well, filter them out before reporting
-        isSSRError
-      ) {
+      // HTML errors contain RSC errors as well, filter them out before reporting
+      if (isSSRError) {
         onHTMLRenderSSRError(err, errorInfo)
       }
     }

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -22,7 +22,7 @@ type SSRErrorHandler = (
   errorInfo?: ErrorInfo
 ) => string | undefined
 
-export type DigestedError = Error & { digest: string }
+export type DigestedError = Error & { digest: string; environmentName?: string }
 
 /**
  * Returns a digest for well-known Next.js errors, otherwise `undefined`. If a
@@ -48,63 +48,7 @@ export function getDigestForWellKnownError(error: unknown): string | undefined {
   return undefined
 }
 
-export function createFlightReactServerErrorHandler(
-  shouldFormatError: boolean,
-  onReactServerRenderError: (err: DigestedError) => void
-): RSCErrorHandler {
-  return (thrownValue: unknown) => {
-    if (typeof thrownValue === 'string') {
-      // TODO-APP: look at using webcrypto instead. Requires a promise to be awaited.
-      return stringHash(thrownValue).toString()
-    }
-
-    // If the response was closed, we don't need to log the error.
-    if (isAbortError(thrownValue)) return
-
-    const digest = getDigestForWellKnownError(thrownValue)
-
-    if (digest) {
-      return digest
-    }
-
-    if (isReactLargeShellError(thrownValue)) {
-      // TODO: Aggregate
-      console.error(thrownValue)
-      return undefined
-    }
-
-    const err = getProperError(thrownValue) as DigestedError
-
-    // If the error already has a digest, respect the original digest,
-    // so it won't get re-generated into another new error.
-    if (!err.digest) {
-      // TODO-APP: look at using webcrypto instead. Requires a promise to be awaited.
-      err.digest = stringHash(err.message + err.stack || '').toString()
-    }
-
-    // Format server errors in development to add more helpful error messages
-    if (shouldFormatError) {
-      formatServerError(err)
-    }
-
-    // Record exception in an active span, if available.
-    const span = getTracer().getActiveScopeSpan()
-    if (span) {
-      span.recordException(err)
-      span.setAttribute('error.type', err.name)
-      span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: err.message,
-      })
-    }
-
-    onReactServerRenderError(err)
-
-    return createDigestWithErrorCode(thrownValue, err.digest)
-  }
-}
-
-export function createHTMLReactServerErrorHandler(
+export function createReactServerErrorHandler(
   shouldFormatError: boolean,
   isNextExport: boolean,
   reactServerErrors: Map<string, DigestedError>,
@@ -132,11 +76,23 @@ export function createHTMLReactServerErrorHandler(
       return undefined
     }
 
-    const err = getProperError(thrownValue) as DigestedError
+    let err = getProperError(thrownValue) as DigestedError
 
     // If the error already has a digest, respect the original digest,
     // so it won't get re-generated into another new error.
-    if (!err.digest) {
+    if (err.digest) {
+      if (
+        process.env.NODE_ENV === 'production' &&
+        reactServerErrors.has(err.digest)
+      ) {
+        // This error is likely an obfuscated error from another react-server
+        // environment (e.g. 'use cache'). We recover the original error here.
+        err = reactServerErrors.get(err.digest)!
+      } else {
+        // The error is not from react-server but has a digest from other means
+        // so we don't need to produce a new one.
+      }
+    } else {
       // TODO-APP: look at using webcrypto instead. Requires a promise to be awaited.
       err.digest = stringHash(err.message + (err.stack || '')).toString()
     }

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -93,8 +93,11 @@ export function createReactServerErrorHandler(
         // so we don't need to produce a new one.
       }
     } else {
-      // TODO-APP: look at using webcrypto instead. Requires a promise to be awaited.
-      err.digest = stringHash(err.message + (err.stack || '')).toString()
+      err.digest = createDigestWithErrorCode(
+        err,
+        // TODO-APP: look at using webcrypto instead. Requires a promise to be awaited.
+        stringHash(err.message + (err.stack || '')).toString()
+      )
     }
 
     // @TODO by putting this here and not at the top it is possible that
@@ -133,7 +136,7 @@ export function createReactServerErrorHandler(
       }
     }
 
-    return createDigestWithErrorCode(thrownValue, err.digest)
+    return err.digest
   }
 }
 
@@ -179,9 +182,12 @@ export function createHTMLErrorHandler(
         // from other means so we don't need to produce a new one
       }
     } else {
-      err.digest = stringHash(
-        err.message + (errorInfo?.componentStack || err.stack || '')
-      ).toString()
+      err.digest = createDigestWithErrorCode(
+        err,
+        stringHash(
+          err.message + (errorInfo?.componentStack || err.stack || '')
+        ).toString()
+      )
     }
 
     // Format server errors in development to add more helpful error messages
@@ -218,7 +224,7 @@ export function createHTMLErrorHandler(
       }
     }
 
-    return createDigestWithErrorCode(thrownValue, err.digest)
+    return err.digest
   }
 }
 

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -89,8 +89,9 @@ export function createReactServerErrorHandler(
         // environment (e.g. 'use cache'). We recover the original error here.
         err = reactServerErrors.get(err.digest)!
       } else {
-        // The error is not from react-server but has a digest from other means
-        // so we don't need to produce a new one.
+        // Either we're in development (where we want to keep the transported
+        // error with environmentName), or the error is not in reactServerErrors
+        // but has a digest from other means. Keep the error as-is.
       }
     } else {
       err.digest = createDigestWithErrorCode(

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -81,7 +81,8 @@ export type ServerOnInstrumentationRequestError = (
   // The request could be middleware, node server or web server request,
   // we normalized them into an aligned format to `onRequestError` API later.
   request: NextRequestHint | BaseNextRequest | IncomingMessage,
-  errorContext: Parameters<InstrumentationOnRequestError>[2]
+  errorContext: Parameters<InstrumentationOnRequestError>[2],
+  silenceLog: boolean
 ) => void | Promise<void>
 
 export interface RenderOptsPartial {

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -9,6 +9,7 @@ import type { CacheLife } from '../use-cache/cache-life'
 // Share the instance module in the next-shared layer
 import { workAsyncStorageInstance } from './work-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
 import type { LazyResult } from '../lib/lazy-result'
+import type { DigestedError } from './create-error-handler'
 
 export interface WorkStore {
   readonly isStaticGeneration: boolean
@@ -114,6 +115,8 @@ export interface WorkStore {
     fn: (...args: TArgs) => R,
     ...args: TArgs
   ) => R
+
+  reactServerErrorsByDigest: Map<string, DigestedError>
 }
 
 export type WorkAsyncStorage = AsyncLocalStorage<WorkStore>

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -145,6 +145,7 @@ export function createWorkStore({
     refreshTagsByCacheKind: createRefreshTagsByCacheKind(),
     runInCleanSnapshot: createSnapshot(),
     shouldTrackFetchMetrics,
+    reactServerErrorsByDigest: new Map(),
   }
 
   // TODO: remove this when we resolve accessing the store outside the execution context

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -823,7 +823,7 @@ export default abstract class Server<
     }
   }
 
-  public logError(err: Error): void {
+  public logError(err: unknown): void {
     if (this.quiet) return
     Log.error(err)
   }

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -999,7 +999,9 @@ export default class DevServer extends Server {
   ) {
     await super.instrumentationOnRequestError(...args)
 
-    const err = args[0]
-    this.logErrorWithOriginalStack(err, 'app-dir')
+    const [err, , , silenceLog] = args
+    if (!silenceLog) {
+      this.logErrorWithOriginalStack(err, 'app-dir')
+    }
   }
 }

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1160,13 +1160,19 @@ export default class NextNodeServer extends BaseServer<
           })
           if (handled) return true
         } catch (apiError) {
-          await this.instrumentationOnRequestError(apiError, req, {
-            routePath: match.definition.page,
-            routerKind: 'Pages Router',
-            routeType: 'route',
-            // Edge runtime does not support ISR
-            revalidateReason: undefined,
-          })
+          const silenceLog = false
+          await this.instrumentationOnRequestError(
+            apiError,
+            req,
+            {
+              routePath: match.definition.page,
+              routerKind: 'Pages Router',
+              routeType: 'route',
+              // Edge runtime does not support ISR
+              revalidateReason: undefined,
+            },
+            silenceLog
+          )
           throw apiError
         }
       }
@@ -2123,7 +2129,10 @@ export default class NextNodeServer extends BaseServer<
 
     // For Node.js runtime production logs, in dev it will be overridden by next-dev-server
     if (!this.renderOpts.dev) {
-      this.logError(args[0] as Error)
+      const [err, , , silenceLog] = args
+      if (!silenceLog) {
+        this.logError(err)
+      }
     }
   }
 

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -420,6 +420,7 @@ export const getHandler = ({
               // if this is a background revalidate we need to report
               // the request error here as it won't be bubbled
               if (previousCacheEntry?.isStale) {
+                const silenceLog = false
                 await routeModule.onRequestError(
                   req,
                   err,
@@ -432,6 +433,7 @@ export const getHandler = ({
                       isOnDemandRevalidate,
                     }),
                   },
+                  silenceLog,
                   routerServerContext
                 )
               }
@@ -742,6 +744,7 @@ export const getHandler = ({
       }
     } catch (err) {
       if (!(err instanceof NoFallbackError)) {
+        const silenceLog = false
         await routeModule.onRequestError(
           req,
           err,
@@ -754,6 +757,7 @@ export const getHandler = ({
               isOnDemandRevalidate,
             }),
           },
+          silenceLog,
           routerServerContext
         )
       }

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -478,12 +478,15 @@ export abstract class RouteModule<
     req: IncomingMessage | BaseNextRequest,
     err: unknown,
     errorContext: RequestErrorContext,
+    silenceLog: boolean,
     routerServerContext?: RouterServerContext[string]
   ) {
-    if (routerServerContext?.logErrorWithOriginalStack) {
-      routerServerContext.logErrorWithOriginalStack(err, 'app-dir')
-    } else {
-      console.error(err)
+    if (!silenceLog) {
+      if (routerServerContext?.logErrorWithOriginalStack) {
+        routerServerContext.logErrorWithOriginalStack(err, 'app-dir')
+      } else {
+        console.error(err)
+      }
     }
     await this.instrumentationOnRequestError(
       req,

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -70,6 +70,7 @@ import { createLazyResult, isResolvedLazyResult } from '../lib/lazy-result'
 import { dynamicAccessAsyncStorage } from '../app-render/dynamic-access-async-storage.external'
 import type { CacheLife } from './cache-life'
 import { RenderStage } from '../app-render/staged-rendering'
+import * as Log from '../../build/output/log'
 
 interface PrivateCacheContext {
   readonly kind: 'private'
@@ -599,8 +600,16 @@ async function generateCacheEntryImpl(
     workStore.dev,
     workStore.isBuildTimePrerendering ?? false,
     workStore.reactServerErrorsByDigest,
-    false,
     (error) => {
+      // In production, we log the original error here. It gets a digest that
+      // can be used to associate the error with the obfuscated error that might
+      // be logged if the error is caught. In development, we prefer logging the
+      // transported error in the server environment. It's not obfuscated and
+      // also includes the (dev-only) environment name.
+      if (process.env.NODE_ENV === 'production') {
+        Log.error(error)
+      }
+
       errors.push(error)
     }
   )

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -52,7 +52,7 @@ import type { CacheEntry } from '../lib/cache-handlers/types'
 import type { CacheSignal } from '../app-render/cache-signal'
 import { decryptActionBoundArgs } from '../app-render/encryption'
 import { InvariantError } from '../../shared/lib/invariant-error'
-import { getDigestForWellKnownError } from '../app-render/create-error-handler'
+import { createReactServerErrorHandler } from '../app-render/create-error-handler'
 import { DYNAMIC_EXPIRE, RUNTIME_PREFETCH_DYNAMIC_STALE } from './constants'
 import { getCacheHandler } from './handlers'
 import { UseCacheTimeoutError } from './use-cache-errors'
@@ -68,7 +68,6 @@ import {
 import type { Params } from '../request/params'
 import { createLazyResult, isResolvedLazyResult } from '../lib/lazy-result'
 import { dynamicAccessAsyncStorage } from '../app-render/dynamic-access-async-storage.external'
-import { isReactLargeShellError } from '../app-render/react-large-shell-error'
 import type { CacheLife } from './cache-life'
 import { RenderStage } from '../app-render/staged-rendering'
 
@@ -596,28 +595,15 @@ async function generateCacheEntryImpl(
   // digests are handled correctly. Error formatting and reporting is not
   // necessary here; the errors are encoded in the stream, and will be reported
   // in the "Server" environment.
-  const handleError = (error: unknown): string | undefined => {
-    const digest = getDigestForWellKnownError(error)
-
-    if (digest) {
-      return digest
+  const handleError = createReactServerErrorHandler(
+    workStore.dev,
+    workStore.isBuildTimePrerendering ?? false,
+    workStore.reactServerErrorsByDigest,
+    false,
+    (error) => {
+      errors.push(error)
     }
-
-    if (isReactLargeShellError(error)) {
-      // TODO: Aggregate
-      console.error(error)
-      return undefined
-    }
-
-    if (process.env.NODE_ENV !== 'development') {
-      // TODO: For now we're also reporting the error here, because in
-      // production, the "Server" environment will only get the obfuscated
-      // error (created by the Flight Client in the cache wrapper).
-      console.error(error)
-    }
-
-    errors.push(error)
-  }
+  )
 
   let stream: ReadableStream<Uint8Array>
 

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -2797,7 +2797,7 @@ describe('Cache Components Errors', () => {
             `)
           })
         } else {
-          it('should show an error at runtime', async () => {
+          it('should log an error at runtime', async () => {
             try {
               await prerender('/use-cache-runtime-error')
             } catch (error) {
@@ -2831,6 +2831,75 @@ describe('Cache Components Errors', () => {
                "⨯ Error: Kaputt!
                    at a (<next-dist-dir>)
                    at b (<next-dist-dir>) {
+                 digest: '<error-digest>'
+               }"
+              `)
+            }
+          })
+        }
+      })
+
+      describe('catching an error at runtime', () => {
+        if (isNextDev) {
+          it('should show a collapsed redbox error', async () => {
+            cliOutputLength = next.cliOutput.length
+            const browser = await next.browser('/use-cache-catch-error')
+
+            await expect(browser).toDisplayCollapsedRedbox(`
+             {
+               "description": "Kaputt!",
+               "environmentLabel": "Cache",
+               "label": "Console Error",
+               "source": "app/use-cache-catch-error/page.tsx (19:9) @ throwAnError
+             > 19 |   throw new Error('Kaputt!')
+                  |         ^",
+               "stack": [
+                 "throwAnError app/use-cache-catch-error/page.tsx (19:9)",
+                 "Page app/use-cache-catch-error/page.tsx (11:7)",
+               ],
+             }
+            `)
+          })
+        } else {
+          it('should log an error at runtime', async () => {
+            try {
+              await prerender('/use-cache-catch-error')
+            } catch (error) {
+              throw new Error('expected build not to fail', { cause: error })
+            }
+
+            await next.start({ skipBuild: true })
+            cliOutputLength = next.cliOutput.length
+            await next.fetch('/use-cache-catch-error')
+
+            await retry(async () => {
+              expect(next.cliOutput.slice(cliOutputLength)).toContain('Error')
+            })
+
+            const output = getDeterministicOutput(
+              next.cliOutput.slice(cliOutputLength),
+              { isMinified: !isDebugPrerender }
+            )
+
+            if (isDebugPrerender) {
+              expect(output).toMatchInlineSnapshot(`
+               "⨯ Error: Kaputt!
+                   at throwAnError (<next-dist-dir>)
+                   at Object.then (<next-dist-dir>) {
+                 digest: '<error-digest>'
+               }
+               [Error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.] {
+                 digest: '<error-digest>'
+               }"
+              `)
+            } else {
+              expect(output).toMatchInlineSnapshot(`
+               "⨯ Error: Kaputt!
+                   at a (<next-dist-dir>)
+                   at b (<next-dist-dir>) {
+                 digest: '<error-digest>'
+               }
+               [Error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.] {
                  digest: '<error-digest>'
                }"
               `)
@@ -3003,10 +3072,23 @@ describe('Cache Components Errors', () => {
               { isMinified: !isDebugPrerender }
             )
 
+            // TODO: Ideally, the error should only be shown once.
             if (isDebugPrerender) {
               if (isTurbopack) {
                 expect(output).toMatchInlineSnapshot(`
-                 "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                 "⨯ Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                     at Private (app/use-cache-private-in-use-cache/page.tsx:15:1)
+                     at stringify (<anonymous>)
+                   13 | }
+                   14 |
+                 > 15 | async function Private() {
+                      | ^
+                   16 |   'use cache: private'
+                   17 |
+                   18 |   return <p>Private</p> {
+                   digest: '<error-digest>'
+                 }
+                 Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
                      at Private (app/use-cache-private-in-use-cache/page.tsx:15:1)
                      at stringify (<anonymous>)
                    13 | }
@@ -3026,7 +3108,19 @@ describe('Cache Components Errors', () => {
                 `)
               } else
                 expect(output).toMatchInlineSnapshot(`
-                 "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                 "⨯ Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                     at Private (webpack:///app/use-cache-private-in-use-cache/page.tsx:15:1)
+                     at stringify (<anonymous>)
+                   13 | }
+                   14 |
+                 > 15 | async function Private() {
+                      | ^
+                   16 |   'use cache: private'
+                   17 |
+                   18 |   return <p>Private</p> {
+                   digest: '<error-digest>'
+                 }
+                 Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
                      at Private (webpack:///app/use-cache-private-in-use-cache/page.tsx:15:1)
                      at stringify (<anonymous>)
                    13 | }
@@ -3047,9 +3141,21 @@ describe('Cache Components Errors', () => {
             } else {
               if (isTurbopack) {
                 expect(output).toMatchInlineSnapshot(`
-                 "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                 "⨯ Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
                      at <unknown> (app/use-cache-private-in-use-cache/page.tsx:15:1)
                      at a (<anonymous>)
+                   13 | }
+                   14 |
+                 > 15 | async function Private() {
+                      | ^
+                   16 |   'use cache: private'
+                   17 |
+                   18 |   return <p>Private</p> {
+                   digest: '<error-digest>'
+                 }
+                 Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                     at <unknown> (app/use-cache-private-in-use-cache/page.tsx:15:1)
+                     at b (<anonymous>)
                    13 | }
                    14 |
                  > 15 | async function Private() {
@@ -3067,9 +3173,14 @@ describe('Cache Components Errors', () => {
                 `)
               } else {
                 expect(output).toMatchInlineSnapshot(`
-                 "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                 "⨯ Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
                      at a (<next-dist-dir>)
                      at b (<anonymous>) {
+                   digest: '<error-digest>'
+                 }
+                 Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
+                     at c (<next-dist-dir>)
+                     at d (<anonymous>) {
                    digest: '<error-digest>'
                  }
                  To get a more detailed stack trace and pinpoint the issue, try one of the following:

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -2817,24 +2817,20 @@ describe('Cache Components Errors', () => {
               { isMinified: !isDebugPrerender }
             )
 
-            // TODO: The obfuscated error should be hidden, and the original
-            // error should have a digest.
             if (isDebugPrerender) {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Kaputt!
+               "⨯ Error: Kaputt!
                    at throwAnError (<next-dist-dir>)
                    at ThrowingComponent (<next-dist-dir>)
-                   at Object.then (<next-dist-dir>)
-               ⨯ [Error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.] {
+                   at Object.then (<next-dist-dir>) {
                  digest: '<error-digest>'
                }"
               `)
             } else {
               expect(output).toMatchInlineSnapshot(`
-               "Error: Kaputt!
+               "⨯ Error: Kaputt!
                    at a (<next-dist-dir>)
-                   at b (<next-dist-dir>)
-               ⨯ [Error: An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.] {
+                   at b (<next-dist-dir>) {
                  digest: '<error-digest>'
                }"
               `)
@@ -3007,7 +3003,6 @@ describe('Cache Components Errors', () => {
               { isMinified: !isDebugPrerender }
             )
 
-            // TODO: Ideally, the error should only be shown once.
             if (isDebugPrerender) {
               if (isTurbopack) {
                 expect(output).toMatchInlineSnapshot(`
@@ -3020,17 +3015,9 @@ describe('Cache Components Errors', () => {
                       | ^
                    16 |   'use cache: private'
                    17 |
-                   18 |   return <p>Private</p>
-                 Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at Private (app/use-cache-private-in-use-cache/page.tsx:15:1)
-                     at stringify (<anonymous>)
-                   13 | }
-                   14 |
-                 > 15 | async function Private() {
-                      | ^
-                   16 |   'use cache: private'
-                   17 |
-                   18 |   return <p>Private</p>
+                   18 |   return <p>Private</p> {
+                   digest: '<error-digest>'
+                 }
                  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3048,17 +3035,9 @@ describe('Cache Components Errors', () => {
                       | ^
                    16 |   'use cache: private'
                    17 |
-                   18 |   return <p>Private</p>
-                 Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at Private (webpack:///app/use-cache-private-in-use-cache/page.tsx:15:1)
-                     at stringify (<anonymous>)
-                   13 | }
-                   14 |
-                 > 15 | async function Private() {
-                      | ^
-                   16 |   'use cache: private'
-                   17 |
-                   18 |   return <p>Private</p>
+                   18 |   return <p>Private</p> {
+                   digest: '<error-digest>'
+                 }
                  To get a more detailed stack trace and pinpoint the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3077,17 +3056,9 @@ describe('Cache Components Errors', () => {
                       | ^
                    16 |   'use cache: private'
                    17 |
-                   18 |   return <p>Private</p>
-                 Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at <unknown> (app/use-cache-private-in-use-cache/page.tsx:15:1)
-                     at b (<anonymous>)
-                   13 | }
-                   14 |
-                 > 15 | async function Private() {
-                      | ^
-                   16 |   'use cache: private'
-                   17 |
-                   18 |   return <p>Private</p>
+                   18 |   return <p>Private</p> {
+                   digest: '<error-digest>'
+                 }
                  To get a more detailed stack trace and pinpoint the issue, try one of the following:
                    - Start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
                    - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.
@@ -3098,10 +3069,9 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
                      at a (<next-dist-dir>)
-                     at b (<anonymous>)
-                 Error: "use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".
-                     at c (<next-dist-dir>)
-                     at d (<anonymous>)
+                     at b (<anonymous>) {
+                   digest: '<error-digest>'
+                 }
                  To get a more detailed stack trace and pinpoint the issue, try one of the following:
                    - Start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
                    - Rerun the production build with \`next build --debug-prerender\` to generate better stack traces.

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-catch-error/layout.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-catch-error/layout.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>
+          <Suspense>{children}</Suspense>
+        </main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-catch-error/page.tsx
+++ b/test/e2e/app-dir/cache-components-errors/fixtures/default/app/use-cache-catch-error/page.tsx
@@ -1,0 +1,30 @@
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+
+  return (
+    <>
+      <p>
+        This page catches an error that's thrown in `'use cache'` at runtime.
+      </p>
+      <CatchingComponent />
+    </>
+  )
+}
+
+async function throwAnError() {
+  'use cache: remote'
+
+  throw new Error('Kaputt!')
+}
+
+async function CatchingComponent() {
+  try {
+    await throwAnError()
+  } catch (error) {
+    console.error(error)
+  }
+
+  return null
+}

--- a/test/e2e/app-dir/cache-components-errors/utils.ts
+++ b/test/e2e/app-dir/cache-components-errors/utils.ts
@@ -116,7 +116,7 @@ export function getDeterministicOutput(
           replaceMinifiedName
         )
         .replace(/at \d+ \(/, replaceNumericModuleId)
-        .replace(/digest: '\d+'/, "digest: '<error-digest>'")
+        .replace(/digest: '\d+(@E\d+)?'/, "digest: '<error-digest>'")
 
       lines.push(convertModuleFunctionSequenceExpression(line))
     }

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -110,8 +110,8 @@ describe('app-dir - errors', () => {
       expect(stripAnsi(next.cliOutput)).toEqual(
         expect.stringMatching(
           isNextDev
-            ? /Error: An undefined error was thrown.*digest: '\d+'/s
-            : /Error: undefined.*digest: '\d+'/s
+            ? /Error: An undefined error was thrown.*digest: '\d+@E\d+'/s
+            : /Error: undefined.*digest: '\d+@E\d+'/s
         )
       )
     })
@@ -133,8 +133,8 @@ describe('app-dir - errors', () => {
       expect(stripAnsi(next.cliOutput)).toEqual(
         expect.stringMatching(
           isNextDev
-            ? /Error: A null error was thrown.*digest: '\d+'/s
-            : /Error: null.*digest: '\d+'/s
+            ? /Error: A null error was thrown.*digest: '\d+@E\d+'/s
+            : /Error: null.*digest: '\d+@E\d+'/s
         )
       )
     })


### PR DESCRIPTION
In production, when throwing an error in `'use cache'` at runtime, we are currently logging the obfuscated error that React is producing when crossing the cache-server boundary. This is not ideal for investigating production issues so we're also logging the original error in the `'use cache'` wrapper as a work-around. But this error does not have a digest,
which makes it non-obvious that it's the same error as the obfuscated one.

With this PR we are fixing this by storing the original error (with a digest) in the `reactServerErrorsByDigest` map (moved to the work store), and retrieving it in the server environment when we log the error. Thus the obfuscated error is not logged, and the original error with a digest is logged instead.

In development, we keep the existing behavior of logging the transported error, which also includes the dev-only `environmentName` property `'Cache'`.

As part of this fix, we're consolidating the `createFlightReactServerErrorHandler` and `createHTMLReactServerErrorHandler` functions, which had a big overlap and confusing names, into a single `createReactServerErrorHandler` function.

closes NAR-536