### PR TITLE
feat(metadata): add WebP and AVIF support for metadata images

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/app-icons.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/app-icons.mdx
@@ -19,11 +19,11 @@ The `favicon` image can only be located in the top level of `app/`.
 
 Next.js will evaluate the file and automatically add the appropriate tags to your app's `<head>` element.
 
-| File convention             | Supported file types                    | Valid locations |
-| --------------------------- | --------------------------------------- | --------------- |
-| [`favicon`](#favicon)       | `.ico`                                  | `app/`          |
-| [`icon`](#icon)             | `.ico`, `.jpg`, `.jpeg`, `.png`, `.svg` | `app/**/*`      |
-| [`apple-icon`](#apple-icon) | `.jpg`, `.jpeg`, `.png`                 | `app/**/*`      |
+| File convention             | Supported file types                                      | Valid locations |
+| --------------------------- | --------------------------------------------------------- | --------------- |
+| [`favicon`](#favicon)       | `.ico`                                                    | `app/`          |
+| [`icon`](#icon)             | `.ico`, `.jpg`, `.jpeg`, `.png`, `.svg`, `.webp`, `.avif` | `app/**/*`      |
+| [`apple-icon`](#apple-icon) | `.jpg`, `.jpeg`, `.png`, `.webp`                          | `app/**/*`      |
 
 ### `favicon`
 
@@ -35,7 +35,7 @@ Add a `favicon.ico` image file to the root `/app` route segment.
 
 ### `icon`
 
-Add an `icon.(ico|jpg|jpeg|png|svg)` image file.
+Add an `icon.(ico|jpg|jpeg|png|svg|webp|avif)` image file.
 
 ```html filename="<head> output"
 <link
@@ -48,7 +48,9 @@ Add an `icon.(ico|jpg|jpeg|png|svg)` image file.
 
 ### `apple-icon`
 
-Add an `apple-icon.(jpg|jpeg|png)` image file.
+Add an `apple-icon.(jpg|jpeg|png|webp)` image file.
+
+> **Good to know**: AVIF is not supported for `apple-icon` because older Safari versions on iOS and macOS do not support the AVIF format.
 
 ```html filename="<head> output"
 <link
@@ -262,7 +264,8 @@ export default function Icon() {}
 
 ## Version History
 
-| Version   | Changes                                              |
-| --------- | ---------------------------------------------------- |
-| `v16.0.0` | `params` is now a promise that resolves to an object |
-| `v13.3.0` | `favicon` `icon` and `apple-icon` introduced         |
+| Version   | Changes                                                                |
+| --------- | ---------------------------------------------------------------------- |
+| `v16.1.0` | Added `.webp` and `.avif` support for `icon`, `.webp` for `apple-icon` |
+| `v16.0.0` | `params` is now a promise that resolves to an object                   |
+| `v13.3.0` | `favicon` `icon` and `apple-icon` introduced                           |

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/opengraph-image.mdx
@@ -9,21 +9,21 @@ They are useful for setting the images that appear on social networks and messag
 
 There are two ways to set Open Graph and Twitter images:
 
-- [Using image files (.jpg, .png, .gif)](#image-files-jpg-png-gif)
+- [Using image files (.jpg, .png, .gif, .webp, .avif)](#image-files-jpg-png-gif-webp-avif)
 - [Using code to generate images (.js, .ts, .tsx)](#generate-images-using-code-js-ts-tsx)
 
-## Image files (.jpg, .png, .gif)
+## Image files (.jpg, .png, .gif, .webp, .avif)
 
 Use an image file to set a route segment's shared image by placing an `opengraph-image` or `twitter-image` image file in the segment.
 
 Next.js will evaluate the file and automatically add the appropriate tags to your app's `<head>` element.
 
-| File convention                                 | Supported file types            |
-| ----------------------------------------------- | ------------------------------- |
-| [`opengraph-image`](#opengraph-image)           | `.jpg`, `.jpeg`, `.png`, `.gif` |
-| [`twitter-image`](#twitter-image)               | `.jpg`, `.jpeg`, `.png`, `.gif` |
-| [`opengraph-image.alt`](#opengraph-imagealttxt) | `.txt`                          |
-| [`twitter-image.alt`](#twitter-imagealttxt)     | `.txt`                          |
+| File convention                                 | Supported file types                              |
+| ----------------------------------------------- | ------------------------------------------------- |
+| [`opengraph-image`](#opengraph-image)           | `.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.avif` |
+| [`twitter-image`](#twitter-image)               | `.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.avif` |
+| [`opengraph-image.alt`](#opengraph-imagealttxt) | `.txt`                                            |
+| [`twitter-image.alt`](#twitter-imagealttxt)     | `.txt`                                            |
 
 > **Good to know**:
 >
@@ -31,7 +31,7 @@ Next.js will evaluate the file and automatically add the appropriate tags to you
 
 ### `opengraph-image`
 
-Add an `opengraph-image.(jpg|jpeg|png|gif)` image file to any route segment.
+Add an `opengraph-image.(jpg|jpeg|png|gif|webp|avif)` image file to any route segment.
 
 ```html filename="<head> output"
 <meta property="og:image" content="<generated>" />
@@ -42,7 +42,7 @@ Add an `opengraph-image.(jpg|jpeg|png|gif)` image file to any route segment.
 
 ### `twitter-image`
 
-Add a `twitter-image.(jpg|jpeg|png|gif)` image file to any route segment.
+Add a `twitter-image.(jpg|jpeg|png|gif|webp|avif)` image file to any route segment.
 
 ```html filename="<head> output"
 <meta name="twitter:image" content="<generated>" />
@@ -53,7 +53,7 @@ Add a `twitter-image.(jpg|jpeg|png|gif)` image file to any route segment.
 
 ### `opengraph-image.alt.txt`
 
-Add an accompanying `opengraph-image.alt.txt` file in the same route segment as the `opengraph-image.(jpg|jpeg|png|gif)` image it's alt text.
+Add an accompanying `opengraph-image.alt.txt` file in the same route segment as the `opengraph-image.(jpg|jpeg|png|gif|webp|avif)` image it's alt text.
 
 ```txt filename="opengraph-image.alt.txt"
 About Acme
@@ -65,7 +65,7 @@ About Acme
 
 ### `twitter-image.alt.txt`
 
-Add an accompanying `twitter-image.alt.txt` file in the same route segment as the `twitter-image.(jpg|jpeg|png|gif)` image it's alt text.
+Add an accompanying `twitter-image.alt.txt` file in the same route segment as the `twitter-image.(jpg|jpeg|png|gif|webp|avif)` image it's alt text.
 
 ```txt filename="twitter-image.alt.txt"
 About Acme
@@ -77,7 +77,7 @@ About Acme
 
 ## Generate images using code (.js, .ts, .tsx)
 
-In addition to using [literal image files](#image-files-jpg-png-gif), you can programmatically **generate** images using code.
+In addition to using [literal image files](#image-files-jpg-png-gif-webp-avif), you can programmatically **generate** images using code.
 
 Generate a route segment's shared image by creating an `opengraph-image` or `twitter-image` route that default exports a function.
 
@@ -523,7 +523,8 @@ export default async function Image() {
 
 ## Version History
 
-| Version   | Changes                                              |
-| --------- | ---------------------------------------------------- |
-| `v16.0.0` | `params` is now a promise that resolves to an object |
-| `v13.3.0` | `opengraph-image` and `twitter-image` introduced.    |
+| Version   | Changes                                                                     |
+| --------- | --------------------------------------------------------------------------- |
+| `v16.1.0` | Added `.webp` and `.avif` support for `opengraph-image` and `twitter-image` |
+| `v16.0.0` | `params` is now a promise that resolves to an object                        |
+| `v13.3.0` | `opengraph-image` and `twitter-image` introduced.                           |

--- a/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
@@ -497,7 +497,7 @@ export const metadata = {
 
 > **Good to know**:
 >
-> - It may be more convenient to use the [file-based Metadata API](/docs/app/api-reference/file-conventions/metadata/opengraph-image#image-files-jpg-png-gif) for Open Graph images. Rather than having to sync the config export with actual files, the file-based API will automatically generate the correct metadata for you.
+> - It may be more convenient to use the [file-based Metadata API](/docs/app/api-reference/file-conventions/metadata/opengraph-image#image-files-jpg-png-gif-webp-avif) for Open Graph images. Rather than having to sync the config export with actual files, the file-based API will automatically generate the correct metadata for you.
 
 ### `robots`
 

--- a/packages/next/src/lib/metadata/is-metadata-route.test.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.test.ts
@@ -96,6 +96,58 @@ describe('isMetadataRouteFile', () => {
       expect(isMetadataRouteFile('/sitemap.xml', [], true)).toBe(true)
     })
 
+    it('should match WebP and AVIF metadata image files', () => {
+      // icon - supports both webp and avif
+      expect(isMetadataRouteFile('/foo/icon.webp', [], true)).toBe(true)
+      expect(isMetadataRouteFile('/foo/icon.avif', [], true)).toBe(true)
+
+      // apple-icon - supports webp but NOT avif (Safari compatibility)
+      expect(isMetadataRouteFile('/bar/apple-icon.webp', [], true)).toBe(true)
+      expect(isMetadataRouteFile('/bar/apple-icon.avif', [], true)).toBe(false)
+
+      // opengraph-image - supports both webp and avif
+      expect(isMetadataRouteFile('/baz/opengraph-image.webp', [], true)).toBe(
+        true
+      )
+      expect(isMetadataRouteFile('/baz/opengraph-image.avif', [], true)).toBe(
+        true
+      )
+
+      // twitter-image - supports both webp and avif
+      expect(isMetadataRouteFile('/qux/twitter-image.webp', [], true)).toBe(
+        true
+      )
+      expect(isMetadataRouteFile('/qux/twitter-image.avif', [], true)).toBe(
+        true
+      )
+    })
+
+    it('should match WebP and AVIF with numeric variants', () => {
+      // icon variants
+      expect(isMetadataRouteFile('/foo/icon1.webp', [], true)).toBe(true)
+      expect(isMetadataRouteFile('/foo/icon2.avif', [], true)).toBe(true)
+
+      // opengraph-image variants
+      expect(isMetadataRouteFile('/bar/opengraph-image1.webp', [], true)).toBe(
+        true
+      )
+      expect(isMetadataRouteFile('/bar/opengraph-image2.avif', [], true)).toBe(
+        true
+      )
+
+      // twitter-image variants
+      expect(isMetadataRouteFile('/baz/twitter-image1.webp', [], true)).toBe(
+        true
+      )
+      expect(isMetadataRouteFile('/baz/twitter-image2.avif', [], true)).toBe(
+        true
+      )
+
+      // apple-icon variants - webp only
+      expect(isMetadataRouteFile('/qux/apple-icon1.webp', [], true)).toBe(true)
+      expect(isMetadataRouteFile('/qux/apple-icon1.avif', [], true)).toBe(false)
+    })
+
     it('should match dynamic metadata routes', () => {
       // with dynamic extensions, passing the 2nd arg: such as ['tsx', 'ts']
       expect(isMetadataRouteFile('/foo/icon.js', ['tsx', 'ts'], true)).toBe(

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -6,11 +6,14 @@ import { isAppRouteRoute } from '../is-app-route-route'
 export const STATIC_METADATA_IMAGES = {
   icon: {
     filename: 'icon',
-    extensions: ['ico', 'jpg', 'jpeg', 'png', 'svg'],
+    extensions: ['ico', 'jpg', 'jpeg', 'png', 'svg', 'webp', 'avif'],
   },
   apple: {
     filename: 'apple-icon',
-    extensions: ['jpg', 'jpeg', 'png'],
+    // Note: AVIF is intentionally excluded for apple-icon because Safari on
+    // older iOS/macOS versions doesn't support AVIF, and apple-icon is
+    // specifically used for Apple devices.
+    extensions: ['jpg', 'jpeg', 'png', 'webp'],
   },
   favicon: {
     filename: 'favicon',
@@ -18,11 +21,11 @@ export const STATIC_METADATA_IMAGES = {
   },
   openGraph: {
     filename: 'opengraph-image',
-    extensions: ['jpg', 'jpeg', 'png', 'gif'],
+    extensions: ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif'],
   },
   twitter: {
     filename: 'twitter-image',
-    extensions: ['jpg', 'jpeg', 'png', 'gif'],
+    extensions: ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif'],
   },
 } as const
 


### PR DESCRIPTION
## Summary

This PR adds support for modern image formats (WebP and AVIF) to Next.js metadata routes, addressing the TODO comment at `packages/next/src/lib/metadata/is-metadata-route.ts:30`:

```typescript
// TODO-METADATA: support more metadata routes with more extensions
```

### Changes

| Metadata Type | New Extensions Added |
|---------------|---------------------|
| `icon` | `.webp`, `.avif` |
| `apple-icon` | `.webp` only |
| `opengraph-image` | `.webp`, `.avif` |
| `twitter-image` | `.webp`, `.avif` |

> **Note:** AVIF is intentionally excluded from `apple-icon` because older Safari versions on iOS and macOS do not support the AVIF format, and `apple-icon` specifically targets Apple devices.

### Why WebP and AVIF?

- **WebP:** 25-35% better compression than JPEG/PNG, 97%+ browser support
- **AVIF:** 50%+ better compression than JPEG, 93%+ browser support
- Aligns with Next.js Image component's format support
- Enables better Core Web Vitals scores for metadata images

### Files Changed

- `packages/next/src/lib/metadata/is-metadata-route.ts` - Added extensions to `STATIC_METADATA_IMAGES`
- `packages/next/src/lib/metadata/is-metadata-route.test.ts` - Added comprehensive tests for new formats
- `docs/.../app-icons.mdx` - Updated documentation for icon and apple-icon
- `docs/.../opengraph-image.mdx` - Updated documentation for opengraph-image and twitter-image

## Test Plan

- [x] Added unit tests for WebP and AVIF file matching
- [x] Added tests for numeric variants (e.g., `icon1.webp`, `opengraph-image2.avif`)
- [x] Added test verifying AVIF is NOT matched for apple-icon
- [x] All existing tests pass (15/15)

```
PASS packages/next/src/lib/metadata/is-metadata-route.test.ts
  ✓ should match WebP and AVIF metadata image files
  ✓ should match WebP and AVIF with numeric variants
Tests: 15 passed, 15 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)