### PR TITLE
Try to improve typed-routes test flakyness

### DIFF
--- a/test/e2e/app-dir/typed-routes/typed-links.test.ts
+++ b/test/e2e/app-dir/typed-routes/typed-links.test.ts
@@ -11,11 +11,17 @@ describe('typed-links', () => {
   }
 
   it('should generate types for next/link', async () => {
+    // To wait for the (dev) server to have started up.
+    await next.render('/')
+
     const dts = await next.readFile(`${next.distDir}/types/link.d.ts`)
     expect(dts).toContain(`declare module 'next/link'`)
   })
 
   it('should include handler route from app/api-test/route.ts in generated link route definitions', async () => {
+    // To wait for the (dev) server to have started up.
+    await next.render('/')
+
     const dts = await next.readFile(`${next.distDir}/types/link.d.ts`)
     // Ensure the app route handler at app/api-test/route.ts ("/api-test") is present
     expect(dts).toContain('`/api-test`')


### PR DESCRIPTION
```
test dev (10/10) / build

FAIL webpack test/e2e/app-dir/typed-routes/typed-routes.test.ts (10.637 s)
  ● typed-routes › should generate route types correctly

    expect(received).toContain(expected) // indexOf

    Expected substring: "
    type AppRoutes = \"/\" | \"/_shop/[[...category]]\" | \"/dashboard\" | \"/dashboard/settings\" | \"/docs/[...slug]\" | \"/gallery/photo/[id]\" | \"/project/[slug]\"
    type AppRouteHandlerRoutes = \"/api-test\" | \"/api/docs/[...slug]\" | \"/api/shop/[[...category]]\" | \"/api/users/[id]\"
    type PageRoutes = \"/about\" | \"/users/[id]\"
    type LayoutRoutes = \"/\" | \"/dashboard\"
    type RedirectRoutes = \"/blog/[category]/[[...slug]]\" | \"/project/[slug]\"
    type RewriteRoutes = \"/api-legacy/[version]/[[...endpoint]]\" | \"/docs-old/[...path]\"
    type Routes = AppRoutes | PageRoutes | LayoutRoutes | RedirectRoutes | RewriteRoutes | AppRouteHandlerRoutes
    "
    Received string:    "// This file is generated automatically by Next.js
    // Do not edit this file manually·
    type AppRoutes = \"/\" | \"/_shop/[[...category]]\" | \"/dashboard\" | \"/dashboard/settings\" | \"/docs/[...slug]\" | \"/gallery/photo/[id]\" | \"/project/[slug]\"
    type AppRouteHandlerRoutes = \"/api-test\" | \"/api/docs/[...slug]\" | \"/api/shop/[[...category]]\" | \"/api/users/[id]\"
    type PageRoutes = \"/about\" | \"/users/[id]\"
    type LayoutRoutes = \"/\" | \"/dashboard\"
    type RedirectRoutes = \"/blog/[category]/[[...slug]]\"
    type RewriteRoutes = \"/api-legacy/[version]/[[...endpoint]]\" | \"/docs-old/[...path]\"
    type Routes = AppRoutes | PageRoutes | LayoutRoutes | RedirectRoutes | RewriteRoutes | AppRouteHandlerRoutes··
    interface ParamMap {
```