### PR TITLE
Turbopack: Expose an environment variable for exposing the `detail` field of issues

### DIFF
--- a/packages/next/src/shared/lib/turbopack/utils.ts
+++ b/packages/next/src/shared/lib/turbopack/utils.ts
@@ -17,6 +17,8 @@ export type IssuesMap = Map<IssueKey, Issue>
 export type EntryIssuesMap = Map<EntryKey, IssuesMap>
 export type TopLevelIssuesMap = IssuesMap
 
+const VERBOSE_ISSUES = !!process.env.NEXT_TURBOPACK_VERBOSE_ISSUES
+
 /**
  * An error generated from emitted Turbopack issues. This can include build
  * errors caused by issues with user code.
@@ -91,7 +93,7 @@ export function processIssues(
 }
 
 export function formatIssue(issue: Issue) {
-  const { filePath, title, description, source, importTraces } = issue
+  const { filePath, title, description, detail, source, importTraces } = issue
   let { documentationLink } = issue
   const formattedTitle = renderStyledStringToErrorAnsi(title).replace(
     /\n/g,
@@ -166,10 +168,10 @@ export function formatIssue(issue: Issue) {
     }
   }
 
-  // TODO: make it possible to enable this for debugging, but not in tests.
-  // if (detail) {
-  //   message += renderStyledStringToErrorAnsi(detail) + '\n\n'
-  // }
+  // TODO: make it easier to enable this for debugging
+  if (VERBOSE_ISSUES && detail) {
+    message += renderStyledStringToErrorAnsi(detail) + '\n\n'
+  }
 
   if (importTraces?.length) {
     // This is the same logic as in turbopack/crates/turbopack-cli-utils/src/issue.rs


### PR DESCRIPTION
We have a `detail` field on Turbopack issues, but there was no way to actually read that value from Next.js.

This adds a hacky environment variable, which is better than nothing.

![Screenshot 2025-11-25 at 3.32.04 PM.png](https://app.graphite.com/user-attachments/assets/aef1b6c2-062f-47c1-98ee-91be68d6cfc7.png)