### PR TITLE
Turbopack: Use `Debug` instead of `Display` for `ValueDebugFormat` impl on `RcStr`

### DIFF
--- a/turbopack/crates/turbo-tasks/src/debug/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/debug/mod.rs
@@ -74,13 +74,13 @@ pub trait ValueDebugFormat {
 
 impl ValueDebugFormat for String {
     fn value_debug_format(&self, _depth: usize) -> ValueDebugFormatString<'_> {
-        ValueDebugFormatString::Sync(format!("{self:#?}"))
+        ValueDebugFormatString::Sync(format!("{self:?}"))
     }
 }
 
 impl ValueDebugFormat for RcStr {
-    fn value_debug_format(&self, _: usize) -> ValueDebugFormatString<'_> {
-        ValueDebugFormatString::Sync(self.to_string())
+    fn value_debug_format(&self, _depth: usize) -> ValueDebugFormatString<'_> {
+        ValueDebugFormatString::Sync(format!("{self:?}"))
     }
 }
 


### PR DESCRIPTION
Stuff like empty `RcStr`s look really confusing if we use `Display`. Also stop using the alternate debug mode for `String`, as it looks like the alternate flag doesn't do anything in this case.