### PR TITLE
Turbopack: Simplify the return type of `FileSystemPath::try_join`

### DIFF
--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -1561,9 +1561,9 @@ pub async fn read_matches(
                     if last_segment.is_empty() {
                         // This means we don't have a last segment, so we just have a directory
                         let joined = if force_in_lookup_dir {
-                            lookup_dir.try_join_inside(parent_path)?
+                            lookup_dir.try_join_inside(parent_path)
                         } else {
-                            lookup_dir.try_join(parent_path)?
+                            lookup_dir.try_join(parent_path)
                         };
                         let Some(fs_path) = joined else {
                             continue;
@@ -1579,9 +1579,9 @@ pub async fn read_matches(
                         Entry::Occupied(e) => Some(e.into_mut()),
                         Entry::Vacant(e) => {
                             let path_option = if force_in_lookup_dir {
-                                lookup_dir.try_join_inside(parent_path)?
+                                lookup_dir.try_join_inside(parent_path)
                             } else {
-                                lookup_dir.try_join(parent_path)?
+                                lookup_dir.try_join(parent_path)
                             };
                             if let Some(path) = path_option {
                                 Some(e.insert((path.raw_read_dir().await?, path)))
@@ -1635,9 +1635,9 @@ pub async fn read_matches(
                     let subpath = &str[..=str.rfind('/').unwrap()];
                     if handled.insert(subpath) {
                         let joined = if force_in_lookup_dir {
-                            lookup_dir.try_join_inside(subpath)?
+                            lookup_dir.try_join_inside(subpath)
                         } else {
-                            lookup_dir.try_join(subpath)?
+                            lookup_dir.try_join(subpath)
                         };
                         let Some(fs_path) = joined else {
                             continue;

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -389,7 +389,7 @@ impl SourceMap {
             origin: FileSystemPath,
         ) -> Result<(BytesStr, BytesStr)> {
             Ok(
-                if let Some(path) = origin.parent().try_join(&source_request)? {
+                if let Some(path) = origin.parent().try_join(&source_request) {
                     let path_str = path.value_to_string().await?;
                     let source = format!("{SOURCE_URL_PROTOCOL}///{path_str}");
                     let source_content = if let Some(source_content) = source_content {

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -128,9 +128,9 @@ pub async fn resolve_source_map_sources(
             } else {
                 // assume it's a relative URL, and just remove any percent encoding from path
                 // segments. Our internal path format is POSIX-like, without percent encoding.
-                origin.parent().try_join(
-                    &urlencoding::decode(source_url).unwrap_or(Cow::Borrowed(source_url)),
-                )?
+                origin
+                    .parent()
+                    .try_join(&urlencoding::decode(source_url).unwrap_or(Cow::Borrowed(source_url)))
             };
 
             if let Some(fs_path) = fs_path {

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -78,7 +78,7 @@ impl ModuleReference for TsReferencePathAssetReference {
                 .origin_path()
                 .await?
                 .parent()
-                .try_join(&self.path)?
+                .try_join(&self.path)
             {
                 let module = self
                     .origin

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -255,7 +255,7 @@ async fn try_join_base_url(
     base_url: RcStr,
 ) -> Result<Vc<FileSystemPathOption>> {
     Ok(Vc::cell(
-        source.ident().path().await?.parent().try_join(&base_url)?,
+        source.ident().path().await?.parent().try_join(&base_url),
     ))
 }
 
@@ -294,7 +294,7 @@ pub async fn tsconfig_resolve_options(
         {
             let mut context_dir = source.ident().path().await?.parent();
             if let Some(base_url) = json["compilerOptions"]["baseUrl"].as_str()
-                && let Some(new_context) = context_dir.try_join(base_url)?
+                && let Some(new_context) = context_dir.try_join(base_url)
             {
                 context_dir = new_context;
             };


### PR DESCRIPTION
This is probably left over from when more of `FileSystemPath` was using `turbo_task::function`s...

We can't ever possibly return an error, so the wrapping `Result` isn't needed.