### PR TITLE
fix(turbopack): Disable ES3 transforms from preset-env

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -8,7 +8,7 @@ use swc_core::{
     common::{Mark, SourceMap, comments::Comments},
     ecma::{
         ast::{ExprStmt, ModuleItem, Pass, Program, Stmt},
-        preset_env::{self, Targets},
+        preset_env::{self, Feature, FeatureOrModule, Targets},
         transforms::{
             base::{
                 assumptions::Assumptions,
@@ -210,6 +210,11 @@ impl EcmascriptInputTransform {
                     swc_core::ecma::preset_env::Config {
                         targets: Some(Targets::Versions(*versions)),
                         mode: None, // Don't insert core-js polyfills
+                        exclude: vec![
+                            FeatureOrModule::Feature(Feature::ReservedWords),
+                            FeatureOrModule::Feature(Feature::MemberExpressionLiterals),
+                            FeatureOrModule::Feature(Feature::PropertyLiterals),
+                        ],
                         ..Default::default()
                     },
                 );

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -210,7 +210,8 @@ impl EcmascriptInputTransform {
                     swc_core::ecma::preset_env::Config {
                         targets: Some(Targets::Versions(*versions)),
                         mode: None, // Don't insert core-js polyfills
-                        // Disable some ancient ES3 transforms, ReservedWords breaks resolving of some idents 
+                        // Disable some ancient ES3 transforms, ReservedWords breaks resolving of
+                        // some idents references
                         exclude: vec![
                             FeatureOrModule::Feature(Feature::ReservedWords),
                             FeatureOrModule::Feature(Feature::MemberExpressionLiterals),

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -210,6 +210,7 @@ impl EcmascriptInputTransform {
                     swc_core::ecma::preset_env::Config {
                         targets: Some(Targets::Versions(*versions)),
                         mode: None, // Don't insert core-js polyfills
+                        // Disable some ancient ES3 transforms, ReservedWords breaks resolving of some idents 
                         exclude: vec![
                             FeatureOrModule::Feature(Feature::ReservedWords),
                             FeatureOrModule::Feature(Feature::MemberExpressionLiterals),


### PR DESCRIPTION
### What?

Disable es3 transforms while applying preset-env.

### Why?

It's not required for turbopack. I'll remove them completely from the binary in the future.

### How?

Fixes #86076
