### PR TITLE
Turbopack: slightly fewer turbo tasks calls during resolving

### DIFF
--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -39,7 +39,7 @@ use turbopack_core::{
     output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
     reference_type::{EntryReferenceSubType, ReferenceType},
     resolve::{
-        origin::{PlainResolveOrigin, ResolveOriginExt},
+        origin::{PlainResolveOrigin, ResolveOrigin, ResolveOriginExt},
         parse::Request,
     },
 };
@@ -287,7 +287,7 @@ async fn build_internal(
                 let ty = ReferenceType::Entry(EntryReferenceSubType::Undefined);
                 let request = request_vc.await?;
                 origin
-                    .resolve_asset(request_vc, origin.resolve_options(ty.clone()).await?, ty)
+                    .resolve_asset(request_vc, origin.resolve_options(ty.clone()), ty)
                     .await?
                     .first_module()
                     .await?

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -15,7 +15,7 @@ use turbopack_core::{
     module_graph::{ModuleGraph, chunk_group_info::ChunkGroupEntry},
     reference_type::{EntryReferenceSubType, ReferenceType},
     resolve::{
-        origin::{PlainResolveOrigin, ResolveOriginExt},
+        origin::{PlainResolveOrigin, ResolveOrigin, ResolveOriginExt},
         parse::Request,
     },
 };
@@ -139,7 +139,7 @@ pub async fn create_web_entry_source(
         .map(|request| async move {
             let ty = ReferenceType::Entry(EntryReferenceSubType::Web);
             Ok(origin
-                .resolve_asset(request, origin.resolve_options(ty.clone()).await?, ty)
+                .resolve_asset(request, origin.resolve_options(ty.clone()), ty)
                 .await?
                 .resolve()
                 .await?

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -332,6 +332,7 @@ pub async fn primary_chunkable_referenced_modules(
                     .resolve_reference()
                     .resolve()
                     .await?
+                    // turn into primary_modules_ref()
                     .primary_modules()
                     .await?;
                 let binding_usage = reference.binding_usage().owned().await?;

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt,
-    ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
+    FxIndexSet, NonLocalValue, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc,
+    debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 
 use crate::{
@@ -299,7 +299,7 @@ pub async fn primary_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<V
 pub struct ResolvedReference {
     pub chunking_type: ChunkingType,
     pub binding_usage: BindingUsage,
-    pub modules: ReadRef<Modules>,
+    pub modules: Vec<ResolvedVc<Box<dyn Module>>>,
 }
 
 #[turbo_tasks::value(transparent)]
@@ -330,10 +330,8 @@ pub async fn primary_chunkable_referenced_modules(
 
                 let resolved = reference
                     .resolve_reference()
-                    .resolve()
                     .await?
-                    // turn into primary_modules_ref()
-                    .primary_modules()
+                    .primary_modules_ref()
                     .await?;
                 let binding_usage = reference.binding_usage().owned().await?;
 

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1628,7 +1628,7 @@ pub async fn url_resolve(
     handle_resolve_error(
         result,
         reference_type,
-        origin.origin_path().owned().await?,
+        origin,
         request,
         resolve_options,
         is_optional,
@@ -3062,10 +3062,7 @@ pub async fn handle_resolve_error(
     is_optional: bool,
     source: Option<IssueSource>,
 ) -> Result<Vc<ModuleResolveResult>> {
-    async fn is_unresolvable(result: Vc<ModuleResolveResult>) -> Result<bool> {
-        Ok(*result.resolve().await?.is_unresolvable().await?)
-    }
-    Ok(match is_unresolvable(result).await {
+    Ok(match result.await?.is_unresolvable_ref() {
         Ok(unresolvable) => {
             if unresolvable {
                 emit_unresolvable_issue(

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -24,7 +24,7 @@ use self::{
         ConditionValue, ImportMapResult, ResolveInPackage, ResolveIntoPackage, ResolveModules,
         ResolveModulesOptions, ResolveOptions, resolve_modules_options,
     },
-    origin::{ResolveOrigin, ResolveOriginExt},
+    origin::ResolveOrigin,
     parse::Request,
     pattern::Pattern,
     plugin::BeforeResolvePlugin,
@@ -1603,7 +1603,7 @@ pub async fn url_resolve(
     issue_source: Option<IssueSource>,
     is_optional: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
-    let resolve_options = origin.resolve_options(reference_type.clone()).await?;
+    let resolve_options = origin.resolve_options(reference_type.clone());
     let rel_request = request.as_relative();
     let origin_path_parent = origin.origin_path().await?.parent();
     let rel_result = resolve(

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1594,8 +1594,9 @@ pub async fn url_resolve(
 ) -> Result<Vc<ModuleResolveResult>> {
     let resolve_options = origin.resolve_options(reference_type.clone()).await?;
     let rel_request = request.as_relative();
+    let origin_path_parent = origin.origin_path().await?.parent();
     let rel_result = resolve(
-        origin.origin_path().await?.parent(),
+        origin_path_parent.clone(),
         reference_type.clone(),
         rel_request,
         resolve_options,
@@ -1603,7 +1604,7 @@ pub async fn url_resolve(
     let result = if *rel_result.is_unresolvable().await? && rel_request.resolve().await? != request
     {
         let result = resolve(
-            origin.origin_path().await?.parent(),
+            origin_path_parent,
             reference_type.clone(),
             request,
             resolve_options,
@@ -3056,18 +3057,18 @@ async fn resolve_package_internal_with_imports_field(
 pub async fn handle_resolve_error(
     result: Vc<ModuleResolveResult>,
     reference_type: ReferenceType,
-    origin_path: FileSystemPath,
+    origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     is_optional: bool,
     source: Option<IssueSource>,
 ) -> Result<Vc<ModuleResolveResult>> {
-    Ok(match result.await?.is_unresolvable_ref() {
-        Ok(unresolvable) => {
-            if unresolvable {
+    Ok(match result.await {
+        Ok(result_ref) => {
+            if result_ref.is_unresolvable_ref() {
                 emit_unresolvable_issue(
                     is_optional,
-                    origin_path,
+                    origin,
                     reference_type,
                     request,
                     resolve_options,
@@ -3081,7 +3082,7 @@ pub async fn handle_resolve_error(
         Err(err) => {
             emit_resolve_error_issue(
                 is_optional,
-                origin_path,
+                origin,
                 reference_type,
                 request,
                 resolve_options,
@@ -3097,7 +3098,7 @@ pub async fn handle_resolve_error(
 pub async fn handle_resolve_source_error(
     result: Vc<ResolveResult>,
     reference_type: ReferenceType,
-    origin_path: FileSystemPath,
+    origin: Vc<Box<dyn ResolveOrigin>>,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     is_optional: bool,
@@ -3111,7 +3112,7 @@ pub async fn handle_resolve_source_error(
             if unresolvable {
                 emit_unresolvable_issue(
                     is_optional,
-                    origin_path,
+                    origin,
                     reference_type,
                     request,
                     resolve_options,
@@ -3125,7 +3126,7 @@ pub async fn handle_resolve_source_error(
         Err(err) => {
             emit_resolve_error_issue(
                 is_optional,
-                origin_path,
+                origin,
                 reference_type,
                 request,
                 resolve_options,
@@ -3140,7 +3141,7 @@ pub async fn handle_resolve_source_error(
 
 async fn emit_resolve_error_issue(
     is_optional: bool,
-    origin_path: FileSystemPath,
+    origin: Vc<Box<dyn ResolveOrigin>>,
     reference_type: ReferenceType,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
@@ -3154,7 +3155,7 @@ async fn emit_resolve_error_issue(
     };
     ResolvingIssue {
         severity,
-        file_path: origin_path.clone(),
+        file_path: origin.origin_path().owned().await?,
         request_type: format!("{reference_type} request"),
         request: request.to_resolved().await?,
         resolve_options: resolve_options.to_resolved().await?,
@@ -3168,7 +3169,7 @@ async fn emit_resolve_error_issue(
 
 async fn emit_unresolvable_issue(
     is_optional: bool,
-    origin_path: FileSystemPath,
+    origin: Vc<Box<dyn ResolveOrigin>>,
     reference_type: ReferenceType,
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
@@ -3181,7 +3182,7 @@ async fn emit_unresolvable_issue(
     };
     ResolvingIssue {
         severity,
-        file_path: origin_path.clone(),
+        file_path: origin.origin_path().owned().await?,
         request_type: format!("{reference_type} request"),
         request: request.to_resolved().await?,
         resolve_options: resolve_options.to_resolved().await?,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -260,6 +260,17 @@ impl ModuleResolveResult {
         })
     }
 
+    /// Returns a set (no duplicates) of primary modules in the result.
+    pub async fn primary_modules_ref(&self) -> Result<Vec<ResolvedVc<Box<dyn Module>>>> {
+        let mut set = FxIndexSet::default();
+        for (_, item) in self.primary.iter() {
+            if let Some(module) = item.as_module().await? {
+                set.insert(module);
+            }
+        }
+        Ok(set.into_iter().collect())
+    }
+
     pub fn affecting_sources_iter(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Source>>> + '_ {
         self.affecting_sources.iter().copied()
     }

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -31,6 +31,17 @@ pub trait ResolveOrigin {
         let _ = request;
         Vc::cell(None)
     }
+
+    /// Get the resolve options that apply for this origin.
+    #[turbo_tasks::function]
+    async fn resolve_options(
+        self: Vc<Self>,
+        reference_type: ReferenceType,
+    ) -> Result<Vc<ResolveOptions>> {
+        Ok(self
+            .asset_context()
+            .resolve_options(self.origin_path().owned().await?, reference_type))
+    }
 }
 
 // TODO it would be nice if these methods can be moved to the trait to allow
@@ -45,12 +56,6 @@ pub trait ResolveOriginExt: Send {
         options: Vc<ResolveOptions>,
         reference_type: ReferenceType,
     ) -> impl Future<Output = Result<Vc<ModuleResolveResult>>> + Send;
-
-    /// Get the resolve options that apply for this origin.
-    fn resolve_options(
-        self: Vc<Self>,
-        reference_type: ReferenceType,
-    ) -> impl std::future::Future<Output = Result<Vc<ResolveOptions>>> + Send;
 
     /// Adds a transition that is used for resolved assets.
     fn with_transition(self: ResolvedVc<Self>, transition: RcStr) -> Vc<Box<dyn ResolveOrigin>>;
@@ -72,16 +77,6 @@ where
             options,
             reference_type,
         )
-    }
-
-    // make a turbotask?
-    async fn resolve_options(
-        self: Vc<Self>,
-        reference_type: ReferenceType,
-    ) -> Result<Vc<ResolveOptions>> {
-        Ok(self
-            .asset_context()
-            .resolve_options(self.origin_path().owned().await?, reference_type))
     }
 
     fn with_transition(self: ResolvedVc<Self>, transition: RcStr) -> Vc<Box<dyn ResolveOrigin>> {

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -74,6 +74,7 @@ where
         )
     }
 
+    // make a turbotask?
     async fn resolve_options(
         self: Vc<Self>,
         reference_type: ReferenceType,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -407,10 +407,12 @@ impl ModuleReference for EsmAssetReference {
         };
 
         if let Some(ModulePart::Evaluation) = &self.export_name {
+            // remove cast
             let module: ResolvedVc<crate::EcmascriptModuleAsset> =
                 ResolvedVc::try_downcast_type(self.origin)
                     .expect("EsmAssetReference origin should be a EcmascriptModuleAsset");
 
+            // move mode into EsmAssetReference
             let tree_shaking_mode = module.options().await?.tree_shaking_mode;
 
             if let Some(TreeShakingMode::ModuleFragments) = tree_shaking_mode {
@@ -433,6 +435,7 @@ impl ModuleReference for EsmAssetReference {
         }
         let request = Request::parse(self.request.clone().into());
 
+        // only if fragment mode
         if let Request::Module { module, .. } = &*request.await?
             && module.is_match(TURBOPACK_PART_IMPORT_SOURCE)
         {
@@ -452,7 +455,7 @@ impl ModuleReference for EsmAssetReference {
         }
 
         let result = esm_resolve(
-            self.get_origin().resolve().await?,
+            self.get_origin(),
             request,
             ty,
             false,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -328,6 +328,7 @@ pub struct EsmAssetReference {
     pub export_name: Option<ModulePart>,
     pub import_usage: ImportUsage,
     pub import_externals: bool,
+    pub tree_shaking_mode: Option<TreeShakingMode>,
     pub is_pure_import: bool,
 }
 
@@ -351,6 +352,7 @@ impl EsmAssetReference {
         export_name: Option<ModulePart>,
         import_usage: ImportUsage,
         import_externals: bool,
+        tree_shaking_mode: Option<TreeShakingMode>,
     ) -> Self {
         EsmAssetReference {
             module,
@@ -361,6 +363,7 @@ impl EsmAssetReference {
             export_name,
             import_usage,
             import_externals,
+            tree_shaking_mode,
             is_pure_import: false,
         }
     }
@@ -374,6 +377,7 @@ impl EsmAssetReference {
         export_name: Option<ModulePart>,
         import_usage: ImportUsage,
         import_externals: bool,
+        tree_shaking_mode: Option<TreeShakingMode>,
     ) -> Self {
         EsmAssetReference {
             module,
@@ -384,6 +388,7 @@ impl EsmAssetReference {
             export_name,
             import_usage,
             import_externals,
+            tree_shaking_mode,
             is_pure_import: true,
         }
     }
@@ -411,11 +416,10 @@ impl ModuleReference for EsmAssetReference {
             EcmaScriptModulesReferenceSubType::Import
         };
 
-        if let Some(ModulePart::Evaluation) = &self.export_name {
-            // move mode into EsmAssetReference
-            let tree_shaking_mode = self.module.options().await?.tree_shaking_mode;
+        let request = Request::parse(self.request.clone().into());
 
-            if let Some(TreeShakingMode::ModuleFragments) = tree_shaking_mode {
+        if let Some(TreeShakingMode::ModuleFragments) = self.tree_shaking_mode {
+            if let Some(ModulePart::Evaluation) = &self.export_name {
                 let side_effect_free_packages =
                     self.module.asset_context().side_effect_free_packages();
 
@@ -434,22 +438,19 @@ impl ModuleReference for EsmAssetReference {
                     .cell());
                 }
             }
-        }
-        let request = Request::parse(self.request.clone().into());
 
-        // only if fragment mode
-        if let Request::Module { module, .. } = &*request.await?
-            && module.is_match(TURBOPACK_PART_IMPORT_SOURCE)
-        {
-            if let Some(part) = &self.export_name {
-                return Ok(*ModuleResolveResult::module(ResolvedVc::upcast(
-                    EcmascriptModulePartAsset::select_part(*self.module, part.clone())
-                        .to_resolved()
-                        .await?,
-                )));
+            if let Request::Module { module, .. } = &*request.await?
+                && module.is_match(TURBOPACK_PART_IMPORT_SOURCE)
+            {
+                if let Some(part) = &self.export_name {
+                    return Ok(*ModuleResolveResult::module(ResolvedVc::upcast(
+                        EcmascriptModulePartAsset::select_part(*self.module, part.clone())
+                            .to_resolved()
+                            .await?,
+                    )));
+                }
+                bail!("export_name is required for part import")
             }
-
-            bail!("export_name is required for part import")
         }
 
         let result = esm_resolve(

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -37,7 +37,7 @@ use turbopack_resolve::ecmascript::esm_resolve;
 
 use super::export::{all_known_export_names, is_export_missing};
 use crate::{
-    ScopeHoistingContext, TreeShakingMode,
+    EcmascriptModuleAsset, ScopeHoistingContext, TreeShakingMode,
     analyzer::imports::ImportAnnotations,
     chunk::{EcmascriptChunkPlaceable, EcmascriptExports},
     code_gen::{CodeGeneration, CodeGenerationHoistedStmt},
@@ -319,6 +319,7 @@ impl EsmAssetReferences {
 #[turbo_tasks::value(shared)]
 #[derive(Hash, Debug)]
 pub struct EsmAssetReference {
+    pub module: ResolvedVc<EcmascriptModuleAsset>,
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     // Request is a string to avoid eagerly parsing into a `Request` VC
     pub request: RcStr,
@@ -342,6 +343,7 @@ impl EsmAssetReference {
 
 impl EsmAssetReference {
     pub fn new(
+        module: ResolvedVc<EcmascriptModuleAsset>,
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         request: RcStr,
         issue_source: IssueSource,
@@ -351,6 +353,7 @@ impl EsmAssetReference {
         import_externals: bool,
     ) -> Self {
         EsmAssetReference {
+            module,
             origin,
             request,
             issue_source,
@@ -363,6 +366,7 @@ impl EsmAssetReference {
     }
 
     pub fn new_pure(
+        module: ResolvedVc<EcmascriptModuleAsset>,
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         request: RcStr,
         issue_source: IssueSource,
@@ -372,6 +376,7 @@ impl EsmAssetReference {
         import_externals: bool,
     ) -> Self {
         EsmAssetReference {
+            module,
             origin,
             request,
             issue_source,
@@ -407,18 +412,15 @@ impl ModuleReference for EsmAssetReference {
         };
 
         if let Some(ModulePart::Evaluation) = &self.export_name {
-            // remove cast
-            let module: ResolvedVc<crate::EcmascriptModuleAsset> =
-                ResolvedVc::try_downcast_type(self.origin)
-                    .expect("EsmAssetReference origin should be a EcmascriptModuleAsset");
-
             // move mode into EsmAssetReference
-            let tree_shaking_mode = module.options().await?.tree_shaking_mode;
+            let tree_shaking_mode = self.module.options().await?.tree_shaking_mode;
 
             if let Some(TreeShakingMode::ModuleFragments) = tree_shaking_mode {
-                let side_effect_free_packages = module.asset_context().side_effect_free_packages();
+                let side_effect_free_packages =
+                    self.module.asset_context().side_effect_free_packages();
 
-                if *module
+                if *self
+                    .module
                     .is_marked_as_side_effect_free(side_effect_free_packages)
                     .await?
                 {
@@ -440,12 +442,8 @@ impl ModuleReference for EsmAssetReference {
             && module.is_match(TURBOPACK_PART_IMPORT_SOURCE)
         {
             if let Some(part) = &self.export_name {
-                let module: ResolvedVc<crate::EcmascriptModuleAsset> =
-                    ResolvedVc::try_downcast_type(self.origin)
-                        .expect("EsmAssetReference origin should be a EcmascriptModuleAsset");
-
                 return Ok(*ModuleResolveResult::module(ResolvedVc::upcast(
-                    EcmascriptModulePartAsset::select_part(*module, part.clone())
+                    EcmascriptModulePartAsset::select_part(*self.module, part.clone())
                         .to_resolved()
                         .await?,
                 )));

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -261,7 +261,7 @@ impl Module for CachedExternalModule {
                         origin
                             .resolve_asset(
                                 Request::parse_string(self.request.clone()),
-                                origin.resolve_options(ReferenceType::Undefined).await?,
+                                origin.resolve_options(ReferenceType::Undefined),
                                 ReferenceType::Undefined,
                             )
                             .await?

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -80,7 +80,7 @@ use turbopack_core::{
     reference_type::{CommonJsReferenceSubType, ReferenceType},
     resolve::{
         FindContextFileResult, ImportUsage, ModulePart, find_context_file,
-        origin::{PlainResolveOrigin, ResolveOrigin, ResolveOriginExt},
+        origin::{PlainResolveOrigin, ResolveOrigin},
         parse::Request,
         pattern::Pattern,
         resolve,
@@ -3914,7 +3914,7 @@ async fn resolve_as_webpack_runtime(
     transforms: Vc<EcmascriptInputTransforms>,
 ) -> Result<Vc<WebpackRuntime>> {
     let ty = ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined);
-    let options = origin.resolve_options(ty.clone()).await?;
+    let options = origin.resolve_options(ty.clone());
 
     let options = apply_cjs_specific_options(options);
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -834,6 +834,7 @@ async fn analyze_ecmascript_module_internal(
                 },
                 import_usage.get(&i).cloned().unwrap_or_default(),
                 import_externals,
+                options.tree_shaking_mode,
             )
             .resolved_cell();
 
@@ -1492,6 +1493,7 @@ async fn analyze_ecmascript_module_internal(
                                                 // logic earlier (see TODO above)
                                                 original_reference.import_usage.clone(),
                                                 original_reference.import_externals,
+                                                original_reference.tree_shaking_mode,
                                             )
                                             .resolved_cell()
                                         },
@@ -2934,6 +2936,7 @@ async fn handle_free_var_reference(
                         },
                         ImportUsage::SideEffects,
                         state.import_externals,
+                        state.tree_shaking_mode,
                     )
                     .resolved_cell())
                 })

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -459,6 +459,7 @@ impl AnalyzeEcmascriptModuleResultBuilder {
 
 struct AnalysisState<'a> {
     handler: &'a Handler,
+    module: ResolvedVc<EcmascriptModuleAsset>,
     source: ResolvedVc<Box<dyn Source>>,
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     compile_time_info: ResolvedVc<CompileTimeInfo>,
@@ -796,7 +797,8 @@ async fn analyze_ecmascript_module_internal(
         for (i, r) in eval_context.imports.references().enumerate() {
             let mut should_add_evaluation = false;
             let reference = EsmAssetReference::new(
-                origin,
+                module,
+                ResolvedVc::upcast(module),
                 RcStr::from(&*r.module_path.to_string_lossy()),
                 r.issue_source
                     .unwrap_or_else(|| IssueSource::from_source_only(source)),
@@ -1056,6 +1058,7 @@ async fn analyze_ecmascript_module_internal(
 
         let mut analysis_state = AnalysisState {
             handler: &handler,
+            module,
             source,
             origin,
             compile_time_info,
@@ -1477,6 +1480,7 @@ async fn analyze_ecmascript_module_internal(
                                         export.clone(),
                                         || {
                                             EsmAssetReference::new(
+                                                original_reference.module,
                                                 original_reference.origin,
                                                 original_reference.request.clone(),
                                                 original_reference.issue_source,
@@ -2902,6 +2906,7 @@ async fn handle_free_var_reference(
                     // import again if the variable reference turns out be dead code in some later
                     // stage of the build, thus mark the import call as /*@__PURE__*/.
                     Ok(EsmAssetReference::new_pure(
+                        state.module,
                         if let Some(lookup_path) = lookup_path {
                             ResolvedVc::upcast(
                                 PlainResolveOrigin::new(

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -10,11 +10,7 @@ use turbopack_core::{
     raw_module::RawModule,
     reference::{ModuleReference, ModuleReferences},
     reference_type::{CommonJsReferenceSubType, ReferenceType},
-    resolve::{
-        ModuleResolveResult,
-        origin::{ResolveOrigin, ResolveOriginExt},
-        parse::Request,
-    },
+    resolve::{ModuleResolveResult, origin::ResolveOrigin, parse::Request},
     source::Source,
 };
 // TODO remove this
@@ -61,8 +57,7 @@ impl Module for TsConfigModuleAsset {
             self.source,
             apply_cjs_specific_options(
                 self.origin
-                    .resolve_options(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined))
-                    .await?,
+                    .resolve_options(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
             ),
         )
         .await?;

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -10,9 +10,7 @@ use turbopack_core::{
     reference::{ModuleReference, ModuleReferences},
     reference_type::{CommonJsReferenceSubType, ReferenceType},
     resolve::{
-        ModuleResolveResult, ModuleResolveResultItem,
-        origin::{ResolveOrigin, ResolveOriginExt},
-        parse::Request,
+        ModuleResolveResult, ModuleResolveResultItem, origin::ResolveOrigin, parse::Request,
         resolve,
     },
     source::Source,
@@ -165,7 +163,7 @@ impl ModuleReference for WebpackRuntimeAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
         let ty = ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined);
-        let options = self.origin.resolve_options(ty.clone()).await?;
+        let options = self.origin.resolve_options(ty.clone());
 
         let options = apply_cjs_specific_options(options);
 

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -94,7 +94,7 @@ pub async fn esm_resolve(
     issue_source: Option<IssueSource>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = ReferenceType::EcmaScriptModules(ty);
-    let options = apply_esm_specific_options(origin.resolve_options(ty.clone()).await?, &ty)
+    let options = apply_esm_specific_options(origin.resolve_options(ty.clone()), &ty)
         .resolve()
         .await?;
     specific_resolve(origin, request, options, ty, is_optional, issue_source).await
@@ -109,7 +109,7 @@ pub async fn cjs_resolve(
     is_optional: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = ReferenceType::CommonJs(ty);
-    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()).await?)
+    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()))
         .resolve()
         .await?;
     specific_resolve(origin, request, options, ty, is_optional, issue_source).await
@@ -124,7 +124,7 @@ pub async fn cjs_resolve_source(
     is_optional: bool,
 ) -> Result<Vc<ResolveResult>> {
     let ty = ReferenceType::CommonJs(ty);
-    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()).await?)
+    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()))
         .resolve()
         .await?;
     let result = resolve(

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -44,7 +44,7 @@ pub fn get_condition_maps(
 
 pub fn apply_esm_specific_options(
     options: Vc<ResolveOptions>,
-    reference_type: ReferenceType,
+    reference_type: &ReferenceType,
 ) -> Vc<ResolveOptions> {
     let clear_extensions = matches!(
         reference_type,
@@ -137,7 +137,7 @@ pub async fn cjs_resolve_source(
     handle_resolve_source_error(
         result,
         ty,
-        origin.origin_path().owned().await?,
+        *origin,
         *request,
         options,
         is_optional,
@@ -161,7 +161,7 @@ async fn specific_resolve(
     handle_resolve_error(
         result,
         reference_type,
-        origin.origin_path().owned().await?,
+        origin,
         request,
         options,
         is_optional,

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -94,7 +94,7 @@ pub async fn esm_resolve(
     issue_source: Option<IssueSource>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = ReferenceType::EcmaScriptModules(ty);
-    let options = apply_esm_specific_options(origin.resolve_options(ty.clone()).await?, ty.clone())
+    let options = apply_esm_specific_options(origin.resolve_options(ty.clone()).await?, &ty)
         .resolve()
         .await?;
     specific_resolve(origin, request, options, ty, is_optional, issue_source).await

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -21,7 +21,7 @@ use turbopack_core::{
             ConditionValue, ImportMap, ImportMapping, ResolveIntoPackage, ResolveModules,
             ResolveOptions,
         },
-        origin::{ResolveOrigin, ResolveOriginExt},
+        origin::ResolveOrigin,
         parse::Request,
         pattern::Pattern,
         resolve,
@@ -417,7 +417,7 @@ pub async fn type_resolve(
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined);
     let context_path = origin.origin_path().await?.parent();
-    let options = origin.resolve_options(ty.clone()).await?;
+    let options = origin.resolve_options(ty.clone());
     let options = apply_typescript_types_options(options);
     let types_request = if let Request::Module {
         module: m,

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -472,16 +472,7 @@ pub async fn type_resolve(
             .asset_context()
             .process_resolve_result(result, ty.clone()),
     );
-    handle_resolve_error(
-        result,
-        ty,
-        origin.origin_path().owned().await?,
-        request,
-        options,
-        false,
-        None,
-    )
-    .await
+    handle_resolve_error(result, ty, origin, request, options, false, None).await
 }
 
 #[turbo_tasks::function]


### PR DESCRIPTION
The difference is barely measureable though...
```
less tasks:
  Time (mean ± σ):      5.429 s ±  0.099 s    [User: 28.337 s, System: 3.512 s]
canary:
  Time (mean ± σ):      5.547 s ±  0.082 s    [User: 28.730 s, System: 3.480 s]
```