### PR TITLE
Turbopack: remove into() which cells internally

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1380,7 +1380,10 @@ impl AppEndpoint {
                         "server/app{manifest_path_prefix}/webpack-stats.json",
                     ))?,
                     AssetContent::file(
-                        File::from(serde_json::to_string_pretty(&webpack_stats)?).into(),
+                        FileContent::Content(File::from(serde_json::to_string_pretty(
+                            &webpack_stats,
+                        )?))
+                        .cell(),
                     ),
                 )
                 .to_resolved()
@@ -1909,7 +1912,10 @@ async fn create_app_paths_manifest(
         VirtualOutputAsset::new(
             path,
             AssetContent::file(
-                File::from(serde_json::to_string_pretty(&app_paths_manifest)?).into(),
+                FileContent::Content(File::from(serde_json::to_string_pretty(
+                    &app_paths_manifest,
+                )?))
+                .cell(),
             ),
         )
         .to_resolved()

--- a/crates/next-api/src/font.rs
+++ b/crates/next-api/src/font.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use next_core::next_manifests::NextFontManifest;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{File, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     output::{OutputAsset, OutputAssets, OutputAssetsReference},
@@ -94,7 +94,10 @@ impl Asset for FontManifest {
         };
 
         Ok(AssetContent::file(
-            File::from(serde_json::to_string_pretty(&next_font_manifest)?).into(),
+            FileContent::Content(File::from(serde_json::to_string_pretty(
+                &next_font_manifest,
+            )?))
+            .cell(),
         ))
     }
 }

--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -10,7 +10,9 @@ use turbo_tasks::{
     NonLocalValue, ResolvedVc, TaskInput, TryFlatJoinIterExt, TryJoinIterExt, Vc,
     trace::TraceRawVcs,
 };
-use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, File, FileSystemPath, glob::Glob};
+use turbo_tasks_fs::{
+    DirectoryContent, DirectoryEntry, File, FileContent, FileSystemPath, glob::Glob,
+};
 use turbopack::externals_tracing_module_context;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -161,7 +163,9 @@ impl Asset for ServerNftJsonAsset {
           "files": server_output_assets
         });
 
-        Ok(AssetContent::file(File::from(json.to_string()).into()))
+        Ok(AssetContent::file(
+            FileContent::Content(File::from(json.to_string())).cell(),
+        ))
     }
 }
 

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -9,7 +9,7 @@ use turbo_tasks::{
     graph::{AdjacencyMap, GraphTraversal, Visit, VisitControlFlow},
 };
 use turbo_tasks_fs::{
-    DirectoryEntry, File, FileSystem, FileSystemPath,
+    DirectoryEntry, File, FileContent, FileSystem, FileSystemPath,
     glob::{Glob, GlobOptions},
 };
 use turbopack_core::{
@@ -349,7 +349,9 @@ impl Asset for NftJsonAsset {
               "files": result
             });
 
-            Ok(AssetContent::file(File::from(json.to_string()).into()))
+            Ok(AssetContent::file(
+                FileContent::Content(File::from(json.to_string())).cell(),
+            ))
         }
         .instrument(span)
         .await

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1212,7 +1212,10 @@ impl PageEndpoint {
             node_root.join(&format!(
                 "server/pages{manifest_path_prefix}/pages-manifest.json",
             ))?,
-            AssetContent::file(File::from(serde_json::to_string_pretty(&pages_manifest)?).into()),
+            AssetContent::file(
+                FileContent::Content(File::from(serde_json::to_string_pretty(&pages_manifest)?))
+                    .cell(),
+            ),
         ));
         Ok(asset)
     }
@@ -1384,7 +1387,8 @@ impl PageEndpoint {
                     "server/pages{manifest_path_prefix}/webpack-stats.json",
                 ))?,
                 AssetContent::file(
-                    File::from(serde_json::to_string_pretty(&webpack_stats)?).into(),
+                    FileContent::Content(File::from(serde_json::to_string_pretty(&webpack_stats)?))
+                        .cell(),
                 ),
             )
             .to_resolved()

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -20,7 +20,7 @@ use swc_core::{
 };
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, ResolvedVc, TryFlatJoinIterExt, Vc};
-use turbo_tasks_fs::{self, File, FileSystemPath, rope::RopeBuilder};
+use turbo_tasks_fs::{self, File, FileContent, FileSystemPath, rope::RopeBuilder};
 use turbopack_core::{
     asset::AssetContent,
     chunk::{
@@ -127,7 +127,7 @@ pub(crate) async fn build_server_actions_loader(
     let file = File::from(contents.build());
     let source = VirtualSource::new_with_ident(
         AssetIdent::from_path(path).with_modifier(rcstr!("server actions loader")),
-        AssetContent::file(file.into()),
+        AssetContent::file(FileContent::Content(file).cell()),
     );
     let import_map = import_map.into_iter().map(|(k, v)| (v, k)).collect();
     let module = asset_context
@@ -209,7 +209,9 @@ async fn build_manifest(
     Ok(ResolvedVc::upcast(
         VirtualOutputAsset::new(
             manifest_path,
-            AssetContent::file(File::from(serde_json::to_string_pretty(&manifest)?).into()),
+            AssetContent::file(
+                FileContent::Content(File::from(serde_json::to_string_pretty(&manifest)?)).cell(),
+            ),
         )
         .to_resolved()
         .await?,

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, bail};
 use turbo_rcstr::rcstr;
 use turbo_tasks::{FxIndexMap, ResolvedVc, ValueToString, Vc};
-use turbo_tasks_fs::{File, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
     chunk::EvaluatableAsset,
@@ -76,14 +76,14 @@ pub async fn bootstrap(
             Vc::upcast(VirtualSource::new(
                 asset.ident().path().await?.join("bootstrap-config.ts")?,
                 AssetContent::file(
-                    File::from(
+                    FileContent::Content(File::from(
                         config
                             .iter()
                             .map(|(k, v)| format!("export const {} = {};\n", k, StringifyJs(v)))
                             .collect::<Vec<_>>()
                             .join(""),
-                    )
-                    .into(),
+                    ))
+                    .cell(),
                 ),
             )),
             ReferenceType::Internal(InnerAssets::empty().to_resolved().await?),

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
-use turbo_tasks_fs::{self, File, FileSystemPath, rope::RopeBuilder};
+use turbo_tasks_fs::{self, File, FileContent, FileSystemPath, rope::RopeBuilder};
 use turbopack::ModuleAssetContext;
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -106,7 +106,7 @@ pub async fn get_app_page_entry(
     let file = File::from(result.build());
     let source = VirtualSource::new_with_ident(
         source.ident().with_query(RcStr::from(format!("?{query}"))),
-        AssetContent::file(file.into()),
+        AssetContent::file(FileContent::Content(file).cell()),
     );
 
     let mut rsc_entry = module_asset_context

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -109,7 +109,7 @@ async fn dynamic_image_metadata_with_generator_source(
     let file = File::from(code);
     let source = VirtualSource::new(
         path.parent().join(&format!("{stem}--metadata.js"))?,
-        AssetContent::file(file.into()),
+        AssetContent::file(FileContent::Content(file).cell()),
     );
 
     Ok(Vc::upcast(source))
@@ -177,7 +177,7 @@ async fn dynamic_image_metadata_without_generator_source(
     let file = File::from(code);
     let source = VirtualSource::new(
         path.parent().join(&format!("{stem}--metadata.js"))?,
-        AssetContent::file(file.into()),
+        AssetContent::file(FileContent::Content(file).cell()),
     );
 
     Ok(Vc::upcast(source))

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -205,7 +205,7 @@ async fn static_route_source(mode: NextMode, path: FileSystemPath) -> Result<Vc<
     let file = File::from(code);
     let source = VirtualSource::new(
         path.parent().join(&format!("{stem}--route-entry.js"))?,
-        AssetContent::file(file.into()),
+        AssetContent::file(FileContent::Content(file).cell()),
     );
 
     Ok(Vc::upcast(source))
@@ -259,7 +259,7 @@ async fn dynamic_text_route_source(path: FileSystemPath) -> Result<Vc<Box<dyn So
     let file = File::from(code);
     let source = VirtualSource::new(
         path.parent().join(&format!("{stem}--route-entry.js"))?,
-        AssetContent::file(file.into()),
+        AssetContent::file(FileContent::Content(file).cell()),
     );
 
     Ok(Vc::upcast(source))
@@ -349,7 +349,7 @@ async fn dynamic_sitemap_route_with_generate_source(
     let file = File::from(code);
     let source = VirtualSource::new(
         path.parent().join(&format!("{stem}--route-entry.js"))?,
-        AssetContent::file(file.into()),
+        AssetContent::file(FileContent::Content(file).cell()),
     );
 
     Ok(Vc::upcast(source))
@@ -400,7 +400,7 @@ async fn dynamic_sitemap_route_without_generate_source(
     let file = File::from(code);
     let source = VirtualSource::new(
         path.parent().join(&format!("{stem}--route-entry.js"))?,
-        AssetContent::file(file.into()),
+        AssetContent::file(FileContent::Content(file).cell()),
     );
 
     Ok(Vc::upcast(source))
@@ -484,7 +484,7 @@ async fn dynamic_image_route_with_metadata_source(
     let file = File::from(code);
     let source = VirtualSource::new(
         path.parent().join(&format!("{stem}--route-entry.js"))?,
-        AssetContent::file(file.into()),
+        AssetContent::file(FileContent::Content(file).cell()),
     );
 
     Ok(Vc::upcast(source))
@@ -518,7 +518,7 @@ async fn dynamic_image_route_without_metadata_source(
     let file = File::from(code);
     let source = VirtualSource::new(
         path.parent().join(&format!("{stem}--route-entry.js"))?,
-        AssetContent::file(file.into()),
+        AssetContent::file(FileContent::Content(file).cell()),
     );
 
     Ok(Vc::upcast(source))

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -149,7 +149,7 @@ impl EcmascriptClientReferenceModule {
 
         let code = code.build();
         let proxy_module_content =
-            AssetContent::file(File::from(code.source_code().clone()).into());
+            AssetContent::file(FileContent::Content(File::from(code.source_code().clone())).cell());
 
         let proxy_source = VirtualSource::new(
             self.server_ident.path().await?.join(

--- a/crates/next-core/src/next_edge/entry.rs
+++ b/crates/next-core/src/next_edge/entry.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use indoc::formatdoc;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
-use turbo_tasks_fs::{File, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent, context::AssetContext, module::Module, reference_type::ReferenceType,
     virtual_source::VirtualSource,
@@ -47,7 +47,7 @@ pub fn wrap_edge_entry(
     // TODO(alexkirsz) Figure out how to name this virtual asset.
     let virtual_source = VirtualSource::new(
         project_root.join("edge-wrapper.js")?,
-        AssetContent::file(file.into()),
+        AssetContent::file(FileContent::Content(file).cell()),
     );
 
     let inner_assets = fxindexmap! {

--- a/crates/next-core/src/next_edge/unsupported.rs
+++ b/crates/next-core/src/next_edge/unsupported.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use indoc::formatdoc;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{File, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
     ident::AssetIdent,
@@ -69,7 +69,7 @@ fn unsupported_module_source(root_path: FileSystemPath, module: Pattern) -> Vc<V
         "#,
         module = module.as_constant_string().map(ToString::to_string).unwrap_or_else(|| module.describe_as_string()),
     };
-    let content = AssetContent::file(File::from(code).into());
+    let content = AssetContent::file(FileContent::Content(File::from(code)).cell());
     VirtualSource::new_with_ident(
         AssetIdent::from_path(root_path).with_modifier(
             format!("unsupported edge import {}", module.describe_as_string()).into(),

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -738,14 +738,14 @@ async fn get_mock_stylesheet(
     let loader_source = Vc::upcast(VirtualSource::new(
         loader_path.clone(),
         AssetContent::file(
-            File::from(format!(
+            FileContent::Content(File::from(format!(
                 "import data from './{}'; export default function load() {{ return data; }};",
                 response_path
                     .file_name()
                     .context("Must exist")?
                     .to_string_lossy(),
-            ))
-            .into(),
+            )))
+            .cell(),
         ),
     ));
     let mocked_response_asset = asset_context

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -9,7 +9,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc,
 };
-use turbo_tasks_fs::{File, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkingContext, ModuleChunkItemIdExt, ModuleId as TurbopackModuleId},
@@ -466,15 +466,15 @@ async fn build_manifest(
         let normalized_manifest_entry = entry_name.replace("%5F", "_");
         Ok(ClientReferenceManifestResult {
             content: AssetContent::file(
-                File::from(formatdoc! {
+                FileContent::Content(File::from(formatdoc! {
                     r#"
                         globalThis.__RSC_MANIFEST = globalThis.__RSC_MANIFEST || {{}};
                         globalThis.__RSC_MANIFEST[{entry_name}] = {manifest}
                     "#,
                     entry_name = StringifyJs(&normalized_manifest_entry),
                     manifest = &client_reference_manifest_json
-                })
-                .into(),
+                }))
+                .cell(),
             )
             .to_resolved()
             .await?,

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -10,7 +10,7 @@ use turbo_tasks::{
     FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryFlatJoinIterExt, TryJoinIterExt,
     Vc, trace::TraceRawVcs,
 };
-use turbo_tasks_fs::{File, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     output::{OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsWithReferenced},
@@ -153,7 +153,7 @@ impl Asset for BuildManifest {
         };
 
         Ok(AssetContent::file(
-            File::from(serde_json::to_string_pretty(&manifest)?).into(),
+            FileContent::Content(File::from(serde_json::to_string_pretty(&manifest)?)).cell(),
         ))
     }
 }
@@ -210,7 +210,7 @@ impl Asset for ClientBuildManifest {
             .collect();
 
         Ok(AssetContent::file(
-            File::from(serde_json::to_string_pretty(&manifest)?).into(),
+            FileContent::Content(File::from(serde_json::to_string_pretty(&manifest)?)).cell(),
         ))
     }
 }

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, bail};
 use serde::Serialize;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
-use turbo_tasks_fs::{File, FileSystemPath, rope::RopeBuilder};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath, rope::RopeBuilder};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     context::AssetContext,
@@ -117,7 +117,7 @@ pub async fn create_page_ssr_entry_module(
 
         source = Vc::upcast(VirtualSource::new_with_ident(
             source.ident(),
-            AssetContent::file(file.into()),
+            AssetContent::file(FileContent::Content(file).cell()),
         ));
     }
 

--- a/crates/next-core/src/page_loader.rs
+++ b/crates/next-core/src/page_loader.rs
@@ -45,7 +45,7 @@ pub async fn create_page_loader_entry_module(
 
     let virtual_source = Vc::upcast(VirtualSource::new(
         page_loader_path,
-        AssetContent::file(file.into()),
+        AssetContent::file(FileContent::Content(file).cell()),
     ));
 
     let module = client_context
@@ -202,6 +202,8 @@ impl Asset for PageLoaderAsset {
             StringifyJs(&chunks_data)
         );
 
-        Ok(AssetContent::file(File::from(content).into()))
+        Ok(AssetContent::file(
+            FileContent::Content(File::from(content)).cell(),
+        ))
     }
 }

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -260,8 +260,10 @@ pub async fn load_next_js_template(
     )?;
 
     let file = File::from(content);
-
-    let source = VirtualSource::new(template_path, AssetContent::file(file.into()));
+    let source = VirtualSource::new(
+        template_path,
+        AssetContent::file(FileContent::Content(file).cell()),
+    );
 
     Ok(Vc::upcast(source))
 }

--- a/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/file.rs
@@ -31,7 +31,7 @@ pub async fn content_from_relative_path(
 
 #[turbo_tasks::function]
 pub fn content_from_str(string: RcStr) -> Vc<FileContent> {
-    File::from(string).into()
+    FileContent::Content(File::from(string)).cell()
 }
 
 /// Loads a file's content from disk and invalidates on change (debug builds).

--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -31,7 +31,7 @@ impl FileSystem for EmbeddedFileSystem {
             None => return Ok(FileContent::NotFound.cell()),
         };
 
-        Ok(File::from(file.contents()).into())
+        Ok(FileContent::Content(File::from(file.contents())).cell())
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1766,13 +1766,6 @@ impl From<File> for FileContent {
     }
 }
 
-// TODO remove this, it hides cell creation
-impl From<File> for Vc<FileContent> {
-    fn from(file: File) -> Self {
-        FileContent::Content(file).cell()
-    }
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum FileComparison {
     Create,

--- a/turbopack/crates/turbopack-analyze/tests/split_chunk.rs
+++ b/turbopack/crates/turbopack-analyze/tests/split_chunk.rs
@@ -124,7 +124,7 @@ impl Asset for TestAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         Ok(AssetContent::file(
-            File::from(self.code.await?.source_code().clone()).into(),
+            FileContent::Content(File::from(self.code.await?.source_code().clone())).cell(),
         ))
     }
 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -140,12 +140,12 @@ impl VersionedContent for EcmascriptBrowserChunkContent {
         let this = self.await?;
 
         Ok(AssetContent::file(
-            File::from(
+            FileContent::Content(File::from(
                 self.code()
                     .to_rope_with_magic_comments(|| *this.source_map)
                     .await?,
-            )
-            .into(),
+            ))
+            .cell(),
         ))
     }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -286,12 +286,12 @@ impl Asset for EcmascriptBrowserEvaluateChunk {
     #[turbo_tasks::function]
     async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
         Ok(AssetContent::file(
-            File::from(
+            FileContent::Content(File::from(
                 self.code()
                     .to_rope_with_magic_comments(|| self.source_map())
                     .await?,
-            )
-            .into(),
+            ))
+            .cell(),
         ))
     }
 }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -8,7 +8,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{
     FxIndexMap, IntoTraitRef, NonLocalValue, ResolvedVc, TryJoinIterExt, Vc, trace::TraceRawVcs,
 };
-use turbo_tasks_fs::File;
+use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::ChunkingContext,
@@ -177,7 +177,7 @@ impl VersionedContent for EcmascriptDevChunkListContent {
     async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
         let code = self.code().await?;
         Ok(AssetContent::file(
-            File::from(code.source_code().clone()).into(),
+            FileContent::Content(File::from(code.source_code().clone())).cell(),
         ))
     }
 

--- a/turbopack/crates/turbopack-core/src/code_builder.rs
+++ b/turbopack/crates/turbopack-core/src/code_builder.rs
@@ -260,7 +260,7 @@ impl GenerateSourceMap for Code {
     #[turbo_tasks::function]
     pub async fn generate_source_map(self: ResolvedVc<Self>) -> Result<Vc<FileContent>> {
         let debug_id = self.debug_id().owned().await?;
-        Ok(File::from(self.await?.generate_source_map_ref(debug_id)).into())
+        Ok(FileContent::Content(File::from(self.await?.generate_source_map_ref(debug_id))).cell())
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -63,7 +63,7 @@ impl GenerateSourceMap for SourceMapReference {
         let content = file.read().await?;
         let content = content.as_content().map(|file| file.content());
         if let Some(source_map) = resolve_source_map_sources(content, &self.from).await? {
-            Ok(File::from(source_map).into())
+            Ok(FileContent::Content(File::from(source_map)).cell())
         } else {
             Ok(FileContent::NotFound.cell())
         }

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -626,7 +626,7 @@ impl SourceMap {
 impl GenerateSourceMap for SourceMap {
     #[turbo_tasks::function]
     fn generate_source_map(&self) -> Result<Vc<FileContent>> {
-        Ok(File::from(self.to_rope()?).into())
+        Ok(FileContent::Content(File::from(self.to_rope()?)).cell())
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/source_map_asset.rs
@@ -5,7 +5,7 @@ use turbo_tasks::{
     FxIndexSet, NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat,
     trace::TraceRawVcs,
 };
-use turbo_tasks_fs::{File, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 
 use crate::{
     asset::{Asset, AssetContent},
@@ -103,7 +103,7 @@ impl Asset for SourceMapAsset {
             Ok(AssetContent::file(content))
         } else {
             Ok(AssetContent::file(
-                File::from(SourceMap::empty_rope()).into(),
+                FileContent::Content(File::from(SourceMap::empty_rope())).cell(),
             ))
         }
     }

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -159,7 +159,9 @@ impl CssChunk {
             code.source_code().clone()
         };
 
-        Ok(AssetContent::file(File::from(rope).into()))
+        Ok(AssetContent::file(
+            FileContent::Content(File::from(rope)).cell(),
+        ))
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/chunk.rs
@@ -160,7 +160,9 @@ impl Asset for SingleItemCssChunk {
             code.source_code().clone()
         };
 
-        Ok(AssetContent::file(File::from(rope).into()))
+        Ok(AssetContent::file(
+            FileContent::Content(File::from(rope)).cell(),
+        ))
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/single_item_chunk/source_map.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{File, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::ChunkingContext,
@@ -58,7 +58,7 @@ impl Asset for SingleItemCssChunkSourceMapAsset {
             Ok(AssetContent::file(content))
         } else {
             Ok(AssetContent::file(
-                File::from(SourceMap::empty_rope()).into(),
+                FileContent::Content(File::from(SourceMap::empty_rope())).cell(),
             ))
         }
     }

--- a/turbopack/crates/turbopack-css/src/chunk/source_map.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/source_map.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{File, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::ChunkingContext,
@@ -54,7 +54,7 @@ impl Asset for CssChunkSourceMapAsset {
             Ok(AssetContent::file(content))
         } else {
             Ok(AssetContent::file(
-                File::from(SourceMap::empty_rope()).into(),
+                FileContent::Content(File::from(SourceMap::empty_rope())).cell(),
             ))
         }
     }

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -5,7 +5,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{
     NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Vc, trace::TraceRawVcs,
 };
-use turbo_tasks_fs::{File, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbo_tasks_hash::{Xxh3Hash64Hasher, encode_hex};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -248,7 +248,7 @@ impl DevHtmlAssetContent {
         .into();
 
         Ok(AssetContent::file(
-            File::from(html).with_content_type(TEXT_HTML_UTF_8).into(),
+            FileContent::Content(File::from(html).with_content_type(TEXT_HTML_UTF_8)).cell(),
         ))
     }
 

--- a/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use rustc_hash::FxHashSet;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, Vc};
-use turbo_tasks_fs::{File, json::parse_json_with_source_context};
+use turbo_tasks_fs::{File, FileContent, json::parse_json_with_source_context};
 use turbopack_core::{
     asset::AssetContent,
     introspect::{Introspectable, IntrospectableChildren},
@@ -183,9 +183,8 @@ impl GetContentSourceContent for IntrospectionSource {
         .into();
         Ok(ContentSourceContent::static_content(
             AssetContent::file(
-                File::from(html)
-                    .with_content_type(mime::TEXT_HTML_UTF_8)
-                    .into(),
+                FileContent::Content(File::from(html).with_content_type(mime::TEXT_HTML_UTF_8))
+                    .cell(),
             )
             .versioned(),
         ))

--- a/turbopack/crates/turbopack-ecmascript/src/single_file_ecmascript_output.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/single_file_ecmascript_output.rs
@@ -94,6 +94,6 @@ impl GenerateSourceMap for SingleFileEcmascriptOutput {
         );
 
         let map = generate_js_source_map(&*sm, mappings, None::<&Rope>, true, true)?;
-        Ok(File::from(map).into())
+        Ok(FileContent::Content(File::from(map)).cell())
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/source_map.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/source_map.rs
@@ -31,7 +31,7 @@ impl GenerateSourceMap for InlineSourceMap {
         if let Some(source_map) =
             resolve_source_map_sources(source_map.as_ref(), &self.origin_path).await?
         {
-            Ok(File::from(source_map).into())
+            Ok(FileContent::Content(File::from(source_map)).cell())
         } else {
             Ok(FileContent::NotFound.cell())
         }

--- a/turbopack/crates/turbopack-env/src/asset.rs
+++ b/turbopack/crates/turbopack-env/src/asset.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use anyhow::Result;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_env::ProcessEnv;
-use turbo_tasks_fs::{File, FileSystemPath, rope::RopeBuilder};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath, rope::RopeBuilder};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     ident::AssetIdent,
@@ -59,6 +59,8 @@ impl Asset for ProcessEnvAsset {
             writeln!(code, "env[{}] = {};", StringifyJs(name), val)?;
         }
 
-        Ok(AssetContent::file(File::from(code.build()).into()))
+        Ok(AssetContent::file(
+            FileContent::Content(File::from(code.build())).cell(),
+        ))
     }
 }

--- a/turbopack/crates/turbopack-mdx/src/lib.rs
+++ b/turbopack/crates/turbopack-mdx/src/lib.rs
@@ -173,9 +173,11 @@ impl MdxTransformedAsset {
 
         match result {
             Ok(mdx_jsx_component) => Ok(MdxTransformResult {
-                content: AssetContent::file(File::from(Rope::from(mdx_jsx_component)).into())
-                    .to_resolved()
-                    .await?,
+                content: AssetContent::file(
+                    FileContent::Content(File::from(Rope::from(mdx_jsx_component))).cell(),
+                )
+                .to_resolved()
+                .await?,
             }
             .cell()),
             Err(err) => {

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -10,7 +10,7 @@ use turbo_tasks::{
     TryJoinIterExt, Vc, duration_span, fxindexmap, get_effects, trace::TraceRawVcs,
 };
 use turbo_tasks_env::{EnvMap, ProcessEnv};
-use turbo_tasks_fs::{File, FileSystemPath, to_sys_path};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath, to_sys_path};
 use turbopack_core::{
     asset::AssetContent,
     changed::content_changed,
@@ -376,7 +376,10 @@ pub async fn get_evaluate_entries(
             Vc::upcast(VirtualSource::new(
                 runtime_asset.ident().path().await?.join("evaluate.js")?,
                 AssetContent::file(
-                    File::from("import { run } from 'RUNTIME'; run(() => import('INNER'))").into(),
+                    FileContent::Content(File::from(
+                        "import { run } from 'RUNTIME'; run(() => import('INNER'))",
+                    ))
+                    .cell(),
                 ),
             )),
             ReferenceType::Internal(ResolvedVc::cell(fxindexmap! {

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -5,7 +5,7 @@
 use anyhow::Result;
 use rustc_hash::FxHashMap;
 use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, Vc};
-use turbo_tasks_fs::{File, FileSystemPath};
+use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     output::{ExpandOutputAssetsInput, OutputAsset, OutputAssets, expand_output_assets},
@@ -97,7 +97,7 @@ fn emit_package_json(dir: FileSystemPath) -> Result<Vc<()>> {
     Ok(emit(
         Vc::upcast(VirtualOutputAsset::new(
             dir.join("package.json")?,
-            AssetContent::file(File::from("{\"type\": \"commonjs\"}").into()),
+            AssetContent::file(FileContent::Content(File::from("{\"type\": \"commonjs\"}")).cell()),
         )),
         dir,
     ))

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -298,7 +298,9 @@ impl Asset for JsonSource {
                     }
                     None => &*json,
                 };
-                Ok(AssetContent::file(File::from(value.to_string()).into()))
+                Ok(AssetContent::file(
+                    FileContent::Content(File::from(value.to_string())).cell(),
+                ))
             }
             FileSystemEntryType::NotFound => {
                 Ok(AssetContent::File(FileContent::NotFound.resolved_cell()).cell())
@@ -364,7 +366,7 @@ pub(crate) async fn config_loader_source(
 
     Ok(Vc::upcast(VirtualSource::new(
         postcss_config_path.append("_.loader.mjs")?,
-        AssetContent::file(File::from(code).into()),
+        AssetContent::file(FileContent::Content(File::from(code)).cell()),
     )))
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/content.rs
@@ -102,12 +102,12 @@ impl VersionedContent for EcmascriptBuildNodeChunkContent {
     async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
         let this = self.await?;
         Ok(AssetContent::file(
-            File::from(
+            FileContent::Content(File::from(
                 self.code()
                     .to_rope_with_magic_comments(|| *this.source_map)
                     .await?,
-            )
-            .into(),
+            ))
+            .cell(),
         ))
     }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -213,7 +213,7 @@ impl Asset for EcmascriptBuildNodeEntryChunk {
     async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
         let code = self.code().await?;
         Ok(AssetContent::file(
-            File::from(code.source_code().clone()).into(),
+            FileContent::Content(File::from(code.source_code().clone())).cell(),
         ))
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -158,12 +158,12 @@ impl Asset for EcmascriptBuildNodeRuntimeChunk {
     #[turbo_tasks::function]
     async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
         Ok(AssetContent::file(
-            File::from(
+            FileContent::Content(File::from(
                 self.code()
                     .to_rope_with_magic_comments(|| self.source_map())
                     .await?,
-            )
-            .into(),
+            ))
+            .cell(),
         ))
     }
 }

--- a/turbopack/crates/turbopack-test-utils/src/snapshot.rs
+++ b/turbopack/crates/turbopack-test-utils/src/snapshot.rs
@@ -73,7 +73,7 @@ pub async fn snapshot_issues<I: IntoIterator<Item = ReadRef<PlainIssue>>>(
             .replace("\\\\", "/")
             .into();
 
-        let asset = AssetContent::file(File::from(content).into());
+        let asset = AssetContent::file(FileContent::Content(File::from(content)).cell());
 
         diff(path, asset).await?;
     }
@@ -127,7 +127,7 @@ pub async fn diff(path: FileSystemPath, actual: Vc<AssetContent>) -> Result<()> 
     if actual != expected {
         if let Some(actual) = actual {
             if *UPDATE {
-                let content = File::from(RcStr::from(actual)).into();
+                let content = FileContent::Content(File::from(RcStr::from(actual))).cell();
                 path.write(content).await?;
                 println!("updated contents of {path_str}");
             } else {

--- a/turbopack/crates/turbopack-wasm/src/loader.rs
+++ b/turbopack/crates/turbopack-wasm/src/loader.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use indoc::{formatdoc, writedoc};
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
-use turbo_tasks_fs::File;
+use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{asset::AssetContent, source::Source, virtual_source::VirtualSource};
 use turbopack_ecmascript::utils::StringifyJs;
 
@@ -57,7 +57,7 @@ pub(crate) async fn instantiating_loader_source(
 
     Ok(Vc::upcast(VirtualSource::new(
         source.ident().path().await?.append("_.loader.mjs")?,
-        AssetContent::file(File::from(code).into()),
+        AssetContent::file(FileContent::Content(File::from(code)).cell()),
     )))
 }
 
@@ -81,6 +81,6 @@ pub(crate) async fn compiling_loader_source(
 
     Ok(Vc::upcast(VirtualSource::new(
         source.ident().path().await?.append("_.loader.mjs")?,
-        AssetContent::file(File::from(code).into()),
+        AssetContent::file(FileContent::Content(File::from(code)).cell()),
     )))
 }

--- a/turbopack/crates/turbopack-wasm/src/source.rs
+++ b/turbopack/crates/turbopack-wasm/src/source.rs
@@ -79,6 +79,8 @@ impl Asset for WebAssemblySource {
         let bytes = file.content().to_bytes();
         let parsed = wat::parse_bytes(&bytes)?;
 
-        Ok(AssetContent::file(File::from(&*parsed).into()))
+        Ok(AssetContent::file(
+            FileContent::Content(File::from(&*parsed)).cell(),
+        ))
     }
 }


### PR DESCRIPTION
This `.into()` hid the cell creation, we have already removed `.into()` as a shorthand for `Vc::cell`, but this was a manual version of that.

It could certainly be more ergonomic though:
```rust
AssetContent::file(FileContent::Content(File::from(some_str)).cell()),
```