### PR TITLE
Fix no-double-tailwind-execution flake

### DIFF
--- a/test/e2e/app-dir/no-double-tailwind-execution/no-double-tailwind-execution.test.ts
+++ b/test/e2e/app-dir/no-double-tailwind-execution/no-double-tailwind-execution.test.ts
@@ -23,38 +23,37 @@ describe('no-double-tailwind-execution', () => {
     const browser = await next.browser('/')
     expect(await browser.elementByCss('p').text()).toBe('hello world')
 
+    function getTailwindProcessingCount() {
+      return [
+        ...next.cliOutput.matchAll(
+          /\[@tailwindcss\/postcss\] app\/globals.css/g
+        ),
+      ].length
+    }
+
+    expect(getTailwindProcessingCount()).toBe(1) // initial
+
     if (isNextDev) {
-      const filePath = 'app/page.tsx'
-      const origContent = await next.readFile(filePath)
-      let getOutput = next.getCliOutputFromHere()
       await next.patchFile(
-        filePath,
-        origContent.replace('hello world', 'hello hmr'),
+        'app/page.tsx',
+        (content) => content.replace('hello world', 'hello hmr'),
         async () => {
           await retry(async () => {
             expect(await browser.elementByCss('p').text()).toBe('hello hmr')
-            let tailwindProcessingCount = [
-              ...getOutput().matchAll(
-                /\[@tailwindcss\/postcss\] app\/globals.css/g
-              ),
-            ].length
-            expect(tailwindProcessingCount).toBe(1)
+            expect(getTailwindProcessingCount()).toBe(2) // dev: initial + hmr
           })
         }
       )
-      // Wait for the patch revert to get processed
+      // Wait for the patchFile revert to get processed
       await retry(async () => {
         expect(await browser.elementByCss('p').text()).toBe('hello world')
       })
     }
 
-    let tailwindProcessingCount = [
-      ...next.cliOutput.matchAll(/\[@tailwindcss\/postcss\] app\/globals.css/g),
-    ].length
     if (isNextDev) {
-      expect(tailwindProcessingCount).toBe(3) // dev: initial + hmr + hmr (revert)
+      expect(getTailwindProcessingCount()).toBe(3) // dev: initial + hmr + hmr (revert)
     } else {
-      expect(tailwindProcessingCount).toBe(1) // build
+      expect(getTailwindProcessingCount()).toBe(1) // build
     }
   })
 })

--- a/test/e2e/app-dir/no-double-tailwind-execution/no-double-tailwind-execution.test.ts
+++ b/test/e2e/app-dir/no-double-tailwind-execution/no-double-tailwind-execution.test.ts
@@ -42,7 +42,12 @@ describe('no-double-tailwind-execution', () => {
           })
         }
       )
+      // Wait for the patch revert to get processed
+      await retry(async () => {
+        expect(await browser.elementByCss('p').text()).toBe('hello world')
+      })
     }
+
     let tailwindProcessingCount = [
       ...next.cliOutput.matchAll(/\[@tailwindcss\/postcss\] app\/globals.css/g),
     ].length


### PR DESCRIPTION
https://github.com/vercel/next.js/runs/56466402435

wait for the `patchFile` revert operation to finish before asserting

```
FAIL webpack test/e2e/app-dir/no-double-tailwind-execution/no-double-tailwind-execution.test.ts (31.136 s)
  no-double-tailwind-execution
    ✕ should run tailwind only once initially and per change (20280 ms)

  ● no-double-tailwind-execution › should run tailwind only once initially and per change

    expect(received).toBe(expected) // Object.is equality

    Expected: 3
    Received: 2

      48 |     ].length
      49 |     if (isNextDev) {
    > 50 |       expect(tailwindProcessingCount).toBe(3) // dev: initial + hmr + hmr (revert)
         |                                       ^
      51 |     } else {
      52 |       expect(tailwindProcessingCount).toBe(1) // build
      53 |     }

      at Object.toBe (e2e/app-dir/no-double-tailwind-execution/no-double-tailwind-execution.test.ts:50:39)
```