### PR TITLE
prevent browser cache from using stale RSC responses from previous builds

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1134,6 +1134,8 @@ export async function handler(
               RSC_CONTENT_TYPE_HEADER
             ),
             cacheControl: cacheEntry.cacheControl,
+            cdnCacheControlHeader:
+              nextConfig.experimental.cdnCacheControlHeader,
           })
         }
 
@@ -1151,6 +1153,7 @@ export async function handler(
           poweredByHeader: nextConfig.poweredByHeader,
           result: RenderResult.EMPTY,
           cacheControl: cacheEntry.cacheControl,
+          cdnCacheControlHeader: nextConfig.experimental.cdnCacheControlHeader,
         })
       }
 
@@ -1240,6 +1243,8 @@ export async function handler(
                 poweredByHeader: nextConfig.poweredByHeader,
                 result: RenderResult.EMPTY,
                 cacheControl: cacheEntry.cacheControl,
+                cdnCacheControlHeader:
+                  nextConfig.experimental.cdnCacheControlHeader,
               })
             } else {
               // Otherwise this case is not expected.
@@ -1256,6 +1261,8 @@ export async function handler(
             poweredByHeader: nextConfig.poweredByHeader,
             result: cachedData.html,
             cacheControl: cacheEntry.cacheControl,
+            cdnCacheControlHeader:
+              nextConfig.experimental.cdnCacheControlHeader,
           })
         }
 
@@ -1271,6 +1278,7 @@ export async function handler(
             RSC_CONTENT_TYPE_HEADER
           ),
           cacheControl: cacheEntry.cacheControl,
+          cdnCacheControlHeader: nextConfig.experimental.cdnCacheControlHeader,
         })
       }
 
@@ -1303,6 +1311,7 @@ export async function handler(
           poweredByHeader: nextConfig.poweredByHeader,
           result: body,
           cacheControl: cacheEntry.cacheControl,
+          cdnCacheControlHeader: nextConfig.experimental.cdnCacheControlHeader,
         })
       }
 
@@ -1329,6 +1338,7 @@ export async function handler(
           poweredByHeader: nextConfig.poweredByHeader,
           result: body,
           cacheControl: { revalidate: 0, expire: undefined },
+          cdnCacheControlHeader: nextConfig.experimental.cdnCacheControlHeader,
         })
       }
 
@@ -1388,6 +1398,7 @@ export async function handler(
         // the response being sent to the client it's dynamic parts are streamed
         // to the client on the same request.
         cacheControl: { revalidate: 0, expire: undefined },
+        cdnCacheControlHeader: nextConfig.experimental.cdnCacheControlHeader,
       })
     }
 

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -22,7 +22,7 @@ import {
   fromNodeOutgoingHttpHeaders,
   toNodeOutgoingHttpHeaders,
 } from '../../server/web/utils'
-import { getCacheControlHeader } from '../../server/lib/cache-control'
+import { setCacheControlHeadersOnHeaders } from '../../server/lib/cache-control'
 import { INFINITE_CACHE, NEXT_CACHE_TAGS_HEADER } from '../../lib/constants'
 import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
 import {
@@ -450,10 +450,7 @@ export async function handler(
         !res.getHeader('Cache-Control') &&
         !headers.get('Cache-Control')
       ) {
-        headers.set(
-          'Cache-Control',
-          getCacheControlHeader(cacheEntry.cacheControl)
-        )
+        setCacheControlHeadersOnHeaders(headers, cacheEntry.cacheControl)
       }
 
       await sendResponse(

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -22,7 +22,7 @@ import {
   fromNodeOutgoingHttpHeaders,
   toNodeOutgoingHttpHeaders,
 } from '../../server/web/utils'
-import { setCacheControlHeadersOnHeaders } from '../../server/lib/cache-control'
+import { setCacheControlHeaders } from '../../server/lib/cache-control'
 import { INFINITE_CACHE, NEXT_CACHE_TAGS_HEADER } from '../../lib/constants'
 import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
 import {
@@ -450,7 +450,11 @@ export async function handler(
         !res.getHeader('Cache-Control') &&
         !headers.get('Cache-Control')
       ) {
-        setCacheControlHeadersOnHeaders(headers, cacheEntry.cacheControl)
+        setCacheControlHeaders(
+          headers,
+          cacheEntry.cacheControl,
+          nextConfig.experimental.cdnCacheControlHeader
+        )
       }
 
       await sendResponse(

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -372,6 +372,7 @@ export default abstract class Server<
       generateEtags: boolean
       poweredByHeader: boolean
       cacheControl: CacheControl | undefined
+      cdnCacheControlHeader?: string
     }
   ): Promise<void>
 
@@ -560,6 +561,8 @@ export default abstract class Server<
         dynamicOnHover: this.nextConfig.experimental.dynamicOnHover ?? false,
         inlineCss: this.nextConfig.experimental.inlineCss ?? false,
         authInterrupts: !!this.nextConfig.experimental.authInterrupts,
+        cdnCacheControlHeader:
+          this.nextConfig.experimental.cdnCacheControlHeader,
       },
       onInstrumentationRequestError:
         this.instrumentationOnRequestError.bind(this),
@@ -1762,6 +1765,8 @@ export default abstract class Server<
         generateEtags,
         poweredByHeader,
         cacheControl,
+        cdnCacheControlHeader:
+          this.nextConfig.experimental.cdnCacheControlHeader,
       })
       res.statusCode = originalStatus
     }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -192,6 +192,7 @@ export const experimentalSchema = {
   memoryBasedWorkersCount: z.boolean().optional(),
   craCompat: z.boolean().optional(),
   caseSensitiveRoutes: z.boolean().optional(),
+  cdnCacheControlHeader: z.string().optional(),
   clientParamParsingOrigins: z.array(z.string()).optional(),
   dynamicOnHover: z.boolean().optional(),
   disableOptimizedLoading: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -280,6 +280,12 @@ export interface ExperimentalConfig {
   linkNoTouchStart?: boolean
   caseSensitiveRoutes?: boolean
   /**
+   * Custom header name to use for CDN cache control instead of the default
+   * 'CDN-Cache-Control'. This can be used to target specific CDN providers
+   * that do not support `CDN-Cache-Control` and have their own custom header.
+   */
+  cdnCacheControlHeader?: string
+  /**
    * The origins that are allowed to write the rewritten headers when
    * performing a non-relative rewrite. When undefined, no non-relative
    * rewrites will get the rewrite headers.
@@ -1507,6 +1513,7 @@ export const defaultConfig = Object.freeze({
     serverMinification: true,
     linkNoTouchStart: false,
     caseSensitiveRoutes: false,
+    cdnCacheControlHeader: undefined,
     clientParamParsingOrigins: undefined,
     dynamicOnHover: false,
     preloadEntriesOnStart: true,
@@ -1655,6 +1662,7 @@ export interface NextConfigRuntime {
     | 'clientParamParsingOrigins'
     | 'adapterPath'
     | 'allowedRevalidateHeaderKeys'
+    | 'cdnCacheControlHeader'
     | 'fetchCacheKeyPrefix'
     | 'isrFlushToDisk'
     | 'optimizeCss'
@@ -1709,6 +1717,7 @@ export function getNextConfigRuntime(
         clientParamParsingOrigins: ex.clientParamParsingOrigins,
         adapterPath: ex.adapterPath,
         allowedRevalidateHeaderKeys: ex.allowedRevalidateHeaderKeys,
+        cdnCacheControlHeader: ex.cdnCacheControlHeader,
         fetchCacheKeyPrefix: ex.fetchCacheKeyPrefix,
         isrFlushToDisk: ex.isrFlushToDisk,
         optimizeCss: ex.optimizeCss,

--- a/packages/next/src/server/lib/cache-control.ts
+++ b/packages/next/src/server/lib/cache-control.ts
@@ -1,3 +1,4 @@
+import type { ServerResponse } from 'http'
 import { CACHE_ONE_YEAR } from '../../lib/constants'
 
 /**
@@ -14,10 +15,16 @@ export interface CacheControl {
   expire: number | undefined
 }
 
+export interface CacheHeaders {
+  'Cache-Control': string
+  'CDN-Cache-Control'?: string
+  'Surrogate-Control'?: string
+}
+
 export function getCacheControlHeader({
   revalidate,
   expire,
-}: CacheControl): string {
+}: CacheControl): CacheHeaders {
   const swrHeader =
     typeof revalidate === 'number' &&
     expire !== undefined &&
@@ -26,10 +33,59 @@ export function getCacheControlHeader({
       : ''
 
   if (revalidate === 0) {
-    return 'private, no-cache, no-store, max-age=0, must-revalidate'
-  } else if (typeof revalidate === 'number') {
-    return `s-maxage=${revalidate}${swrHeader}`
+    return {
+      'Cache-Control':
+        'private, no-cache, no-store, max-age=0, must-revalidate',
+    }
   }
 
-  return `s-maxage=${CACHE_ONE_YEAR}${swrHeader}`
+  // For non-zero revalidation, we want to leverage CDN stale-while-revalidate caching
+  // semantics without allowing the browser to cache the response.
+  const cdnDirective = `max-age=${
+    typeof revalidate === 'number' ? revalidate : CACHE_ONE_YEAR
+  }${swrHeader}`
+
+  return {
+    'Cache-Control': 'max-age=0, must-revalidate',
+    'CDN-Cache-Control': cdnDirective,
+    'Surrogate-Control': cdnDirective,
+  }
+}
+
+/**
+ * Sets cache control headers on a ServerResponse object.
+ * Use this helper to consistently set Cache-Control, CDN-Cache-Control,
+ * and Surrogate-Control headers.
+ */
+export function setCacheControlHeaders(
+  res: ServerResponse,
+  cacheControl: CacheControl
+): void {
+  const cacheHeaders = getCacheControlHeader(cacheControl)
+  res.setHeader('Cache-Control', cacheHeaders['Cache-Control'])
+  if (cacheHeaders['CDN-Cache-Control']) {
+    res.setHeader('CDN-Cache-Control', cacheHeaders['CDN-Cache-Control'])
+  }
+  if (cacheHeaders['Surrogate-Control']) {
+    res.setHeader('Surrogate-Control', cacheHeaders['Surrogate-Control'])
+  }
+}
+
+/**
+ * Sets cache control headers on a Headers object (for Web API responses).
+ * Use this helper to consistently set Cache-Control, CDN-Cache-Control,
+ * and Surrogate-Control headers.
+ */
+export function setCacheControlHeadersOnHeaders(
+  headers: Headers,
+  cacheControl: CacheControl
+): void {
+  const cacheHeaders = getCacheControlHeader(cacheControl)
+  headers.set('Cache-Control', cacheHeaders['Cache-Control'])
+  if (cacheHeaders['CDN-Cache-Control']) {
+    headers.set('CDN-Cache-Control', cacheHeaders['CDN-Cache-Control'])
+  }
+  if (cacheHeaders['Surrogate-Control']) {
+    headers.set('Surrogate-Control', cacheHeaders['Surrogate-Control'])
+  }
 }

--- a/packages/next/src/server/lib/cache-control.ts
+++ b/packages/next/src/server/lib/cache-control.ts
@@ -17,8 +17,7 @@ export interface CacheControl {
 
 export interface CacheHeaders {
   'Cache-Control': string
-  'CDN-Cache-Control'?: string
-  'Surrogate-Control'?: string
+  cdnCacheControl?: string
 }
 
 export function getCacheControlHeader({
@@ -41,51 +40,59 @@ export function getCacheControlHeader({
 
   // For non-zero revalidation, we want to leverage CDN stale-while-revalidate caching
   // semantics without allowing the browser to cache the response.
-  const cdnDirective = `max-age=${
-    typeof revalidate === 'number' ? revalidate : CACHE_ONE_YEAR
-  }${swrHeader}`
+  const maxAge = typeof revalidate === 'number' ? revalidate : CACHE_ONE_YEAR
+  const cdnCacheControl = `max-age=${maxAge}${swrHeader}`
+  const cacheControl = `s-maxage=${maxAge}`
 
   return {
-    'Cache-Control': 'max-age=0, must-revalidate',
-    'CDN-Cache-Control': cdnDirective,
-    'Surrogate-Control': cdnDirective,
+    'Cache-Control': cacheControl,
+    cdnCacheControl: cdnCacheControl,
   }
 }
 
 /**
- * Sets cache control headers on a ServerResponse object.
- * Use this helper to consistently set Cache-Control, CDN-Cache-Control,
- * and Surrogate-Control headers.
+ * The default header name used for CDN cache control.
  */
-export function setCacheControlHeaders(
+export const DEFAULT_CDN_CACHE_CONTROL_HEADER = 'CDN-Cache-Control'
+
+/**
+ * Sets cache control headers on a ServerResponse object.
+ * Use this helper to consistently set Cache-Control and CDN cache control headers.
+ *
+ * @param res - The ServerResponse object
+ * @param cacheControl - The cache control configuration
+ * @param cdnCacheControlHeader - Custom CDN cache control header name from config, falls back to 'CDN-Cache-Control' if undefined
+ */
+export function setResponseCacheControlHeaders(
   res: ServerResponse,
-  cacheControl: CacheControl
+  cacheControl: CacheControl,
+  cdnCacheControlHeader: string | undefined
 ): void {
   const cacheHeaders = getCacheControlHeader(cacheControl)
+  const headerName = cdnCacheControlHeader ?? DEFAULT_CDN_CACHE_CONTROL_HEADER
   res.setHeader('Cache-Control', cacheHeaders['Cache-Control'])
-  if (cacheHeaders['CDN-Cache-Control']) {
-    res.setHeader('CDN-Cache-Control', cacheHeaders['CDN-Cache-Control'])
-  }
-  if (cacheHeaders['Surrogate-Control']) {
-    res.setHeader('Surrogate-Control', cacheHeaders['Surrogate-Control'])
+  if (cacheHeaders.cdnCacheControl) {
+    res.setHeader(headerName, cacheHeaders.cdnCacheControl)
   }
 }
 
 /**
  * Sets cache control headers on a Headers object (for Web API responses).
- * Use this helper to consistently set Cache-Control, CDN-Cache-Control,
- * and Surrogate-Control headers.
+ * Use this helper to consistently set Cache-Control and CDN cache control headers.
+ *
+ * @param headers - The Headers object
+ * @param cacheControl - The cache control configuration
+ * @param cdnCacheControlHeader - Custom CDN cache control header name from config, falls back to 'CDN-Cache-Control' if undefined
  */
-export function setCacheControlHeadersOnHeaders(
+export function setCacheControlHeaders(
   headers: Headers,
-  cacheControl: CacheControl
+  cacheControl: CacheControl,
+  cdnCacheControlHeader: string | undefined
 ): void {
   const cacheHeaders = getCacheControlHeader(cacheControl)
+  const headerName = cdnCacheControlHeader ?? DEFAULT_CDN_CACHE_CONTROL_HEADER
   headers.set('Cache-Control', cacheHeaders['Cache-Control'])
-  if (cacheHeaders['CDN-Cache-Control']) {
-    headers.set('CDN-Cache-Control', cacheHeaders['CDN-Cache-Control'])
-  }
-  if (cacheHeaders['Surrogate-Control']) {
-    headers.set('Surrogate-Control', cacheHeaders['Surrogate-Control'])
+  if (cacheHeaders.cdnCacheControl) {
+    headers.set(headerName, cacheHeaders.cdnCacheControl)
   }
 }

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -605,6 +605,7 @@ export default class NextNodeServer extends BaseServer<
       generateEtags: boolean
       poweredByHeader: boolean
       cacheControl: CacheControl | undefined
+      cdnCacheControlHeader?: string
     }
   ): Promise<void> {
     return sendRenderResult({
@@ -614,6 +615,7 @@ export default class NextNodeServer extends BaseServer<
       generateEtags: options.generateEtags,
       poweredByHeader: options.poweredByHeader,
       cacheControl: options.cacheControl,
+      cdnCacheControlHeader: options.cdnCacheControlHeader,
     })
   }
 

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -101,7 +101,7 @@ import {
 import { getTracer } from './lib/trace/tracer'
 import { RenderSpan } from './lib/trace/constants'
 import { ReflectAdapter } from './web/spec-extension/adapters/reflect'
-import { getCacheControlHeader } from './lib/cache-control'
+import { setCacheControlHeaders } from './lib/cache-control'
 import { getErrorSource } from '../shared/lib/error-source'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import type { PagesDevOverlayBridgeType } from '../next-devtools/userspace/pages/pages-dev-overlay-setup'
@@ -555,10 +555,7 @@ export async function renderToHTMLImpl(
   // ensure we set cache header so it's not rendered on-demand
   // every request
   if (isAutoExport && !dev && isExperimentalCompile) {
-    res.setHeader(
-      'Cache-Control',
-      getCacheControlHeader({ revalidate: false, expire: expireTime })
-    )
+    setCacheControlHeaders(res, { revalidate: false, expire: expireTime })
     isAutoExport = false
   }
 

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -101,7 +101,7 @@ import {
 import { getTracer } from './lib/trace/tracer'
 import { RenderSpan } from './lib/trace/constants'
 import { ReflectAdapter } from './web/spec-extension/adapters/reflect'
-import { setCacheControlHeaders } from './lib/cache-control'
+import { setResponseCacheControlHeaders } from './lib/cache-control'
 import { getErrorSource } from '../shared/lib/error-source'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import type { PagesDevOverlayBridgeType } from '../next-devtools/userspace/pages/pages-dev-overlay-setup'
@@ -287,6 +287,7 @@ export type RenderOptsPartial = {
   expireTime?: number
   experimental: {
     clientTraceMetadata?: string[]
+    cdnCacheControlHeader?: string
   }
 }
 
@@ -555,7 +556,11 @@ export async function renderToHTMLImpl(
   // ensure we set cache header so it's not rendered on-demand
   // every request
   if (isAutoExport && !dev && isExperimentalCompile) {
-    setCacheControlHeaders(res, { revalidate: false, expire: expireTime })
+    setResponseCacheControlHeaders(
+      res,
+      { revalidate: false, expire: expireTime },
+      renderOpts.experimental.cdnCacheControlHeader
+    )
     isAutoExport = false
   }
 

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -17,7 +17,7 @@ import {
 } from '../../response-cache'
 
 import {
-  getCacheControlHeader,
+  setCacheControlHeaders,
   type CacheControl,
 } from '../../lib/cache-control'
 import { normalizeRepeatedSlashes } from '../../../shared/lib/utils'
@@ -607,7 +607,7 @@ export const getHandler = ({
         // If cache control is already set on the response we don't
         // override it to allow users to customize it via next.config
         if (cacheControl && !res.getHeader('Cache-Control')) {
-          res.setHeader('Cache-Control', getCacheControlHeader(cacheControl))
+          setCacheControlHeaders(res, cacheControl)
         }
 
         // notFound: true case

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -17,7 +17,7 @@ import {
 } from '../../response-cache'
 
 import {
-  setCacheControlHeaders,
+  setResponseCacheControlHeaders,
   type CacheControl,
 } from '../../lib/cache-control'
 import { normalizeRepeatedSlashes } from '../../../shared/lib/utils'
@@ -607,7 +607,11 @@ export const getHandler = ({
         // If cache control is already set on the response we don't
         // override it to allow users to customize it via next.config
         if (cacheControl && !res.getHeader('Cache-Control')) {
-          setCacheControlHeaders(res, cacheControl)
+          setResponseCacheControlHeaders(
+            res,
+            cacheControl,
+            nextConfig.experimental.cdnCacheControlHeader
+          )
         }
 
         // notFound: true case
@@ -718,6 +722,7 @@ export const getHandler = ({
           generateEtags: nextConfig.generateEtags,
           poweredByHeader: nextConfig.poweredByHeader,
           cacheControl: routeModule.isDev ? undefined : cacheControl,
+          cdnCacheControlHeader: nextConfig.experimental.cdnCacheControlHeader,
         })
       }
 

--- a/packages/next/src/server/send-payload.ts
+++ b/packages/next/src/server/send-payload.ts
@@ -5,7 +5,7 @@ import type { CacheControl } from './lib/cache-control'
 import { isResSent } from '../shared/lib/utils'
 import { generateETag } from './lib/etag'
 import fresh from 'next/dist/compiled/fresh'
-import { getCacheControlHeader } from './lib/cache-control'
+import { setCacheControlHeaders } from './lib/cache-control'
 import { HTML_CONTENT_TYPE_HEADER } from '../lib/constants'
 
 export function sendEtagResponse(
@@ -58,7 +58,7 @@ export async function sendRenderResult({
   // If cache control is already set on the response we don't
   // override it to allow users to customize it via next.config
   if (cacheControl && !res.getHeader('Cache-Control')) {
-    res.setHeader('Cache-Control', getCacheControlHeader(cacheControl))
+    setCacheControlHeaders(res, cacheControl)
   }
 
   const payload = result.isDynamic ? null : result.toUnchunkedString()

--- a/packages/next/src/server/send-payload.ts
+++ b/packages/next/src/server/send-payload.ts
@@ -5,7 +5,7 @@ import type { CacheControl } from './lib/cache-control'
 import { isResSent } from '../shared/lib/utils'
 import { generateETag } from './lib/etag'
 import fresh from 'next/dist/compiled/fresh'
-import { setCacheControlHeaders } from './lib/cache-control'
+import { setResponseCacheControlHeaders } from './lib/cache-control'
 import { HTML_CONTENT_TYPE_HEADER } from '../lib/constants'
 
 export function sendEtagResponse(
@@ -39,6 +39,7 @@ export async function sendRenderResult({
   generateEtags,
   poweredByHeader,
   cacheControl,
+  cdnCacheControlHeader,
 }: {
   req: IncomingMessage
   res: ServerResponse
@@ -46,6 +47,7 @@ export async function sendRenderResult({
   generateEtags: boolean
   poweredByHeader: boolean
   cacheControl: CacheControl | undefined
+  cdnCacheControlHeader?: string
 }): Promise<void> {
   if (isResSent(res)) {
     return
@@ -58,7 +60,7 @@ export async function sendRenderResult({
   // If cache control is already set on the response we don't
   // override it to allow users to customize it via next.config
   if (cacheControl && !res.getHeader('Cache-Control')) {
-    setCacheControlHeaders(res, cacheControl)
+    setResponseCacheControlHeaders(res, cacheControl, cdnCacheControlHeader)
   }
 
   const payload = result.isDynamic ? null : result.toUnchunkedString()

--- a/test/e2e/app-dir/cdn-cache-control-header/app/layout.tsx
+++ b/test/e2e/app-dir/cdn-cache-control-header/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cdn-cache-control-header/app/page.tsx
+++ b/test/e2e/app-dir/cdn-cache-control-header/app/page.tsx
@@ -1,0 +1,8 @@
+'use cache'
+
+import { cacheLife } from 'next/cache'
+
+export default async function Page() {
+  cacheLife('minutes')
+  return <p>Hello World</p>
+}

--- a/test/e2e/app-dir/cdn-cache-control-header/cdn-cache-control-header.test.ts
+++ b/test/e2e/app-dir/cdn-cache-control-header/cdn-cache-control-header.test.ts
@@ -1,0 +1,28 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('cdn-cache-control-header', () => {
+  const { next, isNextDev, isNextDeploy } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDeploy) {
+    it('should skip for deploy', () => {})
+    return
+  }
+
+  it('should use custom CDN cache control header name from experimental config', async () => {
+    const res = await next.fetch('/')
+
+    // In dev mode, no caching headers are set
+    if (isNextDev) {
+      expect(res.headers.get('cache-control')).toBe('no-store, must-revalidate')
+      expect(res.headers.get('surrogate-control')).toBeNull()
+      expect(res.headers.get('cdn-cache-control')).toBeNull()
+      return
+    }
+
+    expect(res.headers.get('cache-control')).toBe('s-maxage=60')
+    expect(res.headers.get('surrogate-control')).toMatch(/^max-age=\d+/)
+    expect(res.headers.get('cdn-cache-control')).toBeNull()
+  })
+})

--- a/test/e2e/app-dir/cdn-cache-control-header/next.config.js
+++ b/test/e2e/app-dir/cdn-cache-control-header/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    cdnCacheControlHeader: 'Surrogate-Control',
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
+++ b/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
@@ -31,10 +31,14 @@ describe('custom-cache-control', () => {
       const res = await next.fetch('/app-ssg/another')
       // eslint-disable-next-line jest/no-standalone-expect
       expect(res.headers.get('cache-control')).toBe(
-        isNextDev
-          ? 'no-store, must-revalidate'
-          : 's-maxage=120, stale-while-revalidate=31535880'
+        isNextDev ? 'no-store, must-revalidate' : 'max-age=0, must-revalidate'
       )
+      if (!isNextDev) {
+        // eslint-disable-next-line jest/no-standalone-expect
+        expect(res.headers.get('cdn-cache-control')).toBe(
+          'max-age=120, stale-while-revalidate=31535880'
+        )
+      }
     }
   )
 
@@ -69,10 +73,13 @@ describe('custom-cache-control', () => {
   it('should have default cache-control for pages-ssg another', async () => {
     const res = await next.fetch('/pages-ssg/another')
     expect(res.headers.get('cache-control')).toBe(
-      isNextDev
-        ? 'no-store, must-revalidate'
-        : 's-maxage=120, stale-while-revalidate=31535880'
+      isNextDev ? 'no-store, must-revalidate' : 'max-age=0, must-revalidate'
     )
+    if (!isNextDev) {
+      expect(res.headers.get('cdn-cache-control')).toBe(
+        'max-age=120, stale-while-revalidate=31535880'
+      )
+    }
   })
 
   it('should have default cache-control for pages-ssr', async () => {

--- a/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
+++ b/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
@@ -31,7 +31,7 @@ describe('custom-cache-control', () => {
       const res = await next.fetch('/app-ssg/another')
       // eslint-disable-next-line jest/no-standalone-expect
       expect(res.headers.get('cache-control')).toBe(
-        isNextDev ? 'no-store, must-revalidate' : 'max-age=0, must-revalidate'
+        isNextDev ? 'no-store, must-revalidate' : 's-maxage=120'
       )
       if (!isNextDev) {
         // eslint-disable-next-line jest/no-standalone-expect
@@ -73,7 +73,7 @@ describe('custom-cache-control', () => {
   it('should have default cache-control for pages-ssg another', async () => {
     const res = await next.fetch('/pages-ssg/another')
     expect(res.headers.get('cache-control')).toBe(
-      isNextDev ? 'no-store, must-revalidate' : 'max-age=0, must-revalidate'
+      isNextDev ? 'no-store, must-revalidate' : 's-maxage=120'
     )
     if (!isNextDev) {
       expect(res.headers.get('cdn-cache-control')).toBe(

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -554,16 +554,22 @@ describe('use-cache', () => {
       let response = await next.fetch('/cache-life')
 
       expect(response.headers.get('cache-control')).toBe(
+        'max-age=0, must-revalidate'
+      )
+      expect(response.headers.get('cdn-cache-control')).toBe(
         // revalidate is set to 100, expire is set to 300 => SWR 200
-        's-maxage=100, stale-while-revalidate=200'
+        'max-age=100, stale-while-revalidate=200'
       )
 
       response = await next.fetch('/cache-fetch')
 
       expect(response.headers.get('cache-control')).toBe(
+        'max-age=0, must-revalidate'
+      )
+      expect(response.headers.get('cdn-cache-control')).toBe(
         // revalidate is set to 900, expire is one year (31536000, default
         // expireTime) => SWR 31535100
-        's-maxage=900, stale-while-revalidate=31535100'
+        'max-age=900, stale-while-revalidate=31535100'
       )
     })
 

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -553,9 +553,7 @@ describe('use-cache', () => {
     it('should send an SWR cache-control header based on the revalidate and expire values', async () => {
       let response = await next.fetch('/cache-life')
 
-      expect(response.headers.get('cache-control')).toBe(
-        'max-age=0, must-revalidate'
-      )
+      expect(response.headers.get('cache-control')).toBe('s-maxage=100')
       expect(response.headers.get('cdn-cache-control')).toBe(
         // revalidate is set to 100, expire is set to 300 => SWR 200
         'max-age=100, stale-while-revalidate=200'
@@ -563,9 +561,7 @@ describe('use-cache', () => {
 
       response = await next.fetch('/cache-fetch')
 
-      expect(response.headers.get('cache-control')).toBe(
-        'max-age=0, must-revalidate'
-      )
+      expect(response.headers.get('cache-control')).toBe('s-maxage=900')
       expect(response.headers.get('cdn-cache-control')).toBe(
         // revalidate is set to 900, expire is one year (31536000, default
         // expireTime) => SWR 31535100

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -677,10 +677,13 @@ describe('Prerender', () => {
       it('should use correct caching headers for a revalidate page', async () => {
         const initialRes = await fetchViaHTTP(next.url, '/')
         expect(initialRes.headers.get('cache-control')).toBe(
-          isDeploy
-            ? 'public, max-age=0, must-revalidate'
-            : 's-maxage=2, stale-while-revalidate=31535998'
+          'max-age=0, must-revalidate'
         )
+        if (!isDeploy) {
+          expect(initialRes.headers.get('cdn-cache-control')).toBe(
+            'max-age=2, stale-while-revalidate=31535998'
+          )
+        }
       })
 
       it('should use correct caching headers for a fallback-true page (prerendered)', async () => {
@@ -689,8 +692,13 @@ describe('Prerender', () => {
         expect(initialRes.headers.get('cache-control')).toBe(
           isDeploy
             ? 'public, max-age=0, must-revalidate'
-            : 's-maxage=2, stale-while-revalidate=31535998'
+            : 'max-age=0, must-revalidate'
         )
+        if (!isDeploy) {
+          expect(initialRes.headers.get('cdn-cache-control')).toBe(
+            'max-age=2, stale-while-revalidate=31535998'
+          )
+        }
         expect(await initialRes.text()).not.toContain('hi fallback')
 
         const dataRes = await fetchViaHTTP(
@@ -701,17 +709,25 @@ describe('Prerender', () => {
         expect(dataRes.headers.get('cache-control')).toBe(
           isDeploy
             ? 'public, max-age=0, must-revalidate'
-            : 's-maxage=2, stale-while-revalidate=31535998'
+            : 'max-age=0, must-revalidate'
         )
+        if (!isDeploy) {
+          expect(dataRes.headers.get('cdn-cache-control')).toBe(
+            'max-age=2, stale-while-revalidate=31535998'
+          )
+        }
 
         await retry(async () => {
           const finalRes = await fetchViaHTTP(next.url, `/fallback-true/first`)
           expect(finalRes.status).toBe(200)
           expect(finalRes.headers.get('cache-control')).toBe(
-            isDeploy
-              ? 'public, max-age=0, must-revalidate'
-              : 's-maxage=2, stale-while-revalidate=31535998'
+            'max-age=0, must-revalidate'
           )
+          if (!isDeploy) {
+            expect(finalRes.headers.get('cdn-cache-control')).toBe(
+              'max-age=2, stale-while-revalidate=31535998'
+            )
+          }
           expect(await finalRes.text()).not.toContain('hi fallback')
         })
       })
@@ -732,19 +748,25 @@ describe('Prerender', () => {
         )
         expect(dataRes.status).toBe(200)
         expect(dataRes.headers.get('cache-control')).toBe(
-          isDeploy
-            ? 'public, max-age=0, must-revalidate'
-            : 's-maxage=2, stale-while-revalidate=31535998'
+          'max-age=0, must-revalidate'
         )
+        if (!isDeploy) {
+          expect(dataRes.headers.get('cdn-cache-control')).toBe(
+            'max-age=2, stale-while-revalidate=31535998'
+          )
+        }
 
         await retry(async () => {
           const finalRes = await fetchViaHTTP(next.url, `/fallback-true/second`)
           expect(finalRes.status).toBe(200)
           expect(finalRes.headers.get('cache-control')).toBe(
-            isDeploy
-              ? 'public, max-age=0, must-revalidate'
-              : 's-maxage=2, stale-while-revalidate=31535998'
+            'max-age=0, must-revalidate'
           )
+          if (!isDeploy) {
+            expect(finalRes.headers.get('cdn-cache-control')).toBe(
+              'max-age=2, stale-while-revalidate=31535998'
+            )
+          }
           expect(await finalRes.text()).not.toContain('hi fallback')
         })
       })
@@ -1378,8 +1400,15 @@ describe('Prerender', () => {
       it('should use correct caching headers for a no-revalidate page', async () => {
         const initialRes = await fetchViaHTTP(next.url, '/something')
         expect(initialRes.headers.get('cache-control')).toBe(
-          isDeploy ? 'public, max-age=0, must-revalidate' : 's-maxage=31536000'
+          isDeploy
+            ? 'public, max-age=0, must-revalidate'
+            : 'max-age=0, must-revalidate'
         )
+        if (!isDeploy) {
+          expect(initialRes.headers.get('cdn-cache-control')).toBe(
+            'max-age=31536000'
+          )
+        }
         const initialHtml = await initialRes.text()
         expect(initialHtml).toMatch(/hello.*?world/)
       })

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -676,9 +676,7 @@ describe('Prerender', () => {
     if (!isDev) {
       it('should use correct caching headers for a revalidate page', async () => {
         const initialRes = await fetchViaHTTP(next.url, '/')
-        expect(initialRes.headers.get('cache-control')).toBe(
-          'max-age=0, must-revalidate'
-        )
+        expect(initialRes.headers.get('cache-control')).toBe('s-maxage=2')
         if (!isDeploy) {
           expect(initialRes.headers.get('cdn-cache-control')).toBe(
             'max-age=2, stale-while-revalidate=31535998'
@@ -690,9 +688,7 @@ describe('Prerender', () => {
         const initialRes = await fetchViaHTTP(next.url, '/fallback-true/first')
         expect(initialRes.status).toBe(200)
         expect(initialRes.headers.get('cache-control')).toBe(
-          isDeploy
-            ? 'public, max-age=0, must-revalidate'
-            : 'max-age=0, must-revalidate'
+          isDeploy ? 'public, max-age=0, must-revalidate' : 's-maxage=2'
         )
         if (!isDeploy) {
           expect(initialRes.headers.get('cdn-cache-control')).toBe(
@@ -707,9 +703,7 @@ describe('Prerender', () => {
         )
         expect(dataRes.status).toBe(200)
         expect(dataRes.headers.get('cache-control')).toBe(
-          isDeploy
-            ? 'public, max-age=0, must-revalidate'
-            : 'max-age=0, must-revalidate'
+          isDeploy ? 'public, max-age=0, must-revalidate' : 's-maxage=2'
         )
         if (!isDeploy) {
           expect(dataRes.headers.get('cdn-cache-control')).toBe(
@@ -720,9 +714,7 @@ describe('Prerender', () => {
         await retry(async () => {
           const finalRes = await fetchViaHTTP(next.url, `/fallback-true/first`)
           expect(finalRes.status).toBe(200)
-          expect(finalRes.headers.get('cache-control')).toBe(
-            'max-age=0, must-revalidate'
-          )
+          expect(finalRes.headers.get('cache-control')).toBe('s-maxage=2')
           if (!isDeploy) {
             expect(finalRes.headers.get('cdn-cache-control')).toBe(
               'max-age=2, stale-while-revalidate=31535998'
@@ -747,9 +739,7 @@ describe('Prerender', () => {
           `/_next/data/${next.buildId}/fallback-true/second.json`
         )
         expect(dataRes.status).toBe(200)
-        expect(dataRes.headers.get('cache-control')).toBe(
-          'max-age=0, must-revalidate'
-        )
+        expect(dataRes.headers.get('cache-control')).toBe('s-maxage=2')
         if (!isDeploy) {
           expect(dataRes.headers.get('cdn-cache-control')).toBe(
             'max-age=2, stale-while-revalidate=31535998'
@@ -759,9 +749,7 @@ describe('Prerender', () => {
         await retry(async () => {
           const finalRes = await fetchViaHTTP(next.url, `/fallback-true/second`)
           expect(finalRes.status).toBe(200)
-          expect(finalRes.headers.get('cache-control')).toBe(
-            'max-age=0, must-revalidate'
-          )
+          expect(finalRes.headers.get('cache-control')).toBe('s-maxage=2')
           if (!isDeploy) {
             expect(finalRes.headers.get('cdn-cache-control')).toBe(
               'max-age=2, stale-while-revalidate=31535998'
@@ -1400,9 +1388,7 @@ describe('Prerender', () => {
       it('should use correct caching headers for a no-revalidate page', async () => {
         const initialRes = await fetchViaHTTP(next.url, '/something')
         expect(initialRes.headers.get('cache-control')).toBe(
-          isDeploy
-            ? 'public, max-age=0, must-revalidate'
-            : 'max-age=0, must-revalidate'
+          isDeploy ? 'public, max-age=0, must-revalidate' : 's-maxage=31536000'
         )
         if (!isDeploy) {
           expect(initialRes.headers.get('cdn-cache-control')).toBe(

--- a/test/integration/not-found-revalidate/test/index.test.ts
+++ b/test/integration/not-found-revalidate/test/index.test.ts
@@ -81,8 +81,9 @@ const runTests = () => {
     let res = await fetchViaHTTP(appPort, '/fallback-blocking/hello')
     let $ = cheerio.load(await res.text())
 
-    expect(res.headers.get('cache-control')).toBe(
-      `s-maxage=1, stale-while-revalidate=31535999`
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe(
+      `max-age=1, stale-while-revalidate=31535999`
     )
     expect(res.status).toBe(404)
     expect(JSON.parse($('#props').text()).notFound).toBe(true)
@@ -91,8 +92,9 @@ const runTests = () => {
     res = await fetchViaHTTP(appPort, '/fallback-blocking/hello')
     $ = cheerio.load(await res.text())
 
-    expect(res.headers.get('cache-control')).toBe(
-      `s-maxage=1, stale-while-revalidate=31535999`
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe(
+      `max-age=1, stale-while-revalidate=31535999`
     )
     expect(res.status).toBe(404)
     expect(JSON.parse($('#props').text()).notFound).toBe(true)
@@ -102,8 +104,9 @@ const runTests = () => {
     $ = cheerio.load(await res.text())
 
     const props = JSON.parse($('#props').text())
-    expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate=31535999'
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe(
+      'max-age=1, stale-while-revalidate=31535999'
     )
     expect(res.status).toBe(200)
     expect(props.found).toBe(true)
@@ -115,8 +118,9 @@ const runTests = () => {
     $ = cheerio.load(await res.text())
 
     const props2 = JSON.parse($('#props').text())
-    expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate=31535999'
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe(
+      'max-age=1, stale-while-revalidate=31535999'
     )
     expect(res.status).toBe(200)
     expect(props2.found).toBe(true)
@@ -128,8 +132,9 @@ const runTests = () => {
     $ = cheerio.load(await res.text())
 
     const props3 = JSON.parse($('#props').text())
-    expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate=31535999'
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe(
+      'max-age=1, stale-while-revalidate=31535999'
     )
     expect(res.status).toBe(200)
     expect(props3.found).toBe(true)
@@ -147,8 +152,9 @@ const runTests = () => {
     let res = await fetchViaHTTP(appPort, '/fallback-true/world')
     let $ = cheerio.load(await res.text())
 
-    expect(res.headers.get('cache-control')).toBe(
-      `s-maxage=1, stale-while-revalidate=31535999`
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe(
+      `max-age=1, stale-while-revalidate=31535999`
     )
     expect(res.status).toBe(404)
     expect(JSON.parse($('#props').text()).notFound).toBe(true)
@@ -158,8 +164,9 @@ const runTests = () => {
     $ = cheerio.load(await res.text())
 
     const props = JSON.parse($('#props').text())
-    expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate=31535999'
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe(
+      'max-age=1, stale-while-revalidate=31535999'
     )
     expect(res.status).toBe(200)
     expect(props.found).toBe(true)
@@ -171,8 +178,9 @@ const runTests = () => {
     $ = cheerio.load(await res.text())
 
     const props2 = JSON.parse($('#props').text())
-    expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate=31535999'
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe(
+      'max-age=1, stale-while-revalidate=31535999'
     )
     expect(res.status).toBe(200)
     expect(props2.found).toBe(true)
@@ -184,8 +192,9 @@ const runTests = () => {
     $ = cheerio.load(await res.text())
 
     const props3 = JSON.parse($('#props').text())
-    expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate=31535999'
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe(
+      'max-age=1, stale-while-revalidate=31535999'
     )
     expect(res.status).toBe(200)
     expect(props3.found).toBe(true)

--- a/test/integration/not-found-revalidate/test/index.test.ts
+++ b/test/integration/not-found-revalidate/test/index.test.ts
@@ -81,7 +81,7 @@ const runTests = () => {
     let res = await fetchViaHTTP(appPort, '/fallback-blocking/hello')
     let $ = cheerio.load(await res.text())
 
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=1')
     expect(res.headers.get('cdn-cache-control')).toBe(
       `max-age=1, stale-while-revalidate=31535999`
     )
@@ -92,7 +92,7 @@ const runTests = () => {
     res = await fetchViaHTTP(appPort, '/fallback-blocking/hello')
     $ = cheerio.load(await res.text())
 
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=1')
     expect(res.headers.get('cdn-cache-control')).toBe(
       `max-age=1, stale-while-revalidate=31535999`
     )
@@ -104,7 +104,7 @@ const runTests = () => {
     $ = cheerio.load(await res.text())
 
     const props = JSON.parse($('#props').text())
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=1')
     expect(res.headers.get('cdn-cache-control')).toBe(
       'max-age=1, stale-while-revalidate=31535999'
     )
@@ -118,7 +118,7 @@ const runTests = () => {
     $ = cheerio.load(await res.text())
 
     const props2 = JSON.parse($('#props').text())
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=1')
     expect(res.headers.get('cdn-cache-control')).toBe(
       'max-age=1, stale-while-revalidate=31535999'
     )
@@ -132,7 +132,7 @@ const runTests = () => {
     $ = cheerio.load(await res.text())
 
     const props3 = JSON.parse($('#props').text())
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=1')
     expect(res.headers.get('cdn-cache-control')).toBe(
       'max-age=1, stale-while-revalidate=31535999'
     )
@@ -152,7 +152,7 @@ const runTests = () => {
     let res = await fetchViaHTTP(appPort, '/fallback-true/world')
     let $ = cheerio.load(await res.text())
 
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=1')
     expect(res.headers.get('cdn-cache-control')).toBe(
       `max-age=1, stale-while-revalidate=31535999`
     )
@@ -164,7 +164,7 @@ const runTests = () => {
     $ = cheerio.load(await res.text())
 
     const props = JSON.parse($('#props').text())
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=1')
     expect(res.headers.get('cdn-cache-control')).toBe(
       'max-age=1, stale-while-revalidate=31535999'
     )
@@ -178,7 +178,7 @@ const runTests = () => {
     $ = cheerio.load(await res.text())
 
     const props2 = JSON.parse($('#props').text())
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=1')
     expect(res.headers.get('cdn-cache-control')).toBe(
       'max-age=1, stale-while-revalidate=31535999'
     )
@@ -192,7 +192,7 @@ const runTests = () => {
     $ = cheerio.load(await res.text())
 
     const props3 = JSON.parse($('#props').text())
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=1')
     expect(res.headers.get('cdn-cache-control')).toBe(
       'max-age=1, stale-while-revalidate=31535999'
     )

--- a/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
@@ -112,7 +112,8 @@ describe('required server files app router', () => {
       },
     })
     expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe('s-maxage=31536000')
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe('max-age=31536000')
   })
 
   it('should handle optional catchall', async () => {
@@ -171,8 +172,9 @@ describe('required server files app router', () => {
       },
     })
     expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe(
-      's-maxage=3600, stale-while-revalidate=31532400'
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe(
+      'max-age=3600, stale-while-revalidate=31532400'
     )
   })
 

--- a/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
@@ -112,7 +112,7 @@ describe('required server files app router', () => {
       },
     })
     expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=31536000')
     expect(res.headers.get('cdn-cache-control')).toBe('max-age=31536000')
   })
 
@@ -172,7 +172,7 @@ describe('required server files app router', () => {
       },
     })
     expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=3600')
     expect(res.headers.get('cdn-cache-control')).toBe(
       'max-age=3600, stale-while-revalidate=31532400'
     )

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -174,8 +174,9 @@ describe('required server files i18n', () => {
       redirect: 'manual',
     })
     expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate=31535999'
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe(
+      'max-age=1, stale-while-revalidate=31535999'
     )
 
     await waitFor(2000)
@@ -185,8 +186,9 @@ describe('required server files i18n', () => {
       redirect: 'manual',
     })
     expect(res2.status).toBe(404)
-    expect(res2.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate=31535999'
+    expect(res2.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res2.headers.get('cdn-cache-control')).toBe(
+      'max-age=1, stale-while-revalidate=31535999'
     )
   })
 

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -174,7 +174,7 @@ describe('required server files i18n', () => {
       redirect: 'manual',
     })
     expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=1')
     expect(res.headers.get('cdn-cache-control')).toBe(
       'max-age=1, stale-while-revalidate=31535999'
     )
@@ -186,7 +186,7 @@ describe('required server files i18n', () => {
       redirect: 'manual',
     })
     expect(res2.status).toBe(404)
-    expect(res2.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res2.headers.get('cache-control')).toBe('s-maxage=1')
     expect(res2.headers.get('cdn-cache-control')).toBe(
       'max-age=1, stale-while-revalidate=31535999'
     )

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -219,17 +219,19 @@ describe('required server files', () => {
       case: 'redirect no revalidate',
       path: '/optional-ssg/redirect-1',
       dest: '/somewhere',
-      cacheControl: 's-maxage=31536000',
+      cacheControl: 'max-age=0, must-revalidate',
+      cdnCacheControl: 'max-age=31536000',
     },
     {
       case: 'redirect with revalidate',
       path: '/optional-ssg/redirect-2',
       dest: '/somewhere-else',
-      cacheControl: 's-maxage=5, stale-while-revalidate=31535995',
+      cacheControl: 'max-age=0, must-revalidate',
+      cdnCacheControl: 'max-age=5, stale-while-revalidate=31535995',
     },
   ])(
     `should have correct cache-control for $case`,
-    async ({ path, dest, cacheControl }) => {
+    async ({ path, dest, cacheControl, cdnCacheControl }) => {
       const res = await fetchViaHTTP(appPort, path, undefined, {
         redirect: 'manual',
       })
@@ -238,6 +240,7 @@ describe('required server files', () => {
         dest
       )
       expect(res.headers.get('cache-control')).toBe(cacheControl)
+      expect(res.headers.get('cdn-cache-control')).toBe(cdnCacheControl)
 
       const dataRes = await fetchViaHTTP(
         appPort,
@@ -247,6 +250,8 @@ describe('required server files', () => {
           redirect: 'manual',
         }
       )
+      expect(dataRes.headers.get('cache-control')).toBe(cacheControl)
+      expect(dataRes.headers.get('cdn-cache-control')).toBe(cdnCacheControl)
       expect((await dataRes.json()).pageProps).toEqual({
         __N_REDIRECT: dest,
         __N_REDIRECT_STATUS: 307,
@@ -296,22 +301,25 @@ describe('required server files', () => {
       case: 'notFound no revalidate',
       path: '/optional-ssg/not-found-1',
       dest: '/somewhere',
-      cacheControl: 's-maxage=31536000',
+      cacheControl: 'max-age=0, must-revalidate',
+      cdnCacheControl: 'max-age=31536000',
     },
     {
       case: 'notFound with revalidate',
       path: '/optional-ssg/not-found-2',
       dest: '/somewhere-else',
-      cacheControl: 's-maxage=5, stale-while-revalidate=31535995',
+      cacheControl: 'max-age=0, must-revalidate',
+      cdnCacheControl: 'max-age=5, stale-while-revalidate=31535995',
     },
   ])(
     `should have correct cache-control for $case`,
-    async ({ path, dest, cacheControl }) => {
+    async ({ path, dest, cacheControl, cdnCacheControl }) => {
       const res = await fetchViaHTTP(appPort, path, undefined, {
         redirect: 'manual',
       })
       expect(res.status).toBe(404)
       expect(res.headers.get('cache-control')).toBe(cacheControl)
+      expect(res.headers.get('cdn-cache-control')).toBe(cdnCacheControl)
 
       const dataRes = await fetchViaHTTP(
         appPort,
@@ -322,13 +330,15 @@ describe('required server files', () => {
         }
       )
       expect(dataRes.headers.get('cache-control')).toBe(cacheControl)
+      expect(dataRes.headers.get('cdn-cache-control')).toBe(cdnCacheControl)
     }
   )
 
   it('should have the correct cache-control for props with no revalidate', async () => {
     const res = await fetchViaHTTP(appPort, '/optional-ssg/props-no-revalidate')
     expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe('s-maxage=31536000')
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe('max-age=31536000')
     const $ = cheerio.load(await res.text())
     expect(JSON.parse($('#props').text()).params).toEqual({
       rest: ['props-no-revalidate'],
@@ -340,7 +350,8 @@ describe('required server files', () => {
       undefined
     )
     expect(dataRes.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe('s-maxage=31536000')
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe('max-age=31536000')
     expect((await dataRes.json()).pageProps.params).toEqual({
       rest: ['props-no-revalidate'],
     })
@@ -533,8 +544,9 @@ describe('required server files', () => {
       redirect: 'manual',
     })
     expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate=31535999'
+    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cdn-cache-control')).toBe(
+      'max-age=1, stale-while-revalidate=31535999'
     )
 
     await waitFor(2000)
@@ -544,8 +556,9 @@ describe('required server files', () => {
       redirect: 'manual',
     })
     expect(res2.status).toBe(404)
-    expect(res2.headers.get('cache-control')).toBe(
-      's-maxage=1, stale-while-revalidate=31535999'
+    expect(res2.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res2.headers.get('cdn-cache-control')).toBe(
+      'max-age=1, stale-while-revalidate=31535999'
     )
   })
 

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -219,14 +219,14 @@ describe('required server files', () => {
       case: 'redirect no revalidate',
       path: '/optional-ssg/redirect-1',
       dest: '/somewhere',
-      cacheControl: 'max-age=0, must-revalidate',
+      cacheControl: 's-maxage=31536000',
       cdnCacheControl: 'max-age=31536000',
     },
     {
       case: 'redirect with revalidate',
       path: '/optional-ssg/redirect-2',
       dest: '/somewhere-else',
-      cacheControl: 'max-age=0, must-revalidate',
+      cacheControl: 's-maxage=5',
       cdnCacheControl: 'max-age=5, stale-while-revalidate=31535995',
     },
   ])(
@@ -301,14 +301,14 @@ describe('required server files', () => {
       case: 'notFound no revalidate',
       path: '/optional-ssg/not-found-1',
       dest: '/somewhere',
-      cacheControl: 'max-age=0, must-revalidate',
+      cacheControl: 's-maxage=31536000',
       cdnCacheControl: 'max-age=31536000',
     },
     {
       case: 'notFound with revalidate',
       path: '/optional-ssg/not-found-2',
       dest: '/somewhere-else',
-      cacheControl: 'max-age=0, must-revalidate',
+      cacheControl: 's-maxage=5',
       cdnCacheControl: 'max-age=5, stale-while-revalidate=31535995',
     },
   ])(
@@ -337,7 +337,7 @@ describe('required server files', () => {
   it('should have the correct cache-control for props with no revalidate', async () => {
     const res = await fetchViaHTTP(appPort, '/optional-ssg/props-no-revalidate')
     expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=31536000')
     expect(res.headers.get('cdn-cache-control')).toBe('max-age=31536000')
     const $ = cheerio.load(await res.text())
     expect(JSON.parse($('#props').text()).params).toEqual({
@@ -350,7 +350,7 @@ describe('required server files', () => {
       undefined
     )
     expect(dataRes.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=31536000')
     expect(res.headers.get('cdn-cache-control')).toBe('max-age=31536000')
     expect((await dataRes.json()).pageProps.params).toEqual({
       rest: ['props-no-revalidate'],
@@ -544,7 +544,7 @@ describe('required server files', () => {
       redirect: 'manual',
     })
     expect(res.status).toBe(200)
-    expect(res.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res.headers.get('cache-control')).toBe('s-maxage=1')
     expect(res.headers.get('cdn-cache-control')).toBe(
       'max-age=1, stale-while-revalidate=31535999'
     )
@@ -556,7 +556,7 @@ describe('required server files', () => {
       redirect: 'manual',
     })
     expect(res2.status).toBe(404)
-    expect(res2.headers.get('cache-control')).toBe('max-age=0, must-revalidate')
+    expect(res2.headers.get('cache-control')).toBe('s-maxage=1')
     expect(res2.headers.get('cdn-cache-control')).toBe(
       'max-age=1, stale-while-revalidate=31535999'
     )


### PR DESCRIPTION
When we landed #76207 we started propagating the `stale-while-revalidate` value to RSC responses. We wanted a way to express to CDNs that it can keep serving the cached content for some time while a revalidation runs in the background, but we specifically don't want that for private caches. 

As a result of this header, when re-building your application locally (or doing something on the server that would have expired the cache), the browser's disk cache would serve a stale RSC response. We currently encode a buildId in RSC payloads, so the client router will discard RSC responses that don't match what it is expecting.

Unfortunately there isn't a `s-stale-while-revalidate` header to express the intended semantics. This moves the `stale-while-revalidate` configuration into the `CDN-Cache-Control` header, which is becoming standardized and is supported by a wide variety of CDNs. This allows us to specify the SWR behavior more explicitly to CDNs while not impacting private caches like the browser. It restores the previous behavior of only setting `s-maxage` on the `cache-control` itself to avoid influencing browser cache. 

If Next.js is deployed to a CDN that doesn't support this header, it can be customized via `nextConfig.experimental.cdnCacheControlHeader`. Eg, if deployed to Fastly, you'd configure this to `cdnCacheControlHeader: 'Surrogate-Control'`.

Closes NAR-525

Reference docs:

[Vercel](https://vercel.com/docs/headers/cache-control-headers#cdn-cache-control-header)
[Cloudflare](https://developers.cloudflare.com/cache/concepts/cdn-cache-control/)
[Fastly](https://www.fastly.com/documentation/reference/http/http-headers/Surrogate-Control/)

[RFC 9213](https://httpwg.org/specs/rfc9213.html)