### PR TITLE
Turbopack: Module::primary_chunkable_referenced_modules

### DIFF
--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -11,9 +11,7 @@ use turbo_tasks::{
     trace::TraceRawVcs,
 };
 use turbopack::css::chunk::CssChunkPlaceable;
-use turbopack_core::{
-    chunk::ChunkingType, module::Module, reference::primary_chunkable_referenced_modules,
-};
+use turbopack_core::{chunk::ChunkingType, module::Module};
 
 use crate::{
     next_client_reference::{
@@ -187,8 +185,9 @@ impl Visit<FindServerEntriesNode> for FindServerEntries {
         async move {
             // Pass include_traced to reuse the same cached `primary_chunkable_referenced_modules`
             // task result, but the traced references will be filtered out again afterwards.
-            let referenced_modules =
-                primary_chunkable_referenced_modules(parent_module, include_traced).await?;
+            let referenced_modules = parent_module
+                .primary_chunkable_referenced_modules(include_traced)
+                .await?;
 
             let referenced_modules = referenced_modules
                 .iter()

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -2,7 +2,12 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, TaskInput, ValueToString, Vc};
 use turbo_tasks_fs::glob::Glob;
 
-use crate::{asset::Asset, ident::AssetIdent, reference::ModuleReferences, source::OptionSource};
+use crate::{
+    asset::Asset,
+    ident::AssetIdent,
+    reference::{ModuleReferences, ModulesWithRefData, primary_chunkable_referenced_modules},
+    source::OptionSource,
+};
 
 #[derive(Clone, Copy, Debug, TaskInput, Hash)]
 #[turbo_tasks::value(shared)]
@@ -36,6 +41,14 @@ pub trait Module: Asset {
     #[turbo_tasks::function]
     fn references(self: Vc<Self>) -> Vc<ModuleReferences> {
         ModuleReferences::empty()
+    }
+
+    #[turbo_tasks::function]
+    fn primary_chunkable_referenced_modules(
+        self: Vc<Self>,
+        include_traced: bool,
+    ) -> Vc<ModulesWithRefData> {
+        primary_chunkable_referenced_modules(self, include_traced)
     }
 
     /// Signifies the module itself is async, e.g. it uses top-level await, is a wasm module, etc.

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -36,7 +36,7 @@ use crate::{
         style_groups::{StyleGroups, StyleGroupsConfig, compute_style_groups},
         traced_di_graph::TracedDiGraph,
     },
-    reference::{ModuleReference, primary_chunkable_referenced_modules},
+    reference::ModuleReference,
     resolve::BindingUsage,
 };
 
@@ -1671,7 +1671,7 @@ impl
         async move {
             Ok(match (module, chunkable_ref_target) {
                 (Some(module), None) => {
-                    let refs_cell = primary_chunkable_referenced_modules(*module, include_traced);
+                    let refs_cell = module.primary_chunkable_referenced_modules(include_traced);
                     let refs = match refs_cell.await {
                         Ok(refs) => refs,
                         Err(e) => {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -102,7 +102,7 @@ use turbopack_core::{
     module::{Module, OptionModule},
     module_graph::ModuleGraph,
     output::OutputAssetsReference,
-    reference::ModuleReferences,
+    reference::{ModuleReferences, ModulesWithRefData},
     reference_type::InnerAssets,
     resolve::{
         FindContextFileResult, find_context_file, origin::ResolveOrigin, package_json,
@@ -745,6 +745,15 @@ impl Module for EcmascriptModuleAsset {
     #[turbo_tasks::function]
     fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
         Ok(self.analyze().references())
+    }
+
+    #[turbo_tasks::function]
+    fn primary_chunkable_referenced_modules(
+        self: Vc<Self>,
+        include_traced: bool,
+    ) -> Vc<ModulesWithRefData> {
+        self.analyze()
+            .primary_chunkable_referenced_modules(include_traced)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -340,72 +340,42 @@ impl EsmAssetReference {
             *self.origin
         }
     }
-}
 
-impl EsmAssetReference {
-    pub fn new(
-        module: ResolvedVc<EcmascriptModuleAsset>,
-        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
-        request: RcStr,
-        issue_source: IssueSource,
-        annotations: ImportAnnotations,
-        export_name: Option<ModulePart>,
-        import_usage: ImportUsage,
-        import_externals: bool,
-        tree_shaking_mode: Option<TreeShakingMode>,
-    ) -> Self {
-        EsmAssetReference {
-            module,
-            origin,
-            request,
-            issue_source,
-            annotations,
-            export_name,
-            import_usage,
-            import_externals,
-            tree_shaking_mode,
-            is_pure_import: false,
+    pub fn chunking_type_ref(&self) -> Result<Option<ChunkingType>> {
+        if let Some(chunking_type) = self.annotations.chunking_type() {
+            if chunking_type == "parallel" {
+                Ok(Some(ChunkingType::Parallel {
+                    inherit_async: true,
+                    hoisted: true,
+                }))
+            } else if chunking_type == "none" {
+                Ok(None)
+            } else {
+                Err(anyhow!(
+                    "unknown chunking_type: {}",
+                    chunking_type.to_string_lossy()
+                ))
+            }
+        } else {
+            Ok(Some(ChunkingType::Parallel {
+                inherit_async: true,
+                hoisted: true,
+            }))
         }
     }
 
-    pub fn new_pure(
-        module: ResolvedVc<EcmascriptModuleAsset>,
-        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
-        request: RcStr,
-        issue_source: IssueSource,
-        annotations: ImportAnnotations,
-        export_name: Option<ModulePart>,
-        import_usage: ImportUsage,
-        import_externals: bool,
-        tree_shaking_mode: Option<TreeShakingMode>,
-    ) -> Self {
-        EsmAssetReference {
-            module,
-            origin,
-            request,
-            issue_source,
-            annotations,
-            export_name,
-            import_usage,
-            import_externals,
-            tree_shaking_mode,
-            is_pure_import: true,
+    pub fn binding_usage_ref(&self) -> BindingUsage {
+        BindingUsage {
+            import: self.import_usage.clone(),
+            export: match &self.export_name {
+                Some(ModulePart::Export(export_name)) => ExportUsage::Named(export_name.clone()),
+                Some(ModulePart::Evaluation) => ExportUsage::Evaluation,
+                _ => ExportUsage::All,
+            },
         }
     }
-}
 
-#[turbo_tasks::value_impl]
-impl EsmAssetReference {
-    #[turbo_tasks::function]
-    pub(crate) fn get_referenced_asset(self: Vc<Self>) -> Vc<ReferencedAsset> {
-        ReferencedAsset::from_resolve_result(self.resolve_reference())
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ModuleReference for EsmAssetReference {
-    #[turbo_tasks::function]
-    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+    pub async fn resolve_reference_ref(&self) -> Result<Vc<ModuleResolveResult>> {
         let ty = if self.annotations.module_type().is_some_and(|v| v == "json") {
             EcmaScriptModulesReferenceSubType::ImportWithType(ImportWithType::Json)
         } else if self.annotations.module_type().is_some_and(|v| v == "bytes") {
@@ -482,6 +452,74 @@ impl ModuleReference for EsmAssetReference {
     }
 }
 
+impl EsmAssetReference {
+    pub fn new(
+        module: ResolvedVc<EcmascriptModuleAsset>,
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: RcStr,
+        issue_source: IssueSource,
+        annotations: ImportAnnotations,
+        export_name: Option<ModulePart>,
+        import_usage: ImportUsage,
+        import_externals: bool,
+        tree_shaking_mode: Option<TreeShakingMode>,
+    ) -> Self {
+        EsmAssetReference {
+            module,
+            origin,
+            request,
+            issue_source,
+            annotations,
+            export_name,
+            import_usage,
+            import_externals,
+            tree_shaking_mode,
+            is_pure_import: false,
+        }
+    }
+
+    pub fn new_pure(
+        module: ResolvedVc<EcmascriptModuleAsset>,
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        request: RcStr,
+        issue_source: IssueSource,
+        annotations: ImportAnnotations,
+        export_name: Option<ModulePart>,
+        import_usage: ImportUsage,
+        import_externals: bool,
+        tree_shaking_mode: Option<TreeShakingMode>,
+    ) -> Self {
+        EsmAssetReference {
+            module,
+            origin,
+            request,
+            issue_source,
+            annotations,
+            export_name,
+            import_usage,
+            import_externals,
+            tree_shaking_mode,
+            is_pure_import: true,
+        }
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl EsmAssetReference {
+    #[turbo_tasks::function]
+    pub(crate) fn get_referenced_asset(self: Vc<Self>) -> Vc<ReferencedAsset> {
+        ReferencedAsset::from_resolve_result(self.resolve_reference())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ModuleReference for EsmAssetReference {
+    #[turbo_tasks::function]
+    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+        self.resolve_reference_ref().await
+    }
+}
+
 #[turbo_tasks::value_impl]
 impl ValueToString for EsmAssetReference {
     #[turbo_tasks::function]
@@ -494,41 +532,12 @@ impl ValueToString for EsmAssetReference {
 impl ChunkableModuleReference for EsmAssetReference {
     #[turbo_tasks::function]
     fn chunking_type(&self) -> Result<Vc<ChunkingTypeOption>> {
-        Ok(Vc::cell(
-            if let Some(chunking_type) = self.annotations.chunking_type() {
-                if chunking_type == "parallel" {
-                    Some(ChunkingType::Parallel {
-                        inherit_async: true,
-                        hoisted: true,
-                    })
-                } else if chunking_type == "none" {
-                    None
-                } else {
-                    return Err(anyhow!(
-                        "unknown chunking_type: {}",
-                        chunking_type.to_string_lossy()
-                    ));
-                }
-            } else {
-                Some(ChunkingType::Parallel {
-                    inherit_async: true,
-                    hoisted: true,
-                })
-            },
-        ))
+        Ok(Vc::cell(self.chunking_type_ref()?))
     }
 
     #[turbo_tasks::function]
     fn binding_usage(&self) -> Vc<BindingUsage> {
-        BindingUsage {
-            import: self.import_usage.clone(),
-            export: match &self.export_name {
-                Some(ModulePart::Export(export_name)) => ExportUsage::Named(export_name.clone()),
-                Some(ModulePart::Evaluation) => ExportUsage::Evaluation,
-                _ => ExportUsage::All,
-            },
-        }
-        .cell()
+        self.binding_usage_ref().cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -63,11 +63,12 @@ use tokio::sync::OnceCell;
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Upcast,
-    ValueToString, Vc, trace::TraceRawVcs,
+    FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryFlatJoinIterExt,
+    TryJoinIterExt, Upcast, ValueToString, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
+    chunk::{ChunkableModuleReference, ChunkingType},
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, DefinableNameSegment,
         FreeVarReference, FreeVarReferences, FreeVarReferencesIndividual, InputRelativeConstant,
@@ -76,7 +77,7 @@ use turbopack_core::{
     error::PrettyPrintError,
     issue::{IssueExt, IssueSeverity, IssueSource, StyledString, analyze::AnalyzeIssue},
     module::Module,
-    reference::{ModuleReference, ModuleReferences},
+    reference::{ModuleReference, ModuleReferences, ModulesWithRefData, ResolvedReference},
     reference_type::{CommonJsReferenceSubType, ReferenceType},
     resolve::{
         FindContextFileResult, ImportUsage, ModulePart, find_context_file,
@@ -196,6 +197,81 @@ impl AnalyzeEcmascriptModuleResult {
                 .chain(self.references.iter().copied())
                 .collect(),
         ))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn primary_chunkable_referenced_modules(
+        &self,
+        include_traced: bool,
+    ) -> Result<Vc<ModulesWithRefData>> {
+        let mut esm_references: Vec<(ResolvedVc<Box<dyn ModuleReference>>, ResolvedReference)> =
+            self.esm_references
+                .await?
+                .into_iter()
+                .map(async |&reference| {
+                    let reference_value = reference.await?;
+                    let resolved = reference_value
+                        .resolve_reference_ref()
+                        .await?
+                        .await?
+                        .primary_modules_ref()
+                        .await?;
+
+                    let Some(chunking_type) = reference_value.chunking_type_ref()? else {
+                        return Ok(None);
+                    };
+                    if !include_traced && matches!(chunking_type, ChunkingType::Traced) {
+                        return Ok(None);
+                    }
+
+                    Ok(Some((
+                        ResolvedVc::upcast(reference),
+                        ResolvedReference {
+                            chunking_type,
+                            binding_usage: reference_value.binding_usage_ref(),
+                            modules: resolved,
+                        },
+                    )))
+                })
+                .try_flat_join()
+                .await?;
+
+        let reference = self
+            .references
+            .iter()
+            .map(|reference| async {
+                if let Some(reference) =
+                    ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(*reference)
+                    && let Some(chunking_type) = &*reference.chunking_type().await?
+                {
+                    if !include_traced && matches!(chunking_type, ChunkingType::Traced) {
+                        return Ok(None);
+                    }
+
+                    let resolved = reference
+                        .resolve_reference()
+                        .await?
+                        .primary_modules_ref()
+                        .await?;
+                    let binding_usage = reference.binding_usage().owned().await?;
+
+                    return Ok(Some((
+                        ResolvedVc::upcast(reference),
+                        ResolvedReference {
+                            chunking_type: chunking_type.clone(),
+                            binding_usage,
+                            modules: resolved,
+                        },
+                    )));
+                }
+                Ok(None)
+            })
+            .try_flat_join()
+            .await?;
+
+        esm_references.extend(reference.into_iter());
+
+        Ok(Vc::cell(esm_references))
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
once again, difference is almost immeasurable 
```
this:
  Time (mean ± σ):      5.381 s ±  0.149 s    [User: 28.138 s, System: 3.603 s]
  Range (min … max):    5.283 s …  5.783 s    10 runs
canary:
  Time (mean ± σ):      5.541 s ±  0.054 s    [User: 28.472 s, System: 3.544 s]
  Range (min … max):    5.465 s …  5.637 s    10 runs
```