### PR TITLE
Turbopack: Remove dead `resolved_map` option for resolver

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -41,10 +41,7 @@ use crate::{
     next_client::runtime_entry::{RuntimeEntries, RuntimeEntry},
     next_config::NextConfig,
     next_font::local::NextFontLocalResolvePlugin,
-    next_import_map::{
-        get_next_client_fallback_import_map, get_next_client_import_map,
-        get_next_client_resolved_map,
-    },
+    next_import_map::{get_next_client_fallback_import_map, get_next_client_import_map},
     next_shared::{
         resolve::{
             ModuleFeatureReportResolvePlugin, NextSharedRuntimeResolvePlugin,
@@ -146,10 +143,6 @@ pub async fn get_client_resolve_options_context(
     let next_client_fallback_import_map = get_next_client_fallback_import_map(ty.clone())
         .to_resolved()
         .await?;
-    let next_client_resolved_map =
-        get_next_client_resolved_map(project_path.clone(), project_path.clone(), *mode.await?)
-            .to_resolved()
-            .await?;
     let mut custom_conditions: Vec<_> = mode.await?.custom_resolve_conditions().collect();
 
     if *next_config.enable_cache_components().await? {
@@ -161,7 +154,6 @@ pub async fn get_client_resolve_options_context(
         custom_conditions,
         import_map: Some(next_client_import_map),
         fallback_import_map: Some(next_client_fallback_import_map),
-        resolved_map: Some(next_client_resolved_map),
         browser: true,
         module: true,
         before_resolve_plugins: vec![

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -12,7 +12,7 @@ use turbopack_core::{
     resolve::{
         AliasPattern, ExternalTraced, ExternalType, ResolveAliasMap, SubpathValue,
         node::node_cjs_resolve_options,
-        options::{ConditionValue, ImportMap, ImportMapping, ResolvedMap},
+        options::{ConditionValue, ImportMap, ImportMapping},
         parse::Request,
         pattern::Pattern,
         resolve,
@@ -594,18 +594,6 @@ async fn insert_unsupported_node_internal_aliases(import_map: &mut ImportMap) ->
         import_map.insert_alias(AliasPattern::exact(module.clone()), unsupported_replacer);
     });
     Ok(())
-}
-
-pub fn get_next_client_resolved_map(
-    _context: FileSystemPath,
-    _root: FileSystemPath,
-    _mode: NextMode,
-) -> Vc<ResolvedMap> {
-    let glob_mappings = vec![];
-    ResolvedMap {
-        by_glob: glob_mappings,
-    }
-    .cell()
 }
 
 static NEXT_ALIASES: LazyLock<[(RcStr, RcStr); 23]> = LazyLock::new(|| {

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1873,8 +1873,6 @@ async fn resolve_internal_inline(
                                 resolved(
                                     RequestKey::new(matched_pattern.clone()),
                                     path.clone(),
-                                    lookup_path.clone(),
-                                    request,
                                     options_value,
                                     options,
                                     query.clone(),
@@ -1902,7 +1900,6 @@ async fn resolve_internal_inline(
             } => {
                 resolve_relative_request(
                     lookup_path.clone(),
-                    request,
                     options,
                     options_value,
                     path,
@@ -1920,7 +1917,6 @@ async fn resolve_internal_inline(
             } => {
                 resolve_module_request(
                     lookup_path.clone(),
-                    request,
                     options,
                     options_value,
                     module,
@@ -2214,7 +2210,6 @@ async fn resolve_into_folder(
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_relative_request(
     lookup_path: FileSystemPath,
-    request: Vc<Request>,
     options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
     path_pattern: &Pattern,
@@ -2337,8 +2332,6 @@ async fn resolve_relative_request(
                                 resolved(
                                     RequestKey::new(matched_pattern.into()),
                                     path.clone(),
-                                    lookup_path.clone(),
-                                    request,
                                     options_value,
                                     options,
                                     query.clone(),
@@ -2354,8 +2347,6 @@ async fn resolve_relative_request(
                             resolved(
                                 RequestKey::new(matched_pattern.into()),
                                 path.clone(),
-                                lookup_path.clone(),
-                                request,
                                 options_value,
                                 options,
                                 query.clone(),
@@ -2374,8 +2365,6 @@ async fn resolve_relative_request(
                         resolved(
                             RequestKey::new(matched_pattern.into()),
                             path.clone(),
-                            lookup_path.clone(),
-                            request,
                             options_value,
                             options,
                             query.clone(),
@@ -2392,8 +2381,6 @@ async fn resolve_relative_request(
                     resolved(
                         RequestKey::new(matched_pattern.clone()),
                         path.clone(),
-                        lookup_path.clone(),
-                        request,
                         options_value,
                         options,
                         query.clone(),
@@ -2558,7 +2545,6 @@ async fn find_self_reference(
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_module_request(
     lookup_path: FileSystemPath,
-    request: Vc<Request>,
     options: Vc<ResolveOptions>,
     options_value: &ResolveOptions,
     module: &Pattern,
@@ -2642,8 +2628,6 @@ async fn resolve_module_request(
                     let resolved = resolved(
                         RequestKey::new(rcstr!(".")),
                         file.clone(),
-                        lookup_path.clone(),
-                        request,
                         options_value,
                         options,
                         query.clone(),
@@ -2861,8 +2845,6 @@ async fn resolve_import_map_result(
 async fn resolved(
     request_key: RequestKey,
     fs_path: FileSystemPath,
-    original_context: FileSystemPath,
-    original_request: Vc<Request>,
     options_value: &ResolveOptions,
     options: Vc<ResolveOptions>,
     query: RcStr,
@@ -2889,25 +2871,6 @@ async fn resolved(
         return Ok(result);
     }
 
-    if let Some(resolved_map) = options_value.resolved_map {
-        let result = resolved_map
-            .lookup(path.clone(), original_context.clone(), original_request)
-            .await?;
-
-        let resolved_result = resolve_import_map_result(
-            &result,
-            path.parent(),
-            original_context.clone(),
-            original_request,
-            options,
-            query.clone(),
-        )
-        .await?;
-
-        if let Some(result) = resolved_result {
-            return Ok(result);
-        }
-    }
     let source = ResolvedVc::upcast(
         FileSource::new_with_query_and_fragment(path.clone(), query, fragment)
             .to_resolved()

--- a/turbopack/crates/turbopack-resolve/src/resolve.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve.rs
@@ -200,7 +200,6 @@ async fn base_resolve_options(
         },
         default_files: vec![rcstr!("index")],
         import_map: Some(import_map),
-        resolved_map: opt.resolved_map,
         after_resolve_plugins: opt.after_resolve_plugins.clone(),
         before_resolve_plugins: opt.before_resolve_plugins.clone(),
         loose_errors: opt.loose_errors,

--- a/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
+++ b/turbopack/crates/turbopack-resolve/src/resolve_options_context.rs
@@ -6,7 +6,7 @@ use turbopack_core::{
     condition::ContextCondition,
     environment::Environment,
     resolve::{
-        options::{ImportMap, ResolvedMap},
+        options::ImportMap,
         plugin::{AfterResolvePlugin, BeforeResolvePlugin},
     },
 };
@@ -66,9 +66,6 @@ pub struct ResolveOptionsContext {
     /// `ResolveOption::fallback_import_map`. It is always applied last, so
     /// any mapping defined within will take precedence over any other.
     pub fallback_import_map: Option<ResolvedVc<ImportMap>>,
-    #[serde(default)]
-    /// An additional resolved map to use after modules have been resolved.
-    pub resolved_map: Option<ResolvedVc<ResolvedMap>>,
     #[serde(default)]
     /// A list of rules to use a different resolve option context for certain
     /// context paths. The first matching is used.


### PR DESCRIPTION
This was added in <https://github.com/vercel/next.js/commit/ddee23b2e3e0446f0fe166a94fb7a379b32ece30>. It appears the intent was to allow intercepting and substituting certain next.js internal modules.

We use `AfterResolvePlugin` for that use-case these days, so this doesn't seem useful anymore?