### PR TITLE
Allow disabling error patching for debugging

### DIFF
--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -473,6 +473,10 @@ function sourceMapError(
 export function patchErrorInspectNodeJS(
   errorConstructor: ErrorConstructor
 ): void {
+  if (process.env.NEXT_DISABLE_ERROR_PATCHING === '1') {
+    return
+  }
+
   const inspectSymbol = Symbol.for('nodejs.util.inspect.custom')
 
   errorConstructor.prepareStackTrace = prepareUnsourcemappedStackTrace
@@ -513,6 +517,10 @@ export function patchErrorInspectNodeJS(
 export function patchErrorInspectEdgeLite(
   errorConstructor: ErrorConstructor
 ): void {
+  if (process.env.NEXT_DISABLE_ERROR_PATCHING === '1') {
+    return
+  }
+
   const inspectSymbol = Symbol.for('edge-runtime.inspect.custom')
 
   errorConstructor.prepareStackTrace = prepareUnsourcemappedStackTrace


### PR DESCRIPTION
I constantly find myself commenting out this function. Something like this would be useful for debugging.

@eps1lon what do you think?