### PR TITLE
Turbopack: keep sideeffectful barrel file

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-side-effect-barrel/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-side-effect-barrel/input/index.js
@@ -1,0 +1,5 @@
+import { ObjectElement } from './library'
+
+it('shoudl not discard side-effectful barrel files', () => {
+  expect(ObjectElement.foo).toBe('side-effect')
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-side-effect-barrel/input/library/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-side-effect-barrel/input/library/index.js
@@ -1,0 +1,1 @@
+export { ObjectElement } from './registration'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-side-effect-barrel/input/library/object.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-side-effect-barrel/input/library/object.js
@@ -1,0 +1,1 @@
+export const ObjectElement = {}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-side-effect-barrel/input/library/package.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-side-effect-barrel/input/library/package.json
@@ -1,0 +1,5 @@
+{
+  "sideEffects": [
+    "./registration.js"
+  ]
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-side-effect-barrel/input/library/registration.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-side-effect-barrel/input/library/registration.js
@@ -1,0 +1,3 @@
+import { ObjectElement } from './object'
+ObjectElement.foo = 'side-effect'
+export { ObjectElement }


### PR DESCRIPTION
Turbopack incorrectly ignores the second barrel file and drops the assignment.

Closes PACK-5995
Closes #86507


- [x] Test
- [ ] Fix