### PR TITLE
Don't run bundle-analyzer dev script with turborepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "lerna clean -y && lerna bootstrap && lerna run clean && lerna exec 'node ../../scripts/rm.mjs dist'",
     "build": "turbo run build --remote-cache-timeout 60 --summarize true",
     "lerna": "lerna",
-    "dev": "turbo run dev --parallel",
+    "dev": "turbo run dev --parallel --filter='!@next/bundle-analyzer-ui'",
     "pack-next": "tsx scripts/pack-next.ts",
     "test-types": "tsc",
     "test-unit": "jest test/unit/ packages/next/ packages/font",


### PR DESCRIPTION
No reason to always run that with `pnpm dev`