### PR TITLE
WIP: perf: Don't inject the entire nextConfig in edge templates

### DIFF
--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -145,17 +145,14 @@ async fn wrap_edge_page(
 ) -> Result<Vc<Box<dyn Module>>> {
     const INNER: &str = "INNER_PAGE_ENTRY";
 
-    let next_config_val = &*next_config.await?;
-
     let source = load_next_js_template(
         "edge-ssr-app.js",
         project_root.clone(),
         &[("VAR_USERLAND", INNER), ("VAR_PAGE", &page.to_string())],
-        &[
-            // TODO do we really need to pass the entire next config here?
-            // This is bad for invalidation as any config change will invalidate this
-            ("nextConfig", &*serde_json::to_string(next_config_val)?),
-        ],
+        &[(
+            "cacheMaxMemorySize",
+            &*serde_json::to_string(&next_config.cache_max_memory_size().await?)?,
+        )],
         &[("incrementalCacheHandler", None)],
     )
     .await?;

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -136,13 +136,14 @@ async fn wrap_edge_route(
 ) -> Result<Vc<Box<dyn Module>>> {
     let inner = rcstr!("INNER_ROUTE_ENTRY");
 
-    let next_config = &*next_config.await?;
-
     let source = load_next_js_template(
         "edge-app-route.js",
         project_root.clone(),
         &[("VAR_USERLAND", &*inner), ("VAR_PAGE", &page.to_string())],
-        &[("nextConfig", &*serde_json::to_string(next_config)?)],
+        &[(
+            "cacheLifeProfiles",
+            &*serde_json::to_string(&next_config.cache_life().await?)?,
+        )],
         &[],
     )
     .await?;

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -81,10 +81,11 @@ pub struct NextConfig {
     config_file: Option<RcStr>,
     config_file_name: RcStr,
 
+    cache_life: Option<JsonValue>,
     /// In-memory cache size in bytes.
     ///
     /// If `cache_max_memory_size: 0` disables in-memory caching.
-    cache_max_memory_size: Option<f64>,
+    cache_max_memory_size: Option<JsonValue>,
     /// custom path to a cache handler to use
     cache_handler: Option<RcStr>,
     cache_handlers: Option<FxIndexMap<RcStr, RcStr>>,
@@ -835,7 +836,6 @@ pub struct ExperimentalConfig {
     adjust_font_fallbacks_with_size_adjust: Option<bool>,
     after: Option<bool>,
     app_document_preloading: Option<bool>,
-    cache_life: Option<FxIndexMap<String, CacheLifeProfile>>,
     case_sensitive_routes: Option<bool>,
     cpus: Option<f64>,
     cra_compat: Option<bool>,
@@ -906,63 +906,6 @@ pub struct ExperimentalConfig {
     turbopack_remove_unused_exports: Option<bool>,
     /// Devtool option for the segment explorer.
     devtool_segment_explorer: Option<bool>,
-}
-
-#[derive(
-    Clone, Debug, PartialEq, Serialize, Deserialize, TraceRawVcs, NonLocalValue, OperationValue,
-)]
-#[serde(rename_all = "camelCase")]
-pub struct CacheLifeProfile {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stale: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub revalidate: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub expire: Option<u32>,
-}
-
-#[test]
-fn test_cache_life_profiles() {
-    let json = serde_json::json!({
-        "cacheLife": {
-            "frequent": {
-                "stale": 19,
-                "revalidate": 100,
-            },
-        }
-    });
-
-    let config: ExperimentalConfig = serde_json::from_value(json).unwrap();
-    let mut expected_cache_life = FxIndexMap::default();
-
-    expected_cache_life.insert(
-        "frequent".to_string(),
-        CacheLifeProfile {
-            stale: Some(19),
-            revalidate: Some(100),
-            expire: None,
-        },
-    );
-
-    assert_eq!(config.cache_life, Some(expected_cache_life));
-}
-
-#[test]
-fn test_cache_life_profiles_invalid() {
-    let json = serde_json::json!({
-        "cacheLife": {
-            "invalid": {
-                "stale": "invalid_value",
-            },
-        }
-    });
-
-    let result: Result<ExperimentalConfig, _> = serde_json::from_value(json);
-
-    assert!(
-        result.is_err(),
-        "Deserialization should fail due to invalid 'stale' value type"
-    );
 }
 
 #[derive(
@@ -1310,6 +1253,16 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn base_path(&self) -> Vc<Option<RcStr>> {
         Vc::cell(self.base_path.clone())
+    }
+
+    #[turbo_tasks::function]
+    pub fn cache_life(&self) -> Vc<OptionJsonValue> {
+        Vc::cell(self.cache_life.clone())
+    }
+
+    #[turbo_tasks::function]
+    pub fn cache_max_memory_size(&self) -> Vc<OptionJsonValue> {
+        Vc::cell(self.cache_max_memory_size.clone())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -223,8 +223,6 @@ async fn wrap_edge_page(
     const INNER_ERROR: &str = "INNER_ERROR";
     const INNER_ERROR_500: &str = "INNER_500";
 
-    let next_config_val = &*next_config.await?;
-
     let source = load_next_js_template(
         "edge-ssr.js",
         project_root.clone(),
@@ -236,9 +234,10 @@ async fn wrap_edge_page(
             ("VAR_MODULE_GLOBAL_ERROR", INNER_ERROR),
         ],
         &[
-            // TODO do we really need to pass the entire next config here?
-            // This is bad for invalidation as any config change will invalidate this
-            ("nextConfig", &*serde_json::to_string(next_config_val)?),
+            (
+                "cacheMaxMemorySize",
+                &*serde_json::to_string(&next_config.cache_max_memory_size().await?)?,
+            ),
             (
                 "pageRouteModuleOptions",
                 &serde_json::to_string(&get_route_module_options(page.clone(), pathname.clone()))?,

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -616,7 +616,9 @@ export function getEdgeServerEntry(opts: {
       absolutePagePath: opts.absolutePagePath,
       page: opts.page,
       appDirLoader: Buffer.from(opts.appDirLoader || '').toString('base64'),
-      nextConfig: Buffer.from(JSON.stringify(opts.config)).toString('base64'),
+      cacheLifeProfiles: Buffer.from(
+        JSON.stringify(opts.config.cacheLife)
+      ).toString('base64'),
       preferredRegion: opts.preferredRegion,
       middlewareConfig: Buffer.from(
         JSON.stringify(opts.middlewareConfig || {})
@@ -677,9 +679,7 @@ export function getEdgeServerEntry(opts: {
     dev: opts.isDev,
     isServerComponent: opts.isServerComponent,
     page: opts.page,
-    stringifiedConfig: Buffer.from(JSON.stringify(opts.config)).toString(
-      'base64'
-    ),
+    cacheMaxMemorySize: JSON.stringify(opts.config.cacheMaxMemorySize),
     pagesType: opts.pagesType,
     appDirLoader: Buffer.from(opts.appDirLoader || '').toString('base64'),
     sriEnabled: !opts.isDev && !!opts.config.experimental.sri?.algorithm,

--- a/packages/next/src/build/templates/edge-app-route.ts
+++ b/packages/next/src/build/templates/edge-app-route.ts
@@ -7,8 +7,8 @@ import { EdgeRouteModuleWrapper } from '../../server/web/edge-route-module-wrapp
 import * as module from 'VAR_USERLAND'
 
 // injected by the loader afterwards.
-declare const nextConfig: NextConfigComplete
-// INJECT:nextConfig
+declare const cacheLifeProfiles: NextConfigComplete['cacheLife']
+// INJECT:cacheLifeProfiles
 
 const maybeJSONParse = (str?: string) => (str ? JSON.parse(str) : undefined)
 
@@ -28,4 +28,6 @@ if (rscManifest && rscServerManifest) {
 
 export const ComponentMod = module
 
-export default EdgeRouteModuleWrapper.wrap(module.routeModule, { nextConfig })
+export default EdgeRouteModuleWrapper.wrap(module.routeModule, {
+  cacheLifeProfiles,
+})

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -5,7 +5,6 @@ import { IncrementalCache } from '../../server/lib/incremental-cache'
 import * as pageMod from 'VAR_USERLAND'
 
 import type { RequestData } from '../../server/web/types'
-import type { NextConfigComplete } from '../../server/config-shared'
 import { setReferenceManifestsSingleton } from '../../server/app-render/encryption-utils'
 import { createServerModuleMap } from '../../server/app-render/action-utils'
 import { initializeCacheHandlers } from '../../server/use-cache/handlers'
@@ -27,12 +26,12 @@ import { checkIsOnDemandRevalidate } from '../../server/api-utils'
 import { CloseController } from '../../server/web/web-on-close'
 
 declare const incrementalCacheHandler: any
-declare const nextConfig: NextConfigComplete
+declare const cacheMaxMemorySize: number
 // OPTIONAL_IMPORT:incrementalCacheHandler
-// INJECT:nextConfig
+// INJECT:cacheMaxMemorySize
 
 // Initialize the cache handlers interface.
-initializeCacheHandlers(nextConfig.cacheMaxMemorySize)
+initializeCacheHandlers(cacheMaxMemorySize)
 
 const maybeJSONParse = (str?: string) => (str ? JSON.parse(str) : undefined)
 
@@ -77,6 +76,7 @@ async function requestHandler(
   const {
     query,
     params,
+    nextConfig,
     buildId,
     buildManifest,
     prerenderManifest,

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -19,7 +19,6 @@ import RouteModule, {
 import { WebNextRequest, WebNextResponse } from '../../server/base-http/web'
 
 import type { RequestData } from '../../server/web/types'
-import type { NextConfigComplete } from '../../server/config-shared'
 import type { NextFetchEvent } from '../../server/web/spec-extension/fetch-event'
 import type RenderResult from '../../server/render-result'
 import type { RenderResultMetadata } from '../../server/render-result'
@@ -28,20 +27,17 @@ import { BaseServerSpan } from '../../server/lib/trace/constants'
 import { HTML_CONTENT_TYPE_HEADER } from '../../lib/constants'
 
 // injected by the loader afterwards.
-declare const nextConfig: NextConfigComplete
+declare const cacheMaxMemorySize: number
 declare const pageRouteModuleOptions: any
 declare const errorRouteModuleOptions: any
 declare const user500RouteModuleOptions: any
-// INJECT:nextConfig
+// INJECT:cacheMaxMemorySize
 // INJECT:pageRouteModuleOptions
 // INJECT:errorRouteModuleOptions
 // INJECT:user500RouteModuleOptions
 
 // Initialize the cache handlers interface.
-initializeCacheHandlers(nextConfig.cacheMaxMemorySize)
-
-// expose this for the route-module
-;(globalThis as any).nextConfig = nextConfig
+initializeCacheHandlers(cacheMaxMemorySize)
 
 const pageMod = {
   ...userlandPage,
@@ -106,6 +102,7 @@ async function requestHandler(
   const {
     query,
     params,
+    nextConfig,
     buildId,
     isNextDataRequest,
     buildManifest,

--- a/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
@@ -11,7 +11,7 @@ export type EdgeAppRouteLoaderQuery = {
   page: string
   appDirLoader: string
   preferredRegion: string | string[] | undefined
-  nextConfig: string
+  cacheLifeProfiles: string
   middlewareConfig: string
   cacheHandlers: string
 }
@@ -24,7 +24,7 @@ const EdgeAppRouteLoader: webpack.LoaderDefinitionFunction<EdgeAppRouteLoaderQue
       preferredRegion,
       appDirLoader: appDirLoaderBase64 = '',
       middlewareConfig: middlewareConfigBase64 = '',
-      nextConfig: nextConfigBase64,
+      cacheLifeProfiles: cacheLifeProfilesBase64,
       cacheHandlers: cacheHandlersStringified,
     } = this.getOptions()
 
@@ -64,8 +64,8 @@ const EdgeAppRouteLoader: webpack.LoaderDefinitionFunction<EdgeAppRouteLoaderQue
       stringifiedPagePath.length - 1
     )}?${WEBPACK_RESOURCE_QUERIES.edgeSSREntry}`
 
-    const stringifiedConfig = Buffer.from(
-      nextConfigBase64 || '',
+    const stringifiedCacheLifeProfiles = Buffer.from(
+      cacheLifeProfilesBase64 || '',
       'base64'
     ).toString()
 
@@ -76,7 +76,7 @@ const EdgeAppRouteLoader: webpack.LoaderDefinitionFunction<EdgeAppRouteLoaderQue
         VAR_PAGE: page,
       },
       {
-        nextConfig: stringifiedConfig,
+        cacheLifeProfiles: stringifiedCacheLifeProfiles,
       }
     )
   }

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -19,7 +19,7 @@ export type EdgeSSRLoaderQuery = {
   dev: boolean
   isServerComponent: boolean
   page: string
-  stringifiedConfig: string
+  cacheMaxMemorySize: string
   appDirLoader?: string
   pagesType: PAGE_TYPES
   sriEnabled: boolean
@@ -73,7 +73,7 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
       absolute500Path,
       absoluteErrorPath,
       isServerComponent,
-      stringifiedConfig: stringifiedConfigBase64,
+      cacheMaxMemorySize: cacheMaxMemorySizeStringified,
       appDirLoader: appDirLoaderBase64,
       pagesType,
       cacheHandler,
@@ -94,10 +94,6 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
       Buffer.from(middlewareConfigBase64, 'base64').toString()
     )
 
-    const stringifiedConfig = Buffer.from(
-      stringifiedConfigBase64 || '',
-      'base64'
-    ).toString()
     const appDirLoader = Buffer.from(
       appDirLoaderBase64 || '',
       'base64'
@@ -161,7 +157,7 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
           VAR_PAGE: page,
         },
         {
-          nextConfig: stringifiedConfig,
+          cacheMaxMemorySize: cacheMaxMemorySizeStringified,
         },
         {
           incrementalCacheHandler: cacheHandler ?? null,
@@ -178,7 +174,7 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
           VAR_MODULE_GLOBAL_ERROR: errorPath,
         },
         {
-          nextConfig: stringifiedConfig,
+          cacheMaxMemorySize: cacheMaxMemorySizeStringified,
           pageRouteModuleOptions: JSON.stringify(getRouteModuleOptions(page)),
           errorRouteModuleOptions: JSON.stringify(
             getRouteModuleOptions('/_error')

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -18,7 +18,7 @@ import { getEdgePreviewProps } from './get-edge-preview-props'
 import type { NextConfigComplete } from '../config-shared'
 
 export interface WrapOptions {
-  nextConfig: NextConfigComplete
+  cacheLifeProfiles: NextConfigComplete['cacheLife']
 }
 
 /**
@@ -37,7 +37,7 @@ export class EdgeRouteModuleWrapper {
    */
   private constructor(
     private readonly routeModule: AppRouteRouteModule,
-    private readonly nextConfig: NextConfigComplete
+    private readonly cacheLifeProfiles: NextConfigComplete['cacheLife']
   ) {
     // TODO: (wyattjoh) possibly allow the module to define it's own matcher
     this.matcher = new RouteMatcher(routeModule.definition)
@@ -54,7 +54,10 @@ export class EdgeRouteModuleWrapper {
    */
   public static wrap(routeModule: AppRouteRouteModule, options: WrapOptions) {
     // Create the module wrapper.
-    const wrapper = new EdgeRouteModuleWrapper(routeModule, options.nextConfig)
+    const wrapper = new EdgeRouteModuleWrapper(
+      routeModule,
+      options.cacheLifeProfiles
+    )
 
     // Return the wrapping function.
     return (opts: AdapterOptions) => {
@@ -111,7 +114,7 @@ export class EdgeRouteModuleWrapper {
         experimental: {
           authInterrupts: !!process.env.__NEXT_EXPERIMENTAL_AUTH_INTERRUPTS,
         },
-        cacheLifeProfiles: this.nextConfig.cacheLife,
+        cacheLifeProfiles: this.cacheLifeProfiles,
       },
       sharedContext: {
         buildId: '', // TODO: Populate this properly.


### PR DESCRIPTION
It looks like we only do this for the edge runtime. This is bad because:

- It's a lot of extra data to copy around and write out to disk.
- It increases the chance of cache invalidation within Turbopack.
- It means that Turbopack must understand how to serialize `NextConfig`, which means rustc needs to generate some pretty large functions. And Turbopack's `NextConfig` is pretty incomplete, so relying on that is risky.
- It potentially means more invalidations for the reusable deployment outputs project.

Let's see what CI thinks of this change...