### PR TITLE
Turbopack: bincode: Migrate TaskInput serialization to bincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9238,7 +9238,6 @@ dependencies = [
  "turbo-tasks-macros",
  "turbo-tasks-malloc",
  "unsize",
- "unty",
 ]
 
 [[package]]
@@ -9288,6 +9287,7 @@ dependencies = [
  "afl",
  "anyhow",
  "arbitrary",
+ "bincode 2.0.1",
  "libfuzzer-sys",
  "once_cell",
  "serde",
@@ -9426,6 +9426,7 @@ name = "turbo-tasks-macros-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "serde",
  "tokio",
  "trybuild",
@@ -9566,6 +9567,7 @@ name = "turbopack-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
  "clap",
  "codspeed-criterion-compat",
  "console-subscriber",

--- a/crates/next-api/src/operation.rs
+++ b/crates/next-api/src/operation.rs
@@ -123,6 +123,8 @@ fn pick_route(entrypoints: OperationVc<Entrypoints>, key: RcStr, route: &Route) 
     ValueDebugFormat,
     NonLocalValue,
     OperationValue,
+    Encode,
+    Decode,
 )]
 enum EndpointSelector {
     RoutePageHtml(RcStr),

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -612,7 +612,18 @@ enum PageEndpointType {
 }
 
 #[derive(
-    Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Debug, TaskInput, TraceRawVcs,
+    Copy,
+    Clone,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    TaskInput,
+    TraceRawVcs,
+    Encode,
+    Decode,
 )]
 enum SsrChunkType {
     Page,
@@ -621,7 +632,18 @@ enum SsrChunkType {
 }
 
 #[derive(
-    Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, TaskInput, TraceRawVcs,
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    TaskInput,
+    TraceRawVcs,
+    Encode,
+    Decode,
 )]
 enum EmitManifests {
     /// Don't emit any manifests

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -209,10 +209,6 @@ pub struct ProjectOptions {
     pub current_node_js_version: RcStr,
 }
 
-#[derive(
-    Debug, Serialize, Deserialize, Clone, TaskInput, PartialEq, Eq, Hash, TraceRawVcs, NonLocalValue,
-)]
-#[serde(rename_all = "camelCase")]
 pub struct PartialProjectOptions {
     /// A root path from which all files must be nested under. Trying to access
     /// a file outside this root will fail. Think of this as a chroot.

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
@@ -32,11 +33,13 @@ use turbopack_node::{
 };
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 
-use super::transforms::get_next_client_transforms_rules;
 use crate::{
     mode::NextMode,
     next_build::get_postcss_package_mapping,
-    next_client::runtime_entry::{RuntimeEntries, RuntimeEntry},
+    next_client::{
+        runtime_entry::{RuntimeEntries, RuntimeEntry},
+        transforms::get_next_client_transforms_rules,
+    },
     next_config::NextConfig,
     next_font::local::NextFontLocalResolvePlugin,
     next_import_map::{
@@ -405,7 +408,19 @@ pub async fn get_client_module_options_context(
     Ok(module_options_context)
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, TaskInput, TraceRawVcs, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    TaskInput,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+)]
 pub struct ClientChunkingContextOptions {
     pub mode: Vc<NextMode>,
     pub root_path: FileSystemPath,

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
@@ -196,7 +197,19 @@ pub async fn get_edge_resolve_options_context(
     .cell())
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, TaskInput, TraceRawVcs, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    TaskInput,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+)]
 pub struct EdgeChunkingContextOptions {
     pub mode: Vc<NextMode>,
     pub root_path: FileSystemPath,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
@@ -38,10 +39,6 @@ use turbopack_node::{
 use turbopack_nodejs::NodeJsChunkingContext;
 use turbopack_resolve::resolve_options_context::ResolveOptionsContext;
 
-use super::{
-    resolve::ExternalCjsModulesResolvePlugin,
-    transforms::{get_next_server_internal_transforms_rules, get_next_server_transforms_rules},
-};
 use crate::{
     app_structure::CollectedRootParams,
     mode::NextMode,
@@ -49,7 +46,10 @@ use crate::{
     next_config::NextConfig,
     next_font::local::NextFontLocalResolvePlugin,
     next_import_map::{get_next_edge_and_server_fallback_import_map, get_next_server_import_map},
-    next_server::resolve::ExternalPredicate,
+    next_server::{
+        resolve::{ExternalCjsModulesResolvePlugin, ExternalPredicate},
+        transforms::{get_next_server_internal_transforms_rules, get_next_server_transforms_rules},
+    },
     next_shared::{
         resolve::{
             ModuleFeatureReportResolvePlugin, NextExternalResolvePlugin,
@@ -981,7 +981,19 @@ pub async fn get_server_module_options_context(
     Ok(module_options_context)
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, TaskInput, TraceRawVcs, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    TaskInput,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+)]
 pub struct ServerChunkingContextOptions {
     pub mode: Vc<NextMode>,
     pub root_path: FileSystemPath,

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -59,7 +59,18 @@ pub fn defines(define_env: &FxIndexMap<RcStr, Option<RcStr>>) -> CompileTimeDefi
 }
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, TaskInput, Serialize, Deserialize, TraceRawVcs,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    TaskInput,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    Encode,
+    Decode,
 )]
 pub enum PathType {
     PagesPage,

--- a/turbopack/crates/turbo-bincode/src/lib.rs
+++ b/turbopack/crates/turbo-bincode/src/lib.rs
@@ -1,7 +1,7 @@
 #[doc(hidden)]
 pub mod macro_helpers;
 
-use std::ptr::copy_nonoverlapping;
+use std::{any::Any, ptr::copy_nonoverlapping};
 
 use ::smallvec::SmallVec;
 use bincode::{
@@ -17,6 +17,8 @@ pub type TurboBincodeEncoder<'a> =
     EncoderImpl<TurboBincodeWriter<'a>, bincode::config::Configuration>;
 pub type TurboBincodeDecoder<'a> =
     DecoderImpl<TurboBincodeReader<'a>, bincode::config::Configuration, ()>;
+pub type AnyEncodeFn = fn(&dyn Any, &mut TurboBincodeEncoder<'_>) -> Result<(), EncodeError>;
+pub type AnyDecodeFn<T> = fn(&mut TurboBincodeDecoder<'_>) -> Result<T, DecodeError>;
 
 fn new_turbo_bincode_encoder(buf: &mut TurboBincodeBuffer) -> TurboBincodeEncoder<'_> {
     EncoderImpl::new(TurboBincodeWriter::new(buf), TURBO_BINCODE_CONFIG)

--- a/turbopack/crates/turbo-tasks-backend/fuzz/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 afl = "0.15.18"
 anyhow = { workspace = true }
 arbitrary = { version = "1.4.1", features = ["derive"] }
+bincode = { workspace = true }
 libfuzzer-sys = "0.4.9"
 once_cell = { workspace = true }
 serde = { workspace = true }

--- a/turbopack/crates/turbo-tasks-backend/fuzz/src/graph.rs
+++ b/turbopack/crates/turbo-tasks-backend/fuzz/src/graph.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use arbitrary::Arbitrary;
+use bincode::{Decode, Encode};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{self, NonLocalValue, State, TaskInput, TurboTasks, Vc, trace::TraceRawVcs};
@@ -19,6 +20,8 @@ use turbo_tasks_malloc::TurboMalloc;
     Deserialize,
     TraceRawVcs,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub struct TaskReferenceSpec {
     task: u16,
@@ -39,6 +42,8 @@ pub struct TaskReferenceSpec {
     Deserialize,
     TraceRawVcs,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub struct TaskSpec {
     references: Vec<TaskReferenceSpec>,

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -604,17 +604,6 @@ fn encode_task_type(
     buffer: &mut TurboBincodeBuffer,
     task_id: Option<TaskId>,
 ) -> Result<()> {
-    // DO NOT REMOVE THE `inline(never)` ATTRIBUTE!
-    // CachedTaskType's `Encode`/`Decode` implementations use `pot` internally for `TaskInput`s.
-    // TODO: remove `serde` and `pot`, make `TaskInput: Encode + Decode`.
-    //
-    // `pot` uses the pointer address of `&'static str` to deduplicate Symbols.
-    // If this function is inlined into multiple different callsites it might inline the Serialize
-    // implementation too, which can pull a `&'static str` from another crate into this crate.
-    // Since string deduplication between crates is not guaranteed, it can lead to behavior changes
-    // due to the pointer addresses. This can lead to lookup path and store path creating different
-    // serialization of the same task type, which breaks task cache lookups.
-    #[inline(never)]
     fn encode_once_into(
         task_type: &CachedTaskType,
         buffer: &mut TurboBincodeBuffer,

--- a/turbopack/crates/turbo-tasks-backend/tests/trace_transient.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trace_transient.rs
@@ -2,7 +2,7 @@
 #![feature(arbitrary_self_types_pointers)]
 
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_testing::{Registration, register, run_once_without_cache_check};
 
@@ -62,9 +62,7 @@ async fn read_incorrect_task_input_operation(value: IncorrectTaskInput) -> Resul
 
 /// Has an intentionally incorrect `TaskInput` implementation, representing some code that the debug
 /// tracing might be particularly useful with.
-#[derive(
-    Copy, Clone, Debug, PartialEq, Eq, Hash, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
-)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, TraceRawVcs, Encode, Decode, NonLocalValue)]
 struct IncorrectTaskInput(ResolvedVc<u64>);
 
 impl TaskInput for IncorrectTaskInput {

--- a/turbopack/crates/turbo-tasks-backend/tests/transient_collectible.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/transient_collectible.rs
@@ -1,7 +1,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, trace::TraceRawVcs};
 use turbo_tasks_testing::{Registration, register, run_once_without_cache_check};
 
@@ -30,9 +30,7 @@ fn emit_incorrect_task_input_operation(value: IncorrectTaskInput) {
 }
 
 /// Has an intentionally incorrect `TaskInput` implementation
-#[derive(
-    Copy, Clone, Debug, PartialEq, Eq, Hash, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
-)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, TraceRawVcs, Encode, Decode, NonLocalValue)]
 struct IncorrectTaskInput(ResolvedVc<U32Wrapper>);
 
 impl TaskInput for IncorrectTaskInput {

--- a/turbopack/crates/turbo-tasks-macros-tests/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-macros-tests/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 
 [dev-dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
 trybuild = { version = "1.0.104" }

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/task_input.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/task_input.rs
@@ -3,13 +3,13 @@
 //! macro and the `#[turbo_tasks::function]` macro.
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 use turbo_tasks::{Completion, ReadRef, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
 
-#[derive(Clone, TaskInput, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, TraceRawVcs)]
+#[derive(Clone, TaskInput, Debug, PartialEq, Eq, Hash, Encode, Decode, TraceRawVcs)]
 struct OneUnnamedField(u32);
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -56,7 +56,6 @@ turbo-tasks-hash = { workspace = true }
 turbo-tasks-macros = { workspace = true }
 turbo-tasks-malloc = { workspace = true }
 unsize = { workspace = true }
-unty = { workspace = true }
 pot = "3.0.0"
 
 [dev-dependencies]

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -91,46 +91,51 @@ use std::hash::BuildHasherDefault;
 
 pub use anyhow::{Error, Result};
 use auto_hash_map::AutoSet;
-pub use capture_future::TurboTasksPanic;
-pub use collectibles::CollectiblesSource;
-pub use completion::{Completion, Completions};
-pub use display::ValueToString;
-pub use effect::{ApplyEffectsContext, Effects, apply_effects, effect, get_effects};
-pub use id::{ExecutionId, LocalTaskId, TRANSIENT_TASK_BIT, TaskId, TraitTypeId, ValueTypeId};
-pub use invalidation::{
-    InvalidationReason, InvalidationReasonKind, InvalidationReasonSet, Invalidator, get_invalidator,
-};
-pub use join_iter_ext::{JoinIterExt, TryFlatJoinIterExt, TryJoinIterExt};
-pub use key_value_pair::KeyValuePair;
-pub use magic_any::MagicAny;
-pub use manager::{
-    CurrentCellRef, ReadConsistency, ReadTracking, TaskPersistence, TurboTasks, TurboTasksApi,
-    TurboTasksBackendApi, TurboTasksCallApi, Unused, UpdateInfo, dynamic_call, emit, mark_finished,
-    mark_root, mark_session_dependent, mark_stateful, prevent_gc, run, run_once,
-    run_once_with_reason, trait_call, turbo_tasks, turbo_tasks_scope,
-};
-pub use output::OutputContent;
-pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};
-pub use read_options::{ReadCellOptions, ReadOutputOptions};
-pub use read_ref::ReadRef;
 use rustc_hash::FxHasher;
-pub use serialization_invalidation::SerializationInvalidator;
 pub use shrink_to_fit::ShrinkToFit;
-pub use spawn::{
-    JoinHandle, block_for_future, block_in_place, spawn, spawn_blocking, spawn_thread,
-};
-pub use state::{State, TransientState};
-pub use task::{SharedReference, TypedSharedReference, task_input::TaskInput};
-pub use task_execution_reason::TaskExecutionReason;
-pub use trait_ref::{IntoTraitRef, TraitRef};
 pub use turbo_tasks_macros::{TaskInput, function, value_impl};
-pub use value::{TransientInstance, TransientValue};
-pub use value_type::{TraitMethod, TraitType, ValueType};
-pub use vc::{
-    Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, ReadVcFuture, ResolvedVc,
-    Upcast, UpcastStrict, ValueDefault, Vc, VcCast, VcCellCompareMode, VcCellNewMode,
-    VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType,
-    VcValueTypeCast,
+
+pub use crate::{
+    capture_future::TurboTasksPanic,
+    collectibles::CollectiblesSource,
+    completion::{Completion, Completions},
+    display::ValueToString,
+    effect::{ApplyEffectsContext, Effects, apply_effects, effect, get_effects},
+    id::{ExecutionId, LocalTaskId, TRANSIENT_TASK_BIT, TaskId, TraitTypeId, ValueTypeId},
+    invalidation::{
+        InvalidationReason, InvalidationReasonKind, InvalidationReasonSet, Invalidator,
+        get_invalidator,
+    },
+    join_iter_ext::{JoinIterExt, TryFlatJoinIterExt, TryJoinIterExt},
+    key_value_pair::KeyValuePair,
+    magic_any::MagicAny,
+    manager::{
+        CurrentCellRef, ReadConsistency, ReadTracking, TaskPersistence, TurboTasks, TurboTasksApi,
+        TurboTasksBackendApi, TurboTasksCallApi, Unused, UpdateInfo, dynamic_call, emit,
+        mark_finished, mark_root, mark_session_dependent, mark_stateful, prevent_gc, run, run_once,
+        run_once_with_reason, trait_call, turbo_tasks, turbo_tasks_scope,
+    },
+    output::OutputContent,
+    raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError},
+    read_options::{ReadCellOptions, ReadOutputOptions},
+    read_ref::ReadRef,
+    serialization_invalidation::SerializationInvalidator,
+    spawn::{JoinHandle, block_for_future, block_in_place, spawn, spawn_blocking, spawn_thread},
+    state::{State, TransientState},
+    task::{
+        SharedReference, TypedSharedReference,
+        task_input::{EitherTaskInput, TaskInput},
+    },
+    task_execution_reason::TaskExecutionReason,
+    trait_ref::{IntoTraitRef, TraitRef},
+    value::{TransientInstance, TransientValue},
+    value_type::{TraitMethod, TraitType, ValueType},
+    vc::{
+        Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, ReadVcFuture, ResolvedVc,
+        Upcast, UpcastStrict, ValueDefault, Vc, VcCast, VcCellCompareMode, VcCellNewMode,
+        VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType,
+        VcValueTypeCast,
+    },
 };
 
 pub type SliceMap<K, V> = Box<[(K, V)]>;

--- a/turbopack/crates/turbo-tasks/src/magic_any.rs
+++ b/turbopack/crates/turbo-tasks/src/magic_any.rs
@@ -1,6 +1,9 @@
-use std::{any::Any, fmt::Debug, hash::Hash};
+use std::{
+    any::{Any, type_name},
+    fmt::Debug,
+    hash::Hash,
+};
 
-use serde::{Deserialize, Serialize, de::DeserializeSeed};
 use turbo_dyn_eq_hash::{
     DynEq, DynHash, impl_eq_for_dyn, impl_hash_for_dyn, impl_partial_eq_for_dyn,
 };
@@ -26,85 +29,12 @@ impl_partial_eq_for_dyn!(dyn MagicAny);
 impl_eq_for_dyn!(dyn MagicAny);
 impl_hash_for_dyn!(dyn MagicAny);
 
-impl dyn MagicAny {
-    pub fn as_serialize<T: Debug + Eq + Hash + Serialize + Send + Sync + TraceRawVcs + 'static>(
-        &self,
-    ) -> &dyn erased_serde::Serialize {
-        if let Some(r) = (self as &dyn Any).downcast_ref::<T>() {
-            r
-        } else {
-            #[cfg(debug_assertions)]
-            panic!(
-                "MagicAny::as_serializable broken: got {} but expected {}",
-                self.magic_type_name(),
-                std::any::type_name::<T>(),
-            );
-            #[cfg(not(debug_assertions))]
-            panic!("MagicAny::as_serializable bug");
-        }
+pub fn any_as_encode<T: Any>(this: &dyn Any) -> &T {
+    if let Some(enc) = this.downcast_ref::<T>() {
+        return enc;
     }
-}
-
-type MagicAnySerializeFunctor = fn(&dyn MagicAny) -> &dyn erased_serde::Serialize;
-
-#[derive(Clone, Copy)]
-pub struct MagicAnySerializeSeed {
-    functor: MagicAnySerializeFunctor,
-}
-
-impl MagicAnySerializeSeed {
-    pub fn new<T: Debug + Eq + Hash + Serialize + Send + Sync + TraceRawVcs + 'static>() -> Self {
-        fn serialize<T: Debug + Eq + Hash + Serialize + Send + Sync + TraceRawVcs + 'static>(
-            value: &dyn MagicAny,
-        ) -> &dyn erased_serde::Serialize {
-            value.as_serialize::<T>()
-        }
-        Self {
-            functor: serialize::<T>,
-        }
-    }
-
-    pub fn as_serialize<'a>(&self, value: &'a dyn MagicAny) -> &'a dyn erased_serde::Serialize {
-        (self.functor)(value)
-    }
-}
-
-type MagicAnyDeserializeSeedFunctor =
-    fn(&mut dyn erased_serde::Deserializer<'_>) -> Result<Box<dyn MagicAny>, erased_serde::Error>;
-
-#[derive(Clone, Copy)]
-pub struct MagicAnyDeserializeSeed {
-    functor: MagicAnyDeserializeSeedFunctor,
-}
-
-impl MagicAnyDeserializeSeed {
-    pub fn new<T>() -> Self
-    where
-        T: for<'de> Deserialize<'de> + Debug + Eq + Hash + Send + Sync + TraceRawVcs + 'static,
-    {
-        fn deserialize<T>(
-            deserializer: &mut dyn erased_serde::Deserializer<'_>,
-        ) -> Result<Box<dyn MagicAny>, erased_serde::Error>
-        where
-            T: for<'de> Deserialize<'de> + Debug + Eq + Hash + Send + Sync + TraceRawVcs + 'static,
-        {
-            let value: T = erased_serde::deserialize(deserializer)?;
-            Ok(Box::new(value))
-        }
-        Self {
-            functor: deserialize::<T>,
-        }
-    }
-}
-
-impl<'de> DeserializeSeed<'de> for MagicAnyDeserializeSeed {
-    type Value = Box<dyn MagicAny>;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let mut deserializer = <dyn erased_serde::Deserializer>::erase(deserializer);
-        (self.functor)(&mut deserializer).map_err(serde::de::Error::custom)
-    }
+    unreachable!(
+        "any_as_encode::<{}> called with invalid type",
+        type_name::<T>()
+    );
 }

--- a/turbopack/crates/turbo-tasks/src/task/shared_reference.rs
+++ b/turbopack/crates/turbo-tasks/src/task/shared_reference.rs
@@ -8,13 +8,12 @@ use std::{
 use anyhow::Result;
 use bincode::{
     Decode, Encode,
-    de::Decoder,
-    enc::Encoder,
     error::{DecodeError, EncodeError},
     impl_borrow_decode,
 };
 use turbo_bincode::{
-    TurboBincodeDecoder, TurboBincodeEncoder, turbo_bincode_decode, turbo_bincode_encode,
+    TurboBincodeDecode, TurboBincodeDecoder, TurboBincodeEncode, TurboBincodeEncoder,
+    impl_decode_for_turbo_bincode_decode, impl_encode_for_turbo_bincode_encode,
 };
 use unsize::CoerceUnsize;
 
@@ -64,99 +63,44 @@ impl TypedSharedReference {
     pub fn into_untyped(self) -> SharedReference {
         self.reference
     }
+}
 
-    fn encode(&self, enc: &mut TurboBincodeEncoder) -> Result<(), EncodeError> {
+impl TurboBincodeEncode for TypedSharedReference {
+    fn encode(&self, encoder: &mut TurboBincodeEncoder) -> Result<(), EncodeError> {
         let Self { type_id, reference } = self;
         let value_type = registry::get_value_type(*type_id);
         if let Some(bincode) = value_type.bincode {
-            type_id.encode(enc)?;
-            bincode.0(&*reference.0, enc)?;
+            type_id.encode(encoder)?;
+            bincode.0(&*reference.0, encoder)?;
             Ok(())
         } else {
             Err(EncodeError::OtherString(format!(
-                "{:?} is not serializable",
+                "{} is not encodable",
                 value_type.global_name
             )))
         }
     }
+}
 
-    fn decode(dec: &mut TurboBincodeDecoder) -> Result<Self, DecodeError> {
-        let type_id = ValueTypeId::decode(dec)?;
+impl<Context> TurboBincodeDecode<Context> for TypedSharedReference {
+    fn decode(decoder: &mut TurboBincodeDecoder) -> Result<Self, DecodeError> {
+        let type_id = ValueTypeId::decode(decoder)?;
         let value_type = registry::get_value_type(type_id);
         if let Some(bincode) = value_type.bincode {
-            let reference = bincode.1(dec)?;
+            let reference = bincode.1(decoder)?;
             Ok(Self { type_id, reference })
         } else {
             #[cold]
-            fn not_deserializable(value_type: &ValueType) -> DecodeError {
-                DecodeError::OtherString(format!("{value_type} is not deserializable"))
+            fn not_decodable(value_type: &ValueType) -> DecodeError {
+                DecodeError::OtherString(format!("{} is not decodable", value_type.global_name))
             }
-            Err(not_deserializable(value_type))
+            Err(not_decodable(value_type))
         }
     }
 }
 
-impl Encode for TypedSharedReference {
-    fn encode<'a, E: Encoder>(&self, encoder: &'a mut E) -> Result<(), EncodeError> {
-        let maybe_turbo_encoder = if unty::type_equal::<E, TurboBincodeEncoder>() {
-            // SAFETY: Transmute is safe because `&mut E` is `&mut TurboBincodeEncoder`:
-            // - `unty::type_equal::<E, TurboBincodeEncoder>()` does not check lifetimes, but does
-            //   check the type and layout, so we know those are correct.
-            // - The transmuted encoder cannot escape this function, and we know that the lifetime
-            //   of `'f` is at least as long as the function.
-            // - Lifetimes don't change layout. This is not guaranteed, but if this assumption is
-            //   broken, we'd have a different type id, `type_equal` would return `false` and we'd
-            //   fall back to a slower codepath, and wouldn't violate memory safety.
-            // - Two mutable references have the same layout and alignment when they reference
-            //   exactly the same type.
-            // - The explicit lifetime ('a) avoids creating an implitly unbounded lifetime.
-            Ok(unsafe { std::mem::transmute::<&'a mut E, &'a mut TurboBincodeEncoder>(encoder) })
-        } else {
-            Err(encoder)
-        };
-        match maybe_turbo_encoder {
-            Ok(turbo_encoder) => TypedSharedReference::encode(self, turbo_encoder),
-            Err(generic_encoder) => {
-                // The underlying `SharedReference` can only be serialized using
-                // `TurboBincodeEncoder` because the encoder function pointer cannot take type
-                // parameters. This is okay, because we expect any hot codepaths to use
-                // `TurboBincodeEncoder`.
-                //
-                // Create a `TurboBincodeEncoder` and encode this as a nested byte array. We must
-                // redundantly store a size here, otherwise we won't be able to determine what size
-                // buffer to use for `TurboBincodeReader`.
-                let buffer = turbo_bincode_encode(self)?;
-                buffer.encode(generic_encoder)
-            }
-        }
-    }
-}
-
-impl<Context> Decode<Context> for TypedSharedReference {
-    fn decode<'a, D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
-        let maybe_turbo_decoder = if unty::type_equal::<D, TurboBincodeDecoder>() {
-            // SAFETY: See notes on the `Encode::encode` implementation above.
-            Ok(unsafe { std::mem::transmute::<&mut D, &mut TurboBincodeDecoder<'a>>(decoder) })
-        } else {
-            Err(decoder)
-        };
-        match maybe_turbo_decoder {
-            Ok(turbo_decoder) => TypedSharedReference::decode(turbo_decoder),
-            Err(generic_decoder) => {
-                // The underlying `SharedReference` can only be deserialized using
-                // `TurboBincodeDecoder` because the decoder function pointer cannot take type
-                // parameters. This is okay, because we expect any hot codepaths to use
-                // `TurboBincodeDecoder`.
-                //
-                // Decode the nested byte array that was created during encoding, then use a
-                // `TurboBincodeDecoder` to decode the contents.
-                let buffer: Vec<u8> = Decode::decode(generic_decoder)?;
-                turbo_bincode_decode(&buffer)
-            }
-        }
-    }
-}
-
+impl_encode_for_turbo_bincode_encode!(TypedSharedReference);
+impl_decode_for_turbo_bincode_decode!(TypedSharedReference);
 impl_borrow_decode!(TypedSharedReference);
 
 impl Deref for TypedSharedReference {

--- a/turbopack/crates/turbopack-cli/Cargo.toml
+++ b/turbopack/crates/turbopack-cli/Cargo.toml
@@ -38,6 +38,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 console-subscriber = { workspace = true, optional = true }
 dunce = { workspace = true }

--- a/turbopack/crates/turbopack-cli/src/arguments.rs
+++ b/turbopack/crates/turbopack-cli/src/arguments.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use anyhow::anyhow;
+use bincode::{Decode, Encode};
 use clap::{Args, Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
@@ -48,6 +49,8 @@ impl Arguments {
     TaskInput,
     NonLocalValue,
     TraceRawVcs,
+    Encode,
+    Decode,
 )]
 pub enum Target {
     Browser,

--- a/turbopack/crates/turbopack-cli/src/util.rs
+++ b/turbopack/crates/turbopack-cli/src/util.rs
@@ -1,6 +1,7 @@
 use std::{env::current_dir, path::PathBuf};
 
 use anyhow::{Context, Result};
+use bincode::{Decode, Encode};
 use dunce::canonicalize;
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
@@ -8,7 +9,18 @@ use turbo_tasks::{NonLocalValue, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 
 #[derive(
-    Clone, Debug, TaskInput, Hash, PartialEq, Eq, NonLocalValue, Serialize, Deserialize, TraceRawVcs,
+    Clone,
+    Debug,
+    TaskInput,
+    Hash,
+    PartialEq,
+    Eq,
+    NonLocalValue,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    Encode,
+    Decode,
 )]
 pub enum EntryRequest {
     Relative(RcStr),

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -1,6 +1,7 @@
 use std::cmp::Reverse;
 
 use anyhow::Result;
+use bincode::{Decode, Encode};
 use indexmap::map::Entry;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
@@ -23,7 +24,18 @@ use crate::{
 };
 
 #[derive(
-    TaskInput, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, NonLocalValue, TraceRawVcs,
+    TaskInput,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    TraceRawVcs,
+    Encode,
+    Decode,
 )]
 pub struct StyleGroupsConfig {
     pub max_chunk_size: usize,

--- a/turbopack/crates/turbopack-dev-server/src/source/headers.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/headers.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, hash::Hash, mem::replace, ops::DerefMut};
 
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
 
@@ -16,6 +17,8 @@ use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
     Deserialize,
     NonLocalValue,
     TaskInput,
+    Encode,
+    Decode,
 )]
 #[serde(transparent)]
 pub struct Headers(BTreeMap<String, HeaderValue>);
@@ -23,7 +26,18 @@ pub struct Headers(BTreeMap<String, HeaderValue>);
 /// The value of an http header. HTTP headers might contain non-utf-8 bytes. An
 /// header might also occur multiple times.
 #[derive(
-    Clone, Debug, PartialEq, Eq, Hash, TraceRawVcs, Serialize, Deserialize, NonLocalValue, TaskInput,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    TaskInput,
+    Encode,
+    Decode,
 )]
 #[serde(untagged)]
 pub enum HeaderValue {

--- a/turbopack/crates/turbopack-dev-server/src/source/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/mod.rs
@@ -28,7 +28,7 @@ use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::{DeterministicHash, DeterministicHasher, Xxh3Hash64Hasher};
 use turbopack_core::version::{Version, VersionedContent};
 
-use self::{
+use crate::source::{
     headers::Headers, issue_context::IssueFilePathContentSource, query::Query,
     route_tree::RouteTree,
 };
@@ -192,6 +192,8 @@ impl HeaderList {
     Hash,
     Default,
     TaskInput,
+    Encode,
+    Decode,
 )]
 pub struct ContentSourceData {
     /// HTTP method, if requested.

--- a/turbopack/crates/turbopack-dev-server/src/source/query.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/query.rs
@@ -1,13 +1,25 @@
 use std::{collections::BTreeMap, hash::Hash, ops::DerefMut};
 
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
 
-use super::ContentSourceDataFilter;
+use crate::source::ContentSourceDataFilter;
 
 /// A parsed query string from a http request
 #[derive(
-    Clone, Debug, PartialEq, Eq, Default, Hash, TraceRawVcs, Serialize, Deserialize, NonLocalValue,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Default,
+    Hash,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 #[serde(transparent)]
 pub struct Query(BTreeMap<String, QueryValue>);
@@ -44,7 +56,19 @@ impl DerefMut for Query {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, TraceRawVcs, Serialize, Deserialize, NonLocalValue)]
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    TraceRawVcs,
+    Serialize,
+    Deserialize,
+    NonLocalValue,
+    Encode,
+    Decode,
+)]
 #[serde(untagged)]
 pub enum QueryValue {
     /// Simple string value, might be an empty string when there is no value

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -14,7 +14,18 @@ use crate::source::{GetContentSourceContent, GetContentSourceContents};
 /// The type of the route. This will decide about the remaining segments of the
 /// route after the base.
 #[derive(
-    TaskInput, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, TraceRawVcs, NonLocalValue,
+    TaskInput,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub enum RouteType {
     Exact,

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -109,6 +109,8 @@ pub(crate) enum PatternMapping {
     TraceRawVcs,
     TaskInput,
     NonLocalValue,
+    Encode,
+    Decode,
 )]
 pub(crate) enum ResolveType {
     AsyncChunkLoader,

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, iter, sync::Arc, thread::available_parallelism, time::Duration};
 
 use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
 use futures_retry::{FutureRetry, RetryPolicy};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::Value as JsonValue;
@@ -143,6 +144,8 @@ async fn emit_evaluate_pool_assets_with_effects_operation(
     TaskInput,
     NonLocalValue,
     TraceRawVcs,
+    Encode,
+    Decode,
 )]
 pub enum EnvVarTracking {
     WholeEnvTracked,
@@ -509,7 +512,6 @@ async fn pull_operation<T: EvaluateContext>(
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, TaskInput, Debug, Serialize, Deserialize, TraceRawVcs)]
 struct BasicEvaluateContext {
     entries: ResolvedVc<EvaluateEntries>,
     cwd: FileSystemPath,

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -395,7 +395,19 @@ pub enum InfoMessage {
     },
 }
 
-#[derive(Debug, Clone, TaskInput, Hash, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs)]
+#[derive(
+    Debug,
+    Clone,
+    TaskInput,
+    Hash,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    TraceRawVcs,
+    Encode,
+    Decode,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct WebpackResolveOptions {
     alias_fields: Option<Vec<RcStr>>,
@@ -430,7 +442,19 @@ pub enum ResponseMessage {
     TrackFileRead {},
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, TaskInput, Serialize, Deserialize, Debug, TraceRawVcs)]
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    TaskInput,
+    Serialize,
+    Deserialize,
+    Debug,
+    TraceRawVcs,
+    Encode,
+    Decode,
+)]
 pub struct WebpackLoaderContext {
     pub entries: ResolvedVc<EvaluateEntries>,
     pub cwd: FileSystemPath,


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/86338 switches cell storage to use bincode, but it uses a compatibility shim for storing `TaskInput`s using `serde` + `pot`. This PR completes the migration by switching `TaskInput` to use `bincode` as well.

## Binary Size

https://www.npmjs.com/package/@next/swc-darwin-arm64/v/16.0.7
> Unpacked Size: 126 MB

https://www.npmjs.com/package/@next/swc-darwin-arm64/v/16.1.0-canary.14 (prior to #86338)
> Unpacked Size: 128 MB

https://www.npmjs.com/package/@next/swc-darwin-arm64/v/16.1.0-canary.15 (after #86338, but before #86631)
> Unpacked Size: 109 MB

https://www.npmjs.com/package/@next/swc-darwin-arm64/v/16.1.0-canary.16 (after #86631)
> Unpacked Size: 103 MB

## Benchmark Summary

`next build` is consistently faster across a variety of repositories when persistent caching is enabled, and the resulting cache size is consistently smaller.

![Screenshot 2025-12-01 at 9.07.20 PM.png](https://app.graphite.com/user-attachments/assets/2e19f83a-5810-4c55-b67a-aa0dd1c5da22.png)

`cargo build` runs only slightly faster, but there's potential for improving this further by removing unused `serde` macro derives.

## Benchmarking Notes

Performance measurements (aside from cargo build) are taken using `next build`​. This should have proportional benefits for `next dev`​ too, but `next build`​ is more reproducible and easier to measure. `canary` refers to `a8f7b5467485647def4c0f4479a0a83bc4a3673a`.

These numbers are taken with persistent caching enabled with an empty cache, so it's the worst-case scenario for the serialization codepath. We don't care nearly as much about the performance of deserialization because it's less common.

## `cargo build -p next-swc-napi`

This makes builds _slightly_ faster. This branch doesn't clean up the serde derives yet, so there's a bunch of unused macro expansion here, so I think this number is actually pretty good. *There is another ~2% performance improvement in addition to this in #86634.*

```
~/next.js $ hyperfine -w 1 -r 5 -p 'git co a8f7b5467485647def4c0f4479a0a83bc4a3673a && cargo clean' -p 'git co bgw/bincode-task-inputs && cargo clean' 'cargo build -p next-swc-napi' 'cargo build -p next-swc-napi'
Benchmark 1: cargo build -p next-swc-napi
  Time (mean ± σ):     237.476 s ±  1.420 s    [User: 2001.820 s, System: 84.957 s]
  Range (min … max):   235.294 s … 238.862 s    5 runs

Benchmark 2: cargo build -p next-swc-napi
  Time (mean ± σ):     232.366 s ±  1.549 s    [User: 1945.355 s, System: 83.940 s]
  Range (min … max):   230.550 s … 234.485 s    5 runs

Summary
  cargo build -p next-swc-napi ran
    1.02 ± 0.01 times faster than cargo build -p next-swc-napi
```

## next-site

Using `~/front/apps/next-site` on macos with a M2 Pro. Nothing else was running on the machine.

```
hyperfine -p 'rm -rf .next' -w 2 -r 20 'TURBOPACK_PERSISTENT_CACHE=1 TURBO_ENGINE_IGNORE_DIRTY=1 pnpm next build --turbopack --experimental-build-mode=compile'
du -sh .next/cache/turbopack/
du -s .next/cache/turbopack/
```

#### Canary

```
Benchmark 1: TURBOPACK_PERSISTENT_CACHE=1 TURBO_ENGINE_IGNORE_DIRTY=1 pnpm next build --turbopack --experimental-build-mode=compile
  Time (mean ± σ):     14.999 s ±  0.258 s    [User: 84.137 s, System: 8.683 s]
  Range (min … max):   14.400 s … 15.509 s    20 runs
```

```
855M    .next/cache/turbopack/
1751640 .next/cache/turbopack/    (Note: macos measures size in 512B blocks)
```

#### This Branch

```
Benchmark 1: TURBOPACK_PERSISTENT_CACHE=1 TURBO_ENGINE_IGNORE_DIRTY=1 pnpm next build --turbopack --experimental-build-mode=compile
  Time (mean ± σ):     14.106 s ±  0.255 s    [User: 79.976 s, System: 8.421 s]
  Range (min … max):   13.829 s … 14.939 s    20 runs
```

```
767M    .next/cache/turbopack/
1571072 .next/cache/turbopack/    (Note: macos measures size in 512B blocks)
```

## vercel-site

Using `~/front/apps/vercel-site` on macos with a M2 Pro. Nothing else was running on the machine.

```
hyperfine -p 'rm -rf .next' -w 2 -r 20 'TURBOPACK_PERSISTENT_CACHE=1 TURBO_ENGINE_IGNORE_DIRTY=1 pnpm next build --turbopack --experimental-build-mode=compile'
du -sh .next/cache/turbopack/
du -s .next/cache/turbopack/
```

#### Canary

```
Benchmark 1: TURBOPACK_PERSISTENT_CACHE=1 TURBO_ENGINE_IGNORE_DIRTY=1 pnpm next build --turbopack --experimental-build-mode=compile
  Time (mean ± σ):     93.274 s ±  1.630 s    [User: 671.120 s, System: 57.888 s]
  Range (min … max):   91.111 s … 96.881 s    10 runs
```

```
4.3G    .next/cache/turbopack/
9002568 .next/cache/turbopack/    (Note: macos measures size in 512B blocks)
```

#### This Branch

```
Benchmark 1: TURBOPACK_PERSISTENT_CACHE=1 TURBO_ENGINE_IGNORE_DIRTY=1 pnpm next build --turbopack --experimental-build-mode=compile
  Time (mean ± σ):     88.694 s ±  0.963 s    [User: 633.801 s, System: 54.576 s]
  Range (min … max):   87.357 s … 90.037 s    10 runs
```

```
3.7G    .next/cache/turbopack/
7788472 .next/cache/turbopack/    (Note: macos measures size in 512B blocks)
```

## shadcn/ui

Using a low-noise Linux machine: https://github.com/bgw/benchmark-scripts/

```
diff --git a/apps/v4/next.config.mjs b/apps/v4/next.config.mjs
index 7fa0f012..d1137d01 100644
--- a/apps/v4/next.config.mjs
+++ b/apps/v4/next.config.mjs
@@ -27,6 +27,7 @@ const nextConfig = {
   },
   experimental: {
     turbopackFileSystemCacheForDev: true,
+    turbopackFileSystemCacheForBuild: true,
   },
   redirects() {
     return [
```

```
cd ~/shadcn-ui/apps/v4
hyperfine -p 'rm -rf .next' -w 2 'pnpm next build --turbopack --experimental-build-mode=compile'
du -sh .next/cache/turbopack/
du -s .next/cache/turbopack/
```

#### Canary

```
Benchmark 1: pnpm next build --turbopack --experimental-build-mode=compile
  Time (mean ± σ):     62.772 s ±  0.939 s    [User: 163.153 s, System: 11.170 s]
  Range (min … max):   60.739 s … 64.220 s    10 runs
```

```
596M    .next/cache/turbopack/
609636  .next/cache/turbopack/    (Note: Linux measures size in 1024B blocks)
```

#### This Branch

```
Benchmark 1: pnpm next build --turbopack --experimental-build-mode=compile
  Time (mean ± σ):     59.017 s ±  1.014 s    [User: 151.359 s, System: 9.978 s]
  Range (min … max):   57.124 s … 60.343 s    10 runs
```

```
491M    .next/cache/turbopack/
502240  .next/cache/turbopack/    (Note: Linux measures size in 1024B blocks)
```