### PR TITLE
Turbopack: bincode: Add traits for types that require `TurboBincodeEncoder` or `TurboBincodeDecoder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9096,6 +9096,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "unty",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -470,6 +470,7 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 triomphe = { git = "https://github.com/sokra/triomphe", branch = "sokra/unstable" }
 unsize = "1.1.0"
+unty = "0.0.4"
 url = "2.2.2"
 urlencoding = "2.1.2"
 uuid = "1.18.1"

--- a/turbopack/crates/turbo-bincode/Cargo.toml
+++ b/turbopack/crates/turbo-bincode/Cargo.toml
@@ -19,3 +19,4 @@ ringmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 smallvec = { workspace = true }
+unty = { workspace = true }

--- a/turbopack/crates/turbo-bincode/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-bincode/src/macro_helpers.rs
@@ -1,0 +1,62 @@
+use std::{any::type_name, mem::transmute};
+
+pub use bincode;
+use bincode::{
+    de::Decoder,
+    enc::Encoder,
+    error::{DecodeError, EncodeError},
+};
+
+use crate::{TurboBincodeDecode, TurboBincodeDecoder, TurboBincodeEncode, TurboBincodeEncoder};
+
+#[track_caller]
+pub fn encode_for_turbo_bincode_encode_impl<'a, T: TurboBincodeEncode, E: Encoder>(
+    value: &T,
+    encoder: &'a mut E,
+) -> Result<(), EncodeError> {
+    let encoder = if unty::type_equal::<E, TurboBincodeEncoder>() {
+        // SAFETY: Transmute is safe because `&mut E` is `&mut TurboBincodeEncoder`:
+        // - `unty::type_equal::<E, TurboBincodeEncoder>()` does not check lifetimes, but does check
+        //   the type and layout, so we know those are correct.
+        // - The transmuted encoder cannot escape this function, and we know that the lifetime of
+        //   `'a` is at least as long as the function.
+        // - Lifetimes don't change layout. This is not strictly guaranteed, but if this assumption
+        //   is broken, we'd have a different type id (type ids are derived from layout
+        //   information), `type_equal` would return `false`, and we'd panic instead of violating
+        //   memory safety.
+        // - Two mutable references have the same layout and alignment when they reference exactly
+        //   the same type.
+        // - The explicit lifetime ('a) avoids creating an implitly unbounded lifetime.
+        unsafe { transmute::<&'a mut E, &'a mut TurboBincodeEncoder>(encoder) }
+    } else {
+        unreachable!(
+            "{} implements TurboBincodeEncode, but was called with a {} encoder implementation",
+            type_name::<T>(),
+            type_name::<E>(),
+        )
+    };
+    TurboBincodeEncode::encode(value, encoder)
+}
+
+#[track_caller]
+pub fn decode_for_turbo_bincode_decode_impl<
+    'a,
+    Context,
+    T: TurboBincodeDecode<Context>,
+    D: Decoder<Context = Context>,
+>(
+    decoder: &'a mut D,
+) -> Result<T, DecodeError> {
+    let decoder = if unty::type_equal::<D, TurboBincodeDecoder>() {
+        // SAFETY: See notes on the `Encode::encode` implementation on
+        // `encode_for_turbo_bincode_encode_impl`.
+        unsafe { transmute::<&'a mut D, &'a mut TurboBincodeDecoder<'a>>(decoder) }
+    } else {
+        unreachable!(
+            "{} implements TurboBincodeDecode, but was called with a {} decoder implementation",
+            type_name::<T>(),
+            type_name::<D>(),
+        )
+    };
+    TurboBincodeDecode::decode(decoder)
+}


### PR DESCRIPTION
**Example usage:** See `CachedTaskType`​ in `turbopack/crates/turbo-tasks/src/backend.rs`​ on https://github.com/vercel/next.js/pull/86631 for an example of how this is used. That needs to call the encoder/decoder function pointer stored on `native_fn.arg_meta.bincode` with a concrete `TurboBincodeEncoder`/`TurboBincodeDecoder`, so it uses this trait.

---

For `SharedReference` (value cell contents) and `TaskInput`s, we need to generate function pointers to functions that can encode/decode the type.

Those generated functions cannot contain generics, so they require `TurboBincodeEncoder` or `TurboBincodeDecoder<()>` as arguments. That's okay because we don't want to use multiple encoders/decoders anyways, because that would be really bad for binary size and compilation time.

However, `SharedReference` and `TaskInput`s are wrapped in other container types that need to be encoded/decoded (e.g. `TypedSharedReference`. In these cases, the wrapper types need to be able to implement `Encode`/`Decode`, but can't because of the fixed `Encoder`/`Decoder` implementations. So this provides a way to do that, by panicking at runtime if the type doesn't match.

This uses the `unty` crate which is part of the bincode project: https://github.com/bincode-org/unty