### PR TITLE
Allow exporting object and array literals in `'use cache'` files again

### DIFF
--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1895,18 +1895,17 @@ impl<C: Comments> VisitMut for ServerActions<C> {
                             Decl::Var(var) => {
                                 let mut has_export_needing_wrapper = false;
 
-                                // Validate exports and check for cache runtime wrappers. Disallow
-                                // exporting literals, objects, and arrays directly (destructuring
-                                // patterns are allowed since we can't statically know if the
-                                // destructured value is a function).
                                 for decl in &var.decls {
                                     if let Pat::Ident(_) = &decl.name {
                                         if let Some(init) = &decl.init {
-                                            match &**init {
-                                                Expr::Lit(_) | Expr::Object(_) | Expr::Array(_) => {
-                                                    disallowed_export_span = *span;
-                                                }
-                                                _ => {}
+                                            // Disallow exporting literals. Admittedly, this is
+                                            // pretty arbitrary. We don't disallow exporting object
+                                            // and array literals, as that would be too restrictive,
+                                            // especially for page and layout files with
+                                            // 'use cache', that may want to export metadata or
+                                            // viewport objects.
+                                            if let Expr::Lit(_) = &**init {
+                                                disallowed_export_span = *span;
                                             }
                                         }
                                     }

--- a/crates/next-custom-transforms/tests/errors/server-actions/client-graph/3/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/client-graph/3/output.stderr
@@ -1,7 +1,0 @@
-  x Only async functions are allowed to be exported in a "use cache" file.
-  | 
-   ,-[input.js:3:1]
- 2 |     
- 3 | ,-> export const foo = {},
- 4 | `->   bar = [1]
-   `----

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/input.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/input.js
@@ -16,7 +16,7 @@ async function a() {
   }
 }
 
-export const { foo } = {
+export const obj = {
   foo() {
     return 42
   },

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/output.js
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/23/output.js
@@ -1,6 +1,3 @@
-/* __next_internal_action_entry_do_not_use__ {"ffab21efdafbe611287bc25c0462b1e0510d13e48b":"foo"} */ import { registerServerReference } from "private-next-rsc-server-reference";
-import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
-import { cache as $$reactCache__ } from "react";
 // not exported!
 async function a() {
     // this is allowed here
@@ -14,7 +11,7 @@ async function a() {
         console.log(arguments);
     };
 }
-const { foo } = {
+export const obj = {
     foo () {
         return 42;
     },
@@ -25,14 +22,3 @@ const { foo } = {
         console.log(arguments);
     }
 };
-let $$RSC_SERVER_CACHE_foo = foo;
-if (typeof foo === "function") {
-    $$RSC_SERVER_CACHE_foo = $$reactCache__(function() {
-        return $$cache__("default", "ffab21efdafbe611287bc25c0462b1e0510d13e48b", 0, foo, arguments);
-    });
-    registerServerReference($$RSC_SERVER_CACHE_foo, "ffab21efdafbe611287bc25c0462b1e0510d13e48b", null);
-    Object["defineProperty"]($$RSC_SERVER_CACHE_foo, "name", {
-        value: "foo"
-    });
-}
-export { $$RSC_SERVER_CACHE_foo as foo };

--- a/crates/next-custom-transforms/tests/errors/server-actions/server-graph/31/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/server-actions/server-graph/31/output.stderr
@@ -1,7 +1,0 @@
-  x Only async functions are allowed to be exported in a "use cache" file.
-  | 
-   ,-[input.js:3:1]
- 2 |     
- 3 | ,-> export const foo = {},
- 4 | `->   bar = [1]
-   `----

--- a/crates/next-custom-transforms/tests/fixture/server-actions/client-graph/17/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/client-graph/17/input.js
@@ -1,4 +1,5 @@
 'use cache'
 
+// Should not get cache runtime wrappers.
 export const foo = {},
   bar = [1]

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/69/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/69/input.js
@@ -1,4 +1,5 @@
 'use cache'
 
+// Should not get cache runtime wrappers.
 export const foo = {},
   bar = [1]

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/69/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/69/output.js
@@ -1,0 +1,4 @@
+// Should not get cache runtime wrappers.
+export const foo = {}, bar = [
+    1
+];


### PR DESCRIPTION
In #86014 we added a validation for exporting object and array literals from `'use cache'` files. This was a bit too restrictive, and short-sighted, as it would prevent exporting common things like metadata or viewport objects from page and layout files, if the file uses a `'use cache'` top-level directive.