### PR TITLE
Revert "add bundle analyzer as dev dependency to next (#86497)"

### DIFF
--- a/apps/bundle-analyzer/.gitignore
+++ b/apps/bundle-analyzer/.gitignore
@@ -1,1 +1,0 @@
-/next-env.d.ts

--- a/apps/bundle-analyzer/next-env.d.ts
+++ b/apps/bundle-analyzer/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import './.next/types/routes.d.ts'
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/bundle-analyzer/package.json
+++ b/apps/bundle-analyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next/bundle-analyzer-ui",
-  "version": "0.0.1",
+  "version": "16.0.2-canary.16",
   "private": true,
   "scripts": {
     "build": "cross-env NEXT_TEST_NATIVE_DIR=no next build --no-mangling",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -162,7 +162,6 @@
     "@modelcontextprotocol/sdk": "1.18.1",
     "@mswjs/interceptors": "0.23.0",
     "@napi-rs/triples": "1.2.0",
-    "@next/bundle-analyzer-ui": "0.0.1",
     "@next/font": "16.1.0-canary.8",
     "@next/polyfill-module": "16.1.0-canary.8",
     "@next/polyfill-nomodule": "16.1.0-canary.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1200,9 +1200,6 @@ importers:
       '@napi-rs/triples':
         specifier: 1.2.0
         version: 1.2.0
-      '@next/bundle-analyzer-ui':
-        specifier: 0.0.1
-        version: link:../../apps/bundle-analyzer
       '@next/font':
         specifier: 16.1.0-canary.8
         version: link:../font


### PR DESCRIPTION
I believe this is still breaking publishes. Reverts #86497
x-ref: https://github.com/vercel/next.js/actions/runs/19790732218/job/56728905106