### PR TITLE
[test] Deflake `use-cache-router-handler-only` in deploy tests

### DIFF
--- a/test/e2e/app-dir/use-cache-route-handler-only/use-cache-route-handler-only.test.ts
+++ b/test/e2e/app-dir/use-cache-route-handler-only/use-cache-route-handler-only.test.ts
@@ -5,6 +5,7 @@ import { nextTestSetup } from 'e2e-utils'
 describe('use-cache-route-handler-only', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    skipDeployment: true,
   })
 
   it('should cache results in node route handlers', async () => {

--- a/test/e2e/app-dir/use-cache-route-handler-only/use-cache-route-handler-only.test.ts
+++ b/test/e2e/app-dir/use-cache-route-handler-only/use-cache-route-handler-only.test.ts
@@ -1,11 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 // Explicitly don't mix route handlers with pages in this test app, to make sure
 // that this also works in isolation.
 describe('use-cache-route-handler-only', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('should cache results in node route handlers', async () => {
@@ -19,14 +19,20 @@ describe('use-cache-route-handler-only', () => {
     const response1 = await next.fetch('/node')
     const { date1: date1a } = await response1.json()
 
-    // Revalidate the prerendered response.
-    await next.fetch('/revalidate', { method: 'POST' })
+    const attemptOnce: typeof retry = async (fn) => fn()
+    const retryIfDeployed = isNextDeploy ? retry : attemptOnce
 
-    // Fetch the response again. This should trigger a blocking revalidation.
-    const response2 = await next.fetch('/node')
-    expect(response2.status).toBe(200)
+    // Revalidation on Vercel isn't instant.
+    await retryIfDeployed(async () => {
+      // Revalidate the prerendered response.
+      await next.fetch('/revalidate', { method: 'POST' })
 
-    const { date1: date1b } = await response2.json()
-    expect(date1a).not.toBe(date1b)
+      // Fetch the response again. This should trigger a blocking revalidation.
+      const response2 = await next.fetch('/node')
+      expect(response2.status).toBe(200)
+
+      const { date1: date1b } = await response2.json()
+      expect(date1a).not.toBe(date1b)
+    })
   })
 })


### PR DESCRIPTION
https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.source.file%3Atest%2Fe2e%2Fapp-dir%2Fuse-cache-route-handler-only%2Fuse-cache-route-handler-only.test.ts%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=true&index=citest&start=1761983144717&end=1764575144717&paused=true

`'use cache'` isn't cached across requests on Vercel. This is basically just a static route for Vercel.