### PR TITLE
[test] Debug `searchparams-reuse-loading` on Vercel

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -542,8 +542,7 @@ ${ENDGROUP}`)
           ? {}
           : {
               IS_RETRY: isRetry ? 'true' : undefined,
-              TRACE_PLAYWRIGHT:
-                process.env.NEXT_TEST_MODE === 'deploy' ? undefined : 'true',
+              TRACE_PLAYWRIGHT: 'true',
               CIRCLECI: '',
               GITHUB_ACTIONS: '',
               CONTINUOUS_INTEGRATION: '',

--- a/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
+++ b/test/e2e/app-dir/searchparams-reuse-loading/searchparams-reuse-loading.test.ts
@@ -175,7 +175,7 @@ describe('searchparams-reuse-loading', () => {
       it('should correctly return different RSC data for full prefetches with different searchParam values', async () => {
         const rscRequestPromise = new Map<
           string,
-          { resolve: () => Promise<void> }
+          { resolve: () => Promise<void>; headers: Record<string, string> }
         >()
 
         // Track prefetch requests to know when initial prefetching is done
@@ -235,7 +235,14 @@ describe('searchparams-reuse-loading', () => {
                   })
 
                   if (rscRequestPromise.has(promiseKey)) {
-                    throw new Error('Duplicate request')
+                    const previousHeaders =
+                      rscRequestPromise.get(promiseKey)!.headers
+                    throw new Error(
+                      '' +
+                        `Duplicate request for '${promiseKey}'\n` +
+                        `previous headers: ${JSON.stringify(previousHeaders)}\n` +
+                        `new headers: ${JSON.stringify(headers)} `
+                    )
                   }
 
                   rscRequestPromise.set(promiseKey, {
@@ -245,6 +252,7 @@ describe('searchparams-reuse-loading', () => {
                       await new Promise((res) => setTimeout(res, 500))
                       resolvePromise()
                     },
+                    headers,
                   })
 
                   // Await the promise to effectively stall the request


### PR DESCRIPTION
The test is flaking when deployed with the same error: duplicate requests e.g. https://github.com/vercel/next.js/actions/runs/19581837528/job/56081407409#step:33:1076

Including the Promise key and headers for debugging.

Not switching to `create-router-act` since that's also known to be flaky.