### PR TITLE
Turbopack: process.env.TURBOPACK should be a string

### DIFF
--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -419,7 +419,7 @@ pub async fn get_tracing_compile_time_info() -> Result<Vc<CompileTimeInfo>> {
     */
     .defines(
         compile_time_defines!(
-            process.env.TURBOPACK = true,
+            process.env.TURBOPACK = "1",
             // process.env.NODE_ENV = "production",
         )
         .resolved_cell(),

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -188,7 +188,7 @@ pub fn get_client_asset_context(
 fn client_defines(node_env: &NodeEnv) -> CompileTimeDefines {
     compile_time_defines!(
         process.turbopack = true,
-        process.env.TURBOPACK = true,
+        process.env.TURBOPACK = "1",
         process.env.NODE_ENV = node_env.to_string()
     )
 }

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -359,7 +359,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         .defines(
             compile_time_defines!(
                 process.turbopack = true,
-                process.env.TURBOPACK = true,
+                process.env.TURBOPACK = "1",
                 process.env.NODE_ENV = "production",
             )
             .resolved_cell(),

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -291,7 +291,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
 
     let mut defines = compile_time_defines!(
         process.turbopack = true,
-        process.env.TURBOPACK = true,
+        process.env.TURBOPACK = "1",
         process.env.NODE_ENV = "development",
         DEFINED_VALUE = "value",
         DEFINED_TRUE = true,

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -96,7 +96,7 @@ pub async fn node_evaluate_asset_context(
                 compile_time_defines!(
                     process.turbopack = true,
                     process.env.NODE_ENV = node_env.into_owned(),
-                    process.env.TURBOPACK = true
+                    process.env.TURBOPACK = "1"
                 )
                 .resolved_cell(),
             )
@@ -131,7 +131,7 @@ pub async fn config_tracing_module_context(
                 compile_time_defines!(
                     process.turbopack = true,
                     process.env.NODE_ENV = node_env.into_owned(),
-                    process.env.TURBOPACK = true
+                    process.env.TURBOPACK = "1"
                 )
                 .resolved_cell(),
             )


### PR DESCRIPTION
`process.env.FOO`  are always strings, this should be as well.