### PR TITLE
[test] Enable Playwright traces in deploy tests

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -542,8 +542,7 @@ ${ENDGROUP}`)
           ? {}
           : {
               IS_RETRY: isRetry ? 'true' : undefined,
-              TRACE_PLAYWRIGHT:
-                process.env.NEXT_TEST_MODE === 'deploy' ? undefined : 'true',
+              TRACE_PLAYWRIGHT: 'true',
               CIRCLECI: '',
               GITHUB_ACTIONS: '',
               CONTINUOUS_INTEGRATION: '',


### PR DESCRIPTION
Was disabled in https://github.com/vercel/next.js/pull/66721

However, this is critical information when debugging failures that are hard to reproduce.

Seems to work just fine for new deploy tests e.g. https://github.com/vercel/next.js/actions/runs/19817378060/job/56773115738?pr=86679

It was only noise so it won't block the sync if it's still failing. But then I can fix the cause instead of just silencing the bug.