### PR TITLE
[bundle-analyzer] Disable revalidateOnFocus and revalidateOnReconnect

### DIFF
--- a/apps/bundle-analyzer/app/page.tsx
+++ b/apps/bundle-analyzer/app/page.tsx
@@ -61,6 +61,8 @@ export default function Home() {
     isLoading: isAnalyzeLoading,
     error: analyzeError,
   } = useSWR<AnalyzeData>(analyzeDataPath, fetchAnalyzeData, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
     onSuccess: (newData) => {
       const newRootSourceIndex = getRootSourceIndex(newData)
       setSelectedSourceIndex(newRootSourceIndex)


### PR DESCRIPTION
For the `experimental-analyze`, the page resets its selected state `onSuccess`.

https://github.com/vercel/next.js/blob/2307d46f511d02f48d4b8f93713c4bc087c0e5ff/apps/bundle-analyzer/app/page.tsx#L64-L68

However, since SWR revalidates on focus, if you click outside the tab and come back, e.g., write to docs or messengers, it revalidates and resets the state. Since the current view can be inside multiple depths, losing that state for focus can be painful. Therefore, set `revalidateOnFocus` to false. For similar reasons, set `revalidateOnReconnect` to false as well.

### Before

https://github.com/user-attachments/assets/ed04b4c2-f414-4fd9-9a6e-4c910031af9f

### After

https://github.com/user-attachments/assets/4130e3ca-9f3a-4f8b-8a5b-a8eb8d7d23dc