### PR TITLE
Turbopack: normalize distDir separators

### DIFF
--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -488,6 +488,9 @@ function rustifyOptionEnv(
   }))
 }
 
+const normalizePathOnWindows = (p: string) =>
+  path.sep === '\\' ? p.replace(/\\/g, '/') : p
+
 // TODO(sokra) Support wasm option.
 function bindingToApi(
   binding: RawBindings,
@@ -875,13 +878,23 @@ function bindingToApi(
       )
     }
 
+    // These are relative paths, but might be backslash-separated on Windows
+    nextConfigSerializable.distDir = normalizePathOnWindows(
+      nextConfigSerializable.distDir
+    )
+    nextConfigSerializable.distDirRoot = normalizePathOnWindows(
+      nextConfigSerializable.distDirRoot
+    )
+
     // loaderFile is an absolute path, we need it to be relative for turbopack.
     if (nextConfigSerializable.images.loaderFile) {
       nextConfigSerializable.images = {
         ...nextConfigSerializable.images,
         loaderFile:
           './' +
-          path.relative(projectPath, nextConfigSerializable.images.loaderFile),
+          normalizePathOnWindows(
+            path.relative(projectPath, nextConfigSerializable.images.loaderFile)
+          ),
       }
     }
 
@@ -889,9 +902,11 @@ function bindingToApi(
     if (nextConfigSerializable.cacheHandler) {
       nextConfigSerializable.cacheHandler =
         './' +
-        (path.isAbsolute(nextConfigSerializable.cacheHandler)
-          ? path.relative(projectPath, nextConfigSerializable.cacheHandler)
-          : nextConfigSerializable.cacheHandler)
+        normalizePathOnWindows(
+          path.isAbsolute(nextConfigSerializable.cacheHandler)
+            ? path.relative(projectPath, nextConfigSerializable.cacheHandler)
+            : nextConfigSerializable.cacheHandler
+        )
     }
     if (nextConfigSerializable.cacheHandlers) {
       nextConfigSerializable.cacheHandlers = Object.fromEntries(
@@ -902,9 +917,11 @@ function bindingToApi(
           .map(([key, value]) => [
             key,
             './' +
-              (path.isAbsolute(value)
-                ? path.relative(projectPath, value)
-                : value),
+              normalizePathOnWindows(
+                path.isAbsolute(value)
+                  ? path.relative(projectPath, value)
+                  : value
+              ),
           ])
       )
     }


### PR DESCRIPTION
Closes #86652
Closes PACK-6023

Previously, `dist_dir` contained backslashes on Windows which broke various things (among them, relative paths for the externals symlinks):

https://github.com/vercel/next.js/blob/6eed9a05450f2c179b951c97350e305973a09e6f/crates/next-api/src/project.rs#L765