### PR TITLE
[turbopack] Remove the docs on the bundle size gap

### DIFF
--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -168,26 +168,6 @@ module.exports = {
 }
 ```
 
-### Bundle Sizes
-
-From our testing on production applications, we observed that Turbopack generally produces bundles that are similar in size to Webpack. However, the comparison can be difficult since turbopack tends to produce fewer but larger chunks. Our advice is to focus on higher level metrics like [Core Web Vitals](https://web.dev/articles/vitals) or your own application level metrics to compare performance across the two bundlers. We are however aware of one gap that can occasionally cause a large regression.
-
-Turbopack does not yet have an equivalent to the [Inner Graph Optimization](https://webpack.js.org/configuration/optimization/#optimizationinnergraph) in webpack which is enabled by default. This optimization is useful to tree shake large modules. For example:
-
-```js filename=large.module.js
-import heavy from 'some-heavy-dependency.js'
-
-export function usesHeavy() {
-  return heavy.run()
-}
-
-export const CONSTANT_VALUE = 3
-```
-
-If an application only uses `CONSTANT_VALUE` Turbopack will detect this and delete the `usesHeavy` export but not the corresponding `import`. However, with the Inner Graph Optimization, webpack can delete the `import` too which can drop the dependency as well.
-
-We are planning to offer an equivalent to the Inner Graph Optimization in Turbopack but it is still under development. If you are affected by this gap, consider manually splitting modules.
-
 ### Build Caching
 
 Webpack supports [disk build caching](https://webpack.js.org/configuration/cache/#cache) to improve build performance. Turbopack provides a similar opt-in feature, currently in beta. Starting with Next 16, you can enable Turbopack’s filesystem cache by setting the following experimental flags:


### PR DESCRIPTION
The biggest gap was 'Inner graph treeshaking' which was implemented in #85973 as `remove_unused_imports`

So we no longer need to document this issue