### PR TITLE
[test] Ensure CI uses configured Node.js version

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -151,9 +151,22 @@ jobs:
           script: |
             core.setOutput('input_step_key', '${{ inputs.stepName }}'.toLowerCase().replaceAll(/[/.]/g, '-').trim('-'));
 
-      - run: fnm use --install-if-missing ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
-      - run: fnm default ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
-      - run: node -v
+      - name: Use Node.js ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
+        run: |
+          node --version || echo "Node.js not installed yet"
+          # TODO: May be sufficient to just set `$FNM_MULTISHELL_PATH/bin` from `fnm env --json` into GITHUB_PATH
+          fnm_env=$(fnm env)
+          # Debug what we're about to eval
+          echo "$fnm_env"
+          eval "$fnm_env"
+          fnm use --install-if-missing ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
+          fnm default ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
+          node --version
+          which node
+          echo "$FNM_MULTISHELL_PATH/bin" >> "$GITHUB_PATH"
+      # Debug used Node.js version in a separate step to ensure
+      # the Node.js version is set for the entire job
+      - run: node --version
       - name: Prepare corepack
         if: ${{ contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
         run: |


### PR DESCRIPTION
We were missing `fnm`'s shell setup: https://github.com/Schniz/fnm#shell-setup

It only worked incidentally because of self-hosted runners. On GitHub runners you'd get warnings that the Node.js version wasn't set in the system PATH and then the next steps went back to using the Node.js version that's installed on the GitHub images by default.