### PR TITLE
Turbopack: don't read binding_usage in dev

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -460,6 +460,7 @@ impl ClientReferencesGraphs {
         entry: Vc<Box<dyn Module>>,
         has_layout_segments: bool,
         include_traced: bool,
+        include_binding_usage: bool,
     ) -> Result<Vc<ClientReferenceGraphResult>> {
         let span = tracing::info_span!("collect all client references for endpoint");
         async move {
@@ -477,7 +478,9 @@ impl ClientReferencesGraphs {
                 // messes up the order of the server_component_entries.
                 let server_entries = async {
                     if has_layout_segments {
-                        let server_entries = find_server_entries(entry, include_traced).await?;
+                        let server_entries =
+                            find_server_entries(entry, include_traced, include_binding_usage)
+                                .await?;
                         Ok(Some(server_entries))
                     } else {
                         Ok(None)

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -728,7 +728,10 @@ impl PageEndpoint {
 
         if *project.per_page_module_graph().await? {
             let next_mode = project.next_mode();
-            let should_trace = next_mode.await?.is_production();
+            let next_mode_ref = next_mode.await?;
+            let should_trace = next_mode_ref.is_production();
+            let should_read_binding_usage = next_mode_ref.is_production();
+
             let ssr_chunk_module = self.internal_ssr_chunk_module().await?;
             // Implements layout segment optimization to compute a graph "chain" for document, app,
             // page
@@ -745,6 +748,7 @@ impl PageEndpoint {
                     vec![ChunkGroupEntry::Shared(module)],
                     visited_modules,
                     should_trace,
+                    should_read_binding_usage,
                 );
                 graphs.push(graph);
                 visited_modules = visited_modules.concatenate(graph);
@@ -754,6 +758,7 @@ impl PageEndpoint {
                 vec![ChunkGroupEntry::Entry(vec![ssr_chunk_module.ssr_module])],
                 visited_modules,
                 should_trace,
+                should_read_binding_usage,
             );
             graphs.push(graph);
 

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -756,7 +756,7 @@ async fn get_mock_stylesheet(
         .module();
 
     let entries = get_evaluate_entries(mocked_response_asset, asset_context, None);
-    let module_graph = ModuleGraph::from_modules(entries.graph_entries(), false);
+    let module_graph = ModuleGraph::from_modules(entries.graph_entries(), false, false);
 
     let root = mock_fs.root().owned().await?;
     let val = evaluate(

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -308,6 +308,7 @@ async fn build_internal(
     let mut module_graph = ModuleGraph::from_modules(
         Vc::cell(vec![ChunkGroupEntry::Entry(entries.clone())]),
         false,
+        true,
     );
     let module_id_strategy = ResolvedVc::upcast(
         get_global_module_id_strategy(module_graph)

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -161,10 +161,13 @@ pub async fn create_web_entry_source(
                 .map(|&entry| ResolvedVc::upcast(entry)),
         )
         .collect::<Vec<ResolvedVc<Box<dyn Module>>>>();
-    let module_graph =
-        ModuleGraph::from_modules(Vc::cell(vec![ChunkGroupEntry::Entry(all_modules)]), false)
-            .to_resolved()
-            .await?;
+    let module_graph = ModuleGraph::from_modules(
+        Vc::cell(vec![ChunkGroupEntry::Entry(all_modules)]),
+        false,
+        false,
+    )
+    .to_resolved()
+    .await?;
 
     let entries: Vec<_> = entries
         .into_iter()

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -314,6 +314,7 @@ pub struct ModulesWithRefData(Vec<(ResolvedVc<Box<dyn ModuleReference>>, Resolve
 pub async fn primary_chunkable_referenced_modules(
     module: ResolvedVc<Box<dyn Module>>,
     include_traced: bool,
+    include_binding_usage: bool,
 ) -> Result<Vc<ModulesWithRefData>> {
     let modules = module
         .references()
@@ -333,7 +334,11 @@ pub async fn primary_chunkable_referenced_modules(
                     .await?
                     .primary_modules_ref()
                     .await?;
-                let binding_usage = reference.binding_usage().owned().await?;
+                let binding_usage = if include_binding_usage {
+                    reference.binding_usage().owned().await?
+                } else {
+                    BindingUsage::default()
+                };
 
                 return Ok(Some((
                     ResolvedVc::upcast(reference),

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -499,7 +499,7 @@ impl PostCssTransformedAsset {
             .to_resolved()
             .await?;
 
-        let module_graph = ModuleGraph::from_modules(entries.graph_entries(), false)
+        let module_graph = ModuleGraph::from_modules(entries.graph_entries(), false, false)
             .to_resolved()
             .await?;
 

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -245,7 +245,7 @@ impl WebpackLoadersProcessedAsset {
             .to_resolved()
             .await?;
 
-        let module_graph = ModuleGraph::from_modules(entries.graph_entries(), false)
+        let module_graph = ModuleGraph::from_modules(entries.graph_entries(), false, false)
             .to_resolved()
             .await?;
 

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -476,7 +476,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
 
     let entries = get_evaluate_entries(jest_entry_asset, asset_context, None);
 
-    let mut module_graph = ModuleGraph::from_modules(entries.graph_entries(), false);
+    let mut module_graph = ModuleGraph::from_modules(entries.graph_entries(), false, true);
 
     let binding_usage = if options.remove_unused_imports || options.remove_unused_exports {
         Some(

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -432,6 +432,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
     let mut module_graph = ModuleGraph::from_modules(
         Vc::cell(vec![ChunkGroupEntry::Entry(entry_modules.clone())]),
         false,
+        true,
     );
 
     let binding_usage = if options.remove_unused_imports || options.remove_unused_exports {


### PR DESCRIPTION
I'm debating whether this should be `Option<BindingUsage>` instead, so that we can detect if you built the graph without the binding_usage but then still try to enable `remove_unused_exports` (which would now silently noop and never tree shaking anything).