### PR TITLE
Convert Windows paths as well when reading sourcemap

### DIFF
--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -164,7 +164,10 @@ function getSourcemappedFrameIfPossible(
     // or "C:\Users\foo\APP\.next\server\chunks\ssr\[root-of-the-server]__2934a0._.js"
     // will be keyed by Node.js as "file:///APP/.next/server/chunks/ssr/[root-of-the-server]__2934a0._.js".
     // This is likely caused by `callsite.toString()` in `Error.prepareStackTrace converting file URLs to paths.
-    if (!sourceURL.startsWith('file://')) {
+    //
+    // But frame.file might also be "webpack-internal:///(rsc)/./app/bad-sourcemap/page.js" or
+    // "<anonymous>" or "node:internal/process/task_queues" here
+    if (path.isAbsolute(frame.file)) {
       sourceURL = url.pathToFileURL(frame.file).toString()
     }
     let maybeSourceMapPayload: ModernSourceMapPayload | undefined

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -160,10 +160,11 @@ function getSourcemappedFrameIfPossible(
   let sourceMapPayload: ModernSourceMapPayload
   if (sourceMapCacheEntry === undefined) {
     let sourceURL = frame.file
-    // e.g. "/APP/.next/server/chunks/ssr/[root-of-the-server]__2934a0._.js"
+    // e.g. "/Users/foo/APP/.next/server/chunks/ssr/[root-of-the-server]__2934a0._.js"
+    // or "C:\Users\foo\APP\.next\server\chunks\ssr\[root-of-the-server]__2934a0._.js"
     // will be keyed by Node.js as "file:///APP/.next/server/chunks/ssr/[root-of-the-server]__2934a0._.js".
     // This is likely caused by `callsite.toString()` in `Error.prepareStackTrace converting file URLs to paths.
-    if (sourceURL.startsWith('/')) {
+    if (!sourceURL.startsWith('file://')) {
       sourceURL = url.pathToFileURL(frame.file).toString()
     }
     let maybeSourceMapPayload: ModernSourceMapPayload | undefined


### PR DESCRIPTION
Fixes this warning on Windows:
`C:\Users\IEUser\Desktop \next-turbopack-issue-repro\.next\dev|server\chunks\ssr\[turbopack]_runtime.js: Invalid source map. Only conformant source maps can be used to find the original code. Cause: Error:
sourceMapURL could not be parsed`

Because `pathToFileURL` was only called for absolute Unix paths, not Windows paths.