### PR TITLE
[test] Improve app-basepath assertion error

### DIFF
--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -69,7 +69,7 @@ describe('app dir - basepath', () => {
     })
   })
 
-  it.each(['/base/refresh?foo=bar'])(
+  it.each(['/base/refresh', '/base/refresh?foo=bar'])(
     `should only make a single RSC call to the current page (%s)`,
     async (path) => {
       let rscRequests = []

--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, retry } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import type { Request, Response } from 'playwright'
 
 describe('app dir - basepath', () => {
@@ -69,7 +69,7 @@ describe('app dir - basepath', () => {
     })
   })
 
-  it.each(['/base/refresh', '/base/refresh?foo=bar'])(
+  it.each(['/base/refresh?foo=bar'])(
     `should only make a single RSC call to the current page (%s)`,
     async (path) => {
       let rscRequests = []
@@ -88,10 +88,12 @@ describe('app dir - basepath', () => {
           })
         },
       })
+
       await browser.elementByCss('button').click()
       await retry(async () => {
-        expect(rscRequests.length).toBe(1)
-        expect(rscRequests[0]).toContain(`${next.url}${path}`)
+        expect(rscRequests).toEqual([
+          expect.stringContaining(`${next.url}${path}`),
+        ])
       })
     }
   )
@@ -133,7 +135,9 @@ describe('app dir - basepath', () => {
       })
 
       await browser.elementById(buttonId).click()
-      await check(() => browser.url(), /\/base\/another/)
+      await retry(async () =>
+        expect(await browser.url()).toContain('/base/another')
+      )
 
       expect(await browser.waitForElementByCss('#page-2').text()).toBe(`Page 2`)
 
@@ -149,8 +153,8 @@ describe('app dir - basepath', () => {
       const request = requests[0]
       const response = responses[0]
 
-      expect(request.method()).toEqual('POST')
       expect(request.url()).toEqual(`${next.url}${initialPagePath}`)
+      expect(request.method()).toEqual('POST')
       expect(response.status()).toEqual(303)
     }
   )
@@ -181,7 +185,9 @@ describe('app dir - basepath', () => {
     })
 
     await browser.elementById('redirect-absolute-external').click()
-    await check(() => browser.url(), /\/outsideBasePath/)
+    await retry(async () =>
+      expect(await browser.url()).toContain('/outsideBasePath')
+    )
 
     // We expect to see two requests, first a POST invoking the server
     // action. And second a GET request resolving the redirect.
@@ -191,11 +197,11 @@ describe('app dir - basepath', () => {
     const [firstRequest, secondRequest] = requests
     const [firstResponse, secondResponse] = responses
 
-    expect(firstRequest.method()).toEqual('POST')
     expect(firstRequest.url()).toEqual(`${next.url}${initialPagePath}`)
+    expect(firstRequest.method()).toEqual('POST')
 
-    expect(secondRequest.method()).toEqual('GET')
     expect(secondRequest.url()).toEqual(`${next.url}${destinationPagePath}`)
+    expect(secondRequest.method()).toEqual('GET')
 
     expect(firstResponse.status()).toEqual(303)
     // Since this is an external request to a resource outside of NextJS


### PR DESCRIPTION
To make it print out what the second request is when this flake happens:
```

  ● app dir - basepath › should only make a single RSC call to the current page (/base/refresh?foo=bar)

    expect(received).toBe(expected) // Object.is equality

    Expected: 1
    Received: 2

      91 |       await browser.elementByCss('button').click()
      92 |       await retry(async () => {
    > 93 |         expect(rscRequests.length).toBe(1)
         |                                    ^
      94 |         expect(rscRequests[0]).toContain(`${next.url}${path}`)
      95 |       })
      96 |     }

      at toBe (e2e/app-dir/app-basepath/index.test.ts:93:36)
      at fn (lib/next-test-utils.ts:797:20)
      at e2e/app-dir/app-basepath/index.test.ts:92:7
```