### PR TITLE
Log generate params duration in dev

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2248,7 +2248,7 @@ export default abstract class Server<
       isDynamicRoute(pathname) &&
       (components.getStaticPaths || isAppPath)
     ) {
-      let getStaticPathsStart
+      let getStaticPathsStart: bigint | undefined
       if (opts.dev) {
         getStaticPathsStart = process.hrtime.bigint()
       }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2248,6 +2248,11 @@ export default abstract class Server<
       isDynamicRoute(pathname) &&
       (components.getStaticPaths || isAppPath)
     ) {
+      let getStaticPathsStart
+      if (opts.dev) {
+        getStaticPathsStart = process.hrtime.bigint()
+      }
+
       const pathsResults = await this.getStaticPaths({
         pathname,
         urlPathname,
@@ -2255,6 +2260,15 @@ export default abstract class Server<
         page: components.page,
         isAppPath,
       })
+
+      if (opts.dev && getStaticPathsStart && pathsResults.staticPaths?.length) {
+        addRequestMeta(
+          req,
+          'devGenerateStaticParamsDuration',
+          process.hrtime.bigint() - getStaticPathsStart
+        )
+      }
+
       if (isAppPath && this.nextConfig.cacheComponents) {
         if (pathsResults.prerenderedRoutes?.length) {
           let smallestFallbackRouteParams = null

--- a/packages/next/src/server/dev/log-requests.ts
+++ b/packages/next/src/server/dev/log-requests.ts
@@ -47,7 +47,8 @@ export function logRequests(
   requestEndTime: bigint,
   devRequestTimingMiddlewareStart: bigint | undefined,
   devRequestTimingMiddlewareEnd: bigint | undefined,
-  devRequestTimingInternalsEnd: bigint | undefined
+  devRequestTimingInternalsEnd: bigint | undefined,
+  devGenerateStaticParamsDuration: bigint | undefined
 ): void {
   if (!ignoreLoggingIncomingRequests(request, loggingConfig)) {
     logIncomingRequests(
@@ -57,7 +58,8 @@ export function logRequests(
       response.statusCode,
       devRequestTimingMiddlewareStart,
       devRequestTimingMiddlewareEnd,
-      devRequestTimingInternalsEnd
+      devRequestTimingInternalsEnd,
+      devGenerateStaticParamsDuration
     )
   }
 
@@ -75,7 +77,8 @@ function logIncomingRequests(
   statusCode: number,
   devRequestTimingMiddlewareStart: bigint | undefined,
   devRequestTimingMiddlewareEnd: bigint | undefined,
-  devRequestTimingInternalsEnd: bigint | undefined
+  devRequestTimingInternalsEnd: bigint | undefined,
+  devGenerateStaticParamsDuration: bigint | undefined
 ): void {
   const isRSC = getRequestMeta(request, 'isRSCRequest')
   const url = isRSC ? stripNextRscUnionQuery(request.url) : request.url
@@ -114,6 +117,11 @@ function logIncomingRequests(
     // Insert as the first item to be rendered in the list
     times.unshift(['compile', frameworkTime])
     times.push(['render', requestEndTime - devRequestTimingInternalsEnd])
+  }
+
+  if (devGenerateStaticParamsDuration) {
+    // Pages Router getStaticPaths are technically "generate params" as well.
+    times.push(['generate-params', devGenerateStaticParamsDuration])
   }
 
   return writeLine(

--- a/packages/next/src/server/dev/log-requests.ts
+++ b/packages/next/src/server/dev/log-requests.ts
@@ -116,12 +116,14 @@ function logIncomingRequests(
     }
     // Insert as the first item to be rendered in the list
     times.unshift(['compile', frameworkTime])
-    times.push(['render', requestEndTime - devRequestTimingInternalsEnd])
-  }
 
-  if (devGenerateStaticParamsDuration) {
-    // Pages Router getStaticPaths are technically "generate params" as well.
-    times.push(['generate-params', devGenerateStaticParamsDuration])
+    // Insert after compile, before render based on the execution order.
+    if (devGenerateStaticParamsDuration) {
+      // Pages Router getStaticPaths are technically "generate params" as well.
+      times.push(['generate-params', devGenerateStaticParamsDuration])
+    }
+
+    times.push(['render', requestEndTime - devRequestTimingInternalsEnd])
   }
 
   return writeLine(

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -519,7 +519,8 @@ export default class DevServer extends Server {
               requestEnd,
               getRequestMeta(req, 'devRequestTimingMiddlewareStart'),
               getRequestMeta(req, 'devRequestTimingMiddlewareEnd'),
-              getRequestMeta(req, 'devRequestTimingInternalsEnd')
+              getRequestMeta(req, 'devRequestTimingInternalsEnd'),
+              getRequestMeta(req, 'devGenerateStaticParamsDuration')
             )
           })
         }

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -270,6 +270,11 @@ export interface RequestMeta {
   devRequestTimingMiddlewareStart?: bigint
   devRequestTimingMiddlewareEnd?: bigint
   devRequestTimingInternalsEnd?: bigint
+
+  /**
+   * DEV only: The duration of getStaticPaths/generateStaticParams in process.hrtime.bigint()
+   */
+  devGenerateStaticParamsDuration?: bigint
 }
 
 /**


### PR DESCRIPTION
During the request in dev, there's a time to generate params from `getStaticPaths` or `generateStaticParams`. Include that in the request log. Since Pages Router's `getStaticPaths` are technically "generate params" as well, set the label to `generate-params`.

Example:

```
GET / in 0ms (compile: 0ms, generate-params: 0ms, render: 0ms)
```

<img width="1116" height="70" alt="CleanShot 2025-12-02 at 14 39 05@2x" src="https://github.com/user-attachments/assets/fc9ebc45-5b77-4a15-9567-43f0b6ace867" />