### PR TITLE
Abstract deployment id access into module

### DIFF
--- a/packages/next/src/build/deployment-id.ts
+++ b/packages/next/src/build/deployment-id.ts
@@ -1,6 +1,0 @@
-export function getDeploymentIdQueryOrEmptyString(): string {
-  if (process.env.NEXT_DEPLOYMENT_ID) {
-    return `?dpl=${process.env.NEXT_DEPLOYMENT_ID}`
-  }
-  return ''
-}

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -19,7 +19,7 @@ import { getProxiedPluginState } from '../../build-context'
 import { WEBPACK_LAYERS } from '../../../lib/constants'
 import { normalizePagePath } from '../../../shared/lib/page-path/normalize-page-path'
 import { CLIENT_STATIC_FILES_RUNTIME_MAIN_APP } from '../../../shared/lib/constants'
-import { getDeploymentIdQueryOrEmptyString } from '../../deployment-id'
+import { getDeploymentIdQueryOrEmptyString } from '../../../shared/lib/deployment-id'
 import {
   formatBarrelOptimizedResource,
   getModuleReferencesInOrder,

--- a/packages/next/src/client/app-webpack.ts
+++ b/packages/next/src/client/app-webpack.ts
@@ -1,7 +1,7 @@
 // Override chunk URL mapping in the webpack runtime
 // https://github.com/webpack/webpack/blob/2738eebc7880835d88c727d364ad37f3ec557593/lib/RuntimeGlobals.js#L204
 
-import { getDeploymentIdQueryOrEmptyString } from '../build/deployment-id'
+import { getDeploymentIdQueryOrEmptyString } from '../shared/lib/deployment-id'
 import { encodeURIPath } from '../shared/lib/encode-uri-path'
 
 declare const __webpack_require__: any

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -46,6 +46,7 @@ import RootErrorBoundary from './errors/root-error-boundary'
 import DefaultGlobalError from './builtin/global-error'
 import { RootLayoutBoundary } from '../../lib/framework/boundary-components'
 import type { StaticIndicatorState } from '../dev/hot-reloader/app/hot-reloader-app'
+import { getDeploymentIdQueryOrEmptyString } from '../../shared/lib/deployment-id'
 
 const globalMutable: {
   pendingMpaPath?: string
@@ -622,9 +623,7 @@ function RuntimeStyles() {
     }
   }, [renderedStylesSize, forceUpdate])
 
-  const dplId = process.env.NEXT_DEPLOYMENT_ID
-    ? `?dpl=${process.env.NEXT_DEPLOYMENT_ID}`
-    : ''
+  const dplId = getDeploymentIdQueryOrEmptyString()
   return [...runtimeStyles].map((href, i) => (
     <link
       key={i}

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -41,6 +41,7 @@ import {
   urlToUrlWithoutFlightMarker,
 } from '../../route-params'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
+import { deploymentId } from '../../../shared/lib/deployment-id'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
@@ -329,8 +330,8 @@ export async function createFetch<T>(
     headers['Next-Test-Fetch-Priority'] = fetchPriority
   }
 
-  if (process.env.NEXT_DEPLOYMENT_ID) {
-    headers['x-deployment-id'] = process.env.NEXT_DEPLOYMENT_ID
+  if (deploymentId) {
+    headers['x-deployment-id'] = deploymentId
   }
 
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -41,7 +41,7 @@ import {
   urlToUrlWithoutFlightMarker,
 } from '../../route-params'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
-import { deploymentId } from '../../../shared/lib/deployment-id'
+import { getDeploymentId } from '../../../shared/lib/deployment-id'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
@@ -330,6 +330,7 @@ export async function createFetch<T>(
     headers['Next-Test-Fetch-Priority'] = fetchPriority
   }
 
+  const deploymentId = getDeploymentId()
   if (deploymentId) {
     headers['x-deployment-id'] = deploymentId
   }

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -56,7 +56,7 @@ import {
   omitUnusedArgs,
 } from '../../../../shared/lib/server-reference-info'
 import { revalidateEntireCache } from '../../segment-cache/cache'
-import { deploymentId } from '../../../../shared/lib/deployment-id'
+import { getDeploymentId } from '../../../../shared/lib/deployment-id'
 
 const createFromFetch =
   createFromFetchBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromFetch']
@@ -111,6 +111,7 @@ async function fetchServerAction(
     ),
   }
 
+  const deploymentId = getDeploymentId()
   if (deploymentId) {
     headers['x-deployment-id'] = deploymentId
   }

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -56,6 +56,7 @@ import {
   omitUnusedArgs,
 } from '../../../../shared/lib/server-reference-info'
 import { revalidateEntireCache } from '../../segment-cache/cache'
+import { deploymentId } from '../../../../shared/lib/deployment-id'
 
 const createFromFetch =
   createFromFetchBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromFetch']
@@ -110,8 +111,8 @@ async function fetchServerAction(
     ),
   }
 
-  if (process.env.NEXT_DEPLOYMENT_ID) {
-    headers['x-deployment-id'] = process.env.NEXT_DEPLOYMENT_ID
+  if (deploymentId) {
+    headers['x-deployment-id'] = deploymentId
   }
 
   if (nextUrl) {

--- a/packages/next/src/client/route-loader.ts
+++ b/packages/next/src/client/route-loader.ts
@@ -3,7 +3,7 @@ import type { ProxyMatcher } from '../build/analysis/get-page-static-info'
 import getAssetPathFromRoute from '../shared/lib/router/utils/get-asset-path-from-route'
 import { __unsafeCreateTrustedScriptURL } from './trusted-types'
 import { requestIdleCallback } from './request-idle-callback'
-import { getDeploymentIdQueryOrEmptyString } from '../build/deployment-id'
+import { getDeploymentIdQueryOrEmptyString } from '../shared/lib/deployment-id'
 import { encodeURIPath } from '../shared/lib/encode-uri-path'
 
 // 3.8s was arbitrarily chosen as it's what https://web.dev/interactive

--- a/packages/next/src/client/webpack.ts
+++ b/packages/next/src/client/webpack.ts
@@ -2,13 +2,13 @@ declare const __webpack_require__: any
 declare let __webpack_public_path__: string
 
 import {
-  deploymentId,
+  getDeploymentId,
   getDeploymentIdQueryOrEmptyString,
 } from '../shared/lib/deployment-id'
 
 // If we have a deployment ID, we need to append it to the webpack chunk names
 // I am keeping the process check explicit so this can be statically optimized
-if (deploymentId) {
+if (getDeploymentId()) {
   const suffix = getDeploymentIdQueryOrEmptyString()
   const getChunkScriptFilename = __webpack_require__.u
   __webpack_require__.u = (...args: any[]) =>

--- a/packages/next/src/client/webpack.ts
+++ b/packages/next/src/client/webpack.ts
@@ -1,11 +1,14 @@
 declare const __webpack_require__: any
 declare let __webpack_public_path__: string
 
-import { getDeploymentIdQueryOrEmptyString } from '../build/deployment-id'
+import {
+  deploymentId,
+  getDeploymentIdQueryOrEmptyString,
+} from '../shared/lib/deployment-id'
 
 // If we have a deployment ID, we need to append it to the webpack chunk names
 // I am keeping the process check explicit so this can be statically optimized
-if (process.env.NEXT_DEPLOYMENT_ID) {
+if (deploymentId) {
   const suffix = getDeploymentIdQueryOrEmptyString()
   const getChunkScriptFilename = __webpack_require__.u
   __webpack_require__.u = (...args: any[]) =>

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -42,6 +42,7 @@ import type {
   GetStaticPaths,
   GetStaticProps,
 } from '../../../types'
+import { deploymentId } from '../../../shared/lib/deployment-id'
 
 export const getHandler = ({
   srcPage: originalSrcPage,
@@ -257,7 +258,7 @@ export const getHandler = ({
                     buildId,
                     customServer:
                       Boolean(routerServerContext?.isCustomServer) || undefined,
-                    deploymentId: process.env.NEXT_DEPLOYMENT_ID,
+                    deploymentId: deploymentId,
                   },
                   renderOpts: {
                     params,

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -42,7 +42,7 @@ import type {
   GetStaticPaths,
   GetStaticProps,
 } from '../../../types'
-import { deploymentId } from '../../../shared/lib/deployment-id'
+import { getDeploymentId } from '../../../shared/lib/deployment-id'
 
 export const getHandler = ({
   srcPage: originalSrcPage,
@@ -258,7 +258,7 @@ export const getHandler = ({
                     buildId,
                     customServer:
                       Boolean(routerServerContext?.isCustomServer) || undefined,
-                    deploymentId: deploymentId,
+                    deploymentId: getDeploymentId(),
                   },
                   renderOpts: {
                     params,

--- a/packages/next/src/shared/lib/deployment-id.ts
+++ b/packages/next/src/shared/lib/deployment-id.ts
@@ -1,6 +1,11 @@
-export let deploymentId: string | undefined = process.env.NEXT_DEPLOYMENT_ID
+// This could also be a variable instead of a function, but some unit tests want to change the ID at
+// runtime. Even though that would never happen in a real deployment.
+export function getDeploymentId(): string | undefined {
+  return process.env.NEXT_DEPLOYMENT_ID
+}
 
 export function getDeploymentIdQueryOrEmptyString(): string {
+  let deploymentId = getDeploymentId()
   if (deploymentId) {
     return `?dpl=${deploymentId}`
   }

--- a/packages/next/src/shared/lib/deployment-id.ts
+++ b/packages/next/src/shared/lib/deployment-id.ts
@@ -1,0 +1,8 @@
+export let deploymentId: string | undefined = process.env.NEXT_DEPLOYMENT_ID
+
+export function getDeploymentIdQueryOrEmptyString(): string {
+  if (deploymentId) {
+    return `?dpl=${deploymentId}`
+  }
+  return ''
+}

--- a/packages/next/src/shared/lib/image-loader.ts
+++ b/packages/next/src/shared/lib/image-loader.ts
@@ -1,6 +1,6 @@
 import type { ImageLoaderPropsWithConfig } from './image-config'
 import { findClosestQuality } from './find-closest-quality'
-import { deploymentId } from './deployment-id'
+import { getDeploymentId } from './deployment-id'
 
 function defaultLoader({
   config,
@@ -95,6 +95,7 @@ function defaultLoader({
 
   const q = findClosestQuality(quality, config)
 
+  let deploymentId = getDeploymentId()
   return `${config.path}?url=${encodeURIComponent(src)}&w=${width}&q=${q}${
     src.startsWith('/_next/static/media/') && deploymentId
       ? `&dpl=${deploymentId}`

--- a/packages/next/src/shared/lib/image-loader.ts
+++ b/packages/next/src/shared/lib/image-loader.ts
@@ -1,5 +1,6 @@
 import type { ImageLoaderPropsWithConfig } from './image-config'
 import { findClosestQuality } from './find-closest-quality'
+import { deploymentId } from './deployment-id'
 
 function defaultLoader({
   config,
@@ -95,8 +96,8 @@ function defaultLoader({
   const q = findClosestQuality(quality, config)
 
   return `${config.path}?url=${encodeURIComponent(src)}&w=${width}&q=${q}${
-    src.startsWith('/_next/static/media/') && process.env.NEXT_DEPLOYMENT_ID
-      ? `&dpl=${process.env.NEXT_DEPLOYMENT_ID}`
+    src.startsWith('/_next/static/media/') && deploymentId
+      ? `&dpl=${deploymentId}`
       : ''
   }`
 }

--- a/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
@@ -4,6 +4,7 @@ import { preload } from 'react-dom'
 
 import { workAsyncStorage } from '../../../server/app-render/work-async-storage.external'
 import { encodeURIPath } from '../encode-uri-path'
+import { getDeploymentIdQueryOrEmptyString } from '../deployment-id'
 
 export function PreloadChunks({
   moduleIds,
@@ -37,9 +38,7 @@ export function PreloadChunks({
     return null
   }
 
-  const dplId = process.env.NEXT_DEPLOYMENT_ID
-    ? `?dpl=${process.env.NEXT_DEPLOYMENT_ID}`
-    : ''
+  const dplId = getDeploymentIdQueryOrEmptyString()
 
   return (
     <>

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -43,7 +43,7 @@ import { interpolateAs } from './utils/interpolate-as'
 import { disableSmoothScrollDuringRouteTransition } from './utils/disable-smooth-scroll'
 import type { Params } from '../../../server/request/params'
 import { MATCHED_PATH_HEADER } from '../../../lib/constants'
-import { deploymentId } from '../deployment-id'
+import { getDeploymentId } from '../deployment-id'
 
 let resolveRewrites: typeof import('./utils/resolve-rewrites').default
 if (process.env.__NEXT_HAS_REWRITES) {
@@ -498,6 +498,7 @@ function fetchNextData({
   unstable_skipClientCache,
 }: FetchNextDataParams): Promise<FetchDataOutput> {
   const { href: cacheKey } = new URL(dataHref, window.location.href)
+  const deploymentId = getDeploymentId()
   const getData = (params?: { method?: 'HEAD' | 'GET' }) =>
     fetchRetry(dataHref, isServerRender ? 3 : 1, {
       headers: Object.assign(

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -43,6 +43,7 @@ import { interpolateAs } from './utils/interpolate-as'
 import { disableSmoothScrollDuringRouteTransition } from './utils/disable-smooth-scroll'
 import type { Params } from '../../../server/request/params'
 import { MATCHED_PATH_HEADER } from '../../../lib/constants'
+import { deploymentId } from '../deployment-id'
 
 let resolveRewrites: typeof import('./utils/resolve-rewrites').default
 if (process.env.__NEXT_HAS_REWRITES) {
@@ -503,9 +504,7 @@ function fetchNextData({
         {} as HeadersInit,
         isPrefetch ? { purpose: 'prefetch' } : {},
         isPrefetch && hasMiddleware ? { 'x-middleware-prefetch': '1' } : {},
-        process.env.NEXT_DEPLOYMENT_ID
-          ? { 'x-deployment-id': process.env.NEXT_DEPLOYMENT_ID }
-          : {}
+        deploymentId ? { 'x-deployment-id': deploymentId } : {}
       ),
       method: params?.method ?? 'GET',
     })


### PR DESCRIPTION
This also helps with persistent-caching performance, since fewer chunks change (only the ones containing this module, as opposed to the chunks containing all the users of the value)
