### PR TITLE
Fix dev server 400 errors after 5 minutes with Turbopack

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -265,6 +265,14 @@ export async function startServer(
   if (keepAliveTimeout) {
     server.keepAliveTimeout = keepAliveTimeout
   }
+
+  // Disable request/headers timeouts in dev to prevent 400 errors on long-running
+  // operations and idle connections (HMR WebSocket, compilation, etc.)
+  if (isDev) {
+    server.requestTimeout = 0
+    server.headersTimeout = 0
+  }
+
   server.on('upgrade', async (req, socket, head) => {
     try {
       await upgradeHandler(req, socket, head)


### PR DESCRIPTION
Fixes #86718

  Disables HTTP request/headers timeouts in dev mode to prevent 400 Bad Request errors after 5 minutes of idle connection time. Affects HMR WebSocket connections and
  long-running Turbopack compilation tasks.

  Node.js defaults: `requestTimeout=300000ms` (5 min), `headersTimeout=60000ms`. Setting to 0 disables timeouts in development only.