### PR TITLE
docs: Update guidance for page and test file organization

### DIFF
--- a/errors/page-without-valid-component.mdx
+++ b/errors/page-without-valid-component.mdx
@@ -13,7 +13,7 @@ This is a hard error because the page would error when rendered, and causes poor
 Investigate the list of page(s) specified in the error message.
 For each, you'll want to check if the file is meant to be a page.
 
-If the file is not meant to be a page, and instead, is a shared component or file, move the file to a different folder like `components` or `lib`.
+If the file is not meant to be a page, and instead, is a shared component or file, move the file to a different folder like `components` or `lib`. This also applies to colocated test files. If they remain inside the `pages` directory, Next.js will treat them as route files. To avoid this, keep tests in a dedicated folder.
 
 If the file is meant to be a page, double check you have an `export default` with the React Component instead of an `export`. If you're already using `export default`, make sure the returned value is a valid React Component.
 


### PR DESCRIPTION
### What?

This PR improves the documentation for the [Page Without Valid React Component](https://nextjs.org/docs/messages/page-without-valid-component) error. It clarifies that test files placed inside the `pages` directory can also trigger this error. It adds guidance on where to place tests to avoid build failures.

### Why?
Developers commonly encounter this error when unintentionally storing test files next to their page components (co-location). This clarification helps prevent confusion, improves developer experience, and offers a more thorough explanation of typical causes.

### How?
The docs were updated by extending the relevant sentence to include test-file scenarios.
