### PR TITLE
Deterministic functions-config-manifest.json

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -591,7 +591,6 @@ async function writeFunctionsConfigManifest(
   distDir: string,
   manifest: FunctionsConfigManifest
 ): Promise<void> {
-  // manifest.functions =
   let sortedManifest: FunctionsConfigManifest = {
     version: manifest.version,
     functions: Object.fromEntries(

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -591,9 +591,16 @@ async function writeFunctionsConfigManifest(
   distDir: string,
   manifest: FunctionsConfigManifest
 ): Promise<void> {
+  // manifest.functions =
+  let sortedManifest: FunctionsConfigManifest = {
+    version: manifest.version,
+    functions: Object.fromEntries(
+      Object.entries(manifest.functions).sort(([a], [b]) => a.localeCompare(b))
+    ),
+  }
   await writeManifest(
     path.join(distDir, SERVER_DIRECTORY, FUNCTIONS_CONFIG_MANIFEST),
-    manifest
+    sortedManifest
   )
 }
 


### PR DESCRIPTION
This manifest wasn't deterministic across builds
```diff
 - Expected
 + Received

   {
     "version": 1,
     "functions": {
 -     "/api/pages-api/edge": {},
       "/dynamic/pages-page/edge": {},
 +     "/api/pages-api/edge": {},
       "/app-route/edge": {},
       "/force-dynamic/app-route/edge": {},
       "/app-page/edge": {},
       "/force-dynamic/app-page/edge": {}
     }
   }
   
```