### PR TITLE
[test] app-basepath less agressive request reading

### DIFF
--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -76,9 +76,9 @@ describe('app dir - basepath', () => {
       const browser = await next.browser(path, {
         beforePageLoad(page) {
           page.on('request', async (request) => {
-            if (!request.isNavigationRequest()) {
-              // Ignore non-navigation requests, this also prevents us from calling allHeaders on
-              // in-flight requests after the browser was already closed.
+            if (!request.url().includes('_rsc')) {
+              // Filter out most requests earlier, to prevents calling `allHeaders()` on in-flight
+              // static resources requests after the browser was already closed.
               return
             }
 

--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -76,13 +76,21 @@ describe('app dir - basepath', () => {
       const browser = await next.browser(path, {
         beforePageLoad(page) {
           page.on('request', async (request) => {
-            if (!request.url().includes('_rsc')) {
-              // Filter out most requests earlier, to prevents calling `allHeaders()` on in-flight
-              // static resources requests after the browser was already closed.
-              return
+            let headers: { [key: string]: string }
+            try {
+              headers = await request.allHeaders()
+            } catch (e) {
+              if (
+                e.message.includes(
+                  'Target page, context or browser has been closed'
+                )
+              ) {
+                // Ignore errors caused by closed browser during test teardown
+                return
+              }
+              throw e
             }
 
-            let headers = await request.allHeaders()
             if (
               headers['rsc'] === '1' &&
               // Prefetches also include `rsc`

--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -75,16 +75,21 @@ describe('app dir - basepath', () => {
       let rscRequests = []
       const browser = await next.browser(path, {
         beforePageLoad(page) {
-          page.on('request', (request) => {
-            return request.allHeaders().then((headers) => {
-              if (
-                headers['rsc'] === '1' &&
-                // Prefetches also include `rsc`
-                headers['next-router-prefetch'] !== '1'
-              ) {
-                rscRequests.push(request.url())
-              }
-            })
+          page.on('request', async (request) => {
+            if (!request.isNavigationRequest()) {
+              // Ignore non-navigation requests, this also prevents us from calling allHeaders on
+              // in-flight requests after the browser was already closed.
+              return
+            }
+
+            let headers = await request.allHeaders()
+            if (
+              headers['rsc'] === '1' &&
+              // Prefetches also include `rsc`
+              headers['next-router-prefetch'] !== '1'
+            ) {
+              rscRequests.push(request.url())
+            }
           })
         },
       })


### PR DESCRIPTION
Hopefully helps with this
```
  ● app dir - basepath › should properly stream an internal server action redirect() with a relative URL

    request.allHeaders: Target page, context or browser has been closed

      77 |         beforePageLoad(page) {
      78 |           page.on('request', (request) => {
    > 79 |             return request.allHeaders().then((headers) => {
         |                            ^
      80 |               if (
      81 |                 headers['rsc'] === '1' &&
      82 |                 // Prefetches also include `rsc`

      at Page.allHeaders (e2e/app-dir/app-basepath/index.test.ts:79:28)
```