### PR TITLE
Stop apps/bundle-analyzer/next-env.d.ts from changing

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -73,6 +73,7 @@ test/development/mcp-server/fixtures/default-template/app/build-error/page.tsx
 /turbopack/crates/turbopack-tracing/tests/node-file-trace/test/unit/tsx/lib.tsx
 
 /apps/docs/.source/*
+/apps/*/next-env.d.ts
 
 # Symlink files
 readme.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -73,7 +73,6 @@ test/development/mcp-server/fixtures/default-template/app/build-error/page.tsx
 /turbopack/crates/turbopack-tracing/tests/node-file-trace/test/unit/tsx/lib.tsx
 
 /apps/docs/.source/*
-/apps/*/next-env.d.ts
 
 # Symlink files
 readme.md

--- a/apps/bundle-analyzer/.gitignore
+++ b/apps/bundle-analyzer/.gitignore
@@ -1,0 +1,41 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# Dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# Build outputs
+/build
+/.next/
+/out/
+
+# Coverage and test outputs
+/coverage
+
+# Generated content
+*.tsbuildinfo
+next-env.d.ts
+.source
+
+# Logs and debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Environment variables
+.env*
+.env*.local
+
+# Miscellaneous
+.DS_Store
+*.pem
+
+# Deployment
+.vercel

--- a/apps/bundle-analyzer/next-env.d.ts
+++ b/apps/bundle-analyzer/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/bundle-analyzer/next-env.d.ts
+++ b/apps/bundle-analyzer/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts'
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Running `pnpm build` was constantly changing this file because our prettier config mandates different quotes.