### PR TITLE
Deterministically order pages in the `MappedPages`  structure

### DIFF
--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -461,60 +461,65 @@ export async function createPagesMapping({
   appDirOnly: boolean
 }): Promise<MappedPages> {
   const isAppRoute = pagesType === 'app'
-  const pages: MappedPages = {}
-  const promises = pagePaths.map<Promise<void>>(async (pagePath) => {
-    // Do not process .d.ts files as routes
-    if (pagePath.endsWith('.d.ts') && pageExtensions.includes('ts')) {
-      return
-    }
 
-    let pageKey = getPageFromPath(pagePath, pageExtensions)
-    if (isAppRoute) {
-      pageKey = pageKey.replace(/%5F/g, '_')
-      if (pageKey === UNDERSCORE_NOT_FOUND_ROUTE) {
-        pageKey = UNDERSCORE_NOT_FOUND_ROUTE_ENTRY
+  const promises = pagePaths.map<Promise<[string, string] | undefined>>(
+    async (pagePath) => {
+      // Do not process .d.ts files as routes
+      if (pagePath.endsWith('.d.ts') && pageExtensions.includes('ts')) {
+        return
       }
-      if (pageKey === UNDERSCORE_GLOBAL_ERROR_ROUTE) {
-        pageKey = UNDERSCORE_GLOBAL_ERROR_ROUTE_ENTRY
+
+      let pageKey = getPageFromPath(pagePath, pageExtensions)
+      if (isAppRoute) {
+        pageKey = pageKey.replace(/%5F/g, '_')
+        if (pageKey === UNDERSCORE_NOT_FOUND_ROUTE) {
+          pageKey = UNDERSCORE_NOT_FOUND_ROUTE_ENTRY
+        }
+        if (pageKey === UNDERSCORE_GLOBAL_ERROR_ROUTE) {
+          pageKey = UNDERSCORE_GLOBAL_ERROR_ROUTE_ENTRY
+        }
       }
-    }
 
-    const normalizedPath = normalizePathSep(
-      join(
-        pagesType === 'pages'
-          ? PAGES_DIR_ALIAS
-          : pagesType === 'app'
-            ? APP_DIR_ALIAS
-            : ROOT_DIR_ALIAS,
-        pagePath
+      const normalizedPath = normalizePathSep(
+        join(
+          pagesType === 'pages'
+            ? PAGES_DIR_ALIAS
+            : pagesType === 'app'
+              ? APP_DIR_ALIAS
+              : ROOT_DIR_ALIAS,
+          pagePath
+        )
       )
-    )
 
-    let route = pagesType === 'app' ? normalizeMetadataRoute(pageKey) : pageKey
+      let route =
+        pagesType === 'app' ? normalizeMetadataRoute(pageKey) : pageKey
 
-    if (
-      pagesType === 'app' &&
-      isMetadataRouteFile(pagePath, pageExtensions, true)
-    ) {
-      const filePath = join(appDir!, pagePath)
-      const staticInfo = await getPageStaticInfo({
-        nextConfig: {},
-        pageFilePath: filePath,
-        isDev,
-        page: pageKey,
-        pageType: pagesType,
-      })
+      if (
+        pagesType === 'app' &&
+        isMetadataRouteFile(pagePath, pageExtensions, true)
+      ) {
+        const filePath = join(appDir!, pagePath)
+        const staticInfo = await getPageStaticInfo({
+          nextConfig: {},
+          pageFilePath: filePath,
+          isDev,
+          page: pageKey,
+          pageType: pagesType,
+        })
 
-      route = normalizeMetadataPageToRoute(
-        route,
-        !!(staticInfo.generateImageMetadata || staticInfo.generateSitemaps)
-      )
+        route = normalizeMetadataPageToRoute(
+          route,
+          !!(staticInfo.generateImageMetadata || staticInfo.generateSitemaps)
+        )
+      }
+
+      return [route, normalizedPath]
     }
+  )
 
-    pages[route] = normalizedPath
-  })
-
-  await Promise.all(promises)
+  const pages: MappedPages = Object.fromEntries(
+    (await Promise.all(promises)).filter((entry) => entry != null)
+  )
 
   switch (pagesType) {
     case PAGE_TYPES.ROOT: {


### PR DESCRIPTION
Because this object was aggregated during an async function the order of keys would be non-deterministic which could lead to non-determinism elsewhere