### PR TITLE
[turbopack] Move turbo-tasks-testing to dev-dependencies

### DIFF
--- a/crates/next-api/src/operation.rs
+++ b/crates/next-api/src/operation.rs
@@ -148,7 +148,7 @@ async fn pick_endpoint(
     op: OperationVc<Entrypoints>,
     selector: EndpointSelector,
 ) -> Result<Vc<OptionEndpoint>> {
-    let endpoints = op.connect().strongly_consistent().await?;
+    let endpoints = op.read_strongly_consistent().await?;
     let endpoint = match selector {
         EndpointSelector::InstrumentationNodeJs => {
             endpoints.instrumentation.as_ref().map(|i| i.node_js)

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -55,7 +55,6 @@ thread_local = { workspace = true }
 turbo-persistence = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
-turbo-tasks-testing = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
@@ -64,6 +63,7 @@ regex = { workspace = true }
 tempfile = { workspace = true }
 turbo-tasks-malloc = { workspace = true }
 rstest = { workspace = true }
+turbo-tasks-testing = { workspace = true }
 
 
 [[bench]]

--- a/turbopack/crates/turbopack-bench/Cargo.toml
+++ b/turbopack/crates/turbopack-bench/Cargo.toml
@@ -35,9 +35,9 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tungstenite = { workspace = true }
 turbo-tasks = { workspace = true }
-turbo-tasks-testing = { workspace = true }
 turbopack-create-test-app = { workspace = true }
 url = { workspace = true }
+turbo-tasks-testing = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version="0.30.1", features=["signal"] }

--- a/turbopack/crates/turbopack-bench/Cargo.toml
+++ b/turbopack/crates/turbopack-bench/Cargo.toml
@@ -35,9 +35,9 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tungstenite = { workspace = true }
 turbo-tasks = { workspace = true }
+turbo-tasks-testing = { workspace = true }
 turbopack-create-test-app = { workspace = true }
 url = { workspace = true }
-turbo-tasks-testing = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version="0.30.1", features=["signal"] }


### PR DESCRIPTION
This is testonly so shouldn't be built as part of our release