### PR TITLE
Refactor: Navigate and refresh simultaneously

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -6,14 +6,23 @@ import type {
 } from '../router-reducer-types'
 import { handleNavigationResult } from './navigate-reducer'
 import { refresh as refreshUsingSegmentCache } from '../../segment-cache/navigation'
+import { revalidateEntireCache } from '../../segment-cache/cache'
 
 export function refreshReducer(
   state: ReadonlyReducerState,
   action: RefreshAction
 ): ReducerState {
+  // TODO: Currently, all refreshes purge the prefetch cache. In the future,
+  // only client-side refreshes will have this behavior; the server-side
+  // `refresh` should send new data without purging the prefetch cache.
+  const currentNextUrl = state.nextUrl
+  const currentRouterState = state.tree
+  revalidateEntireCache(currentNextUrl, currentRouterState)
+
   const currentUrl = new URL(state.canonicalUrl, action.origin)
   const result = refreshUsingSegmentCache(
     currentUrl,
+    state.cache,
     state.tree,
     state.nextUrl,
     state.renderedSearch,

--- a/packages/next/src/shared/lib/segment.ts
+++ b/packages/next/src/shared/lib/segment.ts
@@ -86,3 +86,4 @@ export function getSelectedLayoutSegmentPath(
 
 export const PAGE_SEGMENT_KEY = '__PAGE__'
 export const DEFAULT_SEGMENT_KEY = '__DEFAULT__'
+export const NOT_FOUND_SEGMENT_KEY = '/_not-found'


### PR DESCRIPTION
This is a refactor of the ppr-navigations module to support navigating to a new tree and refreshing shared layouts within the same navigation.

Rather than modeling navigations and refreshes/revalidations as separate operations, a refresh is considered a special case of a navigation where any existing dynamic data is disregarded, and new data is fetched from the server. The rest of the tree is diffed as usual, and the routing behavior is the same.

Previously, the ppr-navigations module would revert to the "create" path whenever it was missing dynamic data (the CacheNode) for a shared segment. Now, the FlightRouterState alone is used to diff the old and new trees.

When dynamic data is missing, any shared segment (one that exists in both the old and new trees) is considered to be part of a "refresh", and any segment that is present only in the new tree is considered to be part of a "navigation". There are subtle distinctions in behavior between refreshes and navigations. For example, refreshed page segments aren't scrolled to, but navigated page segments are.