### PR TITLE
Turbopack: bincode: Add bincode encode/decode wrappers for `serde_json::Value` when stored in a cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9230,6 +9230,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "triomphe 0.1.12",
+ "turbo-bincode",
  "turbo-dyn-eq-hash",
  "turbo-rcstr",
  "turbo-tasks-hash",

--- a/turbopack/crates/turbo-tasks-macros/src/primitive_input.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/primitive_input.rs
@@ -1,14 +1,11 @@
-use proc_macro2::Span;
 use syn::{
-    Meta, Result, Token, Type,
+    MacroDelimiter, Meta, MetaList, Result, Token, Type,
     parse::{Parse, ParseStream},
-    spanned::Spanned,
 };
 
-#[derive(Debug)]
 pub struct PrimitiveInput {
     pub ty: Type,
-    pub manual_shrink_to_fit: Option<Span>,
+    pub bincode_wrappers: Option<BincodeWrappers>,
 }
 
 impl Parse for PrimitiveInput {
@@ -16,7 +13,7 @@ impl Parse for PrimitiveInput {
         let ty: Type = input.parse()?;
         let mut parsed_input = PrimitiveInput {
             ty,
-            manual_shrink_to_fit: None,
+            bincode_wrappers: None,
         };
         if input.parse::<Option<Token![,]>>()?.is_some() {
             let punctuated = input.parse_terminated(Meta::parse, Token![,])?;
@@ -27,20 +24,56 @@ impl Parse for PrimitiveInput {
                         .map(ToString::to_string)
                         .as_deref()
                         .unwrap_or_default(),
-                    &meta,
+                    meta,
                 ) {
-                    ("manual_shrink_to_fit", Meta::Path(_)) => {
-                        parsed_input.manual_shrink_to_fit = Some(meta.span())
+                    ("bincode_wrappers", meta) => {
+                        let Meta::List(MetaList {
+                            tokens: wrapper_tokens,
+                            delimiter: MacroDelimiter::Paren(..),
+                            ..
+                        }) = meta
+                        else {
+                            return Err(syn::Error::new_spanned(
+                                meta,
+                                "expected parenthesized (EncodeTy, DecodeTy) list",
+                            ));
+                        };
+                        parsed_input.bincode_wrappers = Some(syn::parse2(wrapper_tokens)?);
                     }
                     (_, meta) => {
                         return Err(syn::Error::new_spanned(
                             meta,
-                            "unexpected token, expected: \"manual_shrink_to_fit\"",
+                            "unexpected token, expected: \"bincode_wrappers\"",
                         ));
                     }
                 }
             }
         }
         Ok(parsed_input)
+    }
+}
+
+// TODO: wire this up in https://github.com/vercel/next.js/pull/86338
+#[allow(dead_code)]
+pub struct BincodeWrappers {
+    pub encode_ty: Type,
+    pub decode_ty: Type,
+}
+
+impl Parse for BincodeWrappers {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let punctuated = input.parse_terminated(Type::parse, Token![,])?;
+        let items: [Type; 2] = punctuated
+            .into_iter()
+            .collect::<Vec<_>>()
+            .try_into()
+            .map_err(|_| {
+                syn::Error::new(input.span(), "expected exactly two comma-separated types")
+            })?;
+        let (encode_ty, decode_ty) = items.into();
+        Ok(BincodeWrappers {
+            encode_ty,
+            decode_ty,
+        })
     }
 }

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -48,6 +48,7 @@ tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 triomphe = { workspace = true, features = ["unsize", "unstable"] }
+turbo-bincode = { workspace = true }
 turbo-dyn-eq-hash = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks-hash = { workspace = true }

--- a/turbopack/crates/turbo-tasks/src/primitives.rs
+++ b/turbopack/crates/turbo-tasks/src/primitives.rs
@@ -1,18 +1,25 @@
 use std::time::Duration;
 
+use bincode::{
+    Decode, Encode,
+    de::Decoder,
+    enc::Encoder,
+    error::{DecodeError, EncodeError},
+};
 use turbo_rcstr::RcStr;
 use turbo_tasks_macros::primitive as __turbo_tasks_internal_primitive;
 
 use crate::{
-    Vc, {self as turbo_tasks},
+    self as turbo_tasks, Vc,
+    value_type::{ManualDecodeWrapper, ManualEncodeWrapper},
 };
 
 __turbo_tasks_internal_primitive!(());
-__turbo_tasks_internal_primitive!(String, manual_shrink_to_fit);
+__turbo_tasks_internal_primitive!(String);
 __turbo_tasks_internal_primitive!(RcStr);
 __turbo_tasks_internal_primitive!(Option<String>);
 __turbo_tasks_internal_primitive!(Option<RcStr>);
-__turbo_tasks_internal_primitive!(Vec<RcStr>, manual_shrink_to_fit);
+__turbo_tasks_internal_primitive!(Vec<RcStr>);
 __turbo_tasks_internal_primitive!(Option<u16>);
 __turbo_tasks_internal_primitive!(Option<u64>);
 __turbo_tasks_internal_primitive!(bool);
@@ -29,7 +36,46 @@ __turbo_tasks_internal_primitive!(i64);
 __turbo_tasks_internal_primitive!(i128);
 __turbo_tasks_internal_primitive!(usize);
 __turbo_tasks_internal_primitive!(isize);
-__turbo_tasks_internal_primitive!(serde_json::Value);
+__turbo_tasks_internal_primitive!(
+    serde_json::Value,
+    bincode_wrappers(JsonValueEncodeWrapper, JsonValueDecodeWrapper),
+);
 __turbo_tasks_internal_primitive!(Duration);
-__turbo_tasks_internal_primitive!(Vec<u8>, manual_shrink_to_fit);
-__turbo_tasks_internal_primitive!(Vec<bool>, manual_shrink_to_fit);
+__turbo_tasks_internal_primitive!(Vec<u8>);
+__turbo_tasks_internal_primitive!(Vec<bool>);
+
+// TODO: use this in https://github.com/vercel/next.js/pull/86338
+#[allow(dead_code)]
+struct JsonValueEncodeWrapper<'a>(&'a serde_json::Value);
+
+impl ManualEncodeWrapper for JsonValueEncodeWrapper<'_> {
+    type Value = serde_json::Value;
+
+    fn new<'a>(value: &'a Self::Value) -> impl Encode + 'a {
+        JsonValueEncodeWrapper(value)
+    }
+}
+
+impl Encode for JsonValueEncodeWrapper<'_> {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        turbo_bincode::serde_json::encode(self.0, encoder)
+    }
+}
+
+// TODO: use this in https://github.com/vercel/next.js/pull/86338
+#[allow(dead_code)]
+struct JsonValueDecodeWrapper(serde_json::Value);
+
+impl ManualDecodeWrapper for JsonValueDecodeWrapper {
+    type Value = serde_json::Value;
+
+    fn inner(self) -> Self::Value {
+        self.0
+    }
+}
+
+impl<Context> Decode<Context> for JsonValueDecodeWrapper {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        Ok(Self(turbo_bincode::serde_json::decode(decoder)?))
+    }
+}

--- a/turbopack/crates/turbo-tasks/src/value_type.rs
+++ b/turbopack/crates/turbo-tasks/src/value_type.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use auto_hash_map::{AutoMap, AutoSet};
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use tracing::Span;
 
@@ -96,6 +97,21 @@ pub fn any_as_serialize<T: Any + Serialize + Send + Sync + 'static>(
         "any_as_serialize::<{}> called with invalid type",
         type_name::<T>()
     );
+}
+
+// TODO: use this in https://github.com/vercel/next.js/pull/86338
+#[allow(dead_code)]
+pub trait ManualEncodeWrapper: Encode {
+    type Value;
+    // this uses RPIT to avoid some lifetime problems
+    fn new<'a>(value: &'a Self::Value) -> impl Encode + 'a;
+}
+
+// TODO: use this in https://github.com/vercel/next.js/pull/86338
+#[allow(dead_code)]
+pub trait ManualDecodeWrapper: Decode<()> {
+    type Value;
+    fn inner(self) -> Self::Value;
 }
 
 impl ValueType {


### PR DESCRIPTION
This is used by https://github.com/vercel/next.js/pull/86338.

We store `serde_json::Value` directly in a cell. This worked because it was defined as a "primitive" (similar to how you can store a `Vc<bool>`). However, this doesn't implement `bincode::Encode`/`bincode::Decode`, so it causes problems when trying to store the cells using bincode.

This introduces a wrapper trait that we can implement for primitives to allow us to intercept their encoding/decoding. #86338 modifies `turbopack/crates/turbo-tasks-macros/src/primitive_macro.rs` to call this wrapper if it is provided.