### PR TITLE
[test] Don't use `request.allHeaders()` in sync `page.on()` callbacks

### DIFF
--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -75,22 +75,8 @@ describe('app dir - basepath', () => {
       let rscRequests = []
       const browser = await next.browser(path, {
         beforePageLoad(page) {
-          page.on('request', async (request) => {
-            let headers: { [key: string]: string }
-            try {
-              headers = await request.allHeaders()
-            } catch (e) {
-              if (
-                e.message.includes(
-                  'Target page, context or browser has been closed'
-                )
-              ) {
-                // Ignore errors caused by closed browser during test teardown
-                return
-              }
-              throw e
-            }
-
+          page.on('request', (request) => {
+            const headers = request.headers()
             if (
               headers['rsc'] === '1' &&
               // Prefetches also include `rsc`
@@ -103,6 +89,7 @@ describe('app dir - basepath', () => {
       })
 
       await browser.elementByCss('button').click()
+      await browser.waitForIdleNetwork()
       await retry(async () => {
         expect(rscRequests).toEqual([
           expect.stringContaining(`${next.url}${path}`),

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -107,11 +107,10 @@ describe('Switchable runtime', () => {
         const browser = await webdriver(context.appPort, '/node', {
           beforePageLoad(page) {
             page.on('request', (request) => {
-              return request.allHeaders().then((headers) => {
-                if (headers['rsc'] === '1') {
-                  flightRequest = request.url()
-                }
-              })
+              const headers = request.headers()
+              if (headers['rsc'] === '1') {
+                flightRequest = request.url()
+              }
             })
           },
         })
@@ -639,11 +638,10 @@ describe('Switchable runtime', () => {
         const browser = await webdriver(context.appPort, '/node', {
           beforePageLoad(page) {
             page.on('request', (request) => {
-              request.allHeaders().then((headers) => {
-                if (headers['rsc'] === '1') {
-                  flightRequest = request.url()
-                }
-              })
+              const headers = request.headers()
+              if (headers['rsc'] === '1') {
+                flightRequest = request.url()
+              }
             })
           },
         })


### PR DESCRIPTION
Alternative for #86740.

This should avoid running into these issues:

```
request.allHeaders: Target page, context or browser has been closed
```

The sync `headers()` method is sufficient for these use cases:

> Note that this method does not return security-related headers, including cookie-related ones. You can use `request.allHeaders()` for complete list of headers that include cookie information.

Note: The other occurrences of `request.allHeaders()` we have are fine because they're used in `page.route()` which does handle asynchronous callbacks.