### PR TITLE
Fix typo in fetching data documentation

### DIFF
--- a/docs/01-app/01-getting-started/07-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/07-fetching-data.mdx
@@ -569,7 +569,7 @@ export default async function Page({ params }) {
 
 ### Preloading data
 
-You can preload data by creating an utility function that you eagerly call above blocking requests. `<Item>` conditionally renders based on the `checkIsAvailable()` function.
+You can preload data by creating a utility function that you eagerly call above blocking requests. `<Item>` conditionally renders based on the `checkIsAvailable()` function.
 
 You can call `preload()` before `checkIsAvailable()` to eagerly initiate `<Item/>` data dependencies. By the time `<Item/>` is rendered, its data has already been fetched.
 


### PR DESCRIPTION
Corrects a grammatical error in the data preloading explanation. The phrase "an utility function" was updated to "a utility function" because "utility" begins with a consonant sound. This improves clarity and maintains consistency with standard English usage throughout the documentation.