### PR TITLE
Properly type edge handler fn

### DIFF
--- a/packages/next/src/build/templates/edge-app-route.ts
+++ b/packages/next/src/build/templates/edge-app-route.ts
@@ -1,5 +1,6 @@
 import { setManifestsSingleton } from '../../server/app-render/manifests-singleton'
 import type { NextConfigComplete } from '../../server/config-shared'
+import type { EdgeHandler } from '../../server/web/adapter'
 import { EdgeRouteModuleWrapper } from '../../server/web/edge-route-module-wrapper'
 
 // Import the userland code.
@@ -24,4 +25,8 @@ if (rscManifest && rscServerManifest) {
 
 export const ComponentMod = module
 
-export default EdgeRouteModuleWrapper.wrap(module.routeModule, { nextConfig })
+const handler: EdgeHandler = EdgeRouteModuleWrapper.wrap(module.routeModule, {
+  nextConfig,
+  page: 'VAR_PAGE',
+})
+export default handler

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -1,10 +1,13 @@
 import '../../server/web/globals'
-import { adapter, type NextRequestHint } from '../../server/web/adapter'
+import {
+  adapter,
+  type EdgeHandler,
+  type NextRequestHint,
+} from '../../server/web/adapter'
 import { IncrementalCache } from '../../server/lib/incremental-cache'
 
 import * as pageMod from 'VAR_USERLAND'
 
-import type { RequestData } from '../../server/web/types'
 import type { NextConfigComplete } from '../../server/config-shared'
 import { setManifestsSingleton } from '../../server/app-render/manifests-singleton'
 import { initializeCacheHandlers } from '../../server/use-cache/handlers'
@@ -353,11 +356,13 @@ async function requestHandler(
   )
 }
 
-export default function nHandler(opts: { page: string; request: RequestData }) {
+const handler: EdgeHandler = (opts) => {
   return adapter({
     ...opts,
     IncrementalCache,
     handler: requestHandler,
     incrementalCacheHandler,
+    page: 'VAR_PAGE',
   })
 }
+export default handler

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -1,5 +1,9 @@
 import '../../server/web/globals'
-import { adapter, type NextRequestHint } from '../../server/web/adapter'
+import {
+  adapter,
+  type EdgeHandler,
+  type NextRequestHint,
+} from '../../server/web/adapter'
 import { IncrementalCache } from '../../server/lib/incremental-cache'
 import { initializeCacheHandlers } from '../../server/use-cache/handlers'
 
@@ -18,7 +22,6 @@ import RouteModule, {
 } from '../../server/route-modules/pages/module'
 import { WebNextRequest, WebNextResponse } from '../../server/base-http/web'
 
-import type { RequestData } from '../../server/web/types'
 import type { NextConfigComplete } from '../../server/config-shared'
 import type { NextFetchEvent } from '../../server/web/spec-extension/fetch-event'
 import type RenderResult from '../../server/render-result'
@@ -354,12 +357,14 @@ async function requestHandler(
   )
 }
 
-export default function nHandler(opts: { page: string; request: RequestData }) {
+const handler: EdgeHandler = (opts) => {
   return adapter({
     ...opts,
     IncrementalCache,
     handler: requestHandler,
     incrementalCacheHandler,
     bypassNextUrl: true,
+    page: 'VAR_PAGE',
   })
 }
+export default handler

--- a/packages/next/src/build/templates/middleware.ts
+++ b/packages/next/src/build/templates/middleware.ts
@@ -1,4 +1,4 @@
-import type { AdapterOptions } from '../../server/web/adapter'
+import type { AdapterOptions, EdgeHandler } from '../../server/web/adapter'
 
 import '../../server/web/globals'
 
@@ -13,7 +13,7 @@ const mod = { ..._mod }
 
 const page: string = 'VAR_DEFINITION_PAGE'
 const isProxy = page === '/proxy' || page === '/src/proxy'
-const handler = (isProxy ? mod.proxy : mod.middleware) || mod.default
+const handlerUserland = (isProxy ? mod.proxy : mod.middleware) || mod.default
 
 class ProxyMissingExportError extends Error {
   constructor(message: string) {
@@ -25,7 +25,7 @@ class ProxyMissingExportError extends Error {
 
 // TODO: This spams logs during development. Find a better way to handle this.
 // Removing this will spam "fn is not a function" logs which is worse.
-if (typeof handler !== 'function') {
+if (typeof handlerUserland !== 'function') {
   throw new ProxyMissingExportError(
     `The ${isProxy ? 'Proxy' : 'Middleware'} file "${page}" must export a function named \`${isProxy ? 'proxy' : 'middleware'}\` or a default function.`
   )
@@ -69,12 +69,11 @@ function errorHandledHandler(fn: AdapterOptions['handler']) {
   }
 }
 
-export default function nHandler(
-  opts: Omit<AdapterOptions, 'IncrementalCache' | 'page' | 'handler'>
-) {
+const handler: EdgeHandler = (opts) => {
   return adapter({
     ...opts,
     page,
-    handler: errorHandledHandler(handler),
+    handler: errorHandledHandler(handlerUserland),
   })
 }
+export default handler

--- a/packages/next/src/build/templates/pages-edge-api.ts
+++ b/packages/next/src/build/templates/pages-edge-api.ts
@@ -1,4 +1,4 @@
-import type { AdapterOptions } from '../../server/web/adapter'
+import type { EdgeHandler } from '../../server/web/adapter'
 
 import '../../server/web/globals'
 
@@ -7,23 +7,22 @@ import { IncrementalCache } from '../../server/lib/incremental-cache'
 import { wrapApiHandler } from '../../server/api-utils'
 
 // Import the userland code.
-import handler from 'VAR_USERLAND'
+import handlerUserland from 'VAR_USERLAND'
 
 const page = 'VAR_DEFINITION_PAGE'
 
-if (typeof handler !== 'function') {
+if (typeof handlerUserland !== 'function') {
   throw new Error(
     `The Edge Function "pages${page}" must export a \`default\` function`
   )
 }
 
-export default function (
-  opts: Omit<AdapterOptions, 'IncrementalCache' | 'page' | 'handler'>
-) {
+const handler: EdgeHandler = (opts) => {
   return adapter({
     ...opts,
     IncrementalCache,
     page: 'VAR_DEFINITION_PATHNAME',
-    handler: wrapApiHandler(page, handler),
+    handler: wrapApiHandler(page, handlerUserland),
   })
 }
+export default handler

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -76,6 +76,8 @@ export type AdapterOptions = {
   bypassNextUrl?: boolean
 }
 
+// This has to be compatible with what the Vercel builder does as well:
+// https://github.com/vercel/vercel/blob/0e0a6eb9f12216202ae2f5ee37e4ada1796361fd/packages/next/src/edge-function-source/get-edge-function.ts#L112-L136
 export type EdgeHandler = (opts: {
   request: AdapterOptions['request']
 }) => Promise<FetchEventResult>

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -76,6 +76,10 @@ export type AdapterOptions = {
   bypassNextUrl?: boolean
 }
 
+export type EdgeHandler = (opts: {
+  request: AdapterOptions['request']
+}) => Promise<FetchEventResult>
+
 let propagator: <T>(request: NextRequestHint, fn: () => T) => T = (
   request,
   fn

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -6,7 +6,7 @@ import type {
 
 import './globals'
 
-import { adapter, type AdapterOptions } from './adapter'
+import { adapter, type EdgeHandler } from './adapter'
 import { IncrementalCache } from '../lib/incremental-cache'
 import { RouteMatcher } from '../route-matchers/route-matcher'
 import type { NextFetchEvent } from './spec-extension/fetch-event'
@@ -19,6 +19,7 @@ import type { NextConfigComplete } from '../config-shared'
 
 export interface WrapOptions {
   nextConfig: NextConfigComplete
+  page: string
 }
 
 /**
@@ -52,17 +53,21 @@ export class EdgeRouteModuleWrapper {
    *                override the ones passed from the runtime
    * @returns a function that can be used as a handler for the edge runtime
    */
-  public static wrap(routeModule: AppRouteRouteModule, options: WrapOptions) {
+  public static wrap(
+    routeModule: AppRouteRouteModule,
+    options: WrapOptions
+  ): EdgeHandler {
     // Create the module wrapper.
     const wrapper = new EdgeRouteModuleWrapper(routeModule, options.nextConfig)
 
     // Return the wrapping function.
-    return (opts: AdapterOptions) => {
+    return (opts) => {
       return adapter({
         ...opts,
         IncrementalCache,
         // Bind the handler method to the wrapper so it still has context.
         handler: wrapper.handler.bind(wrapper),
+        page: options.page,
       })
     }
   }

--- a/packages/next/src/server/web/sandbox/sandbox.ts
+++ b/packages/next/src/server/web/sandbox/sandbox.ts
@@ -1,4 +1,4 @@
-import type { NodejsRequestData, FetchEventResult, RequestData } from '../types'
+import type { NodejsRequestData, FetchEventResult } from '../types'
 import type { EdgeFunctionDefinition } from '../../../build/webpack/plugins/middleware-plugin'
 import type { EdgeRuntime } from 'next/dist/compiled/edge-runtime'
 import {
@@ -16,6 +16,7 @@ import {
   RouterServerContextSymbol,
   routerServerGlobal,
 } from '../../lib/router-utils/router-server-context'
+import type { EdgeHandler } from '../adapter'
 
 export const ErrorSource = Symbol('SandboxError')
 
@@ -104,10 +105,7 @@ export async function getRuntimeContext(
 export const run = withTaggedErrors(async function runWithTaggedErrors(params) {
   const runtime = await getRuntimeContext(params)
 
-  // TODO better typesafety here
-  const edgeFunction: (args: {
-    request: RequestData
-  }) => Promise<FetchEventResult> = (
+  const edgeFunction: EdgeHandler = (
     await runtime.context._ENTRIES[`middleware_${params.name}`]
   ).default
 


### PR DESCRIPTION
Followup to https://github.com/vercel/next.js/issues/86765

There were quite a few cases where `page` wasn't actually passed to ​`adapter`​. I hope I'm now passing the right string there.

The old `nHandler(opts: { page: string; request: RequestData }) was a lie, ​packages/next/src/server/web/sandbox/sandbox.ts`​ never passes `page`​