### PR TITLE
Fix developement ux on window

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "check-precompiled": "./scripts/check-pre-compiled.sh",
     "prepublishOnly": "turbo run build",
     "lint-staged": "lint-staged",
-    "next-with-deps": "./scripts/next-with-deps.sh",
+    "next-with-deps": "cross-env ./scripts/next-with-deps.sh",
     "next": "cross-env NEXT_PRIVATE_LOCAL_DEV=1 NEXT_TELEMETRY_DISABLED=1 NODE_OPTIONS=\"--trace-deprecation --enable-source-maps\" next",
     "next-no-sourcemaps": "echo 'No longer supported. Use `pnpm next --disable-source-maps` instead'; exit 1;",
     "clean-trace-jaeger": "node scripts/rm.mjs test/integration/basic/.next && TRACE_TARGET=JAEGER pnpm next build test/integration/basic",

--- a/scripts/next-with-deps.sh
+++ b/scripts/next-with-deps.sh
@@ -4,6 +4,9 @@ START_DIR=$PWD
 # gets last argument which should be the project dir
 for PROJECT_DIR in $@;do :;done
 
+# remove trailing slashes if any
+PROJECT_DIR=${PROJECT_DIR%/}
+
 if [ -z $PROJECT_DIR ];then
   echo "No project directory provided, exiting..."
   exit 1;


### PR DESCRIPTION
### What?

Add cross-env in the next-with-deps for compatibility with windows environement. 
Handle potential trailing slash passed to the directory argument of next-with-deps

### Why?

While trying to make some change to Next I couldn't run the next-with-deps script from GitBash.
Then I noticed that if you have a trailing slash at the end of your command like `pnpm next-with-deps ./examples/{someExampleFolder}/` it'll construct a "wrong path" in `next-with-deps.sh` by having two // in a row (`if [ -d "$PROJECT_DIR/node_modules/$dep" ];then`)
As far as I know two slash in a row is still valid, but it's always good to sanitize paths in my opinion. 

### How?

Added `cross-env` in the package.json script next-with-deps.
In the `next-with-deps.sh` script, the line `PROJECT_DIR=${PROJECT_DIR%/}` removes the trailing slash from the `PROJECT_DIR` variable if it exists. The `/` character in `${PROJECT_DIR%/}` is treated as a pattern, and if the pattern matches the end of the variable's value, it's removed. In this case, the pattern is a slash, so any trailing slash will be removed.

Fixes ( no related issues )
