### PR TITLE
fix: ensure consistent CSS ordering between dev and build with Turbopack

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -297,6 +297,7 @@ export class ClientReferenceManifestPlugin {
       manifest.entryCSSFiles[chunkEntryName] = entrypoint
         .getFiles()
         .filter((f) => !f.startsWith('static/css/pages/') && f.endsWith('.css'))
+        .sort() // Sort CSS files to ensure consistent order between dev and build
         .map((file) => {
           const source = compilation.getAsset(file)!.source.source()
           if (


### PR DESCRIPTION
Fixes #86704

## Problem

CSS prioritization differs between `next dev --turbopack` and `next build --turbopack`, causing layout breakage in production builds. Styles that load correctly in development mode are applied in a different order in production, breaking the visual appearance.

## Root Cause

In [`flight-manifest-plugin.ts:297-318`](https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts#L297-L318), CSS files are collected from webpack entrypoints using:

```typescript
manifest.entryCSSFiles[chunkEntryName] = entrypoint
  .getFiles()
  .filter((f) => !f.startsWith('static/css/pages/') && f.endsWith('.css'))
  .map((file) => { /* ... */ })