### PR TITLE
Remove Vercel mention from Next.js docs

### DIFF
--- a/docs/01-app/02-guides/data-security.mdx
+++ b/docs/01-app/02-guides/data-security.mdx
@@ -397,13 +397,11 @@ However, for this to happen, the captured variables are sent to the client and b
 
 ### Overwriting encryption keys (advanced)
 
-When self-hosting your Next.js application across multiple servers, each server instance may end up with a different encryption key, leading to potential inconsistencies.
+When **self-hosting** your Next.js application across multiple servers, each server instance may end up with a different encryption key, leading to potential inconsistencies.
 
 To mitigate this, you can overwrite the encryption key using the `process.env.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` environment variable. Specifying this variable ensures that your encryption keys are persistent across builds, and all server instances use the same key. This variable **must** be AES-GCM encrypted.
 
 This is an advanced use case where consistent encryption behavior across multiple deployments is critical for your application. You should consider standard security practices such key rotation and signing.
-
-> **Good to know:** Next.js applications deployed to Vercel automatically handle this.
 
 ### Allowed origins (advanced)
 


### PR DESCRIPTION
I think overall it's not appropriate to add Vercel-specific caveats to these guides because they make it look like they're upselling Vercel. I've edited to emphasize the self-hosting condition instead, from which one should be able to infer it doesn't apply to Vercel.
