### PR TITLE
fix: issue where fouc callback is paused in inactive tabs

### DIFF
--- a/packages/next/src/client/dev/fouc.ts
+++ b/packages/next/src/client/dev/fouc.ts
@@ -6,7 +6,11 @@
 //
 // See: https://www.vector-logic.com/blog/posts/on-request-animation-frame-and-embedded-iframes
 const safeCallbackQueue = (callback: () => void) => {
-  if (window.requestAnimationFrame && window.self === window.top) {
+  if (
+    window.requestAnimationFrame &&
+    window.self === window.top &&
+    document.visibilityState === 'visible'
+  ) {
     window.requestAnimationFrame(callback)
   } else {
     window.setTimeout(callback)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

The fouc helper callback queue gets paused in inactive tabs due to the usage of `requestAnimationFrame` (which gets paused at the browser level for resource optimization).

This means that new tabs opened via ctrl+click and Open Link in New Tab popup only commence loading once you visit them.

This only occurs for Turbpopack builds when using the Pages router.

All Webpack builds do not have this issue nor does App router when combined with Turbopack.

I created a clear repro repo for the issue here to aid reviewing: https://github.com/peterjcaulfield/turbopack-render-bug
