### PR TITLE
fix(next/image): handle `?dpl` for src without protocol

### DIFF
--- a/packages/next/src/shared/lib/get-img-props.ts
+++ b/packages/next/src/shared/lib/get-img-props.ts
@@ -232,7 +232,7 @@ function generateImgAttrs({
 }: GenImgAttrsData): GenImgAttrsResult {
   if (unoptimized) {
     const deploymentId = getDeploymentId()
-    if (src.startsWith('/') && deploymentId) {
+    if (src.startsWith('/') && !src.startsWith('//') && deploymentId) {
       const sep = src.includes('?') ? '&' : '?'
       src = `${src}${sep}dpl=${deploymentId}`
     }

--- a/test/unit/next-image-get-img-props.test.ts
+++ b/test/unit/next-image-get-img-props.test.ts
@@ -796,4 +796,28 @@ describe('getImageProps()', () => {
       delete process.env.NEXT_DEPLOYMENT_ID
     }
   })
+  it('should not add query string for unoptimized with no protocol when NEXT_DEPLOYMENT_ID defined', async () => {
+    try {
+      process.env.NEXT_DEPLOYMENT_ID = 'dpl_123'
+      const { props } = getImageProps({
+        alt: 'a nice desc',
+        src: '//example.com/test.png',
+        unoptimized: true,
+        width: 100,
+        height: 200,
+      })
+      expect(warningMessages).toStrictEqual([])
+      expect(Object.entries(props)).toStrictEqual([
+        ['alt', 'a nice desc'],
+        ['loading', 'lazy'],
+        ['width', 100],
+        ['height', 200],
+        ['decoding', 'async'],
+        ['style', { color: 'transparent' }],
+        ['src', '//example.com/test.png'],
+      ])
+    } finally {
+      delete process.env.NEXT_DEPLOYMENT_ID
+    }
+  })
 })


### PR DESCRIPTION
Follow up to previous PR based on this comment: https://github.com/vercel/next.js/pull/86485#discussion_r2589758455

We want to avoid adding `?dpl` when the deployment is an absolute url missing the protocol which is allowed when `unoptimized=true`.