### PR TITLE
Turbopack: remove pages router double template

### DIFF
--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -887,12 +887,16 @@ impl PageEndpoint {
                     runtime: NextRuntime::NodeJs,
                     regions: config.preferred_region.clone(),
                 }
-            } else if runtime == NextRuntime::Edge {
+            } else {
                 let modules = create_page_ssr_entry_module(
                     this.pathname.clone(),
                     reference_type,
                     project_root,
-                    Vc::upcast(edge_module_context),
+                    if runtime == NextRuntime::Edge {
+                        Vc::upcast(edge_module_context)
+                    } else {
+                        Vc::upcast(module_context)
+                    },
                     self.source(),
                     this.original_name.clone(),
                     *this.pages_structure,
@@ -901,26 +905,6 @@ impl PageEndpoint {
                 )
                 .await?;
 
-                InternalSsrChunkModule {
-                    ssr_module: modules.ssr_module,
-                    app_module: modules.app_module,
-                    document_module: modules.document_module,
-                    runtime,
-                    regions: config.preferred_region.clone(),
-                }
-            } else {
-                let modules = create_page_ssr_entry_module(
-                    this.pathname.clone(),
-                    reference_type,
-                    project_root,
-                    Vc::upcast(module_context),
-                    self.source(),
-                    this.original_name.clone(),
-                    *this.pages_structure,
-                    runtime,
-                    this.pages_project.project().next_config(),
-                )
-                .await?;
                 InternalSsrChunkModule {
                     ssr_module: modules.ssr_module,
                     app_module: modules.app_module,

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -91,9 +91,9 @@ pub async fn get_middleware_module(
     let source = load_next_js_template(
         "middleware.js",
         project_root,
-        &[("VAR_USERLAND", INNER), ("VAR_DEFINITION_PAGE", page_path)],
-        &[],
-        &[],
+        [("VAR_USERLAND", INNER), ("VAR_DEFINITION_PAGE", page_path)],
+        [],
+        [],
     )
     .await?;
 

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -76,7 +76,7 @@ pub async fn get_app_page_entry(
     let source = load_next_js_template(
         "app-page.js",
         project_root.clone(),
-        &[
+        [
             ("VAR_DEFINITION_PAGE", &*page.to_string()),
             ("VAR_DEFINITION_PATHNAME", &pathname),
             (
@@ -88,12 +88,12 @@ pub async fn get_app_page_entry(
                 },
             ),
         ],
-        &[
+        [
             ("tree", &*loader_tree_code),
             ("__next_app_require__", &TURBOPACK_REQUIRE.bound()),
             ("__next_app_load_chunk__", &TURBOPACK_LOAD.bound()),
         ],
-        &[],
+        [],
     )
     .await?;
 
@@ -150,13 +150,13 @@ async fn wrap_edge_page(
     let source = load_next_js_template(
         "edge-ssr-app.js",
         project_root.clone(),
-        &[("VAR_USERLAND", INNER), ("VAR_PAGE", &page.to_string())],
-        &[
+        [("VAR_USERLAND", INNER), ("VAR_PAGE", &page.to_string())],
+        [
             // TODO do we really need to pass the entire next config here?
             // This is bad for invalidation as any config change will invalidate this
             ("nextConfig", &*serde_json::to_string(next_config_val)?),
         ],
-        &[("incrementalCacheHandler", None)],
+        [("incrementalCacheHandler", None)],
     )
     .await?;
 

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -73,7 +73,7 @@ pub async fn get_app_route_entry(
     let virtual_source = load_next_js_template(
         "app-route.js",
         project_root.clone(),
-        &[
+        [
             ("VAR_DEFINITION_PAGE", &*page.to_string()),
             ("VAR_DEFINITION_PATHNAME", &pathname),
             ("VAR_DEFINITION_FILENAME", path.file_stem().unwrap()),
@@ -82,8 +82,8 @@ pub async fn get_app_route_entry(
             ("VAR_RESOLVED_PAGE_PATH", &path.value_to_string().await?),
             ("VAR_USERLAND", &inner),
         ],
-        &[("nextConfigOutput", output_type)],
-        &[],
+        [("nextConfigOutput", output_type)],
+        [],
     )
     .await?;
 
@@ -141,9 +141,9 @@ async fn wrap_edge_route(
     let source = load_next_js_template(
         "edge-app-route.js",
         project_root.clone(),
-        &[("VAR_USERLAND", &*inner), ("VAR_PAGE", &page.to_string())],
-        &[("nextConfig", &*serde_json::to_string(next_config)?)],
-        &[],
+        [("VAR_USERLAND", &*inner), ("VAR_PAGE", &page.to_string())],
+        [("nextConfig", &*serde_json::to_string(next_config)?)],
+        [],
     )
     .await?;
 

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -236,12 +236,12 @@ pub enum MiddlewareMatcherKind {
 
 /// Loads a next.js template, replaces `replacements` and `injections` and makes
 /// sure there are none left over.
-pub async fn load_next_js_template(
-    template_path: &str,
+pub async fn load_next_js_template<'b>(
+    template_path: &'b str,
     project_path: FileSystemPath,
-    replacements: &[(&str, &str)],
-    injections: &[(&str, &str)],
-    imports: &[(&str, Option<&str>)],
+    replacements: impl IntoIterator<Item = (&'b str, &'b str)>,
+    injections: impl IntoIterator<Item = (&'b str, &'b str)>,
+    imports: impl IntoIterator<Item = (&'b str, Option<&'b str>)>,
 ) -> Result<Vc<Box<dyn Source>>> {
     let template_path = virtual_next_js_template_path(project_path.clone(), template_path).await?;
 
@@ -254,9 +254,9 @@ pub async fn load_next_js_template(
         &content,
         &template_path.path,
         &package_root.path,
-        replacements.iter().copied(),
-        injections.iter().copied(),
-        imports.iter().copied(),
+        replacements,
+        injections,
+        imports,
     )?;
 
     let file = File::from(content);

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -91,7 +91,7 @@ async function requestHandler(
   req: NextRequestHint,
   _event: NextFetchEvent
 ): Promise<Response> {
-  let srcPage = 'VAR_PAGE'
+  let srcPage = 'VAR_DEFINITION_PATHNAME'
 
   const relativeUrl = `${req.nextUrl.pathname}${req.nextUrl.search}`
   const baseReq = new WebNextRequest(req)
@@ -364,7 +364,7 @@ const handler: EdgeHandler = (opts) => {
     handler: requestHandler,
     incrementalCacheHandler,
     bypassNextUrl: true,
-    page: 'VAR_PAGE',
+    page: 'VAR_DEFINITION_PATHNAME',
   })
 }
 export default handler

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -172,7 +172,7 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
         'edge-ssr',
         {
           VAR_USERLAND: pageModPath,
-          VAR_PAGE: page,
+          VAR_DEFINITION_PATHNAME: page,
           VAR_MODULE_DOCUMENT: documentPath,
           VAR_MODULE_APP: appPath,
           VAR_MODULE_GLOBAL_ERROR: errorPath,


### PR DESCRIPTION
Webpack does:
`templates/edge-ssr.js -> user's pages/index.js`

Turbopack does
`templates/edge-ssr.js { INNER_PAGE_ENTRY => \"[project]/packages/next/dist/esm/build/templates/pages.js { INNER_PAGE => \\\"[project]/test/tmp/next-test-1764875742357-479/pages/index.js`



`VAR_USERLAND` here: https://github.com/vercel/next.js/blob/ee3d017e43eb953a62746a0e6110a94dc7a3c980/packages/next/src/build/templates/edge-ssr.ts#L12-L13
for Webpack is actually the user's page file with the `export default Page()`
for Turbopack is actually whatever `templates/pages.js` exports and it relies on this default reexport: https://github.com/vercel/next.js/blob/38ef2360e1e133f329a9061ce17aad8aaab33cb2/packages/next/src/build/templates/pages.ts#L15 while ignoring everything else in there