### PR TITLE
fix(examples): align with-docker-compose Dockerfiles with with-docker example

### DIFF
--- a/examples/with-docker-compose/next-app/dev.Dockerfile
+++ b/examples/with-docker-compose/next-app/dev.Dockerfile
@@ -2,6 +2,9 @@
 
 FROM node:20-alpine
 
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager

--- a/examples/with-docker-compose/next-app/dev.Dockerfile
+++ b/examples/with-docker-compose/next-app/dev.Dockerfile
@@ -24,7 +24,7 @@ COPY tsconfig.json .
 
 # Next.js collects completely anonymous telemetry data about general usage. Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line to disable telemetry at run time
-# ENV NEXT_TELEMETRY_DISABLED 1
+# ENV NEXT_TELEMETRY_DISABLED=1
 
 # Note: Don't expose ports here, Compose will handle that for us
 

--- a/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
@@ -27,6 +27,8 @@ ENV ENV_VARIABLE=${ENV_VARIABLE}
 ARG NEXT_PUBLIC_ENV_VARIABLE
 ENV NEXT_PUBLIC_ENV_VARIABLE=${NEXT_PUBLIC_ENV_VARIABLE}
 
+ENV NODE_ENV=production
+
 # Next.js collects completely anonymous telemetry data about general usage. Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line to disable telemetry at build time
 # ENV NEXT_TELEMETRY_DISABLED 1

--- a/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
@@ -34,7 +34,7 @@ ENV NODE_ENV=production
 
 # Next.js collects completely anonymous telemetry data about general usage. Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line to disable telemetry at build time
-# ENV NEXT_TELEMETRY_DISABLED 1
+# ENV NEXT_TELEMETRY_DISABLED=1
 
 # Note: Don't expose ports here, Compose will handle that for us
 

--- a/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod-without-multistage.Dockerfile
@@ -2,6 +2,9 @@
 
 FROM node:20-alpine
 
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager

--- a/examples/with-docker-compose/next-app/prod.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod.Dockerfile
@@ -49,6 +49,8 @@ FROM base AS runner
 
 WORKDIR /app
 
+ENV NODE_ENV=production
+
 # Don't run production as root
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs

--- a/examples/with-docker-compose/next-app/prod.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod.Dockerfile
@@ -35,7 +35,7 @@ ENV NEXT_PUBLIC_ENV_VARIABLE=${NEXT_PUBLIC_ENV_VARIABLE}
 
 # Next.js collects completely anonymous telemetry data about general usage. Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line to disable telemetry at build time
-# ENV NEXT_TELEMETRY_DISABLED 1
+# ENV NEXT_TELEMETRY_DISABLED=1
 
 # Build Next.js based on the preferred package manager
 RUN \
@@ -73,7 +73,7 @@ ARG NEXT_PUBLIC_ENV_VARIABLE
 ENV NEXT_PUBLIC_ENV_VARIABLE=${NEXT_PUBLIC_ENV_VARIABLE}
 
 # Uncomment the following line to disable telemetry at run time
-# ENV NEXT_TELEMETRY_DISABLED 1
+# ENV NEXT_TELEMETRY_DISABLED=1
 
 # Note: Don't expose ports here, Compose will handle that for us
 

--- a/examples/with-docker-compose/next-app/prod.Dockerfile
+++ b/examples/with-docker-compose/next-app/prod.Dockerfile
@@ -2,6 +2,9 @@
 
 FROM node:20-alpine AS base
 
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+
 # Step 1. Rebuild the source code only when needed
 FROM base AS builder
 


### PR DESCRIPTION
## Summary

This PR aligns the `with-docker-compose` example Dockerfiles with the `with-docker` example to ensure consistency and fix a production issue:

- **Add `NODE_ENV=production`** to `prod.Dockerfile` and `prod-without-multistage.Dockerfile` - Without this, React DevTools may appear in production builds
- **Add `libc6-compat`** to all three Dockerfiles - Required for some native Node.js modules on Alpine Linux
- **Use modern ENV syntax** (`ENV VAR=value` instead of `ENV VAR value`) for consistency

### Why?

When building with `prod.Dockerfile`, the resulting image was missing `NODE_ENV=production` in the runner stage, causing React to run in development mode (React DevTools visible in browser).

The `with-docker` example already has these configurations correctly set. This PR brings `with-docker-compose` to parity.

## Related

Reference implementation: `examples/with-docker/Dockerfile`