### PR TITLE
[test] Fix external rewrite target URL origin

### DIFF
--- a/test/e2e/skip-trailing-slash-redirect/app/middleware.js
+++ b/test/e2e/skip-trailing-slash-redirect/app/middleware.js
@@ -35,11 +35,11 @@ export default function handler(req) {
     }
 
     console.log(
-      `rewriting to https://middleware-external-rewrite-target-epsp8idgo-uncurated-tests.vercel.app${pathname}`
+      `rewriting to https://middleware-external-rewrite-target.vercel.app${pathname}`
     )
 
     return NextResponse.rewrite(
-      `https://middleware-external-rewrite-target-epsp8idgo-uncurated-tests.vercel.app${pathname}`
+      `https://middleware-external-rewrite-target.vercel.app${pathname}`
     )
   }
 


### PR DESCRIPTION
Switching to the assigned custom domain because the project has now Standard Protection enabled, which requires authentication for all other deployments.

[x-ref](https://github.com/vercel/next.js/actions/runs/19954917697/job/57223360201)