### PR TITLE
Fix: Server refresh() should not purge client cache

### DIFF
--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -34,3 +34,6 @@ export const NEXT_IS_PRERENDER_HEADER = 'x-nextjs-prerender' as const
 export const NEXT_ACTION_NOT_FOUND_HEADER = 'x-nextjs-action-not-found' as const
 export const NEXT_REQUEST_ID_HEADER = 'x-nextjs-request-id' as const
 export const NEXT_HTML_REQUEST_ID_HEADER = 'x-nextjs-html-request-id' as const
+
+// TODO: Should this include nextjs in the name, like the others?
+export const NEXT_ACTION_REVALIDATED_HEADER = 'x-action-revalidated' as const

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -10,6 +10,7 @@ import type { CacheLife } from '../use-cache/cache-life'
 import { workAsyncStorageInstance } from './work-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
 import type { LazyResult } from '../lib/lazy-result'
 import type { DigestedError } from './create-error-handler'
+import type { ActionRevalidationKind } from '../../shared/lib/action-revalidation-kind'
 
 export interface WorkStore {
   readonly isStaticGeneration: boolean
@@ -61,7 +62,7 @@ export interface WorkStore {
   invalidDynamicUsageError?: Error
 
   nextFetchId?: number
-  pathWasRevalidated?: boolean
+  pathWasRevalidated?: ActionRevalidationKind
 
   /**
    * Tags that were revalidated during the current request. They need to be sent

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
@@ -4,6 +4,7 @@ import { ResponseCookies } from '../cookies'
 import { ReflectAdapter } from './reflect'
 import { workAsyncStorage } from '../../../app-render/work-async-storage.external'
 import type { RequestStore } from '../../../app-render/work-unit-async-storage.external'
+import { ActionDidRevalidateStaticAndDynamic } from '../../../../shared/lib/action-revalidation-kind'
 
 /**
  * @internal
@@ -116,7 +117,7 @@ export class MutableRequestCookiesAdapter {
       // TODO-APP: change method of getting workStore
       const workStore = workAsyncStorage.getStore()
       if (workStore) {
-        workStore.pathWasRevalidated = true
+        workStore.pathWasRevalidated = ActionDidRevalidateStaticAndDynamic
       }
 
       const allCookies = responseCookies.getAll()

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -11,6 +11,10 @@ import { workAsyncStorage } from '../../app-render/work-async-storage.external'
 import { workUnitAsyncStorage } from '../../app-render/work-unit-async-storage.external'
 import { DynamicServerError } from '../../../client/components/hooks-server-context'
 import { InvariantError } from '../../../shared/lib/invariant-error'
+import {
+  ActionDidRevalidateDynamicOnly,
+  ActionDidRevalidateStaticAndDynamic as ActionDidRevalidate,
+} from '../../../shared/lib/action-revalidation-kind'
 
 type CacheLifeConfig = {
   expire?: number
@@ -73,8 +77,9 @@ export function refresh() {
   }
 
   if (workStore) {
-    // TODO: break this to it's own field
-    workStore.pathWasRevalidated = true
+    // The Server Action version of refresh() only revalidates the dynamic data
+    // on the client. It doesn't affect cached data.
+    workStore.pathWasRevalidated = ActionDidRevalidateDynamicOnly
   }
 }
 
@@ -226,6 +231,6 @@ function revalidate(
 
   if (!profile || cacheLife?.expire === 0) {
     // TODO: only revalidate if the path matches
-    store.pathWasRevalidated = true
+    store.pathWasRevalidated = ActionDidRevalidate
   }
 }

--- a/packages/next/src/shared/lib/action-revalidation-kind.ts
+++ b/packages/next/src/shared/lib/action-revalidation-kind.ts
@@ -1,0 +1,5 @@
+export type ActionRevalidationKind = 0 | 1 | 2
+
+export const ActionDidNotRevalidate = 0
+export const ActionDidRevalidateStaticAndDynamic = 1
+export const ActionDidRevalidateDynamicOnly = 2

--- a/test/e2e/app-dir/segment-cache/refresh/app/dashboard/client.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/app/dashboard/client.tsx
@@ -11,7 +11,7 @@ export function ClientRefreshButton() {
         router.refresh()
       }}
     >
-      Refresh
+      Client refresh
     </button>
   )
 }

--- a/test/e2e/app-dir/segment-cache/refresh/app/dashboard/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/app/dashboard/layout.tsx
@@ -1,5 +1,19 @@
 import { LinkAccordion } from '../../components/link-accordion'
 import { ClientRefreshButton } from './client'
+import { refresh } from 'next/cache'
+
+function ServerRefreshButton() {
+  return (
+    <form
+      action={async () => {
+        'use server'
+        refresh()
+      }}
+    >
+      <button id="server-refresh-button">Server refresh</button>
+    </form>
+  )
+}
 
 export default function DashboardLayout({
   navbar,
@@ -14,6 +28,7 @@ export default function DashboardLayout({
         {navbar}
         <div>
           <ClientRefreshButton />
+          <ServerRefreshButton />
         </div>
         <ul>
           <li>
@@ -21,6 +36,9 @@ export default function DashboardLayout({
           </li>
           <li>
             <LinkAccordion href="/dashboard/analytics">Analytics</LinkAccordion>
+          </li>
+          <li>
+            <LinkAccordion href="/docs">Docs</LinkAccordion>
           </li>
         </ul>
       </div>

--- a/test/e2e/app-dir/segment-cache/refresh/app/docs/page.tsx
+++ b/test/e2e/app-dir/segment-cache/refresh/app/docs/page.tsx
@@ -1,0 +1,3 @@
+export default function DocsPage() {
+  return <div id="docs-page">Static docs page</div>
+}

--- a/test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
+++ b/test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
@@ -11,7 +11,7 @@ describe('segment cache (refresh)', () => {
     return
   }
 
-  it('refreshes data inside reused default parallel route slots', async () => {
+  it('router.refresh() refreshes both cached and dynamic data', async () => {
     // Load the main Dashboard page. This will render the nav bar into the
     // @navbar slot.
     let page: Playwright.Page
@@ -34,22 +34,108 @@ describe('segment cache (refresh)', () => {
       await link.click()
     })
 
-    // Click the refresh button and confirm the navigation bar is re-rendered,
-    // even though it's not part of the Analytics page.
+    // Reveal the link to the docs page to prefetch it.
     await act(
       async () => {
-        const refreshButton = await browser.elementById('client-refresh-button')
-        await refreshButton.click()
+        const toggleDocsLink = await browser.elementByCss(
+          'input[data-link-accordion="/docs"]'
+        )
+        await toggleDocsLink.click()
       },
       {
-        includes: 'Navbar dynamic render counter',
+        includes: 'Static docs page',
       }
     )
+
+    // Click the client refresh button and confirm the navigation bar is
+    // re-rendered, even though it's not part of the Analytics page.
+    await act(async () => {
+      const refreshButton = await browser.elementById('client-refresh-button')
+      await refreshButton.click()
+    }, [
+      {
+        includes: 'Navbar dynamic render counter',
+      },
+      {
+        // router.refresh() also purges Cache Components from the client cache,
+        // so we must re-prefetch the docs page
+        includes: 'Static docs page',
+      },
+    ])
 
     const navbarDynamicRenderCounter = await browser.elementById(
       'navbar-dynamic-render-counter'
     )
     // If this is still 0, then the nav bar was not successfully refreshed
     expect(await navbarDynamicRenderCounter.textContent()).toBe('1')
+  })
+
+  it('Server Action refresh() refreshes dynamic data only, not cached', async () => {
+    // Load the main Dashboard page. This will render the nav bar into the
+    // @navbar slot.
+    let page: Playwright.Page
+    const browser = await next.browser('/dashboard', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Navigate to the Analytics page. The analytics page does not match the
+    // @navbar slot, so the client reuses the one that was rendered by the
+    // previous page.
+    await act(async () => {
+      const toggleAnalyticsLink = await browser.elementByCss(
+        'input[data-link-accordion="/dashboard/analytics"]'
+      )
+      await toggleAnalyticsLink.click()
+      const link = await browser.elementByCss('a[href="/dashboard/analytics"]')
+      await link.click()
+    })
+
+    // Reveal the link to the docs page to prefetch it.
+    await act(
+      async () => {
+        const toggleDocsLink = await browser.elementByCss(
+          'input[data-link-accordion="/docs"]'
+        )
+        await toggleDocsLink.click()
+      },
+      {
+        includes: 'Static docs page',
+      }
+    )
+
+    // Click the server refresh button and confirm the navigation bar is
+    // re-rendered, even though it's not part of the Analytics page.
+    await act(async () => {
+      const refreshButton = await browser.elementById('server-refresh-button')
+      await refreshButton.click()
+    }, [
+      {
+        includes: 'Navbar dynamic render counter',
+      },
+      {
+        // The server form of refresh() does _not_ purge Cache Components from
+        // the client cache, so we shouldn't need to re-prefetch the docs page.
+        includes: 'Static docs page',
+        block: 'reject',
+      },
+    ])
+
+    const navbarDynamicRenderCounter = await browser.elementById(
+      'navbar-dynamic-render-counter'
+    )
+    // If this is still 0, then the nav bar was not successfully refreshed
+    expect(await navbarDynamicRenderCounter.textContent()).toBe('1')
+
+    // Confirm that navigating the the docs page does not require any
+    // additional requests.
+    await act(async () => {
+      const link = await browser.elementByCss('a[href="/docs"]')
+      await link.click()
+      const docsPage = await browser.elementById('docs-page')
+      expect(await docsPage.textContent()).toBe('Static docs page')
+    }, 'no-requests')
   })
 })


### PR DESCRIPTION
Based on:

- #86367 
- #86747 

---

The server form of refresh() is used to re-render all the dynamic data on the current page. Unlike updateTag/revalidateTag, it does not affect any cached data, so the client cache should not evict any of its entries.