### PR TITLE
Fix validateTurboNextConfig running for next start

### DIFF
--- a/packages/next/src/build/turbopack-analyze/index.ts
+++ b/packages/next/src/build/turbopack-analyze/index.ts
@@ -8,6 +8,7 @@ import { getSupportedBrowsers } from '../utils'
 import { normalizePath } from '../../lib/normalize-path'
 import type { NextConfigComplete } from '../../server/config-shared'
 import type { __ApiPreviewProps } from '../../server/api-utils'
+import { PHASE_PRODUCTION_BUILD } from '../../api/constants'
 
 export type AnalyzeContext = {
   config: NextConfigComplete
@@ -25,7 +26,7 @@ export async function turbopackAnalyze(
 }> {
   await validateTurboNextConfig({
     dir: analyzeContext.dir,
-    isDev: false,
+    configPhase: PHASE_PRODUCTION_BUILD,
   })
 
   const { config, dir, distDir, noMangling } = analyzeContext

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -28,7 +28,7 @@ export async function turbopackBuild(): Promise<{
 }> {
   await validateTurboNextConfig({
     dir: NextBuildContext.dir!,
-    isDev: false,
+    configPhase: PHASE_PRODUCTION_BUILD,
   })
 
   const config = NextBuildContext.config!

--- a/packages/next/src/lib/turbopack-warning.ts
+++ b/packages/next/src/lib/turbopack-warning.ts
@@ -1,10 +1,6 @@
 import type { NextConfigComplete } from '../server/config-shared'
 import loadConfig from '../server/config'
 import * as Log from '../build/output/log'
-import {
-  PHASE_DEVELOPMENT_SERVER,
-  PHASE_PRODUCTION_BUILD,
-} from '../shared/lib/constants'
 
 const unsupportedTurbopackNextConfigOptions = [
   // Left to be implemented (priority)
@@ -45,10 +41,10 @@ const unsupportedTurbopackNextConfigOptions = [
 /**  */
 export async function validateTurboNextConfig({
   dir,
-  isDev,
+  configPhase,
 }: {
   dir: string
-  isDev?: boolean
+  configPhase: Parameters<typeof loadConfig>[0]
 }) {
   const { defaultConfig } =
     require('../server/config-shared') as typeof import('../server/config-shared')
@@ -65,16 +61,15 @@ export async function validateTurboNextConfig({
   const unsupportedConfig: string[] = []
   let rawNextConfig: NextConfigComplete = {} as NextConfigComplete
 
-  const phase = isDev ? PHASE_DEVELOPMENT_SERVER : PHASE_PRODUCTION_BUILD
   try {
     rawNextConfig = interopDefault(
-      await loadConfig(phase, dir, {
+      await loadConfig(configPhase, dir, {
         rawConfig: true,
       })
     )
 
     if (typeof rawNextConfig === 'function') {
-      rawNextConfig = (rawNextConfig as any)(phase, {
+      rawNextConfig = (rawNextConfig as any)(configPhase, {
         defaultConfig,
       })
     }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -25,7 +25,10 @@ import setupDebug from 'next/dist/compiled/debug'
 import { RESTART_EXIT_CODE } from './utils'
 import { formatHostname } from './format-hostname'
 import { initialize } from './router-server'
-import { CONFIG_FILES } from '../../shared/lib/constants'
+import {
+  CONFIG_FILES,
+  PHASE_DEVELOPMENT_SERVER,
+} from '../../shared/lib/constants'
 import { getStartServerInfo, logStartInfo } from './app-info-log'
 import { validateTurboNextConfig } from '../../lib/turbopack-warning'
 import { type Span, trace, flushAllTraces } from '../../trace'
@@ -473,10 +476,10 @@ export async function startServer(
 
         Log.event(`Ready in ${formatDurationText}`)
 
-        if (process.env.TURBOPACK) {
+        if (process.env.TURBOPACK && isDev) {
           await validateTurboNextConfig({
             dir: serverOptions.dir,
-            isDev: serverOptions.isDev,
+            configPhase: PHASE_DEVELOPMENT_SERVER,
           })
         }
       } catch (err) {


### PR DESCRIPTION
This fixes `validateTurboNextConfig` running during `next start` which was caught due to the wrong `phase` being provided to `workflows` config wrapper.

We shouldn't run extra validation during `next start` as this needs to boot as fast as possible and would have already been validated during `next build` or `next dev`.