### PR TITLE
Fix Google Fonts missing font hinting info

### DIFF
--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -69,7 +69,7 @@ pub const GOOGLE_FONTS_STYLESHEET_URL: &str = "https://fonts.googleapis.com/css2
 // Google Fonts will vary responses based on user agent, e.g. only returning
 // references to certain font types for certain browsers.
 pub const USER_AGENT_FOR_GOOGLE_FONTS: RcStr = rcstr!(
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) \
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) \
      Chrome/104.0.0.0 Safari/537.36"
 );
 

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -65,7 +65,7 @@ pub const GOOGLE_FONTS_STYLESHEET_URL: &str = "https://fonts.googleapis.com/css2
 // Always sending this user agent ensures consistent results from Google Fonts.
 // Google Fonts will vary responses based on user agent, e.g. only returning
 // references to certain font types for certain browsers.
-pub const USER_AGENT_FOR_GOOGLE_FONTS: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+pub const USER_AGENT_FOR_GOOGLE_FONTS: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) \
                                                AppleWebKit/537.36 (KHTML, like Gecko) \
                                                Chrome/104.0.0.0 Safari/537.36";
 

--- a/packages/font/src/google/fetch-resource.ts
+++ b/packages/font/src/google/fetch-resource.ts
@@ -24,7 +24,7 @@ export function fetchResource(
         headers: {
           // The file format is based off of the user agent, make sure woff2 files are fetched
           'User-Agent':
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
             'AppleWebKit/537.36 (KHTML, like Gecko) ' +
             'Chrome/104.0.0.0 Safari/537.36',
         },


### PR DESCRIPTION
### What?

Ensure that the fonts fetched from Google Fonts contain font hinting instructions.

### Why?

Google Fonts returns files that have the font hinting instructions removed when the user agent is set as OSX. This is almost certainly due to the fact that OSX disabled sub-pixel antialiasing by default with the release of Mojave.

If you are using a lower desity screen and are on windows(or have manually enabled sub-pixel antialiasing on OSX) then the fonts will render poorly without the font hinting.

Google is only able to safely omit this info (in the interest of saving a bit of bandwidth) because they are doing OS detection, unless next.js wants to do the same it should be using the files that render correctly in all environments.

### How?

The hardcoded user agent in the font fetching logic was replaced with an equivalent windows one.

Fixes #78118
