### PR TITLE
Omit unused arguments from `'use cache'` function calls

### DIFF
--- a/crates/next-custom-transforms/tests/fixture/next-font-with-directive/use-cache/output.js
+++ b/crates/next-custom-transforms/tests/fixture/next-font-with-directive/use-cache/output.js
@@ -7,7 +7,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function Cached({ children }) {
     return <div className={inter.className}>{children}</div>;
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function Cached() {
-    return $$cache__("default", "c0dd5bb6fef67f5ab84327f5164ac2c3111a159337", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "c0dd5bb6fef67f5ab84327f5164ac2c3111a159337", 0, $$RSC_SERVER_CACHE_0_INNER, Array.prototype.slice.call(arguments, 0, 1));
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "c0dd5bb6fef67f5ab84327f5164ac2c3111a159337", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/next.d.ts
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/next.d.ts
@@ -45,6 +45,6 @@ declare module 'private-next-rsc-cache-wrapper' {
     id: string,
     boundArgsLength: number,
     fn: TFn,
-    argsObj: IArguments
+    args: unknown[]
   ): Promise<any>
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/33/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/33/output.js
@@ -6,7 +6,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function fn() {
     return 'hello, ' + v;
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function fn() {
-    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/34/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/34/output.js
@@ -5,7 +5,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function foo() {
     return 'foo';
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function foo() {
-    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
@@ -17,7 +17,7 @@ const $$RSC_SERVER_CACHE_1_INNER = async function bar() {
     return 'bar';
 };
 export var $$RSC_SERVER_CACHE_1 = $$reactCache__(function bar() {
-    return $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, $$RSC_SERVER_CACHE_1_INNER, arguments);
+    return $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, $$RSC_SERVER_CACHE_1_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b743ec5808127cfde405d", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
@@ -32,7 +32,7 @@ const $$RSC_SERVER_CACHE_2_INNER = async function baz() {
     return qux() + 'baz';
 };
 export var $$RSC_SERVER_CACHE_2 = $$reactCache__(function baz() {
-    return $$cache__("default", "8069348c79fce073bae2f70f139565a2fda1c74c74", 0, $$RSC_SERVER_CACHE_2_INNER, arguments);
+    return $$cache__("default", "8069348c79fce073bae2f70f139565a2fda1c74c74", 0, $$RSC_SERVER_CACHE_2_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_2, "8069348c79fce073bae2f70f139565a2fda1c74c74", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
@@ -43,7 +43,7 @@ const $$RSC_SERVER_CACHE_3_INNER = async function quux() {
     return 'quux';
 };
 export var $$RSC_SERVER_CACHE_3 = $$reactCache__(function quux() {
-    return $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", 0, $$RSC_SERVER_CACHE_3_INNER, arguments);
+    return $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", 0, $$RSC_SERVER_CACHE_3_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_3, "8012a8d21b6362b4cc8f5b15560525095bc48dba80", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_3, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/35/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/35/output.js
@@ -5,7 +5,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function my_fn() {
     return 'data';
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function my_fn() {
-    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/36/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/36/output.js
@@ -5,7 +5,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function foo() {
     return 'data A';
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function foo() {
-    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
@@ -16,7 +16,7 @@ const $$RSC_SERVER_CACHE_1_INNER = async function bar() {
     return 'data B';
 };
 export var $$RSC_SERVER_CACHE_1 = $$reactCache__(function bar() {
-    return $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, $$RSC_SERVER_CACHE_1_INNER, arguments);
+    return $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, $$RSC_SERVER_CACHE_1_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b743ec5808127cfde405d", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
@@ -27,7 +27,7 @@ const $$RSC_SERVER_CACHE_2_INNER = async function Cached({ children }) {
     return children;
 };
 export var $$RSC_SERVER_CACHE_2 = $$reactCache__(function Cached() {
-    return $$cache__("default", "c069348c79fce073bae2f70f139565a2fda1c74c74", 0, $$RSC_SERVER_CACHE_2_INNER, arguments);
+    return $$cache__("default", "c069348c79fce073bae2f70f139565a2fda1c74c74", 0, $$RSC_SERVER_CACHE_2_INNER, Array.prototype.slice.call(arguments, 0, 1));
 });
 registerServerReference($$RSC_SERVER_CACHE_2, "c069348c79fce073bae2f70f139565a2fda1c74c74", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
@@ -38,7 +38,7 @@ const $$RSC_SERVER_CACHE_3_INNER = async function baz() {
     return 'data C';
 };
 export var $$RSC_SERVER_CACHE_3 = $$reactCache__(function baz() {
-    return $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", 0, $$RSC_SERVER_CACHE_3_INNER, arguments);
+    return $$cache__("default", "8012a8d21b6362b4cc8f5b15560525095bc48dba80", 0, $$RSC_SERVER_CACHE_3_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_3, "8012a8d21b6362b4cc8f5b15560525095bc48dba80", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_3, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/37/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/37/output.js
@@ -5,7 +5,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function fn() {
     return 'foo';
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function fn() {
-    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/38/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/38/output.js
@@ -5,7 +5,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function foo() {
     return 'data';
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function foo() {
-    return $$cache__("x", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("x", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/39/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/39/output.js
@@ -9,7 +9,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function fn([$$ACTION_ARG_0, $$ACTION_A
     };
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function fn() {
-    return $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 2, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 2, $$RSC_SERVER_CACHE_0_INNER, Array.prototype.slice.call(arguments, 0, 1));
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "c03128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/40/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/40/output.js
@@ -13,7 +13,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function cache([$$ACTION_ARG_0, $$ACTIO
     ];
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function cache() {
-    return $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 2, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 2, $$RSC_SERVER_CACHE_0_INNER, Array.prototype.slice.call(arguments, 0, 2));
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "e03128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/41/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/41/output.js
@@ -18,7 +18,7 @@ const $$RSC_SERVER_CACHE_1_INNER = async function Component({ foo }) {
     return <div>{data}</div>;
 };
 export var $$RSC_SERVER_CACHE_1 = $$reactCache__(function Component() {
-    return $$cache__("default", "c0951c375b4a6a6e89d67b743ec5808127cfde405d", 0, $$RSC_SERVER_CACHE_1_INNER, arguments);
+    return $$cache__("default", "c0951c375b4a6a6e89d67b743ec5808127cfde405d", 0, $$RSC_SERVER_CACHE_1_INNER, Array.prototype.slice.call(arguments, 0, 1));
 });
 registerServerReference($$RSC_SERVER_CACHE_1, "c0951c375b4a6a6e89d67b743ec5808127cfde405d", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/42/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/42/output.js
@@ -9,7 +9,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function fn([$$ACTION_ARG_0, $$ACTION_A
     };
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function fn() {
-    return $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 2, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 2, $$RSC_SERVER_CACHE_0_INNER, Array.prototype.slice.call(arguments, 0, 1));
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "c03128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/43/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/43/output.js
@@ -18,7 +18,7 @@ const $$RSC_SERVER_CACHE_1_INNER = async function getCachedRandom(x, children) {
     };
 };
 export var $$RSC_SERVER_CACHE_1 = $$reactCache__(function getCachedRandom() {
-    return $$cache__("default", "e0951c375b4a6a6e89d67b743ec5808127cfde405d", 0, $$RSC_SERVER_CACHE_1_INNER, arguments);
+    return $$cache__("default", "e0951c375b4a6a6e89d67b743ec5808127cfde405d", 0, $$RSC_SERVER_CACHE_1_INNER, Array.prototype.slice.call(arguments, 0, 2));
 });
 registerServerReference($$RSC_SERVER_CACHE_1, "e0951c375b4a6a6e89d67b743ec5808127cfde405d", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/45/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/45/output.js
@@ -11,7 +11,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function bar() {
     return <Foo/>;
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function bar() {
-    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/46/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/46/output.js
@@ -10,7 +10,7 @@ import { cache as $$reactCache__ } from "react";
     ];
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function f1() {
-    return $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, Array.prototype.slice.call(arguments, 0, 2));
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "e03128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
@@ -35,7 +35,7 @@ const $$RSC_SERVER_CACHE_2_INNER = async function f3(a, b, ...rest) {
     ];
 };
 export var $$RSC_SERVER_CACHE_2 = $$reactCache__(function f3() {
-    return $$cache__("default", "ff69348c79fce073bae2f70f139565a2fda1c74c74", 0, $$RSC_SERVER_CACHE_2_INNER, arguments);
+    return $$cache__("default", "ff69348c79fce073bae2f70f139565a2fda1c74c74", 0, $$RSC_SERVER_CACHE_2_INNER, Array.prototype.slice.call(arguments));
 });
 registerServerReference($$RSC_SERVER_CACHE_2, "ff69348c79fce073bae2f70f139565a2fda1c74c74", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_2, "name", {
@@ -80,7 +80,7 @@ const $$RSC_SERVER_CACHE_5_INNER = async function f6(a, b, c, d, e, f, g) {
     ];
 };
 export var $$RSC_SERVER_CACHE_5 = $$reactCache__(function f6() {
-    return $$cache__("default", "ff471a5eb0be1c31686dd4ba938a80328b80b1615d", 0, $$RSC_SERVER_CACHE_5_INNER, arguments);
+    return $$cache__("default", "ff471a5eb0be1c31686dd4ba938a80328b80b1615d", 0, $$RSC_SERVER_CACHE_5_INNER, Array.prototype.slice.call(arguments, 0, 7));
 });
 registerServerReference($$RSC_SERVER_CACHE_5, "ff471a5eb0be1c31686dd4ba938a80328b80b1615d", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_5, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/48/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/48/output.js
@@ -31,7 +31,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function cache(a, b) {
     </div>;
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function cache() {
-    return $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, Array.prototype.slice.call(arguments, 0, 2));
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "e03128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/49/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/49/output.js
@@ -12,7 +12,7 @@ Object["defineProperty"]($$RSC_SERVER_CACHE_0_INNER, "name", {
     value: ""
 });
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function() {
-    return $$cache__("default", "f03128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "f03128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, Array.prototype.slice.call(arguments, 0, 3));
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "f03128060c414d59f8552e4788b846c0d2b7f74743", null);
 export default $$RSC_SERVER_CACHE_0;

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/50/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/50/output.js
@@ -12,7 +12,7 @@ Object["defineProperty"]($$RSC_SERVER_CACHE_0_INNER, "name", {
     value: ""
 });
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function() {
-    return $$cache__("default", "f03128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "f03128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, Array.prototype.slice.call(arguments, 0, 3));
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "f03128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/52/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/52/output.js
@@ -9,7 +9,7 @@ fn1([$$ACTION_ARG_0, $$ACTION_ARG_1], c) {
     return $$ACTION_ARG_0 + $$ACTION_ARG_1 + c;
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function fn1() {
-    return $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 2, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "e03128060c414d59f8552e4788b846c0d2b7f74743", 2, $$RSC_SERVER_CACHE_0_INNER, Array.prototype.slice.call(arguments, 0, 2));
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "e03128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
@@ -21,7 +21,7 @@ fn2([$$ACTION_ARG_0, $$ACTION_ARG_1]) {
     return $$ACTION_ARG_0 + $$ACTION_ARG_1;
 };
 export var $$RSC_SERVER_CACHE_1 = $$reactCache__(function fn2() {
-    return $$cache__("default", "c0951c375b4a6a6e89d67b743ec5808127cfde405d", 2, $$RSC_SERVER_CACHE_1_INNER, arguments);
+    return $$cache__("default", "c0951c375b4a6a6e89d67b743ec5808127cfde405d", 2, $$RSC_SERVER_CACHE_1_INNER, Array.prototype.slice.call(arguments, 0, 1));
 });
 registerServerReference($$RSC_SERVER_CACHE_1, "c0951c375b4a6a6e89d67b743ec5808127cfde405d", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/53/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/53/output.js
@@ -3,7 +3,7 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 import { cache as $$reactCache__ } from "react";
 const $$RSC_SERVER_CACHE_0_INNER = async function foo() {};
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function foo() {
-    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/54/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/54/output.js
@@ -6,7 +6,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function foo([$$ACTION_ARG_0, $$ACTION_
     return $$ACTION_ARG_0 * $$ACTION_ARG_1;
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function foo() {
-    return $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 2, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 2, $$RSC_SERVER_CACHE_0_INNER, Array.prototype.slice.call(arguments, 0, 1));
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "c03128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/55/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/55/output.js
@@ -5,7 +5,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function fetch1() {
     return fetch('https://example.com').then((res)=>res.json());
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function fetch1() {
-    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/56/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/56/output.js
@@ -7,7 +7,7 @@ const { foo: fooCached } = {
 let $$RSC_SERVER_CACHE_fooCached = fooCached;
 if (typeof fooCached === "function") {
     $$RSC_SERVER_CACHE_fooCached = $$reactCache__(function() {
-        return $$cache__("default", "ffaa88e24cee8047d167e47f4f374dbddc187e2899", 0, fooCached, arguments);
+        return $$cache__("default", "ffaa88e24cee8047d167e47f4f374dbddc187e2899", 0, fooCached, Array.prototype.slice.call(arguments));
     });
     registerServerReference($$RSC_SERVER_CACHE_fooCached, "ffaa88e24cee8047d167e47f4f374dbddc187e2899", null);
     Object["defineProperty"]($$RSC_SERVER_CACHE_fooCached, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/57/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/57/output.js
@@ -5,7 +5,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function foo() {
     return fetch('https://example.com').then((res)=>res.json());
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function foo() {
-    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/58/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/58/output.js
@@ -9,7 +9,7 @@ Object["defineProperty"]($$RSC_SERVER_CACHE_0_INNER, "name", {
     value: ""
 });
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function() {
-    return $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 1, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 1, $$RSC_SERVER_CACHE_0_INNER, Array.prototype.slice.call(arguments, 0, 1));
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "c03128060c414d59f8552e4788b846c0d2b7f74743", null);
 /* __next_internal_action_entry_do_not_use__ {"4090b5db271335765a4b0eab01f044b381b5ebd5cd":"$$RSC_SERVER_ACTION_1","c03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ function createCachedFn(start) {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/60/output.ts
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/60/output.ts
@@ -13,7 +13,7 @@ export default interface D {
 }
 const $$RSC_SERVER_CACHE_0_INNER = async function Page() {};
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function Page() {
-    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/63/output.tsx
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/63/output.tsx
@@ -12,7 +12,7 @@ const $$RSC_SERVER_CACHE_0_INNER = async function getCachedData() {
     return getStuff();
 };
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function getCachedData() {
-    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
@@ -27,7 +27,7 @@ const wrapped = wrap(async ()=>'foo', async ()=>'bar', async ()=>async ()=>'baz'
 export { staticallyKnownFunction };
 const $$RSC_SERVER_CACHE_1_INNER = async function staticallyKnownFunction() {};
 export var $$RSC_SERVER_CACHE_1 = $$reactCache__(function staticallyKnownFunction() {
-    return $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, $$RSC_SERVER_CACHE_1_INNER, arguments);
+    return $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, $$RSC_SERVER_CACHE_1_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b743ec5808127cfde405d", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {
@@ -37,7 +37,7 @@ var staticallyKnownFunction = $$RSC_SERVER_CACHE_1;
 let $$RSC_SERVER_CACHE_getData = getData;
 if (typeof getData === "function") {
     $$RSC_SERVER_CACHE_getData = $$reactCache__(function() {
-        return $$cache__("default", "ff8fa22f08e492db15701f58a1458cc4ebf782f855", 0, getData, arguments);
+        return $$cache__("default", "ff8fa22f08e492db15701f58a1458cc4ebf782f855", 0, getData, Array.prototype.slice.call(arguments));
     });
     registerServerReference($$RSC_SERVER_CACHE_getData, "ff8fa22f08e492db15701f58a1458cc4ebf782f855", null);
     Object["defineProperty"]($$RSC_SERVER_CACHE_getData, "name", {
@@ -48,7 +48,7 @@ export { $$RSC_SERVER_CACHE_getData as getData };
 let $$RSC_SERVER_CACHE_aliased = aliased;
 if (typeof aliased === "function") {
     $$RSC_SERVER_CACHE_aliased = $$reactCache__(function() {
-        return $$cache__("default", "ff27fadf3eeb97c777cea9f14a407b5c0b42ac65bb", 0, aliased, arguments);
+        return $$cache__("default", "ff27fadf3eeb97c777cea9f14a407b5c0b42ac65bb", 0, aliased, Array.prototype.slice.call(arguments));
     });
     registerServerReference($$RSC_SERVER_CACHE_aliased, "ff27fadf3eeb97c777cea9f14a407b5c0b42ac65bb", null);
     Object["defineProperty"]($$RSC_SERVER_CACHE_aliased, "name", {
@@ -59,7 +59,7 @@ export { $$RSC_SERVER_CACHE_aliased as aliased };
 let $$RSC_SERVER_CACHE_Sync = Sync;
 if (typeof Sync === "function") {
     $$RSC_SERVER_CACHE_Sync = $$reactCache__(function() {
-        return $$cache__("default", "ff84effee663e5ce4e0948b55df129a8df904c67aa", 0, Sync, arguments);
+        return $$cache__("default", "ff84effee663e5ce4e0948b55df129a8df904c67aa", 0, Sync, Array.prototype.slice.call(arguments));
     });
     registerServerReference($$RSC_SERVER_CACHE_Sync, "ff84effee663e5ce4e0948b55df129a8df904c67aa", null);
     Object["defineProperty"]($$RSC_SERVER_CACHE_Sync, "name", {
@@ -70,7 +70,7 @@ export { $$RSC_SERVER_CACHE_Sync as Sync };
 let $$RSC_SERVER_CACHE_wrapped = wrapped;
 if (typeof wrapped === "function") {
     $$RSC_SERVER_CACHE_wrapped = $$reactCache__(function() {
-        return $$cache__("default", "ff438bb59117ff1af890c80ca3e39d9e888fc93033", 0, wrapped, arguments);
+        return $$cache__("default", "ff438bb59117ff1af890c80ca3e39d9e888fc93033", 0, wrapped, Array.prototype.slice.call(arguments));
     });
     registerServerReference($$RSC_SERVER_CACHE_wrapped, "ff438bb59117ff1af890c80ca3e39d9e888fc93033", null);
     Object["defineProperty"]($$RSC_SERVER_CACHE_wrapped, "name", {
@@ -81,7 +81,7 @@ export { $$RSC_SERVER_CACHE_wrapped as wrapped };
 let $$RSC_SERVER_CACHE_default = Layout;
 if (typeof Layout === "function") {
     $$RSC_SERVER_CACHE_default = $$reactCache__(function() {
-        return $$cache__("default", "ffc18c215a6b7cdc64bf709f3a714ffdef1bf9651d", 0, Layout, arguments);
+        return $$cache__("default", "ffc18c215a6b7cdc64bf709f3a714ffdef1bf9651d", 0, Layout, Array.prototype.slice.call(arguments));
     });
     registerServerReference($$RSC_SERVER_CACHE_default, "ffc18c215a6b7cdc64bf709f3a714ffdef1bf9651d", null);
     Object["defineProperty"]($$RSC_SERVER_CACHE_default, "name", {
@@ -92,7 +92,7 @@ export default $$RSC_SERVER_CACHE_default;
 let $$RSC_SERVER_CACHE_Other = Other;
 if (typeof Other === "function") {
     $$RSC_SERVER_CACHE_Other = $$reactCache__(function() {
-        return $$cache__("default", "ff1acff246876a467753785a92d1f95ac6fe32c9b9", 0, Other, arguments);
+        return $$cache__("default", "ff1acff246876a467753785a92d1f95ac6fe32c9b9", 0, Other, Array.prototype.slice.call(arguments));
     });
     registerServerReference($$RSC_SERVER_CACHE_Other, "ff1acff246876a467753785a92d1f95ac6fe32c9b9", null);
     Object["defineProperty"]($$RSC_SERVER_CACHE_Other, "name", {
@@ -103,7 +103,7 @@ export { $$RSC_SERVER_CACHE_Other as Other };
 let $$RSC_SERVER_CACHE_getStuff = getStuff;
 if (typeof getStuff === "function") {
     $$RSC_SERVER_CACHE_getStuff = $$reactCache__(function() {
-        return $$cache__("default", "ff980f8c891ae27674b86a4804d306bdb3065c2e4f", 0, getStuff, arguments);
+        return $$cache__("default", "ff980f8c891ae27674b86a4804d306bdb3065c2e4f", 0, getStuff, Array.prototype.slice.call(arguments));
     });
     registerServerReference($$RSC_SERVER_CACHE_getStuff, "ff980f8c891ae27674b86a4804d306bdb3065c2e4f", null);
     Object["defineProperty"]($$RSC_SERVER_CACHE_getStuff, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/64/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/64/output.js
@@ -9,7 +9,7 @@ const Page = withSlug(function Page({ slug }) {
 let $$RSC_SERVER_CACHE_default = Page;
 if (typeof Page === "function") {
     $$RSC_SERVER_CACHE_default = $$reactCache__(function() {
-        return $$cache__("default", "ffc18c215a6b7cdc64bf709f3a714ffdef1bf9651d", 0, Page, arguments);
+        return $$cache__("default", "ffc18c215a6b7cdc64bf709f3a714ffdef1bf9651d", 0, Page, Array.prototype.slice.call(arguments));
     });
     registerServerReference($$RSC_SERVER_CACHE_default, "ffc18c215a6b7cdc64bf709f3a714ffdef1bf9651d", null);
     Object["defineProperty"]($$RSC_SERVER_CACHE_default, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/65/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/65/output.js
@@ -17,7 +17,7 @@ const $$RSC_SERVER_CACHE_1 = wrapItLikeItsHot(({ hot })=>{
 let $$RSC_SERVER_CACHE_default = $$RSC_SERVER_CACHE_1;
 if (typeof $$RSC_SERVER_CACHE_1 === "function") {
     $$RSC_SERVER_CACHE_default = $$reactCache__(function() {
-        return $$cache__("default", "ffc18c215a6b7cdc64bf709f3a714ffdef1bf9651d", 0, $$RSC_SERVER_CACHE_1, arguments);
+        return $$cache__("default", "ffc18c215a6b7cdc64bf709f3a714ffdef1bf9651d", 0, $$RSC_SERVER_CACHE_1, Array.prototype.slice.call(arguments));
     });
     registerServerReference($$RSC_SERVER_CACHE_default, "ffc18c215a6b7cdc64bf709f3a714ffdef1bf9651d", null);
 }

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/67/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/67/output.js
@@ -3,7 +3,7 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 import { cache as $$reactCache__ } from "react";
 const $$RSC_SERVER_CACHE_0_INNER = async function foo() {};
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function foo() {
-    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/68/output.tsx
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/68/output.tsx
@@ -12,7 +12,7 @@ export { type Bar };
 let $$RSC_SERVER_CACHE_foo = foo;
 if (typeof foo === "function") {
     $$RSC_SERVER_CACHE_foo = $$reactCache__(function() {
-        return $$cache__("default", "ffab21efdafbe611287bc25c0462b1e0510d13e48b", 0, foo, arguments);
+        return $$cache__("default", "ffab21efdafbe611287bc25c0462b1e0510d13e48b", 0, foo, Array.prototype.slice.call(arguments));
     });
     registerServerReference($$RSC_SERVER_CACHE_foo, "ffab21efdafbe611287bc25c0462b1e0510d13e48b", null);
     Object["defineProperty"]($$RSC_SERVER_CACHE_foo, "name", {
@@ -23,7 +23,7 @@ export { $$RSC_SERVER_CACHE_foo as foo };
 let $$RSC_SERVER_CACHE_bar = bar;
 if (typeof bar === "function") {
     $$RSC_SERVER_CACHE_bar = $$reactCache__(function() {
-        return $$cache__("default", "ffac840dcaf5e8197cb02b7f3a43c119b7a770b272", 0, bar, arguments);
+        return $$cache__("default", "ffac840dcaf5e8197cb02b7f3a43c119b7a770b272", 0, bar, Array.prototype.slice.call(arguments));
     });
     registerServerReference($$RSC_SERVER_CACHE_bar, "ffac840dcaf5e8197cb02b7f3a43c119b7a770b272", null);
     Object["defineProperty"]($$RSC_SERVER_CACHE_bar, "name", {

--- a/crates/next-custom-transforms/tests/fixture/source-maps/server-graph/use-cache/1/output.js
+++ b/crates/next-custom-transforms/tests/fixture/source-maps/server-graph/use-cache/1/output.js
@@ -3,7 +3,7 @@ import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
 import { cache as $$reactCache__ } from "react";
 const $$RSC_SERVER_CACHE_0_INNER = async function foo() {};
 export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function foo() {
-    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, arguments);
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
@@ -14,7 +14,7 @@ const $$RSC_SERVER_CACHE_1_INNER = async function bar() {
     return foo();
 };
 export var $$RSC_SERVER_CACHE_1 = $$reactCache__(function bar() {
-    return $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, $$RSC_SERVER_CACHE_1_INNER, arguments);
+    return $$cache__("default", "80951c375b4a6a6e89d67b743ec5808127cfde405d", 0, $$RSC_SERVER_CACHE_1_INNER, []);
 });
 registerServerReference($$RSC_SERVER_CACHE_1, "80951c375b4a6a6e89d67b743ec5808127cfde405d", null);
 Object["defineProperty"]($$RSC_SERVER_CACHE_1, "name", {

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -839,10 +839,8 @@ export async function cache(
   id: string,
   boundArgsLength: number,
   originalFn: (...args: unknown[]) => Promise<unknown>,
-  argsObj: IArguments
+  args: unknown[]
 ) {
-  let args = Array.prototype.slice.call(argsObj)
-
   const isPrivate = kind === 'private'
 
   // Private caches are currently only stored in the Resume Data Cache (RDC),
@@ -1124,7 +1122,7 @@ export async function cache(
       )
     }
 
-    const encryptedBoundArgs = args.shift()
+    const encryptedBoundArgs = args.shift() as Promise<string>
     const boundArgs = await decryptActionBoundArgs(id, encryptedBoundArgs)
 
     if (!Array.isArray(boundArgs)) {

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -126,7 +126,7 @@ describe('use-cache-custom-handler', () => {
   if (isNextStart) {
     it('should save a short-lived cache during prerendering at buildtime', async () => {
       expect(next.cliOutput).toMatch(
-        /ModernCustomCacheHandler::set \["[A-Za-z0-9_-]{21}","([0-9a-f]{2})+",\[{"id":"dynamic-cache"},"\$undefined"\]\]/
+        /ModernCustomCacheHandler::set \["[A-Za-z0-9_-]{21}","([0-9a-f]{2})+",\[{"id":"dynamic-cache"}]\]/
       )
     })
   }

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/unused-args/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/unused-args/page.tsx
@@ -1,0 +1,24 @@
+import { connection } from 'next/server'
+
+async function getRandomValue(offset: number) {
+  'use cache: remote'
+  return Math.random() + offset
+}
+
+let renderCount = 0
+
+export default async function Page() {
+  await connection()
+
+  // Create the offsets array based on the render count to force a different
+  // array on each render.
+  const offsets = renderCount++ % 2 === 0 ? [0, 1] : [1, 0]
+
+  // Pass the function reference into the map function, which will pass the
+  // index and array as arguments into getRandomValue. This will create cache
+  // misses if the unused arguments are not properly ignored, because they would
+  // be included in the cache keys.
+  const randomNumbers = await Promise.all(offsets.map(getRandomValue))
+
+  return <p id="numbers">{randomNumbers.sort().join(' ')}</p>
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -1361,17 +1361,26 @@ describe('use-cache', () => {
       expect(initialScale2).toBe(initialScale)
       expect(maximumScale2).toBe(maximumScale)
     })
-
-    it('caches a higher-order component in a "use cache" module', async () => {
-      const browser = await next.browser('/hoc/foo')
-      const slug = await browser.elementById('slug').text()
-      expect(slug).toBe('foo')
-      const date = await browser.elementById('date').text()
-      expect(date).toBeDateString()
-      await browser.refresh()
-      expect(await browser.elementById('date').text()).toBe(date)
-    })
+    // end withCacheComponents
   }
+
+  it('caches a higher-order component in a "use cache" module', async () => {
+    const browser = await next.browser('/hoc/foo')
+    const slug = await browser.elementById('slug').text()
+    expect(slug).toBe('foo')
+    const date = await browser.elementById('date').text()
+    expect(date).toBeDateString()
+    await browser.refresh()
+    expect(await browser.elementById('date').text()).toBe(date)
+  })
+
+  it('ignores unused arguments in a "use cache" function', async () => {
+    const browser = await next.browser('/unused-args')
+    const initialNumbers = await browser.elementById('numbers').text()
+    await browser.refresh()
+    const numbers = await browser.elementById('numbers').text()
+    expect(numbers).toBe(initialNumbers)
+  })
 })
 
 async function getSanitizedLogs(browser: Playwright): Promise<string[]> {

--- a/test/production/custom-server/custom-server.test.ts
+++ b/test/production/custom-server/custom-server.test.ts
@@ -117,6 +117,6 @@ function createCacheSetLogRegExp(id: string) {
   // Expect a requestId, that's provided through ALS, to be present in the log
   // message for the cache handler set call.
   return new RegExp(
-    `set cache \\["[A-Za-z0-9_-]{21}","(?:[0-9a-f]{2})+",\\[{"id":"${id}"},"\\$undefined"\\]\\] requestId: \\d+`
+    `set cache \\["[A-Za-z0-9_-]{21}","(?:[0-9a-f]{2})+",\\[{"id":"${id}"}]\\] requestId: \\d+`
   )
 }


### PR DESCRIPTION
If we know the declared parameters of a `'use cache'` function from static analysis, we can omit any unused arguments from the generated call to the cache wrapper. This avoids issues where extra arguments, like the index and array in a `Array.prototype.map()` call, would cause unexpected cache misses because those would also be included in the cache key, and they might not be deterministic.

In #72506, we already implemented omitting unused arguments for calls to `'use cache'` functions from the client, but the optimization of this PR now affects all calls to `'use cache'` functions, including those from the server. We do keep the change from #72506 regardless, as that is still a useful optimization to reduce the payload that's sent to the server.

Functions that can't be statically analyzed, e.g. because they're re-exports, or results of higher-order functions, will still receive all arguments as before, so they won't benefit from this optimization.

Note that the optimization is safe because we already forbid using `arguments` in `'use cache'` functions at compile time.

The implementation is trivial thanks to the output changes we implemented in #85519.

addresses #86896