### PR TITLE
fix: correct AppType parameter usage for TypeScript

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -28,10 +28,10 @@ export type DocumentType = NextComponentType<
   DocumentProps
 >
 
-export type AppType<P = {}> = NextComponentType<
+export type AppType<PageProps = {}> = NextComponentType<
   AppContextType,
-  P,
-  AppPropsType<any, P>
+  AppInitialProps<PageProps>,
+  AppPropsType<any, PageProps>
 >
 
 export type AppTreeType = ComponentType<


### PR DESCRIPTION
## Description
Fixes #42846 

The `AppType` generic parameter `P` was incorrectly used as `InitialProps` instead of `PageProps`. This fix properly uses `AppInitialProps<PageProps>` for the InitialProps parameter to match the actual structure where pageProps is wrapped in an object.

## Changes
**Before:**
```typescript
export type AppType<P = {}> = NextComponentType<
  AppContextType,
  P,
  AppPropsType<any, P>
>
```

**After:**
```typescript
export type AppType<PageProps = {}> = NextComponentType<
  AppContextType,
  AppInitialProps<PageProps>,
  AppPropsType<any, PageProps>
>
```

## Why This Fix?
According to `NextComponentType` definition:
- 1st param: Context
- 2nd param: InitialProps (should be `AppInitialProps<PageProps>`)
- 3rd param: Props (already correctly using `AppPropsType<any, PageProps>`)

The parameter name is also changed from `P` to `PageProps` for clarity.

## Testing
- TypeScript compilation passes
- Type definitions now correctly reflect the actual structure