### PR TITLE
bundle-analyzer: make `next` depend on `bundle-analyzer-ui` through turbo

### DIFF
--- a/packages/next/turbo.json
+++ b/packages/next/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["@next/bundle-analyzer-ui#build", "^build"],
+      "outputs": ["dist/**"]
+    }
+  }
+}


### PR DESCRIPTION
Test Plan: `pnpm turbo build -F next` and verify `@next/bundle-analyzer-ui#build` is run, and is run before `next#build`.
