### PR TITLE
Fix 'output:export' incorrect file copy in Windows build environment

### DIFF
--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -987,7 +987,7 @@ async function exportAppImpl(
           await Promise.all(
             segmentPaths.map(async (segmentFileSrc) => {
               const segmentPath =
-                '/' + segmentFileSrc.slice(0, -RSC_SEGMENT_SUFFIX.length)
+                sep + segmentFileSrc.slice(0, -RSC_SEGMENT_SUFFIX.length)
               const segmentFilename =
                 convertSegmentPathToStaticExportFilename(segmentPath)
               const segmentFileDest = join(segmentsDirDest, segmentFilename)

--- a/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
@@ -1,5 +1,7 @@
 import { PAGE_SEGMENT_KEY } from '../segment'
 import type { Segment as FlightRouterStateSegment } from '../app-router-types'
+import { sep } from 'path'
+import { escapeStringRegexp } from '../escape-regexp'
 
 // TypeScript trick to simulate opaque types, like in Flow.
 type Opaque<K, T> = T & { __brand: K }
@@ -90,5 +92,5 @@ function encodeToFilesystemAndURLSafeString(value: string) {
 export function convertSegmentPathToStaticExportFilename(
   segmentPath: string
 ): string {
-  return `__next${segmentPath.replace(/\//g, '.')}.txt`
+  return `__next${segmentPath.replace(new RegExp(escapeStringRegexp(sep), 'g'), '.')}.txt`
 }


### PR DESCRIPTION
Fix #85374 (Maybe...)

Go easy on me. that's because, This is my first PullRequest. (and English beginner 😢 )

# Problem

`output:export` copy function, use only slash (`/`) as path characters.
But, Windows Environment use backslash(`\`). so This files is incorrectly copied, and Different 'out' directory content other platform(Linux/macOS).

| Linux(WSL) | Windows | Windows (Fixed) |
|---|---|---|
| <img width="500" src="https://github.com/user-attachments/assets/31ffac19-d728-4217-89d3-79b642201a19" />  |  <img width="500" src="https://github.com/user-attachments/assets/31c20e00-0a1e-4493-aee4-df93c006e0bd" /> | <img width="500" src="https://github.com/user-attachments/assets/f3a95d97-6ed0-4e3d-a85e-3f22db20eb1f" /> |

Also, Always fail (404) for next/link Prefetch in this problem for Windows Build Environment.

<img width="300" src="https://github.com/user-attachments/assets/6fdffc45-d80b-4bb9-bc12-6bff8321b70c" />

# Solution

This PullRequest is replace `'/'` to `path.sep` in `output:export` dist copy function. 
(Node.js Path module)

Thank you.