### PR TITLE
enhance debug-build-paths on glob cases

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -969,5 +969,6 @@
   "968": "Invariant: getNextConfigEdge must only be called in edge runtime",
   "969": "Invariant: nextConfig couldn't be loaded",
   "970": "process.env.NEXT_DEPLOYMENT_ID is missing but runtimeServerDeploymentId is enabled",
-  "971": "The NEXT_DEPLOYMENT_ID environment variable value \"%s\" does not match the provided deploymentId \"%s\" in the config."
+  "971": "The NEXT_DEPLOYMENT_ID environment variable value \"%s\" does not match the provided deploymentId \"%s\" in the config.",
+  "972": "Failed to resolve pattern \"%s\": %s"
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1132,6 +1132,8 @@ export default async function build(
         nextBuildSpan,
         config,
         cacheDir,
+        debugBuildAppPaths,
+        debugBuildPagePaths,
       }
 
       if (appDir && 'exportPathMap' in config) {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1132,8 +1132,10 @@ export default async function build(
         nextBuildSpan,
         config,
         cacheDir,
-        debugBuildAppPaths,
-        debugBuildPagePaths,
+        debugBuildPaths:
+          debugBuildAppPaths !== undefined || debugBuildPagePaths !== undefined
+            ? { app: debugBuildAppPaths, pages: debugBuildPagePaths }
+            : undefined,
       }
 
       if (appDir && 'exportPathMap' in config) {

--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -20,7 +20,6 @@ import { hrtimeDurationToString } from './duration-to-string'
 function verifyTypeScriptSetup(
   dir: string,
   distDir: string,
-  intentDirs: string[],
   typeCheckPreflight: boolean,
   tsconfigPath: string | undefined,
   disableStaticImages: boolean,
@@ -29,8 +28,9 @@ function verifyTypeScriptSetup(
   hasAppDir: boolean,
   hasPagesDir: boolean,
   isolatedDevBuild: boolean | undefined,
-  debugBuildAppPaths: string[] | undefined,
-  debugBuildPagePaths: string[] | undefined
+  appDir: string | undefined,
+  pagesDir: string | undefined,
+  debugBuildPaths: { app?: string[]; pages?: string[] } | undefined
 ) {
   const typeCheckWorker = new Worker(
     require.resolve('../lib/verify-typescript-setup'),
@@ -50,7 +50,6 @@ function verifyTypeScriptSetup(
     .verifyTypeScriptSetup({
       dir,
       distDir,
-      intentDirs,
       typeCheckPreflight,
       tsconfigPath,
       disableStaticImages,
@@ -58,8 +57,9 @@ function verifyTypeScriptSetup(
       hasAppDir,
       hasPagesDir,
       isolatedDevBuild,
-      debugBuildAppPaths,
-      debugBuildPagePaths,
+      appDir,
+      pagesDir,
+      debugBuildPaths,
     })
     .then((result) => {
       typeCheckWorker.end()
@@ -80,8 +80,7 @@ export async function startTypeChecking({
   pagesDir,
   telemetry,
   appDir,
-  debugBuildAppPaths,
-  debugBuildPagePaths,
+  debugBuildPaths,
 }: {
   cacheDir: string
   config: NextConfigComplete
@@ -90,8 +89,7 @@ export async function startTypeChecking({
   pagesDir?: string
   telemetry: Telemetry
   appDir?: string
-  debugBuildAppPaths?: string[]
-  debugBuildPagePaths?: string[]
+  debugBuildPaths?: { app?: string[]; pages?: string[] }
 }) {
   const ignoreTypeScriptErrors = Boolean(config.typescript.ignoreBuildErrors)
 
@@ -119,7 +117,6 @@ export async function startTypeChecking({
         verifyTypeScriptSetup(
           dir,
           config.distDir,
-          [pagesDir, appDir].filter(Boolean) as string[],
           !ignoreTypeScriptErrors,
           config.typescript.tsconfigPath,
           config.images.disableStaticImages,
@@ -128,8 +125,9 @@ export async function startTypeChecking({
           !!appDir,
           !!pagesDir,
           config.experimental.isolatedDevBuild,
-          debugBuildAppPaths,
-          debugBuildPagePaths
+          appDir,
+          pagesDir,
+          debugBuildPaths
         ).then((resolved) => {
           const checkEnd = process.hrtime(typeCheckAndLintStart)
           return [resolved, checkEnd] as const

--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -28,7 +28,9 @@ function verifyTypeScriptSetup(
   enableWorkerThreads: boolean | undefined,
   hasAppDir: boolean,
   hasPagesDir: boolean,
-  isolatedDevBuild: boolean | undefined
+  isolatedDevBuild: boolean | undefined,
+  debugBuildAppPaths: string[] | undefined,
+  debugBuildPagePaths: string[] | undefined
 ) {
   const typeCheckWorker = new Worker(
     require.resolve('../lib/verify-typescript-setup'),
@@ -56,6 +58,8 @@ function verifyTypeScriptSetup(
       hasAppDir,
       hasPagesDir,
       isolatedDevBuild,
+      debugBuildAppPaths,
+      debugBuildPagePaths,
     })
     .then((result) => {
       typeCheckWorker.end()
@@ -76,6 +80,8 @@ export async function startTypeChecking({
   pagesDir,
   telemetry,
   appDir,
+  debugBuildAppPaths,
+  debugBuildPagePaths,
 }: {
   cacheDir: string
   config: NextConfigComplete
@@ -84,6 +90,8 @@ export async function startTypeChecking({
   pagesDir?: string
   telemetry: Telemetry
   appDir?: string
+  debugBuildAppPaths?: string[]
+  debugBuildPagePaths?: string[]
 }) {
   const ignoreTypeScriptErrors = Boolean(config.typescript.ignoreBuildErrors)
 
@@ -119,7 +127,9 @@ export async function startTypeChecking({
           config.experimental.workerThreads,
           !!appDir,
           !!pagesDir,
-          config.experimental.isolatedDevBuild
+          config.experimental.isolatedDevBuild,
+          debugBuildAppPaths,
+          debugBuildPagePaths
         ).then((resolved) => {
           const checkEnd = process.hrtime(typeCheckAndLintStart)
           return [resolved, checkEnd] as const

--- a/packages/next/src/cli/next-test.ts
+++ b/packages/next/src/cli/next-test.ts
@@ -140,13 +140,14 @@ async function runPlaywright(
     const { version: typeScriptVersion } = await verifyTypeScriptSetup({
       dir: baseDir,
       distDir: nextConfig.distDir,
-      intentDirs: [pagesDir, appDir].filter(Boolean) as string[],
       typeCheckPreflight: false,
       tsconfigPath: nextConfig.typescript.tsconfigPath,
       disableStaticImages: nextConfig.images.disableStaticImages,
       hasAppDir: !!appDir,
       hasPagesDir: !!pagesDir,
       isolatedDevBuild: nextConfig.experimental.isolatedDevBuild,
+      appDir: appDir || undefined,
+      pagesDir: pagesDir || undefined,
     })
 
     const isUsingTypeScript = !!typeScriptVersion

--- a/packages/next/src/cli/next-typegen.ts
+++ b/packages/next/src/cli/next-typegen.ts
@@ -57,13 +57,14 @@ const nextTypegen = async (
   await verifyTypeScriptSetup({
     dir: baseDir,
     distDir: nextConfig.distDir,
-    intentDirs: [pagesDir, appDir].filter(Boolean) as string[],
     typeCheckPreflight: false,
     tsconfigPath: nextConfig.typescript.tsconfigPath,
     disableStaticImages: nextConfig.images.disableStaticImages,
     hasAppDir: !!appDir,
     hasPagesDir: !!pagesDir,
     isolatedDevBuild: nextConfig.experimental.isolatedDevBuild,
+    appDir: appDir || undefined,
+    pagesDir: pagesDir || undefined,
   })
 
   console.log('Generating route types...')

--- a/packages/next/src/lib/resolve-build-paths.ts
+++ b/packages/next/src/lib/resolve-build-paths.ts
@@ -7,72 +7,42 @@ import isError from './is-error'
 
 const glob = promisify(globOriginal)
 
-/**
- * Escapes bracket expressions in a glob pattern that correspond to existing
- * Next.js dynamic route directories.
- *
- * Next.js uses brackets for dynamic routes (e.g., [slug], [...params], [[...catchAll]]),
- * but glob treats brackets as character classes. This function escapes brackets
- * that match actual directory names so glob treats them literally.
- *
- * Given directory structure: app/blog/[slug]/page.tsx
- *   Input:  "app/blog/[slug]/__STAR____STAR__/page.tsx"
- *   Output: "app/blog/\[slug\]/__STAR____STAR__/page.tsx"
- *   (where __STAR__ represents asterisk - brackets escaped, glob preserved)
- *
- * Bracket that doesn't exist as directory is left as glob character class:
- *   Input:  "app/[a-z]/page.tsx"  (no [a-z] directory)
- *   Output: "app/[a-z]/page.tsx"  (unchanged, treated as char class)
- */
-function escapeExistingBracketDirs(
-  pattern: string,
-  projectDir: string
-): string {
-  // Match bracket expressions: [name], [...name], [[...name]]
-  const bracketRegex = /\[\[?\.\.\.[^\]]+\]?\]|\[[^\]]+\]/g
-
-  let result = pattern
-  let match: RegExpExecArray | null
-  const replacements: Array<{ from: string; to: string; index: number }> = []
-
-  while ((match = bracketRegex.exec(pattern)) !== null) {
-    const bracketExpr = match[0]
-    const matchIndex = match.index
-
-    // Get the path prefix up to and including this bracket expression
-    const prefixEnd = matchIndex + bracketExpr.length
-    const pathPrefix = pattern.slice(0, prefixEnd)
-
-    // Check if this path exists as a literal directory
-    const fullPath = path.join(projectDir, pathPrefix)
-    if (fs.existsSync(fullPath)) {
-      // Escape the brackets for glob
-      const escaped = bracketExpr.replace(/\[/g, '\\[').replace(/\]/g, '\\]')
-      replacements.push({ from: bracketExpr, to: escaped, index: matchIndex })
-    }
-  }
-
-  // Apply replacements in reverse order to preserve indices
-  for (let i = replacements.length - 1; i >= 0; i--) {
-    const { from, to, index } = replacements[i]
-    result = result.slice(0, index) + to + result.slice(index + from.length)
-  }
-
-  return result
-}
-
 interface ResolvedBuildPaths {
   appPaths: string[]
   pagePaths: string[]
 }
 
 /**
- * Resolves glob patterns and explicit paths to actual file paths
- * Categorizes them into App Router and Pages Router paths
+ * Escapes bracket expressions that correspond to existing directories.
+ * This allows Next.js dynamic routes like [slug] to work with glob patterns.
  *
- * @param patterns - Array of glob patterns or explicit paths
- * @param projectDir - Root project directory
- * @returns Object with categorized app and page paths
+ * e.g., "app/blog/[slug]/** /page.tsx" → "app/blog/\[slug\]/** /page.tsx"
+ *       (if app/blog/[slug] directory exists)
+ */
+function escapeExistingBrackets(pattern: string, projectDir: string): string {
+  // Match bracket expressions: [name], [...name], [[...name]]
+  const bracketRegex = /\[\[?\.\.\.[^\]]+\]?\]|\[[^\]]+\]/g
+  let lastIndex = 0
+  let result = ''
+  let match: RegExpExecArray | null
+
+  while ((match = bracketRegex.exec(pattern)) !== null) {
+    const pathPrefix = pattern.slice(0, match.index + match[0].length)
+    const exists = fs.existsSync(path.join(projectDir, pathPrefix))
+
+    result += pattern.slice(lastIndex, match.index)
+    result += exists
+      ? match[0].replace(/\[/g, '\\[').replace(/\]/g, '\\]')
+      : match[0]
+    lastIndex = match.index + match[0].length
+  }
+
+  return result + pattern.slice(lastIndex)
+}
+
+/**
+ * Resolves glob patterns and explicit paths to actual file paths.
+ * Categorizes them into App Router and Pages Router paths.
  */
 export async function resolveBuildPaths(
   patterns: string[],
@@ -83,53 +53,30 @@ export async function resolveBuildPaths(
 
   for (const pattern of patterns) {
     const trimmed = pattern.trim()
+    if (!trimmed) continue
 
-    if (!trimmed) {
-      continue
-    }
+    try {
+      // Escape brackets that correspond to existing Next.js dynamic route directories
+      const escapedPattern = escapeExistingBrackets(trimmed, projectDir)
+      const matches = (await glob(escapedPattern, {
+        cwd: projectDir,
+      })) as string[]
 
-    // Check if the path exists as a literal file first
-    // This handles paths with special characters like [slug] in Next.js dynamic routes
-    const literalPath = path.join(projectDir, trimmed)
-    if (fs.existsSync(literalPath) && !fs.statSync(literalPath).isDirectory()) {
-      categorizeAndAddPath(trimmed, appPaths, pagePaths)
-      continue
-    }
-
-    // Detect if pattern is glob pattern (contains glob special chars)
-    const isGlobPattern = /[*?[\]{}!]/.test(trimmed)
-
-    if (isGlobPattern) {
-      try {
-        // Escape brackets that correspond to existing Next.js dynamic route directories
-        // e.g., "app/blog/[slug]/**/page.tsx" → "app/blog/\[slug\]/**/page.tsx"
-        const escapedPattern = escapeExistingBracketDirs(trimmed, projectDir)
-
-        // Resolve glob pattern
-        const matches = (await glob(escapedPattern, {
-          cwd: projectDir,
-        })) as string[]
-
-        if (matches.length === 0) {
-          Log.warn(`Glob pattern "${trimmed}" did not match any files`)
-        }
-
-        for (const file of matches) {
-          // Skip directories, only process files
-          if (!fs.statSync(path.join(projectDir, file)).isDirectory()) {
-            categorizeAndAddPath(file, appPaths, pagePaths)
-          }
-        }
-      } catch (error) {
-        throw new Error(
-          `Failed to resolve glob pattern "${trimmed}": ${
-            isError(error) ? error.message : String(error)
-          }`
-        )
+      if (matches.length === 0) {
+        Log.warn(`Pattern "${trimmed}" did not match any files`)
       }
-    } else {
-      // Explicit path - categorize based on prefix
-      categorizeAndAddPath(trimmed, appPaths, pagePaths, projectDir)
+
+      for (const file of matches) {
+        if (!fs.statSync(path.join(projectDir, file)).isDirectory()) {
+          categorizeAndAddPath(file, appPaths, pagePaths)
+        }
+      }
+    } catch (error) {
+      throw new Error(
+        `Failed to resolve pattern "${trimmed}": ${
+          isError(error) ? error.message : String(error)
+        }`
+      )
     }
   }
 
@@ -140,68 +87,23 @@ export async function resolveBuildPaths(
 }
 
 /**
- * Categorizes a file path to either app or pages router based on its prefix,
- * and normalizes it to the format expected by Next.js internal build system.
- *
- * The internal build system expects:
- * - App router: paths with leading slash (e.g., "/page.tsx", "/dashboard/page.tsx")
- * - Pages router: paths with leading slash (e.g., "/index.tsx", "/about.tsx")
+ * Categorizes a file path to either app or pages router based on its prefix.
  *
  * Examples:
  * - "app/page.tsx" → appPaths.add("/page.tsx")
- * - "app/dashboard/page.tsx" → appPaths.add("/dashboard/page.tsx")
  * - "pages/index.tsx" → pagePaths.add("/index.tsx")
- * - "pages/about.tsx" → pagePaths.add("/about.tsx")
- * - "/page.tsx" → appPaths.add("/page.tsx") (already in app router format)
  */
 function categorizeAndAddPath(
   filePath: string,
   appPaths: Set<string>,
-  pagePaths: Set<string>,
-  projectDir?: string
+  pagePaths: Set<string>
 ): void {
-  // Normalize path separators to forward slashes (Windows compatibility)
   const normalized = filePath.replace(/\\/g, '/')
 
-  // Skip non-file entries (like directories without extensions)
-  if (normalized.endsWith('/')) {
-    return
-  }
-
   if (normalized.startsWith('app/')) {
-    // App router path: remove 'app/' prefix and ensure leading slash
-    // "app/page.tsx" → "/page.tsx"
-    // "app/dashboard/page.tsx" → "/dashboard/page.tsx"
-    const withoutPrefix = normalized.slice(4) // Remove "app/"
-    appPaths.add('/' + withoutPrefix)
+    appPaths.add('/' + normalized.slice(4))
   } else if (normalized.startsWith('pages/')) {
-    // Pages router path: remove 'pages/' prefix and add leading slash
-    // "pages/index.tsx" → "/index.tsx"
-    // "pages/about.tsx" → "/about.tsx"
-    const withoutPrefix = normalized.slice(6) // Remove "pages/"
-    pagePaths.add('/' + withoutPrefix)
-  } else if (normalized.startsWith('/')) {
-    // Leading slash suggests app router format (already in correct format)
-    // "/page.tsx" → "/page.tsx" (no change needed)
-    appPaths.add(normalized)
-  } else {
-    // No obvious prefix - try to detect based on file existence
-    if (projectDir) {
-      const appPath = path.join(projectDir, 'app', normalized)
-      const pagesPath = path.join(projectDir, 'pages', normalized)
-
-      if (fs.existsSync(appPath)) {
-        appPaths.add('/' + normalized)
-      } else if (fs.existsSync(pagesPath)) {
-        pagePaths.add('/' + normalized)
-      } else {
-        // Default to pages router for paths without clear indicator
-        pagePaths.add('/' + normalized)
-      }
-    } else {
-      // Without projectDir context, default to pages router
-      pagePaths.add('/' + normalized)
-    }
+    pagePaths.add('/' + normalized.slice(6))
   }
 }
 

--- a/packages/next/src/lib/resolve-build-paths.ts
+++ b/packages/next/src/lib/resolve-build-paths.ts
@@ -7,6 +7,60 @@ import isError from './is-error'
 
 const glob = promisify(globOriginal)
 
+/**
+ * Escapes bracket expressions in a glob pattern that correspond to existing
+ * Next.js dynamic route directories.
+ *
+ * Next.js uses brackets for dynamic routes (e.g., [slug], [...params], [[...catchAll]]),
+ * but glob treats brackets as character classes. This function escapes brackets
+ * that match actual directory names so glob treats them literally.
+ *
+ * Given directory structure: app/blog/[slug]/page.tsx
+ *   Input:  "app/blog/[slug]/__STAR____STAR__/page.tsx"
+ *   Output: "app/blog/\[slug\]/__STAR____STAR__/page.tsx"
+ *   (where __STAR__ represents asterisk - brackets escaped, glob preserved)
+ *
+ * Bracket that doesn't exist as directory is left as glob character class:
+ *   Input:  "app/[a-z]/page.tsx"  (no [a-z] directory)
+ *   Output: "app/[a-z]/page.tsx"  (unchanged, treated as char class)
+ */
+function escapeExistingBracketDirs(
+  pattern: string,
+  projectDir: string
+): string {
+  // Match bracket expressions: [name], [...name], [[...name]]
+  const bracketRegex = /\[\[?\.\.\.[^\]]+\]?\]|\[[^\]]+\]/g
+
+  let result = pattern
+  let match: RegExpExecArray | null
+  const replacements: Array<{ from: string; to: string; index: number }> = []
+
+  while ((match = bracketRegex.exec(pattern)) !== null) {
+    const bracketExpr = match[0]
+    const matchIndex = match.index
+
+    // Get the path prefix up to and including this bracket expression
+    const prefixEnd = matchIndex + bracketExpr.length
+    const pathPrefix = pattern.slice(0, prefixEnd)
+
+    // Check if this path exists as a literal directory
+    const fullPath = path.join(projectDir, pathPrefix)
+    if (fs.existsSync(fullPath)) {
+      // Escape the brackets for glob
+      const escaped = bracketExpr.replace(/\[/g, '\\[').replace(/\]/g, '\\]')
+      replacements.push({ from: bracketExpr, to: escaped, index: matchIndex })
+    }
+  }
+
+  // Apply replacements in reverse order to preserve indices
+  for (let i = replacements.length - 1; i >= 0; i--) {
+    const { from, to, index } = replacements[i]
+    result = result.slice(0, index) + to + result.slice(index + from.length)
+  }
+
+  return result
+}
+
 interface ResolvedBuildPaths {
   appPaths: string[]
   pagePaths: string[]
@@ -34,13 +88,25 @@ export async function resolveBuildPaths(
       continue
     }
 
+    // Check if the path exists as a literal file first
+    // This handles paths with special characters like [slug] in Next.js dynamic routes
+    const literalPath = path.join(projectDir, trimmed)
+    if (fs.existsSync(literalPath) && !fs.statSync(literalPath).isDirectory()) {
+      categorizeAndAddPath(trimmed, appPaths, pagePaths)
+      continue
+    }
+
     // Detect if pattern is glob pattern (contains glob special chars)
     const isGlobPattern = /[*?[\]{}!]/.test(trimmed)
 
     if (isGlobPattern) {
       try {
+        // Escape brackets that correspond to existing Next.js dynamic route directories
+        // e.g., "app/blog/[slug]/**/page.tsx" → "app/blog/\[slug\]/**/page.tsx"
+        const escapedPattern = escapeExistingBracketDirs(trimmed, projectDir)
+
         // Resolve glob pattern
-        const matches = (await glob(trimmed, {
+        const matches = (await glob(escapedPattern, {
           cwd: projectDir,
         })) as string[]
 

--- a/packages/next/src/lib/typescript/runTypeCheck.ts
+++ b/packages/next/src/lib/typescript/runTypeCheck.ts
@@ -23,7 +23,11 @@ export async function runTypeCheck(
   tsConfigPath: string,
   cacheDir?: string,
   isAppDirEnabled?: boolean,
-  isolatedDevBuild?: boolean
+  isolatedDevBuild?: boolean,
+  intentDirs?: string[],
+  hasPagesDir?: boolean,
+  debugBuildAppPaths?: string[],
+  debugBuildPagePaths?: string[]
 ): Promise<TypeCheckResult> {
   const effectiveConfiguration = await getTypeScriptConfiguration(
     typescript,
@@ -50,6 +54,65 @@ export async function runTypeCheck(
     fileNames = fileNames.filter(
       (fileName) => !fileName.startsWith(devTypesDir)
     )
+  }
+
+  // Apply debug build paths filter if specified
+  if (
+    intentDirs &&
+    (debugBuildAppPaths !== undefined || debugBuildPagePaths !== undefined)
+  ) {
+    // Determine appDir and pagesDir from intentDirs
+    // intentDirs is [pagesDir, appDir].filter(Boolean) from type-check.ts
+    let pagesDir: string | undefined
+    let appDir: string | undefined
+
+    if (hasPagesDir && isAppDirEnabled) {
+      pagesDir = intentDirs[0]
+      appDir = intentDirs[1]
+    } else if (hasPagesDir) {
+      pagesDir = intentDirs[0]
+    } else if (isAppDirEnabled) {
+      appDir = intentDirs[0]
+    }
+
+    fileNames = fileNames.filter((fileName) => {
+      // Check if file is in app directory
+      if (appDir && fileName.startsWith(appDir + path.sep)) {
+        // If debugBuildAppPaths is undefined, include all app files
+        if (debugBuildAppPaths === undefined) {
+          return true
+        }
+        // If debugBuildAppPaths is empty array, exclude all app files
+        if (debugBuildAppPaths.length === 0) {
+          return false
+        }
+        // Check if file matches any of the debug paths
+        const relativeToApp = fileName.slice(appDir.length)
+        return debugBuildAppPaths.some((debugPath) =>
+          relativeToApp.startsWith(debugPath.replace(/\.[^/.]+$/, ''))
+        )
+      }
+
+      // Check if file is in pages directory
+      if (pagesDir && fileName.startsWith(pagesDir + path.sep)) {
+        // If debugBuildPagePaths is undefined, include all pages files
+        if (debugBuildPagePaths === undefined) {
+          return true
+        }
+        // If debugBuildPagePaths is empty array, exclude all pages files
+        if (debugBuildPagePaths.length === 0) {
+          return false
+        }
+        // Check if file matches any of the debug paths
+        const relativeToPages = fileName.slice(pagesDir.length)
+        return debugBuildPagePaths.some((debugPath) =>
+          relativeToPages.startsWith(debugPath.replace(/\.[^/.]+$/, ''))
+        )
+      }
+
+      // Keep files outside app/pages directories (shared code, etc.)
+      return true
+    })
   }
 
   if (fileNames.length < 1) {

--- a/packages/next/src/lib/typescript/runTypeCheck.ts
+++ b/packages/next/src/lib/typescript/runTypeCheck.ts
@@ -28,45 +28,13 @@ export interface DebugBuildPaths {
 
 /**
  * Check if a file path matches any of the debug build paths.
- *
- * @param filePath - The file path relative to the app/pages directory
- * @param debugPaths - Array of debug paths to match against
- * @returns true if the file matches any debug path
- *
- * @example
- * // Debug paths come from --debug-build-paths flag, e.g.:
- * // --debug-build-paths 'app/page.tsx,app/blog/[slug]/page.tsx'
- * // These get normalized to: ['/page.tsx', '/blog/[slug]/page.tsx']
- *
- * // The regex /\.[^/.]+$/ removes the file extension:
- * // - '\.'      matches a literal dot
- * // - '[^/.]+'  matches one or more chars that are NOT '/' or '.'
- * // - '$'       matches end of string
- * //
- * // Examples:
- * //   '/page.tsx'           → '/page'
- * //   '/blog/[slug]/page.tsx' → '/blog/[slug]/page'
- * //   '/dashboard/page.ts'  → '/dashboard/page'
- *
- * // Then startsWith checks if file is under the debug path directory:
- * //   filePath='/page.tsx', debugPath='/page.tsx'
- * //     → '/page.tsx'.startsWith('/page') → true
- * //
- * //   filePath='/blog/[slug]/page.tsx', debugPath='/blog/[slug]/page.tsx'
- * //     → '/blog/[slug]/page.tsx'.startsWith('/blog/[slug]/page') → true
- * //
- * //   filePath='/about/page.tsx', debugPath='/page.tsx'
- * //     → '/about/page.tsx'.startsWith('/page') → false
+ * Both filePath and debugPaths are resolved file paths from glob.
  */
 function fileMatchesDebugPaths(
   filePath: string,
   debugPaths: string[]
 ): boolean {
-  return debugPaths.some((debugPath) => {
-    // Remove file extension from debug path for directory-level matching
-    const debugPathWithoutExt = debugPath.replace(/\.[^/.]+$/, '')
-    return filePath.startsWith(debugPathWithoutExt)
-  })
+  return debugPaths.includes(filePath)
 }
 
 export async function runTypeCheck(

--- a/packages/next/src/lib/typescript/runTypeCheck.ts
+++ b/packages/next/src/lib/typescript/runTypeCheck.ts
@@ -26,6 +26,49 @@ export interface DebugBuildPaths {
   pages?: string[]
 }
 
+/**
+ * Check if a file path matches any of the debug build paths.
+ *
+ * @param filePath - The file path relative to the app/pages directory
+ * @param debugPaths - Array of debug paths to match against
+ * @returns true if the file matches any debug path
+ *
+ * @example
+ * // Debug paths come from --debug-build-paths flag, e.g.:
+ * // --debug-build-paths 'app/page.tsx,app/blog/[slug]/page.tsx'
+ * // These get normalized to: ['/page.tsx', '/blog/[slug]/page.tsx']
+ *
+ * // The regex /\.[^/.]+$/ removes the file extension:
+ * // - '\.'      matches a literal dot
+ * // - '[^/.]+'  matches one or more chars that are NOT '/' or '.'
+ * // - '$'       matches end of string
+ * //
+ * // Examples:
+ * //   '/page.tsx'           → '/page'
+ * //   '/blog/[slug]/page.tsx' → '/blog/[slug]/page'
+ * //   '/dashboard/page.ts'  → '/dashboard/page'
+ *
+ * // Then startsWith checks if file is under the debug path directory:
+ * //   filePath='/page.tsx', debugPath='/page.tsx'
+ * //     → '/page.tsx'.startsWith('/page') → true
+ * //
+ * //   filePath='/blog/[slug]/page.tsx', debugPath='/blog/[slug]/page.tsx'
+ * //     → '/blog/[slug]/page.tsx'.startsWith('/blog/[slug]/page') → true
+ * //
+ * //   filePath='/about/page.tsx', debugPath='/page.tsx'
+ * //     → '/about/page.tsx'.startsWith('/page') → false
+ */
+function fileMatchesDebugPaths(
+  filePath: string,
+  debugPaths: string[]
+): boolean {
+  return debugPaths.some((debugPath) => {
+    // Remove file extension from debug path for directory-level matching
+    const debugPathWithoutExt = debugPath.replace(/\.[^/.]+$/, '')
+    return filePath.startsWith(debugPathWithoutExt)
+  })
+}
+
 export async function runTypeCheck(
   typescript: typeof import('typescript'),
   baseDir: string,
@@ -82,9 +125,7 @@ export async function runTypeCheck(
         }
         // Check if file matches any of the debug paths
         const relativeToApp = fileName.slice(appDir.length)
-        return debugAppPaths.some((debugPath) =>
-          relativeToApp.startsWith(debugPath.replace(/\.[^/.]+$/, ''))
-        )
+        return fileMatchesDebugPaths(relativeToApp, debugAppPaths)
       }
 
       // Check if file is in pages directory
@@ -99,9 +140,7 @@ export async function runTypeCheck(
         }
         // Check if file matches any of the debug paths
         const relativeToPages = fileName.slice(pagesDir.length)
-        return debugPagePaths.some((debugPath) =>
-          relativeToPages.startsWith(debugPath.replace(/\.[^/.]+$/, ''))
-        )
+        return fileMatchesDebugPaths(relativeToPages, debugPagePaths)
       }
 
       // Keep files outside app/pages directories (shared code, etc.)

--- a/packages/next/src/lib/typescript/runTypeCheck.ts
+++ b/packages/next/src/lib/typescript/runTypeCheck.ts
@@ -16,6 +16,16 @@ export interface TypeCheckResult {
   incremental: boolean
 }
 
+export interface TypeCheckDirs {
+  app?: string
+  pages?: string
+}
+
+export interface DebugBuildPaths {
+  app?: string[]
+  pages?: string[]
+}
+
 export async function runTypeCheck(
   typescript: typeof import('typescript'),
   baseDir: string,
@@ -24,10 +34,8 @@ export async function runTypeCheck(
   cacheDir?: string,
   isAppDirEnabled?: boolean,
   isolatedDevBuild?: boolean,
-  intentDirs?: string[],
-  hasPagesDir?: boolean,
-  debugBuildAppPaths?: string[],
-  debugBuildPagePaths?: string[]
+  dirs?: TypeCheckDirs,
+  debugBuildPaths?: DebugBuildPaths
 ): Promise<TypeCheckResult> {
   const effectiveConfiguration = await getTypeScriptConfiguration(
     typescript,
@@ -57,55 +65,41 @@ export async function runTypeCheck(
   }
 
   // Apply debug build paths filter if specified
-  if (
-    intentDirs &&
-    (debugBuildAppPaths !== undefined || debugBuildPagePaths !== undefined)
-  ) {
-    // Determine appDir and pagesDir from intentDirs
-    // intentDirs is [pagesDir, appDir].filter(Boolean) from type-check.ts
-    let pagesDir: string | undefined
-    let appDir: string | undefined
-
-    if (hasPagesDir && isAppDirEnabled) {
-      pagesDir = intentDirs[0]
-      appDir = intentDirs[1]
-    } else if (hasPagesDir) {
-      pagesDir = intentDirs[0]
-    } else if (isAppDirEnabled) {
-      appDir = intentDirs[0]
-    }
+  if (dirs && debugBuildPaths) {
+    const { app: appDir, pages: pagesDir } = dirs
+    const { app: debugAppPaths, pages: debugPagePaths } = debugBuildPaths
 
     fileNames = fileNames.filter((fileName) => {
       // Check if file is in app directory
       if (appDir && fileName.startsWith(appDir + path.sep)) {
-        // If debugBuildAppPaths is undefined, include all app files
-        if (debugBuildAppPaths === undefined) {
+        // If debugAppPaths is undefined, include all app files
+        if (debugAppPaths === undefined) {
           return true
         }
-        // If debugBuildAppPaths is empty array, exclude all app files
-        if (debugBuildAppPaths.length === 0) {
+        // If debugAppPaths is empty array, exclude all app files
+        if (debugAppPaths.length === 0) {
           return false
         }
         // Check if file matches any of the debug paths
         const relativeToApp = fileName.slice(appDir.length)
-        return debugBuildAppPaths.some((debugPath) =>
+        return debugAppPaths.some((debugPath) =>
           relativeToApp.startsWith(debugPath.replace(/\.[^/.]+$/, ''))
         )
       }
 
       // Check if file is in pages directory
       if (pagesDir && fileName.startsWith(pagesDir + path.sep)) {
-        // If debugBuildPagePaths is undefined, include all pages files
-        if (debugBuildPagePaths === undefined) {
+        // If debugPagePaths is undefined, include all pages files
+        if (debugPagePaths === undefined) {
           return true
         }
-        // If debugBuildPagePaths is empty array, exclude all pages files
-        if (debugBuildPagePaths.length === 0) {
+        // If debugPagePaths is empty array, exclude all pages files
+        if (debugPagePaths.length === 0) {
           return false
         }
         // Check if file matches any of the debug paths
         const relativeToPages = fileName.slice(pagesDir.length)
-        return debugBuildPagePaths.some((debugPath) =>
+        return debugPagePaths.some((debugPath) =>
           relativeToPages.startsWith(debugPath.replace(/\.[^/.]+$/, ''))
         )
       }

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -37,31 +37,34 @@ export async function verifyTypeScriptSetup({
   dir,
   distDir,
   cacheDir,
-  intentDirs,
   tsconfigPath,
   typeCheckPreflight,
   disableStaticImages,
   hasAppDir,
   hasPagesDir,
   isolatedDevBuild,
-  debugBuildAppPaths,
-  debugBuildPagePaths,
+  appDir,
+  pagesDir,
+  debugBuildPaths,
 }: {
   dir: string
   distDir: string
   cacheDir?: string
   tsconfigPath: string | undefined
-  intentDirs: string[]
   typeCheckPreflight: boolean
   disableStaticImages: boolean
   hasAppDir: boolean
   hasPagesDir: boolean
   isolatedDevBuild: boolean | undefined
-  debugBuildAppPaths?: string[]
-  debugBuildPagePaths?: string[]
+  appDir?: string
+  pagesDir?: string
+  debugBuildPaths?: { app?: string[]; pages?: string[] }
 }): Promise<{ result?: TypeCheckResult; version: string | null }> {
   const tsConfigFileName = tsconfigPath || 'tsconfig.json'
   const resolvedTsConfigPath = path.join(dir, tsConfigFileName)
+
+  // Construct intentDirs from appDir and pagesDir for getTypeScriptIntent
+  const intentDirs = [pagesDir, appDir].filter(Boolean) as string[]
 
   try {
     // Check if the project uses TypeScript:
@@ -164,10 +167,8 @@ export async function verifyTypeScriptSetup({
         cacheDir,
         hasAppDir,
         isolatedDevBuild,
-        intentDirs,
-        hasPagesDir,
-        debugBuildAppPaths,
-        debugBuildPagePaths
+        { app: appDir, pages: pagesDir },
+        debugBuildPaths
       )
     }
     return { result, version: typescriptVersion }

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -44,6 +44,8 @@ export async function verifyTypeScriptSetup({
   hasAppDir,
   hasPagesDir,
   isolatedDevBuild,
+  debugBuildAppPaths,
+  debugBuildPagePaths,
 }: {
   dir: string
   distDir: string
@@ -55,6 +57,8 @@ export async function verifyTypeScriptSetup({
   hasAppDir: boolean
   hasPagesDir: boolean
   isolatedDevBuild: boolean | undefined
+  debugBuildAppPaths?: string[]
+  debugBuildPagePaths?: string[]
 }): Promise<{ result?: TypeCheckResult; version: string | null }> {
   const tsConfigFileName = tsconfigPath || 'tsconfig.json'
   const resolvedTsConfigPath = path.join(dir, tsConfigFileName)
@@ -159,7 +163,11 @@ export async function verifyTypeScriptSetup({
         resolvedTsConfigPath,
         cacheDir,
         hasAppDir,
-        isolatedDevBuild
+        isolatedDevBuild,
+        intentDirs,
+        hasPagesDir,
+        debugBuildAppPaths,
+        debugBuildPagePaths
       )
     }
     return { result, version: typescriptVersion }

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -143,13 +143,14 @@ async function verifyTypeScript(opts: SetupOpts) {
   const verifyResult = await verifyTypeScriptSetup({
     dir: opts.dir,
     distDir: opts.nextConfig.distDir,
-    intentDirs: [opts.pagesDir, opts.appDir].filter(Boolean) as string[],
     typeCheckPreflight: false,
     tsconfigPath: opts.nextConfig.typescript.tsconfigPath,
     disableStaticImages: opts.nextConfig.images.disableStaticImages,
     hasAppDir: !!opts.appDir,
     hasPagesDir: !!opts.pagesDir,
     isolatedDevBuild: opts.nextConfig.experimental.isolatedDevBuild,
+    appDir: opts.appDir,
+    pagesDir: opts.pagesDir,
   })
 
   if (verifyResult.version) {

--- a/test/production/debug-build-path/app/blog/[slug]/comments/page.tsx
+++ b/test/production/debug-build-path/app/blog/[slug]/comments/page.tsx
@@ -1,0 +1,8 @@
+export default async function Comments({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <h1>Comments for: {slug}</h1>
+}

--- a/test/production/debug-build-path/app/blog/[slug]/page.tsx
+++ b/test/production/debug-build-path/app/blog/[slug]/page.tsx
@@ -1,0 +1,8 @@
+export default async function BlogPost({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <h1>Blog Post: {slug}</h1>
+}

--- a/test/production/debug-build-path/app/with-type-error/page.tsx
+++ b/test/production/debug-build-path/app/with-type-error/page.tsx
@@ -1,0 +1,6 @@
+// This file has an intentional type error
+const invalidValue: string = 123
+
+export default function WithTypeError() {
+  return <div>WithTypeError: {invalidValue}</div>
+}

--- a/test/production/debug-build-path/debug-build-paths.test.ts
+++ b/test/production/debug-build-path/debug-build-paths.test.ts
@@ -40,6 +40,26 @@ describe('debug-build-paths', () => {
       // Should not build app routes
       expect(buildResult.cliOutput).not.toContain('Route (app)')
     })
+
+    it('should build dynamic route with literal [slug] path', async () => {
+      // Test that literal paths with brackets work without escaping
+      // The path is checked for file existence before being treated as glob
+      const buildResult = await next.build({
+        args: ['--debug-build-paths', 'app/blog/[slug]/page.tsx'],
+      })
+      expect(buildResult.exitCode).toBe(0)
+      expect(buildResult.cliOutput).toBeDefined()
+
+      // Should build only the blog/[slug] route
+      expect(buildResult.cliOutput).toContain('Route (app)')
+      expect(buildResult.cliOutput).toContain('/blog/[slug]')
+      // Should not build other app routes
+      expect(buildResult.cliOutput).not.toMatch(/○ \/\n/)
+      expect(buildResult.cliOutput).not.toContain('○ /about')
+      expect(buildResult.cliOutput).not.toContain('○ /dashboard')
+      // Should not build pages routes
+      expect(buildResult.cliOutput).not.toContain('Route (pages)')
+    })
   })
 
   describe('glob pattern matching', () => {
@@ -74,6 +94,28 @@ describe('debug-build-paths', () => {
       expect(buildResult.cliOutput).toContain('Route (app)')
       expect(buildResult.cliOutput).toContain('/blog/[slug]')
       // Should not build other app routes (check for exact route, not substring)
+      expect(buildResult.cliOutput).not.toMatch(/○ \/\n/)
+      expect(buildResult.cliOutput).not.toContain('○ /about')
+      expect(buildResult.cliOutput).not.toContain('○ /dashboard')
+      // Should not build pages routes
+      expect(buildResult.cliOutput).not.toContain('Route (pages)')
+    })
+
+    it('should match hybrid pattern with literal [slug] and glob **', async () => {
+      // Test pattern: app/blog/[slug]/**/page.tsx
+      // [slug] should be treated as literal directory (exists on disk)
+      // ** should be treated as glob (match any depth)
+      const buildResult = await next.build({
+        args: ['--debug-build-paths', 'app/blog/[slug]/**/page.tsx'],
+      })
+      expect(buildResult.exitCode).toBe(0)
+      expect(buildResult.cliOutput).toBeDefined()
+
+      // Should build both blog/[slug] and blog/[slug]/comments routes
+      expect(buildResult.cliOutput).toContain('Route (app)')
+      expect(buildResult.cliOutput).toContain('/blog/[slug]')
+      expect(buildResult.cliOutput).toContain('/blog/[slug]/comments')
+      // Should not build other app routes
       expect(buildResult.cliOutput).not.toMatch(/○ \/\n/)
       expect(buildResult.cliOutput).not.toContain('○ /about')
       expect(buildResult.cliOutput).not.toContain('○ /dashboard')

--- a/test/production/debug-build-path/debug-build-paths.test.ts
+++ b/test/production/debug-build-path/debug-build-paths.test.ts
@@ -62,5 +62,71 @@ describe('debug-build-paths', () => {
       expect(buildResult.cliOutput).not.toContain('○ /about')
       expect(buildResult.cliOutput).not.toContain('○ /dashboard')
     })
+
+    it('should match nested routes with app/blog/**/page.tsx pattern', async () => {
+      const buildResult = await next.build({
+        args: ['--debug-build-paths', 'app/blog/**/page.tsx'],
+      })
+      expect(buildResult.exitCode).toBe(0)
+      expect(buildResult.cliOutput).toBeDefined()
+
+      // Should build the blog route
+      expect(buildResult.cliOutput).toContain('Route (app)')
+      expect(buildResult.cliOutput).toContain('/blog/[slug]')
+      // Should not build other app routes (check for exact route, not substring)
+      expect(buildResult.cliOutput).not.toMatch(/○ \/\n/)
+      expect(buildResult.cliOutput).not.toContain('○ /about')
+      expect(buildResult.cliOutput).not.toContain('○ /dashboard')
+      // Should not build pages routes
+      expect(buildResult.cliOutput).not.toContain('Route (pages)')
+    })
+
+    it('should match multiple app routes with explicit patterns', async () => {
+      const buildResult = await next.build({
+        args: [
+          '--debug-build-paths',
+          'app/page.tsx,app/about/page.tsx,app/dashboard/page.tsx,app/blog/**/page.tsx',
+        ],
+      })
+      expect(buildResult.exitCode).toBe(0)
+      expect(buildResult.cliOutput).toBeDefined()
+
+      // Should build specified app routes
+      expect(buildResult.cliOutput).toContain('Route (app)')
+      expect(buildResult.cliOutput).toContain('○ /')
+      expect(buildResult.cliOutput).toContain('○ /about')
+      expect(buildResult.cliOutput).toContain('○ /dashboard')
+      expect(buildResult.cliOutput).toContain('/blog/[slug]')
+      // Should not build routes not specified
+      expect(buildResult.cliOutput).not.toContain('/with-type-error')
+      // Should not build pages routes
+      expect(buildResult.cliOutput).not.toContain('Route (pages)')
+    })
+  })
+
+  describe('typechecking with debug-build-paths', () => {
+    it('should skip typechecking for excluded app routes', async () => {
+      // Build only pages routes, excluding app routes with type error
+      const buildResult = await next.build({
+        args: ['--debug-build-paths', 'pages/foo.tsx'],
+      })
+      // Build should succeed because the file with type error is not checked
+      expect(buildResult.exitCode).toBe(0)
+      expect(buildResult.cliOutput).toContain('Route (pages)')
+      expect(buildResult.cliOutput).toContain('○ /foo')
+      // Should not include app routes
+      expect(buildResult.cliOutput).not.toContain('Route (app)')
+    })
+
+    it('should fail typechecking when route with type error is included', async () => {
+      // Build all app routes including the one with type error
+      const buildResult = await next.build({
+        args: ['--debug-build-paths', 'app/**/page.tsx'],
+      })
+      // Build should fail due to type error in with-type-error/page.tsx
+      expect(buildResult.exitCode).toBe(1)
+      expect(buildResult.cliOutput).toContain('Type error')
+      expect(buildResult.cliOutput).toContain('with-type-error/page.tsx')
+    })
   })
 })


### PR DESCRIPTION
Ensure `--debug-build-paths` also handles type check entries as well, only run type check against the entries going to be built.

There're also minor bug fixes for this cli arg:
- When it contains `[]` in the pattern, which is also considered as glob pattern, we'll do proper encoding if it's pattern not relative file paths.