### PR TITLE
fix: otel error spans from streamed responses

### DIFF
--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -157,6 +157,12 @@ interface NextTracer {
    * through the OpenTelemetry propagator API.
    */
   getTracePropagationData(): ClientTraceDataEntry[]
+
+  /**
+   * Executes a function with the given span set as the active span in the context.
+   * This allows child spans created within the function to automatically parent to this span.
+   */
+  withSpan<T>(span: Span, fn: () => T): T
 }
 
 type NextAttributeNames =
@@ -478,6 +484,11 @@ class NextTracerImpl implements NextTracer {
     if (attributes && !attributes.has(key)) {
       attributes.set(key, value)
     }
+  }
+
+  public withSpan<T>(span: Span, fn: () => T): T {
+    const spanContext = trace.setSpan(context.active(), span)
+    return context.with(spanContext, fn)
   }
 }
 

--- a/test/e2e/opentelemetry/instrumentation/app/app/[param]/loading/error/page.tsx
+++ b/test/e2e/opentelemetry/instrumentation/app/app/[param]/loading/error/page.tsx
@@ -1,0 +1,8 @@
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  // Simulate async work before throwing
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  throw new Error('Error inside Suspense boundary')
+}

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -613,6 +613,129 @@ describe('opentelemetry', () => {
               },
             ])
           })
+
+          it('should handle error inside Suspense boundary', async () => {
+            await next.fetch('/app/param/loading/error', env.fetchInit)
+
+            await expectTrace(getCollector(), [
+              {
+                name: 'GET /app/[param]/loading/error',
+                attributes: {
+                  'http.method': 'GET',
+                  'http.route': '/app/[param]/loading/error',
+                  // The response starts streaming before the error,
+                  // so HTTP status is 200 (unlike synchronous errors which get 500)
+                  'http.status_code': 200,
+                  'http.target': '/app/param/loading/error',
+                  'next.route': '/app/[param]/loading/error',
+                  'next.rsc': false,
+                  'next.span_name': 'GET /app/[param]/loading/error',
+                  'next.span_type': 'BaseServer.handleRequest',
+                },
+                kind: 1,
+                status: { code: 0 },
+                traceId: env.span.traceId,
+                parentId: env.span.rootParentId,
+                spans: [
+                  {
+                    name: 'render route (app) /app/[param]/loading/error',
+                    attributes: {
+                      'next.route': '/app/[param]/loading/error',
+                      'next.span_name':
+                        'render route (app) /app/[param]/loading/error',
+                      'next.span_type': 'AppRender.getBodyResult',
+                      'error.type': 'Error',
+                    },
+                    kind: 0,
+                    // The render span should have error status because an error
+                    // was thrown inside a Suspense boundary during streaming
+                    status: {
+                      code: 2,
+                      message: 'Error inside Suspense boundary',
+                    },
+                    spans: [
+                      {
+                        name: 'build component tree',
+                        attributes: {
+                          'next.span_name': 'build component tree',
+                          'next.span_type':
+                            'NextNodeServer.createComponentTree',
+                        },
+                        kind: 0,
+                        status: { code: 0 },
+                        spans: [
+                          {
+                            name: 'resolve segment modules',
+                            attributes: {
+                              'next.segment': '__PAGE__',
+                              'next.span_name': 'resolve segment modules',
+                              'next.span_type':
+                                'NextNodeServer.getLayoutOrPageModule',
+                            },
+                            kind: 0,
+                            status: { code: 0 },
+                          },
+                          {
+                            name: 'resolve segment modules',
+                            attributes: {
+                              'next.segment': '[param]',
+                              'next.span_name': 'resolve segment modules',
+                              'next.span_type':
+                                'NextNodeServer.getLayoutOrPageModule',
+                            },
+                            kind: 0,
+                            status: { code: 0 },
+                          },
+                        ],
+                      },
+                      {
+                        name: 'generateMetadata /app/[param]/layout',
+                        attributes: {
+                          'next.page': '/app/[param]/layout',
+                          'next.span_name':
+                            'generateMetadata /app/[param]/layout',
+                          'next.span_type': 'ResolveMetadata.generateMetadata',
+                        },
+                        kind: 0,
+                        status: { code: 0 },
+                      },
+                      {
+                        attributes: {
+                          'next.clientComponentLoadCount': isNextDev ? 7 : 6,
+                          'next.span_type':
+                            'NextNodeServer.clientComponentLoading',
+                        },
+                        kind: 0,
+                        name: 'NextNodeServer.clientComponentLoading',
+                        status: {
+                          code: 0,
+                        },
+                      },
+                      {
+                        name: 'start response',
+                        attributes: {
+                          'next.span_name': 'start response',
+                          'next.span_type': 'NextNodeServer.startResponse',
+                        },
+                        kind: 0,
+                        status: { code: 0 },
+                      },
+                    ],
+                  },
+                  {
+                    name: 'resolve page components',
+                    attributes: {
+                      'next.route': '/app/[param]/loading/error',
+                      'next.span_name': 'resolve page components',
+                      'next.span_type': 'NextNodeServer.findPageComponents',
+                    },
+                    kind: 0,
+                    status: { code: 0 },
+                  },
+                ],
+              },
+            ])
+          })
         })
 
         describe('pages', () => {


### PR DESCRIPTION
When an error is thrown inside a Suspense boundary during streaming SSR, the error was not being captured in the "render route (app)" span. This happened because `getTracer().wrap()` ends the span as soon as the stream is created and returned, but errors inside Suspense boundaries occur asynchronously during stream consumption.

This PR changes the span management from using `wrap()` to manually calling `startSpan()` and tracking the span lifecycle. The span now stays open until `allReady` resolves or rejects. A new `withSpan()` helper was added to the tracer to properly activate the span context so child spans are parented. Error handlers now accept an optional `spanToRecordOn` parameter to record exceptions on the correct span rather than relying solely on the active scope span.

Fixes #86517