### PR TITLE
fix: only call `captureOwnerStack` if it exists

### DIFF
--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -160,8 +160,8 @@ function applyOwnerStack(error: Error) {
   // via `throwIfDisallowedDynamic`.
   if (process.env.NODE_ENV !== 'production') {
     const ownerStack =
-      getClientReact()?.captureOwnerStack() ??
-      getServerReact()?.captureOwnerStack()
+      getClientReact()?.captureOwnerStack?.() ??
+      getServerReact()?.captureOwnerStack?.()
 
     if (ownerStack) {
       let stack = ownerStack


### PR DESCRIPTION
Building or starting Next.js in anything other than `production` mode is currently erroring with `TypeError: _getClientReact.captureOwnerStack is not a function`. This used to work but had a regression in https://github.com/vercel/next.js/pull/85486.

In our end-to-end tests we're building and starting with `NODE_ENV=test` so instead of upgrading to the latest version last week because of the CVE discovery, we had to downgrade instead.