### PR TITLE
Better error log for router state header in parseAndValidateFlightRouterState

### DIFF
--- a/packages/next/src/server/app-render/parse-and-validate-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/parse-and-validate-flight-router-state.tsx
@@ -53,9 +53,8 @@ export function parseAndValidateFlightRouterState(
     const state = JSON.parse(decodeURIComponent(stateHeader))
     assert(state, flightRouterStateSchema)
     return state
-  } catch (parseError) {
-    const message =
-      parseError instanceof Error ? parseError.message : 'undefined'
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
 
     throw new Error(
       `The router state header was sent but could not be parsed. Error: '${message}'. Header preview: ${sanitizeHeader(stateHeader)})`

--- a/packages/next/src/server/app-render/parse-and-validate-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/parse-and-validate-flight-router-state.tsx
@@ -19,7 +19,7 @@ export function parseAndValidateFlightRouterState(
   }
   if (Array.isArray(stateHeader)) {
     throw new Error(
-      'Multiple router state headers were sent. This is not allowed.'
+      `Multiple router state headers were sent. This is not allowed (stateHeader length ${stateHeader.length}).`
     )
   }
 
@@ -29,7 +29,9 @@ export function parseAndValidateFlightRouterState(
   // This is around 2,000 nested or parallel route segment states:
   // '{"children":["",{}]}'.length === 20.
   if (stateHeader.length > 20 * 2000) {
-    throw new Error('The router state header was too large.')
+    throw new Error(
+      `The router state header was too large (stateHeader=${stateHeader.substring(0, 1000)}).`
+    )
   }
 
   try {
@@ -37,6 +39,8 @@ export function parseAndValidateFlightRouterState(
     assert(state, flightRouterStateSchema)
     return state
   } catch {
-    throw new Error('The router state header was sent but could not be parsed.')
+    throw new Error(
+      `The router state header was sent but could not be parsed. (stateHeader=${stateHeader.substring(0, 1000)})`
+    )
   }
 }

--- a/packages/next/src/server/app-render/parse-and-validate-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/parse-and-validate-flight-router-state.tsx
@@ -2,6 +2,21 @@ import type { FlightRouterState } from '../../shared/lib/app-router-types'
 import { flightRouterStateSchema } from './types'
 import { assert } from 'next/dist/compiled/superstruct'
 
+const HEADER_MAX_SIZE = 20 * 2000
+const HEADER_MAX_LENGTH = 1_000
+
+// Redact potentially sensitive data
+function sanitizeHeader(header: string) {
+  const sanitizedHeader = header
+    .substring(0, HEADER_MAX_LENGTH)
+    .replace(/[?&]([^=&]+)=([^&]*)/g, (key) => {
+      // Keep structure but hide values
+      return `${key}=[REDACTED]`
+    })
+
+  return `${sanitizedHeader}${sanitizedHeader.length > HEADER_MAX_LENGTH ? '... [truncated]' : ''}).`
+}
+
 export function parseAndValidateFlightRouterState(
   stateHeader: string | string[]
 ): FlightRouterState
@@ -28,9 +43,9 @@ export function parseAndValidateFlightRouterState(
   // resolving of the router state.
   // This is around 2,000 nested or parallel route segment states:
   // '{"children":["",{}]}'.length === 20.
-  if (stateHeader.length > 20 * 2000) {
+  if (stateHeader.length > HEADER_MAX_SIZE) {
     throw new Error(
-      `The router state header was too large (stateHeader=${stateHeader.substring(0, 1000)}).`
+      `The router state header was too large (${stateHeader.length} bytes,max: ${HEADER_MAX_SIZE} bytes). Preview: ${sanitizeHeader(stateHeader)}).`
     )
   }
 
@@ -38,9 +53,12 @@ export function parseAndValidateFlightRouterState(
     const state = JSON.parse(decodeURIComponent(stateHeader))
     assert(state, flightRouterStateSchema)
     return state
-  } catch {
+  } catch (parseError) {
+    const message =
+      parseError instanceof Error ? parseError.message : 'undefined'
+
     throw new Error(
-      `The router state header was sent but could not be parsed. (stateHeader=${stateHeader.substring(0, 1000)})`
+      `The router state header was sent but could not be parsed. Error: '${message}'. Header preview: ${sanitizeHeader(stateHeader)})`
     )
   }
 }


### PR DESCRIPTION
None of next.js dev answer this [issue](https://github.com/vercel/next.js/discussions/54751).
To have a decent error-logging experience i think it is useful adding some info about the error. 

Probably the error is caused by a malformed stateHeader and printing this information in the error message is a smart way to know what's happening.

Merging this PR would be a good deed towards all people stuck with this error log.

---

I used `stateHeader.substring(0, 1000)` to limit the chars printed but You can use whatever you want to achieve this. The important thing is to have a message that makes it clear whats happening
