### PR TITLE
bundle-analyzer: add kbd shortcut labels and fix focus bugs

### DIFF
--- a/apps/bundle-analyzer/components/file-search.tsx
+++ b/apps/bundle-analyzer/components/file-search.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Kbd } from '@/components/ui/kbd'
+
+interface FileSearchProps {
+  value: string
+  onChange: (value: string) => void
+}
+
+export function FileSearch({ value, onChange }: FileSearchProps) {
+  const [focused, setFocused] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (
+        e.key === '/' &&
+        !['INPUT', 'TEXTAREA'].includes((e.target as HTMLElement).tagName)
+      ) {
+        e.preventDefault()
+        inputRef.current?.focus()
+      } else if (
+        e.key === 'Escape' &&
+        document.activeElement === inputRef.current
+      ) {
+        e.preventDefault()
+        onChange('')
+        inputRef.current?.blur()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onChange])
+
+  const handleFocus = () => {
+    setFocused(true)
+  }
+
+  const handleBlur = () => {
+    setFocused(false)
+  }
+
+  return (
+    <div className="relative">
+      <Input
+        ref={inputRef}
+        type="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        placeholder="Search files..."
+        className="w-48 focus:w-80 transition-all duration-200 pr-8"
+      />
+      {!value && !focused && (
+        <Kbd className="absolute right-2 top-1/2 -translate-y-1/2">/</Kbd>
+      )}
+    </div>
+  )
+}

--- a/apps/bundle-analyzer/components/ui/kbd.tsx
+++ b/apps/bundle-analyzer/components/ui/kbd.tsx
@@ -1,0 +1,28 @@
+import { cn } from '@/lib/utils'
+
+function Kbd({ className, ...props }: React.ComponentProps<'kbd'>) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        'bg-muted text-muted-foreground pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm px-1 font-sans text-xs font-medium select-none',
+        "[&_svg:not([class*='size-'])]:size-3",
+        '[[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function KbdGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <kbd
+      data-slot="kbd-group"
+      className={cn('inline-flex items-center gap-1', className)}
+      {...props}
+    />
+  )
+}
+
+export { Kbd, KbdGroup }


### PR DESCRIPTION
- Adds decorated kbd-style shortcut labels to cue the user into using them
- Listens only for the appropriate OS or Ctrl key on Mac/Others
- Esc now clears and focuses the search field and the treemap focus
- Does not trigger in the case where the user has another element focused

![image.png](https://app.graphite.com/user-attachments/assets/6a85d1e7-a711-432d-86b0-f65c0b89de74.png)

