### PR TITLE
[codemod] upgrade to nearest minor by default

### DIFF
--- a/packages/next-codemod/bin/next-codemod.ts
+++ b/packages/next-codemod/bin/next-codemod.ts
@@ -58,18 +58,9 @@ program
   .description(
     'Upgrade Next.js apps to desired versions with a single command.'
   )
-  // The CLI interface must be backwards compatible at all times so that older
-  // versions of Next.js can still run the codemod successfully.
   .argument(
     '[revision]',
-    'Specify the target Next.js version using an NPM dist tag (e.g. "latest", "canary", "rc", "beta") or an exact version number (e.g. "15.0.0").',
-    packageJson.version.includes('-canary.')
-      ? 'canary'
-      : packageJson.version.includes('-rc.')
-        ? 'rc'
-        : packageJson.version.includes('-beta.')
-          ? 'beta'
-          : 'latest'
+    'Specify the upgrade type ("patch", "minor", "major"), an NPM dist tag (e.g. "latest", "canary", "rc"), or an exact version (e.g. "15.0.0"). Defaults to "minor".'
   )
   .usage('[revision] [options]')
   .option('--verbose', 'Verbose output', false)


### PR DESCRIPTION
Change the upgrade codemod to do nearest `minor` version by default if you don't provide semver like `latest` as argument, this is used for upgrade to latest security package without breaking the app.