### PR TITLE
Turbopack: Improve the description on InvalidLoaderRuleConditionIssue

### DIFF
--- a/examples/basic-css/next.config.js
+++ b/examples/basic-css/next.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  turbopack: {
+    rules: {
+      "*.svg": {
+        loaders: ["@svgr/webpack"],
+        as: "*.js",
+        condition: {
+          path: /abc/,
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
It's near-impossible to get this to error on the Rust side (issues are caught before we get here), but I hacked up the code to make it error. It looks like this:

![Screenshot 2025-12-09 at 4.39.24 PM.png](https://app.graphite.com/user-attachments/assets/796b5efa-b2e5-4a9c-bcf3-03cee0a0861d.png)