### PR TITLE
fix: handle notFound in Suspense with cacheComponents enabled

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -62,6 +62,7 @@ import {
   getAccessFallbackErrorTypeByStatus,
   getAccessFallbackHTTPStatus,
   isHTTPAccessFallbackError,
+  HTTP_ERROR_FALLBACK_ERROR_CODE,
 } from '../../client/components/http-access-fallback/http-access-fallback'
 import {
   getURLFromRedirectError,
@@ -2824,18 +2825,76 @@ async function renderToStream(
           // We have a complete HTML Document in the prerender but we need to
           // still include the new server component render because it was not included
           // in the static prelude.
-          const inlinedReactServerDataStream = createInlinedDataReadableStream(
-            reactServerResult.tee(),
-            nonce,
-            formState
-          )
 
-          // End the span since there's no async rendering in this path
-          if (renderSpan.isRecording()) renderSpan.end()
-          return chainStreams(
-            inlinedReactServerDataStream,
-            createDocumentClosingStream()
-          )
+          // We need to consume the RSC stream first to check for HTTP access fallback
+          // errors (like notFound()). If such an error is thrown inside a Suspense
+          // boundary, we can't just send RSC data - we need to do a full dynamic
+          // render to properly display the error page.
+          const rscStream = reactServerResult.consume()
+          const reader = rscStream.getReader()
+          const chunks: Uint8Array[] = []
+
+          // Consume the entire RSC stream to detect any errors
+          try {
+            while (true) {
+              const { done, value } = await reader.read()
+              if (done) break
+              if (value) chunks.push(value)
+            }
+          } finally {
+            reader.releaseLock()
+          }
+
+          // Check if any HTTP access fallback errors were thrown during RSC rendering
+          let hasHTTPAccessFallbackError = false
+          for (const digest of reactServerErrorsByDigest.keys()) {
+            if (digest.startsWith(HTTP_ERROR_FALLBACK_ERROR_CODE)) {
+              hasHTTPAccessFallbackError = true
+              // Set the appropriate status code
+              const httpError = reactServerErrorsByDigest.get(digest)
+              if (httpError && isHTTPAccessFallbackError(httpError)) {
+                res.statusCode = getAccessFallbackHTTPStatus(httpError)
+                metadata.statusCode = res.statusCode
+              }
+              break
+            }
+          }
+
+          // Helper to create a stream from buffered chunks
+          const createBufferedStream = () =>
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                for (const chunk of chunks) {
+                  controller.enqueue(chunk)
+                }
+                controller.close()
+              },
+            })
+
+          // If we have an HTTP access fallback error, we need to do a full dynamic
+          // render to properly display the not-found/forbidden/unauthorized page.
+          // Fall through to the regular dynamic render path below.
+          if (!hasHTTPAccessFallbackError) {
+            // No errors - create a stream from the buffered chunks and send it
+            const inlinedReactServerDataStream = createInlinedDataReadableStream(
+              createBufferedStream(),
+              nonce,
+              formState
+            )
+
+            // End the span since there's no async rendering in this path
+            if (renderSpan.isRecording()) renderSpan.end()
+            return chainStreams(
+              inlinedReactServerDataStream,
+              createDocumentClosingStream()
+            )
+          }
+
+          // We have an HTTP access fallback error - replace reactServerResult with
+          // a new one created from the buffered chunks so the regular dynamic render
+          // path can use it.
+          reactServerResult = new ReactServerResult(createBufferedStream())
+          // Fall through to regular dynamic render for HTTP access fallback errors
         } else if (postponedState) {
           // We assume we have dynamic HTML requiring a resume render to complete
           const { postponed, preludeState } =

--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -8,6 +8,7 @@ import { isAbortError } from '../pipe-readable'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { isDynamicServerError } from '../../client/components/hooks-server-context'
 import { isNextRouterError } from '../../client/components/is-next-router-error'
+import { isHTTPAccessFallbackError } from '../../client/components/http-access-fallback/http-access-fallback'
 import { isPrerenderInterruptedError } from './dynamic-rendering'
 import { getProperError } from '../../lib/is-error'
 import { createDigestWithErrorCode } from '../../lib/error-telemetry-utils'
@@ -68,6 +69,15 @@ export function createReactServerErrorHandler(
     const digest = getDigestForWellKnownError(thrownValue)
 
     if (digest) {
+      // Store HTTP access fallback errors so they can be detected
+      // in DynamicState.DATA mode (where we need to fall back to full
+      // dynamic render if notFound/forbidden/unauthorized was thrown)
+      if (
+        isHTTPAccessFallbackError(thrownValue) &&
+        !reactServerErrors.has(digest)
+      ) {
+        reactServerErrors.set(digest, thrownValue as DigestedError)
+      }
       return digest
     }
 

--- a/test/e2e/app-dir/cache-components/app/cases/not-found-suspense/not-found.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/not-found-suspense/not-found.tsx
@@ -1,0 +1,10 @@
+import { getSentinelValue } from '../../getSentinelValue'
+
+export default function NotFound() {
+  return (
+    <>
+      <p id="not-found-component">Not Found from Suspense!</p>
+      <div id="page">{getSentinelValue()}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components/app/cases/not-found-suspense/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/not-found-suspense/page.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from 'react'
+import { notFound } from 'next/navigation'
+
+async function fetchData() {
+  // Simulate fetching data that doesn't exist
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  return null // Data not found
+}
+
+async function DataComponent() {
+  const data = await fetchData()
+  if (!data) {
+    notFound()
+  }
+  return <p>Data: {data}</p>
+}
+
+async function AnotherAsyncComponent() {
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  return <p id="fetched-data">Fetched Data</p>
+}
+
+export default function Page() {
+  return (
+    <div>
+      <p id="before-suspense">Before Suspense</p>
+      <Suspense fallback={<p>Loading data...</p>}>
+        <DataComponent />
+      </Suspense>
+      <Suspense fallback={<p>Loading more...</p>}>
+        <AnotherAsyncComponent />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/cache-components/app/cases/not-found-with-layout-suspense/layout.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/not-found-with-layout-suspense/layout.tsx
@@ -1,0 +1,28 @@
+import { Suspense } from 'react'
+import { getSentinelValue } from '../../getSentinelValue'
+
+async function fetchData() {
+  // Simulate an async data fetch
+  return new Promise<string>((resolve) => {
+    setTimeout(() => {
+      resolve('Fetched Data')
+    }, 100)
+  })
+}
+
+async function AsyncComponent() {
+  const data = await fetchData()
+  return <div id="async-data">Data: {data}</div>
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <div id="layout">{getSentinelValue()}</div>
+      {children}
+      <Suspense fallback={<div>Loading async...</div>}>
+        <AsyncComponent />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/cache-components/app/cases/not-found-with-layout-suspense/not-found.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/not-found-with-layout-suspense/not-found.tsx
@@ -1,0 +1,10 @@
+import { getSentinelValue } from '../../getSentinelValue'
+
+export default function NotFound() {
+  return (
+    <>
+      <h1 id="not-found-heading">404 - Page Not Found</h1>
+      <div id="page">{getSentinelValue()}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components/app/cases/not-found-with-layout-suspense/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/not-found-with-layout-suspense/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function Page() {
+  notFound()
+}

--- a/test/e2e/app-dir/cache-components/cache-components.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.test.ts
@@ -64,6 +64,56 @@ describe('cache-components', () => {
     }
   })
 
+  it('should handle not-found thrown in a Suspense boundary', async () => {
+    // This tests that notFound() works correctly when thrown inside a Suspense
+    // boundary during streaming. The not-found page should be rendered properly
+    // without "Connection closed" errors.
+    const browser = await next.browser('/cases/not-found-suspense')
+
+    // Wait for the not-found component to appear
+    const notFoundText = await browser
+      .waitForElementByCss('#not-found-component')
+      .text()
+    expect(notFoundText).toBe('Not Found from Suspense!')
+
+    // Check that there are no console errors about "Connection closed"
+    const logs = await browser.log()
+    const connectionClosedErrors = logs.filter(
+      (log: { message: string }) =>
+        log.message.includes('Connection closed') ||
+        log.message.includes('client-side exception')
+    )
+    expect(connectionClosedErrors).toHaveLength(0)
+  })
+
+  it('should handle not-found with async component in layout Suspense boundary', async () => {
+    // This tests the exact reproduction case from the issue:
+    // - notFound() called directly in page
+    // - Async component wrapped in Suspense in layout
+    // - cacheComponents: true
+    // The not-found page should render and the async component should also render.
+    const browser = await next.browser('/cases/not-found-with-layout-suspense')
+
+    // Wait for the not-found component to appear
+    const notFoundHeading = await browser
+      .waitForElementByCss('#not-found-heading')
+      .text()
+    expect(notFoundHeading).toBe('404 - Page Not Found')
+
+    // The async component in the layout should also render
+    const asyncData = await browser.waitForElementByCss('#async-data').text()
+    expect(asyncData).toBe('Data: Fetched Data')
+
+    // Check that there are no console errors about "Connection closed"
+    const logs = await browser.log()
+    const connectionClosedErrors = logs.filter(
+      (log: { message: string }) =>
+        log.message.includes('Connection closed') ||
+        log.message.includes('client-side exception')
+    )
+    expect(connectionClosedErrors).toHaveLength(0)
+  })
+
   it('should prerender pages that render in a microtask', async () => {
     let $ = await next.render$('/cases/microtask', {})
     if (isNextDev) {


### PR DESCRIPTION
## What?

This PR fixes an issue where `notFound()` (and other HTTP access fallback errors like `forbidden()`/`unauthorized()`) would cause "Connection closed" errors when `cacheComponents: true` is enabled and the page has a Suspense boundary with an async component.

## Why?

When `cacheComponents` is enabled and a page is prerendered, subsequent requests use `DynamicState.DATA` mode which only sends RSC data without re-rendering the HTML shell. However, when `notFound()` is thrown during this RSC render, the prerendered HTML doesn't contain the not-found component, causing the client to receive an incomplete stream and display "Connection closed" errors.

## How?

This fix buffers the RSC stream in `DynamicState.DATA` mode to detect HTTP access fallback errors. After consuming the stream:
1. Check `reactServerErrorsByDigest` for any errors with the `HTTP_ERROR_FALLBACK_ERROR_CODE` prefix
2. If no such errors exist, send the buffered RSC data as before
3. If such errors are found, set the appropriate status code and fall through to the full dynamic render path which properly handles the not-found page

## Test Plan

Added two test cases:
- `not-found-suspense`: Tests `notFound()` thrown inside a Suspense boundary
- `not-found-with-layout-suspense`: Exact reproduction of the issue - `notFound()` in page with async component in layout's Suspense

Fixes #86251