### PR TITLE
docs: Add custom labels configuration example

### DIFF
--- a/docs/01-app/01-getting-started/02-project-structure.mdx
+++ b/docs/01-app/01-getting-started/02-project-structure.mdx
@@ -224,6 +224,19 @@ In the `app` directory, nested folders define route structure. Each folder repre
 
 However, even though route structure is defined through folders, a route is **not publicly accessible** until a `page.js` or `route.js` file is added to a route segment.
 
+> **Good to know**: When working with multiple special files (like `page.js`, `layout.js`, etc.), you can customize how they appear in your IDE's editor tabs. For example, in VS Code or Cursor, add this to `.vscode/settings.json`:
+>
+> ```jsonc
+> {
+>   "workbench.editor.customLabels.patterns": {
+>     "**/app/**/{page,layout,loading,error,not-found,global-error,route,template,default}.{js,jsx,ts,tsx}": "${dirname}/${filename}.${extname}",
+>     "**/index.{js,jsx,ts,tsx}": "${dirname}/index.${extname}",
+>   },
+> }
+> ```
+>
+> This will display tabs as `dashboard/page.tsx` instead of just `page.tsx`, making it easier to distinguish between files.
+
 <Image
   alt="A diagram showing how a route is not publicly accessible until a page.js or route.js file is added to a route segment."
   srcLight="/docs/light/project-organization-not-routable.png"

--- a/docs/01-app/01-getting-started/02-project-structure.mdx
+++ b/docs/01-app/01-getting-started/02-project-structure.mdx
@@ -224,7 +224,7 @@ In the `app` directory, nested folders define route structure. Each folder repre
 
 However, even though route structure is defined through folders, a route is **not publicly accessible** until a `page.js` or `route.js` file is added to a route segment.
 
-> **Good to know**: When working with multiple special files (like `page.js`, `layout.js`, etc.), you can customize how they appear in your IDE's editor tabs. For example, in VS Code or Cursor, add this to `.vscode/settings.json`:
+> **Good to know**: When working with multiple special files (like `page.js`, `layout.js`, etc.), you can customize how they appear in your IDE's editor tabs. For example, in VS Code or Cursor, add this to `settings.json`:
 >
 > ```jsonc
 > {


### PR DESCRIPTION
Adds a VS Code/Cursor workspace configuration example for custom editor labels that works with all Next.js file conventions.

This improves the developer experience when working with multiple routing files (page, layout, error, etc.) by displaying the parent directory name alongside the filename in VS Code tabs, making it easier to distinguish between files with identical names.
