### PR TITLE
bundle-analyzer: Show compressed sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9505,6 +9505,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
+ "flate2",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",

--- a/apps/bundle-analyzer/app/page.tsx
+++ b/apps/bundle-analyzer/app/page.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import type React from 'react'
+import { SizeMode } from '@/lib/treemap-layout'
+
 import { useEffect, useMemo, useState } from 'react'
 import useSWR from 'swr'
 import { ErrorState } from '@/components/error-state'
@@ -17,12 +19,17 @@ import { computeActiveEntries, computeModuleDepthMap } from '@/lib/module-graph'
 import { fetchStrict } from '@/lib/utils'
 import { formatBytes } from '@/lib/utils'
 
+enum Environment {
+  Client = 'client',
+  Server = 'server',
+}
+
 export default function Home() {
   const [selectedRoute, setSelectedRoute] = useState<string | null>(null)
-  const [environmentFilter, setEnvironmentFilter] = useState<
-    'client' | 'server'
-  >('client')
-  const [typeFilter, setTypeFilter] = useState<string[]>(['js', 'css', 'json'])
+  const [environmentFilter, setEnvironmentFilter] = useState<Environment>(
+    Environment.Client
+  )
+  const [typeFilter, setTypeFilter] = useState(['js', 'css', 'json'])
   const [selectedSourceIndex, setSelectedSourceIndex] = useState<number | null>(
     null
   )
@@ -69,6 +76,7 @@ export default function Home() {
     client?: boolean
   } | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
+  const [sizeMode, setSizeMode] = useState(SizeMode.Compressed)
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -100,15 +108,15 @@ export default function Home() {
   }, [modulesData, analyzeData])
 
   const filterSource = useMemo(() => {
-    if (!analyzeData) return undefined
+    if (!analyzeData) return () => true
 
     return (sourceIndex: number) => {
       const flags = analyzeData.getSourceFlags(sourceIndex)
 
       // Check environment filter
       const hasEnvironment =
-        (environmentFilter === 'client' && flags.client) ||
-        (environmentFilter === 'server' && flags.server)
+        (environmentFilter === Environment.Client && flags.client) ||
+        (environmentFilter === Environment.Server && flags.server)
 
       // Check type filter
       const hasType =
@@ -157,15 +165,39 @@ export default function Home() {
           />
         </div>
 
-        <div className="basis-2/3 flex justify-end">
+        <div className="basis-2/3 flex justify-end items-center space-x-4">
           {analyzeData && (
             <>
               <ToggleGroup
                 type="single"
-                className="mr-4"
+                value={
+                  sizeMode === SizeMode.Compressed
+                    ? 'compressed'
+                    : 'uncompressed'
+                }
+                onValueChange={(value) => {
+                  if (value)
+                    setSizeMode(
+                      value === 'compressed'
+                        ? SizeMode.Compressed
+                        : SizeMode.Uncompressed
+                    )
+                }}
+                size="sm"
+              >
+                <ToggleGroupItem value="uncompressed">
+                  Uncompressed
+                </ToggleGroupItem>
+                <ToggleGroupItem value="compressed">Compressed</ToggleGroupItem>
+              </ToggleGroup>
+
+              <ControlDivider />
+
+              <ToggleGroup
+                type="single"
                 value={environmentFilter}
                 onValueChange={(value) => {
-                  if (value) setEnvironmentFilter(value as 'client' | 'server')
+                  if (value) setEnvironmentFilter(value as Environment)
                 }}
                 size="sm"
               >
@@ -173,9 +205,10 @@ export default function Home() {
                 <ToggleGroupItem value="server">Server</ToggleGroupItem>
               </ToggleGroup>
 
+              <ControlDivider />
+
               <ToggleGroup
                 type="multiple"
-                className="mr-4"
                 value={typeFilter}
                 onValueChange={(value) => {
                   if (value.length > 0) setTypeFilter(value)
@@ -187,6 +220,8 @@ export default function Home() {
                 <ToggleGroupItem value="json">JSON</ToggleGroupItem>
                 <ToggleGroupItem value="asset">Asset</ToggleGroupItem>
               </ToggleGroup>
+
+              <ControlDivider />
 
               <FileSearch value={searchQuery} onChange={setSearchQuery} />
             </>
@@ -235,6 +270,7 @@ export default function Home() {
                 onHoveredNodeChange={setHoveredNodeInfo}
                 searchQuery={searchQuery}
                 filterSource={filterSource}
+                sizeMode={sizeMode}
               />
             </div>
 
@@ -252,6 +288,7 @@ export default function Home() {
               selectedSourceIndex={selectedSourceIndex}
               moduleDepthMap={moduleDepthMap}
               environmentFilter={environmentFilter}
+              filterSource={filterSource}
             />
           </>
         ) : null}
@@ -266,7 +303,11 @@ export default function Home() {
                   {hoveredNodeInfo.name}
                 </span>
                 <span className="ml-2 text-muted-foreground">
-                  {formatBytes(hoveredNodeInfo.size)}
+                  {`${formatBytes(hoveredNodeInfo.size)} ${
+                    sizeMode === SizeMode.Compressed
+                      ? 'compressed'
+                      : 'uncompressed'
+                  }`}
                 </span>
                 {(hoveredNodeInfo.server || hoveredNodeInfo.client) && (
                   <span className="ml-2 inline-flex gap-1">
@@ -287,6 +328,10 @@ export default function Home() {
       )}
     </main>
   )
+}
+
+function ControlDivider() {
+  return <span className="h-6 w-px bg-muted-foreground/30" />
 }
 
 function getRootSourceIndex(analyzeData: AnalyzeData | undefined): number {

--- a/apps/bundle-analyzer/app/page.tsx
+++ b/apps/bundle-analyzer/app/page.tsx
@@ -170,25 +170,18 @@ export default function Home() {
             <>
               <ToggleGroup
                 type="single"
-                value={
-                  sizeMode === SizeMode.Compressed
-                    ? 'compressed'
-                    : 'uncompressed'
-                }
+                value={sizeMode}
                 onValueChange={(value) => {
-                  if (value)
-                    setSizeMode(
-                      value === 'compressed'
-                        ? SizeMode.Compressed
-                        : SizeMode.Uncompressed
-                    )
+                  if (value) setSizeMode(value as SizeMode)
                 }}
                 size="sm"
               >
-                <ToggleGroupItem value="uncompressed">
+                <ToggleGroupItem value={SizeMode.Uncompressed}>
                   Uncompressed
                 </ToggleGroupItem>
-                <ToggleGroupItem value="compressed">Compressed</ToggleGroupItem>
+                <ToggleGroupItem value={SizeMode.Compressed}>
+                  Compressed
+                </ToggleGroupItem>
               </ToggleGroup>
 
               <ControlDivider />
@@ -201,8 +194,12 @@ export default function Home() {
                 }}
                 size="sm"
               >
-                <ToggleGroupItem value="client">Client</ToggleGroupItem>
-                <ToggleGroupItem value="server">Server</ToggleGroupItem>
+                <ToggleGroupItem value={Environment.Client}>
+                  Client
+                </ToggleGroupItem>
+                <ToggleGroupItem value={Environment.Server}>
+                  Server
+                </ToggleGroupItem>
               </ToggleGroup>
 
               <ControlDivider />
@@ -303,11 +300,7 @@ export default function Home() {
                   {hoveredNodeInfo.name}
                 </span>
                 <span className="ml-2 text-muted-foreground">
-                  {`${formatBytes(hoveredNodeInfo.size)} ${
-                    sizeMode === SizeMode.Compressed
-                      ? 'compressed'
-                      : 'uncompressed'
-                  }`}
+                  {`${formatBytes(hoveredNodeInfo.size)} ${sizeMode}`}
                 </span>
                 {(hoveredNodeInfo.server || hoveredNodeInfo.client) && (
                   <span className="ml-2 inline-flex gap-1">

--- a/apps/bundle-analyzer/components/sidebar.tsx
+++ b/apps/bundle-analyzer/components/sidebar.tsx
@@ -1,6 +1,13 @@
 'use client'
 
 import type React from 'react'
+import { CircleHelp } from 'lucide-react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './ui/tooltip'
 import { ImportChain } from '@/components/import-chain'
 import { Skeleton } from '@/components/ui/skeleton'
 import { AnalyzeData, ModulesData } from '@/lib/analyze-data'
@@ -15,6 +22,7 @@ interface SidebarProps {
   selectedSourceIndex: number | null
   moduleDepthMap: Map<number, number>
   environmentFilter: 'client' | 'server'
+  filterSource?: (sourceIndex: number) => boolean
   isLoading?: boolean
 }
 
@@ -34,9 +42,12 @@ export function Sidebar({
   selectedSourceIndex,
   moduleDepthMap,
   environmentFilter,
+  filterSource,
   isLoading = false,
 }: SidebarProps) {
-  if (isLoading) {
+  filterSource = filterSource ?? (() => true)
+
+  if (isLoading || !analyzeData) {
     return (
       <div
         className="flex-none bg-muted border-l border-border overflow-y-auto"
@@ -56,10 +67,40 @@ export function Sidebar({
     )
   }
 
-  if (!analyzeData) {
-    return null
-  }
+  return (
+    <div
+      className="flex-none bg-muted border-l border-border overflow-y-auto"
+      style={{ width: `${sidebarWidth}%` }}
+    >
+      {selectedSourceIndex != null ? (
+        <SelectionDetails
+          analyzeData={analyzeData}
+          modulesData={modulesData}
+          selectedSourceIndex={selectedSourceIndex}
+          filterSource={filterSource}
+          moduleDepthMap={moduleDepthMap}
+          environmentFilter={environmentFilter}
+        />
+      ) : null}
+    </div>
+  )
+}
 
+function SelectionDetails({
+  analyzeData,
+  modulesData,
+  selectedSourceIndex,
+  filterSource,
+  moduleDepthMap,
+  environmentFilter,
+}: {
+  analyzeData: AnalyzeData
+  modulesData: ModulesData | null
+  selectedSourceIndex: number
+  moduleDepthMap: Map<number, number>
+  environmentFilter: 'client' | 'server'
+  filterSource: (sourceIndex: number) => boolean
+}) {
   const specialModuleType = getSpecialModuleType(
     analyzeData,
     selectedSourceIndex
@@ -76,101 +117,122 @@ export function Sidebar({
 
   const childModuleCount =
     hasChildModules && selectedSourceIndex != null
-      ? analyzeData.getSourceRecursiveModuleCount(selectedSourceIndex)
+      ? analyzeData.getRecursiveModuleCount(selectedSourceIndex, filterSource)
       : null
 
+  const { size, compressedSize } = analyzeData.getRecursiveSizes(
+    selectedSourceIndex,
+    filterSource
+  )
+
+  const chunks =
+    selectedSourceIndex != null
+      ? analyzeData.sourceChunks(selectedSourceIndex)
+      : []
+
   return (
-    <div
-      className="flex-none bg-muted border-l border-border overflow-y-auto"
-      style={{ width: `${sidebarWidth}%` }}
-    >
-      <div className="flex-1 p-3 space-y-8 overflow-y-auto">
-        <div className="space-y-2">
-          <h2 className="text-s font-semibold mb-1 text-foreground truncate">
-            {selectedSource
-              ? selectedSource.path || 'All Route Modules'
-              : 'Unknown Source'}
-          </h2>
-          {selectedSourceIndex != null &&
-          analyzeData.source(selectedSourceIndex) ? (
+    <div className="flex-1 p-3 space-y-8 overflow-y-auto">
+      <div className="space-y-2">
+        <h2 className="text-s font-semibold mb-1 text-foreground truncate">
+          {selectedSource?.path || 'All Route Modules'}
+        </h2>
+        {selectedSourceIndex != null &&
+        analyzeData.source(selectedSourceIndex) ? (
+          <div className="text-xs">
             <div>
-              <div className="text-xs">
-                <span>
-                  {hasChildModules
-                    ? formatBytes(
-                        analyzeData.getSourceRecursiveSize(selectedSourceIndex)
-                      )
-                    : formatBytes(
-                        analyzeData.getSourceOutputSize(selectedSourceIndex)
-                      )}
-                </span>{' '}
-                <span className="text-muted-foreground">bundled</span>
-              </div>
-              {hasChildModules && childModuleCount != null ? (
-                <div className="text-xs">
-                  <span>{childModuleCount} </span>
-                  <span className="text-muted-foreground">
-                    {childModuleCount === 1 ? 'module' : 'modules'}
-                  </span>
-                </div>
-              ) : null}
+              <span>{formatBytes(size)}</span>{' '}
+              <span className="text-muted-foreground">uncompressed</span>
+              <HelpTooltip>
+                Uncompressed modules may still be minified, tree-shaken, and
+                dead-code eliminated. They just don't account for general
+                compression like gzip.
+              </HelpTooltip>
             </div>
-          ) : null}
-        </div>
-
-        {selectedSourceIndex != null &&
-          analyzeData.source(selectedSourceIndex) &&
-          (specialModuleType === SpecialModule.POLYFILL_MODULE ||
-            specialModuleType === SpecialModule.POLYFILL_NOMODULE) && (
-            <dl>
-              <div className="flex items-center gap-2">
-                <dt className="inline-flex items-center">
-                  <Badge variant="polyfill">Polyfill</Badge>
-                </dt>
-                <dd className="text-xs text-muted-foreground">
-                  Next.js built-in polyfills
-                </dd>
-              </div>
-            </dl>
-          )}
-
-        {selectedSourceIndex != null &&
-          analyzeData.source(selectedSourceIndex) &&
-          !hasChildModules && (
             <>
-              {modulesData && (
-                <ImportChain
-                  key={selectedSourceIndex}
-                  startFileId={selectedSourceIndex}
-                  analyzeData={analyzeData}
-                  modulesData={modulesData}
-                  depthMap={moduleDepthMap}
-                  environmentFilter={environmentFilter}
-                />
-              )}
-              {(() => {
-                const chunks = analyzeData.sourceChunks(selectedSourceIndex)
-                if (chunks.length > 0) {
-                  return (
-                    <div className="mt-2">
-                      <p className="text-xs font-semibold text-foreground">
-                        Output Chunks
-                      </p>
-                      <ul className="text-xs text-muted-foreground font-mono mt-1 space-y-1">
-                        {chunks.map((chunk) => (
-                          <li key={chunk} className="break-all">
-                            {chunk}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )
-                }
-                return null
-              })()}
+              <div>
+                <span className="text-muted-foreground">About </span>
+                <span>{formatBytes(compressedSize)}</span>
+                <span className="text-muted-foreground ml-1">compressed</span>
+                <HelpTooltip>
+                  Estimated compressed size. Modules are compressed in isolation
+                  which may differ from their size in the final chunk.
+                </HelpTooltip>
+              </div>
             </>
-          )}
+            {hasChildModules && childModuleCount != null ? (
+              <div>
+                <span>{childModuleCount} </span>
+                <span className="text-muted-foreground">
+                  {childModuleCount === 1 ? 'module' : 'modules'}
+                </span>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
       </div>
+
+      {selectedSourceIndex != null &&
+        analyzeData.source(selectedSourceIndex) &&
+        (specialModuleType === SpecialModule.POLYFILL_MODULE ||
+          specialModuleType === SpecialModule.POLYFILL_NOMODULE) && (
+          <dl className="flex items-center gap-2">
+            <dt className="inline-flex items-center">
+              <Badge variant="polyfill">Polyfill</Badge>
+            </dt>
+            <dd className="text-xs text-muted-foreground">
+              Next.js built-in polyfills
+            </dd>
+          </dl>
+        )}
+
+      {selectedSourceIndex != null &&
+        analyzeData.source(selectedSourceIndex) &&
+        !hasChildModules && (
+          <>
+            {modulesData && (
+              <ImportChain
+                startFileId={selectedSourceIndex}
+                analyzeData={analyzeData}
+                modulesData={modulesData}
+                depthMap={moduleDepthMap}
+                environmentFilter={environmentFilter}
+              />
+            )}
+            {chunks.length > 0 ? (
+              <div className="mt-2">
+                <p className="text-xs font-semibold text-foreground">
+                  Output Chunks
+                </p>
+                <ul className="text-xs text-muted-foreground font-mono mt-1 space-y-1">
+                  {chunks.map((chunk) => (
+                    <li key={chunk} className="break-all">
+                      {chunk}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+          </>
+        )}
     </div>
+  )
+}
+
+function HelpTooltip({ children }: { children: React.ReactNode }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <CircleHelp
+            size={14}
+            className="inline-block ml-1 text-muted-foreground"
+            aria-hidden="true"
+          />
+        </TooltipTrigger>
+        <TooltipContent className="max-w-xs" side="top" align="center">
+          {children}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }

--- a/apps/bundle-analyzer/components/sidebar.tsx
+++ b/apps/bundle-analyzer/components/sidebar.tsx
@@ -142,21 +142,21 @@ function SelectionDetails({
             <div>
               <span>{formatBytes(size)}</span>{' '}
               <span className="text-muted-foreground">uncompressed</span>
-              <HelpTooltip>
+              <InlineHelpTooltip>
                 Uncompressed modules may still be minified, tree-shaken, and
                 dead-code eliminated. They just don't account for general
                 compression like gzip.
-              </HelpTooltip>
+              </InlineHelpTooltip>
             </div>
             <>
               <div>
                 <span className="text-muted-foreground">About </span>
                 <span>{formatBytes(compressedSize)}</span>
                 <span className="text-muted-foreground ml-1">compressed</span>
-                <HelpTooltip>
+                <InlineHelpTooltip>
                   Estimated compressed size. Modules are compressed in isolation
                   which may differ from their size in the final chunk.
-                </HelpTooltip>
+                </InlineHelpTooltip>
               </div>
             </>
             {hasChildModules && childModuleCount != null ? (
@@ -218,7 +218,7 @@ function SelectionDetails({
   )
 }
 
-function HelpTooltip({ children }: { children: React.ReactNode }) {
+function InlineHelpTooltip({ children }: { children: React.ReactNode }) {
   return (
     <TooltipProvider>
       <Tooltip>

--- a/apps/bundle-analyzer/components/treemap-visualizer.tsx
+++ b/apps/bundle-analyzer/components/treemap-visualizer.tsx
@@ -72,6 +72,15 @@ function isPolyfill(specialModuleType: SpecialModule | null): boolean {
   )
 }
 
+function calculateTitleFontSizes(titleBarHeight: number): {
+  titleFontSize: number
+  sizeFontSize: number
+} {
+  const titleFontSize = Math.min(10, titleBarHeight * 0.5)
+  const sizeFontSize = Math.min(9, titleFontSize - 2)
+  return { titleFontSize, sizeFontSize }
+}
+
 const textWidthCache = new Map<string, number>()
 const TEXT_WIDTH_CACHE_SIZE = 30_000 // Shouldn't be more than a few megabytes of memory
 function measureTextCached(
@@ -296,7 +305,7 @@ function drawTreemap(
         ctx.lineTo(rect.x + rect.width, rect.y + titleBarHeight)
         ctx.stroke()
 
-        const titleFontSize = Math.max(10, titleBarHeight * 0.5)
+        const { titleFontSize } = calculateTitleFontSizes(titleBarHeight)
         ctx.fillStyle = colors.text
         ctx.font = `600 ${titleFontSize}px sans-serif`
         ctx.textAlign = 'left'
@@ -479,8 +488,8 @@ function drawTreemap(
       ctx.lineTo(rect.x + rect.width, rect.y + titleBarHeight)
       ctx.stroke()
 
-      const titleFontSize = Math.min(10, titleBarHeight * 0.5)
-      const sizeFontSize = Math.min(9, titleFontSize - 2)
+      const { titleFontSize, sizeFontSize } =
+        calculateTitleFontSizes(titleBarHeight)
       const sizeText = formatBytes(node.size)
       const centerY = rect.y + titleBarHeight / 2
       const gap = 6
@@ -549,8 +558,8 @@ function drawTreemap(
       ctx.lineTo(rect.x + rect.width, rect.y + titleBarHeight)
       ctx.stroke()
 
-      const titleFontSize = Math.max(10, titleBarHeight * 0.5)
-      const sizeFontSize = Math.max(9, titleFontSize - 2)
+      const { titleFontSize, sizeFontSize } =
+        calculateTitleFontSizes(titleBarHeight)
       const sizeText = formatBytes(node.size)
       const centerY = rect.y + titleBarHeight / 2
       const gap = 6

--- a/apps/bundle-analyzer/components/treemap-visualizer.tsx
+++ b/apps/bundle-analyzer/components/treemap-visualizer.tsx
@@ -8,6 +8,7 @@ import {
   computeTreemapLayoutFromAnalyze,
   type LayoutNode,
   type LayoutNodeInfo,
+  SizeMode,
 } from '@/lib/treemap-layout'
 import { SpecialModule } from '@/lib/types'
 import { formatBytes } from '@/lib/utils'
@@ -27,6 +28,7 @@ interface TreemapVisualizerProps {
   filterSource?: (sourceIndex: number) => boolean
   isModulePolyfillChunk?: (sourceIndex: number) => boolean
   isNoModulePolyfillChunk?: (sourceIndex: number) => boolean
+  sizeMode?: SizeMode
 }
 
 function getFileColor(node: {
@@ -68,6 +70,28 @@ function isPolyfill(specialModuleType: SpecialModule | null): boolean {
     specialModuleType === SpecialModule.POLYFILL_MODULE ||
     specialModuleType === SpecialModule.POLYFILL_NOMODULE
   )
+}
+
+function truncateTextWithEllipsisIfNeeded(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number
+): string {
+  const ellipsisWidth = ctx.measureText('...').width
+
+  if (ctx.measureText(text).width <= maxWidth) {
+    return text
+  }
+
+  let truncated = text
+  while (
+    truncated.length > 0 &&
+    ctx.measureText(truncated).width + ellipsisWidth > maxWidth
+  ) {
+    truncated = truncated.slice(0, -1)
+  }
+
+  return truncated.length > 0 ? `${truncated}...` : '...'
 }
 
 function findNodeAtPosition(
@@ -342,7 +366,6 @@ function drawTreemap(
       ctx.textBaseline = 'middle'
 
       const maxWidth = rect.width - 8
-      let displayName = name
 
       const sizeText = formatBytes(node.size)
       const fontSize = 12
@@ -353,17 +376,7 @@ function drawTreemap(
       const hasSpaceForSize = rect.height > 50
 
       ctx.font = `${fontSize}px sans-serif`
-      const nameMetrics = ctx.measureText(displayName)
-
-      if (nameMetrics.width > maxWidth) {
-        while (
-          displayName.length > 0 &&
-          ctx.measureText(`${displayName}...`).width > maxWidth
-        ) {
-          displayName = displayName.slice(0, -1)
-        }
-        displayName += '...'
-      }
+      const displayName = truncateTextWithEllipsisIfNeeded(ctx, name, maxWidth)
 
       if (hasSpaceForSize) {
         ctx.font = `${fontSize}px sans-serif`
@@ -427,16 +440,39 @@ function drawTreemap(
       ctx.stroke()
 
       const titleFontSize = Math.max(10, titleBarHeight * 0.5)
-      ctx.fillStyle = colors.text
-      ctx.font = `600 ${titleFontSize}px sans-serif`
-      ctx.textAlign = 'left'
+      const sizeFontSize = Math.max(9, titleFontSize - 2)
+      const sizeText = formatBytes(node.size)
+      const centerY = rect.y + titleBarHeight / 2
+      const gap = 6
+
       ctx.textBaseline = 'middle'
-      ctx.fillText(
+
+      // Measure size text first to reserve space
+      ctx.font = `${sizeFontSize}px sans-serif`
+      const sizeWidth = ctx.measureText(sizeText).width
+
+      const nameX = rect.x + 8
+      const availableNameWidth = Math.max(0, rect.width - 16 - sizeWidth - gap)
+      ctx.font = `600 ${titleFontSize}px sans-serif`
+      const displayName = truncateTextWithEllipsisIfNeeded(
+        ctx,
         name,
-        rect.x + 8,
-        rect.y + titleBarHeight / 2,
-        rect.width - 16
+        availableNameWidth
       )
+
+      ctx.fillStyle = colors.text
+      ctx.textAlign = 'left'
+      ctx.fillText(displayName, nameX, centerY, availableNameWidth)
+
+      const nameWidth = ctx.measureText(displayName).width
+      const sizeX = nameX + nameWidth + gap
+
+      // Only draw size text if it fits within bounds
+      if (sizeX + sizeWidth <= rect.x + rect.width - 8) {
+        ctx.font = `${sizeFontSize}px sans-serif`
+        ctx.fillStyle = colors.textMuted
+        ctx.fillText(sizeText, sizeX, centerY)
+      }
     }
 
     ctx.globalAlpha = 1.0
@@ -474,16 +510,38 @@ function drawTreemap(
       ctx.stroke()
 
       const titleFontSize = Math.max(10, titleBarHeight * 0.5)
-      ctx.fillStyle = colors.text
-      ctx.font = `600 ${titleFontSize}px sans-serif`
-      ctx.textAlign = 'left'
+      const sizeFontSize = Math.max(9, titleFontSize - 2)
+      const sizeText = formatBytes(node.size)
+      const centerY = rect.y + titleBarHeight / 2
+      const gap = 6
+
       ctx.textBaseline = 'middle'
-      ctx.fillText(
+
+      ctx.font = `${sizeFontSize}px sans-serif`
+      const sizeWidth = ctx.measureText(sizeText).width
+
+      const nameX = rect.x + 8
+      const availableNameWidth = Math.max(0, rect.width - 16 - sizeWidth - gap)
+      ctx.font = `600 ${titleFontSize}px sans-serif`
+      const displayName = truncateTextWithEllipsisIfNeeded(
+        ctx,
         name,
-        rect.x + 8,
-        rect.y + titleBarHeight / 2,
-        rect.width - 16
+        availableNameWidth
       )
+
+      ctx.fillStyle = colors.text
+      ctx.textAlign = 'left'
+      ctx.fillText(displayName, nameX, centerY, availableNameWidth)
+
+      const nameWidth = ctx.measureText(displayName).width
+      const sizeX = nameX + nameWidth + gap
+
+      // Only draw size text if it fits within bounds
+      if (sizeX + sizeWidth <= rect.x + rect.width - 8) {
+        ctx.font = `${sizeFontSize}px sans-serif`
+        ctx.fillStyle = colors.textMuted
+        ctx.fillText(sizeText, sizeX, centerY)
+      }
     }
 
     ctx.globalAlpha = 1.0
@@ -604,6 +662,7 @@ export function TreemapVisualizer({
   onHoveredNodeChangeDelayed,
   searchQuery = '',
   filterSource,
+  sizeMode = SizeMode.Compressed,
 }: TreemapVisualizerProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -708,7 +767,8 @@ export function TreemapVisualizer({
         width: cssDimensions.width,
         height: cssDimensions.height,
       },
-      filterSource
+      filterSource,
+      sizeMode
     )
 
     // If we're not at the root, wrap with ancestor title bars
@@ -731,6 +791,7 @@ export function TreemapVisualizer({
     cssDimensions.width,
     cssDimensions.height,
     filterSource,
+    sizeMode,
   ])
 
   useEffect(() => {
@@ -917,16 +978,16 @@ function getThemeColors() {
   return {
     text: dark ? '#ffffff' : '#000000',
     textMuted: dark ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)',
-    border: dark ? 'rgba(255, 255, 255, 0.2)' : 'rgba(128, 128, 128, 0.2)',
-    dirBg: dark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(128, 128, 128, 0.1)',
-    dirBorder: dark ? 'rgba(255, 255, 255, 0.2)' : 'rgba(128, 128, 128, 0.3)',
-    dirTitleBg: dark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(128, 128, 128, 0.1)',
+    border: dark ? 'rgba(255, 255, 255, 0.4)' : 'rgba(180, 180, 180, 0.5)',
+    dirBg: dark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(230, 230, 230, 0.1)',
+    dirBorder: dark ? 'rgba(255, 255, 255, 0.5)' : 'rgba(180, 180, 180, 0.6)',
+    dirTitleBg: dark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(230, 230, 230, 0.1)',
     dirTitleBorder: dark
-      ? 'rgba(255, 255, 255, 0.15)'
-      : 'rgba(128, 128, 128, 0.2)',
+      ? 'rgba(255, 255, 255, 0.4)'
+      : 'rgba(180, 180, 180, 0.5)',
     collapsedBg: dark
       ? 'rgba(128, 128, 128, 0.15)'
-      : 'rgba(128, 128, 128, 0.2)',
+      : 'rgba(230, 230, 230, 0.2)',
     collapsedText: dark
       ? 'rgba(255, 255, 255, 0.5)'
       : 'rgba(128, 128, 128, 0.6)',

--- a/apps/bundle-analyzer/components/treemap-visualizer.tsx
+++ b/apps/bundle-analyzer/components/treemap-visualizer.tsx
@@ -72,26 +72,66 @@ function isPolyfill(specialModuleType: SpecialModule | null): boolean {
   )
 }
 
+const textWidthCache = new Map<string, number>()
+const TEXT_WIDTH_CACHE_SIZE = 30_000 // Shouldn't be more than a few megabytes of memory
+function measureTextCached(
+  ctx: CanvasRenderingContext2D,
+  text: string
+): number {
+  const cacheKey = `${ctx.font}|${text}`
+
+  let width = textWidthCache.get(cacheKey)
+  if (width !== undefined) {
+    // Move to end -- update the insertion order for LRU
+    textWidthCache.delete(cacheKey)
+    textWidthCache.set(cacheKey, width)
+    return width
+  }
+
+  width = ctx.measureText(text).width
+
+  // LRU-style cache eviction
+  if (textWidthCache.size >= TEXT_WIDTH_CACHE_SIZE) {
+    const firstKey = textWidthCache.keys().next().value
+    if (firstKey !== undefined) {
+      textWidthCache.delete(firstKey)
+    }
+  }
+
+  textWidthCache.set(cacheKey, width)
+  return width
+}
+
 function truncateTextWithEllipsisIfNeeded(
   ctx: CanvasRenderingContext2D,
   text: string,
   maxWidth: number
 ): string {
-  const ellipsisWidth = ctx.measureText('...').width
+  const ellipsisWidth = measureTextCached(ctx, '...')
 
-  if (ctx.measureText(text).width <= maxWidth) {
+  if (measureTextCached(ctx, text) <= maxWidth) {
     return text
   }
 
-  let truncated = text
-  while (
-    truncated.length > 0 &&
-    ctx.measureText(truncated).width + ellipsisWidth > maxWidth
-  ) {
-    truncated = truncated.slice(0, -1)
+  let left = 0
+  let right = text.length
+  let bestLength = 0
+
+  while (left <= right) {
+    const mid = Math.floor((left + right) / 2)
+    const truncated = text.slice(0, mid)
+    // Don't use the cached version since we don't want repeated failures filling it up
+    const width = ctx.measureText(truncated).width
+
+    if (width + ellipsisWidth <= maxWidth) {
+      bestLength = mid
+      left = mid + 1
+    } else {
+      right = mid - 1
+    }
   }
 
-  return truncated.length > 0 ? `${truncated}...` : '...'
+  return bestLength > 0 ? `${text.slice(0, bestLength)}...` : '...'
 }
 
 function findNodeAtPosition(
@@ -439,8 +479,8 @@ function drawTreemap(
       ctx.lineTo(rect.x + rect.width, rect.y + titleBarHeight)
       ctx.stroke()
 
-      const titleFontSize = Math.max(10, titleBarHeight * 0.5)
-      const sizeFontSize = Math.max(9, titleFontSize - 2)
+      const titleFontSize = Math.min(10, titleBarHeight * 0.5)
+      const sizeFontSize = Math.min(9, titleFontSize - 2)
       const sizeText = formatBytes(node.size)
       const centerY = rect.y + titleBarHeight / 2
       const gap = 6
@@ -449,7 +489,7 @@ function drawTreemap(
 
       // Measure size text first to reserve space
       ctx.font = `${sizeFontSize}px sans-serif`
-      const sizeWidth = ctx.measureText(sizeText).width
+      const sizeWidth = measureTextCached(ctx, sizeText)
 
       const nameX = rect.x + 8
       const availableNameWidth = Math.max(0, rect.width - 16 - sizeWidth - gap)
@@ -464,7 +504,7 @@ function drawTreemap(
       ctx.textAlign = 'left'
       ctx.fillText(displayName, nameX, centerY, availableNameWidth)
 
-      const nameWidth = ctx.measureText(displayName).width
+      const nameWidth = measureTextCached(ctx, displayName)
       const sizeX = nameX + nameWidth + gap
 
       // Only draw size text if it fits within bounds
@@ -518,7 +558,7 @@ function drawTreemap(
       ctx.textBaseline = 'middle'
 
       ctx.font = `${sizeFontSize}px sans-serif`
-      const sizeWidth = ctx.measureText(sizeText).width
+      const sizeWidth = measureTextCached(ctx, sizeText)
 
       const nameX = rect.x + 8
       const availableNameWidth = Math.max(0, rect.width - 16 - sizeWidth - gap)
@@ -533,7 +573,7 @@ function drawTreemap(
       ctx.textAlign = 'left'
       ctx.fillText(displayName, nameX, centerY, availableNameWidth)
 
-      const nameWidth = ctx.measureText(displayName).width
+      const nameWidth = measureTextCached(ctx, displayName)
       const sizeX = nameX + nameWidth + gap
 
       // Only draw size text if it fits within bounds

--- a/apps/bundle-analyzer/components/ui/tooltip.tsx
+++ b/apps/bundle-analyzer/components/ui/tooltip.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const TooltipProvider = TooltipPrimitive.Provider
+const Tooltip = TooltipPrimitive.Root
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md outline-none data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/apps/bundle-analyzer/lib/analyze-data.ts
+++ b/apps/bundle-analyzer/lib/analyze-data.ts
@@ -18,6 +18,7 @@ export interface AnalyzeChunkPart {
   source_index: number
   output_file_index: number
   size: number
+  compressed_size: number
 }
 
 export interface AnalyzeOutputFile {
@@ -336,29 +337,31 @@ export class AnalyzeData {
     return parentPath + source.path
   }
 
-  getSourceOutputSize(index: SourceIndex): number {
+  getOwnSizes(index: SourceIndex): {
+    size: number
+    compressedSize: number
+  } {
     const chunkParts = this.sourceChunkParts(index)
-    let totalSize = 0
+    let size = 0
+    let compressedSize = 0
     for (const chunkPartIndex of chunkParts) {
       const chunkPart = this.chunkPart(chunkPartIndex)
       if (chunkPart) {
-        totalSize += chunkPart.size
+        size += chunkPart.size
+        compressedSize += chunkPart.compressed_size
       }
     }
-    return totalSize
+    return { size, compressedSize }
   }
 
-  getSourceRecursiveSize(index: SourceIndex): number {
-    let totalSize = this.getSourceOutputSize(index)
-    const children = this.sourceChildren(index)
-    for (const childIndex of children) {
-      totalSize += this.getSourceRecursiveSize(childIndex)
-    }
-    return totalSize
-  }
+  getRecursiveModuleCount(
+    index: SourceIndex,
+    filterSource: (sourceIndex: SourceIndex) => boolean
+  ): number {
+    const selfVisible = filterSource(index)
+    const selfCount =
+      selfVisible && this.sourceChunkParts(index).length > 0 ? 1 : 0
 
-  getSourceRecursiveModuleCount(index: SourceIndex): number {
-    const selfCount = this.sourceChunkParts(index).length > 0 ? 1 : 0
     const children = this.sourceChildren(index)
     if (children.length === 0) {
       return selfCount
@@ -366,7 +369,7 @@ export class AnalyzeData {
 
     let totalCount = selfCount
     for (const childIndex of children) {
-      totalCount += this.getSourceRecursiveModuleCount(childIndex)
+      totalCount += this.getRecursiveModuleCount(childIndex, filterSource)
     }
     return totalCount
   }
@@ -386,6 +389,35 @@ export class AnalyzeData {
     }
 
     return Array.from(uniqueChunks).sort()
+  }
+
+  getRecursiveSizes(
+    index: SourceIndex,
+    filterSource: (sourceIndex: SourceIndex) => boolean
+  ): { size: number; compressedSize: number } {
+    let size = 0
+    let compressedSize = 0
+
+    if (filterSource(index)) {
+      const { size: ownUncompressedSize, compressedSize: ownCompressedSize } =
+        this.getOwnSizes(index)
+      size += ownUncompressedSize
+      compressedSize += ownCompressedSize
+    }
+
+    for (const childIndex of this.sourceChildren(index)) {
+      const {
+        size: childUncompressedSize,
+        compressedSize: childCompressedSize,
+      } = this.getRecursiveSizes(childIndex, filterSource)
+      size += childUncompressedSize
+      compressedSize += childCompressedSize
+    }
+
+    return {
+      size,
+      compressedSize,
+    }
   }
 
   getSourceFlags(index: SourceIndex): {

--- a/apps/bundle-analyzer/package.json
+++ b/apps/bundle-analyzer/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "1.1.4",
     "@radix-ui/react-popover": "1.1.4",
+    "@radix-ui/react-tooltip": "1.1.4",
     "@radix-ui/react-slot": "1.1.1",
     "@radix-ui/react-toggle-group": "1.1.1",
     "autoprefixer": "^10.4.20",

--- a/crates/next-api/src/analyze.rs
+++ b/crates/next-api/src/analyze.rs
@@ -75,6 +75,7 @@ pub struct AnalyzeChunkPart {
     pub source_index: u32,
     pub output_file_index: u32,
     pub size: u32,
+    pub compressed_size: u32,
 }
 
 #[derive(Serialize)]
@@ -384,6 +385,7 @@ pub async fn analyze_output_assets(output_assets: Vc<OutputAssets>) -> Result<Vc
                 source_index,
                 output_file_index,
                 size: chunk_part.real_size + chunk_part.unaccounted_size,
+                compressed_size: chunk_part.get_compressed_size().await?,
             });
             builder.add_chunk_part_to_output_file(output_file_index, chunk_part_index);
             builder.add_chunk_part_to_source(source_index, chunk_part_index);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,6 +630,9 @@ importers:
       '@radix-ui/react-toggle-group':
         specifier: 1.1.1
         version: 1.1.1(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-tooltip':
+        specifier: 1.1.4
+        version: 1.1.4(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.3)
@@ -4845,6 +4848,9 @@ packages:
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
+  '@radix-ui/primitive@1.1.0':
+    resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
+
   '@radix-ui/primitive@1.1.1':
     resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
 
@@ -4853,6 +4859,19 @@ packages:
 
   '@radix-ui/react-accordion@1.2.12':
     resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
+    peerDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.0':
+    resolution: {integrity: sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==}
     peerDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1
@@ -4929,6 +4948,15 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.0':
+    resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
+    peerDependencies:
+      '@types/react': 19.2.2
+      react: 19.3.0-canary-b45bb335-20251211
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.1':
     resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
     peerDependencies:
@@ -4940,6 +4968,15 @@ packages:
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': 19.2.2
+      react: 19.3.0-canary-b45bb335-20251211
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.0':
+    resolution: {integrity: sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==}
     peerDependencies:
       '@types/react': 19.2.2
       react: 19.3.0-canary-b45bb335-20251211
@@ -5007,6 +5044,19 @@ packages:
       react: 19.3.0-canary-b45bb335-20251211
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.1':
+    resolution: {integrity: sha512-QSxg29lfr/xcev6kSz7MAlmDnzbP1eI/Dwn3Tp1ip0KT5CUELsxkekFEMVBEoykI3oV39hKT4TKZzBNMbcTZYQ==}
+    peerDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-dismissable-layer@1.1.11':
@@ -5136,6 +5186,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.2.0':
+    resolution: {integrity: sha512-ZnRMshKF43aBxVWPWvbj21+7TQCvhuULWJ4gNIKYpRlQt5xGRhLx66tMp8pya2UkGHTSlhpXwmjqltDYHhw7Vg==}
+    peerDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-popper@1.2.1':
     resolution: {integrity: sha512-3kn5Me69L+jv82EKRuQCXdYyf1DqHwD2U/sxoNgBGCB7K9TRc3bQamQ+5EPM9EvyPdli0W41sROd+ZU1dTCztw==}
     peerDependencies:
@@ -5151,6 +5214,19 @@ packages:
 
   '@radix-ui/react-popper@1.2.8':
     resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.2':
+    resolution: {integrity: sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==}
     peerDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1
@@ -5188,6 +5264,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.1':
+    resolution: {integrity: sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==}
+    peerDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-presence@1.1.2':
     resolution: {integrity: sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==}
     peerDependencies:
@@ -5203,6 +5292,19 @@ packages:
 
   '@radix-ui/react-presence@1.1.5':
     resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.0.0':
+    resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
     peerDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1
@@ -5279,6 +5381,15 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-slot@1.1.0':
+    resolution: {integrity: sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==}
+    peerDependencies:
+      '@types/react': 19.2.2
+      react: 19.3.0-canary-b45bb335-20251211
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-slot@1.1.1':
     resolution: {integrity: sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==}
     peerDependencies:
@@ -5325,6 +5436,19 @@ packages:
 
   '@radix-ui/react-toggle@1.1.1':
     resolution: {integrity: sha512-i77tcgObYr743IonC1hrsnnPmszDRn8p+EGUsUt+5a/JFn28fxaM88Py6V2mc8J5kELMWishI0rLnuGLFD/nnQ==}
+    peerDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.1.4':
+    resolution: {integrity: sha512-QpObUH/ZlpaO4YgHSaYzrLO2VuO+ZBFFgGzjMUPwtiYnAzzNNDPJeEGRrT7qNOrWm/Jr08M1vlp+vTHtnSQ0Uw==}
     peerDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1
@@ -5460,6 +5584,19 @@ packages:
       react: 19.3.0-canary-b45bb335-20251211
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.1.0':
+    resolution: {integrity: sha512-N8MDZqtgCgG5S3aV60INAB475osJousYpZ4cTJ2cFbMpdHS5Y6loLTH8LPtkj2QN0x93J30HT/M3qJXM0+lyeQ==}
+    peerDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-visually-hidden@1.2.3':
@@ -21849,6 +21986,8 @@ snapshots:
 
   '@radix-ui/number@1.1.1': {}
 
+  '@radix-ui/primitive@1.1.0': {}
+
   '@radix-ui/primitive@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
@@ -21864,6 +22003,15 @@ snapshots:
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-arrow@1.1.0(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
       react: 19.3.0-canary-b45bb335-20251211
       react-dom: 19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211)
     optionalDependencies:
@@ -21928,6 +22076,12 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-compose-refs@1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)':
+    dependencies:
+      react: 19.3.0-canary-b45bb335-20251211
+    optionalDependencies:
+      '@types/react': 19.2.2
+
   '@radix-ui/react-compose-refs@1.1.1(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)':
     dependencies:
       react: 19.3.0-canary-b45bb335-20251211
@@ -21935,6 +22089,12 @@ snapshots:
       '@types/react': 19.2.2
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)':
+    dependencies:
+      react: 19.3.0-canary-b45bb335-20251211
+    optionalDependencies:
+      '@types/react': 19.2.2
+
+  '@radix-ui/react-context@1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)':
     dependencies:
       react: 19.3.0-canary-b45bb335-20251211
     optionalDependencies:
@@ -22007,6 +22167,19 @@ snapshots:
       react: 19.3.0-canary-b45bb335-20251211
     optionalDependencies:
       '@types/react': 19.2.2
+
+  '@radix-ui/react-dismissable-layer@1.1.1(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)':
     dependencies:
@@ -22150,6 +22323,24 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-popper@1.2.0(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.5(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-arrow': 1.1.0(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-context': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-use-rect': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/rect': 1.1.0
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
   '@radix-ui/react-popper@1.2.1(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)':
     dependencies:
       '@floating-ui/react-dom': 2.1.5(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
@@ -22186,6 +22377,16 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-portal@1.1.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
   '@radix-ui/react-portal@1.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
@@ -22206,6 +22407,16 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-presence@1.1.1(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
   '@radix-ui/react-presence@1.1.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
@@ -22220,6 +22431,15 @@ snapshots:
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-primitive@2.0.0(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
       react: 19.3.0-canary-b45bb335-20251211
       react-dom: 19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211)
     optionalDependencies:
@@ -22295,6 +22515,13 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-slot@1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      react: 19.3.0-canary-b45bb335-20251211
+    optionalDependencies:
+      '@types/react': 19.2.2
+
   '@radix-ui/react-slot@1.1.1(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
@@ -22345,6 +22572,26 @@ snapshots:
       '@radix-ui/primitive': 1.1.1
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-tooltip@1.1.4(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-dismissable-layer': 1.1.1(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-portal': 1.1.2(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-presence': 1.1.1(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-slot': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.2.2)(react@19.3.0-canary-b45bb335-20251211)
+      '@radix-ui/react-visually-hidden': 1.1.0(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
       react: 19.3.0-canary-b45bb335-20251211
       react-dom: 19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211)
     optionalDependencies:
@@ -22444,6 +22691,15 @@ snapshots:
       react: 19.3.0-canary-b45bb335-20251211
     optionalDependencies:
       '@types/react': 19.2.2
+
+  '@radix-ui/react-visually-hidden@1.1.0(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)
+      react: 19.3.0-canary-b45bb335-20251211
+      react-dom: 19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
   '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.3.0-canary-b45bb335-20251211(react@19.3.0-canary-b45bb335-20251211))(react@19.3.0-canary-b45bb335-20251211)':
     dependencies:

--- a/turbopack/crates/turbopack-analyze/Cargo.toml
+++ b/turbopack/crates/turbopack-analyze/Cargo.toml
@@ -11,6 +11,7 @@ bench = false
 [dependencies]
 anyhow = { workspace = true }
 bincode = { workspace = true }
+flate2 = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 turbo-rcstr = { workspace = true }

--- a/turbopack/crates/turbopack-analyze/src/compressed_size.rs
+++ b/turbopack/crates/turbopack-analyze/src/compressed_size.rs
@@ -1,0 +1,17 @@
+use std::io::Write;
+
+use anyhow::Result;
+use flate2::{Compression, write::DeflateEncoder};
+use turbo_rcstr::RcStr;
+
+/// Compresses an asset's content with default-level (level 6) deflate/gzip.
+/// Returns the size in bytes in the compressed output
+pub fn compressed_size_bytes(content: RcStr) -> Result<u32> {
+    // Use deflate over gzip to prevent individual file headers/footers from
+    // skewing the size results.
+    let mut encoder = DeflateEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(content.as_ref())?;
+    let compressed = encoder.finish()?;
+
+    Ok(compressed.len() as u32)
+}

--- a/turbopack/crates/turbopack-analyze/src/lib.rs
+++ b/turbopack/crates/turbopack-analyze/src/lib.rs
@@ -1,3 +1,4 @@
 #![feature(arbitrary_self_types_pointers)]
 
+pub mod compressed_size;
 pub mod split_chunk;

--- a/turbopack/crates/turbopack-analyze/src/split_chunk.rs
+++ b/turbopack/crates/turbopack-analyze/src/split_chunk.rs
@@ -3,13 +3,15 @@ use std::mem::replace;
 use anyhow::Result;
 use bincode::{Decode, Encode};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, NonLocalValue, ValueToString, Vc, trace::TraceRawVcs};
+use turbo_tasks::{FxIndexMap, NonLocalValue, ResolvedVc, ValueToString, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::{FileContent, FileLine, FileLinesContent, rope::Rope};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     output::OutputAsset,
     source_map::{GenerateSourceMap, OriginalToken, SourceMap, SyntheticToken, Token},
 };
+
+use crate::compressed_size::compressed_size_bytes;
 
 #[derive(Clone, Debug, Eq, NonLocalValue, PartialEq, TraceRawVcs, Encode, Decode)]
 pub struct ChunkPartRange {
@@ -23,7 +25,29 @@ pub struct ChunkPart {
     pub source: RcStr,
     pub real_size: u32,
     pub unaccounted_size: u32,
+    pub lines: ResolvedVc<FileLinesContent>,
     pub ranges: Vec<ChunkPartRange>,
+}
+
+impl ChunkPart {
+    pub async fn get_compressed_size(&self) -> Result<u32> {
+        let lines = &*self.lines.await?;
+        let FileLinesContent::Lines(lines) = lines else {
+            return Ok(0);
+        };
+
+        let mut all_range_content = String::new();
+        for range in &self.ranges {
+            all_range_content += &content_between(
+                range.line,
+                range.start_column,
+                range.line,
+                range.end_column,
+                lines,
+            );
+        }
+        compressed_size_bytes(all_range_content.into())
+    }
 }
 
 #[turbo_tasks::value(transparent)]
@@ -42,22 +66,24 @@ pub async fn split_output_asset_into_parts(
         return Ok(Vc::cell(vec![]));
     };
     let content = content.content();
+    let lines_vc = file_content.lines().to_resolved().await?;
+
     let Some(generate_source_map) =
         Vc::try_resolve_sidecast::<Box<dyn GenerateSourceMap>>(asset).await?
     else {
-        return self_mapped(asset, content).await;
+        return self_mapped(asset, content, lines_vc).await;
     };
     let source_map = generate_source_map.generate_source_map().await?;
     let Some(source_map) = source_map.as_content() else {
-        return self_mapped(asset, content).await;
+        return self_mapped(asset, content, lines_vc).await;
     };
     let Some(source_map) = SourceMap::new_from_rope(source_map.content())? else {
-        return unaccounted(asset, content).await;
+        return unaccounted(asset, content, lines_vc).await;
     };
 
-    let lines = file_content.lines().await?;
+    let lines = lines_vc.await?;
     let FileLinesContent::Lines(lines) = &*lines else {
-        return unaccounted(asset, content).await;
+        return unaccounted(asset, content, lines_vc).await;
     };
 
     fn end_of_mapping_column(
@@ -74,6 +100,7 @@ pub async fn split_output_asset_into_parts(
             line_end
         }
     }
+
     fn len_between(
         start_line: u32,
         start_column: u32,
@@ -100,6 +127,7 @@ pub async fn split_output_asset_into_parts(
         chunk_part_range: ChunkPartRange,
         size: u32,
         chunk_parts: &mut FxIndexMap<RcStr, ChunkPart>,
+        lines: ResolvedVc<FileLinesContent>,
     ) {
         let entry = chunk_parts
             .entry(source)
@@ -108,14 +136,28 @@ pub async fn split_output_asset_into_parts(
                 real_size: 0,
                 unaccounted_size: 0,
                 ranges: vec![],
+                lines,
             });
         entry.real_size += size;
+
+        // Check if the new range is adjacent to the last range and merge if so
+        if let Some(last_range) = entry.ranges.last_mut()
+            && last_range.line == chunk_part_range.line
+            && last_range.end_column == chunk_part_range.start_column
+            && chunk_part_range.end_column >= chunk_part_range.start_column
+        {
+            last_range.end_column = chunk_part_range.end_column;
+            return;
+        }
+
         entry.ranges.push(chunk_part_range);
     }
+
     fn add_unaccounted_chunk_part(
         source: RcStr,
         unaccounted: u32,
         chunk_parts: &mut FxIndexMap<RcStr, ChunkPart>,
+        lines: ResolvedVc<FileLinesContent>,
     ) {
         let entry = chunk_parts
             .entry(source)
@@ -124,6 +166,7 @@ pub async fn split_output_asset_into_parts(
                 real_size: 0,
                 unaccounted_size: 0,
                 ranges: vec![],
+                lines,
             });
         entry.unaccounted_size += unaccounted;
     }
@@ -144,17 +187,13 @@ pub async fn split_output_asset_into_parts(
 
     let mut state: State = State::StartOfFile;
 
-    fn end_current_token(
-        lines: &[FileLine],
-        chunk_parts: &mut FxIndexMap<RcStr, ChunkPart>,
-        state: &mut State,
-        token: &Token,
-    ) {
-        if let State::InMapping {
+    for token in source_map.tokens() {
+        // First end the previous mapping if we were in one
+        let end_info = if let State::InMapping {
             ref source,
             current_generated_line,
             current_generated_column,
-        } = *state
+        } = state
         {
             let (Token::Original(OriginalToken {
                 generated_line,
@@ -165,7 +204,7 @@ pub async fn split_output_asset_into_parts(
                 generated_line,
                 generated_column,
                 ..
-            })) = *token;
+            })) = token;
             let mapping_end_column = end_of_mapping_column(
                 current_generated_line,
                 generated_line,
@@ -174,7 +213,7 @@ pub async fn split_output_asset_into_parts(
             );
             // TODO: Handle this better
             let len = mapping_end_column.saturating_sub(current_generated_column);
-            add_chunk_part_range(
+            Some((
                 source.clone(),
                 ChunkPartRange {
                     line: current_generated_line,
@@ -182,61 +221,21 @@ pub async fn split_output_asset_into_parts(
                     end_column: mapping_end_column,
                 },
                 len,
-                chunk_parts,
-            );
-            *state = State::AfterMapping {
-                source: source.clone(),
                 current_generated_line,
-                current_generated_column: mapping_end_column,
+                mapping_end_column,
+            ))
+        } else {
+            None
+        };
+
+        if let Some((source, range, len, line, col)) = end_info {
+            add_chunk_part_range(source.clone(), range, len, &mut chunk_parts, lines_vc);
+            state = State::AfterMapping {
+                source,
+                current_generated_line: line,
+                current_generated_column: col,
             };
         }
-    }
-
-    fn start_new_mapping(
-        lines: &[FileLine],
-        chunk_parts: &mut FxIndexMap<RcStr, ChunkPart>,
-        state: &mut State,
-        original_file: RcStr,
-        generated_line: u32,
-        generated_column: u32,
-    ) {
-        match replace(
-            state,
-            State::InMapping {
-                source: original_file.clone(),
-                current_generated_line: generated_line,
-                current_generated_column: generated_column,
-            },
-        ) {
-            State::InMapping { .. } => {
-                unreachable!();
-            }
-            State::AfterMapping {
-                source,
-                current_generated_line,
-                current_generated_column,
-            } => {
-                let len = len_between(
-                    current_generated_line,
-                    current_generated_column,
-                    generated_line,
-                    generated_column,
-                    lines,
-                );
-                let half = len / 2;
-                add_unaccounted_chunk_part(source, half, chunk_parts);
-                add_unaccounted_chunk_part(original_file.clone(), len - half, chunk_parts);
-            }
-            State::StartOfFile => {
-                let len = len_between(0, 0, generated_line, generated_column, lines);
-                add_unaccounted_chunk_part(original_file.clone(), len, chunk_parts);
-            }
-        }
-    }
-
-    for token in source_map.tokens() {
-        // First end the previous mapping if we were in one
-        end_current_token(lines, &mut chunk_parts, &mut state, &token);
 
         if let Token::Original(OriginalToken {
             original_file,
@@ -245,30 +244,83 @@ pub async fn split_output_asset_into_parts(
             ..
         }) = token
         {
-            // Start a new mapping and put the unaccounted part in between
-            // somewhere
-            start_new_mapping(
-                lines,
-                &mut chunk_parts,
+            // Start a new mapping and put the unaccounted part in between somewhere
+            match replace(
                 &mut state,
-                original_file,
-                generated_line,
-                generated_column,
-            );
+                State::InMapping {
+                    source: original_file.clone(),
+                    current_generated_line: generated_line,
+                    current_generated_column: generated_column,
+                },
+            ) {
+                State::InMapping { .. } => {
+                    unreachable!();
+                }
+                State::AfterMapping {
+                    source,
+                    current_generated_line,
+                    current_generated_column,
+                } => {
+                    let len = len_between(
+                        current_generated_line,
+                        current_generated_column,
+                        generated_line,
+                        generated_column,
+                        lines,
+                    );
+                    let half = len / 2;
+                    add_unaccounted_chunk_part(source, half, &mut chunk_parts, lines_vc);
+                    add_unaccounted_chunk_part(
+                        original_file.clone(),
+                        len - half,
+                        &mut chunk_parts,
+                        lines_vc,
+                    );
+                }
+                State::StartOfFile => {
+                    let len = len_between(0, 0, generated_line, generated_column, lines);
+                    add_unaccounted_chunk_part(
+                        original_file.clone(),
+                        len,
+                        &mut chunk_parts,
+                        lines_vc,
+                    );
+                }
+            }
         }
     }
     let last_line = lines.len() as u32 - 1;
     let last_column = lines[last_line as usize].len() as u32;
-    end_current_token(
-        lines,
-        &mut chunk_parts,
-        &mut state,
-        &Token::Synthetic(SyntheticToken {
-            generated_line: last_line,
-            generated_column: last_column,
-            guessed_original_file: None,
-        }),
-    );
+
+    // End the current token at end of file
+    if let State::InMapping {
+        ref source,
+        current_generated_line,
+        current_generated_column,
+    } = state
+    {
+        let mapping_end_column =
+            end_of_mapping_column(current_generated_line, last_line, last_column, lines);
+        // TODO: Handle this better
+        let len = mapping_end_column.saturating_sub(current_generated_column);
+        add_chunk_part_range(
+            source.clone(),
+            ChunkPartRange {
+                line: current_generated_line,
+                start_column: current_generated_column,
+                end_column: mapping_end_column,
+            },
+            len,
+            &mut chunk_parts,
+            lines_vc,
+        );
+        state = State::AfterMapping {
+            source: source.clone(),
+            current_generated_line,
+            current_generated_column: mapping_end_column,
+        };
+    }
+
     match state {
         State::InMapping { .. } => {
             unreachable!();
@@ -285,32 +337,85 @@ pub async fn split_output_asset_into_parts(
                 last_column,
                 lines,
             );
-            add_unaccounted_chunk_part(source, len, &mut chunk_parts);
+            add_unaccounted_chunk_part(source, len, &mut chunk_parts, lines_vc);
         }
         State::StartOfFile => {
-            return unaccounted(asset, content).await;
+            return unaccounted(asset, content, lines_vc).await;
         }
     }
 
     Ok(Vc::cell(chunk_parts.into_values().collect()))
 }
 
-async fn self_mapped(asset: Vc<Box<dyn OutputAsset>>, content: &Rope) -> Result<Vc<ChunkParts>> {
+async fn self_mapped(
+    asset: Vc<Box<dyn OutputAsset>>,
+    content: &Rope,
+    lines: ResolvedVc<FileLinesContent>,
+) -> Result<Vc<ChunkParts>> {
     let len = content.len().try_into().unwrap_or(u32::MAX);
     Ok(Vc::cell(vec![ChunkPart {
         source: asset.path().to_string().owned().await?,
         real_size: len,
         unaccounted_size: 0,
         ranges: vec![],
+        lines,
     }]))
 }
 
-async fn unaccounted(asset: Vc<Box<dyn OutputAsset>>, content: &Rope) -> Result<Vc<ChunkParts>> {
+async fn unaccounted(
+    asset: Vc<Box<dyn OutputAsset>>,
+    content: &Rope,
+    lines: ResolvedVc<FileLinesContent>,
+) -> Result<Vc<ChunkParts>> {
     let len = content.len().try_into().unwrap_or(u32::MAX);
     Ok(Vc::cell(vec![ChunkPart {
         source: asset.path().to_string().owned().await?,
         real_size: 0,
         unaccounted_size: len,
         ranges: vec![],
+        lines,
     }]))
+}
+
+fn content_between(
+    start_line: u32,
+    start_column: u32,
+    end_line: u32,
+    end_column: u32,
+    lines: &[FileLine],
+) -> RcStr {
+    let start_line = start_line.min(lines.len() as u32 - 1);
+    let end_line = end_line.min(lines.len() as u32 - 1);
+    if start_line == end_line {
+        let start_col = start_column.min(lines[start_line as usize].len() as u32);
+        let end_col = end_column.min(lines[start_line as usize].len() as u32);
+        if end_col < start_col {
+            return RcStr::default();
+        }
+        return lines[start_line as usize]
+            .content
+            .chars()
+            .skip(start_col as usize)
+            .take((end_col - start_col) as usize)
+            .collect::<String>()
+            .into();
+    }
+
+    let mut out = String::new();
+    out += &lines[start_line as usize]
+        .content
+        .chars()
+        .skip(start_column as usize)
+        .collect::<String>();
+
+    for line in &lines[start_line as usize + 1..end_line as usize] {
+        out += &line.content;
+    }
+
+    out += &lines[end_line as usize]
+        .content
+        .chars()
+        .take(end_column as usize)
+        .collect::<String>();
+    out.into()
 }

--- a/turbopack/crates/turbopack-analyze/src/split_chunk.rs
+++ b/turbopack/crates/turbopack-analyze/src/split_chunk.rs
@@ -8,7 +8,7 @@ use turbo_tasks_fs::{FileContent, FileLine, FileLinesContent, rope::Rope};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     output::OutputAsset,
-    source_map::{GenerateSourceMap, OriginalToken, SourceMap, SyntheticToken, Token},
+    source_map::{GenerateSourceMap, OriginalToken, SourceMap, Token},
 };
 
 use crate::compressed_size::compressed_size_bytes;
@@ -111,7 +111,8 @@ pub async fn split_output_asset_into_parts(
         let start_line = start_line.min(lines.len() as u32 - 1);
         let end_line = end_line.min(lines.len() as u32 - 1);
         if start_line == end_line {
-            return end_column - start_column;
+            // TODO: Figure out why start is larger than end sometimes
+            return end_column.saturating_sub(start_column);
         }
         let mut len = lines[start_line as usize].len() as u32 - start_column + 1;
         for line in &lines[start_line as usize + 1..end_line as usize] {
@@ -139,17 +140,6 @@ pub async fn split_output_asset_into_parts(
                 lines,
             });
         entry.real_size += size;
-
-        // Check if the new range is adjacent to the last range and merge if so
-        if let Some(last_range) = entry.ranges.last_mut()
-            && last_range.line == chunk_part_range.line
-            && last_range.end_column == chunk_part_range.start_column
-            && chunk_part_range.end_column >= chunk_part_range.start_column
-        {
-            last_range.end_column = chunk_part_range.end_column;
-            return;
-        }
-
         entry.ranges.push(chunk_part_range);
     }
 
@@ -171,16 +161,68 @@ pub async fn split_output_asset_into_parts(
         entry.unaccounted_size += unaccounted;
     }
 
+    fn end_current_mapping(
+        source: RcStr,
+        current_line: u32,
+        start_column: u32,
+        next_line: u32,
+        next_column: u32,
+        lines: &[FileLine],
+        chunk_parts: &mut FxIndexMap<RcStr, ChunkPart>,
+        lines_vc: ResolvedVc<FileLinesContent>,
+    ) -> State {
+        let mapping_end_column = end_of_mapping_column(current_line, next_line, next_column, lines);
+        let len = mapping_end_column.saturating_sub(start_column);
+        add_chunk_part_range(
+            source.clone(),
+            ChunkPartRange {
+                line: current_line,
+                start_column,
+                end_column: mapping_end_column,
+            },
+            len,
+            chunk_parts,
+            lines_vc,
+        );
+        State::AfterMapping {
+            source,
+            generated_line: current_line,
+            current_generated_column: mapping_end_column,
+        }
+    }
+
+    fn should_extend_mapping(
+        state: &State,
+        new_source: &RcStr,
+        new_line: u32,
+        new_column: u32,
+    ) -> bool {
+        if let State::InMapping {
+            source,
+            generated_line,
+            end_column,
+            ..
+        } = state
+        {
+            // Extend if same source and line, and columns are adjacent or overlapping
+            // end_column <= new_column handles both adjacent (equal) and overlapping cases
+            source == new_source && *generated_line == new_line && *end_column <= new_column
+        } else {
+            false
+        }
+    }
+
     enum State {
         StartOfFile,
         InMapping {
             source: RcStr,
-            current_generated_line: u32,
-            current_generated_column: u32,
+            generated_line: u32,
+            start_column: u32,
+            end_column: u32,
         },
         AfterMapping {
             source: RcStr,
-            current_generated_line: u32,
+            generated_line: u32,
             current_generated_column: u32,
         },
     }
@@ -188,55 +230,6 @@ pub async fn split_output_asset_into_parts(
     let mut state: State = State::StartOfFile;
 
     for token in source_map.tokens() {
-        // First end the previous mapping if we were in one
-        let end_info = if let State::InMapping {
-            ref source,
-            current_generated_line,
-            current_generated_column,
-        } = state
-        {
-            let (Token::Original(OriginalToken {
-                generated_line,
-                generated_column,
-                ..
-            })
-            | Token::Synthetic(SyntheticToken {
-                generated_line,
-                generated_column,
-                ..
-            })) = token;
-            let mapping_end_column = end_of_mapping_column(
-                current_generated_line,
-                generated_line,
-                generated_column,
-                lines,
-            );
-            // TODO: Handle this better
-            let len = mapping_end_column.saturating_sub(current_generated_column);
-            Some((
-                source.clone(),
-                ChunkPartRange {
-                    line: current_generated_line,
-                    start_column: current_generated_column,
-                    end_column: mapping_end_column,
-                },
-                len,
-                current_generated_line,
-                mapping_end_column,
-            ))
-        } else {
-            None
-        };
-
-        if let Some((source, range, len, line, col)) = end_info {
-            add_chunk_part_range(source.clone(), range, len, &mut chunk_parts, lines_vc);
-            state = State::AfterMapping {
-                source,
-                current_generated_line: line,
-                current_generated_column: col,
-            };
-        }
-
         if let Token::Original(OriginalToken {
             original_file,
             generated_line,
@@ -244,13 +237,56 @@ pub async fn split_output_asset_into_parts(
             ..
         }) = token
         {
+            // Check if we can extend the current mapping
+            if should_extend_mapping(&state, &original_file, generated_line, generated_column) {
+                // Same source and line with adjacent columns - update end to next token position
+                if let State::InMapping {
+                    source,
+                    generated_line: current_line,
+                    start_column,
+                    ..
+                } = state
+                {
+                    state = State::InMapping {
+                        source,
+                        generated_line: current_line,
+                        start_column,
+                        end_column: generated_column,
+                    };
+                    continue;
+                }
+            }
+
+            // End the current mapping if we're in one
+            if let State::InMapping {
+                source,
+                generated_line: current_line,
+                start_column,
+                ..
+            } = state
+            {
+                state = end_current_mapping(
+                    source,
+                    current_line,
+                    start_column,
+                    generated_line,
+                    generated_column,
+                    lines,
+                    &mut chunk_parts,
+                    lines_vc,
+                );
+            }
+
             // Start a new mapping and put the unaccounted part in between somewhere
+            // Set end_column to start_column initially; it will be updated when we see the next
+            // token
             match replace(
                 &mut state,
                 State::InMapping {
                     source: original_file.clone(),
-                    current_generated_line: generated_line,
-                    current_generated_column: generated_column,
+                    generated_line,
+                    start_column: generated_column,
+                    end_column: generated_column,
                 },
             ) {
                 State::InMapping { .. } => {
@@ -258,11 +294,11 @@ pub async fn split_output_asset_into_parts(
                 }
                 State::AfterMapping {
                     source,
-                    current_generated_line,
+                    generated_line,
                     current_generated_column,
                 } => {
                     let len = len_between(
-                        current_generated_line,
+                        generated_line,
                         current_generated_column,
                         generated_line,
                         generated_column,
@@ -295,30 +331,21 @@ pub async fn split_output_asset_into_parts(
     // End the current token at end of file
     if let State::InMapping {
         ref source,
-        current_generated_line,
-        current_generated_column,
+        generated_line,
+        start_column,
+        ..
     } = state
     {
-        let mapping_end_column =
-            end_of_mapping_column(current_generated_line, last_line, last_column, lines);
-        // TODO: Handle this better
-        let len = mapping_end_column.saturating_sub(current_generated_column);
-        add_chunk_part_range(
+        state = end_current_mapping(
             source.clone(),
-            ChunkPartRange {
-                line: current_generated_line,
-                start_column: current_generated_column,
-                end_column: mapping_end_column,
-            },
-            len,
+            generated_line,
+            start_column,
+            last_line,
+            last_column,
+            lines,
             &mut chunk_parts,
             lines_vc,
         );
-        state = State::AfterMapping {
-            source: source.clone(),
-            current_generated_line,
-            current_generated_column: mapping_end_column,
-        };
     }
 
     match state {
@@ -327,11 +354,11 @@ pub async fn split_output_asset_into_parts(
         }
         State::AfterMapping {
             source,
-            current_generated_line,
+            generated_line,
             current_generated_column,
         } => {
             let len = len_between(
-                current_generated_line,
+                generated_line,
                 current_generated_column,
                 last_line,
                 last_column,

--- a/turbopack/crates/turbopack-analyze/src/split_chunk.rs
+++ b/turbopack/crates/turbopack-analyze/src/split_chunk.rs
@@ -38,12 +38,13 @@ impl ChunkPart {
 
         let mut all_range_content = String::new();
         for range in &self.ranges {
-            all_range_content += &content_between(
+            append_content_between(
                 range.line,
                 range.start_column,
                 range.line,
                 range.end_column,
                 lines,
+                &mut all_range_content,
             );
         }
         compressed_size_bytes(all_range_content.into())
@@ -404,45 +405,48 @@ async fn unaccounted(
     }]))
 }
 
-fn content_between(
+fn append_content_between(
     start_line: u32,
     start_column: u32,
     end_line: u32,
     end_column: u32,
     lines: &[FileLine],
-) -> RcStr {
+    out: &mut String,
+) {
     let start_line = start_line.min(lines.len() as u32 - 1);
     let end_line = end_line.min(lines.len() as u32 - 1);
-    if start_line == end_line {
-        let start_col = start_column.min(lines[start_line as usize].len() as u32);
-        let end_col = end_column.min(lines[start_line as usize].len() as u32);
-        if end_col < start_col {
-            return RcStr::default();
-        }
-        return lines[start_line as usize]
+
+    let start_column = start_column.min(lines[start_line as usize].len() as u32);
+    let end_column = if start_line == end_line {
+        end_column.min(lines[start_line as usize].len() as u32)
+    } else {
+        lines[start_line as usize].len() as u32
+    };
+
+    if end_column <= start_column {
+        return;
+    }
+
+    out.extend(
+        lines[start_line as usize]
             .content
             .chars()
-            .skip(start_col as usize)
-            .take((end_col - start_col) as usize)
-            .collect::<String>()
-            .into();
-    }
+            .skip(start_column as usize)
+            .take((end_column - start_column) as usize),
+    );
 
-    let mut out = String::new();
-    out += &lines[start_line as usize]
-        .content
-        .chars()
-        .skip(start_column as usize)
-        .collect::<String>();
+    if start_line == end_line {
+        return;
+    }
 
     for line in &lines[start_line as usize + 1..end_line as usize] {
-        out += &line.content;
+        out.push_str(&line.content);
     }
 
-    out += &lines[end_line as usize]
-        .content
-        .chars()
-        .take(end_column as usize)
-        .collect::<String>();
-    out.into()
+    out.extend(
+        lines[end_line as usize]
+            .content
+            .chars()
+            .take(end_column as usize),
+    );
 }

--- a/turbopack/crates/turbopack-analyze/tests/split_chunk.rs
+++ b/turbopack/crates/turbopack-analyze/tests/split_chunk.rs
@@ -10,7 +10,7 @@ use turbo_tasks_fs::{
     File, FileContent, FileSystem, FileSystemPath, VirtualFileSystem, rope::Rope,
 };
 use turbo_tasks_testing::{Registration, register, run_once};
-use turbopack_analyze::split_chunk::{ChunkPart, ChunkPartRange, split_output_asset_into_parts};
+use turbopack_analyze::split_chunk::{ChunkPartRange, split_output_asset_into_parts};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     code_builder::{Code, CodeBuilder},
@@ -59,38 +59,41 @@ async fn split_chunk() {
 
         let parts = split_output_asset_into_parts(asset).await.unwrap();
 
+        assert_eq!(parts.len(), 2);
+
+        assert_eq!(parts[0].source, rcstr!("source1.js"));
+        assert_eq!(parts[0].real_size, 15);
+        assert_eq!(parts[0].unaccounted_size, 51);
         assert_eq!(
-            &*parts,
-            &vec![
-                ChunkPart {
-                    source: rcstr!("source1.js"),
-                    real_size: 15,
-                    unaccounted_size: 51,
-                    ranges: vec![
-                        ChunkPartRange {
-                            line: 2,
-                            start_column: 0,
-                            end_column: 12,
-                        },
-                        ChunkPartRange {
-                            line: 3,
-                            start_column: 0,
-                            end_column: 3,
-                        },
-                    ],
+            parts[0].ranges,
+            vec![
+                ChunkPartRange {
+                    line: 2,
+                    start_column: 0,
+                    end_column: 12
                 },
-                ChunkPart {
-                    source: rcstr!("source2.js"),
-                    real_size: 31,
-                    unaccounted_size: 46,
-                    ranges: vec![ChunkPartRange {
-                        line: 4,
-                        start_column: 0,
-                        end_column: 31,
-                    }],
+                ChunkPartRange {
+                    line: 3,
+                    start_column: 0,
+                    end_column: 3
                 },
             ]
         );
+
+        assert_eq!(parts[1].source, rcstr!("source2.js"));
+        assert_eq!(parts[1].real_size, 31);
+        assert_eq!(parts[1].unaccounted_size, 46);
+        assert_eq!(
+            parts[1].ranges,
+            vec![ChunkPartRange {
+                line: 4,
+                start_column: 0,
+                end_column: 31
+            }]
+        );
+
+        assert_eq!(parts[0].get_compressed_size().await.unwrap(), 17);
+        assert_eq!(parts[1].get_compressed_size().await.unwrap(), 28);
 
         println!("{:#?}", parts);
         anyhow::Ok(())

--- a/turbopack/crates/turbopack-analyze/tests/split_chunk.rs
+++ b/turbopack/crates/turbopack-analyze/tests/split_chunk.rs
@@ -62,8 +62,8 @@ async fn split_chunk() {
         assert_eq!(parts.len(), 2);
 
         assert_eq!(parts[0].source, rcstr!("source1.js"));
-        assert_eq!(parts[0].real_size, 15);
-        assert_eq!(parts[0].unaccounted_size, 51);
+        assert_eq!(parts[0].real_size, 46);
+        assert_eq!(parts[0].unaccounted_size, 34);
         assert_eq!(
             parts[0].ranges,
             vec![
@@ -75,14 +75,14 @@ async fn split_chunk() {
                 ChunkPartRange {
                     line: 3,
                     start_column: 0,
-                    end_column: 3
+                    end_column: 34
                 },
             ]
         );
 
         assert_eq!(parts[1].source, rcstr!("source2.js"));
         assert_eq!(parts[1].real_size, 31);
-        assert_eq!(parts[1].unaccounted_size, 46);
+        assert_eq!(parts[1].unaccounted_size, 30);
         assert_eq!(
             parts[1].ranges,
             vec![ChunkPartRange {
@@ -92,7 +92,7 @@ async fn split_chunk() {
             }]
         );
 
-        assert_eq!(parts[0].get_compressed_size().await.unwrap(), 17);
+        assert_eq!(parts[0].get_compressed_size().await.unwrap(), 43);
         assert_eq!(parts[1].get_compressed_size().await.unwrap(), 28);
 
         println!("{:#?}", parts);


### PR DESCRIPTION
This:

- Adds a global toggle for showing uncompressed or compressed sizes. **Shows compressed sizes by default**
- Estimates these compressed sizes by ~applying the proportion a module takes from its uncompressed chunk to its compressed chunk~ compressing a concatenation of all the module's chunk ranges from the sourcemap.
- Compressed sizes are approximate and computed from the flate2 crate running deflate at level 6. This does not include things like gzip headers since we compute modules individually.
- Shows a compressed size in the sidebar when either a file or directory is selected (directories use recursive sums of their compressed files)
- Shows compressed file sizes by default in the treemap visualization and status bar for both files and directories
- Shows “All Route Modules” for the top-level directory

<img width="1037" height="621" alt="image" src="https://github.com/user-attachments/assets/fda1368d-431e-42b4-be45-63695cdc4905" />
