### PR TITLE
Turbopack: Switch RequestKey's `conditions` field from BTreeMap to FrozenMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9674,6 +9674,7 @@ dependencies = [
  "tokio",
  "tracing",
  "turbo-bincode",
+ "turbo-frozenmap",
  "turbo-prehash",
  "turbo-rcstr",
  "turbo-tasks",

--- a/turbopack/crates/turbo-frozenmap/src/map.rs
+++ b/turbopack/crates/turbo-frozenmap/src/map.rs
@@ -381,6 +381,17 @@ impl<K, V> FrozenMap<K, V> {
             inner: slice.iter(),
         }
     }
+
+    /// Extend this [`FrozenMap`] by constructing a new map with the additional entries. New entries
+    /// with overlapping keys will overwrite existing ones.
+    #[must_use]
+    pub fn extend(&self, entries: impl IntoIterator<Item = (K, V)>) -> Self
+    where
+        K: Clone + Ord,
+        V: Clone,
+    {
+        self.as_slice().iter().cloned().chain(entries).collect()
+    }
 }
 
 // Manual implementation because the derive would add unnecessary `K: Default, V: Default` bounds.

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -39,6 +39,7 @@ swc_sourcemap = { workspace = true }
 swc_core = { workspace = true, features = ["ecma_preset_env", "common"] }
 tracing = { workspace = true }
 turbo-bincode = { workspace = true }
+turbo-frozenmap = { workspace = true }
 turbo-prehash = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
@@ -50,7 +51,6 @@ twox-hash = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
 uuid = { workspace = true}
-
 
 [dev-dependencies]
 rstest = { workspace = true }


### PR DESCRIPTION
Doing this as a small trial of the new `FrozenMap` API. @lukesandberg pointed this out as a potentially good candidate.