### PR TITLE
[turbopack] Rename is_marked_as_side_effect_free to side_effects and return ModuleSideEffects enum

### DIFF
--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
-use turbo_tasks_fs::{FileSystem, VirtualFileSystem, glob::Glob, rope::RopeBuilder};
+use turbo_tasks_fs::{FileSystem, VirtualFileSystem, rope::RopeBuilder};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
@@ -11,7 +11,7 @@ use turbopack_core::{
         EvaluatableAsset,
     },
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::OutputAssetsReference,
     reference::{ModuleReference, ModuleReferences},
@@ -76,10 +76,9 @@ impl Module for HmrEntryModule {
                 .await?,
         )]))
     }
-
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(self: Vc<Self>, _: Vc<Glob>) -> Vc<bool> {
-        Vc::cell(false)
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectful.cell()
     }
 }
 

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -9,6 +9,7 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{
     CssOptionsContext, EcmascriptOptionsContext, JsxTransformOptions, ModuleRule,
     TypescriptTransformOptions, module_options_context::ModuleOptionsContext,
+    side_effect_free_packages_glob,
 };
 use turbopack_browser::{
     BrowserChunkingContext, ChunkSuffix, ContentHashing, CurrentChunkMethod,
@@ -338,7 +339,11 @@ pub async fn get_client_module_options_context(
         execution_context: Some(execution_context),
         tree_shaking_mode: tree_shaking_mode_for_user_code,
         enable_postcss_transform,
-        side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
+        side_effect_free_packages: Some(
+            side_effect_free_packages_glob(next_config.optimize_package_imports())
+                .to_resolved()
+                .await?,
+        ),
         keep_last_successful_parse: next_mode.is_development(),
         analyze_mode: if next_mode.is_development() {
             AnalyzeMode::CodeGeneration

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -6,7 +6,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkGroupType, ChunkableModuleReference, ChunkingType, ChunkingTypeOption},
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     reference::{ModuleReference, ModuleReferences},
     resolve::ModuleResolveResult,
     source::OptionSource,
@@ -56,6 +56,10 @@ impl Module for CssClientReferenceModule {
                 .to_resolved()
                 .await?,
         )]))
+    }
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectful.cell()
     }
 }
 

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -14,7 +14,7 @@ use turbopack_core::{
     code_builder::CodeBuilder,
     context::AssetContext,
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::{ModuleGraph, binding_usage_info::ModuleExportUsageInfo},
     output::OutputAssetsReference,
     reference::{ModuleReference, ModuleReferences},
@@ -240,6 +240,12 @@ impl Module for EcmascriptClientReferenceModule {
             .collect();
 
         Ok(Vc::cell(references))
+    }
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        // These just re-export some specially tagged functions, however we do assume that client
+        // references are executed client side so we need to preserve these in the graph.
+        ModuleSideEffects::SideEffectful.cell()
     }
 }
 

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::OutputAssetsReference,
     reference::{ModuleReferences, SingleChunkableModuleReference},
@@ -70,6 +70,11 @@ impl Module for NextDynamicEntryModule {
             .to_resolved()
             .await?,
         )]))
+    }
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        // This just exports another import
+        ModuleSideEffects::ModuleEvaluationIsSideEffectFree.cell()
     }
 }
 

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -10,6 +10,7 @@ use turbopack::{
     module_options::{
         CssOptionsContext, EcmascriptOptionsContext, ExternalsTracingOptions, JsxTransformOptions,
         ModuleOptionsContext, ModuleRule, TypescriptTransformOptions,
+        side_effect_free_packages_glob,
     },
     transition::Transition,
 };
@@ -593,7 +594,11 @@ pub async fn get_server_module_options_context(
             ..Default::default()
         },
         tree_shaking_mode: tree_shaking_mode_for_user_code,
-        side_effect_free_packages: next_config.optimize_package_imports().owned().await?,
+        side_effect_free_packages: Some(
+            side_effect_free_packages_glob(next_config.optimize_package_imports())
+                .to_resolved()
+                .await?,
+        ),
         analyze_mode: if next_mode.is_development() {
             AnalyzeMode::CodeGeneration
         } else {

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::OutputAssetsReference,
     reference::ModuleReferences,
@@ -66,6 +66,11 @@ impl Module for NextServerComponentModule {
                 .to_resolved()
                 .await?,
         )]))
+    }
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        // This just exports another import
+        ModuleSideEffects::ModuleEvaluationIsSideEffectFree.cell()
     }
 }
 

--- a/crates/next-core/src/next_server_utility/server_utility_module.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_module.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::OutputAssetsReference,
     reference::ModuleReferences,
@@ -66,6 +66,12 @@ impl Module for NextServerUtilityModule {
                 .to_resolved()
                 .await?,
         )]))
+    }
+
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        // This just exports another import
+        ModuleSideEffects::ModuleEvaluationIsSideEffectFree.cell()
     }
 }
 

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 use tracing::Instrument;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
-use turbo_tasks_fs::{FileContent, glob::Glob, rope::Rope};
+use turbo_tasks_fs::{FileContent, rope::Rope};
 use turbopack::{ModuleAssetContext, module_options::CustomModuleType};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -18,7 +18,7 @@ use turbopack_core::{
     },
     context::AssetContext,
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::OutputAssetsReference,
     resolve::ModulePart,
@@ -99,11 +99,8 @@ impl Module for RawEcmascriptModule {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
-        self: Vc<Self>,
-        _side_effect_free_packages: Vc<Glob>,
-    ) -> Vc<bool> {
-        Vc::cell(false)
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectful.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/context.rs
+++ b/turbopack/crates/turbopack-core/src/context.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, bail};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{FileSystemPath, glob::Glob};
+use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
     compile_time_info::CompileTimeInfo,
@@ -104,7 +104,4 @@ pub trait AssetContext {
     /// Gets a new AssetContext with the transition applied.
     #[turbo_tasks::function]
     fn with_transition(self: Vc<Self>, transition: RcStr) -> Vc<Box<dyn AssetContext>>;
-
-    #[turbo_tasks::function]
-    fn side_effect_free_packages(self: Vc<Self>) -> Vc<Glob>;
 }

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -1,8 +1,5 @@
-use bincode::{Decode, Encode};
-use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, ValueToString, Vc, trace::TraceRawVcs};
-use turbo_tasks_fs::glob::Glob;
+use turbo_tasks::{ResolvedVc, TaskInput, ValueToString, Vc};
 
 use crate::{asset::Asset, ident::AssetIdent, reference::ModuleReferences, source::OptionSource};
 
@@ -13,9 +10,8 @@ pub enum StyleType {
     GlobalStyle,
 }
 
-#[derive(
-    Serialize, Deserialize, Hash, Eq, PartialEq, Debug, NonLocalValue, TraceRawVcs, Encode, Decode,
-)]
+#[derive(Hash, Debug, Copy, Clone)]
+#[turbo_tasks::value(shared)]
 pub enum ModuleSideEffects {
     /// Analysis determined that the module evaluation is side effect free
     /// the module may still be side effectful based on its imports.
@@ -64,12 +60,7 @@ pub trait Module: Asset {
 
     /// Returns true if the module is marked as side effect free in package.json or by other means.
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
-        self: Vc<Self>,
-        _side_effect_free_packages: Vc<Glob>,
-    ) -> Vc<bool> {
-        Vc::cell(false)
-    }
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects>;
 }
 
 #[turbo_tasks::value_trait]

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -48,6 +48,7 @@ pub mod chunk_group_info;
 pub mod merged_modules;
 pub mod module_batch;
 pub(crate) mod module_batches;
+mod side_effect_module_info;
 pub(crate) mod style_groups;
 mod traced_di_graph;
 
@@ -1959,7 +1960,7 @@ pub mod tests {
     use crate::{
         asset::{Asset, AssetContent},
         ident::AssetIdent,
-        module::Module,
+        module::{Module, ModuleSideEffects},
         module_graph::{
             GraphEntries, GraphTraversalAction, ModuleGraph, ModuleGraphRef, SingleModuleGraph,
             VisitedModules, chunk_group_info::ChunkGroupEntry,
@@ -2356,6 +2357,10 @@ pub mod tests {
             };
 
             Ok(Vc::cell(references))
+        }
+        #[turbo_tasks::function]
+        fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+            ModuleSideEffects::SideEffectful.cell()
         }
     }
 

--- a/turbopack/crates/turbopack-core/src/module_graph/side_effect_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/side_effect_module_info.rs
@@ -15,7 +15,7 @@ pub struct SideEffectFreeModules(FxHashSet<ResolvedVc<Box<dyn Module>>>);
 
 /// Computes the set of side effect free modules in the module graph.
 ///
-/// This leverages the module graph to compute if modules with `ModuleEvalutationIsSideEffectFree`
+/// This leverages the module graph to compute if modules with `ModuleEvaluationIsSideEffectFree`
 /// status are actually side effectful or not.
 ///
 /// A current limitation is that the module graph doesn't contain information on how 'late' imports

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -103,6 +103,7 @@ impl Module for NodeAddonModule {
 
     #[turbo_tasks::function]
     fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        // We assume that a node addon could have arbitrary side effects when loading.
         ModuleSideEffects::SideEffectful.cell()
     }
 }

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -10,7 +10,7 @@ use crate::{
     asset::{Asset, AssetContent},
     file_source::FileSource,
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     raw_module::RawModule,
     reference::{ModuleReferences, TracedModuleReference},
     resolve::pattern::{Pattern, PatternMatch, read_matches},
@@ -99,6 +99,11 @@ impl Module for NodeAddonModule {
 
         // Most addon modules don't have references to other modules.
         Ok(ModuleReferences::empty())
+    }
+
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectful.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/raw_module.rs
+++ b/turbopack/crates/turbopack-core/src/raw_module.rs
@@ -3,11 +3,11 @@ use turbo_tasks::{ResolvedVc, Vc};
 use crate::{
     asset::{Asset, AssetContent},
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     source::{OptionSource, Source},
 };
 
-/// A module where source code doesn't need to be parsed but can be usd as is.
+/// A module where source code doesn't need to be parsed but can be used as is.
 /// This module has no references to other modules.
 #[turbo_tasks::value]
 pub struct RawModule {
@@ -24,6 +24,10 @@ impl Module for RawModule {
     #[turbo_tasks::function]
     fn source(&self) -> Vc<OptionSource> {
         Vc::cell(Some(self.source))
+    }
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectful.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -8,7 +8,7 @@ use turbopack_core::{
     context::AssetContext,
     environment::Environment,
     ident::AssetIdent,
-    module::{Module, StyleModule, StyleType},
+    module::{Module, ModuleSideEffects, StyleModule, StyleType},
     module_graph::ModuleGraph,
     output::{OutputAssetsReference, OutputAssetsWithReferenced},
     reference::{ModuleReference, ModuleReferences},
@@ -152,6 +152,11 @@ impl Module for CssModuleAsset {
             ParseCssResult::Unparsable => Ok(ModuleReferences::empty()),
             ParseCssResult::NotFound => Ok(ModuleReferences::empty()),
         }
+    }
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        // global css is always a side effect
+        ModuleSideEffects::SideEffectful.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -16,7 +16,7 @@ use turbopack_core::{
         Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
         OptionStyledString, StyledString,
     },
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::OutputAssetsReference,
     reference::{ModuleReference, ModuleReferences},
@@ -110,6 +110,13 @@ impl Module for ModuleCssAsset {
             .collect();
 
         Ok(Vc::cell(references))
+    }
+
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        // modules can still effect global styles using `:root` selectors and other similar features
+        // We could do better with some static analysis if we want
+        ModuleSideEffects::SideEffectful.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/benches/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/references.rs
@@ -77,6 +77,7 @@ async fn setup(
         layer,
     }
     .resolved_cell();
+
     let module = EcmascriptModuleAsset::builder(
         ResolvedVc::upcast(
             FileSource::new(fs.root().await?.join(file).unwrap())
@@ -96,6 +97,7 @@ async fn setup(
         }
         .resolved_cell(),
         compile_time_info,
+        None,
     )
     .build()
     .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/module.rs
@@ -1,12 +1,11 @@
 use anyhow::Result;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkableModule, ChunkingContext, availability_info::AvailabilityInfo},
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     reference::{ModuleReferences, SingleModuleReference},
 };
@@ -68,11 +67,8 @@ impl Module for AsyncLoaderModule {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
-        self: Vc<Self>,
-        _side_effect_free_packages: Vc<Glob>,
-    ) -> Vc<bool> {
-        Vc::cell(true)
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectFree.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -190,9 +190,11 @@ pub enum SideEffectsDeclaration {
 #[turbo_tasks::function]
 pub async fn get_side_effect_free_declaration(
     path: FileSystemPath,
-    side_effect_free_packages: Vc<Glob>,
+    side_effect_free_packages: Option<Vc<Glob>>,
 ) -> Result<Vc<SideEffectsDeclaration>> {
-    if side_effect_free_packages.await?.matches(&path.path) {
+    if let Some(side_effect_free_packages) = side_effect_free_packages
+        && side_effect_free_packages.await?.matches(&path.path)
+    {
         return Ok(SideEffectsDeclaration::SideEffectFree.cell());
     }
 

--- a/turbopack/crates/turbopack-ecmascript/src/inlined_bytes_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/inlined_bytes_module.rs
@@ -3,12 +3,12 @@ use std::io::{Read, Write};
 use anyhow::{Result, bail};
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
-use turbo_tasks_fs::{FileContent, glob::Glob, rope::RopeBuilder};
+use turbo_tasks_fs::{FileContent, rope::RopeBuilder};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::OutputAssetsReference,
     source::Source,
@@ -51,11 +51,8 @@ impl Module for InlinedBytesJsModule {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
-        self: Vc<Self>,
-        _side_effect_free_packages: Vc<Glob>,
-    ) -> Vc<bool> {
-        Vc::cell(true)
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectFree.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -786,16 +786,11 @@ impl Module for EcmascriptModuleAsset {
         let this = self.await?;
         // Check package.json first, so that we can skip parsing the module if it's marked that way.
         // We need to respect package.json configuration over any static analysis we might do.
-        let side_effects_declaration = match &this.side_effect_free_packages {
-            Some(side_effect_free_packages) => {
-                *get_side_effect_free_declaration(
-                    self.ident().path().owned().await?,
-                    **side_effect_free_packages,
-                )
-                .await?
-            }
-            None => SideEffectsDeclaration::None,
-        };
+        let side_effects_declaration = *get_side_effect_free_declaration(
+            self.ident().path().owned().await?,
+            this.side_effect_free_packages.map(|g| *g),
+        )
+        .await?;
         Ok((match side_effects_declaration {
             SideEffectsDeclaration::SideEffectful => ModuleSideEffects::SideEffectful,
             SideEffectsDeclaration::SideEffectFree => ModuleSideEffects::SideEffectFree,

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -118,7 +118,10 @@ pub use turbopack_resolve::ecmascript as resolve;
 use self::chunk::{EcmascriptChunkItemContent, EcmascriptChunkType, EcmascriptExports};
 use crate::{
     analyzer::graph::EvalContext,
-    chunk::{EcmascriptChunkPlaceable, placeable::is_marked_as_side_effect_free},
+    chunk::{
+        EcmascriptChunkPlaceable,
+        placeable::{SideEffectsDeclaration, get_side_effect_free_declaration},
+    },
     code_gen::{CodeGens, ModifiableAst},
     merged_module::MergedEcmascriptModule,
     parse::generate_js_source_map,
@@ -337,6 +340,7 @@ pub struct EcmascriptModuleAssetBuilder {
     transforms: ResolvedVc<EcmascriptInputTransforms>,
     options: ResolvedVc<EcmascriptOptions>,
     compile_time_info: ResolvedVc<CompileTimeInfo>,
+    side_effect_free_packages: Option<ResolvedVc<Glob>>,
     inner_assets: Option<ResolvedVc<InnerAssets>>,
 }
 
@@ -360,6 +364,7 @@ impl EcmascriptModuleAssetBuilder {
                 *self.transforms,
                 *self.options,
                 *self.compile_time_info,
+                self.side_effect_free_packages.map(|g| *g),
                 *inner_assets,
             )
         } else {
@@ -370,6 +375,7 @@ impl EcmascriptModuleAssetBuilder {
                 *self.transforms,
                 *self.options,
                 *self.compile_time_info,
+                self.side_effect_free_packages.map(|g| *g),
             )
         }
     }
@@ -383,6 +389,7 @@ pub struct EcmascriptModuleAsset {
     pub transforms: ResolvedVc<EcmascriptInputTransforms>,
     pub options: ResolvedVc<EcmascriptOptions>,
     pub compile_time_info: ResolvedVc<CompileTimeInfo>,
+    pub side_effect_free_packages: Option<ResolvedVc<Glob>>,
     pub inner_assets: Option<ResolvedVc<InnerAssets>>,
     #[turbo_tasks(debug_ignore)]
     last_successful_parse: turbo_tasks::TransientState<ReadRef<ParseResult>>,
@@ -396,6 +403,7 @@ impl core::fmt::Debug for EcmascriptModuleAsset {
             .field("transforms", &self.transforms)
             .field("options", &self.options)
             .field("compile_time_info", &self.compile_time_info)
+            .field("side_effect_free_packages", &self.side_effect_free_packages)
             .field("inner_assets", &self.inner_assets)
             .finish()
     }
@@ -464,6 +472,7 @@ impl EcmascriptModuleAsset {
         transforms: ResolvedVc<EcmascriptInputTransforms>,
         options: ResolvedVc<EcmascriptOptions>,
         compile_time_info: ResolvedVc<CompileTimeInfo>,
+        side_effect_free_packages: Option<ResolvedVc<Glob>>,
     ) -> EcmascriptModuleAssetBuilder {
         EcmascriptModuleAssetBuilder {
             source,
@@ -472,6 +481,7 @@ impl EcmascriptModuleAsset {
             transforms,
             options,
             compile_time_info,
+            side_effect_free_packages,
             inner_assets: None,
         }
     }
@@ -633,13 +643,14 @@ async fn determine_module_type_for_directory(
 #[turbo_tasks::value_impl]
 impl EcmascriptModuleAsset {
     #[turbo_tasks::function]
-    pub fn new(
+    fn new(
         source: ResolvedVc<Box<dyn Source>>,
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
         ty: EcmascriptModuleAssetType,
         transforms: ResolvedVc<EcmascriptInputTransforms>,
         options: ResolvedVc<EcmascriptOptions>,
         compile_time_info: ResolvedVc<CompileTimeInfo>,
+        side_effect_free_packages: Option<ResolvedVc<Glob>>,
     ) -> Vc<Self> {
         Self::cell(EcmascriptModuleAsset {
             source,
@@ -647,21 +658,22 @@ impl EcmascriptModuleAsset {
             ty,
             transforms,
             options,
-
             compile_time_info,
+            side_effect_free_packages,
             inner_assets: None,
             last_successful_parse: Default::default(),
         })
     }
 
     #[turbo_tasks::function]
-    pub async fn new_with_inner_assets(
+    async fn new_with_inner_assets(
         source: ResolvedVc<Box<dyn Source>>,
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
         ty: EcmascriptModuleAssetType,
         transforms: ResolvedVc<EcmascriptInputTransforms>,
         options: ResolvedVc<EcmascriptOptions>,
         compile_time_info: ResolvedVc<CompileTimeInfo>,
+        side_effect_free_packages: Option<ResolvedVc<Glob>>,
         inner_assets: ResolvedVc<InnerAssets>,
     ) -> Result<Vc<Self>> {
         if inner_assets.await?.is_empty() {
@@ -672,6 +684,7 @@ impl EcmascriptModuleAsset {
                 *transforms,
                 *options,
                 *compile_time_info,
+                side_effect_free_packages.map(|g| *g),
             ))
         } else {
             Ok(Self::cell(EcmascriptModuleAsset {
@@ -681,6 +694,7 @@ impl EcmascriptModuleAsset {
                 transforms,
                 options,
                 compile_time_info,
+                side_effect_free_packages,
                 inner_assets: Some(inner_assets),
                 last_successful_parse: Default::default(),
             }))
@@ -768,20 +782,26 @@ impl Module for EcmascriptModuleAsset {
     }
 
     #[turbo_tasks::function]
-    async fn is_marked_as_side_effect_free(
-        self: Vc<Self>,
-        side_effect_free_packages: Vc<Glob>,
-    ) -> Result<Vc<bool>> {
+    async fn side_effects(self: Vc<Self>) -> Result<Vc<ModuleSideEffects>> {
+        let this = self.await?;
         // Check package.json first, so that we can skip parsing the module if it's marked that way.
-        let pkg_side_effect_free = is_marked_as_side_effect_free(
-            self.ident().path().owned().await?,
-            side_effect_free_packages,
-        );
-        Ok(if *pkg_side_effect_free.await? {
-            pkg_side_effect_free
-        } else {
-            Vc::cell(self.analyze().await?.side_effects == ModuleSideEffects::SideEffectFree)
+        // We need to respect package.json configuration over any static analysis we might do.
+        let side_effects_declaration = match &this.side_effect_free_packages {
+            Some(side_effect_free_packages) => {
+                *get_side_effect_free_declaration(
+                    self.ident().path().owned().await?,
+                    **side_effect_free_packages,
+                )
+                .await?
+            }
+            None => SideEffectsDeclaration::None,
+        };
+        Ok((match side_effects_declaration {
+            SideEffectsDeclaration::SideEffectful => ModuleSideEffects::SideEffectful,
+            SideEffectsDeclaration::SideEffectFree => ModuleSideEffects::SideEffectFree,
+            SideEffectsDeclaration::None => self.analyze().await?.side_effects,
         })
+        .cell())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -786,12 +786,12 @@ impl Module for EcmascriptModuleAsset {
         let this = self.await?;
         // Check package.json first, so that we can skip parsing the module if it's marked that way.
         // We need to respect package.json configuration over any static analysis we might do.
-        let side_effects_declaration = *get_side_effect_free_declaration(
+        Ok((match *get_side_effect_free_declaration(
             self.ident().path().owned().await?,
             this.side_effect_free_packages.map(|g| *g),
         )
-        .await?;
-        Ok((match side_effects_declaration {
+        .await?
+        {
             SideEffectsDeclaration::SideEffectful => ModuleSideEffects::SideEffectful,
             SideEffectsDeclaration::SideEffectFree => ModuleSideEffects::SideEffectFree,
             SideEffectsDeclaration::None => self.analyze().await?.side_effects,

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -1,14 +1,13 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
-use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
         ChunkableModule, ChunkingContext, ChunkingContextExt, availability_info::AvailabilityInfo,
     },
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::{
         ModuleGraph, chunk_group_info::ChunkGroup, module_batch::ChunkableModuleOrBatch,
     },
@@ -154,11 +153,8 @@ impl Module for ManifestAsyncModule {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
-        self: Vc<Self>,
-        _side_effect_free_packages: Vc<Glob>,
-    ) -> Vc<bool> {
-        Vc::cell(true)
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectFree.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/merged_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/merged_module.rs
@@ -7,7 +7,7 @@ use turbopack_core::{
         MergeableModuleExposure, MergeableModules, MergeableModulesExposed,
     },
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::OutputAssetsReference,
     reference::ModuleReferences,
@@ -83,13 +83,18 @@ impl Module for MergedEcmascriptModule {
     }
 
     #[turbo_tasks::function]
-    async fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
+    fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
         panic!("references() should not be called");
     }
 
     #[turbo_tasks::function]
-    async fn is_self_async(&self) -> Result<Vc<bool>> {
+    fn is_self_async(&self) -> Result<Vc<bool>> {
         panic!("is_self_async() should not be called");
+    }
+    #[turbo_tasks::function]
+    fn side_effects(&self) -> Vc<ModuleSideEffects> {
+        // If needed this could be computed by merging the effects from all the merged modules
+        panic!("side_effects() should not be called");
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -6,15 +6,14 @@ use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::{
-    FileContent, FileSystem, FileSystemPath, LinkType, VirtualFileSystem, glob::Glob,
-    rope::RopeBuilder,
+    FileContent, FileSystem, FileSystemPath, LinkType, VirtualFileSystem, rope::RopeBuilder,
 };
 use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{AsyncModuleInfo, ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     ident::{AssetIdent, Layer},
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::{
         OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsReferences,
@@ -360,7 +359,7 @@ impl Module for CachedExternalModule {
                             // == false`. Optimize this case by using `ModuleWithoutSelfAsync` to
                             // short circuit that computation and thus defer parsing traced modules
                             // to emitting to not block all of chunking on this.
-                            .map(|m| Vc::upcast(ModuleWithoutSelfAsync::new(*m))),
+                            .map(|m| Vc::upcast(SideEffectfulModuleWithoutSelfAsync::new(*m))),
                     )
                     .map(|s| {
                         Vc::upcast::<Box<dyn ModuleReference>>(TracedModuleReference::new(s))
@@ -382,11 +381,8 @@ impl Module for CachedExternalModule {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
-        self: Vc<Self>,
-        _side_effect_free_packages: Vc<Glob>,
-    ) -> Vc<bool> {
-        Vc::cell(false)
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectful.cell()
     }
 }
 
@@ -531,23 +527,23 @@ impl EcmascriptChunkItem for CachedExternalModuleChunkItem {
     }
 }
 
-/// A wrapper "passthrough" module type that always returns `false` for `is_self_async`. Be careful
-/// when using it, as it may hide async dependencies.
+/// A wrapper "passthrough" module type that always returns `false` for `is_self_async` and
+/// `SideEffects` for `side_effects`.Be careful when using it, as it may hide async dependencies.
 #[turbo_tasks::value]
-pub struct ModuleWithoutSelfAsync {
+struct SideEffectfulModuleWithoutSelfAsync {
     module: ResolvedVc<Box<dyn Module>>,
 }
 
 #[turbo_tasks::value_impl]
-impl ModuleWithoutSelfAsync {
+impl SideEffectfulModuleWithoutSelfAsync {
     #[turbo_tasks::function]
-    pub fn new(module: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
-        Self::cell(ModuleWithoutSelfAsync { module })
+    fn new(module: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
+        Self::cell(SideEffectfulModuleWithoutSelfAsync { module })
     }
 }
 
 #[turbo_tasks::value_impl]
-impl Asset for ModuleWithoutSelfAsync {
+impl Asset for SideEffectfulModuleWithoutSelfAsync {
     #[turbo_tasks::function]
     fn content(&self) -> Vc<AssetContent> {
         self.module.content()
@@ -555,7 +551,7 @@ impl Asset for ModuleWithoutSelfAsync {
 }
 
 #[turbo_tasks::value_impl]
-impl Module for ModuleWithoutSelfAsync {
+impl Module for SideEffectfulModuleWithoutSelfAsync {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
         self.module.ident()
@@ -571,6 +567,10 @@ impl Module for ModuleWithoutSelfAsync {
         self.module.references()
     }
 
+    #[turbo_tasks::function]
+    fn side_effects(&self) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectful.cell()
+    }
     // Don't override and use default is_self_async that always returns false
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -20,7 +20,7 @@ use turbo_tasks::{
     FxIndexMap, NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat,
     trace::TraceRawVcs,
 };
-use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath, glob::Glob};
+use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
@@ -29,7 +29,7 @@ use turbopack_core::{
     },
     ident::AssetIdent,
     issue::IssueSource,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::OutputAssetsReference,
     reference::{ModuleReference, ModuleReferences},
@@ -445,11 +445,8 @@ impl Module for RequireContextAsset {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
-        self: Vc<Self>,
-        _side_effect_free_packages: Vc<Glob>,
-    ) -> Vc<bool> {
-        Vc::cell(true)
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectFree.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/facade/module.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{Result, bail};
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{File, FileContent, glob::Glob};
+use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
@@ -10,7 +10,7 @@ use turbopack_core::{
         MergeableModules, MergeableModulesExposed,
     },
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     reference::ModuleReferences,
     resolve::{ExportUsage, ModulePart},
@@ -182,16 +182,11 @@ impl Module for EcmascriptModuleFacadeModule {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
-        &self,
-        side_effect_free_packages: Vc<Glob>,
-    ) -> Result<Vc<bool>> {
+    fn side_effects(&self) -> Result<Vc<ModuleSideEffects>> {
         Ok(match self.part {
-            ModulePart::Facade => self
-                .module
-                .is_marked_as_side_effect_free(side_effect_free_packages),
+            ModulePart::Facade => self.module.side_effects(),
             ModulePart::RenamedExport { .. } | ModulePart::RenamedNamespace { .. } => {
-                Vc::cell(true)
+                ModuleSideEffects::SideEffectFree.cell()
             }
             _ => bail!("Unexpected ModulePart for EcmascriptModuleFacadeModule"),
         })

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/locals/module.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 
 use anyhow::{Result, bail};
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
@@ -10,7 +9,7 @@ use turbopack_core::{
         MergeableModulesExposed,
     },
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     reference::ModuleReferences,
     resolve::ModulePart,
@@ -73,9 +72,8 @@ impl Module for EcmascriptModuleLocalsModule {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(&self, side_effect_free_packages: Vc<Glob>) -> Vc<bool> {
-        self.module
-            .is_marked_as_side_effect_free(side_effect_free_packages)
+    fn side_effects(&self) -> Vc<ModuleSideEffects> {
+        self.module.side_effects()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -1,16 +1,14 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext, EvaluatableAsset},
-    context::AssetContext,
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     reference::{ModuleReference, ModuleReferences, SingleChunkableModuleReference},
-    resolve::{ExportUsage, ModulePart, origin::ResolveOrigin},
+    resolve::{ExportUsage, ModulePart},
 };
 
 use super::{
@@ -175,17 +173,11 @@ impl EcmascriptModulePartAsset {
                         ),
                     ));
                 }
-                let side_effect_free_packages = module.asset_context().side_effect_free_packages();
                 let source_module = Vc::upcast(module);
                 let FollowExportsWithSideEffectsResult {
                     side_effects,
                     result,
-                } = &*follow_reexports_with_side_effects(
-                    source_module,
-                    export.clone(),
-                    side_effect_free_packages,
-                )
-                .await?;
+                } = &*follow_reexports_with_side_effects(source_module, export.clone()).await?;
                 let FollowExportsResult {
                     module: final_module,
                     export_name: new_export,
@@ -256,30 +248,20 @@ struct FollowExportsWithSideEffectsResult {
 async fn follow_reexports_with_side_effects(
     module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
     export_name: RcStr,
-    side_effect_free_packages: Vc<Glob>,
 ) -> Result<Vc<FollowExportsWithSideEffectsResult>> {
     let mut side_effects = vec![];
 
     let mut current_module = module;
     let mut current_export_name = export_name;
     let result = loop {
-        let is_side_effect_free = *current_module
-            .is_marked_as_side_effect_free(side_effect_free_packages)
-            .await?;
-
-        if !is_side_effect_free {
+        if *current_module.side_effects().await? != ModuleSideEffects::SideEffectFree {
             side_effects.push(only_effects(*current_module).to_resolved().await?);
         }
 
         // We ignore the side effect of the entry module here, because we need to proceed.
-        let result = follow_reexports(
-            *current_module,
-            current_export_name.clone(),
-            side_effect_free_packages,
-            true,
-        )
-        .to_resolved()
-        .await?;
+        let result = follow_reexports(*current_module, current_export_name.clone(), true)
+            .to_resolved()
+            .await?;
 
         let FollowExportsResult {
             module,
@@ -353,15 +335,12 @@ impl Module for EcmascriptModulePartAsset {
     }
 
     #[turbo_tasks::function]
-    async fn is_marked_as_side_effect_free(
-        &self,
-        side_effect_free_packages: Vc<Glob>,
-    ) -> Result<Vc<bool>> {
+    async fn side_effects(&self) -> Vc<ModuleSideEffects> {
         match self.part {
-            ModulePart::Exports | ModulePart::Export(..) => Ok(Vc::cell(true)),
-            _ => Ok(self
-                .full_module
-                .is_marked_as_side_effect_free(side_effect_free_packages)),
+            ModulePart::Exports | ModulePart::Export(..) => {
+                ModuleSideEffects::SideEffectFree.cell()
+            }
+            _ => self.full_module.side_effects(),
         }
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -6,7 +6,7 @@ use turbo_tasks_fs::DirectoryContent;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     raw_module::RawModule,
     reference::{ModuleReference, ModuleReferences},
     reference_type::{CommonJsReferenceSubType, ReferenceType},
@@ -172,6 +172,11 @@ impl Module for TsConfigModuleAsset {
             }
         }
         Ok(Vc::cell(references))
+    }
+
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectful.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -6,7 +6,7 @@ use turbopack_core::{
     asset::{Asset, AssetContent},
     file_source::FileSource,
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     reference::{ModuleReference, ModuleReferences},
     reference_type::{CommonJsReferenceSubType, ReferenceType},
     resolve::{
@@ -61,6 +61,11 @@ impl Module for WebpackModuleAsset {
     #[turbo_tasks::function]
     fn references(&self) -> Vc<ModuleReferences> {
         module_references(*self.source, *self.runtime, *self.transforms)
+    }
+
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectful.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
-use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
@@ -9,7 +8,7 @@ use turbopack_core::{
         ChunkingTypeOption,
     },
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     reference::{ModuleReference, ModuleReferences},
     resolve::ModuleResolveResult,
@@ -59,11 +58,8 @@ impl Module for WorkerLoaderModule {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
-        self: Vc<Self>,
-        _side_effect_free_packages: Vc<Glob>,
-    ) -> Vc<bool> {
-        Vc::cell(true)
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectFree.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-json/src/lib.rs
+++ b/turbopack/crates/turbopack-json/src/lib.rs
@@ -14,13 +14,13 @@ use std::fmt::Write;
 use anyhow::{Error, Result, bail};
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
-use turbo_tasks_fs::{FileContent, FileJsonContent, glob::Glob};
+use turbo_tasks_fs::{FileContent, FileJsonContent};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     code_builder::CodeBuilder,
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::OutputAssetsReference,
     source::Source,
@@ -59,11 +59,8 @@ impl Module for JsonModuleAsset {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
-        self: Vc<Self>,
-        _side_effect_free_packages: Vc<Glob>,
-    ) -> Vc<bool> {
-        Vc::cell(true)
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectFree.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-static/src/css.rs
+++ b/turbopack/crates/turbopack-static/src/css.rs
@@ -1,11 +1,10 @@
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::ChunkingContext,
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     output::OutputAsset,
     source::Source,
 };
@@ -53,11 +52,9 @@ impl Module for StaticUrlCssModule {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
-        self: Vc<Self>,
-        _side_effect_free_packages: Vc<Glob>,
-    ) -> Vc<bool> {
-        Vc::cell(true)
+
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectFree.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-static/src/ecma.rs
+++ b/turbopack/crates/turbopack-static/src/ecma.rs
@@ -1,12 +1,11 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::glob::Glob;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssetsReference, OutputAssetsWithReferenced},
     source::Source,
@@ -65,11 +64,8 @@ impl Module for StaticUrlJsModule {
     }
 
     #[turbo_tasks::function]
-    fn is_marked_as_side_effect_free(
-        self: Vc<Self>,
-        _side_effect_free_packages: Vc<Glob>,
-    ) -> Vc<bool> {
-        Vc::cell(true)
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        ModuleSideEffects::SideEffectFree.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-test-utils/src/noop_asset_context.rs
+++ b/turbopack/crates/turbopack-test-utils/src/noop_asset_context.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{FileSystemPath, glob::Glob};
+use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     compile_time_info::CompileTimeInfo,
     context::{AssetContext, ProcessResult},
@@ -72,10 +72,5 @@ impl AssetContext for NoopAssetContext {
         _transition: RcStr,
     ) -> Result<Vc<Box<dyn AssetContext>>> {
         Ok(Vc::upcast(self))
-    }
-
-    #[turbo_tasks::function]
-    async fn side_effect_free_packages(&self) -> Result<Vc<Glob>> {
-        Ok(Glob::new(rcstr!(""), Default::default()))
     }
 }

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -10,7 +10,7 @@ use turbopack_core::{
     },
     context::AssetContext,
     ident::AssetIdent,
-    module::{Module, OptionModule},
+    module::{Module, ModuleSideEffects, OptionModule},
     module_graph::ModuleGraph,
     output::{OutputAssetsReference, OutputAssetsWithReferenced},
     reference::{ModuleReferences, SingleChunkableModuleReference},
@@ -143,6 +143,14 @@ impl Module for WebAssemblyModuleAsset {
     #[turbo_tasks::function]
     fn is_self_async(self: Vc<Self>) -> Vc<bool> {
         Vc::cell(true)
+    }
+
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        // Both versions of this module have a top level await that instantiates a wasm module
+        // wasm module instantiation can trigger arbitrary side effects from the native start
+        // function
+        ModuleSideEffects::SideEffectful.cell()
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/raw.rs
+++ b/turbopack/crates/turbopack-wasm/src/raw.rs
@@ -6,7 +6,7 @@ use turbopack_core::{
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     context::AssetContext,
     ident::AssetIdent,
-    module::Module,
+    module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     output::{OutputAsset, OutputAssetsReference, OutputAssetsWithReferenced},
     source::{OptionSource, Source},
@@ -63,6 +63,12 @@ impl Module for RawWebAssemblyModuleAsset {
     #[turbo_tasks::function]
     fn source(&self) -> Vc<OptionSource> {
         Vc::cell(Some(ResolvedVc::upcast(self.source)))
+    }
+
+    #[turbo_tasks::function]
+    fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
+        // this just exports a path
+        ModuleSideEffects::SideEffectFree.cell()
     }
 }
 

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -1,11 +1,15 @@
 use std::fmt::Debug;
 
+use anyhow::Result;
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use turbo_esregex::EsRegex;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, ResolvedVc, ValueDefault, Vc, trace::TraceRawVcs};
-use turbo_tasks_fs::FileSystemPath;
+use turbo_tasks_fs::{
+    FileSystemPath,
+    glob::{Glob, GlobOptions},
+};
 use turbopack_core::{
     chunk::SourceMapsType, compile_time_info::CompileTimeInfo, condition::ContextCondition,
     environment::Environment, resolve::options::ImportMapping,
@@ -182,7 +186,6 @@ pub struct ExternalsTracingOptions {
 
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Default)]
-#[serde(default)]
 pub struct ModuleOptionsContext {
     pub ecmascript: EcmascriptOptionsContext,
     pub css: CssOptionsContext,
@@ -196,7 +199,7 @@ pub struct ModuleOptionsContext {
 
     pub environment: Option<ResolvedVc<Environment>>,
     pub execution_context: Option<ResolvedVc<ExecutionContext>>,
-    pub side_effect_free_packages: Vec<RcStr>,
+    pub side_effect_free_packages: Option<ResolvedVc<Glob>>,
     pub tree_shaking_mode: Option<TreeShakingMode>,
 
     /// Generate (non-emitted) output assets for static assets and externals, to facilitate
@@ -286,4 +289,21 @@ impl ValueDefault for ModuleOptionsContext {
     fn value_default() -> Vc<Self> {
         Self::cell(Default::default())
     }
+}
+
+#[turbo_tasks::function]
+pub async fn side_effect_free_packages_glob(
+    side_effect_free_packages: ResolvedVc<Vec<RcStr>>,
+) -> Result<Vc<Glob>> {
+    let side_effect_free_packages = &*side_effect_free_packages.await?;
+    if side_effect_free_packages.is_empty() {
+        return Ok(Glob::new(rcstr!(""), GlobOptions::default()));
+    }
+
+    let mut globs = String::new();
+    globs.push_str("**/node_modules/{");
+    globs.push_str(&side_effect_free_packages.join(","));
+    globs.push_str("}/**");
+
+    Ok(Glob::new(globs.into(), GlobOptions::default()))
 }


### PR DESCRIPTION
Refactor the  `is_marked_side_effect_free` API

* Rename `side_effects`
* Change it to return `ModuleSideEffects` instead of a `bool`
* Remove the `side_effect_packages` from its parameters, instead arrange to pass that to the EcmascriptModule constructor since that is where we need it.
     - This cleans up callsites and fixes a tiny issue where we construct that glob multiple times.
