### PR TITLE
Turbopack: Use batch get request to read more efficient from database

### DIFF
--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license = "MIT"
 
 [features]
-default = ["stats"]
+default = []
 verify_sst_content = []
 strict_checks = []
 stats = ["quick_cache/stats"]

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license = "MIT"
 
 [features]
-default = []
+default = ["stats"]
 verify_sst_content = []
 strict_checks = []
 stats = ["quick_cache/stats"]

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1395,6 +1395,88 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         Ok(None)
     }
 
+    pub fn batch_get<K: QueryKey>(
+        &self,
+        family: usize,
+        keys: &[K],
+    ) -> Result<Vec<Option<ArcSlice<u8>>>> {
+        debug_assert!(family < FAMILIES, "Family index out of bounds");
+        let mut cells: Vec<(u64, usize, Option<LookupValue>)> = Vec::with_capacity(keys.len());
+        for (index, key) in keys.iter().enumerate() {
+            let hash = hash_key(key);
+            cells.push((hash, index, None));
+        }
+        cells.sort_by_key(|(hash, _, _)| *hash);
+        let inner = self.inner.read();
+        for meta in inner.meta_files.iter().rev() {
+            for (hash, index, result) in cells.iter_mut() {
+                if result.is_some() {
+                    continue;
+                }
+                let key = &keys[*index];
+                match meta.lookup(
+                    family as u32,
+                    *hash,
+                    key,
+                    &self.amqf_cache,
+                    &self.key_block_cache,
+                    &self.value_block_cache,
+                )? {
+                    MetaLookupResult::FamilyMiss => {
+                        #[cfg(feature = "stats")]
+                        self.stats.miss_family.fetch_add(1, Ordering::Relaxed);
+                    }
+                    MetaLookupResult::RangeMiss => {
+                        #[cfg(feature = "stats")]
+                        self.stats.miss_range.fetch_add(1, Ordering::Relaxed);
+                    }
+                    MetaLookupResult::QuickFilterMiss => {
+                        #[cfg(feature = "stats")]
+                        self.stats.miss_amqf.fetch_add(1, Ordering::Relaxed);
+                    }
+                    MetaLookupResult::SstLookup(sst_result) => match sst_result {
+                        SstLookupResult::Found(found) => {
+                            *result = Some(found);
+                        }
+                        SstLookupResult::NotFound => {
+                            #[cfg(feature = "stats")]
+                            self.stats.miss_key.fetch_add(1, Ordering::Relaxed);
+                        }
+                    },
+                }
+            }
+        }
+        let mut results = vec![None; keys.len()];
+        for (hash, index, result) in cells {
+            if let Some(result) = result {
+                inner.accessed_key_hashes[family].insert(hash);
+                let result = match result {
+                    LookupValue::Deleted => {
+                        #[cfg(feature = "stats")]
+                        self.stats.hits_deleted.fetch_add(1, Ordering::Relaxed);
+                        None
+                    }
+                    LookupValue::Slice { value } => {
+                        #[cfg(feature = "stats")]
+                        self.stats.hits_small.fetch_add(1, Ordering::Relaxed);
+                        Some(value)
+                    }
+                    LookupValue::Blob { sequence_number } => {
+                        #[cfg(feature = "stats")]
+                        self.stats.hits_blob.fetch_add(1, Ordering::Relaxed);
+                        let blob = self.read_blob(sequence_number)?;
+                        Some(blob)
+                    }
+                };
+                results[index] = result;
+            } else {
+                #[cfg(feature = "stats")]
+                self.stats.miss_global.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        Ok(results)
+    }
+
     /// Returns database statistics.
     #[cfg(feature = "stats")]
     pub fn statistics(&self) -> Statistics {

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -32,10 +32,7 @@ use crate::{
     key::{StoreKey, hash_key},
     lookup_entry::{LookupEntry, LookupValue},
     merge_iter::MergeIter,
-    meta_file::{
-        AmqfCache, MetaBatchLookupResult, MetaEntryFlags, MetaFile, MetaLookupResult,
-        StaticSortedFileRange,
-    },
+    meta_file::{AmqfCache, MetaEntryFlags, MetaFile, MetaLookupResult, StaticSortedFileRange},
     meta_file_builder::MetaFileBuilder,
     parallel_scheduler::ParallelScheduler,
     sst_filter::SstFilter,
@@ -1429,7 +1426,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         cells.sort_by_key(|(hash, _, _)| *hash);
         let inner = self.inner.read();
         for meta in inner.meta_files.iter().rev() {
-            let result = meta.batch_lookup(
+            let _result = meta.batch_lookup(
                 family as u32,
                 keys,
                 &mut cells,
@@ -1441,13 +1438,13 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
             #[cfg(feature = "stats")]
             {
-                let MetaBatchLookupResult {
+                let crate::meta_file::MetaBatchLookupResult {
                     family_miss,
                     range_misses,
                     quick_filter_misses,
                     sst_misses,
                     hits: _,
-                } = result;
+                } = _result;
                 if family_miss {
                     self.stats.miss_family.fetch_add(1, Ordering::Relaxed);
                 }
@@ -1467,8 +1464,6 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                         .fetch_add(sst_misses as u64, Ordering::Relaxed);
                 }
             }
-            #[cfg(not(feature = "stats"))]
-            let _ = result;
 
             if empty_cells == 0 {
                 break;

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1374,7 +1374,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                             LookupValue::Deleted => {
                                 #[cfg(feature = "stats")]
                                 self.stats.hits_deleted.fetch_add(1, Ordering::Relaxed);
-                                span.record("result_size", &"deleted");
+                                span.record("result_size", "deleted");
                                 return Ok(None);
                             }
                             LookupValue::Slice { value } => {
@@ -1401,7 +1401,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         }
         #[cfg(feature = "stats")]
         self.stats.miss_global.fetch_add(1, Ordering::Relaxed);
-        span.record("result_size", &"not found");
+        span.record("result_size", "not found");
         Ok(None)
     }
 

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -32,7 +32,10 @@ use crate::{
     key::{StoreKey, hash_key},
     lookup_entry::{LookupEntry, LookupValue},
     merge_iter::MergeIter,
-    meta_file::{AmqfCache, MetaEntryFlags, MetaFile, MetaLookupResult, StaticSortedFileRange},
+    meta_file::{
+        AmqfCache, MetaBatchLookupResult, MetaEntryFlags, MetaFile, MetaLookupResult,
+        StaticSortedFileRange,
+    },
     meta_file_builder::MetaFileBuilder,
     parallel_scheduler::ParallelScheduler,
     sst_filter::SstFilter,
@@ -1402,6 +1405,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     ) -> Result<Vec<Option<ArcSlice<u8>>>> {
         debug_assert!(family < FAMILIES, "Family index out of bounds");
         let mut cells: Vec<(u64, usize, Option<LookupValue>)> = Vec::with_capacity(keys.len());
+        let mut empty_cells = keys.len();
         for (index, key) in keys.iter().enumerate() {
             let hash = hash_key(key);
             cells.push((hash, index, None));
@@ -1409,41 +1413,49 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         cells.sort_by_key(|(hash, _, _)| *hash);
         let inner = self.inner.read();
         for meta in inner.meta_files.iter().rev() {
-            for (hash, index, result) in cells.iter_mut() {
-                if result.is_some() {
-                    continue;
+            let result = meta.batch_lookup(
+                family as u32,
+                keys,
+                &mut cells,
+                &mut empty_cells,
+                &self.amqf_cache,
+                &self.key_block_cache,
+                &self.value_block_cache,
+            )?;
+
+            #[cfg(feature = "stats")]
+            {
+                let MetaBatchLookupResult {
+                    family_miss,
+                    range_misses,
+                    quick_filter_misses,
+                    sst_misses,
+                    hits: _,
+                } = result;
+                if family_miss {
+                    self.stats.miss_family.fetch_add(1, Ordering::Relaxed);
                 }
-                let key = &keys[*index];
-                match meta.lookup(
-                    family as u32,
-                    *hash,
-                    key,
-                    &self.amqf_cache,
-                    &self.key_block_cache,
-                    &self.value_block_cache,
-                )? {
-                    MetaLookupResult::FamilyMiss => {
-                        #[cfg(feature = "stats")]
-                        self.stats.miss_family.fetch_add(1, Ordering::Relaxed);
-                    }
-                    MetaLookupResult::RangeMiss => {
-                        #[cfg(feature = "stats")]
-                        self.stats.miss_range.fetch_add(1, Ordering::Relaxed);
-                    }
-                    MetaLookupResult::QuickFilterMiss => {
-                        #[cfg(feature = "stats")]
-                        self.stats.miss_amqf.fetch_add(1, Ordering::Relaxed);
-                    }
-                    MetaLookupResult::SstLookup(sst_result) => match sst_result {
-                        SstLookupResult::Found(found) => {
-                            *result = Some(found);
-                        }
-                        SstLookupResult::NotFound => {
-                            #[cfg(feature = "stats")]
-                            self.stats.miss_key.fetch_add(1, Ordering::Relaxed);
-                        }
-                    },
+                if range_misses > 0 {
+                    self.stats
+                        .miss_range
+                        .fetch_add(range_misses as u64, Ordering::Relaxed);
                 }
+                if quick_filter_misses > 0 {
+                    self.stats
+                        .miss_amqf
+                        .fetch_add(quick_filter_misses as u64, Ordering::Relaxed);
+                }
+                if sst_misses > 0 {
+                    self.stats
+                        .miss_key
+                        .fetch_add(sst_misses as u64, Ordering::Relaxed);
+                }
+            }
+            #[cfg(not(feature = "stats"))]
+            let _ = result;
+
+            if empty_cells == 0 {
+                break;
             }
         }
         let mut results = vec![None; keys.len()];

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1341,6 +1341,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     /// might hold onto a block of the database and it should not be hold long-term.
     pub fn get<K: QueryKey>(&self, family: usize, key: &K) -> Result<Option<ArcSlice<u8>>> {
         debug_assert!(family < FAMILIES, "Family index out of bounds");
+        let span =
+            tracing::trace_span!("database read", family, result_size = tracing::field::Empty)
+                .entered();
         let hash = hash_key(key);
         let inner = self.inner.read();
         for meta in inner.meta_files.iter().rev() {
@@ -1371,17 +1374,20 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                             LookupValue::Deleted => {
                                 #[cfg(feature = "stats")]
                                 self.stats.hits_deleted.fetch_add(1, Ordering::Relaxed);
+                                span.record("result_size", &"deleted");
                                 return Ok(None);
                             }
                             LookupValue::Slice { value } => {
                                 #[cfg(feature = "stats")]
                                 self.stats.hits_small.fetch_add(1, Ordering::Relaxed);
+                                span.record("result_size", value.len());
                                 return Ok(Some(value));
                             }
                             LookupValue::Blob { sequence_number } => {
                                 #[cfg(feature = "stats")]
                                 self.stats.hits_blob.fetch_add(1, Ordering::Relaxed);
                                 let blob = self.read_blob(sequence_number)?;
+                                span.record("result_size", blob.len());
                                 return Ok(Some(blob));
                             }
                         }
@@ -1395,6 +1401,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         }
         #[cfg(feature = "stats")]
         self.stats.miss_global.fetch_add(1, Ordering::Relaxed);
+        span.record("result_size", &"not found");
         Ok(None)
     }
 
@@ -1404,6 +1411,15 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         keys: &[K],
     ) -> Result<Vec<Option<ArcSlice<u8>>>> {
         debug_assert!(family < FAMILIES, "Family index out of bounds");
+        let span = tracing::trace_span!(
+            "database batch read",
+            family,
+            keys = keys.len(),
+            not_found = tracing::field::Empty,
+            deleted = tracing::field::Empty,
+            result_size = tracing::field::Empty
+        )
+        .entered();
         let mut cells: Vec<(u64, usize, Option<LookupValue>)> = Vec::with_capacity(keys.len());
         let mut empty_cells = keys.len();
         for (index, key) in keys.iter().enumerate() {
@@ -1458,6 +1474,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                 break;
             }
         }
+        let mut deleted = 0;
+        let mut not_found = 0;
+        let mut result_size = 0;
         let mut results = vec![None; keys.len()];
         for (hash, index, result) in cells {
             if let Some(result) = result {
@@ -1466,17 +1485,20 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                     LookupValue::Deleted => {
                         #[cfg(feature = "stats")]
                         self.stats.hits_deleted.fetch_add(1, Ordering::Relaxed);
+                        deleted += 1;
                         None
                     }
                     LookupValue::Slice { value } => {
                         #[cfg(feature = "stats")]
                         self.stats.hits_small.fetch_add(1, Ordering::Relaxed);
+                        result_size += value.len();
                         Some(value)
                     }
                     LookupValue::Blob { sequence_number } => {
                         #[cfg(feature = "stats")]
                         self.stats.hits_blob.fetch_add(1, Ordering::Relaxed);
                         let blob = self.read_blob(sequence_number)?;
+                        result_size += blob.len();
                         Some(blob)
                     }
                 };
@@ -1484,8 +1506,12 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             } else {
                 #[cfg(feature = "stats")]
                 self.stats.miss_global.fetch_add(1, Ordering::Relaxed);
+                not_found += 1;
             }
         }
+        span.record("not_found", not_found);
+        span.record("deleted", deleted);
+        span.record("result_size", result_size);
         Ok(results)
     }
 

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -441,11 +441,13 @@ impl MetaFile {
         value_block_cache: &BlockCache,
     ) -> Result<MetaBatchLookupResult> {
         if key_family != self.family {
+            #[cfg(feature = "stats")]
             return Ok(MetaBatchLookupResult {
-                #[cfg(feature = "stats")]
                 family_miss: true,
                 ..Default::default()
             });
+            #[cfg(not(feature = "stats"))]
+            return Ok(MetaBatchLookupResult {});
         }
         #[allow(unused_mut, reason = "It's used when stats are enabled")]
         let mut lookup_result = MetaBatchLookupResult::default();

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Ordering,
     fmt::Display,
     fs::File,
     hash::BuildHasherDefault,
@@ -20,6 +21,7 @@ use turbo_bincode::turbo_bincode_decode;
 
 use crate::{
     QueryKey,
+    lookup_entry::LookupValue,
     static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile, StaticSortedFileMetaData},
 };
 
@@ -209,6 +211,22 @@ pub enum MetaLookupResult {
     QuickFilterMiss,
     /// The key was looked up in the SST file. It was in the AMQF filter.
     SstLookup(SstLookupResult),
+}
+
+/// The result of a batch lookup operation.
+#[derive(Default)]
+pub struct MetaBatchLookupResult {
+    /// The key was not found because it is from a different key family.
+    pub family_miss: bool,
+    /// The key was not found because it is out of the range of this SST file. But it was the
+    /// correct key family.
+    pub range_misses: usize,
+    /// The key was not found because it was not in the AMQF filter. But it was in the range.
+    pub quick_filter_misses: usize,
+    /// The key was unsuccessfully looked up in the SST file. It was in the AMQF filter.
+    pub sst_misses: usize,
+    /// The key was found in the SST file.
+    pub hits: usize,
 }
 
 /// The key family and hash range of an SST file.
@@ -405,5 +423,70 @@ impl MetaFile {
             }
         }
         Ok(miss_result)
+    }
+
+    pub fn batch_lookup<K: QueryKey>(
+        &self,
+        key_family: u32,
+        keys: &[K],
+        cells: &mut [(u64, usize, Option<LookupValue>)],
+        empty_cells: &mut usize,
+        amqf_cache: &AmqfCache,
+        key_block_cache: &BlockCache,
+        value_block_cache: &BlockCache,
+    ) -> Result<MetaBatchLookupResult> {
+        if key_family != self.family {
+            return Ok(MetaBatchLookupResult {
+                family_miss: true,
+                ..Default::default()
+            });
+        }
+        let mut lookup_result = MetaBatchLookupResult::default();
+        for entry in self.entries.iter().rev() {
+            let start_index = cells
+                .binary_search_by(|(hash, _, _)| hash.cmp(&entry.min_hash).then(Ordering::Greater))
+                .err()
+                .unwrap();
+            if start_index >= cells.len() {
+                lookup_result.range_misses += 1;
+                continue;
+            }
+            let end_index = cells
+                .binary_search_by(|(hash, _, _)| hash.cmp(&entry.max_hash).then(Ordering::Less))
+                .err()
+                .unwrap()
+                .checked_sub(1);
+            let Some(end_index) = end_index else {
+                lookup_result.range_misses += 1;
+                continue;
+            };
+            let amqf = entry.amqf(self, amqf_cache)?;
+            for (hash, index, result) in &mut cells[start_index..=end_index] {
+                if result.is_some() {
+                    continue;
+                }
+                if !amqf.contains_fingerprint(*hash) {
+                    lookup_result.quick_filter_misses += 1;
+                    continue;
+                }
+                let sst_result = entry.sst(self)?.lookup(
+                    *hash,
+                    &keys[*index],
+                    key_block_cache,
+                    value_block_cache,
+                )?;
+                if let SstLookupResult::Found(value) = sst_result {
+                    *result = Some(value);
+                    *empty_cells -= 1;
+                    lookup_result.hits += 1;
+                    if *empty_cells == 0 {
+                        return Ok(lookup_result);
+                    }
+                } else {
+                    lookup_result.sst_misses += 1;
+                }
+            }
+        }
+        Ok(lookup_result)
     }
 }

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -217,15 +217,20 @@ pub enum MetaLookupResult {
 #[derive(Default)]
 pub struct MetaBatchLookupResult {
     /// The key was not found because it is from a different key family.
+    #[cfg(feature = "stats")]
     pub family_miss: bool,
     /// The key was not found because it is out of the range of this SST file. But it was the
     /// correct key family.
+    #[cfg(feature = "stats")]
     pub range_misses: usize,
     /// The key was not found because it was not in the AMQF filter. But it was in the range.
+    #[cfg(feature = "stats")]
     pub quick_filter_misses: usize,
     /// The key was unsuccessfully looked up in the SST file. It was in the AMQF filter.
+    #[cfg(feature = "stats")]
     pub sst_misses: usize,
     /// The key was found in the SST file.
+    #[cfg(feature = "stats")]
     pub hits: usize,
 }
 
@@ -437,10 +442,12 @@ impl MetaFile {
     ) -> Result<MetaBatchLookupResult> {
         if key_family != self.family {
             return Ok(MetaBatchLookupResult {
+                #[cfg(feature = "stats")]
                 family_miss: true,
                 ..Default::default()
             });
         }
+        #[allow(unused_mut, reason = "It's used when stats are enabled")]
         let mut lookup_result = MetaBatchLookupResult::default();
         for entry in self.entries.iter().rev() {
             let start_index = cells
@@ -448,7 +455,10 @@ impl MetaFile {
                 .err()
                 .unwrap();
             if start_index >= cells.len() {
-                lookup_result.range_misses += 1;
+                #[cfg(feature = "stats")]
+                {
+                    lookup_result.range_misses += 1;
+                }
                 continue;
             }
             let end_index = cells
@@ -457,7 +467,10 @@ impl MetaFile {
                 .unwrap()
                 .checked_sub(1);
             let Some(end_index) = end_index else {
-                lookup_result.range_misses += 1;
+                #[cfg(feature = "stats")]
+                {
+                    lookup_result.range_misses += 1;
+                }
                 continue;
             };
             let amqf = entry.amqf(self, amqf_cache)?;
@@ -466,7 +479,10 @@ impl MetaFile {
                     continue;
                 }
                 if !amqf.contains_fingerprint(*hash) {
-                    lookup_result.quick_filter_misses += 1;
+                    #[cfg(feature = "stats")]
+                    {
+                        lookup_result.quick_filter_misses += 1;
+                    }
                     continue;
                 }
                 let sst_result = entry.sst(self)?.lookup(
@@ -478,12 +494,18 @@ impl MetaFile {
                 if let SstLookupResult::Found(value) = sst_result {
                     *result = Some(value);
                     *empty_cells -= 1;
-                    lookup_result.hits += 1;
+                    #[cfg(feature = "stats")]
+                    {
+                        lookup_result.hits += 1;
+                    }
                     if *empty_cells == 0 {
                         return Ok(lookup_result);
                     }
                 } else {
-                    lookup_result.sst_misses += 1;
+                    #[cfg(feature = "stats")]
+                    {
+                        lookup_result.sst_misses += 1;
+                    }
                 }
             }
         }

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -475,6 +475,13 @@ impl MetaFile {
                 }
                 continue;
             };
+            if start_index > end_index {
+                #[cfg(feature = "stats")]
+                {
+                    lookup_result.range_misses += 1;
+                }
+                continue;
+            }
             let amqf = entry.amqf(self, amqf_cache)?;
             for (hash, index, result) in &mut cells[start_index..=end_index] {
                 if result.is_some() {

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -449,6 +449,10 @@ impl MetaFile {
             #[cfg(not(feature = "stats"))]
             return Ok(MetaBatchLookupResult {});
         }
+        debug_assert!(
+            cells.is_sorted_by_key(|(hash, _, _)| *hash),
+            "Cells must be sorted by key hash"
+        );
         #[allow(unused_mut, reason = "It's used when stats are enabled")]
         let mut lookup_result = MetaBatchLookupResult::default();
         for entry in self.entries.iter().rev() {

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -1185,17 +1185,17 @@ fn batch_get_with_overwrites() -> Result<()> {
 
     assert_eq!(results.len(), 50);
     // First 25 should have new values
-    for i in 0..25 {
+    for (i, result) in results.iter().enumerate().take(25) {
         assert_eq!(
-            results[i].as_deref(),
+            result.as_deref(),
             Some(&[i as u8 + 100][..]),
             "Failed at index {i}"
         );
     }
     // Last 25 should have original values
-    for i in 25..50 {
+    for (i, result) in results.iter().enumerate().skip(25) {
         assert_eq!(
-            results[i].as_deref(),
+            result.as_deref(),
             Some(&[i as u8][..]),
             "Failed at index {i}"
         );

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -837,3 +837,469 @@ fn merge_file_removal() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn batch_get_basic() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+        path.to_path_buf(),
+        RayonParallelScheduler,
+    )?;
+
+    // Write some test data
+    let batch = db.write_batch()?;
+    for i in 0..100u8 {
+        batch.put(0, vec![i], vec![i].into())?;
+    }
+    db.commit_write_batch(batch)?;
+
+    // Test batch_get with mixed existing and non-existing keys
+    let keys_to_fetch = vec![vec![10u8], vec![20u8], vec![200u8], vec![50u8], vec![255u8]];
+    let results = db.batch_get(0, &keys_to_fetch)?;
+
+    assert_eq!(results.len(), 5);
+    assert_eq!(results[0].as_deref(), Some(&[10u8][..]));
+    assert_eq!(results[1].as_deref(), Some(&[20u8][..]));
+    assert_eq!(results[2], None); // 200 doesn't exist
+    assert_eq!(results[3].as_deref(), Some(&[50u8][..]));
+    assert_eq!(results[4], None); // 255 doesn't exist
+
+    db.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn batch_get_all_existing() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+        path.to_path_buf(),
+        RayonParallelScheduler,
+    )?;
+
+    // Write test data
+    let batch = db.write_batch()?;
+    for i in 0..50u8 {
+        batch.put(0, vec![i], vec![i * 2].into())?;
+    }
+    db.commit_write_batch(batch)?;
+
+    // Fetch all existing keys
+    let keys_to_fetch: Vec<Vec<u8>> = (0..50u8).map(|i| vec![i]).collect();
+    let results = db.batch_get(0, &keys_to_fetch)?;
+
+    assert_eq!(results.len(), 50);
+    for (i, result) in results.iter().enumerate() {
+        assert_eq!(result.as_deref(), Some(&[(i * 2) as u8][..]));
+    }
+
+    db.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn batch_get_none_existing() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+        path.to_path_buf(),
+        RayonParallelScheduler,
+    )?;
+
+    // Write some data but query different keys
+    let batch = db.write_batch()?;
+    for i in 0..10u8 {
+        batch.put(0, vec![i], vec![i].into())?;
+    }
+    db.commit_write_batch(batch)?;
+
+    // Fetch non-existing keys
+    let keys_to_fetch: Vec<Vec<u8>> = (100..110u8).map(|i| vec![i]).collect();
+    let results = db.batch_get(0, &keys_to_fetch)?;
+
+    assert_eq!(results.len(), 10);
+    for result in results.iter() {
+        assert_eq!(result, &None);
+    }
+
+    db.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn batch_get_empty() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+        path.to_path_buf(),
+        RayonParallelScheduler,
+    )?;
+
+    // Write some data
+    let batch = db.write_batch()?;
+    batch.put(0, vec![1u8], vec![1u8].into())?;
+    db.commit_write_batch(batch)?;
+
+    // Fetch with empty key list
+    let keys_to_fetch: Vec<Vec<u8>> = vec![];
+    let results = db.batch_get(0, &keys_to_fetch)?;
+
+    assert_eq!(results.len(), 0);
+
+    db.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn batch_get_duplicate_keys() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+        path.to_path_buf(),
+        RayonParallelScheduler,
+    )?;
+
+    // Write test data
+    let batch = db.write_batch()?;
+    batch.put(0, vec![42u8], vec![100u8].into())?;
+    batch.put(0, vec![43u8], vec![101u8].into())?;
+    db.commit_write_batch(batch)?;
+
+    // Fetch with duplicate keys - results should maintain order
+    let keys_to_fetch = vec![
+        vec![42u8],
+        vec![43u8],
+        vec![42u8],
+        vec![99u8], // non-existing
+        vec![42u8],
+    ];
+    let results = db.batch_get(0, &keys_to_fetch)?;
+
+    assert_eq!(results.len(), 5);
+    assert_eq!(results[0].as_deref(), Some(&[100u8][..]));
+    assert_eq!(results[1].as_deref(), Some(&[101u8][..]));
+    assert_eq!(results[2].as_deref(), Some(&[100u8][..]));
+    assert_eq!(results[3], None);
+    assert_eq!(results[4].as_deref(), Some(&[100u8][..]));
+
+    db.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn batch_get_large_batch() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+        path.to_path_buf(),
+        RayonParallelScheduler,
+    )?;
+
+    // Write many entries
+    let batch = db.write_batch()?;
+    for i in 0..1000u32 {
+        batch.put(
+            0,
+            i.to_be_bytes().to_vec(),
+            (i * 2).to_be_bytes().to_vec().into(),
+        )?;
+    }
+    db.commit_write_batch(batch)?;
+
+    // Fetch a large batch (every 10th entry)
+    let keys_to_fetch: Vec<Vec<u8>> = (0..1000u32)
+        .filter(|i| i % 10 == 0)
+        .map(|i| i.to_be_bytes().to_vec())
+        .collect();
+    let results = db.batch_get(0, &keys_to_fetch)?;
+
+    assert_eq!(results.len(), 100);
+    for (idx, i) in (0..1000u32).filter(|i| i % 10 == 0).enumerate() {
+        assert_eq!(
+            results[idx].as_deref(),
+            Some(&(i * 2).to_be_bytes()[..]),
+            "Failed at index {idx} for key {i}"
+        );
+    }
+
+    db.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn batch_get_different_sizes() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+        path.to_path_buf(),
+        RayonParallelScheduler,
+    )?;
+
+    // Write values of different sizes
+    let batch = db.write_batch()?;
+    batch.put(0, vec![1u8], vec![1u8; 10].into())?; // small
+    batch.put(0, vec![2u8], vec![2u8; 1024].into())?; // medium
+    batch.put(0, vec![3u8], vec![3u8; 10 * 1024].into())?; // larger
+    db.commit_write_batch(batch)?;
+
+    // Fetch all with different sizes
+    let keys_to_fetch = vec![vec![1u8], vec![2u8], vec![3u8], vec![4u8]];
+    let results = db.batch_get(0, &keys_to_fetch)?;
+
+    assert_eq!(results.len(), 4);
+    assert_eq!(results[0].as_deref(), Some(&vec![1u8; 10][..]));
+    assert_eq!(results[1].as_deref(), Some(&vec![2u8; 1024][..]));
+    assert_eq!(results[2].as_deref(), Some(&vec![3u8; 10 * 1024][..]));
+    assert_eq!(results[3], None);
+
+    db.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn batch_get_across_families() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+        path.to_path_buf(),
+        RayonParallelScheduler,
+    )?;
+
+    // Write to multiple families
+    let batch = db.write_batch()?;
+    for family in 0..4u32 {
+        for i in 0..20u8 {
+            batch.put(family, vec![i], vec![family as u8, i].into())?;
+        }
+    }
+    db.commit_write_batch(batch)?;
+
+    // Fetch from each family separately
+    for family in 0..4usize {
+        let keys_to_fetch: Vec<Vec<u8>> = (0..20u8).map(|i| vec![i]).collect();
+        let results = db.batch_get(family, &keys_to_fetch)?;
+
+        assert_eq!(results.len(), 20);
+        for (i, result) in results.iter().enumerate() {
+            assert_eq!(
+                result.as_deref(),
+                Some(&vec![family as u8, i as u8][..]),
+                "Failed at family {family}, index {i}"
+            );
+        }
+    }
+
+    // Verify family isolation - keys from family 0 shouldn't be in family 1
+    let keys_to_fetch: Vec<Vec<u8>> = (0..20u8).map(|i| vec![i]).collect();
+    let results_f0 = db.batch_get(0, &keys_to_fetch)?;
+    let results_f1 = db.batch_get(1, &keys_to_fetch)?;
+
+    // Same keys, but different values per family
+    assert_ne!(results_f0[0].as_deref(), results_f1[0].as_deref());
+
+    db.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn batch_get_after_compaction() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+        path.to_path_buf(),
+        RayonParallelScheduler,
+    )?;
+
+    // Write data across multiple batches to create multiple SST files
+    for batch_num in 0..5u8 {
+        let batch = db.write_batch()?;
+        for i in 0..20u8 {
+            let key = batch_num * 20 + i;
+            batch.put(0, vec![key], vec![key].into())?;
+        }
+        db.commit_write_batch(batch)?;
+    }
+
+    // Fetch before compaction
+    let keys_to_fetch: Vec<Vec<u8>> = (0..100u8).map(|i| vec![i]).collect();
+    let results_before = db.batch_get(0, &keys_to_fetch)?;
+
+    // Compact database
+    db.full_compact()?;
+
+    // Fetch after compaction
+    let results_after = db.batch_get(0, &keys_to_fetch)?;
+
+    // Results should be identical
+    assert_eq!(results_before.len(), results_after.len());
+    for i in 0..100 {
+        assert_eq!(
+            results_before[i].as_deref(),
+            results_after[i].as_deref(),
+            "Mismatch at index {i}"
+        );
+        assert_eq!(results_after[i].as_deref(), Some(&[i as u8][..]));
+    }
+
+    db.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn batch_get_with_overwrites() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+        path.to_path_buf(),
+        RayonParallelScheduler,
+    )?;
+
+    // Write initial data
+    let batch = db.write_batch()?;
+    for i in 0..50u8 {
+        batch.put(0, vec![i], vec![i].into())?;
+    }
+    db.commit_write_batch(batch)?;
+
+    // Overwrite some keys
+    let batch = db.write_batch()?;
+    for i in 0..25u8 {
+        batch.put(0, vec![i], vec![i + 100].into())?;
+    }
+    db.commit_write_batch(batch)?;
+
+    // Fetch all keys
+    let keys_to_fetch: Vec<Vec<u8>> = (0..50u8).map(|i| vec![i]).collect();
+    let results = db.batch_get(0, &keys_to_fetch)?;
+
+    assert_eq!(results.len(), 50);
+    // First 25 should have new values
+    for i in 0..25 {
+        assert_eq!(
+            results[i].as_deref(),
+            Some(&[i as u8 + 100][..]),
+            "Failed at index {i}"
+        );
+    }
+    // Last 25 should have original values
+    for i in 25..50 {
+        assert_eq!(
+            results[i].as_deref(),
+            Some(&[i as u8][..]),
+            "Failed at index {i}"
+        );
+    }
+
+    db.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn batch_get_comparison_with_get() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+        path.to_path_buf(),
+        RayonParallelScheduler,
+    )?;
+
+    // Write test data
+    let batch = db.write_batch()?;
+    for i in 0..100u32 {
+        batch.put(
+            0,
+            i.to_be_bytes().to_vec(),
+            (i * 3).to_be_bytes().to_vec().into(),
+        )?;
+    }
+    db.commit_write_batch(batch)?;
+
+    // Prepare keys
+    let keys_to_fetch: Vec<Vec<u8>> = (0..150u32)
+        .filter(|i| i % 3 == 0)
+        .map(|i| i.to_be_bytes().to_vec())
+        .collect();
+
+    // Get results using batch_get
+    let batch_results = db.batch_get(0, &keys_to_fetch)?;
+
+    // Get results using individual get calls
+    let mut individual_results = Vec::new();
+    for key in &keys_to_fetch {
+        individual_results.push(db.get(0, key)?);
+    }
+
+    // Compare results
+    assert_eq!(batch_results.len(), individual_results.len());
+    for (i, (batch_result, individual_result)) in batch_results
+        .iter()
+        .zip(individual_results.iter())
+        .enumerate()
+    {
+        assert_eq!(
+            batch_result.as_deref(),
+            individual_result.as_deref(),
+            "Mismatch at index {i}"
+        );
+    }
+
+    db.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn batch_get_after_restore() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    // Write data and close
+    {
+        let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+            path.to_path_buf(),
+            RayonParallelScheduler,
+        )?;
+
+        let batch = db.write_batch()?;
+        for i in 0..100u8 {
+            batch.put(0, vec![i], vec![i, i + 1].into())?;
+        }
+        db.commit_write_batch(batch)?;
+        db.shutdown()?;
+    }
+
+    // Reopen and test batch_get
+    {
+        let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+            path.to_path_buf(),
+            RayonParallelScheduler,
+        )?;
+
+        let keys_to_fetch: Vec<Vec<u8>> = (0..100u8).step_by(5).map(|i| vec![i]).collect();
+        let results = db.batch_get(0, &keys_to_fetch)?;
+
+        assert_eq!(results.len(), 20);
+        for (idx, i) in (0..100u8).step_by(5).enumerate() {
+            assert_eq!(
+                results[idx].as_deref(),
+                Some(&vec![i, i + 1][..]),
+                "Failed at index {idx} for key {i}"
+            );
+        }
+
+        db.shutdown()?;
+    }
+
+    Ok(())
+}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1639,7 +1639,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             let mut task = ctx.task(task_id, TaskDataCategory::All);
             if let Some(tasks) = task.prefetch() {
                 drop(task);
-                ctx.prepare_tasks(tasks.into_iter());
+                ctx.prepare_tasks(tasks);
                 task = ctx.task(task_id, TaskDataCategory::All);
             }
             let in_progress = remove!(task, InProgress)?;

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2170,6 +2170,14 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
     ) {
         debug_assert!(!output_dependent_tasks.is_empty());
 
+        if output_dependent_tasks.len() > 1 {
+            ctx.prepare_tasks(
+                output_dependent_tasks
+                    .iter()
+                    .map(|&id| (id, TaskDataCategory::All)),
+            );
+        }
+
         let mut queue = AggregationUpdateQueue::new();
         for dependent_task_id in output_dependent_tasks {
             #[cfg(feature = "trace_task_output_dependencies")]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -4,12 +4,10 @@ mod storage;
 
 use std::{
     borrow::Cow,
-    cmp::min,
     fmt::{self, Write},
     future::Future,
     hash::BuildHasherDefault,
     mem::take,
-    ops::Range,
     pin::Pin,
     sync::{
         Arc, LazyLock,
@@ -26,8 +24,8 @@ use smallvec::{SmallVec, smallvec};
 use tokio::time::{Duration, Instant};
 use tracing::{Span, trace_span};
 use turbo_tasks::{
-    CellId, FxDashMap, FxIndexMap, KeyValuePair, RawVc, ReadCellOptions, ReadConsistency,
-    ReadOutputOptions, ReadTracking, TRANSIENT_TASK_BIT, TaskExecutionReason, TaskId, TraitTypeId,
+    CellId, FxDashMap, KeyValuePair, RawVc, ReadCellOptions, ReadConsistency, ReadOutputOptions,
+    ReadTracking, TRANSIENT_TASK_BIT, TaskExecutionReason, TaskId, TraitTypeId,
     TurboTasksBackendApi, ValueTypeId,
     backend::{
         Backend, CachedTaskType, CellContent, TaskExecutionSpec, TransientTaskRoot,
@@ -39,7 +37,7 @@ use turbo_tasks::{
     task_statistics::TaskStatisticsApi,
     trace::TraceRawVcs,
     turbo_tasks,
-    util::{IdFactoryWithReuse, good_chunk_size},
+    util::IdFactoryWithReuse,
 };
 
 pub use self::{operation::AnyOperation, storage::TaskDataCategory};
@@ -169,10 +167,6 @@ impl Default for BackendOptions {
 pub enum TurboTasksBackendJob {
     InitialSnapshot,
     FollowUpSnapshot,
-    Prefetch {
-        data: Arc<FxIndexMap<TaskId, bool>>,
-        range: Option<Range<usize>>,
-    },
 }
 
 pub struct TurboTasksBackend<B: BackingStorage>(Arc<TurboTasksBackendInner<B>>);
@@ -1643,6 +1637,11 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         {
             let mut ctx = self.execute_context(turbo_tasks);
             let mut task = ctx.task(task_id, TaskDataCategory::All);
+            if let Some(tasks) = task.prefetch() {
+                drop(task);
+                ctx.prepare_tasks(tasks.into_iter());
+                task = ctx.task(task_id, TaskDataCategory::All);
+            }
             let in_progress = remove!(task, InProgress)?;
             let InProgressState::Scheduled { done_event, reason } = in_progress else {
                 task.add_new(CachedDataItem::InProgress { value: in_progress });
@@ -2577,41 +2576,6 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                             );
                             return;
                         }
-                    }
-                }
-                TurboTasksBackendJob::Prefetch { data, range } => {
-                    let range: Range<usize> = if let Some(range) = range {
-                        range
-                    } else {
-                        if data.len() > 128 {
-                            let chunk_size = good_chunk_size(data.len());
-                            let chunks = data.len().div_ceil(chunk_size);
-                            for i in 0..chunks {
-                                turbo_tasks.schedule_backend_background_job(
-                                    TurboTasksBackendJob::Prefetch {
-                                        data: data.clone(),
-                                        range: Some(
-                                            (i * chunk_size)..min(data.len(), (i + 1) * chunk_size),
-                                        ),
-                                    },
-                                );
-                            }
-                            return;
-                        }
-                        0..data.len()
-                    };
-
-                    let _span = trace_span!("prefetching").entered();
-                    let mut ctx = self.execute_context(turbo_tasks);
-                    for i in range {
-                        let (&task, &with_data) = data.get_index(i).unwrap();
-                        let category = if with_data {
-                            TaskDataCategory::All
-                        } else {
-                            TaskDataCategory::Meta
-                        };
-                        // Prefetch the task
-                        drop(ctx.task(task, category));
                     }
                 }
             }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2235,9 +2235,9 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         debug_assert!(!new_children.is_empty());
 
         let mut queue = AggregationUpdateQueue::new();
-        for &child_id in new_children {
-            let child_task = ctx.task(child_id, TaskDataCategory::Meta);
+        ctx.for_each_task_meta(new_children.iter().copied(), |child_task, ctx| {
             if !child_task.has_key(&CachedDataItemKey::Output {}) {
+                let child_id = child_task.id();
                 make_task_dirty_internal(
                     child_task,
                     child_id,
@@ -2248,7 +2248,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     ctx,
                 );
             }
-        }
+        });
 
         queue.execute(ctx);
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1501,12 +1501,8 @@ impl AggregationUpdateQueue {
         ctx: &mut impl ExecuteContext,
         update: AggregatedDataUpdate,
     ) {
-        for upper_id in upper_ids {
-            let mut upper = ctx.task(
-                upper_id,
-                // For performance reasons this should stay `Meta` and not `All`
-                TaskDataCategory::Meta,
-            );
+        // For performance reasons this should stay `Meta` and not `All`
+        ctx.for_each_task_meta(upper_ids.iter().copied(), |mut upper, ctx| {
             let diff = update.apply(&mut upper, ctx.should_track_activeness(), self);
             if !diff.is_empty() {
                 let upper_ids = get_uppers(&upper);
@@ -1520,7 +1516,7 @@ impl AggregationUpdateQueue {
                     );
                 }
             }
-        }
+        });
     }
 
     fn inner_of_uppers_lost_follower(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1952,13 +1952,9 @@ impl AggregationUpdateQueue {
 
                 let has_data = !data.is_empty();
                 if has_data || !is_active {
-                    for upper_id in upper_ids.iter() {
-                        // add data to upper
-                        let mut upper = ctx.task(
-                            *upper_id,
-                            // For performance reasons this should stay `Meta` and not `All`
-                            TaskDataCategory::Meta,
-                        );
+                    // add data to upper
+                    // For performance reasons this should stay `Meta` and not `All`
+                    ctx.for_each_task_meta(upper_ids.iter().copied(), |mut upper, ctx| {
                         if has_data {
                             let diff = data.apply(&mut upper, ctx.should_track_activeness(), self);
                             if !diff.is_empty() {
@@ -1979,7 +1975,7 @@ impl AggregationUpdateQueue {
                                 is_active = true;
                             }
                         }
-                    }
+                    });
                 }
                 if !children.is_empty() {
                     self.push(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1561,13 +1561,9 @@ impl AggregationUpdateQueue {
                 drop(follower);
 
                 if !data.is_empty() {
-                    for upper_id in removed_uppers.iter() {
-                        // remove data from upper
-                        let mut upper = ctx.task(
-                            *upper_id,
-                            // For performance reasons this should stay `Meta` and not `All`
-                            TaskDataCategory::Meta,
-                        );
+                    // remove data from upper
+                    // For performance reasons this should stay `Meta` and not `All`
+                    ctx.for_each_task_meta(removed_uppers.iter().copied(), |mut upper, ctx| {
                         let diff = data.apply(&mut upper, ctx.should_track_activeness(), self);
                         if !diff.is_empty() {
                             let upper_ids = get_uppers(&upper);
@@ -1579,7 +1575,7 @@ impl AggregationUpdateQueue {
                                 .into(),
                             )
                         }
-                    }
+                    });
                 }
                 if !followers.is_empty() {
                     self.push(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -215,12 +215,11 @@ where
     }
 
     fn get_tx(&self) -> Option<&<B as BackingStorageSealed>::ReadTransaction<'tx>> {
-        let tx = match &self.transaction {
+        match &self.transaction {
             TransactionState::None => unreachable!(),
             TransactionState::Borrowed(tx) => *tx,
             TransactionState::Owned(tx) => tx.as_ref(),
-        };
-        tx
+        }
     }
 
     fn prepare_tasks_with_callback(
@@ -307,7 +306,7 @@ where
                 self.restore_task_data_batch(&tasks_to_restore_for_data, TaskDataCategory::Data)
             {
                 data.into_iter()
-                    .zip(tasks_to_restore_for_data_indicies.into_iter())
+                    .zip(tasks_to_restore_for_data_indicies)
                     .for_each(|(items, idx)| {
                         tasks[idx].2 = Some(items);
                     });
@@ -322,7 +321,7 @@ where
                 self.restore_task_data_batch(&tasks_to_restore_for_meta, TaskDataCategory::Meta)
             {
                 data.into_iter()
-                    .zip(tasks_to_restore_for_meta_indicies.into_iter())
+                    .zip(tasks_to_restore_for_meta_indicies)
                     .for_each(|(items, idx)| {
                         tasks[idx].3 = Some(items);
                     });

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -10,7 +10,7 @@ mod update_collectible;
 use std::{
     fmt::{Debug, Formatter},
     mem::transmute,
-    sync::{Arc, atomic::Ordering},
+    sync::atomic::Ordering,
 };
 
 use bincode::{Decode, Encode};
@@ -103,7 +103,7 @@ where
     _operation_guard: Option<OperationGuard<'e, B>>,
     transaction: TransactionState<'e, 'tx, B>,
     #[cfg(debug_assertions)]
-    active_task_locks: Arc<std::sync::atomic::AtomicU8>,
+    active_task_locks: std::sync::Arc<std::sync::atomic::AtomicU8>,
 }
 
 impl<'e, 'tx, B: BackingStorage> ExecuteContextImpl<'e, 'tx, B>
@@ -120,7 +120,7 @@ where
             _operation_guard: Some(backend.start_operation()),
             transaction: TransactionState::None,
             #[cfg(debug_assertions)]
-            active_task_locks: Arc::new(std::sync::atomic::AtomicU8::new(0)),
+            active_task_locks: std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0)),
         }
     }
 
@@ -135,7 +135,7 @@ where
             _operation_guard: Some(backend.start_operation()),
             transaction: TransactionState::Borrowed(transaction),
             #[cfg(debug_assertions)]
-            active_task_locks: Arc::new(std::sync::atomic::AtomicU8::new(0)),
+            active_task_locks: std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0)),
         }
     }
 
@@ -584,7 +584,7 @@ impl<'e, B: BackingStorage> ChildExecuteContext<'e> for ChildExecuteContextImpl<
             _operation_guard: None,
             transaction: TransactionState::None,
             #[cfg(debug_assertions)]
-            active_task_locks: Arc::new(std::sync::atomic::AtomicU8::new(0)),
+            active_task_locks: std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0)),
         }
     }
 }
@@ -740,7 +740,7 @@ pub struct TaskGuardImpl<'a, B: BackingStorage> {
     #[cfg(debug_assertions)]
     category: TaskDataCategory,
     #[cfg(debug_assertions)]
-    active_task_locks: Arc<std::sync::atomic::AtomicU8>,
+    active_task_locks: std::sync::Arc<std::sync::atomic::AtomicU8>,
 }
 
 #[cfg(debug_assertions)]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -188,11 +188,10 @@ where
         &mut self,
         task_ids: &[TaskId],
         category: TaskDataCategory,
-    ) -> Vec<Vec<CachedDataItem>> {
+    ) -> Option<Vec<Vec<CachedDataItem>>> {
         if !self.ensure_transaction() {
-            // TODO this is an unnecessary allocation
-            // If we don't need to restore, we can just return an empty vector for each task
-            return vec![Vec::new(); task_ids.len()];
+            // If we don't need to restore, we return None
+            return None;
         }
         let tx = self.get_tx();
         // Safety: `tx` is a valid transaction from `self.backend.backing_storage`.
@@ -202,7 +201,7 @@ where
                 .batch_lookup_data(tx, task_ids, category)
         };
         match result {
-            Ok(result) => result,
+            Ok(result) => Some(result),
             Err(e) => {
                 panic!(
                     "Failed to restore task data (corrupted database or bug): {:?}",
@@ -304,22 +303,34 @@ where
         }
 
         if !tasks_to_restore_for_data.is_empty() {
-            let data =
-                self.restore_task_data_batch(&tasks_to_restore_for_data, TaskDataCategory::Data);
-            data.into_iter()
-                .zip(tasks_to_restore_for_data_indicies.into_iter())
-                .for_each(|(items, idx)| {
-                    tasks[idx].2 = Some(items);
-                });
+            if let Some(data) =
+                self.restore_task_data_batch(&tasks_to_restore_for_data, TaskDataCategory::Data)
+            {
+                data.into_iter()
+                    .zip(tasks_to_restore_for_data_indicies.into_iter())
+                    .for_each(|(items, idx)| {
+                        tasks[idx].2 = Some(items);
+                    });
+            } else {
+                for idx in tasks_to_restore_for_data_indicies {
+                    tasks[idx].2 = Some(Vec::new());
+                }
+            }
         }
         if !tasks_to_restore_for_meta.is_empty() {
-            let data =
-                self.restore_task_data_batch(&tasks_to_restore_for_meta, TaskDataCategory::Meta);
-            data.into_iter()
-                .zip(tasks_to_restore_for_meta_indicies.into_iter())
-                .for_each(|(items, idx)| {
-                    tasks[idx].3 = Some(items);
-                });
+            if let Some(data) =
+                self.restore_task_data_batch(&tasks_to_restore_for_meta, TaskDataCategory::Meta)
+            {
+                data.into_iter()
+                    .zip(tasks_to_restore_for_meta_indicies.into_iter())
+                    .for_each(|(items, idx)| {
+                        tasks[idx].3 = Some(items);
+                    });
+            } else {
+                for idx in tasks_to_restore_for_meta_indicies {
+                    tasks[idx].3 = Some(Vec::new());
+                }
+            }
         }
 
         for (task_id, category, items_for_data, items_for_meta) in tasks {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -21,7 +21,6 @@ use turbo_tasks::{
 use crate::{
     backend::{
         OperationGuard, TaskDataCategory, TransientTask, TurboTasksBackend, TurboTasksBackendInner,
-        TurboTasksBackendJob,
         storage::{SpecificTaskDataCategory, StorageWriteGuard, get, iter_many, remove},
     },
     backing_storage::{BackingStorage, BackingStorageSealed},
@@ -545,14 +544,7 @@ where
         self.schedule_task(task);
     }
 
-    fn schedule_task(&self, mut task: Self::TaskGuardImpl) {
-        if let Some(tasks_to_prefetch) = task.prefetch() {
-            self.turbo_tasks
-                .schedule_backend_background_job(TurboTasksBackendJob::Prefetch {
-                    data: Arc::new(tasks_to_prefetch),
-                    range: None,
-                });
-        }
+    fn schedule_task(&self, task: Self::TaskGuardImpl) {
         self.turbo_tasks.schedule(task.id());
     }
 
@@ -650,7 +642,10 @@ pub trait TaskGuard: Debug {
     where
         F: for<'a> FnMut(CachedDataItemKey, CachedDataItemValueRef<'a>) -> bool + 'l;
     fn invalidate_serialization(&mut self);
-    fn prefetch(&mut self) -> Option<FxIndexMap<TaskId, bool>>;
+    /// Determine which tasks to prefetch for a task.
+    /// Only returns Some once per task.
+    /// It returns a set of tasks and which info is needed.
+    fn prefetch(&mut self) -> Option<FxIndexMap<TaskId, TaskDataCategory>>;
     fn is_immutable(&self) -> bool;
     fn is_dirty(&self) -> bool {
         get!(self, Dirty).is_some_and(|dirtyness| match dirtyness {
@@ -984,18 +979,16 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
         }
     }
 
-    fn prefetch(&mut self) -> Option<FxIndexMap<TaskId, bool>> {
-        if !self.task.state().prefetched() {
-            self.task.state_mut().set_prefetched(true);
-            let map = iter_many!(self, OutputDependency { target } => (target, false))
-                .chain(iter_many!(self, CellDependency { target } => (target.task, true)))
-                .chain(iter_many!(self, CollectiblesDependency { target } => (target.task, true)))
-                .collect::<FxIndexMap<_, _>>();
-            if map.len() > 16 {
-                return Some(map);
-            }
+    fn prefetch(&mut self) -> Option<FxIndexMap<TaskId, TaskDataCategory>> {
+        if self.task.state().prefetched() {
+            return None;
         }
-        None
+        self.task.state_mut().set_prefetched(true);
+        let map = iter_many!(self, OutputDependency { target } => (target, TaskDataCategory::Meta))
+            .chain(iter_many!(self, CellDependency { target } => (target.task, TaskDataCategory::All)))
+            .chain(iter_many!(self, CollectiblesDependency { target } => (target.task, TaskDataCategory::All)))
+            .collect::<FxIndexMap<_, _>>();
+        (map.len() > 1).then_some(map)
     }
 
     fn is_immutable(&self) -> bool {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         TurboTasksBackendJob,
         storage::{SpecificTaskDataCategory, StorageWriteGuard, get, iter_many, remove},
     },
-    backing_storage::BackingStorage,
+    backing_storage::{BackingStorage, BackingStorageSealed},
     data::{
         CachedDataItem, CachedDataItemKey, CachedDataItemType, CachedDataItemValue,
         CachedDataItemValueRef, CachedDataItemValueRefMut, Dirtyness,
@@ -50,6 +50,27 @@ pub trait ExecuteContext<'e>: Sized {
     where
         'e: 'l;
     fn task(&mut self, task_id: TaskId, category: TaskDataCategory) -> Self::TaskGuardImpl;
+    /// Prepares (as in fetches from persistent storage) a list of tasks.
+    /// The iterator should not have duplicates, as this would cause over-fetching.
+    fn prepare_tasks(
+        &mut self,
+        task_ids: impl IntoIterator<Item = (TaskId, TaskDataCategory)> + Clone,
+    );
+    fn for_each_task(
+        &mut self,
+        task_ids: impl IntoIterator<Item = (TaskId, TaskDataCategory)>,
+        func: impl FnMut(Self::TaskGuardImpl, &mut Self),
+    );
+    fn for_each_task_meta(
+        &mut self,
+        task_ids: impl IntoIterator<Item = TaskId>,
+        func: impl FnMut(Self::TaskGuardImpl, &mut Self),
+    ) {
+        self.for_each_task(
+            task_ids.into_iter().map(|id| (id, TaskDataCategory::Meta)),
+            func,
+        )
+    }
     fn is_once_task(&self, task_id: TaskId) -> bool;
     fn task_pair(
         &mut self,
@@ -119,17 +140,12 @@ where
         }
     }
 
-    fn restore_task_data(
-        &mut self,
-        task_id: TaskId,
-        category: TaskDataCategory,
-    ) -> Vec<CachedDataItem> {
+    fn ensure_transaction(&mut self) -> bool {
         if matches!(self.transaction, TransactionState::None) {
             let check_backing_storage = self.backend.should_restore()
                 && self.backend.local_is_partial.load(Ordering::Acquire);
             if !check_backing_storage {
-                // If we don't need to restore, we can just return an empty vector
-                return Vec::new();
+                return false;
             }
             let tx = self.backend.backing_storage.start_read_transaction();
             let tx = tx.map(|tx| {
@@ -138,11 +154,19 @@ where
             });
             self.transaction = TransactionState::Owned(tx);
         }
-        let tx = match &self.transaction {
-            TransactionState::None => unreachable!(),
-            TransactionState::Borrowed(tx) => *tx,
-            TransactionState::Owned(tx) => tx.as_ref(),
-        };
+        true
+    }
+
+    fn restore_task_data(
+        &mut self,
+        task_id: TaskId,
+        category: TaskDataCategory,
+    ) -> Vec<CachedDataItem> {
+        if !self.ensure_transaction() {
+            // If we don't need to restore, we can just return an empty vector
+            return Vec::new();
+        }
+        let tx = self.get_tx();
         // Safety: `tx` is a valid transaction from `self.backend.backing_storage`.
         let result = unsafe {
             self.backend
@@ -158,6 +182,181 @@ where
                     e.context(format!("{category:?} for {task_name} ({task_id}))"))
                 )
             }
+        }
+    }
+
+    fn restore_task_data_batch(
+        &mut self,
+        task_ids: &[TaskId],
+        category: TaskDataCategory,
+    ) -> Vec<Vec<CachedDataItem>> {
+        if !self.ensure_transaction() {
+            // TODO this is an unnecessary allocation
+            // If we don't need to restore, we can just return an empty vector for each task
+            return vec![Vec::new(); task_ids.len()];
+        }
+        let tx = self.get_tx();
+        // Safety: `tx` is a valid transaction from `self.backend.backing_storage`.
+        let result = unsafe {
+            self.backend
+                .backing_storage
+                .batch_lookup_data(tx, task_ids, category)
+        };
+        match result {
+            Ok(result) => result,
+            Err(e) => {
+                panic!(
+                    "Failed to restore task data (corrupted database or bug): {:?}",
+                    e.context(format!(
+                        "{category:?} for batch of {} tasks",
+                        task_ids.len()
+                    ))
+                )
+            }
+        }
+    }
+
+    fn get_tx(&self) -> Option<&<B as BackingStorageSealed>::ReadTransaction<'tx>> {
+        let tx = match &self.transaction {
+            TransactionState::None => unreachable!(),
+            TransactionState::Borrowed(tx) => *tx,
+            TransactionState::Owned(tx) => tx.as_ref(),
+        };
+        tx
+    }
+
+    fn prepare_tasks_with_callback(
+        &mut self,
+        task_ids: impl IntoIterator<Item = (TaskId, TaskDataCategory)>,
+        call_prepared_task_callback_for_transient_tasks: bool,
+        mut prepared_task_callback: impl FnMut(
+            &mut Self,
+            TaskId,
+            TaskDataCategory,
+            StorageWriteGuard<'e>,
+        ),
+    ) {
+        let mut data_count = 0;
+        let mut meta_count = 0;
+        let mut all_count = 0;
+        let mut tasks = task_ids
+            .into_iter()
+            .filter(|&(id, category)| {
+                if id.is_transient() {
+                    if call_prepared_task_callback_for_transient_tasks {
+                        let mut task = self.backend.storage.access_mut(id);
+                        if !task.state().is_restored(category) {
+                            task.state_mut().set_restored(TaskDataCategory::All);
+                        }
+                        prepared_task_callback(self, id, category, task);
+                    }
+                    false
+                } else {
+                    true
+                }
+            })
+            .inspect(|(_, category)| match category {
+                TaskDataCategory::Data => data_count += 1,
+                TaskDataCategory::Meta => meta_count += 1,
+                TaskDataCategory::All => all_count += 1,
+            })
+            .map(|(id, category)| (id, category, None, None))
+            .collect::<Vec<_>>();
+        data_count += all_count;
+        meta_count += all_count;
+
+        let mut tasks_to_restore_for_data = Vec::with_capacity(data_count);
+        let mut tasks_to_restore_for_data_indicies = Vec::with_capacity(data_count);
+        let mut tasks_to_restore_for_meta = Vec::with_capacity(meta_count);
+        let mut tasks_to_restore_for_meta_indicies = Vec::with_capacity(meta_count);
+        for (i, &(task_id, category, _, _)) in tasks.iter().enumerate() {
+            #[cfg(debug_assertions)]
+            if self.active_task_locks.fetch_add(1, Ordering::AcqRel) != 0 {
+                panic!(
+                    "Concurrent task lock acquisition detected. This is not allowed and indicates \
+                     a bug. It can lead to deadlocks."
+                );
+            }
+
+            let task = self.backend.storage.access_mut(task_id);
+            let mut ready = true;
+            if matches!(category, TaskDataCategory::Data | TaskDataCategory::All)
+                && !task.state().is_restored(TaskDataCategory::Data)
+            {
+                tasks_to_restore_for_data.push(task_id);
+                tasks_to_restore_for_data_indicies.push(i);
+                ready = false;
+            }
+            if matches!(category, TaskDataCategory::Meta | TaskDataCategory::All)
+                && !task.state().is_restored(TaskDataCategory::Meta)
+            {
+                tasks_to_restore_for_meta.push(task_id);
+                tasks_to_restore_for_meta_indicies.push(i);
+                ready = false;
+            }
+            if ready {
+                prepared_task_callback(self, task_id, category, task);
+            }
+            #[cfg(debug_assertions)]
+            self.active_task_locks.fetch_sub(1, Ordering::AcqRel);
+        }
+        if tasks_to_restore_for_meta.is_empty() && tasks_to_restore_for_data.is_empty() {
+            return;
+        }
+
+        if !tasks_to_restore_for_data.is_empty() {
+            let data =
+                self.restore_task_data_batch(&tasks_to_restore_for_data, TaskDataCategory::Data);
+            data.into_iter()
+                .zip(tasks_to_restore_for_data_indicies.into_iter())
+                .for_each(|(items, idx)| {
+                    tasks[idx].2 = Some(items);
+                });
+        }
+        if !tasks_to_restore_for_meta.is_empty() {
+            let data =
+                self.restore_task_data_batch(&tasks_to_restore_for_meta, TaskDataCategory::Meta);
+            data.into_iter()
+                .zip(tasks_to_restore_for_meta_indicies.into_iter())
+                .for_each(|(items, idx)| {
+                    tasks[idx].3 = Some(items);
+                });
+        }
+
+        for (task_id, category, items_for_data, items_for_meta) in tasks {
+            if items_for_data.is_none() && items_for_meta.is_none() {
+                continue;
+            }
+            #[cfg(debug_assertions)]
+            if self.active_task_locks.fetch_add(1, Ordering::AcqRel) != 0 {
+                panic!(
+                    "Concurrent task lock acquisition detected. This is not allowed and indicates \
+                     a bug. It can lead to deadlocks."
+                );
+            }
+
+            let mut task = self.backend.storage.access_mut(task_id);
+            if let Some(items) = items_for_data
+                && !task.state().is_restored(TaskDataCategory::Data)
+            {
+                // TODO store items groups by type to be able to use extend here
+                for item in items {
+                    task.add(item);
+                }
+                task.state_mut().set_restored(TaskDataCategory::Data);
+            }
+            if let Some(items) = items_for_meta
+                && !task.state().is_restored(TaskDataCategory::Meta)
+            {
+                // TODO store items groups by type to be able to use extend here
+                for item in items {
+                    task.add(item);
+                }
+                task.state_mut().set_restored(TaskDataCategory::Meta);
+            }
+            prepared_task_callback(self, task_id, category, task);
+            #[cfg(debug_assertions)]
+            self.active_task_locks.fetch_sub(1, Ordering::AcqRel);
         }
     }
 }
@@ -218,6 +417,51 @@ where
             #[cfg(debug_assertions)]
             active_task_locks: self.active_task_locks.clone(),
         }
+    }
+
+    fn prepare_tasks(&mut self, task_ids: impl IntoIterator<Item = (TaskId, TaskDataCategory)>) {
+        self.prepare_tasks_with_callback(task_ids, false, |_, _, _, _| {});
+    }
+
+    fn for_each_task(
+        &mut self,
+        task_ids: impl IntoIterator<Item = (TaskId, TaskDataCategory)>,
+        mut func: impl FnMut(Self::TaskGuardImpl, &mut Self),
+    ) {
+        let backend = self.backend;
+        #[cfg(debug_assertions)]
+        let active_task_locks = self.active_task_locks.clone();
+        #[cfg(debug_assertions)]
+        let task_ids = task_ids.into_iter().collect::<Vec<_>>();
+        #[cfg(debug_assertions)]
+        let input_count = task_ids.len();
+        #[cfg(debug_assertions)]
+        let mut count = 0;
+        self.prepare_tasks_with_callback(task_ids, true, |this, task_id, category, task| {
+            // The prepare_tasks_with_callback already increased the active_task_locks count and
+            // checked for concurrent access but it will also decrement it again, so we
+            // need to increase it again here as Drop will decrement it
+            #[cfg(debug_assertions)]
+            active_task_locks.fetch_add(1, Ordering::AcqRel);
+
+            #[cfg(debug_assertions)]
+            {
+                count += 1;
+            }
+
+            let guard: TaskGuardImpl<'_, B> = TaskGuardImpl {
+                task,
+                task_id,
+                backend,
+                #[cfg(debug_assertions)]
+                category,
+                #[cfg(debug_assertions)]
+                active_task_locks: active_task_locks.clone(),
+            };
+            func(guard, this);
+        });
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(count, input_count);
     }
 
     fn is_once_task(&self, task_id: TaskId) -> bool {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -430,37 +430,24 @@ where
         let backend = self.backend;
         #[cfg(debug_assertions)]
         let active_task_locks = self.active_task_locks.clone();
-        #[cfg(debug_assertions)]
-        let task_ids = task_ids.into_iter().collect::<Vec<_>>();
-        #[cfg(debug_assertions)]
-        let input_count = task_ids.len();
-        #[cfg(debug_assertions)]
-        let mut count = 0;
-        self.prepare_tasks_with_callback(task_ids, true, |this, task_id, category, task| {
+        self.prepare_tasks_with_callback(task_ids, true, |this, task_id, _category, task| {
             // The prepare_tasks_with_callback already increased the active_task_locks count and
             // checked for concurrent access but it will also decrement it again, so we
             // need to increase it again here as Drop will decrement it
             #[cfg(debug_assertions)]
             active_task_locks.fetch_add(1, Ordering::AcqRel);
 
-            #[cfg(debug_assertions)]
-            {
-                count += 1;
-            }
-
             let guard: TaskGuardImpl<'_, B> = TaskGuardImpl {
                 task,
                 task_id,
                 backend,
                 #[cfg(debug_assertions)]
-                category,
+                category: _category,
                 #[cfg(debug_assertions)]
                 active_task_locks: active_task_locks.clone(),
             };
             func(guard, this);
         });
-        #[cfg(debug_assertions)]
-        debug_assert_eq!(count, input_count);
     }
 
     fn is_once_task(&self, task_id: TaskId) -> bool {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -189,6 +189,7 @@ where
         task_ids: &[TaskId],
         category: TaskDataCategory,
     ) -> Option<Vec<Vec<CachedDataItem>>> {
+        debug_assert!(task_ids.len() > 1, "Use restore_task_data for single task");
         if !self.ensure_transaction() {
             // If we don't need to restore, we return None
             return None;
@@ -301,33 +302,51 @@ where
             return;
         }
 
-        if !tasks_to_restore_for_data.is_empty() {
-            if let Some(data) =
-                self.restore_task_data_batch(&tasks_to_restore_for_data, TaskDataCategory::Data)
-            {
-                data.into_iter()
-                    .zip(tasks_to_restore_for_data_indicies)
-                    .for_each(|(items, idx)| {
-                        tasks[idx].2 = Some(items);
-                    });
-            } else {
-                for idx in tasks_to_restore_for_data_indicies {
-                    tasks[idx].2 = Some(Vec::new());
+        match tasks_to_restore_for_data.len() {
+            0 => {}
+            1 => {
+                let task_id = tasks_to_restore_for_data[0];
+                let data = self.restore_task_data(task_id, TaskDataCategory::Data);
+                let idx = tasks_to_restore_for_data_indicies[0];
+                tasks[idx].2 = Some(data);
+            }
+            _ => {
+                if let Some(data) =
+                    self.restore_task_data_batch(&tasks_to_restore_for_data, TaskDataCategory::Data)
+                {
+                    data.into_iter()
+                        .zip(tasks_to_restore_for_data_indicies)
+                        .for_each(|(items, idx)| {
+                            tasks[idx].2 = Some(items);
+                        });
+                } else {
+                    for idx in tasks_to_restore_for_data_indicies {
+                        tasks[idx].2 = Some(Vec::new());
+                    }
                 }
             }
         }
-        if !tasks_to_restore_for_meta.is_empty() {
-            if let Some(data) =
-                self.restore_task_data_batch(&tasks_to_restore_for_meta, TaskDataCategory::Meta)
-            {
-                data.into_iter()
-                    .zip(tasks_to_restore_for_meta_indicies)
-                    .for_each(|(items, idx)| {
-                        tasks[idx].3 = Some(items);
-                    });
-            } else {
-                for idx in tasks_to_restore_for_meta_indicies {
-                    tasks[idx].3 = Some(Vec::new());
+        match tasks_to_restore_for_meta.len() {
+            0 => {}
+            1 => {
+                let task_id = tasks_to_restore_for_meta[0];
+                let data = self.restore_task_data(task_id, TaskDataCategory::Meta);
+                let idx = tasks_to_restore_for_meta_indicies[0];
+                tasks[idx].3 = Some(data);
+            }
+            _ => {
+                if let Some(data) =
+                    self.restore_task_data_batch(&tasks_to_restore_for_meta, TaskDataCategory::Meta)
+                {
+                    data.into_iter()
+                        .zip(tasks_to_restore_for_meta_indicies)
+                        .for_each(|(items, idx)| {
+                            tasks[idx].3 = Some(items);
+                        });
+                } else {
+                    for idx in tasks_to_restore_for_meta_indicies {
+                        tasks[idx].3 = Some(Vec::new());
+                    }
                 }
             }
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -87,6 +87,22 @@ pub trait BackingStorageSealed: 'static + Send + Sync {
         task_id: TaskId,
         category: TaskDataCategory,
     ) -> Result<Vec<CachedDataItem>>;
+    /// # Safety
+    ///
+    /// `tx` must be a transaction from this BackingStorage instance.
+    unsafe fn batch_lookup_data(
+        &self,
+        tx: Option<&Self::ReadTransaction<'_>>,
+        task_ids: &[TaskId],
+        category: TaskDataCategory,
+    ) -> Result<Vec<Vec<CachedDataItem>>> {
+        let mut results = Vec::with_capacity(task_ids.len());
+        for &task_id in task_ids {
+            let data = unsafe { self.lookup_data(tx, task_id, category)? };
+            results.push(data);
+        }
+        Ok(results)
+    }
 
     fn shutdown(&self) -> Result<()> {
         Ok(())
@@ -200,6 +216,24 @@ where
             Either::Right(this) => {
                 let tx = tx.map(|tx| read_transaction_right_or_panic(tx.as_ref()));
                 unsafe { this.lookup_data(tx, task_id, category) }
+            }
+        }
+    }
+
+    unsafe fn batch_lookup_data(
+        &self,
+        tx: Option<&Self::ReadTransaction<'_>>,
+        task_ids: &[TaskId],
+        category: TaskDataCategory,
+    ) -> Result<Vec<Vec<CachedDataItem>>> {
+        match self {
+            Either::Left(this) => {
+                let tx = tx.map(|tx| read_transaction_left_or_panic(tx.as_ref()));
+                unsafe { this.batch_lookup_data(tx, task_ids, category) }
+            }
+            Either::Right(this) => {
+                let tx = tx.map(|tx| read_transaction_right_or_panic(tx.as_ref()));
+                unsafe { this.batch_lookup_data(tx, task_ids, category) }
             }
         }
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -98,6 +98,7 @@ pub trait BackingStorageSealed: 'static + Send + Sync {
     ) -> Result<Vec<Vec<CachedDataItem>>> {
         let mut results = Vec::with_capacity(task_ids.len());
         for &task_id in task_ids {
+            // TODO more efficient batch implementation
             let data = unsafe { self.lookup_data(tx, task_id, category)? };
             results.push(data);
         }

--- a/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
@@ -35,6 +35,20 @@ pub trait KeyValueDatabase {
         key: &[u8],
     ) -> Result<Option<Self::ValueBuffer<'l>>>;
 
+    fn batch_get<'l, 'db: 'l>(
+        &'l self,
+        transaction: &'l Self::ReadTransaction<'db>,
+        key_space: KeySpace,
+        keys: &[&[u8]],
+    ) -> Result<Vec<Option<Self::ValueBuffer<'l>>>> {
+        let mut results = Vec::with_capacity(keys.len());
+        for key in keys {
+            let value = self.get(transaction, key_space, key)?;
+            results.push(value);
+        }
+        Ok(results)
+    }
+
     type SerialWriteBatch<'l>: SerialWriteBatch<'l>
         = UnimplementedWriteBatch
     where

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -84,6 +84,15 @@ impl KeyValueDatabase for TurboKeyValueDatabase {
         self.db.get(key_space as usize, &key)
     }
 
+    fn batch_get<'l, 'db: 'l>(
+        &'l self,
+        _transaction: &'l Self::ReadTransaction<'db>,
+        key_space: KeySpace,
+        keys: &[&[u8]],
+    ) -> Result<Vec<Option<Self::ValueBuffer<'l>>>> {
+        self.db.batch_get(key_space as usize, keys)
+    }
+
     type ConcurrentWriteBatch<'l>
         = TurboWriteBatch<'l>
     where

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -523,11 +523,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
         ) -> Result<Vec<CachedDataItem>> {
             let Some(bytes) = database.get(
                 tx,
-                match category {
-                    TaskDataCategory::Meta => KeySpace::TaskMeta,
-                    TaskDataCategory::Data => KeySpace::TaskData,
-                    TaskDataCategory::All => unreachable!(),
-                },
+                category_to_key_space(category),
                 IntKey::new(*task_id).as_ref(),
             )?
             else {
@@ -539,6 +535,52 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
         inner
             .with_tx(tx, |tx| lookup(&inner.database, tx, task_id, category))
             .with_context(|| format!("Looking up data for {task_id} from database failed"))
+    }
+
+    unsafe fn batch_lookup_data(
+        &self,
+        tx: Option<&Self::ReadTransaction<'_>>,
+        task_ids: &[TaskId],
+        category: TaskDataCategory,
+    ) -> Result<Vec<Vec<CachedDataItem>>> {
+        let inner = &*self.inner;
+        fn lookup<D: KeyValueDatabase>(
+            database: &D,
+            tx: &D::ReadTransaction<'_>,
+            task_ids: &[TaskId],
+            category: TaskDataCategory,
+        ) -> Result<Vec<Vec<CachedDataItem>>> {
+            let int_keys: Vec<_> = task_ids.iter().map(|&id| IntKey::new(*id)).collect();
+            let keys = int_keys.iter().map(|k| k.as_ref()).collect::<Vec<_>>();
+            let bytes = database.batch_get(
+                tx,
+                match category {
+                    TaskDataCategory::Meta => KeySpace::TaskMeta,
+                    TaskDataCategory::Data => KeySpace::TaskData,
+                    TaskDataCategory::All => unreachable!(),
+                },
+                &keys,
+            )?;
+            Ok(bytes
+                .into_iter()
+                .map(|opt_bytes| {
+                    if let Some(bytes) = opt_bytes {
+                        let result: Vec<CachedDataItem> = turbo_bincode_decode(bytes.borrow())?;
+                        Ok(result)
+                    } else {
+                        Ok(Vec::new())
+                    }
+                })
+                .collect::<Result<Vec<_>>>()?)
+        }
+        inner
+            .with_tx(tx, |tx| lookup(&inner.database, tx, task_ids, category))
+            .with_context(|| {
+                format!(
+                    "Looking up data for {} tasks from database failed",
+                    task_ids.len()
+                )
+            })
     }
 
     fn shutdown(&self) -> Result<()> {
@@ -764,4 +806,12 @@ fn encode_task_data(task: TaskId, data: &Vec<CachedDataItem>) -> Result<TurboBin
         turbo_bincode_encode(&filtered_data)
     })
     .with_context(|| format!("Unable to serialize data items for {task}: {filtered_data:#?}"))
+}
+
+fn category_to_key_space(category: TaskDataCategory) -> KeySpace {
+    match category {
+        TaskDataCategory::Meta => KeySpace::TaskMeta,
+        TaskDataCategory::Data => KeySpace::TaskData,
+        TaskDataCategory::All => unreachable!(),
+    }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -561,7 +561,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
                 },
                 &keys,
             )?;
-            Ok(bytes
+            bytes
                 .into_iter()
                 .map(|opt_bytes| {
                     if let Some(bytes) = opt_bytes {
@@ -571,7 +571,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
                         Ok(Vec::new())
                     }
                 })
-                .collect::<Result<Vec<_>>>()?)
+                .collect::<Result<Vec<_>>>()
         }
         inner
             .with_tx(tx, |tx| lookup(&inner.database, tx, task_ids, category))

--- a/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
@@ -87,7 +87,7 @@ pub async fn compute_binding_usage_info(
     remove_unused_imports: bool,
 ) -> Result<Vc<BindingUsageInfo>> {
     let span_outer = tracing::info_span!(
-        "compute bindung usage info",
+        "compute binding usage info",
         visit_count = tracing::field::Empty,
         unused_reference_count = tracing::field::Empty
     );


### PR DESCRIPTION
### What?

Making a batch read from database can be more efficient:
* Order keys by hash for better cache locallity (in AMQF, key blocks, value blocks)
* Use binary search to filter keys by min/max hash of the SST files
* Only need to check family once instead of per key

Prefetch tasks with batch reads.
Add helper for "for each task" which can use batch read.

add tracing for database reads