### PR TITLE
[turbopack] Rename graph traversal algorithms

### DIFF
--- a/crates/next-api/src/analyze.rs
+++ b/crates/next-api/src/analyze.rs
@@ -430,7 +430,7 @@ pub async fn analyze_module_graphs(module_graphs: Vc<ModuleGraphs>) -> Result<Vc
     let mut all_async_edges = FxIndexSet::default();
     for &module_graph in module_graphs.await? {
         let module_graph = module_graph.read_graphs().await?;
-        module_graph.traverse_all_edges_unordered(|parent, node| {
+        module_graph.traverse_edges_unordered(|parent, node| {
             if let Some((parent_node, reference)) = parent {
                 all_modules.insert(parent_node);
                 all_modules.insert(node);

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -173,7 +173,7 @@ impl NextDynamicGraph {
 
             // module -> the client reference entry (if any)
             let mut state_map = FxHashMap::default();
-            graph.traverse_edges_from_entries_dfs(
+            graph.traverse_edges_dfs(
                 entries,
                 &mut (),
                 |parent_info, node, _| {
@@ -351,7 +351,7 @@ impl ServerActionsGraph {
                 }
 
                 let mut result = FxIndexMap::default();
-                graph.traverse_nodes_from_entries_dfs(
+                graph.traverse_nodes_dfs(
                     vec![entry],
                     &mut result,
                     |node, result| {
@@ -559,7 +559,7 @@ impl ClientReferencesGraph {
             let mut server_components = FxIndexSet::default();
 
             // Perform a DFS traversal to find all server components included by this page.
-            graph.traverse_nodes_from_entries_dfs(
+            graph.traverse_nodes_dfs(
                 entries,
                 &mut (),
                 |node, _| {
@@ -615,7 +615,7 @@ impl ClientReferencesGraph {
             // necessarily rendered at the same time (not-found, or parallel routes), we need to
             // determine the order of client references individually for each server component.
             for sc in server_components.iter().copied() {
-                graph.traverse_nodes_from_entries_dfs(
+                graph.traverse_nodes_dfs(
                     std::iter::once(ResolvedVc::upcast(sc)),
                     &mut (),
                     |node, _| {
@@ -786,7 +786,7 @@ async fn validate_pages_css_imports_individual(
 
     let mut candidates = vec![];
 
-    graph.traverse_edges_from_entries_dfs(
+    graph.traverse_edges_dfs(
         entries,
         &mut (),
         |parent_info, node, _| {

--- a/crates/next-api/src/routes_hashes_manifest.rs
+++ b/crates/next-api/src/routes_hashes_manifest.rs
@@ -64,7 +64,7 @@ pub async fn endpoint_hashes(
 
     let module_graph = module_graph.read_graphs().await?;
 
-    module_graph.traverse_nodes_from_entries_dfs(
+    module_graph.traverse_nodes_dfs(
         modules,
         &mut all_modules,
         |module, all_modules| {

--- a/crates/next-api/src/webpack_stats.rs
+++ b/crates/next-api/src/webpack_stats.rs
@@ -58,7 +58,7 @@ where
     let asset_reasons = {
         let module_graph = module_graph.read_graphs().await?;
         let mut edges = vec![];
-        module_graph.traverse_all_edges_unordered(|parent, current| {
+        module_graph.traverse_edges_unordered(|parent, current| {
             if let Some((parent_node, r)) = parent {
                 edges.push((
                     parent_node,

--- a/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/async_module_info.rs
@@ -80,7 +80,7 @@ async fn compute_async_module_info_single(
     let mut async_modules = FxHashSet::default();
     async_modules.extend(self_async_modules.iter());
 
-    graph.traverse_edges_from_entries_dfs_reversed(
+    graph.traverse_edges_reverse_dfs(
         self_async_modules,
         &mut (),
         // child is the previously visited module which must be async

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -446,7 +446,7 @@ pub async fn compute_chunk_group_info(graph: &ModuleGraphRef) -> Result<Vc<Chunk
         let module_depth: FxHashMap<ResolvedVc<Box<dyn Module>>, usize> = {
             let mut module_depth =
                 FxHashMap::with_capacity_and_hasher(module_count, Default::default());
-            graph.traverse_edges_from_entries_bfs(
+            graph.traverse_edges_bfs(
                 entries.iter().flat_map(|e| e.entries()),
                 |parent, node| {
                     if let Some((parent, _)) = parent {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1120,7 +1120,7 @@ impl ModuleGraphRef {
     ///    - Receives the module and the `state`
     ///    - Can return [GraphTraversalAction]s to control the traversal
     /// * `visit_postorder` - Called after visiting children of a node.
-    pub fn traverse_nodes_from_entries_dfs<S>(
+    pub fn traverse_nodes_dfs<S>(
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         state: &mut S,
@@ -1181,7 +1181,7 @@ impl ModuleGraphRef {
     ///    - Receives (originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode, state &S
     ///    - Can return [GraphTraversalAction]s to control the traversal
-    pub fn traverse_edges_from_entries_bfs(
+    pub fn traverse_edges_bfs(
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         mut visitor: impl FnMut(
@@ -1222,55 +1222,6 @@ impl ModuleGraphRef {
         Ok(())
     }
 
-    /// Traverses all reachable edges exactly once and calls the visitor with the edge source and
-    /// target.
-    ///
-    /// This means that target nodes can be revisited (once per incoming edge).
-    ///
-    /// * `entry` - The entry module to start the traversal from
-    /// * `visitor` - Called before visiting the children of a node.
-    ///    - Receives (originating &SingleModuleGraphNode, edge &ChunkingType), target
-    ///      &SingleModuleGraphNode, state &S
-    ///    - Can return [GraphTraversalAction]s to control the traversal
-    pub fn traverse_edges_from_entry_dfs(
-        &self,
-        entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
-        mut visitor: impl FnMut(
-            Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
-            ResolvedVc<Box<dyn Module>>,
-        ) -> GraphTraversalAction,
-    ) -> Result<()> {
-        let mut stack = entries
-            .into_iter()
-            .map(|e| self.get_entry(e))
-            .collect::<Result<Vec<_>>>()?;
-        let mut visited = FxHashSet::default();
-        for entry_node in &stack {
-            visitor(None, self.get_node(*entry_node)?.module());
-        }
-        while let Some(node) = stack.pop() {
-            if visited.insert(node) {
-                let node_weight = self.get_node(node)?;
-                for (edge, succ) in self.iter_graphs_neighbors_rev(node, Direction::Outgoing) {
-                    let succ_weight = self.get_node(succ)?;
-                    let action = visitor(
-                        Some((node_weight.module(), self.get_edge(edge)?)),
-                        succ_weight.module(),
-                    );
-                    if !self.should_visit_node(succ_weight, Direction::Outgoing) {
-                        continue;
-                    }
-                    let succ = succ_weight.target_idx(Direction::Outgoing).unwrap_or(succ);
-                    if !visited.contains(&succ) && action == GraphTraversalAction::Continue {
-                        stack.push(succ);
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
     /// Traverses all edges exactly once (in an unspecified order) and calls the visitor with the
     /// edge source and target.
     ///
@@ -1279,7 +1230,7 @@ impl ModuleGraphRef {
     /// * `visitor` - Called before visiting the children of a node.
     ///    - Receives (originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode
-    pub fn traverse_all_edges_unordered(
+    pub fn traverse_edges_unordered(
         &self,
         mut visitor: impl FnMut(
             Option<(ResolvedVc<Box<dyn Module>>, &'_ RefData)>,
@@ -1288,7 +1239,9 @@ impl ModuleGraphRef {
     ) -> Result<()> {
         let entries = self.graphs.iter().flat_map(|g| g.entry_modules());
 
-        self.traverse_edges_from_entries_dfs(
+        // Despite the name we need to do a DFS to respect 'reachability' if an edge was trimmed we
+        // should not follow it, and this is the only way to do that.
+        self.traverse_edges_dfs(
             entries,
             &mut (),
             |parent, target, _| {
@@ -1317,7 +1270,7 @@ impl ModuleGraphRef {
     /// * `visit_postorder` - Called after visiting the children of a node. Return
     ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode, state &S
-    pub fn traverse_edges_from_entries_dfs<S>(
+    pub fn traverse_edges_dfs<S>(
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         state: &mut S,
@@ -1332,7 +1285,7 @@ impl ModuleGraphRef {
             &mut S,
         ) -> Result<()>,
     ) -> Result<()> {
-        self.traverse_edges_from_entries_dfs_impl::<S>(
+        self.traverse_edges_dfs_impl::<S>(
             entries,
             state,
             visit_preorder,
@@ -1357,7 +1310,7 @@ impl ModuleGraphRef {
     /// * `visit_postorder` - Called after visiting the parents of a node. Return
     ///    - Receives: (originating &SingleModuleGraphNode, edge &ChunkingType), target
     ///      &SingleModuleGraphNode, state &S
-    pub fn traverse_edges_from_entries_dfs_reversed<S>(
+    pub fn traverse_edges_reverse_dfs<S>(
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         state: &mut S,
@@ -1372,7 +1325,7 @@ impl ModuleGraphRef {
             &mut S,
         ) -> Result<()>,
     ) -> Result<()> {
-        self.traverse_edges_from_entries_dfs_impl::<S>(
+        self.traverse_edges_dfs_impl::<S>(
             entries,
             state,
             visit_preorder,
@@ -1381,7 +1334,7 @@ impl ModuleGraphRef {
         )
     }
 
-    fn traverse_edges_from_entries_dfs_impl<S>(
+    fn traverse_edges_dfs_impl<S>(
         &self,
         entries: impl IntoIterator<Item = ResolvedVc<Box<dyn Module>>>,
         state: &mut S,
@@ -1985,7 +1938,7 @@ pub mod tests {
                 let mut preorder_visits = Vec::new();
                 let mut postorder_visits = Vec::new();
 
-                graph.traverse_edges_from_entries_dfs(
+                graph.traverse_edges_dfs(
                     entry_modules,
                     &mut (),
                     |parent, target, _| {
@@ -2045,7 +1998,7 @@ pub mod tests {
                 let mut preorder_visits = Vec::new();
                 let mut postorder_visits = Vec::new();
 
-                graph.traverse_edges_from_entries_dfs(
+                graph.traverse_edges_dfs(
                     entry_modules,
                     &mut (),
                     |parent, target, _| {
@@ -2199,7 +2152,7 @@ pub mod tests {
             // test traversing forward from a in the child graph
             {
                 let mut visited_forward = Vec::new();
-                child_graph.traverse_edges_from_entries_dfs(
+                child_graph.traverse_edges_dfs(
                     vec![a_module],
                     &mut (),
                     |_parent, child, _state_| {
@@ -2250,7 +2203,7 @@ pub mod tests {
                     .next()
                     .unwrap();
                 let mut visited_reverse = Vec::new();
-                child_graph.traverse_edges_from_entries_dfs_reversed(
+                child_graph.traverse_edges_reverse_dfs(
                     vec![d_module],
                     &mut (),
                     |_parent, child, _state_| {
@@ -2272,7 +2225,7 @@ pub mod tests {
             // VisitedModule in this graph
             {
                 let mut visited_reverse = Vec::new();
-                child_graph.traverse_edges_from_entries_dfs_reversed(
+                child_graph.traverse_edges_reverse_dfs(
                     vec![b_module],
                     &mut (),
                     |_parent, child, _state_| {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -1240,7 +1240,7 @@ impl ModuleGraphRef {
         let entries = self.graphs.iter().flat_map(|g| g.entry_modules());
 
         // Despite the name we need to do a DFS to respect 'reachability' if an edge was trimmed we
-        // should not follow it, and this is the only way to do that.
+        // should not follow it, and this is a reasonable way to do that.
         self.traverse_edges_dfs(
             entries,
             &mut (),

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -289,7 +289,7 @@ impl PreBatches {
             this: self,
         };
         let mut visited = FxHashSet::default();
-        module_graph.traverse_edges_from_entries_dfs(
+        module_graph.traverse_edges_dfs(
             std::iter::once(entry),
             &mut state,
             |parent_info, node, state| {
@@ -355,7 +355,7 @@ pub async fn compute_module_batches(
 
         // Walk the module graph and mark all modules that are boundary modules (referenced from a
         // different chunk group bitmap)
-        module_graph.traverse_all_edges_unordered(|parent, node| {
+        module_graph.traverse_edges_unordered(|parent, node| {
             if let Some((parent, ty)) = parent {
                 let std::collections::hash_set::Entry::Vacant(entry) =
                     pre_batches.boundary_modules.entry(node)

--- a/turbopack/crates/turbopack-core/src/module_graph/side_effect_module_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/side_effect_module_info.rs
@@ -75,7 +75,7 @@ async fn compute_side_effect_free_module_info_single(
     // dependencies are side effect free.
 
     let mut locally_side_effect_free_modules_that_have_side_effects = FxHashSet::default();
-    graph.traverse_edges_from_entries_dfs_reversed(
+    graph.traverse_edges_reverse_dfs(
         // Start from all the side effectful nodes
         module_side_effects.iter().filter_map(|(m, e)| {
             if *e == ModuleSideEffects::SideEffectful {

--- a/turbopack/crates/turbopack/src/global_module_ids.rs
+++ b/turbopack/crates/turbopack/src/global_module_ids.rs
@@ -30,7 +30,7 @@ pub async fn get_global_module_id_strategy(
 
         // And additionally, all the modules that are inserted by chunking (i.e. async loaders)
         let mut async_idents = vec![];
-        module_graph.traverse_all_edges_unordered(|parent, current| {
+        module_graph.traverse_edges_unordered(|parent, current| {
             if let Some((
                 _,
                 &RefData {


### PR DESCRIPTION
* remove `traverse_edges_from_entry_dfs` it is dead
* rename a number of traversal methods to shorter names. mostly by dropping `from_entries` which i don't believe is useful.
* rename `travserve_edges_from_entries_dfs_reversed` to `traverse_edges_reverse_dfs` which is a bit better, but could probably still use some work.

I explored ways to share logic across our DFS implementations and ultimately determined that the juice wasn't worth the squeeze