### PR TITLE
Fix: External redirect swallowed by Next.js

### DIFF
--- a/test/e2e/app-dir/external-redirect/app/layout.tsx
+++ b/test/e2e/app-dir/external-redirect/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/external-redirect/app/page.tsx
+++ b/test/e2e/app-dir/external-redirect/app/page.tsx
@@ -1,0 +1,29 @@
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  //
+  return (
+    <>
+      <p>
+        This tests a regression case where an action called outside of a React
+        transition scope (onClick, in this case) results in a server-side
+        redirect. Before the fix, the external redirect would get swallowed by
+        Next.js.
+      </p>
+      <p>
+        Clicking the button should redirect to localhost:9292. (The redirect
+        doesn't need to actually load; the associated e2e test will intercept
+        the request.)
+      </p>
+      <button
+        id="external-redirect-from-action-on-click"
+        onClick={async () => {
+          'use server'
+          redirect('http://localhost:9292')
+        }}
+      >
+        External Redirect
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/external-redirect/components/link-accordion.tsx
+++ b/test/e2e/app-dir/external-redirect/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/external-redirect/external-redirect.test.ts
+++ b/test/e2e/app-dir/external-redirect/external-redirect.test.ts
@@ -1,0 +1,33 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('external-redirect', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('regression: Server Action triggered from onClick redirects to external URL', async () => {
+    let page
+    const browser = await next.browser('/', {
+      async beforePageLoad(p) {
+        page = p
+        await page.route('**/*', (route) => {
+          const req = route.request()
+          // Intercept the request to the external page and mock the response.
+          if (req.url().includes('localhost:9292')) {
+            return route.fulfill({
+              status: 200,
+              body: '<!DOCTYPE html><html><body>External page</body></html>',
+            })
+          }
+          return route.continue()
+        })
+      },
+    })
+    const button = await browser.elementById(
+      'external-redirect-from-action-on-click'
+    )
+    await button.click()
+    await page.waitForNavigation('http://localhost:9292')
+    expect(await page.innerHTML('body')).toBe('External page')
+  })
+})

--- a/test/e2e/app-dir/external-redirect/next.config.js
+++ b/test/e2e/app-dir/external-redirect/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
Fix for a regression introduced by https://github.com/vercel/next.js/pull/86367.

When a Server Action performed an external redirect, Next.js was no longer triggering an MPA navigation from directly inside the response handler. It would end up working regardless if the Server Action was called from a React action, like a form action or useTransition hook, because the Server Action would rethrow the redirect error and trigger a "late" redirect during rendering. But if the Server Action was called from outside of a React scope — onClick, for example — it would do nothing.