### PR TITLE
Fix: Missing null check in LRU cleanup

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache-map.ts
+++ b/packages/next/src/client/components/segment-cache/cache-map.ts
@@ -396,7 +396,7 @@ function dropRef<V extends MapValue>(value: V): void {
   value.ref = null
 }
 
-function deleteMapEntry<V extends MapValue>(entry: MapEntry<V>): void {
+export function deleteMapEntry<V extends MapValue>(entry: MapEntry<V>): void {
   // Delete the entry from the cache.
   const emptyEntry: EmptyMapEntry<V> = entry as any
   emptyEntry.value = null

--- a/packages/next/src/client/components/segment-cache/lru.ts
+++ b/packages/next/src/client/components/segment-cache/lru.ts
@@ -1,5 +1,5 @@
 import type { MapEntry } from './cache-map'
-import { deleteFromCacheMap } from './cache-map'
+import { deleteMapEntry } from './cache-map'
 
 // We use an LRU for memory management. We must update this whenever we add or
 // remove a new cache entry, or when an entry changes size.
@@ -119,7 +119,7 @@ function cleanup() {
     if (tail !== null) {
       // Delete the entry from the map. In turn, this will remove it from
       // the LRU.
-      deleteFromCacheMap(tail.value)
+      deleteMapEntry(tail)
     }
   }
 }


### PR DESCRIPTION
Unfortunately this field is not strongly typed because it's a cyclic type and I wasn't able to soundly model it with TypeScript. Skill issue I'm sure.

Don't have an exact repro yet but the previous code was obviously wrong.

The way this should have been structured regardless is to delete the wrapper MapEntry object instead of the value it contains. The non-nullness of the wrapper object _is_ properly typed, and avoids an unnecessary indirection.

As a follow up, I'll look into how to model this type properly.