### PR TITLE
Refactor: Unify history traversal with other nav types

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -17,6 +17,7 @@ import {
 } from '../../segment-cache/navigation'
 import { NavigationResultTag } from '../../segment-cache/types'
 import { getStaleTimeMs } from '../../segment-cache/cache'
+import { FreshnessPolicy } from '../ppr-navigations'
 
 // These values are set by `define-env-plugin` (based on `nextConfig.experimental.staleTimes`)
 // and default to 5 minutes (static) / 0 seconds (dynamic)
@@ -161,14 +162,13 @@ export function navigateReducer(
   // implementation. Eventually we'll rewrite the router reducer to a
   // state machine.
   const currentUrl = new URL(state.canonicalUrl, location.origin)
-  const shouldRefreshDynamicData = false
   const result = navigateUsingSegmentCache(
     url,
     currentUrl,
     state.cache,
     state.tree,
     state.nextUrl,
-    shouldRefreshDynamicData,
+    FreshnessPolicy.Default,
     shouldScroll,
     mutable
   )

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -8,6 +8,7 @@ import { handleNavigationResult } from './navigate-reducer'
 import { navigateToSeededRoute } from '../../segment-cache/navigation'
 import { revalidateEntireCache } from '../../segment-cache/cache'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
+import { FreshnessPolicy } from '../ppr-navigations'
 
 export function refreshReducer(
   state: ReadonlyReducerState,
@@ -33,7 +34,6 @@ export function refreshReducer(
   const url = currentUrl
   const currentFlightRouterState = state.tree
   const shouldScroll = true
-  const shouldRefreshDynamicData = true
 
   const seedFlightRouterState = state.tree
   const seedRenderedSearch = state.renderedSearch
@@ -49,7 +49,7 @@ export function refreshReducer(
     seedRenderedSearch,
     seedData,
     seedHead,
-    shouldRefreshDynamicData,
+    FreshnessPolicy.RefreshAll,
     nextUrlForRefresh,
     shouldScroll
   )

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -61,6 +61,7 @@ import {
   type ActionRevalidationKind,
 } from '../../../../shared/lib/action-revalidation-kind'
 import { isExternalURL } from '../../app-router-utils'
+import { FreshnessPolicy } from '../ppr-navigations'
 
 const createFromFetch =
   createFromFetchBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromFetch']
@@ -388,8 +389,10 @@ export function serverActionReducer(
 
       // If the action triggered a revalidation of the cache, we should also
       // refresh all the dynamic data.
-      const shouldRefreshDynamicData =
-        revalidationKind !== ActionDidNotRevalidate
+      const freshnessPolicy =
+        revalidationKind === ActionDidNotRevalidate
+          ? FreshnessPolicy.Default
+          : FreshnessPolicy.RefreshAll
 
       // The server may have sent back new data. If so, we will perform a
       // "seeded" navigation that uses the data from the response.
@@ -421,7 +424,7 @@ export function serverActionReducer(
             seedRenderedSearch,
             seedData,
             seedHead,
-            shouldRefreshDynamicData,
+            freshnessPolicy,
             nextUrl,
             shouldScroll
           )
@@ -443,7 +446,7 @@ export function serverActionReducer(
         state.cache,
         currentFlightRouterState,
         nextUrl,
-        shouldRefreshDynamicData,
+        freshnessPolicy,
         shouldScroll,
         mutable
       )


### PR DESCRIPTION
This merges the logic inside updateCacheNodeOnPopstateRestoration into the function used for all other navigation types.

The main difference between history traversal navigations and other navigation types is our treatment of dynamic data. History traversal operations are allowed to reuse dynamic data regardless of its freshness or staleness. So I've updated the `shouldRefreshDynamicData` argument to be an enum that accounts for our various freshness policies. As of now, there are three: Default, HistoryTraversal, and RefreshAll.

This is part of an ongoing series of refactors to unify all navigation types into a single flow, both to simplify the implementation, and to ensure the behavior is consistent.