### PR TITLE
docs: recommend WOFF/WOFF2 formats for local fonts

### DIFF
--- a/docs/01-app/01-getting-started/13-fonts.mdx
+++ b/docs/01-app/01-getting-started/13-fonts.mdx
@@ -198,3 +198,9 @@ const roboto = localFont({
   ],
 })
 ```
+
+## Notes
+
+When using local fonts on the web, prefer **WOFF** or **WOFF2** formats over other font formats. These formats are optimized for web usage and provide better performance.
+
+[Learn more about font file formats](https://www.whitepeakdigital.com/blog/font-file-types-explained/)


### PR DESCRIPTION
Adds a note recommending the use of `WOFF/WOFF2` formats for local fonts and links to an external article for more details.
