### PR TITLE
Reflect runtime type of `resHeaders` in static types

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -414,7 +414,7 @@ export async function initialize(opts: {
           req.url = removePathPrefix(origUrl, config.assetPrefix)
         }
 
-        if (resHeaders) {
+        if (resHeaders !== null) {
           for (const key of Object.keys(resHeaders)) {
             res.setHeader(key, resHeaders[key])
           }
@@ -441,8 +441,10 @@ export async function initialize(opts: {
       })
 
       // apply any response headers from routing
-      for (const key of Object.keys(resHeaders || {})) {
-        res.setHeader(key, resHeaders[key])
+      if (resHeaders !== null) {
+        for (const key of Object.keys(resHeaders)) {
+          res.setHeader(key, resHeaders[key])
+        }
       }
 
       // handle redirect

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -117,7 +117,7 @@ export function getResolveRoutes(
     finished: boolean
     statusCode?: number
     bodyStream?: ReadableStream | null
-    resHeaders: Record<string, string | string[]>
+    resHeaders: Record<string, string | string[]> | null
     parsedUrl: NextUrlWithParsedQuery
     matchedOutput?: FsOutput | null
   }> {
@@ -752,10 +752,12 @@ export function getResolveRoutes(
             parsedDestination.pathname
           )
 
+          // @ts-expect-error // custom ParsedUrl
+          const unsafeParsedUrl: NextUrlWithParsedQuery = parsedDestination
           return {
             finished: true,
-            // @ts-expect-error custom ParsedUrl
-            parsedUrl: parsedDestination,
+            parsedUrl: unsafeParsedUrl,
+            resHeaders: null,
             statusCode: getRedirectStatus(route),
           }
         }
@@ -826,9 +828,11 @@ export function getResolveRoutes(
           }
 
           if (parsedDestination.protocol) {
+            // @ts-expect-error // custom ParsedUrl
+            const unsafeParsedUrl: NextUrlWithParsedQuery = parsedDestination
             return {
-              // @ts-expect-error custom ParsedUrl
-              parsedUrl: parsedDestination,
+              parsedUrl: unsafeParsedUrl,
+              resHeaders: null,
               finished: true,
             }
           }


### PR DESCRIPTION
`resHeaders` could be `undefined` at runtime. All usages accounted for that but the TS types claimed it was non-nullable.

It's now nullable and I adjusted usages to be exact.