### PR TITLE
[ci] Stop running build_and_deploy on tag pushes

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -3,6 +3,8 @@ name: build-and-deploy
 
 on:
   push:
+    tags-ignore:
+      - '*'
   # we need the preview tarball for deploy tests
   pull_request:
     types: [opened, synchronize]


### PR DESCRIPTION
It's redundant. The release check is based on the commit message so the first one publishes to npm and the 2nd is wasted.

Not only is the 2nd run redundant, it also can cause both runs to slow each other down. We retry a failed publish so run 1 could retry a failed publish because it was already published in 2. And then 2 in turn could be stuck in retrying as well because 1 published a different package.

## Test plan

- [ ] Will trigger canary release once that's merged -> https://github.com/vercel/next.js/actions/runs/20243277859/job/58116629624 -> 