### PR TITLE
[ci] Stop building when creating release

### DIFF
--- a/packages/create-next-app/package.json
+++ b/packages/create-next-app/package.json
@@ -22,10 +22,9 @@
   ],
   "scripts": {
     "dev": "ncc build ./index.ts -w -o dist/",
-    "prerelease": "node ../../scripts/rm.mjs dist",
-    "release": "ncc build ./index.ts -o ./dist/ --minify --no-cache --no-source-map-register",
+    "prebuild": "node ../../scripts/rm.mjs dist",
+    "build": "ncc build ./index.ts -o ./dist/ --minify --no-cache --no-source-map-register",
     "prepublishOnly": "cd ../../ && turbo run build",
-    "build": "pnpm release",
     "lint-fix": "pnpm prettier -w --plugin prettier-plugin-tailwindcss 'templates/*-tw/{ts,js}/{app,pages}/**/*.{js,ts,tsx}'"
   },
   "devDependencies": {

--- a/packages/next-env/package.json
+++ b/packages/next-env/package.json
@@ -22,10 +22,10 @@
   ],
   "scripts": {
     "dev": "ncc build ./index.ts -w -o dist/",
-    "prerelease": "node ../../scripts/rm.mjs dist",
+    "prebuild:source": "node ../../scripts/rm.mjs dist",
     "types": "tsc --declaration --emitDeclarationOnly --declarationDir dist",
-    "release": "ncc build ./index.ts -o ./dist/ --minify --no-cache --no-source-map-register",
-    "build": "pnpm release && pnpm types",
+    "build:source": "ncc build ./index.ts -o ./dist/ --minify --no-cache --no-source-map-register",
+    "build": "pnpm build:source && pnpm types",
     "prepublishOnly": "cd ../../ && turbo run build"
   },
   "devDependencies": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -79,8 +79,7 @@
   },
   "scripts": {
     "dev": "cross-env NEXT_SERVER_NO_MANGLE=1 taskr",
-    "release": "taskr release",
-    "build": "pnpm release",
+    "build": "taskr release",
     "prepublishOnly": "cd ../../ && turbo run build",
     "types": "tsc --project tsconfig.build.json --declaration --emitDeclarationOnly --stripInternal --declarationDir dist",
     "typescript": "tsec --noEmit",


### PR DESCRIPTION
Lerna implicitly runs the `release` scripts in each package on `lerna version` which builds from source for some packages (e.g. https://github.com/vercel/next.js/actions/runs/20215733181/job/58028355225#step:14:151)

The actual building and publishing of artifacts happens in build_and_deploy.yml, so we don't need to do it when creating the release.

Couldn't find any other explicit usage of the `release` scripts.

## Test plan

- [x] Will trigger canary release once that's merged: This didn't actually work. Following up in 