### PR TITLE
[ci] Ensure runners use configured Node.js version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,7 +75,7 @@ jobs:
     with:
       skipInstallBuild: 'yes'
       stepName: 'build-native-windows'
-      runs_on_labels: '["windows-test","self-hosted","x64"]'
+      runs_on_labels: '["windows","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
 
     secrets: inherit
@@ -603,7 +603,7 @@ jobs:
       nodeVersion: ${{ matrix.node }}
       afterBuild: node run-tests.js --type unit
       stepName: 'test-unit-windows-${{ matrix.node }}'
-      runs_on_labels: '["windows-test","self-hosted","x64"]'
+      runs_on_labels: '["windows","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
 
     secrets: inherit
@@ -766,7 +766,7 @@ jobs:
           test/e2e/app-dir/proxy-runtime-nodejs/proxy-runtime-nodejs.test.ts \
           test/development/app-dir/segment-explorer/segment-explorer.test.ts
       stepName: 'test-dev-windows'
-      runs_on_labels: '["windows-test","self-hosted","x64"]'
+      runs_on_labels: '["windows","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
@@ -795,7 +795,7 @@ jobs:
           test/integration/create-next-app/index.test.ts \
           test/integration/create-next-app/package-manager/pnpm.test.ts
       stepName: 'test-integration-windows'
-      runs_on_labels: '["windows-test","self-hosted","x64"]'
+      runs_on_labels: '["windows","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
@@ -824,7 +824,7 @@ jobs:
           test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts \
           test/e2e/app-dir/proxy-runtime-nodejs/proxy-runtime-nodejs.test.ts
       stepName: 'test-prod-windows'
-      runs_on_labels: '["windows-test","self-hosted","x64"]'
+      runs_on_labels: '["windows","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,7 +75,7 @@ jobs:
     with:
       skipInstallBuild: 'yes'
       stepName: 'build-native-windows'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-test","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
 
     secrets: inherit
@@ -603,7 +603,7 @@ jobs:
       nodeVersion: ${{ matrix.node }}
       afterBuild: node run-tests.js --type unit
       stepName: 'test-unit-windows-${{ matrix.node }}'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-test","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
 
     secrets: inherit
@@ -766,7 +766,7 @@ jobs:
           test/e2e/app-dir/proxy-runtime-nodejs/proxy-runtime-nodejs.test.ts \
           test/development/app-dir/segment-explorer/segment-explorer.test.ts
       stepName: 'test-dev-windows'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-test","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
@@ -795,7 +795,7 @@ jobs:
           test/integration/create-next-app/index.test.ts \
           test/integration/create-next-app/package-manager/pnpm.test.ts
       stepName: 'test-integration-windows'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-test","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 
@@ -824,7 +824,7 @@ jobs:
           test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts \
           test/e2e/app-dir/proxy-runtime-nodejs/proxy-runtime-nodejs.test.ts
       stepName: 'test-prod-windows'
-      runs_on_labels: '["windows","self-hosted","x64"]'
+      runs_on_labels: '["windows-test","self-hosted","x64"]'
       buildNativeTarget: 'x86_64-pc-windows-msvc'
     secrets: inherit
 

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -151,7 +151,7 @@ jobs:
           script: |
             core.setOutput('input_step_key', '${{ inputs.stepName }}'.toLowerCase().replaceAll(/[/.]/g, '-').trim('-'));
 
-      - name: Use Node.js ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
+      - name: Use Node.js ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }} for default shell
         run: |
           node --version || echo "Node.js not installed yet"
           # TODO: May be sufficient to just set `$FNM_MULTISHELL_PATH/bin` from `fnm env --json` into GITHUB_PATH
@@ -163,7 +163,9 @@ jobs:
           fnm default ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
           node --version
           which node
-          echo "$FNM_MULTISHELL_PATH/bin" >> "$GITHUB_PATH"
+          NODE_SHELL_PATH=$(dirname "$(which node)")
+          echo "Adding '$NODE_SHELL_PATH' to GITHUB_PATH"
+          echo "$NODE_SHELL_PATH" >> "$GITHUB_PATH"
       # Debug used Node.js version in a separate step to ensure
       # the Node.js version is set for the entire job
       - run: node --version

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -153,7 +153,8 @@ jobs:
 
       - name: Use Node.js ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }} for default shell
         run: |
-          node --version || echo "Node.js not installed yet"
+          node --version || echo "Cannot determine version of Node.js yet"
+          which node || echo "Cannot determine path of Node.js yet"
           # TODO: May be sufficient to just set `$FNM_MULTISHELL_PATH/bin` from `fnm env --json` into GITHUB_PATH
           fnm_env=$(fnm env)
           # Debug what we're about to eval
@@ -168,7 +169,11 @@ jobs:
           echo "$NODE_SHELL_PATH" >> "$GITHUB_PATH"
       # Debug used Node.js version in a separate step to ensure
       # the Node.js version is set for the entire job
-      - run: node --version
+      - name: Verify Node.js version
+        run: |
+          echo $PATH
+          which node
+          node --version
       - name: Prepare corepack
         if: ${{ contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
         run: |

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -155,6 +155,7 @@ jobs:
         run: |
           node --version || echo "Cannot determine version of Node.js yet"
           which node || echo "Cannot determine path of Node.js yet"
+          echo $PATH
           # TODO: May be sufficient to just set `$FNM_MULTISHELL_PATH/bin` from `fnm env --json` into GITHUB_PATH
           fnm_env=$(fnm env)
           # Debug what we're about to eval
@@ -167,10 +168,13 @@ jobs:
           NODE_SHELL_PATH=$(dirname "$(which node)")
           echo "Adding '$NODE_SHELL_PATH' to GITHUB_PATH"
           echo "$NODE_SHELL_PATH" >> "$GITHUB_PATH"
+          echo "Adding '$FNM_MULTISHELL_PATH' to GITHUB_ENV"
+          echo "FNM_MULTISHELL_PATH=\"$FNM_MULTISHELL_PATH\"" >> $GITHUB_ENV
       # Debug used Node.js version in a separate step to ensure
       # the Node.js version is set for the entire job
       - name: Verify Node.js version
         run: |
+          echo "$FNM_MULTISHELL_PATH"
           echo $PATH
           which node
           node --version

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -153,9 +153,8 @@ jobs:
 
       - name: Use Node.js ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }} for default shell
         run: |
-          node --version || echo "Cannot determine version of Node.js yet"
-          which node || echo "Cannot determine path of Node.js yet"
-          echo $PATH
+          node --version || true
+          which node || true
           # TODO: May be sufficient to just set `$FNM_MULTISHELL_PATH/bin` from `fnm env --json` into GITHUB_PATH
           fnm_env=$(fnm env)
           # Debug what we're about to eval
@@ -168,14 +167,10 @@ jobs:
           NODE_SHELL_PATH=$(dirname "$(which node)")
           echo "Adding '$NODE_SHELL_PATH' to GITHUB_PATH"
           echo "$NODE_SHELL_PATH" >> "$GITHUB_PATH"
-          echo "Adding '$FNM_MULTISHELL_PATH' to GITHUB_ENV"
-          echo "FNM_MULTISHELL_PATH=\"$FNM_MULTISHELL_PATH\"" >> $GITHUB_ENV
       # Debug used Node.js version in a separate step to ensure
       # the Node.js version is set for the entire job
       - name: Verify Node.js version
         run: |
-          echo "$FNM_MULTISHELL_PATH"
-          echo $PATH
           which node
           node --version
       - name: Prepare corepack


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/86720 which only fixed it for Unix runners.

The `FNM_MULTISHELL_PATH` variable contains a win32 path but we need a unix path since we're using Bash by default.
We also need to update our runners to not have an existing Node.js path in `PATH`. GitHub Actions wants to isolate steps from another so agnostic tools trying to mutate the environment can't work. We need to specifically handle those mutations via `GITHUB_PATH` and `GITHUB_ENV`.

With runners without a pre-configured bash profile (designated default): https://github.com/vercel/next.js/actions/runs/20248003051/job/58132998115?pr=87183#step:7:28
With current runner setup having pre-configured bash profile: https://github.com/vercel/next.js/actions/runs/20248124244/job/58133406989?pr=87183#step:7:29

Note that you have to look at jobs with runners not starting out with the desired Node.js version i.e. we need to remove the custom profile setups.
