### PR TITLE
[ci] Cancel in-progress pull_request_stats with native concurrency features

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - uses: styfle/cancel-workflow-action@0.12.1
         with:
-          workflow_id: 444921, 444987, 57419851
+          workflow_id: 444987, 57419851
           access_token: ${{ github.token }}

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -4,6 +4,10 @@ on:
 
 name: Generate Pull Request Stats
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.5.5


### PR DESCRIPTION
The custom cancel action is no longer needed: https://github.com/styfle/cancel-workflow-action/tree/0.12.1/

## test plan

- [x] Have to test after 
  <img width="2564" height="370" alt="CleanShot 2025-12-15 at 21 02 58@2x" src="https://github.com/user-attachments/assets/5e245222-d605-4fe7-a6c5-21a64d7ecf54" />
merge since cancel runs with the workflow source from `canary`
   > Canceling since a higher priority waiting request for Generate Pull Request Stats-refs/pull/87145/merge exists
   
   -- https://github.com/vercel/next.js/actions/runs/20245738337?pr=87145
  