### PR TITLE
[ci] Cancel in-progress build_and_deploy for PRs

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -11,6 +11,12 @@ on:
     types: [opened, synchronize]
   workflow_dispatch:
 
+concurrency:
+  # Limit concurrent runs to 1 per PR,
+  # but allow concurrent runs on push if they potentially use different source code
+  group: ${{ github.event_name == 'pull_request' && format('{0}-pr-{1}', github.workflow, github.ref_name) || format('{0}-sha-{1}', github.workflow, github.sha) }}
+  cancel-in-progress: true
+
 env:
   NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.5.5

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - uses: styfle/cancel-workflow-action@0.12.1
         with:
-          workflow_id: 444987, 57419851
+          workflow_id: 57419851
           access_token: ${{ github.token }}


### PR DESCRIPTION
Broke in https://github.com/vercel/next.js/pull/50436

Doesn't cancel pushes on `canary` as expected:
<img width="2552" height="336" alt="CleanShot 2025-12-15 at 21 46 10@2x" src="https://github.com/user-attachments/assets/279b6016-058f-4d04-81d2-77d0933355d1" />
