### PR TITLE
[ci] Stop using restore-keys for package manager stores

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -101,10 +101,8 @@ jobs:
         id: cache-pnpm-store
         with:
           path: ${{ steps.get-store-path.outputs.STORE_PATH }}
-          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-store-
-            pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
+          # Do not use restore-keys since it leads to indefinite growth of the cache.
 
       - run: pnpm install
 

--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -65,10 +65,8 @@ jobs:
         id: cache-pnpm-store
         with:
           path: ${{ steps.get-store-path.outputs.STORE_PATH }}
-          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-store-
-            pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
+          # Do not use restore-keys since it leads to indefinite growth of the cache.
 
       - run: pnpm install
 

--- a/.github/workflows/release-next-rspack.yml
+++ b/.github/workflows/release-next-rspack.yml
@@ -79,9 +79,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-pnpm-
+          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-v2-${{ hashFiles('**/pnpm-lock.yaml') }}
+          # Do not use restore-keys since it leads to indefinite growth of the cache.
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -97,10 +97,8 @@ jobs:
         id: cache-pnpm-store
         with:
           path: ${{ steps.get-store-path.outputs.STORE_PATH }}
-          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-store-
-            pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
+          # Do not use restore-keys since it leads to indefinite growth of the cache.
 
       - run: pnpm install
 


### PR DESCRIPTION
Package manager stores are append-only. If you cache them with restore keys based on prefixes, you can cause indefinite growth if packages are added more frequent than the cache eviction policy.

Brings the pnpm store down from 695MB to 665MB ([after](https://github.com/vercel/next.js/actions/runs/20245085503/job/58122965225#step:16:5)/[before](https://github.com/vercel/next.js/actions/runs/20245139588/job/58123121237#step:6:32)). That's currently negligible and more about preventing future regressions. Especially because even a couple of wasted download size accumulates over time until noticeable.

The caching built into GitHub actions doesn't use restore keys either: https://github.com/actions/setup-node/blob/395ad3262231945c25e8478fd5baf05154b1d79f/src/cache-restore.ts#L60-L67

See https://github.com/mui/material-ui/pull/29040 for an in-depth explainer