### PR TITLE
ci: fix node version configuration on windows runners

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -154,16 +154,10 @@ jobs:
       - name: Use Node.js ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
         run: |
           node --version || echo "Node.js not installed yet"
-          # TODO: May be sufficient to just set `$FNM_MULTISHELL_PATH/bin` from `fnm env --json` into GITHUB_PATH
-          fnm_env=$(fnm env)
-          # Debug what we're about to eval
-          echo "$fnm_env"
-          eval "$fnm_env"
           fnm use --install-if-missing ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
           fnm default ${{ inputs.nodeVersion || env.NODE_LTS_VERSION }}
           node --version
           which node
-          echo "$FNM_MULTISHELL_PATH/bin" >> "$GITHUB_PATH"
       # Debug used Node.js version in a separate step to ensure
       # the Node.js version is set for the entire job
       - run: node --version


### PR DESCRIPTION
This hasn't been working properly on Windows machines since #86720. `fnm env` creates a unique `FNM_MULTISHELL_PATH` for each shell session (different random IDs each time). Adding that path to `GITHUB_PATH` meant subsequent steps had a stale path. It seems to have still "worked" on the Linux runners by coincidence, but on Windows it failed because the stale path took precedence.

<img width="1738" height="872" alt="CleanShot 2025-12-15 at 12 58 30@2x" src="https://github.com/user-attachments/assets/5adc5632-5334-4197-86e8-627281763ff8" />

x-ref: https://github.com/vercel/next.js/actions/runs/20245943005/job/58127481871?pr=86955