### PR TITLE
[ci] Stop running explicit build when creating release

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -104,8 +104,6 @@ jobs:
 
       - run: pnpm install
 
-      - run: pnpm run build
-
       - run: node ./scripts/start-release.js --release-type ${{ github.event.inputs.releaseType || 'canary' }} --semver-type ${{ github.event.inputs.semverType }}
         env:
           RELEASE_BOT_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "debug": "cross-env NEXT_PRIVATE_LOCAL_DEV=1 NEXT_TELEMETRY_DISABLED=1 node --inspect --trace-deprecation --enable-source-maps packages/next/dist/bin/next",
     "debug-brk": "cross-env NEXT_PRIVATE_LOCAL_DEV=1 NEXT_TELEMETRY_DISABLED=1 node --inspect-brk --trace-deprecation --enable-source-maps packages/next/dist/bin/next",
     "postinstall": "node scripts/git-configure.mjs && node scripts/install-native.mjs",
-    "version": "pnpm install --no-frozen-lockfile && IS_PUBLISH=yes ./scripts/check-pre-compiled.sh && git add .",
+    "version": "pnpm install --no-frozen-lockfile && git add .",
     "prepare": "husky",
     "sync-react": "node ./scripts/sync-react.js",
     "update-google-fonts": "node ./scripts/update-google-fonts.js",

--- a/scripts/check-pre-compiled.sh
+++ b/scripts/check-pre-compiled.sh
@@ -16,7 +16,7 @@ cd ../../
 # Make sure to exit with 1 if there are changes after running ncc-compiled
 # step to ensure we get any changes committed
 
-if [[ ! -z $(git status -s) ]] && [[ -z $IS_PUBLISH ]];then
+if [[ ! -z $(git status -s) ]];then
   echo "Detected changes"
   git diff -a --stat
   exit 1


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/87178. I thought Lerna was invoking the `release` script but we're actually explicitly invoking it in a top-level `version` script.

Also removes the `pnpm build` step from the Job which I meant to include in the original PR.

## test plan

- [x] release with these changes (~3min faster): https://github.com/vercel/next.js/actions/runs/20263596514 -> https://github.com/vercel/next.js/commit/20da8eadc08f5a204234841aa67e3dc2f5271512 -> https://github.com/vercel/next.js/actions/runs/20263628436