### PR TITLE
[turbopack] Flag `turbopackInferModuleSideEffects` so it is only enabled in canary builds

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -469,7 +469,7 @@ export interface ExperimentalConfig {
    * analyze module code to determine if it has side effects. This can improve tree shaking
    * and bundle size at the cost of some additional analysis.
    *
-   * Defaults to `true`.
+   * Defaults to `true` in canary builds only
    */
   turbopackInferModuleSideEffects?: boolean
 
@@ -1576,6 +1576,7 @@ export const defaultConfig = Object.freeze({
     mcpServer: true,
     turbopackFileSystemCacheForDev: true,
     turbopackFileSystemCacheForBuild: false,
+    turbopackInferModuleSideEffects: !isStableBuild(),
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,


### PR DESCRIPTION
Since we are aiming for a release this week, lets flag this off since it probably won't get enough dogfooding before then.

Also this will unblock landing #86675