### PR TITLE
[turbopack] Enable inferring module side effects by default

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -484,7 +484,7 @@ export interface ExperimentalConfig {
    * analyze module code to determine if it has side effects. This can improve tree shaking
    * and bundle size at the cost of some additional analysis.
    *
-   * Defaults to `true` in canary builds only
+   * Defaults to `true`
    */
   turbopackInferModuleSideEffects?: boolean
 
@@ -1613,7 +1613,7 @@ export const defaultConfig = Object.freeze({
     mcpServer: true,
     turbopackFileSystemCacheForDev: true,
     turbopackFileSystemCacheForBuild: false,
-    turbopackInferModuleSideEffects: !isStableBuild(),
+    turbopackInferModuleSideEffects: true,
     devCacheControlNoCache: false,
   },
   htmlLimitedBots: undefined,


### PR DESCRIPTION
This was disabled for the 16.1 release.  so re-enable it just to get rid of the slightly odd `!isStableBuild` pattern and also ensure i don't forget to ship it for 16.2