### PR TITLE
fix(eslint): support pageExtensions in no-html-link-for-pages rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -60,6 +60,31 @@ export default defineRule({
               type: 'string',
             },
           },
+          {
+            type: 'object',
+            properties: {
+              pagesDir: {
+                oneOf: [
+                  {
+                    type: 'string',
+                  },
+                  {
+                    type: 'array',
+                    items: {
+                      type: 'string',
+                    },
+                  },
+                ],
+              },
+              pageExtensions: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+            },
+            additionalProperties: false,
+          },
         ],
       },
     ],
@@ -69,19 +94,58 @@ export default defineRule({
    * Creates an ESLint rule listener.
    */
   create(context) {
-    const ruleOptions: (string | string[])[] = context.options
+    const ruleOptions: (
+      | string
+      | string[]
+      | { pagesDir?: string | string[]; pageExtensions?: string[] }
+    )[] = context.options
     const [customPagesDirectory] = ruleOptions
+
+    let pagesDirs: string[]
+    let pageExtensions: string[] = ['tsx', 'ts', 'jsx', 'js']
 
     const rootDirs = getRootDirs(context)
 
-    const pagesDirs = (
-      customPagesDirectory
-        ? [customPagesDirectory]
-        : rootDirs.map((dir) => [
+    // Handle different option formats
+    if (
+      typeof customPagesDirectory === 'object' &&
+      !Array.isArray(customPagesDirectory)
+    ) {
+      // Object format with pagesDir and pageExtensions
+      const options = customPagesDirectory as {
+        pagesDir?: string | string[]
+        pageExtensions?: string[]
+      }
+
+      if (options.pageExtensions) {
+        pageExtensions = options.pageExtensions
+      }
+
+      if (options.pagesDir) {
+        pagesDirs = Array.isArray(options.pagesDir)
+          ? options.pagesDir
+          : [options.pagesDir]
+      } else {
+        pagesDirs = rootDirs
+          .map((dir) => [
             path.join(dir, 'pages'),
             path.join(dir, 'src', 'pages'),
           ])
-    ).flat()
+          .flat()
+      }
+    } else {
+      // Legacy string or array format
+      pagesDirs = (
+        customPagesDirectory
+          ? Array.isArray(customPagesDirectory)
+            ? customPagesDirectory
+            : [customPagesDirectory]
+          : rootDirs.map((dir) => [
+              path.join(dir, 'pages'),
+              path.join(dir, 'src', 'pages'),
+            ])
+      ).flat()
+    }
 
     const foundPagesDirs = pagesDirs.filter((dir) => {
       if (fsExistsSyncCache[dir] === undefined) {
@@ -107,8 +171,16 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -6,27 +6,50 @@ import * as fs from 'fs'
 const fsReadDirSyncCache = {}
 
 /**
+ * Creates a regex pattern from page extensions.
+ * For example, ['tsx', 'ts', 'jsx', 'js'] becomes /\.(tsx|ts|jsx|js)$/
+ * For custom extensions like ['page.tsx', 'page.ts'], becomes /\.(page\.tsx|page\.ts)$/
+ */
+function createExtensionRegex(pageExtensions: string[]): RegExp {
+  const escapedExtensions = pageExtensions.map((ext) =>
+    ext.replace(/\./g, '\\.')
+  )
+  return new RegExp(`\\.(${escapedExtensions.join('|')})$`)
+}
+
+/**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[]
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extensionRegex = createExtensionRegex(pageExtensions)
+  const indexRegex = new RegExp(
+    `^index\\.(${pageExtensions.map((ext) => ext.replace(/\./g, '\\.')).join('|')})$`
+  )
+
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    if (extensionRegex.test(dirent.name)) {
+      if (indexRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(indexRegex, '')}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extensionRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -36,24 +59,40 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[]
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extensionRegex = createExtensionRegex(pageExtensions)
+  const pageRegex = new RegExp(
+    `^page\\.(${pageExtensions.map((ext) => ext.replace(/\./g, '\\.')).join('|')})$`
+  )
+  const layoutRegex = new RegExp(
+    `^layout\\.(${pageExtensions.map((ext) => ext.replace(/\./g, '\\.')).join('|')})$`
+  )
+
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extensionRegex.test(dirent.name)) {
+      if (pageRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageRegex, '')}`)
+      } else if (!layoutRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extensionRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
-      if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+      if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
+        res.push(
+          ...parseUrlForAppDir(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -136,13 +175,16 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = ['tsx', 'ts', 'jsx', 'js']
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +198,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = ['tsx', 'ts', 'jsx', 'js']
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -10,6 +10,7 @@ const withCustomPagesDir = path.join(__dirname, 'with-custom-pages-dir')
 const withNestedPagesDir = path.join(__dirname, 'with-nested-pages-dir')
 const withoutPagesDir = path.join(__dirname, 'without-pages-dir')
 const withAppDir = path.join(__dirname, 'with-app-dir')
+const withCustomExtensions = path.join(__dirname, 'with-custom-extensions')
 
 const linters = {
   withoutPages: new Linter({
@@ -26,6 +27,10 @@ const linters = {
   }),
   withCustomPages: new Linter({
     cwd: withCustomPagesDir,
+    configType: 'eslintrc',
+  }),
+  withCustomExtensions: new Linter({
+    cwd: withCustomExtensions,
     configType: 'eslintrc',
   }),
 }
@@ -70,6 +75,18 @@ const linterConfigWithNestedContentRootDirDirectory = {
     next: {
       rootDir: path.join(withNestedPagesDir, 'demos/with-nextjs'),
     },
+  },
+}
+const linterConfigWithPageExtensions = {
+  ...linterConfig,
+  rules: {
+    'no-html-link-for-pages': [
+      2,
+      {
+        pagesDir: path.join(withCustomExtensions, 'pages'),
+        pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
+      },
+    ],
   },
 }
 
@@ -493,6 +510,52 @@ describe('no-html-link-for-pages', function () {
     assert.equal(
       report.message,
       'Do not use an `<a>` element to navigate to `/photo/1/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('valid link element with custom page extensions', function () {
+    const report = linters.withCustomExtensions.verify(
+      validCode,
+      linterConfigWithPageExtensions,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
+  })
+  it('invalid static route with custom page extensions', function () {
+    const [report] = linters.withCustomExtensions.verify(
+      invalidStaticCode,
+      linterConfigWithPageExtensions,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('invalid dynamic route with custom page extensions', function () {
+    const invalidDynamicCodeWithCustomExt = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/products/123'>Product</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+    const [report] = linters.withCustomExtensions.verify(
+      invalidDynamicCodeWithCustomExt,
+      linterConfigWithPageExtensions,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/products/123/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
     )
   })
 })

--- a/test/unit/eslint-plugin-next/with-custom-extensions/pages/index.page.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-extensions/pages/index.page.tsx
@@ -1,0 +1,1 @@
+export default () => {}

--- a/test/unit/eslint-plugin-next/with-custom-extensions/pages/products/[id].page.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-extensions/pages/products/[id].page.tsx
@@ -1,0 +1,1 @@
+export default () => {}


### PR DESCRIPTION
## Summary

Add support for custom `pageExtensions` option in the `no-html-link-for-pages` ESLint rule. This allows projects using custom page extensions (e.g., `.page.tsx`, `.page.ts`) to properly detect internal routes.

### Changes
- Add `pageExtensions` option to rule schema
- Update `url.ts` to accept `pageExtensions` parameter  
- Create dynamic regex patterns based on provided extensions
- Add tests for custom page extensions

### Usage

```js
// .eslintrc.js
module.exports = {
  rules: {
    '@next/next/no-html-link-for-pages': [
      'error',
      {
        pagesDir: 'src/pages',
        pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js']
      }
    ]
  }
}
```

## How tested

- Added 3 new test cases for custom page extensions
- All 26 tests pass

Fixes #53473