### PR TITLE
fix(head): add warning for invalid children in next/head

### DIFF
--- a/errors/invalid-head-child.mdx
+++ b/errors/invalid-head-child.mdx
@@ -1,0 +1,91 @@
+---
+title: Invalid Head Child
+---
+
+## Why This Error Occurred
+
+An invalid HTML element was used as a child of the `next/head` component.
+
+The `<Head>` component from `next/head` is designed to manage the document `<head>` and only accepts specific HTML elements that are valid within a `<head>` tag.
+
+Valid children elements are:
+
+- `<title>`
+- `<meta>`
+- `<link>`
+- `<script>`
+- `<style>`
+- `<base>`
+- `<noscript>`
+
+## Possible Ways to Fix It
+
+### Move Invalid Elements Outside Head
+
+If you're trying to add elements like `<div>`, `<span>`, or other body elements, move them outside the `<Head>` component:
+
+**Before:**
+
+```jsx filename="pages/index.js"
+import Head from 'next/head'
+
+function Index() {
+  return (
+    <>
+      <Head>
+        <title>My page title</title>
+        <div>This is invalid!</div>
+      </Head>
+    </>
+  )
+}
+
+export default Index
+```
+
+**After:**
+
+```jsx filename="pages/index.js"
+import Head from 'next/head'
+
+function Index() {
+  return (
+    <>
+      <Head>
+        <title>My page title</title>
+      </Head>
+      <div>This is valid now!</div>
+    </>
+  )
+}
+
+export default Index
+```
+
+### Use Valid Head Elements
+
+Ensure you're only using valid `<head>` elements inside the `<Head>` component:
+
+```jsx filename="pages/index.js"
+import Head from 'next/head'
+
+function Index() {
+  return (
+    <>
+      <Head>
+        <title>My page title</title>
+        <meta name="description" content="Page description" />
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+    </>
+  )
+}
+
+export default Index
+```
+
+## Useful Links
+
+- [next/head](/docs/pages/api-reference/components/head)
+- [MDN: HTML head element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head)

--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -13,6 +13,16 @@ export function defaultHead(): JSX.Element[] {
   return head
 }
 
+const VALID_HEAD_TAGS = [
+  'title',
+  'meta',
+  'link',
+  'script',
+  'style',
+  'base',
+  'noscript',
+]
+
 function onlyReactElement(
   list: Array<React.ReactElement<any>>,
   child: React.ReactElement | number | string
@@ -43,6 +53,21 @@ function onlyReactElement(
       )
     )
   }
+
+  // In development, warn about invalid tags
+  if (process.env.NODE_ENV === 'development') {
+    if (
+      typeof child.type === 'string' &&
+      !VALID_HEAD_TAGS.includes(child.type)
+    ) {
+      warnOnce(
+        `<${child.type}> is not a valid child of next/head. ` +
+          `Valid children are: ${VALID_HEAD_TAGS.join(', ')}. ` +
+          `See: https://nextjs.org/docs/messages/invalid-head-child`
+      )
+    }
+  }
+
   return list.concat(child)
 }
 


### PR DESCRIPTION
## Summary

Add development-time warning when invalid HTML elements are used as children of the `next/head` component. This helps developers identify issues early instead of seeing confusing "next-head-count is missing" errors at runtime.

### Problem

When developers accidentally put invalid elements like `<div>` inside `<Head>`, they get a cryptic "next-head-count is missing" error that doesn't help identify the root cause.

### Solution

Add validation in development mode that warns about invalid children with a clear message:

```
Warning: <div> is not a valid child of next/head. 
Valid children are: title, meta, link, script, style, base, noscript.
See: https://nextjs.org/docs/messages/invalid-head-child
```

### Changes
- Add `VALID_HEAD_TAGS` constant
- Add `warnOnce()` call for invalid element types in development
- Create `/errors/invalid-head-child.mdx` documentation page

## How tested

Manual testing with invalid Head children in development mode.

Fixes #20924