### PR TITLE
[ci] Fix releaseStats in build-and-deploy

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -709,6 +709,9 @@ jobs:
         env:
           PR_STATS_COMMENT_TOKEN: ${{ secrets.PR_STATS_COMMENT_TOKEN }}
           NEXT_SKIP_NATIVE_POSTINSTALL: 1
+          # This uses the webpack bundle analyzer and for consistent results we need to use webpack.
+          # Once there is an equivalent analyzer for turbopack, we can remove this.
+          IS_WEBPACK_TEST: 1
 
   upload_turbopack_bytesize:
     if: ${{ needs.deploy-target.outputs.value != 'automated-preview'}}


### PR DESCRIPTION
Sames as for Generate PR stats (https://github.com/vercel/next.js/blob/ece6982fbcdd97d9b14cba3bd1c0b73ae6232155/.github/workflows/pull_request_stats.yml#L70)