### PR TITLE
Log available core count on next server init

### DIFF
--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -1,5 +1,6 @@
 import { loadEnvConfig } from '@next/env'
 import * as inspector from 'inspector'
+import os from 'os'
 import * as Log from '../../build/output/log'
 import { bold, purple, strikethrough } from '../../lib/picocolors'
 import {
@@ -97,6 +98,11 @@ export function logStartInfo({
       }
     }
   }
+
+  // Report available cores to put execution times in perspective
+  // `availableCores` is preferred over `cpus().length` because it reflects any restrictions applied to containers
+  const availableCores = os.availableParallelism()
+  Log.bootstrap(`- Available Cores: ${availableCores}`)
 
   // New line after the bootstrap info
   Log.info('')


### PR DESCRIPTION
@timneutkens suggested yesterday it might be useful to log the core count when the server starts, so that we can contextualize the compile time numbers. This is a simple change, but I'm not sure the best place to log this, so it's open to input

On running `next dev`:
```
> next dev

▲ Next.js 16.1.0-canary.24 (Turbopack)
- Local:         http://localhost:3000
- Network:       http://192.168.1.31:3000
- Available Cores: 10

✓ Starting...
```