### PR TITLE
Move off of deprecated url.parse

### DIFF
--- a/packages/create-next-app/helpers/is-online.ts
+++ b/packages/create-next-app/helpers/is-online.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process'
 import { lookup } from 'node:dns/promises'
-import url from 'node:url'
+import { URL } from 'node:url'
 
 function getProxy(): string | undefined {
   if (process.env.https_proxy) {
@@ -27,7 +27,14 @@ export async function getOnline(): Promise<boolean> {
       return false
     }
 
-    const { hostname } = url.parse(proxy)
+    let url: URL
+    try {
+      url = new URL(proxy)
+    } catch {
+      // Invalid proxy URL
+      return false
+    }
+    const { hostname } = url
     if (!hostname) {
       // Invalid proxy URL
       return false

--- a/packages/next/src/lib/try-to-parse-path.ts
+++ b/packages/next/src/lib/try-to-parse-path.ts
@@ -1,6 +1,5 @@
 import type { Token } from 'next/dist/compiled/path-to-regexp'
 import { parse, tokensToRegexp } from 'next/dist/compiled/path-to-regexp'
-import { parse as parseURL } from 'url'
 import isError from './is-error'
 import { normalizeTokensForRegexp } from './route-pattern-normalizer'
 
@@ -67,8 +66,8 @@ export function tryToParsePath(
   const result: ParseResult = { route, parsedPath: route }
   try {
     if (options?.handleUrl) {
-      const parsed = parseURL(route, true)
-      result.parsedPath = `${parsed.pathname!}${parsed.hash || ''}`
+      const parsed = new URL(route, 'http://n')
+      result.parsedPath = `${parsed.pathname}${parsed.hash || ''}`
     }
 
     result.tokens = parse(result.parsedPath)

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -18,7 +18,6 @@ import type {
   ServerOnInstrumentationRequestError,
 } from './app-render/types'
 import type { ServerComponentsHmrCache } from './response-cache'
-import type { UrlWithParsedQuery } from 'url'
 import {
   NormalizeError,
   DecodeError,
@@ -46,7 +45,7 @@ import type { PathnameNormalizer } from './normalizers/request/pathname-normaliz
 import type { InstrumentationModule } from './instrumentation/types'
 
 import * as path from 'path'
-import { format as formatUrl, parse as parseUrl } from 'url'
+import { format as formatUrl } from 'url'
 import { formatHostname } from './lib/format-hostname'
 import {
   APP_PATHS_MANIFEST,
@@ -75,7 +74,10 @@ import {
 import { removePathPrefix } from '../shared/lib/router/utils/remove-path-prefix'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
 import { getHostname } from '../shared/lib/get-hostname'
-import { parseUrl as parseUrlUtil } from '../shared/lib/router/utils/parse-url'
+import {
+  parseUrl,
+  parseUrl as parseUrlUtil,
+} from '../shared/lib/router/utils/parse-url'
 import { getNextPathnameInfo } from '../shared/lib/router/utils/get-next-pathname-info'
 import {
   RSC_HEADER,
@@ -953,7 +955,7 @@ export default abstract class Server<
           throw new Error('Invariant: url can not be undefined')
         }
 
-        parsedUrl = parseUrl(req.url!, true)
+        parsedUrl = parseUrl(req.url)
       }
 
       if (!parsedUrl.pathname) {
@@ -1681,7 +1683,7 @@ export default abstract class Server<
   protected async run(
     req: ServerRequest,
     res: ServerResponse,
-    parsedUrl: UrlWithParsedQuery
+    parsedUrl: NextUrlWithParsedQuery
   ): Promise<void> {
     return getTracer().trace(BaseServerSpan.run, async () =>
       this.runImpl(req, res, parsedUrl)
@@ -1691,7 +1693,7 @@ export default abstract class Server<
   private async runImpl(
     req: ServerRequest,
     res: ServerResponse,
-    parsedUrl: UrlWithParsedQuery
+    parsedUrl: NextUrlWithParsedQuery
   ): Promise<void> {
     await this.handleCatchallRenderRequest(req, res, parsedUrl)
   }
@@ -2963,7 +2965,7 @@ export default abstract class Server<
     parsedUrl?: Pick<NextUrlWithParsedQuery, 'pathname' | 'query'>,
     setHeaders = true
   ): Promise<void> {
-    const { pathname, query } = parsedUrl ? parsedUrl : parseUrl(req.url!, true)
+    const { pathname, query } = parsedUrl ? parsedUrl : parseUrl(req.url)
 
     // Ensure the locales are provided on the request meta.
     if (this.nextConfig.i18n) {

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -368,7 +368,7 @@ export async function initialize(opts: {
           req.url = removePathPrefix(origUrl, config.assetPrefix)
         }
 
-        const parsedUrl = url.parse(req.url || '/')
+        const parsedUrl = parseUrlUtil(req.url || '/')
 
         const hotReloaderResult = await development.bundler.hotReloader.run(
           req,
@@ -508,14 +508,9 @@ export async function initialize(opts: {
         if (!(req.method === 'GET' || req.method === 'HEAD')) {
           res.setHeader('Allow', ['GET', 'HEAD'])
           res.statusCode = 405
-          return await invokeRender(
-            url.parse('/405', true),
-            '/405',
-            handleIndex,
-            {
-              invokeStatus: 405,
-            }
-          )
+          return await invokeRender(parseUrlUtil('/405'), '/405', handleIndex, {
+            invokeStatus: 405,
+          })
         }
 
         try {
@@ -574,7 +569,7 @@ export async function initialize(opts: {
             const invokeStatus = err.statusCode
             res.statusCode = err.statusCode
             return await invokeRender(
-              url.parse(invokePath, true),
+              parseUrlUtil(invokePath),
               invokePath,
               handleIndex,
               {
@@ -684,7 +679,7 @@ export async function initialize(opts: {
           console.error(err)
         }
         res.statusCode = Number(invokeStatus)
-        return await invokeRender(url.parse(invokePath, true), invokePath, 0, {
+        return await invokeRender(parseUrlUtil(invokePath), invokePath, 0, {
           invokeStatus: res.statusCode,
         })
       } catch (err2) {

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -10,7 +10,6 @@ import type { NextJsHotReloaderInterface } from '../../dev/hot-reloader-types'
 import { createDefineEnv } from '../../../build/swc'
 import { installBindings } from '../../../build/swc/install-bindings'
 import fs from 'fs'
-import url from 'url'
 import path from 'path'
 import qs from 'querystring'
 import Watchpack from 'next/dist/compiled/watchpack'
@@ -81,6 +80,7 @@ import {
   MIDDLEWARE_FILENAME,
   PROXY_FILENAME,
 } from '../../../lib/constants'
+import { parseUrl } from '../../../lib/url'
 import {
   createRouteTypesManifest,
   writeRouteTypesManifest,
@@ -1213,9 +1213,10 @@ async function startWatcher(
   opts.fsChecker.devVirtualFsItems.add(devTurbopackMiddlewareManifestPath)
 
   async function requestHandler(req: IncomingMessage, res: ServerResponse) {
-    const parsedUrl = url.parse(req.url || '/')
+    const parsedUrl = parseUrl(req.url || '/')
+    const pathname = parsedUrl !== undefined ? parsedUrl.pathname : null
 
-    if (parsedUrl.pathname?.includes(clientPagesManifestPath)) {
+    if (pathname !== null && pathname.includes(clientPagesManifestPath)) {
       res.statusCode = 200
       res.setHeader('Content-Type', JSON_CONTENT_TYPE_HEADER)
       res.end(
@@ -1229,8 +1230,9 @@ async function startWatcher(
     }
 
     if (
-      parsedUrl.pathname?.includes(devMiddlewareManifestPath) ||
-      parsedUrl.pathname?.includes(devTurbopackMiddlewareManifestPath)
+      pathname !== null &&
+      (pathname.includes(devMiddlewareManifestPath) ||
+        pathname.includes(devTurbopackMiddlewareManifestPath))
     ) {
       res.statusCode = 200
       res.setHeader('Content-Type', JSON_CONTENT_TYPE_HEADER)

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -22,7 +22,6 @@ import type { Params } from './request/params'
 import type { MiddlewareRouteMatch } from '../shared/lib/router/utils/middleware-route-matcher'
 import type { RouteMatch } from './route-matches/route-match'
 import type { IncomingMessage, ServerResponse } from 'http'
-import type { UrlWithParsedQuery } from 'url'
 import type { ParsedUrlQuery } from 'querystring'
 import type { ParsedUrl } from '../shared/lib/router/utils/parse-url'
 import type { CacheControl } from './lib/cache-control'
@@ -1636,7 +1635,7 @@ export default class NextNodeServer extends BaseServer<
     request: NodeNextRequest
     response: NodeNextResponse
     parsedUrl: ParsedUrl
-    parsed: UrlWithParsedQuery
+    parsed: NextUrlWithParsedQuery
     onWarning?: (warning: Error) => void
   }) {
     if (process.env.NEXT_MINIMAL) {

--- a/packages/next/src/server/next.ts
+++ b/packages/next/src/server/next.ts
@@ -3,7 +3,6 @@ import type {
   NodeRequestHandler,
   Options as ServerOptions,
 } from './next-server'
-import type { UrlWithParsedQuery } from 'url'
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { Duplex } from 'stream'
 import type { NextUrlWithParsedQuery, RequestMeta } from './request-meta'
@@ -148,7 +147,7 @@ export class NextServer implements NextWrapperServer {
     return async (
       req: IncomingMessage,
       res: ServerResponse,
-      parsedUrl?: UrlWithParsedQuery
+      parsedUrl?: NextUrlWithParsedQuery
     ) => {
       return getTracer().trace(NextServerSpan.getRequestHandler, async () => {
         const requestHandler = await this.getServerRequestHandler()
@@ -165,7 +164,7 @@ export class NextServer implements NextWrapperServer {
     return async (
       req: IncomingMessage,
       res: ServerResponse,
-      parsedUrl?: UrlWithParsedQuery
+      parsedUrl?: NextUrlWithParsedQuery
     ) => {
       return getTracer().trace(
         NextServerSpan.getRequestHandlerWithMetadata,
@@ -444,7 +443,7 @@ class NextCustomServer implements NextWrapperServer {
     return async (
       req: IncomingMessage,
       res: ServerResponse,
-      parsedUrl?: UrlWithParsedQuery
+      parsedUrl?: NextUrlWithParsedQuery
     ) => {
       this.setupWebSocketHandler(this.options.httpServer, req)
 

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -1,6 +1,5 @@
 import type { IncomingMessage } from 'http'
 import type { ParsedUrlQuery } from 'querystring'
-import type { UrlWithParsedQuery } from 'url'
 import type { BaseNextRequest } from './base-http'
 import type { CloneableBody } from './body-streams'
 import type { RouteMatch } from './route-matches/route-match'
@@ -357,6 +356,26 @@ type NextQueryMetadata = {
 
 export type NextParsedUrlQuery = ParsedUrlQuery & NextQueryMetadata
 
-export interface NextUrlWithParsedQuery extends UrlWithParsedQuery {
+/**
+ * subset of `url.parse` return value
+ */
+interface LegacyUrl {
+  auth?: string | null
+  hash: string | null
+  hostname: string | null
+  href: string
+  pathname: string | null
+  protocol: string | null
+  search: string | null
+  slashes: boolean | null
+  port: string | null
+  query: string | null | ParsedUrlQuery
+}
+interface LegacyUrlWithParsedQuery extends LegacyUrl {
+  query: ParsedUrlQuery
+}
+
+// TODO: Remove in favor of WHATWG URLs
+export interface NextUrlWithParsedQuery extends LegacyUrlWithParsedQuery {
   query: NextParsedUrlQuery
 }

--- a/packages/next/src/server/server-utils.ts
+++ b/packages/next/src/server/server-utils.ts
@@ -2,8 +2,8 @@ import type { Rewrite } from '../lib/load-custom-routes'
 import type { RouteMatchFn } from '../shared/lib/router/utils/route-matcher'
 import type { NextConfig } from './config'
 import type { BaseNextRequest } from './base-http'
+import type { NextUrlWithParsedQuery } from './request-meta'
 import type { ParsedUrlQuery } from 'querystring'
-import type { UrlWithParsedQuery } from 'url'
 
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
 import { getPathMatch } from '../shared/lib/router/utils/path-match'
@@ -218,11 +218,13 @@ export function getServerUtils({
 
   function handleRewrites(
     req: BaseNextRequest | IncomingMessage,
-    parsedUrl: DeepReadonly<UrlWithParsedQuery>
+    parsedUrl: DeepReadonly<NextUrlWithParsedQuery>
   ) {
     // Here we deep clone the parsedUrl to avoid mutating the original. We also
     // cast this to a mutable type so we can mutate it within this scope.
-    const rewrittenParsedUrl = structuredClone(parsedUrl) as UrlWithParsedQuery
+    const rewrittenParsedUrl = structuredClone(
+      parsedUrl
+    ) as NextUrlWithParsedQuery
     const rewriteParams: Record<string, string> = {}
     let fsPathname = rewrittenParsedUrl.pathname
 

--- a/packages/next/src/shared/lib/router/utils/parse-relative-url.test.ts
+++ b/packages/next/src/shared/lib/router/utils/parse-relative-url.test.ts
@@ -4,11 +4,12 @@ describe('relative urls', () => {
   it('should return valid pathname', () => {
     expect(parseRelativeUrl('/').pathname).toBe('/')
     expect(parseRelativeUrl('/abc').pathname).toBe('/abc')
+    expect(parseRelativeUrl('//**y/\\').pathname).toBe('//**y//')
+    expect(parseRelativeUrl('//google.com').pathname).toBe('//google.com')
   })
 
   it('should throw for invalid pathname', () => {
-    expect(() => parseRelativeUrl('//**y/\\')).toThrow()
-    expect(() => parseRelativeUrl('//google.com')).toThrow()
+    expect(() => parseRelativeUrl('http://example.com/abc')).toThrow()
   })
 })
 

--- a/packages/next/src/shared/lib/router/utils/parse-relative-url.ts
+++ b/packages/next/src/shared/lib/router/utils/parse-relative-url.ts
@@ -49,10 +49,13 @@ export function parseRelativeUrl(
         )
       : globalBase
 
-  const { pathname, searchParams, search, hash, href, origin } = new URL(
-    url,
-    resolvedBase
+  const { pathname, searchParams, search, hash, href, origin } = url.startsWith(
+    '/'
   )
+    ? // 'http://localhost:3000///' would be received as '///' in Node.js' IncomingMessage
+      // See https://nodejs.org/api/http.html#messageurl
+      new URL(`${resolvedBase.origin}${url}`)
+    : new URL(url, resolvedBase)
 
   if (origin !== globalBase.origin) {
     throw new Error(`invariant: invalid relative URL, router received ${url}`)

--- a/packages/next/src/shared/lib/router/utils/parse-relative-url.ts
+++ b/packages/next/src/shared/lib/router/utils/parse-relative-url.ts
@@ -3,12 +3,17 @@ import { getLocationOrigin } from '../../utils'
 import { searchParamsToUrlQuery } from './querystring'
 
 export interface ParsedRelativeUrl {
+  auth: string | null
   hash: string
+  host: string | null
+  hostname: string | null
   href: string
   pathname: string
+  port: string | null
+  protocol: string | null
   query: ParsedUrlQuery
   search: string
-  slashes: undefined
+  slashes: null
 }
 
 /**
@@ -54,13 +59,18 @@ export function parseRelativeUrl(
   }
 
   return {
+    auth: null,
+    host: null,
+    hostname: null,
     pathname,
+    port: null,
+    protocol: null,
     query: parseQuery ? searchParamsToUrlQuery(searchParams) : undefined,
     search,
     hash,
     href: href.slice(origin.length),
     // We don't know for relative URLs at this point since we set a custom, internal
     // base that isn't surfaced to users.
-    slashes: undefined,
+    slashes: null,
   }
 }

--- a/packages/next/src/shared/lib/router/utils/parse-relative-url.ts
+++ b/packages/next/src/shared/lib/router/utils/parse-relative-url.ts
@@ -54,7 +54,8 @@ export function parseRelativeUrl(
   )
     ? // 'http://localhost:3000///' would be received as '///' in Node.js' IncomingMessage
       // See https://nodejs.org/api/http.html#messageurl
-      new URL(`${resolvedBase.origin}${url}`)
+      // Not using `origin` to support other protocols
+      new URL(`${resolvedBase.protocol}//${resolvedBase.host}${url}`)
     : new URL(url, resolvedBase)
 
   if (origin !== globalBase.origin) {

--- a/packages/next/src/shared/lib/router/utils/parse-url.ts
+++ b/packages/next/src/shared/lib/router/utils/parse-url.ts
@@ -4,16 +4,17 @@ import { searchParamsToUrlQuery } from './querystring'
 import { parseRelativeUrl } from './parse-relative-url'
 
 export interface ParsedUrl {
+  auth: string | null
   hash: string
-  hostname?: string | null
+  hostname: string | null
   href: string
-  pathname: string
-  port?: string | null
-  protocol?: string | null
-  query: ParsedUrlQuery
   origin?: string | null
+  pathname: string
+  port: string | null
+  protocol: string | null
+  query: ParsedUrlQuery
   search: string
-  slashes: boolean | undefined
+  slashes: boolean | null
 }
 
 export function parseUrl(url: string): ParsedUrl {
@@ -22,15 +23,25 @@ export function parseUrl(url: string): ParsedUrl {
   }
 
   const parsedURL = new URL(url)
+  const username = parsedURL.username
+  const password = parsedURL.password
+  const auth = username
+    ? password
+      ? `${username}:${password}`
+      : username
+    : null
+  const pathname = parsedURL.pathname
+  const search = parsedURL.search
   return {
+    auth,
     hash: parsedURL.hash,
     hostname: parsedURL.hostname,
     href: parsedURL.href,
-    pathname: parsedURL.pathname,
+    pathname,
     port: parsedURL.port,
     protocol: parsedURL.protocol,
     query: searchParamsToUrlQuery(parsedURL.searchParams),
-    search: parsedURL.search,
+    search,
     origin: parsedURL.origin,
     slashes:
       parsedURL.href.slice(

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
@@ -14,14 +14,18 @@ describe('parseDestination', () => {
 
     expect(result).toMatchInlineSnapshot(`
      {
+       "auth": null,
        "hash": "",
-       "hostname": undefined,
+       "host": null,
+       "hostname": null,
        "href": "/hello/:name",
        "origin": undefined,
        "pathname": "/hello/:name",
+       "port": null,
+       "protocol": null,
        "query": {},
        "search": "",
-       "slashes": undefined,
+       "slashes": null,
      }
     `)
   })
@@ -39,6 +43,7 @@ describe('parseDestination', () => {
 
     expect(result).toMatchInlineSnapshot(`
      {
+       "auth": null,
        "hash": "#bar",
        "hostname": "o:foo.com",
        "href": "https://o:foo.com/hello/:name#bar",
@@ -66,6 +71,7 @@ describe('parseDestination', () => {
 
     expect(result).toMatchInlineSnapshot(`
      {
+       "auth": null,
        "hash": "",
        "hostname": "o:foo.com",
        "href": "https://o:foo.com/hello/:name?foo=:bar",

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.ts
@@ -5,7 +5,7 @@ import type { RouteHas } from '../../../../lib/load-custom-routes'
 import type { BaseNextRequest } from '../../../../server/base-http'
 
 import { escapeStringRegexp } from '../../escape-regexp'
-import { parseUrl } from './parse-url'
+import { parseUrl, type ParsedUrl } from './parse-url'
 import {
   INTERCEPTION_ROUTE_MARKERS,
   isInterceptionRouteAppPath,
@@ -163,7 +163,7 @@ export function parseDestination(args: {
   destination: string
   params: Readonly<Params>
   query: Readonly<NextParsedUrlQuery>
-}) {
+}): ParsedUrl {
   let escaped = args.destination
   for (const param of Object.keys({ ...args.params, ...args.query })) {
     if (!param) continue

--- a/packages/next/src/shared/lib/router/utils/resolve-rewrites.ts
+++ b/packages/next/src/shared/lib/router/utils/resolve-rewrites.ts
@@ -6,11 +6,9 @@ import { removeTrailingSlash } from './remove-trailing-slash'
 import { normalizeLocalePath } from '../../i18n/normalize-locale-path'
 import { removeBasePath } from '../../../../client/remove-base-path'
 import { parseRelativeUrl, type ParsedRelativeUrl } from './parse-relative-url'
+import type { ParsedUrl } from './parse-url'
 
-interface ParsedAs extends Omit<ParsedRelativeUrl, 'slashes'> {
-  slashes: boolean | undefined
-}
-
+type ParsedAs = ParsedRelativeUrl | ParsedUrl
 export default function resolveRewrites(
   asPath: string,
   pages: string[],

--- a/test/e2e/i18n-ignore-redirect-source-locale/redirects-with-basepath.test.ts
+++ b/test/e2e/i18n-ignore-redirect-source-locale/redirects-with-basepath.test.ts
@@ -1,6 +1,6 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 
@@ -58,7 +58,9 @@ describe('i18n-ignore-redirect-source-locale with basepath', () => {
     'get redirected to the new page, from: %s to: sv',
     async (locale) => {
       const browser = await webdriver(next.url, `basepath/${locale}/to-sv`)
-      await check(() => browser.elementById('current-locale').text(), 'sv')
+      await retry(async () => {
+        expect(await browser.elementById('current-locale').text()).toBe('sv')
+      })
     }
   )
 
@@ -66,7 +68,9 @@ describe('i18n-ignore-redirect-source-locale with basepath', () => {
     'get redirected to the new page, from: %s to: en',
     async (locale) => {
       const browser = await webdriver(next.url, `basepath/${locale}/to-en`)
-      await check(() => browser.elementById('current-locale').text(), 'en')
+      await retry(async () => {
+        expect(await browser.elementById('current-locale').text()).toBe('en')
+      })
     }
   )
 
@@ -74,7 +78,9 @@ describe('i18n-ignore-redirect-source-locale with basepath', () => {
     'get redirected to the new page, from: %s to: /',
     async (locale) => {
       const browser = await webdriver(next.url, `basepath/${locale}/to-slash`)
-      await check(() => browser.elementById('current-locale').text(), 'en')
+      await retry(async () => {
+        expect(await browser.elementById('current-locale').text()).toBe('en')
+      })
     }
   )
 
@@ -82,10 +88,11 @@ describe('i18n-ignore-redirect-source-locale with basepath', () => {
     'get redirected to the new page, from and to: %s',
     async (locale) => {
       const browser = await webdriver(next.url, `basepath/${locale}/to-same`)
-      await check(
-        () => browser.elementById('current-locale').text(),
-        locale === '' ? 'en' : locale.slice(1)
-      )
+      await retry(async () => {
+        expect(await browser.elementById('current-locale').text()).toBe(
+          locale === '' ? 'en' : locale.slice(1)
+        )
+      })
     }
   )
 })


### PR DESCRIPTION
`url.parse` is deprecated. This moves to our internal parse util. 

As a follow-up, we should try to move completely to WHATWG urls so that we don't have to maintain our custom parsing logic. At the boundary, we still need to accept the old `UrlObject` since that's part of our custom server interface.
`url.format` is already considered legacy so we should fast-follow.

Fixes https://github.com/vercel/next.js/issues/83183
Closes https://linear.app/vercel/issue/NEXT-4831