### PR TITLE
bundle-analyzer: make running the web server default

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -213,8 +213,8 @@ program
   .option('--no-mangling', 'Disables mangling.')
   .option('--profile', 'Enables production profiling for React.')
   .option(
-    '--output',
-    'Only write analysis files to disk. Does not start the server.'
+    '-o, --output [path]',
+    'Only write analysis files to disk. Does not start the server. Optionally specify a custom output path (defaults to .next/diagnostics/analyze).'
   )
   .addOption(
     new Option(

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -202,7 +202,7 @@ program
 program
   .command('experimental-analyze')
   .description(
-    'Analyze bundle output. Does not produce build artifacts. Only compatible with Turbopack.'
+    'Analyze production bundle output with an interactive web ui. Does not produce an application build. Only compatible with Turbopack.'
   )
   .argument(
     '[directory]',
@@ -212,7 +212,10 @@ program
   )
   .option('--no-mangling', 'Disables mangling.')
   .option('--profile', 'Enables production profiling for React.')
-  .option('--serve', 'Serve the bundle analyzer in a browser after analysis.')
+  .option(
+    '--output',
+    'Only write analysis files to disk. Does not start the server.'
+  )
   .addOption(
     new Option(
       '--port <port>',
@@ -227,7 +230,7 @@ program
     return import('../cli/next-analyze.js')
       .then((mod) => mod.nextAnalyze(options, directory))
       .then(() => {
-        if (!options.serve) {
+        if (options.output) {
           // The Next.js process is held open by something on the event loop. Exit manually like the `build` command does.
           // TODO: Fix the underlying issue so this is not necessary.
           process.exit(0)

--- a/packages/next/src/build/analyze/index.ts
+++ b/packages/next/src/build/analyze/index.ts
@@ -37,7 +37,7 @@ export type AnalyzeOptions = {
   reactProductionProfiling?: boolean
   noMangling?: boolean
   appDirOnly?: boolean
-  serve?: boolean
+  output?: boolean
   port?: number
 }
 
@@ -46,7 +46,7 @@ export default async function analyze({
   reactProductionProfiling = false,
   noMangling = false,
   appDirOnly = false,
-  serve = false,
+  output = false,
   port = 4000,
 }: AnalyzeOptions): Promise<void> {
   try {
@@ -78,8 +78,8 @@ export default async function analyze({
 
     const durationString = durationToString(analyzeDuration)
     let logMessage = `Analyze completed in ${durationString}.`
-    if (!serve) {
-      logMessage += ` To explore the analyze results, run \`next experimental-analyze --serve\`.`
+    if (output) {
+      logMessage += ` Results written to ${ANALYZE_PATH}.\nTo explore the analyze results interactively, run \`next experimental-analyze\` without \`--output\`.`
     }
     Log.event(logMessage)
 
@@ -108,7 +108,7 @@ export default async function analyze({
       })
     )
 
-    if (serve) {
+    if (!output) {
       await startServer(path.join(dir, ANALYZE_PATH), port)
     }
   } catch (e) {

--- a/packages/next/src/build/analyze/index.ts
+++ b/packages/next/src/build/analyze/index.ts
@@ -37,7 +37,7 @@ export type AnalyzeOptions = {
   reactProductionProfiling?: boolean
   noMangling?: boolean
   appDirOnly?: boolean
-  output?: boolean
+  output?: boolean | string
   port?: number
 }
 
@@ -77,9 +77,16 @@ export default async function analyze({
       await turbopackAnalyze(analyzeContext)
 
     const durationString = durationToString(analyzeDuration)
+
+    // Determine the output path: use custom path if provided, otherwise default
+    const outputPath = typeof output === 'string' ? output : ANALYZE_PATH
+    const resolvedOutputPath = path.isAbsolute(outputPath)
+      ? outputPath
+      : path.join(dir, outputPath)
+
     let logMessage = `Analyze completed in ${durationString}.`
     if (output) {
-      logMessage += ` Results written to ${ANALYZE_PATH}.\nTo explore the analyze results interactively, run \`next experimental-analyze\` without \`--output\`.`
+      logMessage += ` Results written to ${outputPath}.\nTo explore the analyze results interactively, run \`next experimental-analyze\` without \`--output\`.`
     }
     Log.event(logMessage)
 
@@ -87,16 +94,16 @@ export default async function analyze({
 
     await cp(
       path.join(__dirname, '../../bundle-analyzer'),
-      path.join(dir, ANALYZE_PATH),
+      resolvedOutputPath,
       { recursive: true }
     )
 
     // Collect and write routes for the bundle analyzer
     const routes = await collectRoutesForAnalyze(dir, config, appDirOnly)
 
-    await mkdir(path.join(dir, ANALYZE_PATH, 'data'), { recursive: true })
+    await mkdir(path.join(resolvedOutputPath, 'data'), { recursive: true })
     await writeFile(
-      path.join(dir, ANALYZE_PATH, 'data', 'routes.json'),
+      path.join(resolvedOutputPath, 'data', 'routes.json'),
       JSON.stringify(routes, null, 2)
     )
 
@@ -109,7 +116,7 @@ export default async function analyze({
     )
 
     if (!output) {
-      await startServer(path.join(dir, ANALYZE_PATH), port)
+      await startServer(resolvedOutputPath, port)
     }
   } catch (e) {
     const telemetry = traceGlobals.get('telemetry') as Telemetry | undefined

--- a/packages/next/src/cli/next-analyze.ts
+++ b/packages/next/src/cli/next-analyze.ts
@@ -13,7 +13,7 @@ export type NextAnalyzeOptions = {
   profile?: boolean
   mangling: boolean
   port: number
-  serve: boolean
+  output: boolean
   experimentalAppOnly?: boolean
 }
 
@@ -21,7 +21,7 @@ const nextAnalyze = async (options: NextAnalyzeOptions, directory?: string) => {
   process.on('SIGTERM', () => process.exit(143))
   process.on('SIGINT', () => process.exit(130))
 
-  const { profile, mangling, experimentalAppOnly, serve, port } = options
+  const { profile, mangling, experimentalAppOnly, output, port } = options
 
   if (!mangling) {
     warn(
@@ -46,7 +46,7 @@ const nextAnalyze = async (options: NextAnalyzeOptions, directory?: string) => {
     reactProductionProfiling: profile,
     noMangling: !mangling,
     appDirOnly: experimentalAppOnly,
-    serve,
+    output,
     port,
   })
 }

--- a/packages/next/src/cli/next-analyze.ts
+++ b/packages/next/src/cli/next-analyze.ts
@@ -13,7 +13,7 @@ export type NextAnalyzeOptions = {
   profile?: boolean
   mangling: boolean
   port: number
-  output: boolean
+  output: boolean | string
   experimentalAppOnly?: boolean
 }
 


### PR DESCRIPTION
This removes `next experimental-analyze --serve` in favor of simply `next experimental-analyze`. This is by far the most common use case and should be the simplest to express.

Output-only mode can now be used with `next experimental-analyze --output` as well as `next experimental-analyze --output path/to/my/output`. `-o` is fine as well.

Test Plan:
- Added e2e tests
- Ran `next experimental-analyze` and verified analyze data was created and the web server ran. Verified the ui functioned as expected
- Ran `next experimental-analyze --output` and verified the output files and stdout message were written
