### PR TITLE
test: fix actions deployment tests

### DIFF
--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -82,7 +82,7 @@ describe('unrecognized server actions', () => {
     )
   }
 
-  it('should 404 when POSTing a urlencoded action to a nonexistent page', async () => {
+  it('should error when POSTing a urlencoded action to a nonexistent page', async () => {
     const res = await next.fetch('/non-existent-route', {
       method: 'POST',
       headers: {
@@ -92,7 +92,8 @@ describe('unrecognized server actions', () => {
       body: 'foo=bar',
     })
 
-    expect(res.status).toBe(404)
+    // On Vercel, this would hit the 404 route which is a static page, and returns a 405 instead.
+    expect(res.status).toBe(isNextDeploy ? 405 : 404)
   })
 
   describe.each(['nodejs', 'edge'])(

--- a/test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
+++ b/test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
@@ -1,11 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('app-dir - no server actions', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
-  it('should 404 when triggering a fetch action on an app with no server actions', async () => {
+  it('should error when triggering a fetch action on an app with no server actions', async () => {
     const res = await next.fetch('/', {
       method: 'POST',
       headers: {
@@ -15,19 +15,23 @@ describe('app-dir - no server actions', () => {
 
     expect(res.status).toBe(404)
     expect(res.headers.get('x-nextjs-action-not-found')).toBe('1')
-    expect(next.cliOutput).toContain(
-      'Failed to find Server Action "abc123". This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action'
-    )
+
+    // Runtime logs and custom headers are not forwarded to the client when deployed.
+    if (!isNextDeploy) {
+      expect(next.cliOutput).toContain(
+        'Failed to find Server Action "abc123". This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action'
+      )
+    }
   })
 
-  it('should 404 when triggering an MPA action on an app with no server actions', async () => {
+  it('should error when triggering an MPA action on an app with no server actions', async () => {
     const formData = new FormData()
     formData.append('test', 'value')
 
     const res = await next.fetch('/', {
       method: 'POST',
       headers: {
-        'Content-Type': 'multipart/form-data',
+        'Content-Type': 'multipart/form-data; boundary=test',
       },
       // @ts-expect-error: node-fetch types don't seem to like FormData
       body: formData,
@@ -35,8 +39,12 @@ describe('app-dir - no server actions', () => {
 
     expect(res.status).toBe(404)
     expect(res.headers.get('x-nextjs-action-not-found')).toBe('1')
-    expect(next.cliOutput).toContain(
-      'Failed to find Server Action. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action'
-    )
+
+    // Runtime logs are not available when deployed.
+    if (!isNextDeploy) {
+      expect(next.cliOutput).toContain(
+        'Failed to find Server Action. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action'
+      )
+    }
   })
 })


### PR DESCRIPTION
Fixes a few failing deployment tests that weren't validated when landed last week.

- next.cliOutput is not available when deployed because it's part of runtime logs
- status code changes on Vercel because POSTing to a static 404 page is treated differently. 