### PR TITLE
[test] Move off of as much `url.parse` as possible

### DIFF
--- a/test/development/basic/misc.test.ts
+++ b/test/development/basic/misc.test.ts
@@ -1,4 +1,3 @@
-import url from 'url'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
@@ -69,7 +68,7 @@ describe.each([[''], ['/docs']])(
           }
         )
 
-        const { pathname, hostname } = url.parse(
+        const { pathname, hostname } = new URL(
           res.headers.get('location') || ''
         )
         expect(res.status).toBe(308)

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -6,7 +6,6 @@ import { fetchViaHTTP, getDistDir, renderViaHTTP } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { BUILD_MANIFEST, REACT_LOADABLE_MANIFEST } from 'next/constants'
 import path from 'path'
-import url from 'url'
 
 const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
@@ -47,7 +46,7 @@ describe('Client Navigation rendering', () => {
     it('should should not contain scripts that are not js', async () => {
       const $ = await get$('/')
       $('script[src]').each((_index, element) => {
-        const parsedUrl = url.parse($(element).attr('src'))
+        const parsedUrl = new URL($(element).attr('src'))
         if (!parsedUrl.pathname.endsWith('.js')) {
           throw new Error(
             `Page includes script that is not a javascript file ${parsedUrl.pathname}`

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -46,7 +46,7 @@ describe('Client Navigation rendering', () => {
     it('should should not contain scripts that are not js', async () => {
       const $ = await get$('/')
       $('script[src]').each((_index, element) => {
-        const parsedUrl = new URL($(element).attr('src'))
+        const parsedUrl = new URL($(element).attr('src'), next.url)
         if (!parsedUrl.pathname.endsWith('.js')) {
           throw new Error(
             `Page includes script that is not a javascript file ${parsedUrl.pathname}`

--- a/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
+++ b/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
@@ -14,7 +14,10 @@ describe('app-fetch-deduping', () => {
       beforeAll(async () => {
         externalServerPort = await findPort()
         externalServer = http.createServer((req, res) => {
-          const parsedUrl = new URL(req.url)
+          const parsedUrl = new URL(
+            req.url,
+            `http://localhost:${externalServerPort}`
+          )
           const overrideStatus = parsedUrl.searchParams.get('status')
 
           // if the requested url has a "status" search param, override the response status

--- a/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
+++ b/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
@@ -1,6 +1,5 @@
 import { findPort, retry } from 'next-test-utils'
 import http from 'http'
-import url from 'url'
 import { outdent } from 'outdent'
 import { isNextDev, isNextStart, nextTestSetup } from 'e2e-utils'
 
@@ -15,8 +14,8 @@ describe('app-fetch-deduping', () => {
       beforeAll(async () => {
         externalServerPort = await findPort()
         externalServer = http.createServer((req, res) => {
-          const parsedUrl = url.parse(req.url, true)
-          const overrideStatus = parsedUrl.query.status
+          const parsedUrl = new URL(req.url)
+          const overrideStatus = parsedUrl.searchParams.get('status')
 
           // if the requested url has a "status" search param, override the response status
           if (overrideStatus) {

--- a/test/e2e/basepath/basepath.test.ts
+++ b/test/e2e/basepath/basepath.test.ts
@@ -1,4 +1,3 @@
-import url from 'url'
 import assert from 'assert'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
@@ -456,14 +455,14 @@ describe('basePath', () => {
   it('should have correct href for a link', async () => {
     const browser = await webdriver(next.url, `${basePath}/hello`)
     const href = await browser.elementByCss('a').getAttribute('href')
-    const { pathname } = url.parse(href)
+    const { pathname } = new URL(href)
     expect(pathname).toBe(`${basePath}/other-page`)
   })
 
   it('should have correct href for a link to /', async () => {
     const browser = await webdriver(next.url, `${basePath}/link-to-root`)
     const href = await browser.elementByCss('#link-back').getAttribute('href')
-    const { pathname } = url.parse(href)
+    const { pathname } = new URL(href)
     expect(pathname).toBe(`${basePath}`)
   })
 

--- a/test/e2e/basepath/basepath.test.ts
+++ b/test/e2e/basepath/basepath.test.ts
@@ -455,14 +455,14 @@ describe('basePath', () => {
   it('should have correct href for a link', async () => {
     const browser = await webdriver(next.url, `${basePath}/hello`)
     const href = await browser.elementByCss('a').getAttribute('href')
-    const { pathname } = new URL(href)
+    const { pathname } = new URL(href, await browser.url())
     expect(pathname).toBe(`${basePath}/other-page`)
   })
 
   it('should have correct href for a link to /', async () => {
     const browser = await webdriver(next.url, `${basePath}/link-to-root`)
     const href = await browser.elementByCss('#link-back').getAttribute('href')
-    const { pathname } = new URL(href)
+    const { pathname } = new URL(href, await browser.url())
     expect(pathname).toBe(`${basePath}`)
   })
 

--- a/test/e2e/basepath/redirect-and-rewrite.test.ts
+++ b/test/e2e/basepath/redirect-and-rewrite.test.ts
@@ -1,4 +1,3 @@
-import url from 'url'
 import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 
@@ -110,7 +109,7 @@ describe('basePath', () => {
         redirect: 'manual',
       }
     )
-    const { pathname } = url.parse(res.headers.get('location') || '')
+    const { pathname } = new URL(res.headers.get('location') || '')
     expect(pathname).toBe(`${basePath}/somewhere-else`)
     expect(res.status).toBe(307)
     const text = await res.text()
@@ -144,7 +143,7 @@ describe('basePath', () => {
         redirect: 'manual',
       }
     )
-    const { pathname } = url.parse(res.headers.get('location') || '')
+    const { pathname } = new URL(res.headers.get('location') || '')
     expect(pathname).toBe('/another-destination')
     expect(res.status).toBe(307)
     const text = await res.text()

--- a/test/integration/basepath-root-catch-all/test/index.test.ts
+++ b/test/integration/basepath-root-catch-all/test/index.test.ts
@@ -8,7 +8,6 @@ import {
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 import fs from 'fs-extra'
-import url from 'url'
 
 let app
 let appPort
@@ -22,7 +21,7 @@ const runTests = () => {
     await browser.waitForElementByCss('#url')
 
     const dataUrl = await browser.elementByCss('#url').text()
-    const { pathname } = url.parse(dataUrl)
+    const { pathname } = new URL(dataUrl)
     expect(pathname).toBe(`/_next/data/${buildId}/root/catch-all.json`)
   })
 }

--- a/test/integration/basepath-root-catch-all/test/index.test.ts
+++ b/test/integration/basepath-root-catch-all/test/index.test.ts
@@ -21,7 +21,7 @@ const runTests = () => {
     await browser.waitForElementByCss('#url')
 
     const dataUrl = await browser.elementByCss('#url').text()
-    const { pathname } = new URL(dataUrl)
+    const { pathname } = new URL(dataUrl, await browser.url())
     expect(pathname).toBe(`/_next/data/${buildId}/root/catch-all.json`)
   })
 }

--- a/test/integration/custom-routes-i18n-index-redirect/test/index.test.ts
+++ b/test/integration/custom-routes-i18n-index-redirect/test/index.test.ts
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import url from 'url'
 import http from 'http'
 import { join } from 'path'
 import {
@@ -35,9 +34,9 @@ const runTests = () => {
         const text = await res.text()
         expect(text).toEqual(dest)
         if (dest.startsWith('/')) {
-          const parsed = url.parse(res.headers.get('location'))
+          const parsed = new URL(res.headers.get('location'))
           expect(parsed.pathname).toBe(dest)
-          expect(parsed.query).toBe(null)
+          expect(parsed.search).toBe('')
         } else {
           expect(res.headers.get('location')).toBe(dest)
         }

--- a/test/integration/custom-routes-i18n/test/index.test.ts
+++ b/test/integration/custom-routes-i18n/test/index.test.ts
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import url from 'url'
 import http from 'http'
 import { join } from 'path'
 import cheerio from 'cheerio'
@@ -42,9 +41,9 @@ const runTests = () => {
         const text = await res.text()
         expect(text).toEqual(dest)
         if (dest.startsWith('/')) {
-          const parsed = url.parse(res.headers.get('location'))
+          const parsed = new URL(res.headers.get('location'))
           expect(parsed.pathname).toBe(dest)
-          expect(parsed.query).toBe(null)
+          expect(parsed.search).toBe('')
         } else {
           expect(res.headers.get('location')).toBe(dest)
         }

--- a/test/integration/custom-routes/test/index.test.ts
+++ b/test/integration/custom-routes/test/index.test.ts
@@ -391,21 +391,24 @@ const runTests = (isDev = false) => {
     const res1 = await fetchViaHTTP(appPort, '/redir-chain1', undefined, {
       redirect: 'manual',
     })
-    const res1location = new URL(res1.headers.get('location')).pathname
+    const res1location = new URL(res1.headers.get('location'), res1.url)
+      .pathname
     expect(res1.status).toBe(301)
     expect(res1location).toBe('/redir-chain2')
 
     const res2 = await fetchViaHTTP(appPort, res1location, undefined, {
       redirect: 'manual',
     })
-    const res2location = new URL(res2.headers.get('location')).pathname
+    const res2location = new URL(res2.headers.get('location'), res2.url)
+      .pathname
     expect(res2.status).toBe(302)
     expect(res2location).toBe('/redir-chain3')
 
     const res3 = await fetchViaHTTP(appPort, res2location, undefined, {
       redirect: 'manual',
     })
-    const res3location = new URL(res3.headers.get('location')).pathname
+    const res3location = new URL(res3.headers.get('location'), res3.url)
+      .pathname
     expect(res3.status).toBe(303)
     expect(res3location).toBe('/')
   })
@@ -442,7 +445,7 @@ const runTests = (isDev = false) => {
     const res = await fetchViaHTTP(appPort, '/redirect1', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = new URL(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'), res.url)
     expect(res.status).toBe(307)
     expect(pathname).toBe('/')
   })
@@ -451,7 +454,7 @@ const runTests = (isDev = false) => {
     const res = await fetchViaHTTP(appPort, '/hello/123/another', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = new URL(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'), res.url)
     expect(res.status).toBe(307)
     expect(pathname).toBe('/blog/123')
   })
@@ -465,7 +468,10 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname, hash, search } = new URL(res.headers.get('location'))
+    const { pathname, hash, search } = new URL(
+      res.headers.get('location'),
+      res.url
+    )
     expect(res.status).toBe(301)
     expect(pathname).toBe('/docs/v2/network/status-codes')
     expect(hash).toBe('#500')
@@ -476,7 +482,7 @@ const runTests = (isDev = false) => {
     const res = await fetchViaHTTP(appPort, '/redirect2', undefined, {
       redirect: 'manual',
     })
-    const { pathname, search } = new URL(res.headers.get('location'))
+    const { pathname, search } = new URL(res.headers.get('location'), res.url)
     expect(res.status).toBe(301)
     expect(pathname).toBe('/')
     expect(search).toEqual('')
@@ -491,7 +497,7 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname, search } = new URL(res.headers.get('location'))
+    const { pathname, search } = new URL(res.headers.get('location'), res.url)
     expect(res.status).toBe(307)
     expect(pathname).toBe('/somewhere')
     expect(search).toEqual('')
@@ -579,7 +585,10 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname, searchParams } = new URL(res.headers.get('location'))
+    const { pathname, searchParams } = new URL(
+      res.headers.get('location'),
+      res.url
+    )
     expect(res.status).toBe(307)
     expect(pathname).toBe('/with-params')
     expect(Object.fromEntries(searchParams)).toEqual({
@@ -598,7 +607,10 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname, searchParams } = new URL(res.headers.get('location'))
+    const { pathname, searchParams } = new URL(
+      res.headers.get('location'),
+      res.url
+    )
     expect(res.status).toBe(307)
     expect(pathname).toBe('/with-params')
     expect(Object.fromEntries(searchParams)).toEqual({
@@ -648,7 +660,7 @@ const runTests = (isDev = false) => {
     const res = await fetchViaHTTP(appPort, '/redirect-override', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = new URL(res.headers.get('location') || '')
+    const { pathname } = new URL(res.headers.get('location') || '', res.url)
     expect(res.status).toBe(307)
     expect(pathname).toBe('/thank-you-next')
   })
@@ -805,7 +817,7 @@ const runTests = (isDev = false) => {
     expect(res.status).toBe(200)
     expect(
       [...externalServerHits].map((u) => {
-        const { pathname, searchParams } = new URL(u)
+        const { pathname, searchParams } = new URL(u, res.url)
         return {
           pathname,
           query: Object.fromEntries(searchParams),
@@ -829,7 +841,7 @@ const runTests = (isDev = false) => {
     const res = await fetchViaHTTP(appPort, '/unnamed/first/final', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = new URL(res.headers.get('location') || '')
+    const { pathname } = new URL(res.headers.get('location') || '', res.url)
     expect(res.status).toBe(307)
     expect(pathname).toBe('/got-unnamed')
   })
@@ -843,7 +855,7 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname } = new URL(res.headers.get('location') || '')
+    const { pathname } = new URL(res.headers.get('location') || '', res.url)
     expect(res.status).toBe(307)
     expect(pathname).toBe('/first')
   })
@@ -906,7 +918,8 @@ const runTests = (isDev = false) => {
     )
 
     const { pathname, hostname, searchParams } = new URL(
-      res.headers.get('location') || ''
+      res.headers.get('location') || '',
+      res.url
     )
     expect(res.status).toBe(307)
     expect(pathname).toBe(encodeURI('/\\google.com/about'))
@@ -932,7 +945,7 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname } = new URL(res.headers.get('location') || '')
+    const { pathname } = new URL(res.headers.get('location') || '', res.url)
     expect(res.status).toBe(307)
     expect(pathname).toBe('/integrations/-some/thing')
   })
@@ -1273,7 +1286,7 @@ const runTests = (isDev = false) => {
     })
 
     expect(res.status).toBe(307)
-    const parsed = new URL(res.headers.get('location'))
+    const parsed = new URL(res.headers.get('location'), res.url)
 
     expect(parsed.pathname).toBe('/another')
     expect(Object.fromEntries(parsed.searchParams)).toEqual({
@@ -1299,7 +1312,7 @@ const runTests = (isDev = false) => {
     )
 
     expect(res.status).toBe(307)
-    const parsed = new URL(res.headers.get('location'))
+    const parsed = new URL(res.headers.get('location'), res.url)
 
     expect(parsed.pathname).toBe('/another')
     expect(Object.fromEntries(parsed.searchParams)).toEqual({
@@ -1322,7 +1335,7 @@ const runTests = (isDev = false) => {
     })
 
     expect(res.status).toBe(307)
-    const parsed = new URL(res.headers.get('location'))
+    const parsed = new URL(res.headers.get('location'), res.url)
 
     expect(parsed.pathname).toBe('/another')
     expect(Object.fromEntries(parsed.searchParams)).toEqual({
@@ -1349,7 +1362,7 @@ const runTests = (isDev = false) => {
     })
 
     expect(res.status).toBe(307)
-    const parsed = new URL(res.headers.get('location'))
+    const parsed = new URL(res.headers.get('location'), res.url)
 
     expect(parsed.pathname).toBe('/another')
     expect(Object.fromEntries(parsed.searchParams)).toEqual({
@@ -1371,7 +1384,7 @@ const runTests = (isDev = false) => {
     })
 
     expect(res.status).toBe(307)
-    const parsed = new URL(res.headers.get('location'))
+    const parsed = new URL(res.headers.get('location'), res.url)
 
     expect(parsed.protocol).toBe('https:')
     expect(parsed.hostname).toBe('hello.example.com')
@@ -1391,10 +1404,15 @@ const runTests = (isDev = false) => {
       }
     )
     expect(res.status).toBe(307)
-    const parsed = new URL(res.headers.get('location'))
+    const parsed = new URL(res.headers.get('location'), res.url)
 
     expect(parsed.pathname).toBe('/somewhere')
-    expect(Object.fromEntries(parsed.searchParams)).toEqual({
+    const query = {}
+    for (const key of parsed.searchParams.keys()) {
+      const values = parsed.searchParams.getAll(key)
+      query[key] = values.length > 1 ? values : values[0]
+    }
+    expect(query).toEqual({
       hello: ['world', 'another'],
       value: 'another',
     })
@@ -2740,7 +2758,7 @@ describe('Custom routes', () => {
         expect(res.headers.get('x-custom-header')).toBeFalsy()
         expect(res.headers.get('x-another-header')).toBeFalsy()
 
-        const { pathname } = new URL(res2.headers.get('location'))
+        const { pathname } = new URL(res2.headers.get('location'), res.url)
         expect(res2.status).toBe(301)
         expect(pathname).toBe('/docs/v2/advanced/now-for-github')
 

--- a/test/integration/custom-routes/test/index.test.ts
+++ b/test/integration/custom-routes/test/index.test.ts
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 import http from 'http'
-import url from 'url'
 import stripAnsi from 'strip-ansi'
 import fs from 'fs-extra'
 import { join } from 'path'
@@ -392,21 +391,21 @@ const runTests = (isDev = false) => {
     const res1 = await fetchViaHTTP(appPort, '/redir-chain1', undefined, {
       redirect: 'manual',
     })
-    const res1location = url.parse(res1.headers.get('location')).pathname
+    const res1location = new URL(res1.headers.get('location')).pathname
     expect(res1.status).toBe(301)
     expect(res1location).toBe('/redir-chain2')
 
     const res2 = await fetchViaHTTP(appPort, res1location, undefined, {
       redirect: 'manual',
     })
-    const res2location = url.parse(res2.headers.get('location')).pathname
+    const res2location = new URL(res2.headers.get('location')).pathname
     expect(res2.status).toBe(302)
     expect(res2location).toBe('/redir-chain3')
 
     const res3 = await fetchViaHTTP(appPort, res2location, undefined, {
       redirect: 'manual',
     })
-    const res3location = url.parse(res3.headers.get('location')).pathname
+    const res3location = new URL(res3.headers.get('location')).pathname
     expect(res3.status).toBe(303)
     expect(res3location).toBe('/')
   })
@@ -443,7 +442,7 @@ const runTests = (isDev = false) => {
     const res = await fetchViaHTTP(appPort, '/redirect1', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'))
     expect(res.status).toBe(307)
     expect(pathname).toBe('/')
   })
@@ -452,7 +451,7 @@ const runTests = (isDev = false) => {
     const res = await fetchViaHTTP(appPort, '/hello/123/another', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'))
     expect(res.status).toBe(307)
     expect(pathname).toBe('/blog/123')
   })
@@ -466,24 +465,21 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname, hash, query } = url.parse(
-      res.headers.get('location'),
-      true
-    )
+    const { pathname, hash, search } = new URL(res.headers.get('location'))
     expect(res.status).toBe(301)
     expect(pathname).toBe('/docs/v2/network/status-codes')
     expect(hash).toBe('#500')
-    expect(query).toEqual({})
+    expect(search).toEqual('')
   })
 
   it('should redirect successfully with provided statusCode', async () => {
     const res = await fetchViaHTTP(appPort, '/redirect2', undefined, {
       redirect: 'manual',
     })
-    const { pathname, query } = url.parse(res.headers.get('location'), true)
+    const { pathname, search } = new URL(res.headers.get('location'))
     expect(res.status).toBe(301)
     expect(pathname).toBe('/')
-    expect(query).toEqual({})
+    expect(search).toEqual('')
   })
 
   it('should redirect successfully with catchall', async () => {
@@ -495,10 +491,10 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname, query } = url.parse(res.headers.get('location'), true)
+    const { pathname, search } = new URL(res.headers.get('location'))
     expect(res.status).toBe(307)
     expect(pathname).toBe('/somewhere')
-    expect(query).toEqual({})
+    expect(search).toEqual('')
   })
 
   it('should server static files through a rewrite', async () => {
@@ -583,10 +579,10 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname, query } = url.parse(res.headers.get('location'), true)
+    const { pathname, searchParams } = new URL(res.headers.get('location'))
     expect(res.status).toBe(307)
     expect(pathname).toBe('/with-params')
-    expect(query).toEqual({
+    expect(Object.fromEntries(searchParams)).toEqual({
       first: 'hello',
       second: 'world',
       a: 'b',
@@ -602,11 +598,11 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname, query } = url.parse(res.headers.get('location'), true)
+    const { pathname, searchParams } = new URL(res.headers.get('location'))
     expect(res.status).toBe(307)
     expect(pathname).toBe('/with-params')
-    expect(query).toEqual({
-      // this should be decoded since url.parse decodes query values
+    expect(Object.fromEntries(searchParams)).toEqual({
+      // this should be decoded since new URL decodes query values
       first: 'hello world?w=24&focalpoint=center',
       second: 'world',
       a: 'b',
@@ -652,7 +648,7 @@ const runTests = (isDev = false) => {
     const res = await fetchViaHTTP(appPort, '/redirect-override', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = url.parse(res.headers.get('location') || '')
+    const { pathname } = new URL(res.headers.get('location') || '')
     expect(res.status).toBe(307)
     expect(pathname).toBe('/thank-you-next')
   })
@@ -809,10 +805,10 @@ const runTests = (isDev = false) => {
     expect(res.status).toBe(200)
     expect(
       [...externalServerHits].map((u) => {
-        const { pathname, query } = url.parse(u, true)
+        const { pathname, searchParams } = new URL(u)
         return {
           pathname,
-          query,
+          query: Object.fromEntries(searchParams),
         }
       })
     ).toEqual([
@@ -833,7 +829,7 @@ const runTests = (isDev = false) => {
     const res = await fetchViaHTTP(appPort, '/unnamed/first/final', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = url.parse(res.headers.get('location') || '')
+    const { pathname } = new URL(res.headers.get('location') || '')
     expect(res.status).toBe(307)
     expect(pathname).toBe('/got-unnamed')
   })
@@ -847,7 +843,7 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname } = url.parse(res.headers.get('location') || '')
+    const { pathname } = new URL(res.headers.get('location') || '')
     expect(res.status).toBe(307)
     expect(pathname).toBe('/first')
   })
@@ -909,14 +905,13 @@ const runTests = (isDev = false) => {
       }
     )
 
-    const { pathname, hostname, query } = url.parse(
-      res.headers.get('location') || '',
-      true
+    const { pathname, hostname, searchParams } = new URL(
+      res.headers.get('location') || ''
     )
     expect(res.status).toBe(307)
     expect(pathname).toBe(encodeURI('/\\google.com/about'))
     expect(hostname).not.toBe('google.com')
-    expect(query).toEqual({})
+    expect(Object.fromEntries(searchParams)).toEqual({})
   })
 
   it('should handle unnamed parameters with multi-match successfully', async () => {
@@ -937,7 +932,7 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname } = url.parse(res.headers.get('location') || '')
+    const { pathname } = new URL(res.headers.get('location') || '')
     expect(res.status).toBe(307)
     expect(pathname).toBe('/integrations/-some/thing')
   })
@@ -1278,10 +1273,10 @@ const runTests = (isDev = false) => {
     })
 
     expect(res.status).toBe(307)
-    const parsed = url.parse(res.headers.get('location'), true)
+    const parsed = new URL(res.headers.get('location'))
 
     expect(parsed.pathname).toBe('/another')
-    expect(parsed.query).toEqual({
+    expect(Object.fromEntries(parsed.searchParams)).toEqual({
       myHeader: 'hello world!!',
     })
 
@@ -1304,10 +1299,10 @@ const runTests = (isDev = false) => {
     )
 
     expect(res.status).toBe(307)
-    const parsed = url.parse(res.headers.get('location'), true)
+    const parsed = new URL(res.headers.get('location'))
 
     expect(parsed.pathname).toBe('/another')
-    expect(parsed.query).toEqual({
+    expect(Object.fromEntries(parsed.searchParams)).toEqual({
       value: 'hellooo',
       'my-query': 'hellooo',
     })
@@ -1327,10 +1322,10 @@ const runTests = (isDev = false) => {
     })
 
     expect(res.status).toBe(307)
-    const parsed = url.parse(res.headers.get('location'), true)
+    const parsed = new URL(res.headers.get('location'))
 
     expect(parsed.pathname).toBe('/another')
-    expect(parsed.query).toEqual({
+    expect(Object.fromEntries(parsed.searchParams)).toEqual({
       authorized: '1',
     })
 
@@ -1354,10 +1349,10 @@ const runTests = (isDev = false) => {
     })
 
     expect(res.status).toBe(307)
-    const parsed = url.parse(res.headers.get('location'), true)
+    const parsed = new URL(res.headers.get('location'))
 
     expect(parsed.pathname).toBe('/another')
-    expect(parsed.query).toEqual({
+    expect(Object.fromEntries(parsed.searchParams)).toEqual({
       host: '1',
     })
   })
@@ -1376,12 +1371,12 @@ const runTests = (isDev = false) => {
     })
 
     expect(res.status).toBe(307)
-    const parsed = url.parse(res.headers.get('location'), true)
+    const parsed = new URL(res.headers.get('location'))
 
     expect(parsed.protocol).toBe('https:')
     expect(parsed.hostname).toBe('hello.example.com')
     expect(parsed.pathname).toBe('/some-path/end')
-    expect(parsed.query).toEqual({
+    expect(Object.fromEntries(parsed.searchParams)).toEqual({
       a: 'b',
     })
   })
@@ -1396,10 +1391,10 @@ const runTests = (isDev = false) => {
       }
     )
     expect(res.status).toBe(307)
-    const parsed = url.parse(res.headers.get('location'), true)
+    const parsed = new URL(res.headers.get('location'))
 
     expect(parsed.pathname).toBe('/somewhere')
-    expect(parsed.query).toEqual({
+    expect(Object.fromEntries(parsed.searchParams)).toEqual({
       hello: ['world', 'another'],
       value: 'another',
     })
@@ -2745,7 +2740,7 @@ describe('Custom routes', () => {
         expect(res.headers.get('x-custom-header')).toBeFalsy()
         expect(res.headers.get('x-another-header')).toBeFalsy()
 
-        const { pathname } = url.parse(res2.headers.get('location'))
+        const { pathname } = new URL(res2.headers.get('location'))
         expect(res2.status).toBe(301)
         expect(pathname).toBe('/docs/v2/advanced/now-for-github')
 

--- a/test/integration/dynamic-routing/test/index.test.ts
+++ b/test/integration/dynamic-routing/test/index.test.ts
@@ -3,7 +3,6 @@
 import webdriver from 'next-webdriver'
 import { join, dirname } from 'path'
 import fs from 'fs-extra'
-import url from 'url'
 import {
   waitForRedbox,
   renderViaHTTP,
@@ -234,12 +233,13 @@ function runTests({ dev }) {
     ]) {
       const { id, pathname, query, hash, navQuery } = expectedValues
 
-      const parsedHref = url.parse(
-        await browser.elementByCss(`#${id}`).getAttribute('href'),
-        true
+      const parsedHref = new URL(
+        await browser.elementByCss(`#${id}`).getAttribute('href')
       )
       expect(parsedHref.pathname).toBe(pathname)
-      expect(parsedHref.query || {}).toEqual(query)
+      expect(Object.fromEntries(parsedHref.searchParams.entries())).toEqual(
+        query
+      )
       expect(parsedHref.hash || '').toBe(hash)
 
       await browser.eval('window.beforeNav = 1')
@@ -262,25 +262,23 @@ function runTests({ dev }) {
 
   it('should handle only hash on dynamic route', async () => {
     const browser = await webdriver(appPort, '/post-1')
-    const parsedHref = url.parse(
+    const parsedHref = new URL(
       await browser
         .elementByCss('#dynamic-route-only-hash')
-        .getAttribute('href'),
-      true
+        .getAttribute('href')
     )
     expect(parsedHref.pathname).toBe('/post-1')
     expect(parsedHref.hash).toBe('#only-hash')
-    expect(parsedHref.query || {}).toEqual({})
+    expect(Object.fromEntries(parsedHref.searchParams.entries())).toEqual({})
 
-    const parsedHref2 = url.parse(
+    const parsedHref2 = new URL(
       await browser
         .elementByCss('#dynamic-route-only-hash-obj')
-        .getAttribute('href'),
-      true
+        .getAttribute('href')
     )
     expect(parsedHref2.pathname).toBe('/post-1')
     expect(parsedHref2.hash).toBe('#only-hash-obj')
-    expect(parsedHref2.query || {}).toEqual({})
+    expect(Object.fromEntries(parsedHref2.searchParams.entries())).toEqual({})
 
     expect(await browser.eval('window.location.hash')).toBe('')
 
@@ -543,9 +541,9 @@ function runTests({ dev }) {
         .elementByCss('#view-post-1-interpolated')
         .getAttribute('href')
 
-      const parsedHref = url.parse(href, true)
+      const parsedHref = new URL(href)
       expect(parsedHref.pathname).toBe('/post-1')
-      expect(parsedHref.query).toEqual({})
+      expect(Object.fromEntries(parsedHref.searchParams.entries())).toEqual({})
 
       await browser.elementByCss('#view-post-1-interpolated').click()
       await browser.waitForElementByCss('#asdf')
@@ -569,10 +567,11 @@ function runTests({ dev }) {
         .elementByCss('#view-post-1-interpolated-more-query')
         .getAttribute('href')
 
-      const parsedHref = url.parse(href, true)
+      const parsedHref = new URL(href)
       expect(parsedHref.pathname).toBe('/post-1')
-      expect(parsedHref.query).toEqual({ another: 'value' })
-
+      expect(Object.fromEntries(parsedHref.searchParams.entries())).toEqual({
+        another: 'value',
+      })
       await browser.elementByCss('#view-post-1-interpolated-more-query').click()
       await browser.waitForElementByCss('#asdf')
 
@@ -672,7 +671,7 @@ function runTests({ dev }) {
         .elementByCss('#view-post-1-comment-1-interpolated')
         .getAttribute('href')
 
-      expect(url.parse(href).pathname).toBe('/post-1/comment-1')
+      expect(new URL(href).pathname).toBe('/post-1/comment-1')
 
       await browser.elementByCss('#view-post-1-comment-1-interpolated').click()
       await browser.waitForElementByCss('#asdf')
@@ -904,7 +903,7 @@ function runTests({ dev }) {
         .elementByCss('#ssg-catch-all-single-interpolated')
         .getAttribute('href')
 
-      expect(url.parse(href).pathname).toBe('/p1/p2/all-ssg/hello')
+      expect(new URL(href).pathname).toBe('/p1/p2/all-ssg/hello')
 
       await browser.elementByCss('#ssg-catch-all-single-interpolated').click()
       await browser.waitForElementByCss('#all-ssg-content')
@@ -962,7 +961,7 @@ function runTests({ dev }) {
         .elementByCss('#ssg-catch-all-multi-interpolated')
         .getAttribute('href')
 
-      expect(url.parse(href).pathname).toBe('/p1/p2/all-ssg/hello1/hello2')
+      expect(new URL(href).pathname).toBe('/p1/p2/all-ssg/hello1/hello2')
 
       await browser.elementByCss('#ssg-catch-all-multi-interpolated').click()
       await browser.waitForElementByCss('#all-ssg-content')

--- a/test/integration/dynamic-routing/test/index.test.ts
+++ b/test/integration/dynamic-routing/test/index.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import webdriver from 'next-webdriver'
+import webdriver, { type Playwright } from 'next-webdriver'
 import { join, dirname } from 'path'
 import fs from 'fs-extra'
 import {
@@ -234,7 +234,8 @@ function runTests({ dev }) {
       const { id, pathname, query, hash, navQuery } = expectedValues
 
       const parsedHref = new URL(
-        await browser.elementByCss(`#${id}`).getAttribute('href')
+        await browser.elementByCss(`#${id}`).getAttribute('href'),
+        await browser.url()
       )
       expect(parsedHref.pathname).toBe(pathname)
       expect(Object.fromEntries(parsedHref.searchParams.entries())).toEqual(
@@ -265,7 +266,8 @@ function runTests({ dev }) {
     const parsedHref = new URL(
       await browser
         .elementByCss('#dynamic-route-only-hash')
-        .getAttribute('href')
+        .getAttribute('href'),
+      await browser.url()
     )
     expect(parsedHref.pathname).toBe('/post-1')
     expect(parsedHref.hash).toBe('#only-hash')
@@ -274,7 +276,8 @@ function runTests({ dev }) {
     const parsedHref2 = new URL(
       await browser
         .elementByCss('#dynamic-route-only-hash-obj')
-        .getAttribute('href')
+        .getAttribute('href'),
+      await browser.url()
     )
     expect(parsedHref2.pathname).toBe('/post-1')
     expect(parsedHref2.hash).toBe('#only-hash-obj')
@@ -541,7 +544,7 @@ function runTests({ dev }) {
         .elementByCss('#view-post-1-interpolated')
         .getAttribute('href')
 
-      const parsedHref = new URL(href)
+      const parsedHref = new URL(href, await browser.url())
       expect(parsedHref.pathname).toBe('/post-1')
       expect(Object.fromEntries(parsedHref.searchParams.entries())).toEqual({})
 
@@ -567,7 +570,7 @@ function runTests({ dev }) {
         .elementByCss('#view-post-1-interpolated-more-query')
         .getAttribute('href')
 
-      const parsedHref = new URL(href)
+      const parsedHref = new URL(href, await browser.url())
       expect(parsedHref.pathname).toBe('/post-1')
       expect(Object.fromEntries(parsedHref.searchParams.entries())).toEqual({
         another: 'value',
@@ -671,7 +674,9 @@ function runTests({ dev }) {
         .elementByCss('#view-post-1-comment-1-interpolated')
         .getAttribute('href')
 
-      expect(new URL(href).pathname).toBe('/post-1/comment-1')
+      expect(new URL(href, await browser.url()).pathname).toBe(
+        '/post-1/comment-1'
+      )
 
       await browser.elementByCss('#view-post-1-comment-1-interpolated').click()
       await browser.waitForElementByCss('#asdf')
@@ -903,7 +908,9 @@ function runTests({ dev }) {
         .elementByCss('#ssg-catch-all-single-interpolated')
         .getAttribute('href')
 
-      expect(new URL(href).pathname).toBe('/p1/p2/all-ssg/hello')
+      expect(new URL(href, await browser.url()).pathname).toBe(
+        '/p1/p2/all-ssg/hello'
+      )
 
       await browser.elementByCss('#ssg-catch-all-single-interpolated').click()
       await browser.waitForElementByCss('#all-ssg-content')
@@ -952,7 +959,7 @@ function runTests({ dev }) {
   })
 
   it('[ssg: catch-all] should pass params in getStaticProps during client navigation (multi interpolated)', async () => {
-    let browser
+    let browser: Playwright
     try {
       browser = await webdriver(appPort, '/')
       await browser.eval('window.beforeNav = 1')
@@ -961,7 +968,9 @@ function runTests({ dev }) {
         .elementByCss('#ssg-catch-all-multi-interpolated')
         .getAttribute('href')
 
-      expect(new URL(href).pathname).toBe('/p1/p2/all-ssg/hello1/hello2')
+      expect(new URL(href, await browser.url()).pathname).toBe(
+        '/p1/p2/all-ssg/hello1/hello2'
+      )
 
       await browser.elementByCss('#ssg-catch-all-multi-interpolated').click()
       await browser.waitForElementByCss('#all-ssg-content')

--- a/test/integration/env-config/test/index.test.ts
+++ b/test/integration/env-config/test/index.test.ts
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import url from 'url'
 import fs from 'fs-extra'
 import { join } from 'path'
 import cheerio from 'cheerio'
@@ -79,7 +78,7 @@ const runTests = (mode = 'dev', didReload = false) => {
     const res = await fetchViaHTTP(appPort, '/hello', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'))
 
     expect(res.status).toBe(307)
     expect(pathname).toBe('/another')

--- a/test/integration/file-serving/test/index.test.ts
+++ b/test/integration/file-serving/test/index.test.ts
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 /* eslint-disable jest/no-identical-title */
-import url from 'url'
 import fs from 'fs-extra'
 import { join } from 'path'
 import {
@@ -23,7 +22,7 @@ const expectStatus = async (path) => {
   const checkRes = async (res) => {
     if (res.status === 308) {
       const redirectDest = res.headers.get('location')
-      const parsedUrl = url.parse(redirectDest, true)
+      const parsedUrl = new URL(redirectDest)
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
     } else {
       try {

--- a/test/integration/gssp-redirect-base-path/test/index.test.ts
+++ b/test/integration/gssp-redirect-base-path/test/index.test.ts
@@ -1,5 +1,4 @@
 /* eslint-env jest */
-import url from 'url'
 import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -32,7 +31,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(307)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'))
 
     expect(pathname).toBe(`${basePath}/404`)
   })
@@ -51,7 +50,7 @@ const runTests = (isDev: boolean) => {
     const text = await res.text()
     expect(text).toEqual(`/404`)
 
-    const parsedUrl = url.parse(res.headers.get('location'))
+    const parsedUrl = new URL(res.headers.get('location'))
     expect(parsedUrl.pathname).toBe(`/404`)
 
     const browser = await webdriver(appPort, `${basePath}`)
@@ -61,7 +60,7 @@ const runTests = (isDev: boolean) => {
       /oops not found/
     )
 
-    const parsedUrl2 = url.parse(await browser.eval('window.location.href'))
+    const parsedUrl2 = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl2.pathname).toBe('/404')
   })
 
@@ -79,7 +78,7 @@ const runTests = (isDev: boolean) => {
     const text = await res.text()
     expect(text).toEqual(`${basePath}/404`)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'))
 
     expect(pathname).toBe(`${basePath}/404`)
     expect(res.headers.get('refresh')).toContain(`url=${basePath}/404`)
@@ -99,7 +98,7 @@ const runTests = (isDev: boolean) => {
     const text = await res.text()
     expect(text).toEqual(`${basePath}/404`)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'))
 
     expect(pathname).toBe(`${basePath}/404`)
     expect(res.headers.get('refresh')).toBe(null)
@@ -119,7 +118,7 @@ const runTests = (isDev: boolean) => {
     const text = await res.text()
     expect(text).toEqual(`${basePath}/404`)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'))
 
     expect(pathname).toBe(`${basePath}/404`)
     expect(res.headers.get('refresh')).toBe(null)
@@ -143,7 +142,7 @@ const runTests = (isDev: boolean) => {
       },
     })
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref)
     expect(pathname).toBe(`${basePath}/gsp-blog/redirect-dest-_gsp-blog_first`)
   })
 
@@ -166,7 +165,7 @@ const runTests = (isDev: boolean) => {
         },
       })
       const initialHref = await browser.eval(() => (window as any).initialHref)
-      const { pathname } = url.parse(initialHref)
+      const { pathname } = new URL(initialHref)
       // since it was cached the initial value is now the redirect
       // result
       expect(pathname).toBe(`${basePath}/gsp-blog/first`)
@@ -185,7 +184,7 @@ const runTests = (isDev: boolean) => {
     await browser.waitForElementByCss('#index')
 
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref)
     expect(pathname).toBe(`${basePath}/gsp-blog/redirect-dest-_`)
   })
 
@@ -202,7 +201,7 @@ const runTests = (isDev: boolean) => {
       await browser.waitForElementByCss('#index')
 
       const initialHref = await browser.eval(() => (window as any).initialHref)
-      const { pathname } = url.parse(initialHref)
+      const { pathname } = new URL(initialHref)
       expect(pathname).toBe(`${basePath}`)
     })
   }
@@ -225,7 +224,7 @@ const runTests = (isDev: boolean) => {
     expect(initialHref).toBeFalsy()
 
     const curUrl = await browser.url()
-    const { pathname } = url.parse(curUrl)
+    const { pathname } = new URL(curUrl)
     expect(pathname).toBe('/docs/missing')
   })
 
@@ -274,7 +273,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(307)
 
-    const parsed = url.parse(res.headers.get('location'))
+    const parsed = new URL(res.headers.get('location'))
     expect(parsed.hostname).toBe('example.vercel.sh')
     expect(parsed.pathname).toBe('/')
   })
@@ -390,8 +389,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual(`${basePath}`)
+    const { pathname, search } = new URL(curUrl)
+    expect(pathname + search).toEqual(`${basePath}`)
   })
 
   it('should not replace history of the origin page when GSSP page is navigated to client-side (external)', async () => {
@@ -418,8 +417,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual(`${basePath}`)
+    const { pathname, search } = new URL(curUrl)
+    expect(pathname + search).toEqual(`${basePath}`)
   })
 
   it('should not replace history of the origin page when GSP page is navigated to client-side (internal)', async () => {
@@ -446,8 +445,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual(`${basePath}`)
+    const { pathname, search } = new URL(curUrl)
+    expect(pathname + search).toEqual(`${basePath}`)
   })
 
   it('should not replace history of the origin page when GSP page is navigated to client-side (external)', async () => {
@@ -474,8 +473,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual(`${basePath}`)
+    const { pathname, search } = new URL(curUrl)
+    expect(pathname + search).toEqual(`${basePath}`)
   })
 }
 

--- a/test/integration/gssp-redirect/test/index.test.ts
+++ b/test/integration/gssp-redirect/test/index.test.ts
@@ -1,5 +1,4 @@
 /* eslint-env jest */
-import url from 'url'
 import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -30,7 +29,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(307)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'))
 
     expect(pathname).toBe('/404')
   })
@@ -46,7 +45,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(308)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'))
 
     expect(pathname).toBe('/404')
     expect(res.headers.get('refresh')).toMatch(/url=\/404/)
@@ -63,7 +62,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(301)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'))
 
     expect(pathname).toBe('/404')
     expect(res.headers.get('refresh')).toBe(null)
@@ -80,7 +79,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(303)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'))
 
     expect(pathname).toBe('/404')
     expect(res.headers.get('refresh')).toBe(null)
@@ -104,7 +103,7 @@ const runTests = (isDev: boolean) => {
       },
     })
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref)
     expect(pathname).toBe('/gsp-blog/redirect-dest-_gsp-blog_first')
   })
 
@@ -126,7 +125,7 @@ const runTests = (isDev: boolean) => {
       },
     })
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref)
     expect(pathname).toBe('/gsp-blog/first')
   })
 
@@ -148,7 +147,7 @@ const runTests = (isDev: boolean) => {
       },
     })
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref)
     expect(pathname).toBe('/gsp-blog/first')
   })
 
@@ -170,7 +169,7 @@ const runTests = (isDev: boolean) => {
       },
     })
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref)
     expect(pathname).toBe('/gsp-blog/first')
   })
 
@@ -192,7 +191,7 @@ const runTests = (isDev: boolean) => {
       },
     })
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref)
     expect(pathname).toBe('/gsp-blog/first')
   })
 
@@ -215,7 +214,7 @@ const runTests = (isDev: boolean) => {
         },
       })
       const initialHref = await browser.eval(() => (window as any).initialHref)
-      const { pathname } = url.parse(initialHref)
+      const { pathname } = new URL(initialHref)
       // since it was cached the initial value is now the redirect
       // result
       expect(pathname).toBe('/gsp-blog/first')
@@ -230,7 +229,7 @@ const runTests = (isDev: boolean) => {
     await browser.waitForElementByCss('#index')
 
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref)
     expect(pathname).toBe('/gsp-blog/redirect-dest-_')
   })
 
@@ -243,7 +242,7 @@ const runTests = (isDev: boolean) => {
       await browser.waitForElementByCss('#index')
 
       const initialHref = await browser.eval(() => (window as any).initialHref)
-      const { pathname } = url.parse(initialHref)
+      const { pathname } = new URL(initialHref)
       expect(pathname).toBe('/')
     })
   }
@@ -266,7 +265,7 @@ const runTests = (isDev: boolean) => {
     expect(initialHref).toBeFalsy()
 
     const curUrl = await browser.url()
-    const { pathname } = url.parse(curUrl)
+    const { pathname } = new URL(curUrl)
     expect(pathname).toBe('/missing')
   })
 
@@ -315,7 +314,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(307)
 
-    const parsed = url.parse(res.headers.get('location'))
+    const parsed = new URL(res.headers.get('location'))
     expect(parsed.hostname).toBe('example.vercel.sh')
     expect(parsed.pathname).toBe('/')
   })
@@ -427,8 +426,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual('/')
+    const { pathname, search } = new URL(curUrl)
+    expect(pathname + search).toEqual('/')
   })
 
   it('should not replace history of the origin page when GSSP page is navigated to client-side (external)', async () => {
@@ -451,8 +450,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual('/')
+    const { pathname, search } = new URL(curUrl)
+    expect(pathname + search).toEqual('/')
   })
 
   it('should not replace history of the origin page when GSP page is navigated to client-side (internal)', async () => {
@@ -475,8 +474,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual('/')
+    const { pathname, search } = new URL(curUrl)
+    expect(pathname + search).toEqual('/')
   })
 
   it('should not replace history of the origin page when GSP page is navigated to client-side (external)', async () => {
@@ -499,8 +498,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual('/')
+    const { pathname, search } = new URL(curUrl)
+    expect(pathname + search).toEqual('/')
   })
 }
 

--- a/test/integration/i18n-support/test/index.test.ts
+++ b/test/integration/i18n-support/test/index.test.ts
@@ -1,4 +1,3 @@
-import url from 'url'
 import http from 'http'
 import fs from 'fs-extra'
 import { join } from 'path'
@@ -287,9 +286,11 @@ describe('i18n Support', () => {
           } else {
             expect(res.status).toBe(307)
 
-            const parsed = url.parse(res.headers.get('location'), true)
+            const parsed = new URL(res.headers.get('location'))
             expect(parsed.pathname).toBe(`/${locale}/`)
-            expect(parsed.query).toEqual({})
+            expect(Object.fromEntries(parsed.searchParams.entries())).toEqual(
+              {}
+            )
           }
         }
       })
@@ -485,9 +486,11 @@ describe('i18n Support', () => {
           } else {
             expect(res.status).toBe(307)
 
-            const parsed = url.parse(res.headers.get('location'), true)
+            const parsed = new URL(res.headers.get('location'))
             expect(parsed.pathname).toBe(`/${locale}`)
-            expect(parsed.query).toEqual({})
+            expect(Object.fromEntries(parsed.searchParams.entries())).toEqual(
+              {}
+            )
           }
         }
       })

--- a/test/integration/i18n-support/test/index.test.ts
+++ b/test/integration/i18n-support/test/index.test.ts
@@ -237,9 +237,10 @@ describe('i18n Support', () => {
             )
             hrefs.sort()
 
+            const baseURL = await browser.url()
             assert.deepEqual(
               hrefs.map((href) =>
-                new URL(href).pathname
+                new URL(href, baseURL).pathname
                   .replace(ctx.basePath, '')
                   .replace(/^\/_next\/data\/[^/]+/, '')
               ),
@@ -286,7 +287,7 @@ describe('i18n Support', () => {
           } else {
             expect(res.status).toBe(307)
 
-            const parsed = new URL(res.headers.get('location'))
+            const parsed = new URL(res.headers.get('location'), res.url)
             expect(parsed.pathname).toBe(`/${locale}/`)
             expect(Object.fromEntries(parsed.searchParams.entries())).toEqual(
               {}
@@ -486,7 +487,7 @@ describe('i18n Support', () => {
           } else {
             expect(res.status).toBe(307)
 
-            const parsed = new URL(res.headers.get('location'))
+            const parsed = new URL(res.headers.get('location'), res.url)
             expect(parsed.pathname).toBe(`/${locale}`)
             expect(Object.fromEntries(parsed.searchParams.entries())).toEqual(
               {}

--- a/test/integration/i18n-support/test/shared.ts
+++ b/test/integration/i18n-support/test/shared.ts
@@ -485,6 +485,7 @@ export function runTests(ctx) {
       `${ctx.basePath || ''}/links?nextLocale=go`
     )
 
+    let baseURL = await browser.url()
     for (const [element, pathname] of [
       ['#to-another', '/another'],
       ['#to-gsp', '/gsp'],
@@ -494,7 +495,7 @@ export function runTests(ctx) {
       ['#to-gssp-slug', '/gssp/first'],
     ]) {
       const href = await browser.elementByCss(element).getAttribute('href')
-      const { hostname, pathname: hrefPathname } = new URL(href)
+      const { hostname, pathname: hrefPathname } = new URL(href, baseURL)
       expect(hostname).not.toBe('example.com')
       expect(hrefPathname).toBe(`${ctx.basePath || ''}/go${pathname}`)
     }
@@ -504,6 +505,7 @@ export function runTests(ctx) {
       `${ctx.basePath || ''}/links?nextLocale=go-BE`
     )
 
+    baseURL = await browser.url()
     for (const [element, pathname] of [
       ['#to-another', '/another'],
       ['#to-gsp', '/gsp'],
@@ -513,7 +515,7 @@ export function runTests(ctx) {
       ['#to-gssp-slug', '/gssp/first'],
     ]) {
       const href = await browser.elementByCss(element).getAttribute('href')
-      const { hostname, pathname: hrefPathname } = new URL(href)
+      const { hostname, pathname: hrefPathname } = new URL(href, baseURL)
       expect(hostname).not.toBe('example.com')
       expect(hrefPathname).toBe(`${ctx.basePath || ''}/go-BE${pathname}`)
     }

--- a/test/integration/i18n-support/test/shared.ts
+++ b/test/integration/i18n-support/test/shared.ts
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import url from 'url'
 import glob from 'glob'
 import fs from 'fs-extra'
 import cheerio from 'cheerio'
@@ -372,7 +371,10 @@ export function runTests(ctx) {
       ctx.basePath || '/'
     )
 
-    await browser.get(browser.initUrl)
+    await browser.get(
+      // @ts-expect-error found when converting to TypeScript
+      browser.initUrl
+    )
     await browser.waitForElementByCss('#index')
 
     await browser.eval(`(function() {
@@ -492,7 +494,7 @@ export function runTests(ctx) {
       ['#to-gssp-slug', '/gssp/first'],
     ]) {
       const href = await browser.elementByCss(element).getAttribute('href')
-      const { hostname, pathname: hrefPathname } = url.parse(href)
+      const { hostname, pathname: hrefPathname } = new URL(href)
       expect(hostname).not.toBe('example.com')
       expect(hrefPathname).toBe(`${ctx.basePath || ''}/go${pathname}`)
     }
@@ -511,7 +513,7 @@ export function runTests(ctx) {
       ['#to-gssp-slug', '/gssp/first'],
     ]) {
       const href = await browser.elementByCss(element).getAttribute('href')
-      const { hostname, pathname: hrefPathname } = url.parse(href)
+      const { hostname, pathname: hrefPathname } = new URL(href)
       expect(hostname).not.toBe('example.com')
       expect(hrefPathname).toBe(`${ctx.basePath || ''}/go-BE${pathname}`)
     }
@@ -1891,13 +1893,13 @@ export function runTests(ctx) {
       ['/en/another/', '/en/another', 'localhost', {}],
       ['/fr/', '/fr', 'localhost', {}],
       ['/fr/another/', '/fr/another', 'localhost', {}],
-    ]) {
+    ] as const) {
       const res = await fetchViaHTTP(ctx.appPort, testPath, undefined, {
         redirect: 'manual',
       })
       expect(res.status).toBe(308)
 
-      const parsed = url.parse(res.headers.get('location'), true)
+      const parsed = new URL(res.headers.get('location'))
       expect(parsed.pathname).toBe(path)
 
       if (hostname === 'localhost') {
@@ -1905,7 +1907,7 @@ export function runTests(ctx) {
       } else {
         expect(parsed.hostname).toBe(hostname)
       }
-      expect(parsed.query).toEqual(query)
+      expect(Object.fromEntries(parsed.searchParams.entries())).toEqual(query)
     }
   })
 
@@ -1933,11 +1935,11 @@ export function runTests(ctx) {
       expect(res.status).toBe(shouldRedirect ? 307 : 200)
 
       if (shouldRedirect) {
-        const parsed = url.parse(res.headers.get('location'), true)
+        const parsed = new URL(res.headers.get('location'))
         expect(parsed.pathname).toBe(
           `${ctx.basePath}${locale || ''}${pathname || '/somewhere-else'}`
         )
-        expect(parsed.query).toEqual({})
+        expect(Object.fromEntries(parsed.searchParams.entries())).toEqual({})
       }
     }
   })
@@ -1951,7 +1953,7 @@ export function runTests(ctx) {
       ['/add-header-3', true],
       ['/en/add-header-3', true],
       ['/nl-NL/add-header-3', true],
-    ]) {
+    ] as const) {
       const res = await fetchViaHTTP(
         ctx.appPort,
         `${ctx.basePath}${path}`,
@@ -2201,9 +2203,9 @@ export function runTests(ctx) {
     ).toEqual({})
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('fr')
 
-    let parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    let parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/fr/another`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
 
     await browser.eval('window.history.back()')
     await browser.waitForElementByCss('#links')
@@ -2223,9 +2225,11 @@ export function runTests(ctx) {
       'en-US'
     )
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/links`)
-    expect(parsedUrl.query).toEqual({ nextLocale: 'fr' })
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({
+      nextLocale: 'fr',
+    })
 
     await browser.eval('window.history.forward()')
     await browser.waitForElementByCss('#another')
@@ -2245,9 +2249,9 @@ export function runTests(ctx) {
     ).toEqual({})
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('fr')
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/fr/another`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
     expect(await browser.eval('window.beforeNav')).toBe(1)
     expect(await browser.eval('window.caughtWarns')).toEqual([])
   })
@@ -2293,9 +2297,9 @@ export function runTests(ctx) {
     ).toEqual({ slug: 'first' })
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('nl')
 
-    let parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    let parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/nl/gsp/fallback/first`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
 
     await browser.eval('window.history.back()')
     await browser.waitForElementByCss('#links')
@@ -2315,9 +2319,11 @@ export function runTests(ctx) {
       'en-US'
     )
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/links`)
-    expect(parsedUrl.query).toEqual({ nextLocale: 'nl' })
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({
+      nextLocale: 'nl',
+    })
 
     await browser.eval('window.history.forward()')
     await browser.waitForElementByCss('#gsp')
@@ -2337,9 +2343,9 @@ export function runTests(ctx) {
     ).toEqual({ slug: 'first' })
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('nl')
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/nl/gsp/fallback/first`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
     expect(await browser.eval('window.beforeNav')).toBe(1)
     expect(await browser.eval('window.caughtWarns')).toEqual([])
   })
@@ -2415,9 +2421,9 @@ export function runTests(ctx) {
     ).toEqual({})
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('fr')
 
-    let parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    let parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/fr/another`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
 
     await browser.eval('window.history.back()')
     await browser.waitForElementByCss('#links')
@@ -2439,9 +2445,11 @@ export function runTests(ctx) {
       'en-US'
     )
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/locale-false`)
-    expect(parsedUrl.query).toEqual({ nextLocale: 'fr' })
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({
+      nextLocale: 'fr',
+    })
 
     await browser.eval('window.history.forward()')
     await browser.waitForElementByCss('#another')
@@ -2461,9 +2469,9 @@ export function runTests(ctx) {
     ).toEqual({})
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('fr')
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/fr/another`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
     expect(await browser.eval('window.beforeNav')).toBe(1)
     expect(await browser.eval('window.caughtWarns')).toEqual([])
   })
@@ -2511,9 +2519,9 @@ export function runTests(ctx) {
     ).toEqual({ slug: 'first' })
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('nl')
 
-    let parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    let parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/nl/gsp/fallback/first`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
 
     await browser.eval('window.history.back()')
     await browser.waitForElementByCss('#links')
@@ -2535,9 +2543,11 @@ export function runTests(ctx) {
       'en-US'
     )
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/locale-false`)
-    expect(parsedUrl.query).toEqual({ nextLocale: 'nl' })
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({
+      nextLocale: 'nl',
+    })
 
     await browser.eval('window.history.forward()')
     await browser.waitForElementByCss('#gsp')
@@ -2557,9 +2567,9 @@ export function runTests(ctx) {
     ).toEqual({ slug: 'first' })
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('nl')
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/nl/gsp/fallback/first`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
     expect(await browser.eval('window.beforeNav')).toBe(1)
     expect(await browser.eval('window.caughtWarns')).toEqual([])
   })
@@ -2666,7 +2676,7 @@ export function runTests(ctx) {
 
     expect(res.status).toBe(200)
 
-    // const result = url.parse(res.headers.get('location'), true)
+    // const result = new URL(res.headers.get('location'), true)
     // expect(result.pathname).toBe('/')
     // expect(result.query).toEqual({})
 
@@ -2684,7 +2694,7 @@ export function runTests(ctx) {
 
     expect(res2.status).toBe(200)
 
-    // const result2 = url.parse(res2.headers.get('location'), true)
+    // const result2 = new URL(res2.headers.get('location'), true)
     // expect(result2.pathname).toBe('/')
     // expect(result2.query).toEqual({})
   })
@@ -2699,7 +2709,7 @@ export function runTests(ctx) {
 
   //   expect(res.status).toBe(307)
 
-  //   const parsedUrl = url.parse(res.headers.get('location'), true)
+  //   const parsedUrl = new URL(res.headers.get('location'), true)
   //   expect(parsedUrl.pathname).toBe('/')
   //   expect(parsedUrl.query).toEqual({})
   //   expect(res.headers.get('set-cookie')).toContain('NEXT_LOCALE=en-US')
@@ -2814,13 +2824,15 @@ export function runTests(ctx) {
           }
 
           if (shouldRedirect) {
-            const parsedUrl = url.parse(res.headers.get('location'), true)
+            const parsedUrl = new URL(res.headers.get('location'))
 
             const expectedPathname = `/${
               expectedDomainItem.defaultLocale === locale ? '' : locale
             }`
             expect(parsedUrl.pathname).toBe(expectedPathname)
-            expect(parsedUrl.query).toEqual({})
+            expect(
+              Object.fromEntries(parsedUrl.searchParams.entries())
+            ).toEqual({})
             expect(parsedUrl.hostname).toBe(expectedDomainItem.domain)
           } else {
             const html = await res.text()
@@ -2939,8 +2951,8 @@ export function runTests(ctx) {
         const pagePath = join(ctx.buildPagesDir, locale, 'not-found.html')
         const dataPath = join(ctx.buildPagesDir, locale, 'not-found.json')
         console.log(pagePath)
-        expect(await fs.exists(pagePath)).toBe(!skippedLocales.includes(locale))
-        expect(await fs.exists(dataPath)).toBe(!skippedLocales.includes(locale))
+        expect(fs.existsSync(pagePath)).toBe(!skippedLocales.includes(locale))
+        expect(fs.existsSync(dataPath)).toBe(!skippedLocales.includes(locale))
       }
     })
   }
@@ -2972,12 +2984,9 @@ export function runTests(ctx) {
         expect(props.is404).toBe(true)
         expect(props.locale).toBe(locale)
 
-        const parsedUrl = url.parse(
-          await browser.eval('window.location.href'),
-          true
-        )
+        const parsedUrl = new URL(await browser.eval('window.location.href'))
         expect(parsedUrl.pathname).toBe(`${ctx.basePath}/${locale}/not-found`)
-        expect(parsedUrl.query).toEqual({})
+        expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
       }
     }
   })
@@ -3004,7 +3013,7 @@ export function runTests(ctx) {
     expect(await browser.elementByCss('#router-pathname').text()).toBe('/frank')
     expect(await browser.elementByCss('#router-as-path').text()).toBe('/frank')
     expect(
-      url.parse(await browser.eval(() => window.location.href)).pathname
+      new URL(await browser.eval(() => window.location.href)).pathname
     ).toBe(`${ctx.basePath}/fr/frank`)
     expect(await browser.eval('window.beforeNav')).toBe(1)
   })
@@ -3048,15 +3057,11 @@ export function runTests(ctx) {
     expect(props.locale).toBe('en')
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('en')
 
-    const parsedUrl = url.parse(
-      await browser.eval('window.location.href'),
-      true
-    )
+    const parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(
       `${ctx.basePath}/en/not-found/fallback/first`
     )
-    expect(parsedUrl.query).toEqual({})
-
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
     if (ctx.isDev) {
       // make sure page doesn't reload un-necessarily in development
       await waitFor(10 * 1000)
@@ -3084,15 +3089,11 @@ export function runTests(ctx) {
     expect(props.locale).toBe('en')
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('en')
 
-    const parsedUrl = url.parse(
-      await browser.eval('window.location.href'),
-      true
-    )
+    const parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(
       `${ctx.basePath}/en/not-found/fallback/first`
     )
-    expect(parsedUrl.query).toEqual({})
-
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
     if (ctx.isDev) {
       // make sure page doesn't reload un-necessarily in development
       await waitFor(10 * 1000)
@@ -3119,15 +3120,11 @@ export function runTests(ctx) {
     expect(props.locale).toBe('en')
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('en')
 
-    const parsedUrl = url.parse(
-      await browser.eval('window.location.href'),
-      true
-    )
+    const parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(
       `${ctx.basePath}/en/not-found/blocking-fallback/first`
     )
-    expect(parsedUrl.query).toEqual({})
-
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
     if (ctx.isDev) {
       // make sure page doesn't reload un-necessarily in development
       await waitFor(10 * 1000)
@@ -3155,15 +3152,11 @@ export function runTests(ctx) {
     expect(props.locale).toBe('en')
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('en')
 
-    const parsedUrl = url.parse(
-      await browser.eval('window.location.href'),
-      true
-    )
+    const parsedUrl = new URL(await browser.eval('window.location.href'))
     expect(parsedUrl.pathname).toBe(
       `${ctx.basePath}/en/not-found/blocking-fallback/first`
     )
-    expect(parsedUrl.query).toEqual({})
-
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
     if (ctx.isDev) {
       // make sure page doesn't reload un-necessarily in development
       await waitFor(10 * 1000)
@@ -3186,7 +3179,7 @@ export function runTests(ctx) {
 
     expect(res.status).toBe(200)
 
-    // const parsedUrl = url.parse(res.headers.get('location'), true)
+    // const parsedUrl = new URL(res.headers.get('location'), true)
 
     // expect(parsedUrl.pathname).toBe('/')
     // expect(parsedUrl.query).toEqual({})
@@ -3206,7 +3199,7 @@ export function runTests(ctx) {
 
     expect(res2.status).toBe(200)
 
-    // const parsedUrl2 = url.parse(res.headers.get('location'), true)
+    // const parsedUrl2 = new URL(res.headers.get('location'), true)
 
     // expect(parsedUrl2.pathname).toBe('/')
     // expect(parsedUrl2.query).toEqual({})
@@ -3290,9 +3283,9 @@ export function runTests(ctx) {
     )
     expect(res.status).toBe(307)
 
-    const parsedUrl = url.parse(res.headers.get('location'), true)
+    const parsedUrl = new URL(res.headers.get('location'))
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/nl-NL`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
 
     const res2 = await fetchViaHTTP(
       ctx.appPort,
@@ -3307,9 +3300,11 @@ export function runTests(ctx) {
     )
     expect(res2.status).toBe(307)
 
-    const parsedUrl2 = url.parse(res2.headers.get('location'), true)
+    const parsedUrl2 = new URL(res2.headers.get('location'))
     expect(parsedUrl2.pathname).toBe(`${ctx.basePath}/en`)
-    expect(parsedUrl2.query).toEqual({ hello: 'world' })
+    expect(Object.fromEntries(parsedUrl2.searchParams.entries())).toEqual({
+      hello: 'world',
+    })
   })
 
   it('should use default locale for / without accept-language', async () => {
@@ -3450,7 +3445,7 @@ export function runTests(ctx) {
       expect(await browser.elementByCss('#router-pathname').text()).toBe('/')
       expect(await browser.elementByCss('#router-as-path').text()).toBe('/')
       expect(
-        url.parse(await browser.eval(() => window.location.href)).pathname
+        new URL(await browser.eval(() => window.location.href)).pathname
       ).toBe(`${ctx.basePath || '/'}`)
     }
 
@@ -3478,7 +3473,7 @@ export function runTests(ctx) {
       '/another'
     )
     expect(
-      url.parse(await browser.eval(() => window.location.href)).pathname
+      new URL(await browser.eval(() => window.location.href)).pathname
     ).toBe(`${ctx.basePath}/another`)
 
     await browser.elementByCss('#to-index').click()
@@ -3504,7 +3499,7 @@ export function runTests(ctx) {
     expect(await browser.elementByCss('#router-pathname').text()).toBe('/gsp')
     expect(await browser.elementByCss('#router-as-path').text()).toBe('/gsp')
     expect(
-      url.parse(await browser.eval(() => window.location.href)).pathname
+      new URL(await browser.eval(() => window.location.href)).pathname
     ).toBe(`${ctx.basePath}/gsp`)
 
     await browser.elementByCss('#to-index').click()

--- a/test/integration/repeated-slashes/test/index.test.ts
+++ b/test/integration/repeated-slashes/test/index.test.ts
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 import { join } from 'path'
 import fs from 'fs-extra'
-import url from 'url'
 import webdriver from 'next-webdriver'
 import escapeRegex from 'escape-string-regexp'
 import {
@@ -66,11 +65,11 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
       )
 
       expect(res.status).toBe(307)
-      const parsedUrl = url.parse(res.headers.get('location'), true)
+      const parsedUrl = new URL(res.headers.get('location'))
 
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
       expect(parsedUrl.pathname).toBe('/test/google.com')
-      expect(parsedUrl.query).toEqual({})
+      expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
       expect(await res.text()).toBe('/test/google.com')
 
       const res2 = await fetchViaHTTP(
@@ -83,11 +82,11 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
       )
 
       expect(res2.status).toBe(307)
-      const parsedUrl2 = url.parse(res2.headers.get('location'), true)
+      const parsedUrl2 = new URL(res2.headers.get('location'))
 
       expect(parsedUrl2.hostname).toBeOneOf(['localhost', '127.0.0.1'])
       expect(parsedUrl2.pathname).toBe('/test/google.com')
-      expect(parsedUrl2.query).toEqual({})
+      expect(Object.fromEntries(parsedUrl2.searchParams.entries())).toEqual({})
       expect(await res2.text()).toBe('/test/google.com')
     })
   }
@@ -99,10 +98,10 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
       })
       expect(res.status).toBe(308)
 
-      const parsedUrl = url.parse(res.headers.get('location'), true)
+      const parsedUrl = new URL(res.headers.get('location'))
       expect(parsedUrl.pathname).toBe('/google.com')
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
-      expect(parsedUrl.query).toEqual({})
+      expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
     }
 
     const browser = await webdriver(appPort, '//google.com')
@@ -128,10 +127,12 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
         }
       )
       expect(res.status).toBe(308)
-      const parsedUrl = url.parse(res.headers.get('location'), true)
+      const parsedUrl = new URL(res.headers.get('location'))
       expect(parsedUrl.pathname).toBe('/google.com')
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
-      expect(parsedUrl.query).toEqual({ h: '1' })
+      expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({
+        h: '1',
+      })
     }
 
     const browser = await webdriver(appPort, '//google.com?h=1')
@@ -152,10 +153,10 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
         redirect: 'manual',
       })
       expect(res.status).toBe(308)
-      const parsedUrl = url.parse(res.headers.get('location'), true)
+      const parsedUrl = new URL(res.headers.get('location'))
       expect(parsedUrl.pathname).toBe('/google.com')
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
-      expect(parsedUrl.query).toEqual({})
+      expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
     }
 
     const browser = await webdriver(appPort, '//google.com#hello')
@@ -240,10 +241,10 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
         redirect: 'manual',
       })
       expect(res.status).toBe(308)
-      const parsedUrl = url.parse(res.headers.get('location'), true)
+      const parsedUrl = new URL(res.headers.get('location'))
       expect(parsedUrl.pathname).toBe('/google.com')
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
-      expect(parsedUrl.query).toEqual({})
+      expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
       expect(await res.text()).toBe('/google.com')
     }
 
@@ -265,10 +266,10 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
         redirect: 'manual',
       })
       expect(res.status).toBe(308)
-      const parsedUrl = url.parse(res.headers.get('location'), true)
+      const parsedUrl = new URL(res.headers.get('location'))
       expect(parsedUrl.pathname).toBe(isExport ? '//google.com' : '/google.com')
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
-      expect(parsedUrl.query).toEqual({})
+      expect(Object.fromEntries(parsedUrl.searchParams.entries())).toEqual({})
       expect(await res.text()).toBe('/google.com')
     }
 

--- a/test/production/app-dir/app-edge-middleware/app-edge-middleware.test.ts
+++ b/test/production/app-dir/app-edge-middleware/app-edge-middleware.test.ts
@@ -54,7 +54,7 @@ describe('app edge middleware', () => {
         `,
         'middleware.js': `
           import { NextResponse } from 'next/server';
-          import { parse } from 'url';
+          import { URL } from 'url';
           export async function middleware() { 
             return NextResponse.next() 
           }

--- a/test/production/custom-server/server.js
+++ b/test/production/custom-server/server.js
@@ -42,6 +42,7 @@ async function main() {
             await app.render(req, res, '/page-error')
           } else {
             parsedUrl.pathname = pathname
+            // TODO: Accept WHATWG URLs in Next.js request handlers
             await handle(req, res, parsedUrl)
           }
         } catch (err) {

--- a/test/production/pages-dir/production/fixture/pages/another.js
+++ b/test/production/pages-dir/production/fixture/pages/another.js
@@ -1,7 +1,7 @@
 import url from 'url'
 import Link from 'next/link'
 
-console.log(url.parse('https://example.com'))
+console.log(new url.URL('https://example.com'))
 
 export default () => (
   <div>

--- a/test/production/pages-dir/production/fixture/pages/another.js
+++ b/test/production/pages-dir/production/fixture/pages/another.js
@@ -1,7 +1,9 @@
 import url from 'url'
 import Link from 'next/link'
 
-console.log(new url.URL('https://example.com'))
+// `url` is shimmed partially by Next.js in the browser so we have to test a method
+// that's not deprected in Node.js but also available in the shim.
+console.log(url.resolve('/one/two/three', 'four'))
 
 export default () => (
   <div>

--- a/test/production/pages-dir/production/test/security.ts
+++ b/test/production/pages-dir/production/test/security.ts
@@ -2,7 +2,6 @@
 import webdriver from 'next-webdriver'
 import { readFileSync } from 'fs'
 import http from 'http'
-import url from 'url'
 import { join } from 'path'
 import { getBrowserBodyText, waitFor, fetchViaHTTP } from 'next-test-utils'
 import { recursiveReadDir } from 'next/dist/lib/recursive-readdir'
@@ -215,9 +214,7 @@ export default (next: NextInstance) => {
         }
       )
 
-      const { pathname, hostname } = url.parse(
-        res.headers.get('location') || ''
-      )
+      const { pathname, hostname } = new URL(res.headers.get('location') || '')
       expect(res.status).toBe(307)
       expect(pathname).toBe(encodeURI('/\\google.com/about'))
       expect(hostname).toBeOneOf(['localhost', '127.0.0.1'])
@@ -233,9 +230,7 @@ export default (next: NextInstance) => {
         }
       )
 
-      const { pathname, hostname } = url.parse(
-        res.headers.get('location') || ''
-      )
+      const { pathname, hostname } = new URL(res.headers.get('location') || '')
       expect(res.status).toBe(307)
       expect(pathname).toBe('/%25google.com/about')
       expect(hostname).toBeOneOf(['localhost', '127.0.0.1'])
@@ -251,13 +246,13 @@ export default (next: NextInstance) => {
         }
       )
 
-      const { pathname, hostname, query } = url.parse(
+      const { pathname, hostname, search } = new URL(
         res.headers.get('location') || ''
       )
       expect(res.status).toBe(308)
       expect(pathname).toBe('/trailing-redirect')
       expect(hostname).toBeOneOf(['localhost', '127.0.0.1'])
-      expect(query).toBe(
+      expect(search).toBe(
         'url=https%3A%2F%2Fgoogle.com%2Fimage%3Fcrop%3Dfocalpoint%26w%3D24&w=1200&q=100'
       )
     })
@@ -272,9 +267,7 @@ export default (next: NextInstance) => {
         }
       )
 
-      const { pathname, hostname } = url.parse(
-        res.headers.get('location') || ''
-      )
+      const { pathname, hostname } = new URL(res.headers.get('location') || '')
       expect(res.status).toBe(307)
       expect(pathname).toBe('/%2fgoogle.com/about')
       expect(hostname).not.toBe('google.com')
@@ -290,12 +283,12 @@ export default (next: NextInstance) => {
         }
       )
 
-      const { pathname, hostname, query } = url.parse(
+      const { pathname, hostname, search } = new URL(
         res.headers.get('location') || ''
       )
       expect(res.status).toBe(307)
       expect(pathname).toBe('/about')
-      expect(query).toBe('foo=%2Fgoogle.com')
+      expect(search).toBe('foo=%2Fgoogle.com')
       expect(hostname).not.toBe('google.com')
       expect(hostname).not.toMatch(/google/)
     })
@@ -308,9 +301,7 @@ export default (next: NextInstance) => {
         { redirect: 'manual' }
       )
 
-      const { pathname, hostname } = url.parse(
-        res.headers.get('location') || ''
-      )
+      const { pathname, hostname } = new URL(res.headers.get('location') || '')
       expect(res.status).toBe(308)
       expect(pathname).toBe('/%2fexample.com')
       expect(hostname).not.toBe('example.com')

--- a/test/production/pages-dir/production/test/security.ts
+++ b/test/production/pages-dir/production/test/security.ts
@@ -253,7 +253,7 @@ export default (next: NextInstance) => {
       expect(pathname).toBe('/trailing-redirect')
       expect(hostname).toBeOneOf(['localhost', '127.0.0.1'])
       expect(search).toBe(
-        'url=https%3A%2F%2Fgoogle.com%2Fimage%3Fcrop%3Dfocalpoint%26w%3D24&w=1200&q=100'
+        '?url=https%3A%2F%2Fgoogle.com%2Fimage%3Fcrop%3Dfocalpoint%26w%3D24&w=1200&q=100'
       )
     })
 
@@ -288,7 +288,7 @@ export default (next: NextInstance) => {
       )
       expect(res.status).toBe(307)
       expect(pathname).toBe('/about')
-      expect(search).toBe('foo=%2Fgoogle.com')
+      expect(search).toBe('?foo=%2Fgoogle.com')
       expect(hostname).not.toBe('google.com')
       expect(hostname).not.toMatch(/google/)
     })


### PR DESCRIPTION
`url.parse` is deprecated in favor of WHATWG URLs. 

Almost all tests don't actually test integration with `url.parse`.

The remaining places test integration with the Next.js request handler which does accept `url.parse` values.

We may deprecate that specific signature in favor of accepting WHATWG URLs instead.