### PR TITLE
turbopack: Support query conditions in rules

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -702,6 +702,8 @@ pub enum ConfigConditionItem {
         #[serde(default)]
         path: Option<ConfigConditionPath>,
         #[serde(default)]
+        query: Option<RegexComponents>,
+        #[serde(default)]
         content: Option<RegexComponents>,
     },
 }
@@ -723,8 +725,16 @@ impl TryFrom<ConfigConditionItem> for ConditionItem {
             ConfigConditionItem::Builtin(cond) => {
                 ConditionItem::Builtin(RcStr::from(cond.as_str()))
             }
-            ConfigConditionItem::Base { path, content } => ConditionItem::Base {
+            ConfigConditionItem::Base {
+                path,
+                query,
+                content,
+            } => ConditionItem::Base {
                 path: path.map(ConditionPath::try_from).transpose()?,
+                query: query
+                    .map(EsRegex::try_from)
+                    .transpose()?
+                    .map(EsRegex::resolved_cell),
                 content: content
                     .map(EsRegex::try_from)
                     .transpose()?
@@ -2077,6 +2087,10 @@ mod tests {
                         "browser",
                         {
                             "path": { "type": "glob", "value": "*.svg"},
+                            "query": {
+                                "source": "@someQuery",
+                                "flags": ""
+                            },
                             "content": {
                                 "source": "@someTag",
                                 "flags": ""
@@ -2107,6 +2121,10 @@ mod tests {
                                 ),
                                 ConfigConditionItem::Base {
                                     path: Some(ConfigConditionPath::Glob(rcstr!("*.svg"))),
+                                    query: Some(RegexComponents {
+                                        source: rcstr!("@someQuery"),
+                                        flags: rcstr!(""),
+                                    }),
                                     content: Some(RegexComponents {
                                         source: rcstr!("@someTag"),
                                         flags: rcstr!(""),

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -193,6 +193,7 @@ pub async fn get_babel_loader_rules(
                 ReactCompilerCompilationMode::Annotation => {
                     loader_conditions.push(ConditionItem::Base {
                         path: None,
+                        query: None,
                         content: Some(
                             EsRegex::new(r#"['"]use memo['"]"#, "")
                                 .expect("valid const regex")
@@ -203,6 +204,7 @@ pub async fn get_babel_loader_rules(
                 ReactCompilerCompilationMode::Infer => {
                     loader_conditions.push(ConditionItem::Base {
                         path: None,
+                        query: None,
                         // Matches declaration or useXXX or </ (closing jsx) or /> (self closing
                         // jsx)
                         content: Some(

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -197,6 +197,9 @@ module.exports = {
             {
               any: [
                 { path: '*.svg' },
+                // 'query' is always a RegExp, and matches anywhere in the
+                // full query string, which can be empty, or start with `?`.
+                { query: /[?&]svgr(?=&|$)/ },
                 // 'content' is always a RegExp, and can match
                 // anywhere in the file.
                 { content: /\<svg\W/ },

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -949,6 +949,7 @@ function bindingToApi(
         path?:
           | { type: 'regex'; value: { source: string; flags: string } }
           | { type: 'glob'; value: string }
+        query?: { source: string; flags: string }
         content?: { source: string; flags: string }
       }
 
@@ -984,6 +985,7 @@ function bindingToApi(
                   value: regexComponents(cond.path),
                 }
               : { type: 'glob', value: cond.path },
+        query: cond.query && regexComponents(cond.query),
         content: cond.content && regexComponents(cond.content),
       }
     }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -128,6 +128,7 @@ const zTurbopackCondition: zod.ZodType<TurbopackRuleCondition> = z.union([
   zTurbopackLoaderBuiltinCondition,
   z.strictObject({
     path: z.union([z.string(), z.instanceof(RegExp)]).optional(),
+    query: z.instanceof(RegExp).optional(),
     content: z.instanceof(RegExp).optional(),
   }),
 ])

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -117,6 +117,7 @@ export type TurbopackRuleCondition =
   | TurbopackLoaderBuiltinCondition
   | {
       path?: string | RegExp
+      query?: RegExp
       content?: RegExp
     }
 

--- a/test/e2e/turbopack-loader-config/app/api/route.ts
+++ b/test/e2e/turbopack-loader-config/app/api/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import foo from '../../foo.js'
-import bar from '../../bar.js'
+// @ts-expect-error -- ignore
+import bar from '../../bar.js?test=hi'
 
 export async function GET(_req) {
   return NextResponse.json(

--- a/test/e2e/turbopack-loader-config/next.config.ts
+++ b/test/e2e/turbopack-loader-config/next.config.ts
@@ -35,7 +35,10 @@ export default {
           condition: {
             any: [
               {
-                all: ['development', { not: { not: { content: /export/ } } }],
+                all: [
+                  'development',
+                  { not: { not: { query: /test=hi/, content: /export/ } } },
+                ],
               },
             ],
           },
@@ -49,7 +52,10 @@ export default {
         // this should match on production
         {
           condition: {
-            all: [{ not: 'development' }, { content: /export/ }],
+            all: [
+              { not: 'development' },
+              { query: /test=hi/, content: /export/ },
+            ],
           },
           loaders: [
             {

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -117,7 +117,11 @@ async fn rule_condition_from_webpack_condition(
                 anyhow::bail!("{name:?} is not a valid built-in condition")
             }
         },
-        ConditionItem::Base { path, content } => {
+        ConditionItem::Base {
+            path,
+            query,
+            content,
+        } => {
             let mut rule_conditions = Vec::new();
             match &path {
                 Some(ConditionPath::Glob(glob)) => rule_conditions.push(
@@ -127,6 +131,9 @@ async fn rule_condition_from_webpack_condition(
                     rule_conditions.push(RuleCondition::ResourcePathEsRegex(regex.await?));
                 }
                 None => {}
+            }
+            if let Some(query) = query {
+                rule_conditions.push(RuleCondition::ResourceQueryEsRegex(query.await?));
             }
             if let Some(content) = content {
                 rule_conditions.push(RuleCondition::ResourceContentEsRegex(content.await?));

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -56,6 +56,7 @@ pub enum ConditionItem {
     Builtin(RcStr),
     Base {
         path: Option<ConditionPath>,
+        query: Option<ResolvedVc<EsRegex>>,
         content: Option<ResolvedVc<EsRegex>>,
     },
 }

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -31,6 +31,7 @@ pub enum RuleCondition {
     ContentTypeStartsWith(String),
     ContentTypeEmpty,
     ResourcePathEsRegex(#[turbo_tasks(trace_ignore)] ReadRef<EsRegex>),
+    ResourceQueryEsRegex(#[turbo_tasks(trace_ignore)] ReadRef<EsRegex>),
     ResourceContentEsRegex(#[turbo_tasks(trace_ignore)] ReadRef<EsRegex>),
     /// For paths that are within the same filesystem as the `base`, it need to
     /// match the relative path from base to resource. This includes `./` or
@@ -269,6 +270,10 @@ impl RuleCondition {
                     }
                     RuleCondition::ResourcePathEsRegex(regex) => {
                         return Ok(regex.is_match(&path.path));
+                    }
+                    RuleCondition::ResourceQueryEsRegex(regex) => {
+                        let ident = source.ident().await?;
+                        return Ok(regex.is_match(&ident.query));
                     }
                     RuleCondition::ResourceContentEsRegex(regex) => {
                         let content = source.content().file_content().await?;


### PR DESCRIPTION
Accepts a regular expression under the `query` key in turbopack conditions. An updated example has been added to the documentation.

This is roughly equivalent to the `resourceQuery` condition in webpack rules: https://webpack.js.org/configuration/module/#ruleresourcequery

Fixes #65360
Fixes #67452
Fixes #79311