### PR TITLE
Read from segment cache unknown routes

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -6,7 +6,7 @@ import type {
 import { handleNavigationResult } from './navigate-reducer'
 import {
   convertServerPatchToFullTree,
-  navigateToSeededRoute,
+  navigateToKnownRoute,
 } from '../../segment-cache/navigation'
 import { revalidateEntireCache } from '../../segment-cache/cache'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
@@ -54,7 +54,7 @@ export function refreshDynamicData(
   )
 
   const now = Date.now()
-  const result = navigateToSeededRoute(
+  const result = navigateToKnownRoute(
     now,
     currentUrl,
     currentCanonicalUrl,

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -60,12 +60,10 @@ export function restoreReducer(
     state.cache,
     state.tree,
     restoreSeed.routeTree,
+    restoreSeed.metadataVaryPath,
     FreshnessPolicy.HistoryTraversal,
     null,
     null,
-    null,
-    null,
-    false,
     false,
     accumulation
   )

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -51,7 +51,7 @@ import { revalidateEntireCache } from '../../segment-cache/cache'
 import { getDeploymentId } from '../../../../shared/lib/deployment-id'
 import {
   convertServerPatchToFullTree,
-  navigateToSeededRoute,
+  navigateToKnownRoute,
   navigate as navigateUsingSegmentCache,
 } from '../../segment-cache/navigation'
 import type { NormalizedSearch } from '../../segment-cache/cache-key'
@@ -407,7 +407,7 @@ export function serverActionReducer(
           flightDataRenderedSearch
         )
         const now = Date.now()
-        const result = navigateToSeededRoute(
+        const result = navigateToKnownRoute(
           now,
           redirectUrl,
           redirectCanonicalUrl,

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -6,7 +6,7 @@ import type {
   Mutable,
 } from '../router-reducer-types'
 import { handleExternalUrl, handleNavigationResult } from './navigate-reducer'
-import { navigateToSeededRoute } from '../../segment-cache/navigation'
+import { navigateToKnownRoute } from '../../segment-cache/navigation'
 import { refreshReducer } from './refresh-reducer'
 import { FreshnessPolicy } from '../ppr-navigations'
 
@@ -45,7 +45,7 @@ export function serverPatchReducer(
   const pendingPush = false
   const shouldScroll = true
   const now = Date.now()
-  const result = navigateToSeededRoute(
+  const result = navigateToKnownRoute(
     now,
     retryUrl,
     retryCanonicalUrl,

--- a/test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
+++ b/test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
@@ -57,15 +57,13 @@ describe('mismatching prefetch', () => {
           // Simultaneously, the dynamic content for page A is requested.
         },
         // When the dynamic request is received, Next.js will discover that the
-        // route has changed and rewrite to page B.
-        [
-          { includes: 'Dynamic page b' },
-          // It's expected that the dynamic page for B is requested twice:
-          // once due to the mismatching prefetch, and again during the
-          // retry, because a retry caused by a mismatch implicitly
-          // performs a soft refresh of all the dynamic data on the page.
-          { includes: 'Dynamic page b' },
-        ]
+        // route has changed and rewrite to page B. The client will detect a
+        // mismatch and render again using the new route from the server.
+        //
+        // This shouldn't require a second dynamic request, though, because we
+        // can reuse the data sent by the server. So, page B should only render
+        // once on the server.
+        [{ includes: 'Dynamic page b' }]
       )
 
       // The redirected page loads successfully.


### PR DESCRIPTION
Based on:

- https://github.com/vercel/next.js/pull/87203
- https://github.com/vercel/next.js/pull/87256

---

Currently, there's a cliff when navigating to a route that is unknown to the client. The prefetch cache is bypassed completely because we don't know the structure of the target route, and therefore we don't know which segments we might be able to use to construct a loading state (or even a fully cached response).

However, because RSC responses are streaming, we can take advantage of the fact that the first chunk of the response contains the route tree. So as soon as we receive the first chunk, we can show a cached loading state to the user (if available), even while we wait for the rest of the response to arrive from the server.

To access a segment's cache, you need its corresponding RouteTree. Previously this was not available during an unprefetched navigation because those objects were only created during a prefetch. But now that we've migrated the navigation implementation to use RouteTrees, too, we can access the cache directly inside the main navigation function, rather than having to do two separate passes like before.

In other words, the only difference between a navigation to an unknown route versus a prefetched route is the extra latency required to get those first bytes from the server. Once the route tree resolves, the rest of the implementation and behavior is identical.